### PR TITLE
feat(tls) add duplex upgrade

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -729,6 +729,7 @@ pub const EventLoopTimer = struct {
         TimerObject,
         TestRunner,
         StatWatcherScheduler,
+        UpgradedDuplex,
 
         pub fn Type(comptime T: Tag) type {
             return switch (T) {
@@ -736,6 +737,7 @@ pub const EventLoopTimer = struct {
                 .TimerObject => TimerObject,
                 .TestRunner => JSC.Jest.TestRunner,
                 .StatWatcherScheduler => StatWatcherScheduler,
+                .UpgradedDuplex => uws.UpgradedDuplex,
             };
         }
     };
@@ -795,6 +797,9 @@ pub const EventLoopTimer = struct {
                 }
                 if (comptime t.Type() == StatWatcherScheduler) {
                     return container.timerCallback();
+                }
+                if (comptime t.Type() == uws.UpgradedDuplex) {
+                    return container.onTimeout();
                 }
 
                 if (comptime t.Type() == JSC.Jest.TestRunner) {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1740,6 +1740,7 @@ fn NewSocket(comptime ssl: bool) type {
                 globalObject.throw("Timeout must be a positive integer", .{});
                 return .zero;
             }
+            log("timeout({d})", .{t});
 
             this.socket.setTimeout(@as(c_uint, @intCast(t)));
 
@@ -3249,6 +3250,14 @@ pub const DuplexUpgradeContext = struct {
         }
     }
 
+    fn onTimeout(this: *DuplexUpgradeContext) void {
+        const socket = TLSSocket.Socket.fromDuplex(&this.upgrade);
+
+        if (this.tls) |tls| {
+            tls.onTimeout(socket);
+        }
+    }
+
     fn onClose(this: *DuplexUpgradeContext) void {
         const socket = TLSSocket.Socket.fromDuplex(&this.upgrade);
 
@@ -3424,6 +3433,7 @@ pub fn jsUpgradeDuplexToTLS(globalObject: *JSC.JSGlobalObject, callframe: *JSC.C
         .onEnd = @ptrCast(&DuplexUpgradeContext.onEnd),
         .onWritable = @ptrCast(&DuplexUpgradeContext.onWritable),
         .onError = @ptrCast(&DuplexUpgradeContext.onError),
+        .onTimeout = @ptrCast(&DuplexUpgradeContext.onTimeout),
         .ctx = @ptrCast(duplexContext),
     });
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -790,7 +790,7 @@ pub const Listener = struct {
         if (socket.ext(**anyopaque)) |ctx| {
             ctx.* = bun.cast(**anyopaque, this_socket);
         }
-        socket.setTimeout(120000);
+        socket.setTimeout(120);
     }
 
     pub fn addServerName(this: *Listener, global: *JSC.JSGlobalObject, hostname: JSValue, tls: JSValue) JSValue {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -3443,7 +3443,12 @@ pub fn jsUpgradeDuplexToTLS(globalObject: *JSC.JSGlobalObject, callframe: *JSC.C
 
     duplexContext.startTLS();
 
-    return tls_js_value;
+    const array = JSC.JSValue.createEmptyArray(globalObject, 2);
+    array.putIndex(globalObject, 0, tls_js_value);
+    // data, end, drain and close events must be reported
+    array.putIndex(globalObject, 1, duplexContext.upgrade.getJSHandlers(globalObject));
+
+    return array;
 }
 pub fn createNodeTLSBinding(global: *JSC.JSGlobalObject) JSC.JSValue {
     return JSC.JSArray.create(global, &.{

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -116,7 +116,7 @@ pub fn SSLWrapper(comptime T: type) type {
             // We cannot shutdown read in SSL, the read direction is closed by the peer.
             // So we just ignore the onData data, we still wanna to wait until we received the shutdown
             const DummyReadHandler = struct {
-                fn onData(_: T, _: *This, _: []const u8) void {}
+                fn onData(_: T, _: []const u8) void {}
             };
             this.handlers.onData = DummyReadHandler.onData;
         }
@@ -176,19 +176,19 @@ pub fn SSLWrapper(comptime T: type) type {
         }
 
         // Return if we have pending data to be read or write
-        pub fn hasPendingData(this: *This) bool {
+        pub fn hasPendingData(this: *const This) bool {
             const ssl = this.ssl orelse return false;
 
             return BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_wbio(ssl)) > 0 or BoringSSL.BIO_ctrl_pending(BoringSSL.SSL_get_rbio(ssl)) > 0;
         }
 
         // We sent or received a shutdown (closing or closed)
-        pub fn isShutdown(this: *This) bool {
+        pub fn isShutdown(this: *const This) bool {
             return this.flags.closed_notified or this.flags.received_ssl_shutdown or this.flags.sent_ssl_shutdown;
         }
 
         // We sent and received the shutdown (fully closed)
-        pub fn isClosed(this: *This) bool {
+        pub fn isClosed(this: *const This) bool {
             return this.flags.received_ssl_shutdown and this.flags.sent_ssl_shutdown;
         }
 

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -133,7 +133,7 @@ pub fn SSLWrapper(comptime T: type) type {
             // The peer might continue sending data for some period of time before handling the local application's shutdown indication.
             // This will start a full shutdown process if fast_shutdown = false, we can assume that the other side will complete the 2-step shutdown ASAP.
             const ret = BoringSSL.SSL_shutdown(ssl);
-            if (fast_shutdown and ret == 0) {
+            if (fast_shutdown) {
                 // This allows for a more rapid shutdown process if the application does not wish to wait for the peer.
                 // This alternative "fast shutdown" approach should only be done if it is known that the peer will not send more data, otherwise there is a risk of an application exposing itself to a truncation attack.
                 // The full SSL_shutdown() process, in which both parties send close_notify alerts and SSL_shutdown() returns 1, provides a cryptographically authenticated indication of the end of a connection.

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -40,4 +40,5 @@ export default [
   // Bun-specific
   ["ERR_FORMDATA_PARSE_ERROR", TypeError, "TypeError"],
   ["ERR_BODY_ALREADY_USED", Error, "Error"],
+  ["ERR_STREAM_WRAP", Error, "Error"],
 ] as ErrorCodeMapping;

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -1448,6 +1448,42 @@ pub const Encoder = struct {
         };
     }
 
+    pub fn decodeStringAtRuntime(str: bun.String, encoding: JSC.Node.Encoding) []u8 {
+        return if (str.is8Bit()) constructFromAtRuntime(u8, str.byteSlice(), encoding) else constructFromAtRuntime(u16, str.utf16(), encoding);
+    }
+
+    pub fn constructFromAtRuntime(comptime T: type, input: []const T, encoding: JSC.Node.Encoding) []u8 {
+        switch (comptime T) {
+            u16 => {
+                return switch (encoding) {
+                    .ucs2 => constructFromU16(input.ptr, input.len, .utf16le),
+                    .utf16le => constructFromU16(input.ptr, input.len, .utf16le),
+                    .utf8 => constructFromU16(input.ptr, input.len, .utf8),
+                    .ascii => constructFromU16(input.ptr, input.len, .ascii),
+                    .hex => constructFromU16(input.ptr, input.len, .hex),
+                    .base64 => constructFromU16(input.ptr, input.len, .base64),
+                    .base64url => constructFromU16(input.ptr, input.len, .base64url),
+                    .latin1 => constructFromU16(input.ptr, input.len, .latin1),
+                    else => constructFromU16(input.ptr, input.len, .utf8),
+                };
+            },
+            u8 => {
+                return switch (encoding) {
+                    .ucs2 => constructFromU8(input.ptr, input.len, .utf16le),
+                    .utf16le => constructFromU8(input.ptr, input.len, .utf16le),
+                    .utf8 => constructFromU8(input.ptr, input.len, .utf8),
+                    .ascii => constructFromU8(input.ptr, input.len, .ascii),
+                    .hex => constructFromU8(input.ptr, input.len, .hex),
+                    .base64 => constructFromU8(input.ptr, input.len, .base64),
+                    .base64url => constructFromU8(input.ptr, input.len, .base64url),
+                    .latin1 => constructFromU8(input.ptr, input.len, .latin1),
+                    else => constructFromU8(input.ptr, input.len, .utf8),
+                };
+            },
+            else => @compileError("Unsupported type for constructFrom: " ++ @typeName(T)),
+        }
+    }
+
     pub fn constructFromU8(input: [*]const u8, len: usize, comptime encoding: JSC.Node.Encoding) []u8 {
         if (len == 0) return &[_]u8{};
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -1448,42 +1448,6 @@ pub const Encoder = struct {
         };
     }
 
-    pub fn decodeStringAtRuntime(str: bun.String, encoding: JSC.Node.Encoding) []u8 {
-        return if (str.is8Bit()) constructFromAtRuntime(u8, str.byteSlice(), encoding) else constructFromAtRuntime(u16, str.utf16(), encoding);
-    }
-
-    pub fn constructFromAtRuntime(comptime T: type, input: []const T, encoding: JSC.Node.Encoding) []u8 {
-        switch (comptime T) {
-            u16 => {
-                return switch (encoding) {
-                    .ucs2 => constructFromU16(input.ptr, input.len, .utf16le),
-                    .utf16le => constructFromU16(input.ptr, input.len, .utf16le),
-                    .utf8 => constructFromU16(input.ptr, input.len, .utf8),
-                    .ascii => constructFromU16(input.ptr, input.len, .ascii),
-                    .hex => constructFromU16(input.ptr, input.len, .hex),
-                    .base64 => constructFromU16(input.ptr, input.len, .base64),
-                    .base64url => constructFromU16(input.ptr, input.len, .base64url),
-                    .latin1 => constructFromU16(input.ptr, input.len, .latin1),
-                    else => constructFromU16(input.ptr, input.len, .utf8),
-                };
-            },
-            u8 => {
-                return switch (encoding) {
-                    .ucs2 => constructFromU8(input.ptr, input.len, .utf16le),
-                    .utf16le => constructFromU8(input.ptr, input.len, .utf16le),
-                    .utf8 => constructFromU8(input.ptr, input.len, .utf8),
-                    .ascii => constructFromU8(input.ptr, input.len, .ascii),
-                    .hex => constructFromU8(input.ptr, input.len, .hex),
-                    .base64 => constructFromU8(input.ptr, input.len, .base64),
-                    .base64url => constructFromU8(input.ptr, input.len, .base64url),
-                    .latin1 => constructFromU8(input.ptr, input.len, .latin1),
-                    else => constructFromU8(input.ptr, input.len, .utf8),
-                };
-            },
-            else => @compileError("Unsupported type for constructFrom: " ++ @typeName(T)),
-        }
-    }
-
     pub fn constructFromU8(input: [*]const u8, len: usize, comptime encoding: JSC.Node.Encoding) []u8 {
         if (len == 0) return &[_]u8{};
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -13,7 +13,9 @@ pub const Socket = opaque {};
 pub const ConnectingSocket = opaque {};
 const debug = bun.Output.scoped(.uws, false);
 const uws = @This();
-
+const SSLWrapper = @import("../bun.js/api/bun/ssl_wrapper.zig").SSLWrapper;
+const TextEncoder = @import("../bun.js/webcore/encoding.zig").Encoder;
+const JSC = bun.JSC;
 pub const CloseCode = enum(i32) {
     normal = 0,
     failure = 1,
@@ -56,7 +58,7 @@ pub const InternalLoopData = extern struct {
         return this.recv_buf[0..LIBUS_RECV_BUFFER_LENGTH];
     }
 
-    pub fn setParentEventLoop(this: *InternalLoopData, parent: bun.JSC.EventLoopHandle) void {
+    pub fn setParentEventLoop(this: *InternalLoopData, parent: JSC.EventLoopHandle) void {
         switch (parent) {
             .js => |ptr| {
                 this.parent_tag = 1;
@@ -69,14 +71,353 @@ pub const InternalLoopData = extern struct {
         }
     }
 
-    pub fn getParent(this: *InternalLoopData) bun.JSC.EventLoopHandle {
+    pub fn getParent(this: *InternalLoopData) JSC.EventLoopHandle {
         const parent = this.parent_ptr orelse @panic("Parent loop not set - pointer is null");
         return switch (this.parent_tag) {
             0 => @panic("Parent loop not set - tag is zero"),
-            1 => .{ .js = bun.cast(*bun.JSC.EventLoop, parent) },
-            2 => .{ .mini = bun.cast(*bun.JSC.MiniEventLoop, parent) },
+            1 => .{ .js = bun.cast(*JSC.EventLoop, parent) },
+            2 => .{ .mini = bun.cast(*JSC.MiniEventLoop, parent) },
             else => @panic("Parent loop data corrupted - tag is invalid"),
         };
+    }
+};
+
+pub const UpgradedDuplex = struct {
+    pub const CertError = struct {
+        error_no: i32 = 0,
+        code: [:0]const u8 = "",
+        reason: [:0]const u8 = "",
+    };
+
+    const WrapperType = SSLWrapper(*UpgradedDuplex);
+
+    wrapper: ?WrapperType,
+    origin: JSC.Strong = .{}, // any duplex
+    ssl_error: CertError = .{},
+    vm: *JSC.VirtualMachine,
+    handlers: Handlers,
+
+    onDataCallback: JSC.Strong = .{},
+    onEndCallback: JSC.Strong = .{},
+    onWritbaleCallback: JSC.Strong = .{},
+
+    pub const Handlers = struct {
+        ctx: *anyopaque,
+        onOpen: *const fn (*anyopaque) void,
+        onHandshake: *const fn (*anyopaque, bool, uws.us_bun_verify_error_t) void,
+        onData: *const fn (*anyopaque, []const u8) void,
+        onClose: *const fn (*anyopaque) void,
+        onEnd: *const fn (*anyopaque) void,
+        onWritable: *const fn (*anyopaque) void,
+    };
+
+    fn onOpen(this: *UpgradedDuplex) void {
+        this.handlers.onOpen(this.handlers.ctx);
+    }
+
+    fn onData(this: *UpgradedDuplex, decoded_data: []const u8) void {
+        this.handlers.onData(this.handlers.ctx, decoded_data);
+    }
+
+    fn onHandshake(this: *UpgradedDuplex, handshake_success: bool, ssl_error: uws.us_bun_verify_error_t) void {
+        this.ssl_error = .{
+            .error_no = ssl_error.error_no,
+            .code = bun.default_allocator.dupeZ(u8, ssl_error.code[0..bun.len(ssl_error.code) :0]) catch bun.outOfMemory(),
+            .reason = bun.default_allocator.dupeZ(u8, ssl_error.reason[0..bun.len(ssl_error.reason) :0]) catch bun.outOfMemory(),
+        };
+        this.handlers.onHandshake(this.handlers.ctx, handshake_success, ssl_error);
+    }
+
+    fn onClose(this: *UpgradedDuplex) void {
+        defer this.deinit();
+
+        this.handlers.onClose(this.handlers.ctx);
+    }
+
+    fn callWriteOrEnd(this: *UpgradedDuplex, data: ?[]const u8, msg_more: bool) void {
+        if (this.vm.isShuttingDown()) {
+            return;
+        }
+        if (this.origin.get()) |duplex| {
+            const globalThis = this.origin.globalThis.?;
+            const push = if (msg_more) duplex.getFunction(globalThis, "write") catch return orelse return else duplex.getFunction(globalThis, "end") catch return orelse return;
+            if (data) |data_| {
+                const buffer = JSC.BinaryType.toJS(.Buffer, data_, globalThis);
+                buffer.ensureStillAlive();
+                this.vm.eventLoop().runCallback(push, globalThis, duplex, &[_]JSC.JSValue{buffer});
+            } else {
+                this.vm.eventLoop().runCallback(push, globalThis, duplex, &[_]JSC.JSValue{JSC.JSValue.jsNull()});
+            }
+        }
+    }
+
+    fn internalWrite(this: *UpgradedDuplex, encoded_data: []const u8) void {
+        this.callWriteOrEnd(encoded_data, true);
+    }
+
+    pub fn flush(this: *UpgradedDuplex) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.flush();
+        }
+    }
+
+    fn onInternalReceiveData(this: *UpgradedDuplex, data: []const u8) void {
+        if (this.wrapper) |*wrapper| {
+            wrapper.receiveData(data);
+        }
+    }
+
+    fn onReceivedData(
+        globalObject: *JSC.JSGlobalObject,
+        callframe: *JSC.CallFrame,
+    ) JSC.JSValue {
+        const function = callframe.callee();
+        const args = callframe.arguments(1);
+
+        if (JSC.getFunctionData(function)) |self| {
+            const this = @as(*UpgradedDuplex, @ptrCast(@alignCast(self)));
+            if (args.len >= 1) {
+                const data_arg = args.ptr[0];
+                if (this.origin.get()) |duplex| {
+                    if (data_arg.isEmptyOrUndefinedOrNull()) {
+                        return JSC.JSValue.jsUndefined();
+                    }
+                    if (data_arg.asArrayBuffer(globalObject)) |array_buffer| {
+                        // yay fast path
+                        const payload = array_buffer.slice();
+                        this.onInternalReceiveData(payload);
+                    } else if (bun.String.tryFromJS(data_arg, globalObject)) |data_str| {
+                        defer data_str.deref();
+
+                        // slow path we are encoded as a string
+                        var encoding: JSC.Node.Encoding = .utf8;
+                        // we need to check every time because the encoding can change at any time
+                        if (duplex.getTruthy(globalObject, "readableEncoding")) |encoding_| {
+                            encoding = JSC.Node.Encoding.fromJS(encoding_, globalObject) orelse .utf8;
+                        }
+                        // TODO: optimize this using a shared buffer instead of allocating memory every time
+                        const payload = TextEncoder.decodeStringAtRuntime(data_str, encoding);
+                        defer bun.default_allocator.free(payload);
+                        this.onInternalReceiveData(payload);
+                    }
+                }
+            }
+        }
+        return JSC.JSValue.jsUndefined();
+    }
+
+    fn onEnd(
+        globalObject: *JSC.JSGlobalObject,
+        callframe: *JSC.CallFrame,
+    ) void {
+        _ = globalObject;
+        const function = callframe.callee();
+
+        if (JSC.getFunctionData(function)) |self| {
+            const this = @as(*UpgradedDuplex, @ptrCast(@alignCast(self)));
+
+            if (this.wrapper != null) {
+                this.handlers.onEnd(this.handlers.ctx);
+            }
+        }
+    }
+
+    fn onWritable(
+        globalObject: *JSC.JSGlobalObject,
+        callframe: *JSC.CallFrame,
+    ) JSC.JSValue {
+        _ = globalObject;
+        const function = callframe.callee();
+
+        if (JSC.getFunctionData(function)) |self| {
+            const this = @as(*UpgradedDuplex, @ptrCast(@alignCast(self)));
+
+            this.handlers.onWritable(this.handlers.ctx);
+
+            if (this.wrapper) |*wrapper| {
+                _ = wrapper.flush();
+            }
+        }
+
+        return JSC.JSValue.jsUndefined();
+    }
+
+    pub fn from(
+        globalThis: *JSC.JSGlobalObject,
+        origin: JSC.JSValue,
+        handlers: UpgradedDuplex.Handlers,
+    ) UpgradedDuplex {
+        return UpgradedDuplex{
+            .vm = globalThis.bunVM(),
+            .origin = JSC.Strong.create(origin, globalThis),
+            .wrapper = null,
+            .handlers = handlers,
+        };
+    }
+
+    pub fn startTLS(this: *UpgradedDuplex, ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool) !void {
+        this.wrapper = try WrapperType.init(ssl_options, is_client, .{
+            .ctx = this,
+            .onOpen = UpgradedDuplex.onOpen,
+            .onHandshake = UpgradedDuplex.onHandshake,
+            .onData = UpgradedDuplex.onData,
+            .onClose = UpgradedDuplex.onClose,
+            .write = UpgradedDuplex.internalWrite,
+        });
+        if (this.origin.get()) |duplex| {
+            const globalThis = this.origin.globalThis.?;
+
+            const addEventListener = try duplex.getFunction(globalThis, "addEventListener") orelse return;
+            const dataCallback = JSC.NewFunctionWithData(
+                globalThis,
+                null,
+                0,
+                onReceivedData,
+                false,
+                this,
+            );
+            dataCallback.ensureStillAlive();
+            JSC.setFunctionData(dataCallback, this);
+
+            this.onDataCallback = JSC.Strong.create(dataCallback, globalThis);
+
+            const endCallback = JSC.NewFunctionWithData(
+                globalThis,
+                null,
+                0,
+                onReceivedData,
+                false,
+                this,
+            );
+            endCallback.ensureStillAlive();
+            JSC.setFunctionData(dataCallback, this);
+
+            this.onEndCallback = JSC.Strong.create(endCallback, globalThis);
+
+            const writableCallback = JSC.NewFunctionWithData(
+                globalThis,
+                null,
+                0,
+                onWritable,
+                false,
+                this,
+            );
+            writableCallback.ensureStillAlive();
+            JSC.setFunctionData(writableCallback, this);
+
+            this.onEndCallback = JSC.Strong.create(endCallback, globalThis);
+
+            this.vm.eventLoop().runCallback(addEventListener, globalThis, duplex, &[_]JSC.JSValue{ bun.String.static("data").toJS(globalThis), dataCallback });
+            this.vm.eventLoop().runCallback(addEventListener, globalThis, duplex, &[_]JSC.JSValue{ bun.String.static("end").toJS(globalThis), endCallback });
+            this.vm.eventLoop().runCallback(addEventListener, globalThis, duplex, &[_]JSC.JSValue{ bun.String.static("drain").toJS(globalThis), writableCallback });
+        }
+        this.wrapper.?.start();
+    }
+
+    pub fn encodeAndWrite(this: *UpgradedDuplex, data: []const u8, msg_more: bool) i32 {
+        if (this.wrapper) |*wrapper| {
+            const result: i32 = @as(i32, @intCast(wrapper.writeData(data) catch 0));
+            if (result == data.len and !msg_more) {
+                this.shutdown();
+            }
+            return result;
+        }
+        return 0;
+    }
+
+    pub fn rawWrite(this: *UpgradedDuplex, encoded_data: []const u8, msg_more: bool) i32 {
+        this.callWriteOrEnd(encoded_data, msg_more);
+        return @intCast(encoded_data.len);
+    }
+
+    pub fn close(this: *UpgradedDuplex) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.shutdown(true);
+        }
+    }
+
+    pub fn shutdown(this: *UpgradedDuplex) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.shutdown(false);
+        }
+    }
+
+    pub fn shutdownRead(this: *UpgradedDuplex) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.shutdownRead();
+        }
+    }
+
+    pub fn isShutdown(this: *UpgradedDuplex) bool {
+        if (this.wrapper) |wrapper| {
+            return wrapper.isShutdown();
+        }
+        return true;
+    }
+
+    pub fn isClosed(this: *UpgradedDuplex) bool {
+        if (this.wrapper) |wrapper| {
+            return wrapper.isClosed();
+        }
+        return true;
+    }
+
+    pub fn isEstablished(this: *UpgradedDuplex) bool {
+        return !this.isClosed();
+    }
+
+    pub fn ssl(this: *UpgradedDuplex) ?*BoringSSL.SSL {
+        if (this.wrapper) |wrapper| {
+            return wrapper.ssl;
+        }
+        return null;
+    }
+
+    pub fn sslError(this: *UpgradedDuplex) us_bun_verify_error_t {
+        return .{
+            .error_no = this.ssl_error.error_no,
+            .code = @ptrCast(this.ssl_error.code.ptr),
+            .reason = @ptrCast(this.ssl_error.reason.ptr),
+        };
+    }
+
+    pub fn setTimeout(this: *UpgradedDuplex, seconds: c_uint) void {
+        // TODO: handle timeout
+        _ = this;
+        _ = seconds;
+    }
+
+    pub fn deinit(this: *UpgradedDuplex) void {
+        if (this.wrapper) |*wrapper| {
+            wrapper.deinit();
+            this.wrapper = null;
+        }
+        if (this.origin.get()) |origin| {
+            const globalThis = this.origin.globalThis.?;
+            const removeEventListener = origin.getFunction(globalThis, "removeEventListener") catch null;
+            if (removeEventListener) |removeEventListener_| {
+                if (this.onDataCallback.get()) |dataCallback| {
+                    this.vm.eventLoop().runCallback(removeEventListener_, globalThis, origin, &[_]JSC.JSValue{ bun.String.static("data").toJS(globalThis), dataCallback });
+                }
+                if (this.onEndCallback.get()) |endCallback| {
+                    this.vm.eventLoop().runCallback(removeEventListener_, globalThis, origin, &[_]JSC.JSValue{ bun.String.static("end").toJS(globalThis), endCallback });
+                }
+                if (this.onWritbaleCallback.get()) |endCallback| {
+                    this.vm.eventLoop().runCallback(removeEventListener_, globalThis, origin, &[_]JSC.JSValue{ bun.String.static("drain").toJS(globalThis), endCallback });
+                }
+            }
+        }
+        this.origin.deinit();
+        this.onDataCallback.deinit();
+        this.onEndCallback.deinit();
+        const ssl_error = this.ssl_error;
+        this.ssl_error = .{};
+        if (ssl_error.reason.len > 0) {
+            bun.default_allocator.free(ssl_error.reason);
+        }
+        if (ssl_error.code.len > 0) {
+            bun.default_allocator.free(ssl_error.code);
+        }
     }
 };
 
@@ -84,6 +425,7 @@ pub const InternalSocket = union(enum) {
     done: *Socket,
     connecting: *ConnectingSocket,
     detached: void,
+    upgradedDuplex: *UpgradedDuplex,
     pub fn isDetached(this: InternalSocket) bool {
         return this == .detached;
     }
@@ -109,6 +451,9 @@ pub const InternalSocket = union(enum) {
                     socket,
                 );
             },
+            .upgradedDuplex => |socket| {
+                socket.close();
+            },
         }
     }
 
@@ -117,6 +462,7 @@ pub const InternalSocket = union(enum) {
             .done => |socket| us_socket_is_closed(@intFromBool(is_ssl), socket) > 0,
             .connecting => |socket| us_connecting_socket_is_closed(@intFromBool(is_ssl), socket) > 0,
             .detached => true,
+            .upgradedDuplex => |socket| socket.isClosed(),
         };
     }
 
@@ -125,6 +471,7 @@ pub const InternalSocket = union(enum) {
             .done => this.done,
             .connecting => null,
             .detached => null,
+            .upgradedDuplex => null,
         };
     }
 
@@ -132,15 +479,19 @@ pub const InternalSocket = union(enum) {
         return switch (this) {
             .done => switch (other) {
                 .done => this.done == other.done,
-                .connecting, .detached => false,
+                .upgradedDuplex, .connecting, .detached => false,
             },
             .connecting => switch (other) {
-                .done, .detached => false,
+                .upgradedDuplex, .done, .detached => false,
                 .connecting => this.connecting == other.connecting,
             },
             .detached => switch (other) {
                 .detached => true,
-                .done, .connecting => false,
+                .upgradedDuplex, .done, .connecting => false,
+            },
+            .upgradedDuplex => switch (other) {
+                .upgradedDuplex => this.upgradedDuplex == other.upgradedDuplex,
+                .done, .connecting, .detached => false,
             },
         };
     }
@@ -159,18 +510,24 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             return this.socket.isDetached();
         }
         pub fn verifyError(this: ThisSocket) us_bun_verify_error_t {
-            const socket = this.socket.get() orelse return std.mem.zeroes(us_bun_verify_error_t);
-            const ssl_error: us_bun_verify_error_t = uws.us_socket_verify_error(comptime ssl_int, socket);
-            return ssl_error;
+            switch (this.socket) {
+                .done => |socket| return uws.us_socket_verify_error(comptime ssl_int, socket),
+                .upgradedDuplex => |socket| return socket.sslError(),
+                .connecting, .detached => return std.mem.zeroes(us_bun_verify_error_t),
+            }
         }
 
         pub fn isEstablished(this: ThisSocket) bool {
-            const socket = this.socket.get() orelse return false;
-            return us_socket_is_established(comptime ssl_int, socket) > 0;
+            switch (this.socket) {
+                .done => |socket| return us_socket_is_established(comptime ssl_int, socket) > 0,
+                .upgradedDuplex => |socket| return socket.isEstablished(),
+                .connecting, .detached => return false,
+            }
         }
 
         pub fn timeout(this: ThisSocket, seconds: c_uint) void {
             switch (this.socket) {
+                .upgradedDuplex => |socket| socket.setTimeout(seconds),
                 .done => |socket| us_socket_timeout(comptime ssl_int, socket, seconds),
                 .connecting => |socket| us_connecting_socket_timeout(comptime ssl_int, socket, seconds),
                 .detached => {},
@@ -198,6 +555,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     }
                 },
                 .detached => {},
+                .upgradedDuplex => |socket| socket.setTimeout(seconds),
             }
         }
 
@@ -212,6 +570,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     us_connecting_socket_long_timeout(comptime ssl_int, socket, minutes);
                 },
                 .detached => {},
+                .upgradedDuplex => |socket| socket.setTimeout(minutes * 60),
             }
         }
 
@@ -364,6 +723,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .done => |socket| us_socket_get_native_handle(comptime ssl_int, socket),
                 .connecting => |socket| us_connecting_socket_get_native_handle(comptime ssl_int, socket),
                 .detached => null,
+                .upgradedDuplex => |socket| if (is_ssl) @as(*anyopaque, @ptrCast(socket.ssl())) else null,
             } orelse return null);
         }
 
@@ -397,6 +757,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .done => |sock| us_socket_ext(comptime ssl_int, sock),
                 .connecting => |sock| us_connecting_socket_ext(comptime ssl_int, sock),
                 .detached => return null,
+                .upgradedDuplex => return null,
             };
 
             return @as(*align(alignment) ContextType, @ptrCast(@alignCast(ptr)));
@@ -408,44 +769,67 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .done => |socket| return us_socket_context(comptime ssl_int, socket),
                 .connecting => |socket| return us_connecting_socket_context(comptime ssl_int, socket),
                 .detached => return null,
+                .upgradedDuplex => return null,
             }
         }
 
         pub fn flush(this: ThisSocket) void {
-            const socket = this.socket.get() orelse return;
-            return us_socket_flush(
-                comptime ssl_int,
-                socket,
-            );
-        }
-        pub fn write(this: ThisSocket, data: []const u8, msg_more: bool) i32 {
-            const socket = this.socket.get() orelse return 0;
-            const result = us_socket_write(
-                comptime ssl_int,
-                socket,
-                data.ptr,
-                // truncate to 31 bits since sign bit exists
-                @as(i32, @intCast(@as(u31, @truncate(data.len)))),
-                @as(i32, @intFromBool(msg_more)),
-            );
-
-            if (comptime Environment.allow_assert) {
-                debug("us_socket_write({*}, {d}) = {d}", .{ this.getNativeHandle(), data.len, result });
+            switch (this.socket) {
+                .upgradedDuplex => |socket| {
+                    return socket.flush();
+                },
+                .done => |socket| {
+                    return us_socket_flush(
+                        comptime ssl_int,
+                        socket,
+                    );
+                },
+                .connecting, .detached => return,
             }
+        }
 
-            return result;
+        pub fn write(this: ThisSocket, data: []const u8, msg_more: bool) i32 {
+            switch (this.socket) {
+                .upgradedDuplex => |socket| {
+                    return socket.encodeAndWrite(data, msg_more);
+                },
+                .done => |socket| {
+                    const result = us_socket_write(
+                        comptime ssl_int,
+                        socket,
+                        data.ptr,
+                        // truncate to 31 bits since sign bit exists
+                        @as(i32, @intCast(@as(u31, @truncate(data.len)))),
+                        @as(i32, @intFromBool(msg_more)),
+                    );
+
+                    if (comptime Environment.allow_assert) {
+                        debug("us_socket_write({*}, {d}) = {d}", .{ this.getNativeHandle(), data.len, result });
+                    }
+
+                    return result;
+                },
+                .connecting, .detached => return 0,
+            }
         }
 
         pub fn rawWrite(this: ThisSocket, data: []const u8, msg_more: bool) i32 {
-            const socket = this.socket.get() orelse return 0;
-            return us_socket_raw_write(
-                comptime ssl_int,
-                socket,
-                data.ptr,
-                // truncate to 31 bits since sign bit exists
-                @as(i32, @intCast(@as(u31, @truncate(data.len)))),
-                @as(i32, @intFromBool(msg_more)),
-            );
+            switch (this.socket) {
+                .done => |socket| {
+                    return us_socket_raw_write(
+                        comptime ssl_int,
+                        socket,
+                        data.ptr,
+                        // truncate to 31 bits since sign bit exists
+                        @as(i32, @intCast(@as(u31, @truncate(data.len)))),
+                        @as(i32, @intFromBool(msg_more)),
+                    );
+                },
+                .connecting, .detached => return 0,
+                .upgradedDuplex => |socket| {
+                    return socket.rawWrite(data, msg_more);
+                },
+            }
         }
         pub fn shutdown(this: ThisSocket) void {
             // debug("us_socket_shutdown({d})", .{@intFromPtr(this.socket)});
@@ -463,6 +847,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     );
                 },
                 .detached => {},
+                .upgradedDuplex => |socket| {
+                    socket.shutdown();
+                },
             }
         }
 
@@ -483,6 +870,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     );
                 },
                 .detached => {},
+                .upgradedDuplex => |socket| {
+                    socket.shutdownRead();
+                },
             }
         }
 
@@ -501,6 +891,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     ) > 0;
                 },
                 .detached => return true,
+                .upgradedDuplex => |socket| {
+                    return socket.isShutdown();
+                },
             }
         }
 
@@ -527,6 +920,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     );
                 },
                 .detached => return 0,
+                .upgradedDuplex => |socket| {
+                    return socket.sslError().error_no;
+                },
             }
         }
 
@@ -538,23 +934,30 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             return this.socket.close(comptime is_ssl, code);
         }
         pub fn localPort(this: ThisSocket) i32 {
-            const socket = this.socket.get() orelse return 0;
-            return us_socket_local_port(
-                comptime ssl_int,
-                socket,
-            );
+            switch (this.socket) {
+                .done => |socket| {
+                    return us_socket_local_port(
+                        comptime ssl_int,
+                        socket,
+                    );
+                },
+                .upgradedDuplex, .connecting, .detached => return 0,
+            }
         }
         pub fn remoteAddress(this: ThisSocket, buf: [*]u8, length: *i32) void {
-            const socket = this.socket.get() orelse {
-                length.* = 0;
-                return;
-            };
-            return us_socket_remote_address(
-                comptime ssl_int,
-                socket,
-                buf,
-                length,
-            );
+            switch (this.socket) {
+                .done => |socket| {
+                    return us_socket_remote_address(
+                        comptime ssl_int,
+                        socket,
+                        buf,
+                        length,
+                    );
+                },
+                .upgradedDuplex, .connecting, .detached => return {
+                    length.* = 0;
+                },
+            }
         }
 
         /// Get the local address of a socket in binary format.
@@ -565,19 +968,23 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         /// # Returns
         /// This function returns a slice of the buffer on success, or null on failure.
         pub fn localAddressBinary(this: ThisSocket, buf: []u8) ?[]const u8 {
-            const socket = this.socket.get() orelse return null;
-            var length: i32 = @intCast(buf.len);
-            us_socket_local_address(
-                comptime ssl_int,
-                socket,
-                buf.ptr,
-                &length,
-            );
+            switch (this.socket) {
+                .done => |socket| {
+                    var length: i32 = @intCast(buf.len);
+                    us_socket_local_address(
+                        comptime ssl_int,
+                        socket,
+                        buf.ptr,
+                        &length,
+                    );
 
-            if (length <= 0) {
-                return null;
+                    if (length <= 0) {
+                        return null;
+                    }
+                    return buf[0..@intCast(length)];
+                },
+                .upgradedDuplex, .connecting, .detached => return null,
             }
-            return buf[0..@intCast(length)];
         }
 
         /// Get the local address of a socket in text format.
@@ -663,6 +1070,12 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             const this_socket = try connectAnon(host, port, socket_ctx, ctx);
             @field(ctx, socket_field_name) = this_socket;
             return ctx;
+        }
+
+        pub fn fromDuplex(
+            duplex: *UpgradedDuplex,
+        ) ThisSocket {
+            return ThisSocket{ .socket = .{ .upgradedDuplex = duplex } };
         }
 
         pub fn fromFd(

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -483,6 +483,7 @@ pub const UpgradedDuplex = struct {
         this.vm.timer.insert(&this.event_loop_timer);
     }
     pub fn setTimeout(this: *UpgradedDuplex, seconds: c_uint) void {
+        log("setTimeout({d})", .{seconds});
         this.setTimeoutInMilliseconds(seconds * 1000);
     }
 

--- a/src/js/internal/net.ts
+++ b/src/js/internal/net.ts
@@ -1,3 +1,3 @@
-const [addServerName] = $zig("socket.zig", "createNodeTLSBinding");
+const [addServerName, upgradeDuplexToTLS] = $zig("socket.zig", "createNodeTLSBinding");
 
-export default { addServerName };
+export default { addServerName, upgradeDuplexToTLS };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -753,7 +753,7 @@ const Socket = (function (InternalSocket) {
     }
 
     setTimeout(timeout, callback) {
-      this[bunSocketInternal]?.timeout(timeout);
+      this[bunSocketInternal]?.timeout(timeout / 1000);
       this.timeout = timeout;
       if (callback) this.once("timeout", callback);
       return this;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -562,7 +562,7 @@ const Socket = (function (InternalSocket) {
         if (connection) {
           if (upgradeDuplex) {
             this.connecting = true;
-            this.#upgraded = true;
+            this.#upgraded = connection;
             const result = upgradeDuplexToTLS(connection, {
               data: this,
               tls,
@@ -579,7 +579,7 @@ const Socket = (function (InternalSocket) {
 
             if (socket) {
               this.connecting = true;
-              this.#upgraded = !!connection;
+              this.#upgraded = connection;
               const result = socket.upgradeTLS({
                 data: this,
                 tls,
@@ -604,7 +604,7 @@ const Socket = (function (InternalSocket) {
                 if (!socket) return;
 
                 this.connecting = true;
-                this.#upgraded = !!connection;
+                this.#upgraded = connection;
                 const result = socket.upgradeTLS({
                   data: this,
                   tls,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -133,7 +133,8 @@ const Socket = (function (InternalSocket) {
         const self = socket.data;
         if (!self) return;
 
-        socket.timeout(self.timeout);
+        socket.timeout(Math.ceil(self.timeout / 1000));
+
         if (self.#unrefOnConnected) socket.unref();
         self[bunSocketInternal] = socket;
         self.connecting = false;
@@ -434,7 +435,7 @@ const Socket = (function (InternalSocket) {
     #attach(port, socket) {
       this.remotePort = port;
       socket.data = this;
-      socket.timeout(this.timeout);
+      socket.timeout(Math.ceil(this.timeout / 1000));
       if (this.#unrefOnConnected) socket.unref();
       this[bunSocketInternal] = socket;
       this.connecting = false;
@@ -589,7 +590,6 @@ const Socket = (function (InternalSocket) {
                 const [raw, tls] = result;
                 // replace socket
                 connection[bunSocketInternal] = raw;
-                raw.timeout(raw.timeout);
                 this.once("end", this.#closeRawConnection);
                 raw.connecting = false;
                 this[bunSocketInternal] = tls;
@@ -615,7 +615,6 @@ const Socket = (function (InternalSocket) {
                   const [raw, tls] = result;
                   // replace socket
                   connection[bunSocketInternal] = raw;
-                  raw.timeout(raw.timeout);
                   this.once("end", this.#closeRawConnection);
                   raw.connecting = false;
                   this[bunSocketInternal] = tls;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -753,7 +753,9 @@ const Socket = (function (InternalSocket) {
     }
 
     setTimeout(timeout, callback) {
-      this[bunSocketInternal]?.timeout(timeout / 1000);
+      // internally or timeouts are in seconds
+      // we use Math.ceil because 0 would disable the timeout and less than 1 second but greater than 1ms would be 1 second (the minimum)
+      this[bunSocketInternal]?.timeout(Math.ceil(timeout / 1000));
       this.timeout = timeout;
       if (callback) this.once("timeout", callback);
       return this;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -564,17 +564,19 @@ const Socket = (function (InternalSocket) {
           if (upgradeDuplex) {
             this.connecting = true;
             this.#upgraded = connection;
-            const result = upgradeDuplexToTLS(connection, {
+
+            const [result, events] = upgradeDuplexToTLS(connection, {
               data: this,
               tls,
               socket: this.#handlers,
             });
-            if (result) {
-              this[bunSocketInternal] = result;
-            } else {
-              this[bunSocketInternal] = null;
-              throw new Error("Invalid duplex");
-            }
+
+            connection.on("data", events[0]);
+            connection.on("end", events[1]);
+            connection.on("drain", events[2]);
+            connection.on("close", events[3]);
+
+            this[bunSocketInternal] = result;
           } else {
             const socket = connection[bunSocketInternal];
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -431,12 +431,20 @@ for (const { name, connect } of tests) {
         port: 443,
         host: "bun.sh",
       });
+
+      const timer = setTimeout(() => {
+        socket.end();
+        done(new Error("timeout did not trigger"));
+      }, 8000);
       socket.setTimeout(1000, () => {
+        clearTimeout(timer);
         done();
         socket.end();
       });
 
       socket.on("error", err => {
+        clearTimeout(timer);
+
         socket.end();
         done(err);
       });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,310 +1,429 @@
-import { expect, it } from "bun:test";
+import tls, { TLSSocket, connect as tlsConnect, checkServerIdentity, createServer, Server } from "tls";
+import net from "net";
+import { join } from "path";
+import { it, expect, describe } from "bun:test";
 import { tls as COMMON_CERT_ } from "harness";
 import { join } from "path";
 import tls, { checkServerIdentity, connect, TLSSocket } from "tls";
 
+import { Duplex } from "node:stream";
+
 const symbolConnectOptions = Symbol.for("::buntlsconnectoptions::");
 
-it("should work with alpnProtocols", done => {
-  try {
-    let socket: TLSSocket | null = connect({
-      ALPNProtocols: ["http/1.1"],
-      host: "bun.sh",
-      servername: "bun.sh",
-      port: 443,
-      rejectUnauthorized: false,
-    });
+class SocketProxy extends Duplex {
+  socket: net.Socket;
+  constructor(socket: net.Socket) {
+    super();
+    this.socket = socket;
 
-    socket.on("error", err => {
-      done(err);
-    });
-
-    socket.on("secureConnect", () => {
-      done(socket?.alpnProtocol === "http/1.1" ? undefined : "alpnProtocol is not http/1.1");
-      socket?.end();
-      socket = null;
-    });
-  } catch (err) {
-    done(err);
-  }
-});
-const COMMON_CERT = { ...COMMON_CERT_ };
-
-it("Bun.serve() should work with tls and Bun.file()", async () => {
-  using server = Bun.serve({
-    port: 0,
-    fetch() {
-      return new Response(Bun.file(join(import.meta.dir, "fixtures/index.html")));
-    },
-    tls: {
-      cert: COMMON_CERT.cert,
-      key: COMMON_CERT.key,
-    },
-  });
-  const res = await fetch(`https://${server.hostname}:${server.port}/`, { tls: { rejectUnauthorized: false } });
-  expect(await res.text()).toBe("<h1>HELLO</h1>");
-});
-
-it("should have peer certificate when using self asign certificate", async () => {
-  using server = Bun.serve({
-    tls: {
-      cert: COMMON_CERT.cert,
-      key: COMMON_CERT.key,
-      passphrase: COMMON_CERT.passphrase,
-    },
-    port: 0,
-    fetch() {
-      return new Response("Hello World");
-    },
-  });
-
-  const { promise: socketPromise, resolve: resolveSocket, reject: rejectSocket } = Promise.withResolvers();
-  const socket = connect(
-    {
-      ALPNProtocols: ["http/1.1"],
-      host: server.hostname,
-      servername: "localhost",
-      port: server.port,
-      rejectUnauthorized: false,
-      requestCert: true,
-    },
-    resolveSocket,
-  ).on("error", rejectSocket);
-
-  await socketPromise;
-
-  try {
-    expect(socket).toBeDefined();
-    const cert = socket.getPeerCertificate();
-    expect(cert).toBeDefined();
-    expect(cert.subject).toMatchObject({
-      C: "US",
-      CN: "server-bun",
-      L: "San Francisco",
-      O: "Oven",
-      OU: "Team Bun",
-      ST: "CA",
-    });
-    expect(cert.issuer).toBeDefined();
-    expect(cert.issuer).toMatchObject({
-      C: "US",
-      CN: "server-bun",
-      L: "San Francisco",
-      O: "Oven",
-      OU: "Team Bun",
-      ST: "CA",
-    });
-    expect(cert.subjectaltname).toBe("DNS:localhost, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1");
-    expect(cert.infoAccess).toBeUndefined();
-    expect(cert.ca).toBeFalse();
-    expect(cert.bits).toBe(2048);
-    expect(cert.modulus).toBe(
-      "BEEE8773AF7C8861EC11351188B9B1798734FB0729B674369BE3285A29FE5DACBFAB700D09D7904CF1027D89298BD68BE0EF1DF94363012B0DEB97F632CB76894BCC216535337B9DB6125EF68996DD35B4BEA07E86C41DA071907A86651E84F8C72141F889CC0F770554791E9F07BBE47C375D2D77B44DBE2AB0ED442BC1F49ABE4F8904977E3DFD61CD501D8EFF819FF1792AEDFFACA7D281FD1DB8C5D972D22F68FA7103CA11AC9AAED1CDD12C33C0B8B47964B37338953D2415EDCE8B83D52E2076CA960385CC3A5CA75A75951AAFDB2AD3DB98A6FDD4BAA32F575FEA7B11F671A9EAA95D7D9FAF958AC609F3C48DEC5BDDCF1BC1542031ED9D4B281D7DD1",
-    );
-    expect(cert.exponent).toBe("0x10001");
-    expect(cert.pubkey).toBeInstanceOf(Buffer);
-    expect(cert.valid_from).toBe("Sep  6 23:27:34 2023 GMT"); // yes this space is intentional
-    expect(cert.valid_to).toBe("Sep  5 23:27:34 2025 GMT");
-    expect(cert.fingerprint).toBe("E3:90:9C:A8:AB:80:48:37:8D:CE:11:64:45:3A:EB:AD:C8:3C:B3:5C");
-    expect(cert.fingerprint256).toBe(
-      "53:DD:15:78:60:FD:66:8C:43:9E:19:7E:CF:2C:AF:49:3C:D1:11:EC:61:2D:F5:DC:1D:0A:FA:CD:12:F9:F8:E0",
-    );
-    expect(cert.fingerprint512).toBe(
-      "2D:31:CB:D2:A0:CA:E5:D4:B5:59:11:48:4B:BC:65:11:4F:AB:02:24:59:D8:73:43:2F:9A:31:92:BC:AF:26:66:CD:DB:8B:03:74:0C:C1:84:AF:54:2D:7C:FD:EF:07:6E:85:66:98:6B:82:4F:A5:72:97:A2:19:8C:7B:57:D6:15",
-    );
-    expect(cert.serialNumber).toBe("1DA7A7B8D71402ED2D8C3646A5CEDF2B8117EFC8");
-    expect(cert.raw).toBeInstanceOf(Buffer);
-  } finally {
-    socket.end();
-  }
-});
-
-it("should have peer certificate", async () => {
-  const socket = (await new Promise((resolve, reject) => {
-    const instance = connect(
-      {
-        ALPNProtocols: ["http/1.1"],
-        host: "bun.sh",
-        servername: "bun.sh",
-        port: 443,
-        rejectUnauthorized: false,
-        requestCert: true,
-      },
-      function () {
-        resolve(instance);
-      },
-    ).on("error", reject);
-  })) as TLSSocket;
-
-  try {
-    expect(socket).toBeDefined();
-    const cert = socket.getPeerCertificate();
-    expect(cert).toBeDefined();
-    expect(cert.subject).toBeDefined();
-    // this should never change
-    expect(cert.subject.CN).toBe("bun.sh");
-    expect(cert.subjectaltname).toContain("DNS:bun.sh");
-    expect(cert.infoAccess).toBeDefined();
-    // we just check the types this can change over time
-    const infoAccess = cert.infoAccess as NodeJS.Dict<string[]>;
-    expect(infoAccess["OCSP - URI"]).toBeDefined();
-    expect(infoAccess["CA Issuers - URI"]).toBeDefined();
-    expect(cert.ca).toBeFalse();
-    expect(cert.bits).toBeInteger();
-    // These can change:
-    // expect(typeof cert.modulus).toBe("string");
-    // expect(typeof cert.exponent).toBe("string");
-    expect(cert.pubkey).toBeInstanceOf(Buffer);
-    expect(typeof cert.valid_from).toBe("string");
-    expect(typeof cert.valid_to).toBe("string");
-    expect(typeof cert.fingerprint).toBe("string");
-    expect(typeof cert.fingerprint256).toBe("string");
-    expect(typeof cert.fingerprint512).toBe("string");
-    expect(typeof cert.serialNumber).toBe("string");
-    expect(cert.raw).toBeInstanceOf(Buffer);
-  } finally {
-    socket.end();
-  }
-});
-
-it("getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work", async () => {
-  const allowedCipherObjects = [
-    {
-      name: "TLS_AES_128_GCM_SHA256",
-      standardName: "TLS_AES_128_GCM_SHA256",
-      version: "TLSv1/SSLv3",
-    },
-    {
-      name: "TLS_AES_256_GCM_SHA384",
-      standardName: "TLS_AES_256_GCM_SHA384",
-      version: "TLSv1/SSLv3",
-    },
-    {
-      name: "TLS_CHACHA20_POLY1305_SHA256",
-      standardName: "TLS_CHACHA20_POLY1305_SHA256",
-      version: "TLSv1/SSLv3",
-    },
-  ];
-  const socket = (await new Promise((resolve, reject) => {
-    connect({
-      ALPNProtocols: ["http/1.1"],
-      host: "bun.sh",
-      servername: "bun.sh",
-      port: 443,
-      rejectUnauthorized: false,
-      requestCert: true,
-    })
-      .on("secure", resolve)
-      .on("error", reject);
-  })) as TLSSocket;
-
-  try {
-    const cipher = socket.getCipher();
-    let hadMatch = false;
-    for (const allowedCipher of allowedCipherObjects) {
-      if (cipher.name === allowedCipher.name) {
-        expect(cipher).toMatchObject(allowedCipher);
-        hadMatch = true;
-        break;
+    // Handle incoming data from the socket
+    this.socket.on("data", chunk => {
+      // Push data to be read by the Duplex stream
+      if (!this.push(chunk)) {
+        this.socket.pause();
       }
-    }
-    if (!hadMatch) {
-      throw new Error(`Unexpected cipher ${cipher.name}`);
-    }
-    expect(socket.getProtocol()).toBe("TLSv1.3");
-    expect(typeof socket.getEphemeralKeyInfo()).toBe("object");
-    expect(socket.getSharedSigalgs()).toBeInstanceOf(Array);
-    expect(socket.getSession()).toBeInstanceOf(Buffer);
-    expect(socket.exportKeyingMaterial(512, "client finished")).toBeInstanceOf(Buffer);
-    expect(socket.isSessionReused()).toBe(false);
+    });
 
-    // BoringSSL does not support these methods for >= TLSv1.3
-    expect(socket.getFinished()).toBeUndefined();
-    expect(socket.getPeerFinished()).toBeUndefined();
-  } finally {
-    socket.end();
+    // Handle when the socket ends
+    this.socket.on("end", () => {
+      this.push(null); // Signal that no more data will be provided
+    });
+
+    // Handle socket errors
+    this.socket.on("error", err => {
+      console.error("Socket error:", err);
+      this.destroy(err); // Destroy the stream on error
+    });
+
+    // Handle socket close
+    this.socket.on("close", () => {
+      this.push(null); // Signal the end of data if the socket closes
+    });
+
+    this.socket.on("drain", () => {
+      this.emit("drain");
+    });
   }
-});
+
+  // Implement the _read method to receive data
+  _read(size: number) {
+    // Resume the socket if it was paused
+    if (this.socket.isPaused()) {
+      this.socket.resume();
+    }
+  }
+
+  // Implement the _write method to send data
+  _write(chunk, encoding, callback) {
+    // Write data to the socket
+    this.socket.write(chunk, encoding, callback);
+  }
+
+  // Implement the _final method to handle stream ending
+  _final(callback) {
+    // End the socket connection
+    this.socket.end();
+    callback();
+  }
+}
+function duplexProxy(options: tls.ConnectionOptions, callback?: () => void): TLSSocket {
+  if (typeof options === "number") {
+    // handle port, host, options
+    let options = arguments[2] || {};
+    let callback = arguments[3];
+    if (typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+    //@ts-ignore
+
+    const socket = net.connect(arguments[0], arguments[1], options);
+    const duplex = new SocketProxy(socket);
+    return tls.connect(
+      {
+        ...options,
+        socket: duplex,
+        host: arguments[1],
+        servername: options.servername || arguments[1],
+      },
+      callback,
+    );
+  }
+
+  //@ts-ignore
+  const socket = net.connect(options);
+  const duplex = new SocketProxy(socket);
+  return tls.connect(
+    {
+      ...options,
+      socket: duplex,
+      host: options.host,
+      servername: options.servername || options.host,
+    },
+    callback,
+  );
+}
+const tests = [
+  {
+    name: "tls.connect",
+    connect: tlsConnect,
+  },
+  {
+    name: "tls.connect using duplex proxy",
+    connect: duplexProxy,
+  },
+];
 
 it("should have checkServerIdentity", async () => {
   expect(checkServerIdentity).toBeFunction();
   expect(tls.checkServerIdentity).toBeFunction();
 });
 
-// Test using only options
-it("should process options correctly when connect is called with only options", done => {
-  let socket = connect({
-    port: 443,
-    host: "bun.sh",
-    rejectUnauthorized: false,
-  });
+for (const { name, connect } of tests) {
+  describe(name, () => {
+    it("should work with alpnProtocols", done => {
+      try {
+        let socket: TLSSocket | null = connect({
+          ALPNProtocols: ["http/1.1"],
+          host: "bun.sh",
+          servername: "bun.sh",
+          port: 443,
+          rejectUnauthorized: false,
+        });
 
-  socket.on("secureConnect", () => {
-    expect(socket.remotePort).toBe(443);
-    expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
-    socket.end();
-    done();
-  });
+        socket.on("error", err => {
+          done(err);
+        });
 
-  socket.on("error", err => {
-    socket.end();
-    done(err);
-  });
-});
+        socket.on("secureConnect", () => {
+          done(socket?.alpnProtocol === "http/1.1" ? undefined : "alpnProtocol is not http/1.1");
+          socket?.end();
+          socket = null;
+        });
+      } catch (err) {
+        done(err);
+      }
+    });
+    const COMMON_CERT = { ...COMMON_CERT_ };
 
-// Test using port and host
-it("should process port and host correctly", done => {
-  let socket = connect(443, "bun.sh", {
-    rejectUnauthorized: false,
-  });
+    it("Bun.serve() should work with tls and Bun.file()", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(Bun.file(join(import.meta.dir, "fixtures/index.html")));
+        },
+        tls: {
+          cert: COMMON_CERT.cert,
+          key: COMMON_CERT.key,
+        },
+      });
+      const res = await fetch(`https://${server.hostname}:${server.port}/`, { tls: { rejectUnauthorized: false } });
+      expect(await res.text()).toBe("<h1>HELLO</h1>");
+    });
 
-  socket.on("secureConnect", () => {
-    expect(socket.remotePort).toBe(443);
-    expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
-    socket.end();
-    done();
-  });
+    it("should have peer certificate when using self asign certificate", async () => {
+      using server = Bun.serve({
+        tls: {
+          cert: COMMON_CERT.cert,
+          key: COMMON_CERT.key,
+          passphrase: COMMON_CERT.passphrase,
+        },
+        port: 0,
+        fetch() {
+          return new Response("Hello World");
+        },
+      });
 
-  socket.on("error", err => {
-    socket.end();
-    done(err);
-  });
-});
+      const { promise: socketPromise, resolve: resolveSocket, reject: rejectSocket } = Promise.withResolvers();
+      const socket = connect(
+        {
+          ALPNProtocols: ["http/1.1"],
+          host: server.hostname,
+          servername: "localhost",
+          port: server.port,
+          rejectUnauthorized: false,
+          requestCert: true,
+        },
+        resolveSocket,
+      ).on("error", rejectSocket);
 
-// Test using port, host, and callback
-it("should process port, host, and callback correctly", done => {
-  let socket = connect(
-    443,
-    "bun.sh",
-    {
-      rejectUnauthorized: false,
-    },
-    () => {
-      expect(socket.remotePort).toBe(443);
-      expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
-      socket.end();
-      done();
-    },
-  ).on("error", err => {
-    done(err);
-  });
-});
+      await socketPromise;
 
-// Additional tests to ensure the callback is optional and handled correctly
-it("should handle the absence of a callback gracefully", done => {
-  let socket = connect(443, "bun.sh", {
-    rejectUnauthorized: false,
-  });
+      try {
+        expect(socket).toBeDefined();
+        const cert = socket.getPeerCertificate();
+        expect(cert).toBeDefined();
+        expect(cert.subject).toMatchObject({
+          C: "US",
+          CN: "server-bun",
+          L: "San Francisco",
+          O: "Oven",
+          OU: "Team Bun",
+          ST: "CA",
+        });
+        expect(cert.issuer).toBeDefined();
+        expect(cert.issuer).toMatchObject({
+          C: "US",
+          CN: "server-bun",
+          L: "San Francisco",
+          O: "Oven",
+          OU: "Team Bun",
+          ST: "CA",
+        });
+        expect(cert.subjectaltname).toBe("DNS:localhost, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1");
+        expect(cert.infoAccess).toBeUndefined();
+        expect(cert.ca).toBeFalse();
+        expect(cert.bits).toBe(2048);
+        expect(cert.modulus).toBe(
+          "BEEE8773AF7C8861EC11351188B9B1798734FB0729B674369BE3285A29FE5DACBFAB700D09D7904CF1027D89298BD68BE0EF1DF94363012B0DEB97F632CB76894BCC216535337B9DB6125EF68996DD35B4BEA07E86C41DA071907A86651E84F8C72141F889CC0F770554791E9F07BBE47C375D2D77B44DBE2AB0ED442BC1F49ABE4F8904977E3DFD61CD501D8EFF819FF1792AEDFFACA7D281FD1DB8C5D972D22F68FA7103CA11AC9AAED1CDD12C33C0B8B47964B37338953D2415EDCE8B83D52E2076CA960385CC3A5CA75A75951AAFDB2AD3DB98A6FDD4BAA32F575FEA7B11F671A9EAA95D7D9FAF958AC609F3C48DEC5BDDCF1BC1542031ED9D4B281D7DD1",
+        );
+        expect(cert.exponent).toBe("0x10001");
+        expect(cert.pubkey).toBeInstanceOf(Buffer);
+        expect(cert.valid_from).toBe("Sep  6 23:27:34 2023 GMT"); // yes this space is intentional
+        expect(cert.valid_to).toBe("Sep  5 23:27:34 2025 GMT");
+        expect(cert.fingerprint).toBe("E3:90:9C:A8:AB:80:48:37:8D:CE:11:64:45:3A:EB:AD:C8:3C:B3:5C");
+        expect(cert.fingerprint256).toBe(
+          "53:DD:15:78:60:FD:66:8C:43:9E:19:7E:CF:2C:AF:49:3C:D1:11:EC:61:2D:F5:DC:1D:0A:FA:CD:12:F9:F8:E0",
+        );
+        expect(cert.fingerprint512).toBe(
+          "2D:31:CB:D2:A0:CA:E5:D4:B5:59:11:48:4B:BC:65:11:4F:AB:02:24:59:D8:73:43:2F:9A:31:92:BC:AF:26:66:CD:DB:8B:03:74:0C:C1:84:AF:54:2D:7C:FD:EF:07:6E:85:66:98:6B:82:4F:A5:72:97:A2:19:8C:7B:57:D6:15",
+        );
+        expect(cert.serialNumber).toBe("1DA7A7B8D71402ED2D8C3646A5CEDF2B8117EFC8");
+        expect(cert.raw).toBeInstanceOf(Buffer);
+      } finally {
+        socket.end();
+      }
+    });
 
-  socket.on("secureConnect", () => {
-    expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
-    expect(socket.remotePort).toBe(443);
-    socket.end();
-    done();
-  });
+    it("should have peer certificate", async () => {
+      const socket = (await new Promise((resolve, reject) => {
+        const instance = connect(
+          {
+            ALPNProtocols: ["http/1.1"],
+            host: "bun.sh",
+            servername: "bun.sh",
+            port: 443,
+            rejectUnauthorized: false,
+            requestCert: true,
+          },
+          function () {
+            resolve(instance);
+          },
+        ).on("error", reject);
+      })) as TLSSocket;
 
-  socket.on("error", err => {
-    socket.end();
-    done(err);
+      try {
+        expect(socket).toBeDefined();
+        const cert = socket.getPeerCertificate();
+        expect(cert).toBeDefined();
+        expect(cert.subject).toBeDefined();
+        // this should never change
+        expect(cert.subject.CN).toBe("bun.sh");
+        expect(cert.subjectaltname).toContain("DNS:bun.sh");
+        expect(cert.infoAccess).toBeDefined();
+        // we just check the types this can change over time
+        const infoAccess = cert.infoAccess as NodeJS.Dict<string[]>;
+        expect(infoAccess["OCSP - URI"]).toBeDefined();
+        expect(infoAccess["CA Issuers - URI"]).toBeDefined();
+        expect(cert.ca).toBeFalse();
+        expect(cert.bits).toBeInteger();
+        // These can change:
+        // expect(typeof cert.modulus).toBe("string");
+        // expect(typeof cert.exponent).toBe("string");
+        expect(cert.pubkey).toBeInstanceOf(Buffer);
+        expect(typeof cert.valid_from).toBe("string");
+        expect(typeof cert.valid_to).toBe("string");
+        expect(typeof cert.fingerprint).toBe("string");
+        expect(typeof cert.fingerprint256).toBe("string");
+        expect(typeof cert.fingerprint512).toBe("string");
+        expect(typeof cert.serialNumber).toBe("string");
+        expect(cert.raw).toBeInstanceOf(Buffer);
+      } finally {
+        socket.end();
+      }
+    });
+
+    it("getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work", async () => {
+      const allowedCipherObjects = [
+        {
+          name: "TLS_AES_128_GCM_SHA256",
+          standardName: "TLS_AES_128_GCM_SHA256",
+          version: "TLSv1/SSLv3",
+        },
+        {
+          name: "TLS_AES_256_GCM_SHA384",
+          standardName: "TLS_AES_256_GCM_SHA384",
+          version: "TLSv1/SSLv3",
+        },
+        {
+          name: "TLS_CHACHA20_POLY1305_SHA256",
+          standardName: "TLS_CHACHA20_POLY1305_SHA256",
+          version: "TLSv1/SSLv3",
+        },
+      ];
+      const socket = (await new Promise((resolve, reject) => {
+        connect({
+          ALPNProtocols: ["http/1.1"],
+          host: "bun.sh",
+          servername: "bun.sh",
+          port: 443,
+          rejectUnauthorized: false,
+          requestCert: true,
+        })
+          .on("secure", resolve)
+          .on("error", reject);
+      })) as TLSSocket;
+
+      try {
+        const cipher = socket.getCipher();
+        let hadMatch = false;
+        for (const allowedCipher of allowedCipherObjects) {
+          if (cipher.name === allowedCipher.name) {
+            expect(cipher).toMatchObject(allowedCipher);
+            hadMatch = true;
+            break;
+          }
+        }
+        if (!hadMatch) {
+          throw new Error(`Unexpected cipher ${cipher.name}`);
+        }
+        expect(socket.getProtocol()).toBe("TLSv1.3");
+        expect(typeof socket.getEphemeralKeyInfo()).toBe("object");
+        expect(socket.getSharedSigalgs()).toBeInstanceOf(Array);
+        expect(socket.getSession()).toBeInstanceOf(Buffer);
+        expect(socket.exportKeyingMaterial(512, "client finished")).toBeInstanceOf(Buffer);
+        expect(socket.isSessionReused()).toBe(false);
+
+        // BoringSSL does not support these methods for >= TLSv1.3
+        expect(socket.getFinished()).toBeUndefined();
+        expect(socket.getPeerFinished()).toBeUndefined();
+      } finally {
+        socket.end();
+      }
+    });
+
+    // Test using only options
+    it("should process options correctly when connect is called with only options", done => {
+      let socket = connect({
+        port: 443,
+        host: "bun.sh",
+        rejectUnauthorized: false,
+      });
+
+      socket.on("secureConnect", () => {
+        expect(socket.remotePort).toBe(443);
+        expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
+        socket.end();
+        done();
+      });
+
+      socket.on("error", err => {
+        socket.end();
+        done(err);
+      });
+    });
+
+    // Test using port and host
+    it("should process port and host correctly", done => {
+      let socket = connect(443, "bun.sh", {
+        rejectUnauthorized: false,
+      });
+
+      socket.on("secureConnect", () => {
+        if (connect === tlsConnect) {
+          expect(socket.remotePort).toBe(443);
+        }
+        expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
+        socket.end();
+        done();
+      });
+
+      socket.on("error", err => {
+        socket.end();
+        done(err);
+      });
+    });
+
+    // Test using port, host, and callback
+    it("should process port, host, and callback correctly", done => {
+      let socket = connect(
+        443,
+        "bun.sh",
+        {
+          rejectUnauthorized: false,
+        },
+        () => {
+          if (connect === tlsConnect) {
+            expect(socket.remotePort).toBe(443);
+          }
+          expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
+          socket.end();
+          done();
+        },
+      ).on("error", err => {
+        done(err);
+      });
+    });
+
+    // Additional tests to ensure the callback is optional and handled correctly
+    it("should handle the absence of a callback gracefully", done => {
+      let socket = connect(443, "bun.sh", {
+        rejectUnauthorized: false,
+      });
+
+      socket.on("secureConnect", () => {
+        expect(socket[symbolConnectOptions].serverName).toBe("bun.sh");
+        if (connect === tlsConnect) {
+          expect(socket.remotePort).toBe(443);
+        }
+        socket.end();
+        done();
+      });
+
+      socket.on("error", err => {
+        socket.end();
+        done(err);
+      });
+    });
   });
-});
+}

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -425,5 +425,20 @@ for (const { name, connect } of tests) {
         done(err);
       });
     });
+
+    it("should timeout", done => {
+      let socket = connect(443, "bun.sh", {
+        rejectUnauthorized: false,
+      });
+      socket.setTimeout(1000, () => {
+        done();
+        socket.end();
+      });
+
+      socket.on("error", err => {
+        socket.end();
+        done(err);
+      });
+    });
   });
 }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -427,9 +427,7 @@ for (const { name, connect } of tests) {
     });
 
     it("should timeout", done => {
-      let socket = connect(443, "bun.sh", {
-        rejectUnauthorized: false,
-      });
+      const socket = connect(443, "bun.sh");
       socket.setTimeout(1000, () => {
         done();
         socket.end();

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -440,7 +440,7 @@ for (const { name, connect } of tests) {
         socket.end();
         done(err);
       });
-    });
+    }, 10_000); // 10 seconds because uWS sometimes is not that precise with timeouts
 
     it("should be able to transfer data", done => {
       const socket = connect({


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/5147
Fix: https://github.com/oven-sh/bun/issues/13736
Fix: https://github.com/oven-sh/bun/issues/4033
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
- [X] - node:tls connect tests
- [ ] - MSSQL integrated tests
- [ ] - MySQL integrated tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
