### PR TITLE
fix(node:http) emit request `close` event and mark `complete` only after close

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2356,6 +2356,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 if (request.internal_abort_callback.trigger(globalThis)) {
                     any_js_calls = true;
                 }
+                // we can already clean this strong refs
+                request.internal_abort_callback.deinit();
                 this.request_weakref.deinit();
             }
             // if signal is not aborted, abort the signal
@@ -2425,6 +2427,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             if (this.request_weakref.get()) |request| {
                 request.request_context = AnyRequestContext.Null;
+                // we can already clean this strong refs
+                request.internal_abort_callback.deinit();
                 this.request_weakref.deinit();
             }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2337,6 +2337,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             assert(this.server != null);
             // mark request as aborted
             this.flags.aborted = true;
+
             this.detachResponse();
             var any_js_calls = false;
             var vm = this.server.?.vm;
@@ -2350,6 +2351,13 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.deref();
             }
 
+            if (this.request_weakref.get()) |request| {
+                request.request_context = AnyRequestContext.Null;
+                if (request.internal_abort_callback.trigger(globalThis)) {
+                    any_js_calls = true;
+                }
+                this.request_weakref.deinit();
+            }
             // if signal is not aborted, abort the signal
             if (this.signal) |signal| {
                 this.signal = null;

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -23,7 +23,7 @@ using namespace JSC;
 using namespace WebCore;
 
 extern "C" uWS::HttpRequest* Request__getUWSRequest(void*);
-extern "C" void Request__setInternalAbortCallback(void*, EncodedJSValue, EncodedJSValue, JSC::JSGlobalObject*);
+extern "C" void Request__setInternalAbortCallback(void*, EncodedJSValue, JSC::JSGlobalObject*);
 
 static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject* prototype, JSObject* objectValue, JSC::InternalFieldTuple* tuple, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
 {
@@ -332,12 +332,11 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPAssignAbortCallback, (JSGlobalObject * globalObje
     // This is an internal binding.
     JSValue requestValue = callFrame->uncheckedArgument(0);
     JSValue callback = callFrame->uncheckedArgument(1);
-    JSValue ctx = callFrame->uncheckedArgument(2);
 
-    ASSERT(callFrame->argumentCount() == 3);
+    ASSERT(callFrame->argumentCount() == 2);
 
     if (auto* jsRequest = jsDynamicCast<WebCore::JSRequest*>(requestValue)) {
-        Request__setInternalAbortCallback(jsRequest->wrapped(), JSValue::encode(callback), JSValue::encode(ctx), globalObject);
+        Request__setInternalAbortCallback(jsRequest->wrapped(), JSValue::encode(callback), globalObject);
     }
 
     return JSValue::encode(jsNull());

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -329,12 +329,12 @@ pub const Request = struct {
             signal.unref();
             this.signal = null;
         }
+        this.internal_abort_callback.deinit();
     }
 
     pub fn finalize(this: *Request) void {
         this.finalizeWithoutDeinit();
         _ = this.body.unref();
-        this.internal_abort_callback.deinit();
         if (this.weak_ptr_data.onFinalize()) {
             this.destroy();
         }

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -20,7 +20,7 @@ const {
   getHeader: (headers: Headers, name: string) => string | undefined;
   setHeader: (headers: Headers, name: string, value: string) => void;
   assignHeaders: (object: any, req: Request, headersTuple: any) => boolean;
-  assignAbortCallback: (req: Request, callback: () => void, ctx: any) => void;
+  assignAbortCallback: (req: Request, callback: () => void) => void;
   Response: (typeof globalThis)["Response"];
   Request: (typeof globalThis)["Request"];
   Headers: (typeof globalThis)["Headers"];
@@ -649,7 +649,7 @@ Server.prototype = {
           const prevIsNextIncomingMessageHTTPS = isNextIncomingMessageHTTPS;
           isNextIncomingMessageHTTPS = isHTTPS;
           const http_req = new RequestClass(req);
-          assignAbortCallback(req, onRequestAborted, http_req);
+          assignAbortCallback(req, onRequestAborted.bind(http_req));
           isNextIncomingMessageHTTPS = prevIsNextIncomingMessageHTTPS;
 
           const upgrade = http_req.headers.upgrade;

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -10,6 +10,7 @@ const {
   getHeader,
   setHeader,
   assignHeaders: assignHeadersFast,
+  assignAbortCallback,
   Response,
   Request,
   Headers,
@@ -19,6 +20,7 @@ const {
   getHeader: (headers: Headers, name: string) => string | undefined;
   setHeader: (headers: Headers, name: string, value: string) => void;
   assignHeaders: (object: any, req: Request, headersTuple: any) => boolean;
+  assignAbortCallback: (req: Request, callback: () => void, ctx: any) => void;
   Response: (typeof globalThis)["Response"];
   Request: (typeof globalThis)["Request"];
   Headers: (typeof globalThis)["Headers"];
@@ -647,7 +649,7 @@ Server.prototype = {
           const prevIsNextIncomingMessageHTTPS = isNextIncomingMessageHTTPS;
           isNextIncomingMessageHTTPS = isHTTPS;
           const http_req = new RequestClass(req);
-          req.signal.addEventListener("abort", onRequestAborted.bind(http_req));
+          assignAbortCallback(req, onRequestAborted, http_req);
           isNextIncomingMessageHTTPS = prevIsNextIncomingMessageHTTPS;
 
           const upgrade = http_req.headers.upgrade;

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -787,7 +787,6 @@ function IncomingMessage(req, defaultIncomingOpts) {
   this._dumped = false;
   this[noBodySymbol] = false;
   this[abortedSymbol] = false;
-  this[readCompleteSymbol] = false;
   this.complete = false;
   Readable.$call(this);
   var { type = "request", [kInternalRequest]: nodeReq } = defaultIncomingOpts || {};
@@ -1164,6 +1163,10 @@ function emitCloseNT(self) {
   }
 }
 
+function emitRequestCloseNT(self) {
+  self.emit("close");
+}
+
 function onServerResponseClose() {
   // EventEmitter.emit makes a copy of the 'close' listeners array before
   // calling the listeners. detachSocket() unregisters onServerResponseClose
@@ -1312,7 +1315,7 @@ ServerResponse.prototype._final = function (callback) {
     );
     if (shouldEmitClose) {
       req.complete = true;
-      req.emit("close");
+      process.nextTick(emitRequestCloseNT, req);
     }
     callback && callback();
     return;
@@ -1323,7 +1326,7 @@ ServerResponse.prototype._final = function (callback) {
     controller.end();
     if (shouldEmitClose) {
       req.complete = true;
-      req.emit("close");
+      process.nextTick(emitRequestCloseNT, req);
     }
     callback();
     const deferred = this[deferredSymbol];

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1295,7 +1295,8 @@ function drainHeadersIfObservable() {
 }
 
 ServerResponse.prototype._final = function (callback) {
-  const shouldEmitClose = !this[finishedSymbol];
+  const req = this.req;
+  const shouldEmitClose = req && req.emit && !this[finishedSymbol];
 
   if (!this.headersSent) {
     var data = this[firstWriteSymbol] || "";
@@ -1310,7 +1311,6 @@ ServerResponse.prototype._final = function (callback) {
       }),
     );
     if (shouldEmitClose) {
-      const req = this.req;
       req.complete = true;
       req.emit("close");
     }
@@ -1322,7 +1322,6 @@ ServerResponse.prototype._final = function (callback) {
   ensureReadableStreamController.$call(this, controller => {
     controller.end();
     if (shouldEmitClose) {
-      const req = this.req;
       req.complete = true;
       req.emit("close");
     }

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -2224,6 +2224,10 @@ function _writeHead(statusCode, reason, obj, response) {
     // consisting only of the Status-Line and optional headers, and is
     // terminated by an empty line.
     response._hasBody = false;
+    const req = response.req;
+    if (req) {
+      req.complete = true;
+    }
   }
 }
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2294,6 +2294,7 @@ it("should emit close when connection is aborted", async () => {
       .catch(() => {});
 
     const [req, res] = await once(server, "request");
+    expect(req.complete).toBe(false);
     const closeEvent = once(req, "close");
     controller.abort();
     await closeEvent;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2294,7 +2294,6 @@ it("should emit close when connection is aborted", async () => {
       .catch(() => {});
 
     const [req, res] = await once(server, "request");
-    expect(req.complete).toBe(false);
     const closeEvent = once(req, "close");
     controller.abort();
     await closeEvent;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3,7 +3,7 @@ import { bunExe } from "bun:harness";
 import { bunEnv, randomPort } from "harness";
 import { createTest } from "node-harness";
 import { spawnSync } from "node:child_process";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
 import nodefs, { unlinkSync } from "node:fs";
 import http, {
   Agent,
@@ -2148,51 +2148,6 @@ it("should error with faulty args", async () => {
   server.close();
 });
 
-it("should mark complete true", async () => {
-  const { promise: serve, resolve: resolveServe } = Promise.withResolvers();
-  const server = createServer(async (req, res) => {
-    let count = 0;
-    let data = "";
-    req.on("data", chunk => {
-      data += chunk.toString();
-    });
-    while (!req.complete) {
-      await Bun.sleep(100);
-      count++;
-      if (count > 10) {
-        res.writeHead(500, { "Content-Type": "text/plain" });
-        res.end("Request timeout");
-        return;
-      }
-    }
-    res.writeHead(200, { "Content-Type": "text/plain" });
-    res.end(data);
-  });
-
-  server.listen(0, () => {
-    resolveServe(`http://localhost:${server.address().port}`);
-  });
-
-  const url = await serve;
-  try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Hotel 1",
-        price: 100,
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe('{"name":"Hotel 1","price":100}');
-  } finally {
-    server.close();
-  }
-});
-
 it("should propagate exception in sync data handler", async () => {
   const { exitCode, stdout } = Bun.spawnSync({
     cmd: [bunExe(), "run", path.join(import.meta.dir, "node-http-error-in-data-handler-fixture.1.js")],
@@ -2307,4 +2262,44 @@ it("should not emit continue event #7480", done => {
     receivedContinue = true;
   });
   req.end();
+});
+
+it("should emit close, and complete should be true only after close", async () => {
+  const server = http.createServer().listen(0);
+  try {
+    await once(server, "listening");
+    fetch(`http://localhost:${server.address().port}`)
+      .then(res => res.text())
+      .catch(() => {});
+
+    const [req, res] = await once(server, "request");
+    expect(req.complete).toBe(false);
+    const closeEvent = once(req, "close");
+    res.end("hi");
+
+    await closeEvent;
+    expect(req.complete).toBe(true);
+  } finally {
+    server.closeAllConnections();
+  }
+});
+
+it("should emit close when connection is aborted", async () => {
+  const server = http.createServer().listen(0);
+  try {
+    await once(server, "listening");
+    const controller = new AbortController();
+    fetch(`http://localhost:${server.address().port}`, { signal: controller.signal })
+      .then(res => res.text())
+      .catch(() => {});
+
+    const [req, res] = await once(server, "request");
+    expect(req.complete).toBe(false);
+    const closeEvent = once(req, "close");
+    controller.abort();
+    await closeEvent;
+    expect(req.complete).toBe(true);
+  } finally {
+    server.close();
+  }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2264,7 +2264,7 @@ it("should not emit continue event #7480", done => {
   req.end();
 });
 
-it("should emit close, and complete should be true only after close", async () => {
+it("should emit close, and complete should be true only after close #13373", async () => {
   const server = http.createServer().listen(0);
   try {
     await once(server, "listening");


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13373
Fix: https://github.com/oven-sh/bun/issues/7716
Fix: https://github.com/oven-sh/bun/issues/13745 (remove default timeout on server)
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
