### PR TITLE
add hkdfSync + hkdf to node:crypto

### DIFF
--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -135,7 +135,7 @@ pub const NodeCrypto = struct {
             };
         };
 
-        // This can also be a KeyObject
+        // This can also be a KeyObject according to node types, but that's not supported right now
         // Be sure to test with all listed here: <string> | <ArrayBuffer> | <Buffer> | <TypedArray> | <DataView> | <KeyObject>
         // Be sure this works with a keylen of 0
         const ikm = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, arguments[1]) orelse {

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -106,10 +106,6 @@ pub const NodeCrypto = struct {
         callframe: *JSC.CallFrame,
     ) JSC.JSValue {
         const arguments = callframe.arguments(5).slice();
-        if (arguments.len < 5) {
-            globalThis.throwNotEnoughArguments("hkdfSync", 5, arguments.len);
-            return .null;
-        }
 
         // From BunObject PBKDF2 `fromJS`
         const algorithm = brk: {

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -12,91 +12,202 @@ const EVP = Crypto.EVP;
 const PBKDF2 = EVP.PBKDF2;
 const JSValue = JSC.JSValue;
 const validators = @import("./util/validators.zig");
-fn randomInt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
-    const arguments = callframe.arguments(2).slice();
 
+pub const NodeCrypto = struct {
+    /// src/js/node/crypto.ts calls this function through the zig operator `$zig()`
+    /// We create the 'crypto' object that users import with 100% (ideally) native code
+    pub fn create(globalThis: *JSC.JSGlobalObject) JSC.JSValue {
+        const ncrypto = JSC.JSValue.createEmptyObject(globalThis, 4);
 
-    //min, max
-    if (!arguments[0].isNumber()) return globalThis.throwInvalidArgumentTypeValue("min", "safe integer", arguments[0]);
-    if (!arguments[1].isNumber()) return globalThis.throwInvalidArgumentTypeValue("max", "safe integer", arguments[1]);
-    const min = arguments[0].to(i64);
-    const max = arguments[1].to(i64);
-    
-    if(min > validators.NUMBER__MAX_SAFE_INTEGER or min < validators.NUMBER__MIN_SAFE_INTEGER) {
-      return globalThis.throwInvalidArgumentRangeValue("min", "It must be a safe integer type number", min);
-    }
-    if(max > validators.NUMBER__MAX_SAFE_INTEGER) {
-      return globalThis.throwInvalidArgumentRangeValue("max", "It must be a safe integer type number", max);
-    }
-    if(min >= max) {
-      return globalThis.throwInvalidArgumentRangeValue("max", "should be greater than min", max);
-    }
-    const diff = max - min;
-    if(diff > 281474976710655) {
-      return globalThis.throwInvalidArgumentRangeValue("max - min", "It must be <= 281474976710655", diff);
+        ncrypto.put(globalThis, JSC.ZigString.static("pbkdf2"), JSC.NewFunction(globalThis, JSC.ZigString.static("pbkdf2"), 5, pbkdf2, true));
+        ncrypto.put(globalThis, JSC.ZigString.static("pbkdf2Sync"), JSC.NewFunction(globalThis, JSC.ZigString.static("pbkdf2Sync"), 5, pbkdf2Sync, true));
+        ncrypto.put(globalThis, JSC.ZigString.static("randomInt"), JSC.NewFunction(globalThis, JSC.ZigString.static("randomInt"), 2, randomInt, true));
+        ncrypto.put(globalThis, JSC.ZigString.static("hkdfSync"), JSC.NewFunction(globalThis, JSC.ZigString.static("hkdfSync"), 2, hkdfSync, true));
+
+        return ncrypto;
     }
 
-    return JSC.JSValue.jsNumberFromInt64(std.crypto.random.intRangeLessThan(i64, min, max));
-}
+    fn randomInt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
+        const arguments = callframe.arguments(2).slice();
 
-fn pbkdf2(
-    globalThis: *JSC.JSGlobalObject,
-    callframe: *JSC.CallFrame,
-) JSC.JSValue {
-    const arguments = callframe.arguments(5);
+        //min, max
+        if (!arguments[0].isNumber()) return globalThis.throwInvalidArgumentTypeValue("min", "safe integer", arguments[0]);
+        if (!arguments[1].isNumber()) return globalThis.throwInvalidArgumentTypeValue("max", "safe integer", arguments[1]);
+        const min = arguments[0].to(i64);
+        const max = arguments[1].to(i64);
 
-    const data = PBKDF2.fromJS(globalThis, arguments.slice(), true) orelse {
-        assert(globalThis.hasException());
-        return .zero;
-    };
+        if (min > validators.NUMBER__MAX_SAFE_INTEGER or min < validators.NUMBER__MIN_SAFE_INTEGER) {
+            return globalThis.throwInvalidArgumentRangeValue("min", "It must be a safe integer type number", min);
+        }
+        if (max > validators.NUMBER__MAX_SAFE_INTEGER) {
+            return globalThis.throwInvalidArgumentRangeValue("max", "It must be a safe integer type number", max);
+        }
+        if (min >= max) {
+            return globalThis.throwInvalidArgumentRangeValue("max", "should be greater than min", max);
+        }
+        const diff = max - min;
+        if (diff > 281474976710655) {
+            return globalThis.throwInvalidArgumentRangeValue("max - min", "It must be <= 281474976710655", diff);
+        }
 
-    const job = PBKDF2.Job.create(JSC.VirtualMachine.get(), globalThis, &data);
-    return job.promise.value();
-}
-
-fn pbkdf2Sync(
-    globalThis: *JSC.JSGlobalObject,
-    callframe: *JSC.CallFrame,
-) JSC.JSValue {
-    const arguments = callframe.arguments(5);
-
-    var data = PBKDF2.fromJS(globalThis, arguments.slice(), false) orelse {
-        assert(globalThis.hasException());
-        return .zero;
-    };
-    defer data.deinit();
-    var out_arraybuffer = JSC.JSValue.createBufferFromLength(globalThis, @intCast(data.length));
-    if (out_arraybuffer == .zero or globalThis.hasException()) {
-        data.deinit();
-        return .zero;
+        return JSC.JSValue.jsNumberFromInt64(std.crypto.random.intRangeLessThan(i64, min, max));
     }
 
-    const output = out_arraybuffer.asArrayBuffer(globalThis) orelse {
-        data.deinit();
-        globalThis.throwOutOfMemory();
-        return .zero;
-    };
+    fn pbkdf2(
+        globalThis: *JSC.JSGlobalObject,
+        callframe: *JSC.CallFrame,
+    ) JSC.JSValue {
+        const arguments = callframe.arguments(5);
 
-    if (!data.run(output.slice())) {
-        const err = Crypto.createCryptoError(globalThis, BoringSSL.ERR_get_error());
-        BoringSSL.ERR_clear_error();
-        globalThis.throwValue(err);
-        return .zero;
+        const data = PBKDF2.fromJS(globalThis, arguments.slice(), true) orelse {
+            assert(globalThis.hasException());
+            return .zero;
+        };
+
+        const job = PBKDF2.Job.create(JSC.VirtualMachine.get(), globalThis, &data);
+        return job.promise.value();
     }
 
-    return out_arraybuffer;
-}
+    fn pbkdf2Sync(
+        globalThis: *JSC.JSGlobalObject,
+        callframe: *JSC.CallFrame,
+    ) JSC.JSValue {
+        const arguments = callframe.arguments(5);
 
-const jsPbkdf2 = JSC.toJSHostFunction(pbkdf2);
-const jsPbkdf2Sync = JSC.toJSHostFunction(pbkdf2Sync);
-const jsRandomInt = JSC.toJSHostFunction(randomInt);
+        var data = PBKDF2.fromJS(globalThis, arguments.slice(), false) orelse {
+            assert(globalThis.hasException());
+            return .zero;
+        };
+        defer data.deinit();
+        var out_arraybuffer = JSC.JSValue.createBufferFromLength(globalThis, @intCast(data.length));
+        if (out_arraybuffer == .zero or globalThis.hasException()) {
+            data.deinit();
+            return .zero;
+        }
 
-pub fn createNodeCryptoBindingZig(global: *JSC.JSGlobalObject) JSC.JSValue {
-    const crypto = JSC.JSValue.createEmptyObject(global, 3);
+        const output = out_arraybuffer.asArrayBuffer(globalThis) orelse {
+            data.deinit();
+            globalThis.throwOutOfMemory();
+            return .zero;
+        };
 
-    crypto.put(global, bun.String.init("pbkdf2"), JSC.JSFunction.create(global, "pbkdf2", jsPbkdf2, 5, .{}));
-    crypto.put(global, bun.String.init("pbkdf2Sync"), JSC.JSFunction.create(global, "pbkdf2Sync", jsPbkdf2Sync, 5, .{}));
-    crypto.put(global, bun.String.init("randomInt"), JSC.JSFunction.create(global, "randomInt", jsRandomInt, 2, .{}));
+        if (!data.run(output.slice())) {
+            const err = Crypto.createCryptoError(globalThis, BoringSSL.ERR_get_error());
+            BoringSSL.ERR_clear_error();
+            globalThis.throwValue(err);
+            return .zero;
+        }
 
-    return crypto;
-}
+        return out_arraybuffer;
+    }
+
+    fn hkdfSync(
+        globalThis: *JSC.JSGlobalObject,
+        callframe: *JSC.CallFrame,
+    ) JSC.JSValue {
+        const arguments = callframe.arguments(5).slice();
+        if (arguments.len < 5) {
+            globalThis.throwNotEnoughArguments("hkdfSync", 5, arguments.len);
+            return JSC.JSValue.null;
+        }
+
+        if (!arguments[0].isString()) {
+            // todo: FIX field
+            globalThis.throwInvalidArgumentType("hkdfSync", "digest", "<string>");
+            return JSC.JSValue.null;
+        }
+
+        // From BunObject PBKDF2 `fromJS`
+        const algorithm = brk: {
+            if (!arguments[0].isString()) {
+                _ = globalThis.throwInvalidArgumentTypeValue("algorithm", "string", arguments[0]);
+                return JSC.JSValue.null;
+            }
+
+            const algorithm = EVP.Algorithm.map.fromJSCaseInsensitive(globalThis, arguments[0]) orelse {
+                if (!globalThis.hasException()) {
+                    const slice = arguments[0].toSlice(globalThis, bun.default_allocator);
+                    defer slice.deinit();
+                    const name = slice.slice();
+                    globalThis.ERR_CRYPTO_INVALID_DIGEST("Unsupported algorithm \"{s}\"", .{name}).throw();
+                }
+                return JSC.JSValue.null;
+            };
+
+            break :brk EVP.Algorithm.md(algorithm) orelse {
+                if (!globalThis.hasException()) {
+                    const slice = arguments[0].toSlice(globalThis, bun.default_allocator);
+                    defer slice.deinit();
+                    const name = slice.slice();
+                    globalThis.ERR_CRYPTO_INVALID_DIGEST("Unsupported algorithm \"{s}\"", .{name}).throw();
+                }
+                return JSC.JSValue.null;
+            };
+        };
+        _ = algorithm;
+
+        // This can also be a KeyObject
+        // Be sure to test with all listed here: <string> | <ArrayBuffer> | <Buffer> | <TypedArray> | <DataView> | <KeyObject>
+        // Be sure this works with a keylen of 0
+        const ikm = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, arguments[1]) orelse {
+            globalThis.throwInvalidArgumentType("hkdfSync", "ikm", "<string> | <ArrayBuffer> | <Buffer>");
+            return JSC.JSValue.null;
+        };
+        const salt = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, arguments[2]) orelse {
+            globalThis.throwInvalidArgumentType("hkdfSync", "salt", "<string> | <ArrayBuffer> | <Buffer>");
+            return JSC.JSValue.null;
+        };
+        const info = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, arguments[3]) orelse {
+            globalThis.throwInvalidArgumentType("hkdfSync", "info", "<string> | <ArrayBuffer> | <Buffer>");
+            return JSC.JSValue.null;
+        };
+        _ = ikm;
+        _ = salt;
+        _ = info;
+
+        if (!arguments[4].isAnyInt()) { // seems to filter negative values automatically
+            _ = globalThis.throwInvalidArgumentTypeValue("keylen", "integer", arguments[4]);
+            return JSC.JSValue.null;
+        }
+
+        // ensure this coersion is safe
+        const keylen = arguments[4].coerce(i64, globalThis);
+
+        if (keylen <= 0) {
+            _ = globalThis.throwInvalidArgumentRangeValue("keylen", "integer", keylen);
+            return JSC.JSValue.null;
+        }
+
+        // check constriant about hash size
+
+        const out_key = JSC.JSValue.createBufferFromLength(globalThis, @intCast(keylen + 1));
+        const out_key_ptr = @as([*c]u8, @ptrCast(out_key.asArrayBuffer(globalThis).?.ptr)); // what happens if Null is returned from `asArrayBuffer`?
+        _ = out_key_ptr;
+
+        BoringSSL.load();
+        // https://github.com/nodejs/node/blob/main/src/crypto/crypto_hkdf.cc
+        // Node Code to Copy
+        //   if (HMAC(
+        //           params.digest,
+        //           salt.data(),
+        //           salt.size(),
+        //           reinterpret_cast<const unsigned char*>(params.key->GetSymmetricKey()),
+        //           params.key->GetSymmetricKeySize(),
+        //           pseudorandom_key,
+        //           &prk_len) == nullptr) {
+        //     return false;
+        //   }
+        //   if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(), EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) ||
+        //       !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), pseudorandom_key, prk_len)) {
+        //     return false;
+        //   }
+        //
+        //   size_t length = params.length;
+        //   ByteSource::Builder buf(length);
+        //   if (EVP_PKEY_derive(ctx.get(), buf.data<unsigned char>(), &length) <= 0)
+        //     return false;
+        //
+
+        return out_key;
+    }
+};

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -142,14 +142,21 @@ pub const NodeCrypto = struct {
             globalThis.throwInvalidArgumentType("hkdfSync", "ikm", "<string> | <ArrayBuffer> | <Buffer>");
             return .null;
         };
+        defer ikm.deinit();
         const salt = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, arguments[2]) orelse {
             globalThis.throwInvalidArgumentType("hkdfSync", "salt", "<string> | <ArrayBuffer> | <Buffer>");
             return .null;
         };
+        defer salt.deinit();
         const info = JSC.Node.StringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, arguments[3]) orelse {
             globalThis.throwInvalidArgumentType("hkdfSync", "info", "<string> | <ArrayBuffer> | <Buffer>");
             return .null;
         };
+        defer info.deinit();
+        if (info.slice().len > 1024) {
+            globalThis.throw("Argument info canot be longer than 1024 bytes. Recieved {} bytes.", .{info.slice().len});
+            return .null;
+        }
 
         if (!arguments[4].isAnyInt()) {
             _ = globalThis.throwInvalidArgumentTypeValue("keylen", "integer", arguments[4]);

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -175,17 +175,11 @@ pub const NodeCrypto = struct {
         if (keylen > max_keylen) {
             const digest_bun_str = arguments[0].toBunString(globalThis);
             defer digest_bun_str.deref();
-            globalThis.throw(
-                \\"keylen" cannot be larger than 255 times the byte size of the digest output in bytes.
-                \\Digest "{s}" is {} bytes, so the keylen limit is {}. Recieved {}.
-            ,
-                .{
-                    digest_bun_str.byteSlice(),
-                    BoringSSL.EVP_MD_size(algorithm),
-                    max_keylen,
-                    keylen,
-                },
-            );
+
+            var err = globalThis.createErrorInstance("Invalid key length", .{});
+            err.put(globalThis, ZigString.static("code"), ZigString.init(@tagName(.ERR_CRYPTO_INVALID_KEYLEN)).toJS(globalThis));
+            err.put(globalThis, ZigString.static("name"), ZigString.init("RangeError").toJS(globalThis));
+            globalThis.throwValue(err);
             return .null;
         }
 

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -31,6 +31,10 @@ const doesnt_exist = C.doesnt_exist;
 const struct_tm = C.struct_tm;
 const enum_ssl_verify_result_t = C.enum_ssl_verify_result_t;
 
+pub extern fn HKDF(out_key: [*c]u8, out_len: usize, digest: ?*const EVP_MD, secret: [*c]const u8, secret_len: usize, salt: [*c]const u8, salt_len: usize, info: [*c]const u8, info_len: usize) c_int;
+pub extern fn HKDF_extract(out_key: [*c]u8, out_len: [*c]usize, digest: ?*const EVP_MD, secret: [*c]const u8, secret_len: usize, salt: [*c]const u8, salt_len: usize) c_int;
+pub extern fn HKDF_expand(out_key: [*c]u8, out_len: usize, digest: ?*const EVP_MD, prk: [*c]const u8, prk_len: usize, info: [*c]const u8, info_len: usize) c_int;
+
 pub const CRYPTO_THREADID = c_int;
 pub const struct_asn1_null_st = opaque {};
 pub const ASN1_NULL = struct_asn1_null_st;

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -24,7 +24,12 @@ const {
   randomInt: _randomInt,
   pbkdf2: pbkdf2_,
   pbkdf2Sync: pbkdf2Sync_,
-} = $zig("node_crypto_binding.zig", "createNodeCryptoBindingZig");
+  hkdfSync: _hkdfSync,
+} = $zig("node_crypto_binding.zig", "NodeCrypto.create");
+
+function hkdfSync(digest, ikm, salt, info, keylen) {
+  return _hkdfSync(digest, ikm, salt, info, keylen);
+}
 
 function randomInt(min, max, callback) {
   if (max == null) {
@@ -12171,6 +12176,7 @@ __export(crypto_exports, {
   getRandomValues: () => getRandomValues,
   randomUUID: () => randomUUID,
   randomInt: () => randomInt,
+  hkdfSync: () => hkdfSync,
   getCurves: () => getCurves,
   scrypt: () => scrypt,
   scryptSync: () => scryptSync,

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -28,17 +28,17 @@ const {
 } = $zig("node_crypto_binding.zig", "NodeCrypto.create");
 
 function hkdfSync(digest, ikm, salt, info, keylen) {
-  return _hkdfSync(digest, ikm, salt, info, keylen);
+  return _hkdfSync(digest, ikm, salt, info, keylen).buffer;
 }
 
 function hkdf(digest, ikm, salt, info, keylen, callback) {
   if (callback != null) {
     // Causes weird test failures
     // process.nextTick(() => callback(null, _hkdfSync(digest, ikm, salt, info, keylen)));
-    callback(null, _hkdfSync(digest, ikm, salt, info, keylen));
+    callback(null, hkdfSync(digest, ikm, salt, info, keylen));
     return;
   }
-  return _hkdfSync(digest, ikm, salt, info, keylen);
+  return hkdfSync(digest, ikm, salt, info, keylen);
 }
 
 function randomInt(min, max, callback) {

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -36,13 +36,15 @@ function hkdfSync(digest, ikm, salt, info, keylen) {
 }
 
 function hkdf(digest, ikm, salt, info, keylen, callback) {
-  if (callback != null) {
-    // Causes weird test failures
-    // process.nextTick(() => callback(null, _hkdfSync(digest, ikm, salt, info, keylen)));
-    callback(null, hkdfSync(digest, ikm, salt, info, keylen));
-    return;
+  let res = hkdfSync(digest, ikm, salt, info, keylen);
+
+  if (!$isCallable(callback)) {
+    const err = new TypeError('The "callback" argument must be of type function. Received ' + typeof callback);
+    err.code = "ERR_INVALID_ARG_TYPE";
+    throw err;
   }
-  return hkdfSync(digest, ikm, salt, info, keylen);
+
+  process.nextTick(() => callback(null, res));
 }
 
 function randomInt(min, max, callback) {

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -31,6 +31,16 @@ function hkdfSync(digest, ikm, salt, info, keylen) {
   return _hkdfSync(digest, ikm, salt, info, keylen);
 }
 
+function hkdf(digest, ikm, salt, info, keylen, callback) {
+  if (callback != null) {
+    // Causes weird test failures
+    // process.nextTick(() => callback(null, _hkdfSync(digest, ikm, salt, info, keylen)));
+    callback(null, _hkdfSync(digest, ikm, salt, info, keylen));
+    return;
+  }
+  return _hkdfSync(digest, ikm, salt, info, keylen);
+}
+
 function randomInt(min, max, callback) {
   if (max == null) {
     max = min;
@@ -12177,6 +12187,7 @@ __export(crypto_exports, {
   randomUUID: () => randomUUID,
   randomInt: () => randomInt,
   hkdfSync: () => hkdfSync,
+  hkdf: () => hkdf,
   getCurves: () => getCurves,
   scrypt: () => scrypt,
   scryptSync: () => scryptSync,

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -28,6 +28,10 @@ const {
 } = $zig("node_crypto_binding.zig", "NodeCrypto.create");
 
 function hkdfSync(digest, ikm, salt, info, keylen) {
+  if (ikm instanceof KeyObject) {
+    ikm = ikm.export();
+  }
+
   return _hkdfSync(digest, ikm, salt, info, keylen).buffer;
 }
 

--- a/test/js/node/crypto/hkdf.test.ts
+++ b/test/js/node/crypto/hkdf.test.ts
@@ -42,8 +42,7 @@ test('rejects bad callback type', () => {
     expect(false).toBeTrue();
   } catch (e){
     expect(e).toBeInstanceOf(TypeError);
-    expect(e.toString()).toInclude("TypeError");
-    expect(e.toString()).toInclude("not a function");
+    expect(e.toString()).toInclude("must be of type function");
   }
 });
 
@@ -53,28 +52,33 @@ test("rejects negative key size", () => {
     expect(false).toBeTrue();
   } catch (e) {
     expect(e).toBeInstanceOf(RangeError);
-    expect(e.toString()).toInclude("range");
+    expect(e.toString()).toInclude("\"keylen\" is out of range")
   }
 
   try {
     crypto.hkdf("sha512", "key", "salt", "info", -10, (err, ab) => {});
     expect(false).toBeTrue();
   } catch (e) {
-    expect(e.toString()).toInclude("range");
+    expect(e).toBeInstanceOf(RangeError);
+    expect(e.toString()).toInclude("\"keylen\" is out of range")
   }
 });
 
 test("rejects excessive key size", () => {
   try {
     crypto.hkdfSync("sha512", "key", "salt", "info", 200000)
+    expect(false).toBeTrue();
   } catch (e) {
-    expect(e.toString()).toInclude("cannot be larger");
+    expect(e.code).toBe("ERR_CRYPTO_INVALID_KEYLEN");
+    expect(e.toString()).toInclude("Invalid key length");
   }
 
   try {
     crypto.hkdf("sha512", "key", "salt", "info", 200000, (err, ab) => {})
+    expect(false).toBeTrue();
   } catch (e) {
-    expect(e.toString()).toInclude("cannot be larger");
+    expect(e.code).toBe("ERR_CRYPTO_INVALID_KEYLEN");
+    expect(e.toString()).toInclude("Invalid key length");
   }
 });
 

--- a/test/js/node/crypto/hkdf.test.ts
+++ b/test/js/node/crypto/hkdf.test.ts
@@ -72,7 +72,7 @@ test("rejects excessive key size", () => {
   }
 
   try {
-    crypto.hkdfSync("sha512", "key", "salt", "info", 200000, (err, ab) => {})
+    crypto.hkdf("sha512", "key", "salt", "info", 200000, (err, ab) => {})
   } catch (e) {
     expect(e.toString()).toInclude("cannot be larger");
   }
@@ -90,8 +90,7 @@ test("trivial", async () => {
 
   expect(err).toBeNull();
   expect(outSync).toStrictEqual(out);
-  expect(out.toString("hex")).toStrictEqual("24156e2c35525baaf3d0fbb92b734c8032a110a3f12e2596e441e1924870d84c3a500652a723738024432451046fd237efad8392fb686c5277a59e0105391653");
-  // value from node
+  expect(Buffer.from(out).toString("hex")).toStrictEqual("24156e2c35525baaf3d0fbb92b734c8032a110a3f12e2596e441e1924870d84c3a500652a723738024432451046fd237efad8392fb686c5277a59e0105391653");
 });
 
 const rfcTestCase = async (testNo, digest, ikm, salt, info, keylen, expected) => {
@@ -107,7 +106,7 @@ const rfcTestCase = async (testNo, digest, ikm, salt, info, keylen, expected) =>
 
     expect(err).toBeNull();
     expect(outSync).toStrictEqual(out);
-    expect(out.toString("hex")).toStrictEqual(expected);
+    expect(Buffer.from(out).toString("hex")).toStrictEqual(expected);
   })
 }
 

--- a/test/js/node/crypto/hkdf.test.ts
+++ b/test/js/node/crypto/hkdf.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+import crypto from "node:crypto";
+
+test("rejects fewer than 5 args", () => {
+  try {
+    crypto.hkdfSync();
+    expect(false).toBeTrue();
+  } catch (e) {
+    expect(e.toString()).toInclude("The \"algorithm\" argument must be of type string");
+  }
+  try {
+    crypto.hkdf();
+    expect(false).toBeTrue();
+  } catch (e) {
+    expect(e.toString()).toInclude("The \"algorithm\" argument must be of type string");
+  }
+});
+
+test("rejects invalid hash algorithm", () => {
+  try {
+    crypto.hkdfSync("notahash", "key", "salt", "info", 64)
+    expect(false).toBeTrue();
+  } catch (e) {
+    expect(e.toString()).toInclude("Unsupported algorithm");
+  }
+
+  try {
+    crypto.hkdf("notahash", "key", "salt", "info", 64, (err, ab) => {})
+    expect(false).toBeTrue();
+  } catch (e) {
+    expect(e.toString()).toInclude("Unsupported algorithm");
+  }
+});
+
+test('rejects bad callback type', () => {
+  try {
+    crypto.hkdf("sha512", "key", "salt", "info", 64, "notacallback");
+    expect(false).toBeTrue();
+  } catch (e){
+    expect(e.toString()).toInclude("TypeError");
+    expect(e.toString()).toInclude("not a function");
+  }
+})
+
+test("rejects negative key size", () => {
+  try {
+    crypto.hkdfSync("sha512", "key", "salt", "info", -10);
+    expect(false).toBeTrue();
+  } catch (e) {
+    expect(e.toString()).toInclude("range");
+  }
+
+  try {
+    crypto.hkdf("sha512", "key", "salt", "info", -10, (err, ab) => {});
+    expect(false).toBeTrue();
+  } catch (e) {
+    expect(e.toString()).toInclude("range");
+  }
+});
+
+test("rejects excessive key size", () => {
+  try {
+    crypto.hkdfSync("sha512", "key", "salt", "info", 200000)
+  } catch (e) {
+    expect(e.toString()).toInclude("cannot be larger");
+  }
+
+  try {
+    crypto.hkdfSync("sha512", "key", "salt", "info", 200000, (err, ab) => {})
+  } catch (e) {
+    expect(e.toString()).toInclude("cannot be larger");
+  }
+})
+

--- a/test/js/node/crypto/hkdf.test.ts
+++ b/test/js/node/crypto/hkdf.test.ts
@@ -79,7 +79,9 @@ test("rejects excessive key size", () => {
 });
 
 test("trivial", async () => {
-  let outSync = crypto.hkdfSync("sha512", "key", "salt", "info", 64);
+  const key = crypto.createSecretKey("key");
+
+  let outSync = crypto.hkdfSync("sha512", key, "salt", "info", 64);
 
   const { promise, resolve } = Promise.withResolvers();
 

--- a/test/js/node/crypto/hkdf.test.ts
+++ b/test/js/node/crypto/hkdf.test.ts
@@ -6,12 +6,14 @@ test("rejects fewer than 5 args", () => {
     crypto.hkdfSync();
     expect(false).toBeTrue();
   } catch (e) {
+    expect(e).toBeInstanceOf(TypeError);
     expect(e.toString()).toInclude("The \"algorithm\" argument must be of type string");
   }
   try {
     crypto.hkdf();
     expect(false).toBeTrue();
   } catch (e) {
+    expect(e).toBeInstanceOf(TypeError);
     expect(e.toString()).toInclude("The \"algorithm\" argument must be of type string");
   }
 });
@@ -21,6 +23,7 @@ test("rejects invalid hash algorithm", () => {
     crypto.hkdfSync("notahash", "key", "salt", "info", 64)
     expect(false).toBeTrue();
   } catch (e) {
+    expect(e).toBeInstanceOf(TypeError);
     expect(e.toString()).toInclude("Unsupported algorithm");
   }
 
@@ -28,6 +31,7 @@ test("rejects invalid hash algorithm", () => {
     crypto.hkdf("notahash", "key", "salt", "info", 64, (err, ab) => {})
     expect(false).toBeTrue();
   } catch (e) {
+    expect(e).toBeInstanceOf(TypeError);
     expect(e.toString()).toInclude("Unsupported algorithm");
   }
 });
@@ -37,16 +41,18 @@ test('rejects bad callback type', () => {
     crypto.hkdf("sha512", "key", "salt", "info", 64, "notacallback");
     expect(false).toBeTrue();
   } catch (e){
+    expect(e).toBeInstanceOf(TypeError);
     expect(e.toString()).toInclude("TypeError");
     expect(e.toString()).toInclude("not a function");
   }
-})
+});
 
 test("rejects negative key size", () => {
   try {
     crypto.hkdfSync("sha512", "key", "salt", "info", -10);
     expect(false).toBeTrue();
   } catch (e) {
+    expect(e).toBeInstanceOf(RangeError);
     expect(e.toString()).toInclude("range");
   }
 
@@ -70,5 +76,98 @@ test("rejects excessive key size", () => {
   } catch (e) {
     expect(e.toString()).toInclude("cannot be larger");
   }
-})
+});
+
+test("trivial", async () => {
+  let outSync = crypto.hkdfSync("sha512", "key", "salt", "info", 64);
+
+  const { promise, resolve } = Promise.withResolvers();
+
+  crypto.hkdf("sha512", "key", "salt", "info", 64, (err, result) => {
+    resolve([err, result]);
+  });
+  const [err, out] = await promise;
+
+  expect(err).toBeNull();
+  expect(outSync).toStrictEqual(out);
+  expect(out.toString("hex")).toStrictEqual("24156e2c35525baaf3d0fbb92b734c8032a110a3f12e2596e441e1924870d84c3a500652a723738024432451046fd237efad8392fb686c5277a59e0105391653");
+  // value from node
+});
+
+const rfcTestCase = async (testNo, digest, ikm, salt, info, keylen, expected) => {
+  test(`RFC 5869 Test Vector ${testNo}`, async () => {
+    let outSync = crypto.hkdfSync(digest, Buffer.from(ikm, "hex"), Buffer.from(salt, "hex"), Buffer.from(info, "hex"), keylen);
+
+    const { promise, resolve } = Promise.withResolvers();
+
+    crypto.hkdf(digest, Buffer.from(ikm, "hex"), Buffer.from(salt, "hex"), Buffer.from(info, "hex"), keylen, (err, result) => {
+      resolve([err, result]);
+    });
+    const [err, out] = await promise;
+
+    expect(err).toBeNull();
+    expect(outSync).toStrictEqual(out);
+    expect(out.toString("hex")).toStrictEqual(expected);
+  })
+}
+
+rfcTestCase(
+  1,
+  "sha256",
+  "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+  "000102030405060708090a0b0c",
+  "f0f1f2f3f4f5f6f7f8f9",
+  42,
+  "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+);
+
+rfcTestCase(
+  2,
+  "sha256",
+  "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
+  "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+  "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+  82,
+  "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87",
+);
+
+rfcTestCase(
+  3,
+  "sha256",
+  "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+  "",
+  "",
+  42,
+  "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8",
+);
+
+rfcTestCase(
+  4,
+  "sha1",
+  "0b0b0b0b0b0b0b0b0b0b0b",
+  "000102030405060708090a0b0c",
+  "f0f1f2f3f4f5f6f7f8f9",
+  42,
+  "085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896",
+);
+
+rfcTestCase(
+  5,
+  "sha1",
+  "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
+  "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+  "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+  82,
+  "0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4",
+);
+
+rfcTestCase(
+  6,
+  "sha1",
+  "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+  "",
+  "",
+  42,
+  "0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918",
+);
 


### PR DESCRIPTION
### What does this PR do?

~~Note: `KeyObject` input for the `ikm` arg is not supported, although it is allowed in `@types/node`. There aren't Zig bindings for `KeyObject`.~~
Implemented KeyObject processing in JS.

This adds to new functions to `node:crypto` namespace that were missing. This brings bun closer to node drop in compatibility.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?


<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)


- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)



- [ ] I added TypeScript types for the new methods, getters, or setters
Not necessary because these functions are already defined in `@types/node` 

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
