### PR TITLE
Experiment: free cloned body values sooner

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -5050,7 +5050,9 @@ pub const AnyBlob = union(enum) {
                     return JSC.ArrayBuffer.create(global, "", TypedArrayView);
                 }
 
+                bun.assertMimalloc(&this.InternalBlob.bytes.allocator, @src());
                 const bytes = this.InternalBlob.toOwnedSlice();
+
                 this.* = .{ .Blob = .{} };
 
                 return JSC.ArrayBuffer.fromDefaultAllocator(

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3725,3 +3725,9 @@ pub fn WeakPtr(comptime T: type, comptime weakable_field: std.meta.FieldEnum(T))
         }
     };
 }
+
+pub inline fn assertMimalloc(allocator: *const std.mem.Allocator, loc: std.builtin.SourceLocation) void {
+    if (allocator.vtable != default_allocator.vtable and allocator.vtable != MimallocArena.v_table) {
+        Output.panic("Internal error: expected default allocator in use at {s}:{s}:{d}", .{ loc.file, loc.fn_name, loc.line });
+    }
+}


### PR DESCRIPTION
### What does this PR do?



Free cloned body values sooner


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
