### PR TITLE
fix(fetch) fix lifecycle of SSL Proxy, fix lifecycle of tls_props, fix handling chunked encoded redirects when proxing.

### DIFF
--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -154,15 +154,16 @@ pub fn SSLWrapper(comptime T: type) type {
 
             // we sent the shutdown
             this.flags.sent_ssl_shutdown = ret >= 0;
-            defer if (ret < 0) {
+            if (ret < 0) {
                 const err = BoringSSL.SSL_get_error(ssl, ret);
                 BoringSSL.ERR_clear_error();
 
                 if (err == BoringSSL.SSL_ERROR_SSL or err == BoringSSL.SSL_ERROR_SYSCALL) {
                     this.flags.fatal_error = true;
                     this.triggerCloseCallback();
+                    return false;
                 }
-            };
+            }
             return ret == 1; // truly closed
         }
 
@@ -424,7 +425,6 @@ pub fn SSLWrapper(comptime T: type) type {
                         if (read > 0) {
                             this.triggerDataCallback(buffer[0..read]);
                         }
-
                         this.triggerCloseCallback();
                         return false;
                     } else {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -132,6 +132,7 @@ for (const proxy_tls of [false, true]) {
 }
 test("proxy can handle redirects #12007", async () => {
   using server = Bun.serve({
+    tls: tlsCert,
     port: 0,
     async fetch(req) {
       if (req.url.endsWith("/bunbun")) {
@@ -146,7 +147,7 @@ test("proxy can handle redirects #12007", async () => {
   const response = await fetch(`${server.url.origin}/bunbun`, {
     proxy: httpsProxyServer.url,
     tls: {
-      ca: tlsCert.cert,
+      cert: tlsCert.cert,
       rejectUnauthorized: false,
     },
   });
@@ -157,6 +158,7 @@ test("proxy can handle redirects #12007", async () => {
 
 test("proxy can handle redirects with body #12007", async () => {
   using server = Bun.serve({
+    tls: tlsCert,
     port: 0,
     async fetch(req) {
       if (req.url.endsWith("/bunbun")) {
@@ -171,7 +173,7 @@ test("proxy can handle redirects with body #12007", async () => {
   const response = await fetch(`${server.url.origin}/bunbun`, {
     proxy: httpsProxyServer.url,
     tls: {
-      ca: tlsCert.cert,
+      cert: tlsCert.cert,
       rejectUnauthorized: false,
     },
   });
@@ -185,6 +187,7 @@ test("proxy can handle redirects with body #12007", async () => {
 
 test("proxy can handle redirects with chunked body #12007", async () => {
   using server = Bun.serve({
+    tls: tlsCert,
     port: 0,
     async fetch(req) {
       async function* body() {
@@ -209,7 +212,7 @@ test("proxy can handle redirects with chunked body #12007", async () => {
   const response = await fetch(`${server.url.origin}/bunbun`, {
     proxy: httpsProxyServer.url,
     tls: {
-      ca: tlsCert.cert,
+      cert: tlsCert.cert,
       rejectUnauthorized: false,
     },
   });

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -132,7 +132,7 @@ for (const proxy_tls of [false, true]) {
 }
 
 for (const server_tls of [false, true]) {
-  describe(`proxy can handle redirects with server ${server_tls ? "TLS" : "non-TLS"}`, () => {
+  describe(`proxy can handle redirects with ${server_tls ? "TLS" : "non-TLS"} server`, () => {
     test("with empty body #12007", async () => {
       using server = Bun.serve({
         tls: server_tls ? tlsCert : undefined,

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -130,8 +130,20 @@ for (const proxy_tls of [false, true]) {
     }
   }
 }
-test("#12007", async () => {
-  const response = await fetch("https://nopecha.com/demo/cloudflare", {
+test("proxy can handle redirects #12007", async () => {
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (req.url.endsWith("/bunbun")) {
+        return Response.redirect("/bun", 302);
+      }
+      if (req.url.endsWith("/bun")) {
+        return Response.redirect("/", 302);
+      }
+      return new Response("", { status: 403 });
+    },
+  });
+  const response = await fetch(`${server.url.origin}/bunbun`, {
     proxy: httpsProxyServer.url,
     tls: {
       ca: tlsCert.cert,

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -130,7 +130,18 @@ for (const proxy_tls of [false, true]) {
     }
   }
 }
-
+test("#12007", async () => {
+  const response = await fetch("https://nopecha.com/demo/cloudflare", {
+    proxy: httpsProxyServer.url,
+    tls: {
+      ca: tlsCert.cert,
+      rejectUnauthorized: false,
+    },
+  });
+  expect(response.ok).toBe(false);
+  expect(response.status).toBe(403);
+  expect(response.statusText).toBe("Forbidden");
+});
 test("unsupported protocol", async () => {
   expect(
     fetch("https://httpbin.org/get", {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, test, describe } from "bun:test";
 import { tls as tlsCert } from "harness";
 import { once } from "node:events";
 import net from "node:net";
@@ -130,99 +130,104 @@ for (const proxy_tls of [false, true]) {
     }
   }
 }
-test("proxy can handle redirects #12007", async () => {
-  using server = Bun.serve({
-    tls: tlsCert,
-    port: 0,
-    async fetch(req) {
-      if (req.url.endsWith("/bunbun")) {
-        return Response.redirect("/bun", 302);
-      }
-      if (req.url.endsWith("/bun")) {
-        return Response.redirect("/", 302);
-      }
-      return new Response("", { status: 403 });
-    },
-  });
-  const response = await fetch(`${server.url.origin}/bunbun`, {
-    proxy: httpsProxyServer.url,
-    tls: {
-      cert: tlsCert.cert,
-      rejectUnauthorized: false,
-    },
-  });
-  expect(response.ok).toBe(false);
-  expect(response.status).toBe(403);
-  expect(response.statusText).toBe("Forbidden");
-});
 
-test("proxy can handle redirects with body #12007", async () => {
-  using server = Bun.serve({
-    tls: tlsCert,
-    port: 0,
-    async fetch(req) {
-      if (req.url.endsWith("/bunbun")) {
-        return new Response("Hello, bunbun", { status: 302, headers: { Location: "/bun" } });
-      }
-      if (req.url.endsWith("/bun")) {
-        return new Response("Hello, bun", { status: 302, headers: { Location: "/" } });
-      }
-      return new Response("BUN!", { status: 200 });
-    },
-  });
-  const response = await fetch(`${server.url.origin}/bunbun`, {
-    proxy: httpsProxyServer.url,
-    tls: {
-      cert: tlsCert.cert,
-      rejectUnauthorized: false,
-    },
-  });
-  expect(response.ok).toBe(true);
-  expect(response.status).toBe(200);
-  expect(response.statusText).toBe("OK");
+for (const server_tls of [false, true]) {
+  describe(`proxy can handle redirects with server ${server_tls ? "TLS" : "non-TLS"}`, () => {
+    test("with empty body #12007", async () => {
+      using server = Bun.serve({
+        tls: server_tls ? tlsCert : undefined,
+        port: 0,
+        async fetch(req) {
+          if (req.url.endsWith("/bunbun")) {
+            return Response.redirect("/bun", 302);
+          }
+          if (req.url.endsWith("/bun")) {
+            return Response.redirect("/", 302);
+          }
+          return new Response("", { status: 403 });
+        },
+      });
+      const response = await fetch(`${server.url.origin}/bunbun`, {
+        proxy: httpsProxyServer.url,
+        tls: {
+          cert: tlsCert.cert,
+          rejectUnauthorized: false,
+        },
+      });
+      expect(response.ok).toBe(false);
+      expect(response.status).toBe(403);
+      expect(response.statusText).toBe("Forbidden");
+    });
 
-  const result = await response.text();
-  expect(result).toBe("BUN!");
-});
+    test("with body #12007", async () => {
+      using server = Bun.serve({
+        tls: server_tls ? tlsCert : undefined,
+        port: 0,
+        async fetch(req) {
+          if (req.url.endsWith("/bunbun")) {
+            return new Response("Hello, bunbun", { status: 302, headers: { Location: "/bun" } });
+          }
+          if (req.url.endsWith("/bun")) {
+            return new Response("Hello, bun", { status: 302, headers: { Location: "/" } });
+          }
+          return new Response("BUN!", { status: 200 });
+        },
+      });
+      const response = await fetch(`${server.url.origin}/bunbun`, {
+        proxy: httpsProxyServer.url,
+        tls: {
+          cert: tlsCert.cert,
+          rejectUnauthorized: false,
+        },
+      });
+      expect(response.ok).toBe(true);
+      expect(response.status).toBe(200);
+      expect(response.statusText).toBe("OK");
 
-test("proxy can handle redirects with chunked body #12007", async () => {
-  using server = Bun.serve({
-    tls: tlsCert,
-    port: 0,
-    async fetch(req) {
-      async function* body() {
-        await Bun.sleep(100);
-        yield "bun";
-        await Bun.sleep(100);
-        yield "bun";
-        await Bun.sleep(100);
-        yield "bun";
-        await Bun.sleep(100);
-        yield "bun";
-      }
-      if (req.url.endsWith("/bunbun")) {
-        return new Response(body, { status: 302, headers: { Location: "/bun" } });
-      }
-      if (req.url.endsWith("/bun")) {
-        return new Response(body, { status: 302, headers: { Location: "/" } });
-      }
-      return new Response(body, { status: 200 });
-    },
-  });
-  const response = await fetch(`${server.url.origin}/bunbun`, {
-    proxy: httpsProxyServer.url,
-    tls: {
-      cert: tlsCert.cert,
-      rejectUnauthorized: false,
-    },
-  });
-  expect(response.ok).toBe(true);
-  expect(response.status).toBe(200);
-  expect(response.statusText).toBe("OK");
+      const result = await response.text();
+      expect(result).toBe("BUN!");
+    });
 
-  const result = await response.text();
-  expect(result).toBe("bunbunbunbun");
-});
+    test("with chunked body #12007", async () => {
+      using server = Bun.serve({
+        tls: server_tls ? tlsCert : undefined,
+        port: 0,
+        async fetch(req) {
+          async function* body() {
+            await Bun.sleep(100);
+            yield "bun";
+            await Bun.sleep(100);
+            yield "bun";
+            await Bun.sleep(100);
+            yield "bun";
+            await Bun.sleep(100);
+            yield "bun";
+          }
+          if (req.url.endsWith("/bunbun")) {
+            return new Response(body, { status: 302, headers: { Location: "/bun" } });
+          }
+          if (req.url.endsWith("/bun")) {
+            return new Response(body, { status: 302, headers: { Location: "/" } });
+          }
+          return new Response(body, { status: 200 });
+        },
+      });
+      const response = await fetch(`${server.url.origin}/bunbun`, {
+        proxy: httpsProxyServer.url,
+        tls: {
+          cert: tlsCert.cert,
+          rejectUnauthorized: false,
+        },
+      });
+      expect(response.ok).toBe(true);
+      expect(response.status).toBe(200);
+      expect(response.statusText).toBe("OK");
+
+      const result = await response.text();
+      expect(result).toBe("bunbunbunbun");
+    });
+  });
+}
 
 test("unsupported protocol", async () => {
   expect(


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/12007
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Added tests

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
