### PR TITLE
Implement napi_handle_scope and napi_escapable_handle_scope

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -33,6 +33,8 @@
 
 #include "AsyncContextFrame.h"
 
+#include "napi_handle_scope.h"
+
 #ifndef WIN32
 #include <errno.h>
 #include <dlfcn.h>
@@ -405,6 +407,8 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen,
         JSC::throwTypeError(globalObject, scope, "symbol 'napi_register_module_v1' not found in native module. Is this a Node API (napi) module?"_s);
         return JSC::JSValue::encode(JSC::JSValue {});
     }
+
+    NapiHandleScope handleScope(globalObject);
 
     EncodedJSValue exportsValue = JSC::JSValue::encode(exports);
     JSC::JSValue resultValue = JSValue::decode(napi_register_module_v1(globalObject, exportsValue));

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -129,6 +129,7 @@
 #include "libusockets.h"
 #include "ModuleLoader.h"
 #include "napi_external.h"
+#include "napi_handle_scope.h"
 #include "napi.h"
 #include "NodeHTTP.h"
 #include "NodeVM.h"
@@ -2856,6 +2857,10 @@ void GlobalObject::finishCreation(VM& vm)
                 Bun::NapiPrototype::createStructure(init.vm, init.owner, init.owner->objectPrototype()));
         });
 
+    m_NapiHandleScopeStructure.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
+        init.set(Bun::NapiHandleScope::createStructure(init.vm, init.owner));
+    });
+
     m_cachedNodeVMGlobalObjectStructure.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
             init.set(WebCore::createNodeVMGlobalObjectStructure(init.vm));
@@ -3537,6 +3542,8 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_pendingNapiModuleAndExports[0]);
     visitor.append(thisObject->m_pendingNapiModuleAndExports[1]);
 
+    visitor.append(thisObject->m_currentNapiHandleScope);
+
     thisObject->m_asyncBoundFunctionStructure.visit(visitor);
     thisObject->m_bunObject.visit(visitor);
     thisObject->m_cachedNodeVMGlobalObjectStructure.visit(visitor);
@@ -3575,6 +3582,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_NapiExternalStructure.visit(visitor);
     thisObject->m_NAPIFunctionStructure.visit(visitor);
     thisObject->m_NapiPrototypeStructure.visit(visitor);
+    thisObject->m_NapiHandleScopeStructure.visit(visitor);
     thisObject->m_nativeMicrotaskTrampoline.visit(visitor);
     thisObject->m_navigatorObject.visit(visitor);
     thisObject->m_NodeVMScriptClassStructure.visit(visitor);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2857,8 +2857,8 @@ void GlobalObject::finishCreation(VM& vm)
                 Bun::NapiPrototype::createStructure(init.vm, init.owner, init.owner->objectPrototype()));
         });
 
-    m_NapiHandleScopeStructure.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
-        init.set(Bun::NapiHandleScope::createStructure(init.vm, init.owner));
+    m_NapiHandleScopeImplStructure.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
+        init.set(Bun::NapiHandleScopeImpl::createStructure(init.vm, init.owner));
     });
 
     m_cachedNodeVMGlobalObjectStructure.initLater(
@@ -3542,7 +3542,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_pendingNapiModuleAndExports[0]);
     visitor.append(thisObject->m_pendingNapiModuleAndExports[1]);
 
-    visitor.append(thisObject->m_currentNapiHandleScope);
+    visitor.append(thisObject->m_currentNapiHandleScopeImpl);
 
     thisObject->m_asyncBoundFunctionStructure.visit(visitor);
     thisObject->m_bunObject.visit(visitor);
@@ -3582,7 +3582,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_NapiExternalStructure.visit(visitor);
     thisObject->m_NAPIFunctionStructure.visit(visitor);
     thisObject->m_NapiPrototypeStructure.visit(visitor);
-    thisObject->m_NapiHandleScopeStructure.visit(visitor);
+    thisObject->m_NapiHandleScopeImplStructure.visit(visitor);
     thisObject->m_nativeMicrotaskTrampoline.visit(visitor);
     thisObject->m_navigatorObject.visit(visitor);
     thisObject->m_NodeVMScriptClassStructure.visit(visitor);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -29,6 +29,7 @@ class Performance;
 
 namespace Bun {
 class InternalModuleRegistry;
+class NapiHandleScope;
 } // namespace Bun
 
 namespace v8 {
@@ -405,6 +406,11 @@ public:
     // When a napi module initializes on dlopen, we need to know what the value is
     mutable JSC::WriteBarrier<Unknown> m_pendingNapiModuleAndExports[2];
 
+    // The handle scope where all new NAPI values will be created. You must not pass any napi_values
+    // back to a NAPI function without putting them in the handle scope, as the NAPI function may
+    // move them off the stack which will cause them to get collected if not in the handle scope.
+    JSC::WriteBarrier<Bun::NapiHandleScope> m_currentNapiHandleScope;
+
     // The original, unmodified Error.prepareStackTrace.
     //
     // We set a default value for this to mimick Node.js behavior It is a
@@ -564,6 +570,8 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_NapiExternalStructure;
     LazyProperty<JSGlobalObject, Structure> m_NapiPrototypeStructure;
     LazyProperty<JSGlobalObject, Structure> m_NAPIFunctionStructure;
+    LazyProperty<JSGlobalObject, Structure> m_NapiHandleScopeStructure;
+
     LazyProperty<JSGlobalObject, Structure> m_JSSQLStatementStructure;
     LazyProperty<JSGlobalObject, v8::GlobalInternals> m_V8GlobalInternals;
 

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -29,7 +29,7 @@ class Performance;
 
 namespace Bun {
 class InternalModuleRegistry;
-class NapiHandleScope;
+class NapiHandleScopeImpl;
 } // namespace Bun
 
 namespace v8 {
@@ -284,6 +284,7 @@ public:
     Structure* NapiExternalStructure() const { return m_NapiExternalStructure.getInitializedOnMainThread(this); }
     Structure* NapiPrototypeStructure() const { return m_NapiPrototypeStructure.getInitializedOnMainThread(this); }
     Structure* NAPIFunctionStructure() const { return m_NAPIFunctionStructure.getInitializedOnMainThread(this); }
+    Structure* NapiHandleScopeImplStructure() const { return m_NapiHandleScopeImplStructure.getInitializedOnMainThread(this); }
 
     Structure* JSSQLStatementStructure() const { return m_JSSQLStatementStructure.getInitializedOnMainThread(this); }
 
@@ -409,7 +410,7 @@ public:
     // The handle scope where all new NAPI values will be created. You must not pass any napi_values
     // back to a NAPI function without putting them in the handle scope, as the NAPI function may
     // move them off the stack which will cause them to get collected if not in the handle scope.
-    JSC::WriteBarrier<Bun::NapiHandleScope> m_currentNapiHandleScope;
+    JSC::WriteBarrier<Bun::NapiHandleScopeImpl> m_currentNapiHandleScopeImpl;
 
     // The original, unmodified Error.prepareStackTrace.
     //
@@ -570,7 +571,7 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_NapiExternalStructure;
     LazyProperty<JSGlobalObject, Structure> m_NapiPrototypeStructure;
     LazyProperty<JSGlobalObject, Structure> m_NAPIFunctionStructure;
-    LazyProperty<JSGlobalObject, Structure> m_NapiHandleScopeStructure;
+    LazyProperty<JSGlobalObject, Structure> m_NapiHandleScopeImplStructure;
 
     LazyProperty<JSGlobalObject, Structure> m_JSSQLStatementStructure;
     LazyProperty<JSGlobalObject, v8::GlobalInternals> m_V8GlobalInternals;

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1928,6 +1928,7 @@ JSC_DEFINE_HOST_FUNCTION(NapiClass_ConstructorFunction,
     });
     NAPICallFrame frame(JSC::ArgList(args), nullptr);
     frame.newTarget = newTarget;
+    Bun::NapiHandleScope handleScope(jsCast<Zig::GlobalObject*>(globalObject));
 
     napi->constructor()(globalObject, reinterpret_cast<JSC::CallFrame*>(NAPICallFrame::toNapiCallbackInfo(frame)));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -724,7 +724,7 @@ extern "C" napi_status napi_delete_property(napi_env env, napi_value object,
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     if (LIKELY(result)) {
-        *result = toNapi(deleteResult);
+        *result = deleteResult;
     }
 
     scope.clearException();
@@ -749,7 +749,7 @@ extern "C" napi_status napi_has_own_property(napi_env env, napi_value object,
 
     auto keyProp = toJS(key);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    *result = toNapi(target->hasOwnProperty(globalObject, JSC::PropertyName(keyProp.toPropertyKey(globalObject))));
+    *result = target->hasOwnProperty(globalObject, JSC::PropertyName(keyProp.toPropertyKey(globalObject)));
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     scope.clearException();
@@ -2016,7 +2016,7 @@ extern "C" napi_status napi_get_all_property_names(
 
     JSC::JSArray* exportKeys = ownPropertyKeys(globalObject, object, jsc_property_mode, jsc_key_mode);
     // TODO: filter
-    *result = toNapi(JSC::JSValue::encode(exportKeys));
+    *result = toNapi(JSC::JSValue(exportKeys));
     return napi_ok;
 }
 

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -994,6 +994,7 @@ extern "C" void napi_module_register(napi_module* mod)
 
     JSC::Strong<JSC::JSObject> strongObject = { vm, object };
 
+    Bun::NapiHandleScope handleScope(globalObject);
     JSValue resultValue = toJS(mod->nm_register_func(toNapi(globalObject), toNapi(object, globalObject)));
 
     RETURN_IF_EXCEPTION(scope, void());

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -7,7 +7,7 @@
 #include "JavaScriptCore/JSGlobalObject.h"
 #include "JavaScriptCore/SourceCode.h"
 #include "js_native_api_types.h"
-#include "v8/V8HandleScope.h"
+#include "napi_handle_scope.h"
 
 #include "helpers.h"
 #include <JavaScriptCore/JSObjectInlines.h>
@@ -372,10 +372,10 @@ public:
                                                                 // and receives the actual count of args.
         napi_value* argv, // [out] Array of values
         napi_value* this_arg, // [out] Receives the JS 'this' arg for the call
-        void** data)
+        void** data, Zig::GlobalObject* globalObject)
     {
         if (this_arg != nullptr) {
-            *this_arg = toNapi(callframe.thisValue());
+            *this_arg = toNapi(callframe.thisValue(), globalObject);
         }
 
         if (data != nullptr) {
@@ -401,7 +401,7 @@ public:
 
             if (overflow > 0) {
                 while (overflow--) {
-                    *argv = toNapi(jsUndefined());
+                    *argv = toNapi(jsUndefined(), globalObject);
                     argv++;
                 }
             }
@@ -439,7 +439,7 @@ public:
         NAPICallFrame frame(JSC::ArgList(args), function->m_dataPtr);
 
         auto scope = DECLARE_THROW_SCOPE(vm);
-        v8::HandleScope handleScope(v8::Isolate::fromGlobalObject(static_cast<Zig::GlobalObject*>(globalObject)));
+        Bun::NapiHandleScope handleScope(jsCast<Zig::GlobalObject*>(globalObject));
 
         auto result = callback(env, NAPICallFrame::toNapiCallbackInfo(frame));
 
@@ -698,7 +698,7 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
     auto keyProp = toJS(key);
     JSC::EnsureStillAliveScope ensureAlive2(keyProp);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    *result = toNapi(target->getIfPropertyExists(globalObject, keyProp.toPropertyKey(globalObject)));
+    *result = toNapi(target->getIfPropertyExists(globalObject, keyProp.toPropertyKey(globalObject)), globalObject);
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     scope.clearException();
@@ -796,7 +796,7 @@ extern "C" napi_status napi_create_arraybuffer(napi_env env,
 {
     NAPI_PREMABLE
 
-    JSC::JSGlobalObject* globalObject = toJS(env);
+    Zig::GlobalObject* globalObject = toJS(env);
     if (UNLIKELY(!globalObject || !result)) {
         return napi_invalid_arg;
     }
@@ -819,7 +819,7 @@ extern "C" napi_status napi_create_arraybuffer(napi_env env,
     if (LIKELY(data && jsArrayBuffer->impl())) {
         *data = jsArrayBuffer->impl()->data();
     }
-    *result = toNapi(jsArrayBuffer);
+    *result = toNapi(jsArrayBuffer, globalObject);
     return napi_ok;
 }
 
@@ -883,7 +883,7 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     PROPERTY_NAME_FROM_UTF8(name);
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    *result = toNapi(target->getIfPropertyExists(globalObject, name));
+    *result = toNapi(target->getIfPropertyExists(globalObject, name), globalObject);
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     scope.clearException();
@@ -916,11 +916,11 @@ node_api_create_external_string_latin1(napi_env env,
             finalize_callback(toNapi(defaultGlobalObject()), nullptr, hint);
         }
     });
-    JSGlobalObject* globalObject = defaultGlobalObject(env);
+    Zig::GlobalObject* globalObject = toJS(env);
 
     JSString* out = JSC::jsString(globalObject->vm(), WTF::String(impl));
     ensureStillAliveHere(out);
-    *result = toNapi(out);
+    *result = toNapi(out, globalObject);
     ensureStillAliveHere(out);
 
     return napi_ok;
@@ -954,11 +954,11 @@ node_api_create_external_string_utf16(napi_env env,
             finalize_callback(toNapi(defaultGlobalObject()), nullptr, hint);
         }
     });
-    JSGlobalObject* globalObject = defaultGlobalObject(env);
+    Zig::GlobalObject* globalObject = toJS(env);
 
     JSString* out = JSC::jsString(globalObject->vm(), WTF::String(impl));
     ensureStillAliveHere(out);
-    *result = toNapi(out);
+    *result = toNapi(out, globalObject);
     ensureStillAliveHere(out);
 
     return napi_ok;
@@ -994,7 +994,7 @@ extern "C" void napi_module_register(napi_module* mod)
 
     JSC::Strong<JSC::JSObject> strongObject = { vm, object };
 
-    JSValue resultValue = toJS(mod->nm_register_func(toNapi(globalObject), toNapi(object)));
+    JSValue resultValue = toJS(mod->nm_register_func(toNapi(globalObject), toNapi(object, globalObject)));
 
     RETURN_IF_EXCEPTION(scope, void());
 
@@ -1167,7 +1167,7 @@ extern "C" napi_status napi_create_function(napi_env env, const char* utf8name,
     auto* function = NAPIFunction::create(vm, globalObject, length, name, method, data);
 
     ASSERT(function->isCallable());
-    *result = toNapi(JSC::JSValue(function));
+    *result = toNapi(JSC::JSValue(function), globalObject);
 
     return napi_ok;
 }
@@ -1184,9 +1184,10 @@ extern "C" napi_status napi_get_cb_info(
     NAPI_PREMABLE
 
     JSC::CallFrame* callFrame = reinterpret_cast<JSC::CallFrame*>(cbinfo);
+    Zig::GlobalObject* globalObject = toJS(env);
 
     if (NAPICallFrame* frame = NAPICallFrame::get(callFrame).value_or(nullptr)) {
-        NAPICallFrame::extract(*frame, argc, argv, this_arg, data);
+        NAPICallFrame::extract(*frame, argc, argv, this_arg, data, globalObject);
         return napi_ok;
     }
 
@@ -1201,14 +1202,14 @@ extern "C" napi_status napi_get_cb_info(
         memcpy(argv, callFrame->addressOfArgumentsStart(), argsToCopy * sizeof(JSC::JSValue));
 
         for (size_t i = outputArgsCount; i < inputArgsCount; i++) {
-            argv[i] = toNapi(JSC::jsUndefined());
+            argv[i] = toNapi(JSC::jsUndefined(), globalObject);
         }
     }
 
     JSC::JSValue thisValue = callFrame->thisValue();
 
     if (this_arg != nullptr) {
-        *this_arg = toNapi(thisValue);
+        *this_arg = toNapi(thisValue, globalObject);
     }
 
     if (data != nullptr) {
@@ -1453,7 +1454,7 @@ extern "C" napi_status napi_get_reference_value(napi_env env, napi_ref ref,
         return napi_invalid_arg;
     }
     NapiRef* napiRef = toJS(ref);
-    *result = toNapi(napiRef->value());
+    *result = toNapi(napiRef->value(), toJS(env));
 
     return napi_ok;
 }
@@ -1579,7 +1580,7 @@ extern "C" napi_status napi_get_and_clear_last_exception(napi_env env,
     }
 
     auto globalObject = toJS(env);
-    *result = toNapi(JSC::JSValue(globalObject->vm().lastException()));
+    *result = toNapi(JSC::JSValue(globalObject->vm().lastException()), globalObject);
     globalObject->vm().clearLastException();
     return napi_ok;
 }
@@ -1629,7 +1630,7 @@ extern "C" napi_status node_api_symbol_for(napi_env env,
     }
 
     auto description = WTF::String::fromUTF8({ utf8description, length == NAPI_AUTO_LENGTH ? strlen(utf8description) : length });
-    *result = toNapi(JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey(description)));
+    *result = toNapi(JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey(description)), globalObject);
 
     return napi_ok;
 }
@@ -1652,7 +1653,7 @@ extern "C" napi_status node_api_create_syntax_error(napi_env env,
         return napi_generic_failure;
     }
 
-    *result = toNapi(err);
+    *result = toNapi(err, toJS(env));
     return napi_ok;
 }
 
@@ -1704,7 +1705,7 @@ extern "C" napi_status napi_create_type_error(napi_env env, napi_value code,
         return napi_generic_failure;
     }
 
-    *result = toNapi(err);
+    *result = toNapi(err, toJS(env));
     return napi_ok;
 }
 
@@ -1730,7 +1731,7 @@ extern "C" napi_status napi_create_error(napi_env env, napi_value code,
         return napi_generic_failure;
     }
 
-    *result = toNapi(err);
+    *result = toNapi(err, toJS(env));
     return napi_ok;
 }
 extern "C" napi_status napi_throw_range_error(napi_env env, const char* code,
@@ -1799,7 +1800,7 @@ extern "C" napi_status napi_get_global(napi_env env, napi_value* result)
     }
 
     Zig::GlobalObject* globalObject = toJS(env);
-    *result = toNapi(globalObject->globalThis());
+    *result = toNapi(globalObject->globalThis(), globalObject);
     return napi_ok;
 }
 
@@ -1824,7 +1825,7 @@ extern "C" napi_status napi_create_range_error(napi_env env, napi_value code,
     if (UNLIKELY(!err)) {
         return napi_generic_failure;
     }
-    *result = toNapi(err);
+    *result = toNapi(err, toJS(env));
     return napi_ok;
 }
 
@@ -1843,12 +1844,12 @@ extern "C" napi_status napi_get_new_target(napi_env env,
     CallFrame* callFrame = reinterpret_cast<JSC::CallFrame*>(cbinfo);
 
     if (NAPICallFrame* frame = NAPICallFrame::get(callFrame).value_or(nullptr)) {
-        *result = toNapi(frame->newTarget);
+        *result = toNapi(frame->newTarget, toJS(env));
         return napi_ok;
     }
 
     JSC::JSValue newTarget = callFrame->newTarget();
-    *result = toNapi(newTarget);
+    *result = toNapi(newTarget, toJS(env));
     return napi_ok;
 }
 
@@ -1874,7 +1875,7 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
     }
     auto dataView = JSC::DataView::create(arraybufferPtr->impl(), byte_offset, length);
 
-    *result = toNapi(dataView->wrap(globalObject, globalObject));
+    *result = toNapi(dataView->wrap(globalObject, globalObject), globalObject);
 
     return napi_ok;
 }
@@ -2014,7 +2015,7 @@ extern "C" napi_status napi_get_all_property_names(
 
     JSC::JSArray* exportKeys = ownPropertyKeys(globalObject, object, jsc_property_mode, jsc_key_mode);
     // TODO: filter
-    *result = toNapi(JSC::JSValue(exportKeys));
+    *result = toNapi(JSC::JSValue(exportKeys), globalObject);
     return napi_ok;
 }
 
@@ -2086,7 +2087,7 @@ extern "C" napi_status napi_define_class(napi_env env,
         napiClass->dataPtr = data;
     }
 
-    *result = toNapi(value);
+    *result = toNapi(value, globalObject);
     return napi_ok;
 }
 
@@ -2108,10 +2109,10 @@ extern "C" napi_status napi_coerce_to_string(napi_env env, napi_value value,
     // .toString() can throw
     JSC::JSValue resultValue = JSC::JSValue(jsValue.toString(globalObject));
     JSC::EnsureStillAliveScope ensureStillAlive1(resultValue);
-    *result = toNapi(resultValue);
+    *result = toNapi(resultValue, globalObject);
 
     if (UNLIKELY(scope.exception())) {
-        *result = toNapi(JSC::jsUndefined());
+        *result = toNapi(JSC::jsUndefined(), globalObject);
         return napi_generic_failure;
     }
     scope.clearException();
@@ -2139,13 +2140,13 @@ extern "C" napi_status napi_get_property_names(napi_env env, napi_value object,
     JSC::EnsureStillAliveScope ensureStillAlive(jsValue);
     JSC::JSValue value = JSC::ownPropertyKeys(globalObject, jsValue.getObject(), PropertyNameMode::Strings, DontEnumPropertiesMode::Include);
     if (UNLIKELY(scope.exception())) {
-        *result = toNapi(JSC::jsUndefined());
+        *result = toNapi(JSC::jsUndefined(), globalObject);
         return napi_generic_failure;
     }
     scope.clearException();
     JSC::EnsureStillAliveScope ensureStillAlive1(value);
 
-    *result = toNapi(value);
+    *result = toNapi(value, globalObject);
 
     return napi_ok;
 }
@@ -2175,7 +2176,7 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
 
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTFMove(arrayBuffer), 0, length);
 
-    *result = toNapi(buffer);
+    *result = toNapi(buffer, globalObject);
     return napi_ok;
 }
 
@@ -2202,7 +2203,7 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
 
     auto* buffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared), WTFMove(arrayBuffer));
 
-    *result = toNapi(buffer);
+    *result = toNapi(buffer, globalObject);
 
     return napi_ok;
 }
@@ -2215,7 +2216,7 @@ extern "C" napi_status napi_create_double(napi_env env, double value,
         return napi_invalid_arg;
     }
 
-    *result = toNapi(jsDoubleNumber(value));
+    *result = toNapi(jsDoubleNumber(value), toJS(env));
     return napi_ok;
 }
 
@@ -2331,7 +2332,7 @@ extern "C" napi_status napi_get_element(napi_env env, napi_value objectValue,
     JSValue element = object->getIndex(toJS(env), index);
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
-    *result = toNapi(element);
+    *result = toNapi(element, toJS(env));
 
     return napi_ok;
 }
@@ -2370,7 +2371,7 @@ extern "C" napi_status napi_create_object(napi_env env, napi_value* result)
 
     JSValue value = JSValue(NapiPrototype::create(vm, globalObject->NapiPrototypeStructure()));
 
-    *result = toNapi(value);
+    *result = toNapi(value, globalObject);
     JSC::EnsureStillAliveScope ensureStillAlive(value);
 
     return napi_ok;
@@ -2391,7 +2392,7 @@ extern "C" napi_status napi_create_external(napi_env env, void* data,
     auto* structure = globalObject->NapiExternalStructure();
     JSValue value = Bun::NapiExternal::create(vm, structure, data, finalize_hint, reinterpret_cast<void*>(finalize_cb));
     JSC::EnsureStillAliveScope ensureStillAlive(value);
-    *result = toNapi(value);
+    *result = toNapi(value, globalObject);
     return napi_ok;
 }
 
@@ -2566,7 +2567,7 @@ extern "C" napi_status napi_run_script(napi_env env, napi_value script,
 {
     NAPI_PREMABLE
 
-    JSC::JSGlobalObject* globalObject = toJS(env);
+    Zig::GlobalObject* globalObject = toJS(env);
     if (UNLIKELY(result == nullptr)) {
         return napi_invalid_arg;
     }
@@ -2594,7 +2595,7 @@ extern "C" napi_status napi_run_script(napi_env env, napi_value script,
     }
 
     if (result != nullptr) {
-        *result = toNapi(value);
+        *result = toNapi(value, globalObject);
     }
 
     RELEASE_AND_RETURN(throwScope, napi_ok);
@@ -2647,7 +2648,7 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
         }
     }
 
-    *result = toNapi(bigint);
+    *result = toNapi(bigint, globalObject);
     return napi_ok;
 }
 
@@ -2675,12 +2676,13 @@ extern "C" napi_status napi_create_symbol(napi_env env, napi_value description,
         }
 
         if (descriptionString->length() > 0) {
-            *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString->value(globalObject)));
+            *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString->value(globalObject)),
+                globalObject);
             return napi_ok;
         }
     }
 
-    *result = toNapi(JSC::Symbol::create(vm));
+    *result = toNapi(JSC::Symbol::create(vm), globalObject);
     return napi_ok;
 }
 
@@ -2716,7 +2718,7 @@ extern "C" napi_status napi_new_instance(napi_env env, napi_value constructor,
 
     auto value = construct(globalObject, constructorObject, constructData, args);
     RETURN_IF_EXCEPTION(throwScope, napi_pending_exception);
-    *result = toNapi(value);
+    *result = toNapi(value, globalObject);
 
     RELEASE_AND_RETURN(throwScope, napi_ok);
 }
@@ -2756,9 +2758,9 @@ extern "C" napi_status napi_call_function(napi_env env, napi_value recv_napi,
 
     if (result_ptr) {
         if (result.isEmpty()) {
-            *result_ptr = toNapi(JSC::jsUndefined());
+            *result_ptr = toNapi(JSC::jsUndefined(), globalObject);
         } else {
-            *result_ptr = toNapi(result);
+            *result_ptr = toNapi(result, globalObject);
         }
     }
 

--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -38,14 +38,9 @@ static inline Zig::GlobalObject* toJS(napi_env val)
     return reinterpret_cast<Zig::GlobalObject*>(val);
 }
 
-static inline napi_value toNapi(JSC::EncodedJSValue val)
-{
-    return reinterpret_cast<napi_value>(val);
-}
-
 static inline napi_value toNapi(JSC::JSValue val)
 {
-    return toNapi(JSC::JSValue::encode(val));
+    return reinterpret_cast<napi_value>(JSC::JSValue::encode(val));
 }
 
 static inline napi_env toNapi(JSC::JSGlobalObject* val)
@@ -60,7 +55,6 @@ public:
 
     void call(JSC::JSGlobalObject* globalObject, void* data);
 };
-
 
 // This is essentially JSC::JSWeakValue, except with a JSCell* instead of a
 // JSObject*. Sometimes, a napi embedder might want to store a JSC::Exception, a

--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -1,9 +1,5 @@
 #pragma once
 
-namespace Zig {
-class GlobalObject;
-}
-
 #include "root.h"
 #include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/VM.h>
@@ -14,6 +10,8 @@ class GlobalObject;
 #include "js_native_api_types.h"
 #include <JavaScriptCore/JSWeakValue.h>
 #include "JSFFIFunction.h"
+#include "ZigGlobalObject.h"
+#include "napi_handle_scope.h"
 
 namespace JSC {
 class JSGlobalObject;
@@ -38,8 +36,11 @@ static inline Zig::GlobalObject* toJS(napi_env val)
     return reinterpret_cast<Zig::GlobalObject*>(val);
 }
 
-static inline napi_value toNapi(JSC::JSValue val)
+static inline napi_value toNapi(JSC::JSValue val, Zig::GlobalObject* globalObject)
 {
+    if (val.isCell()) {
+        globalObject->m_currentNapiHandleScopeImpl.get()->append(val);
+    }
     return reinterpret_cast<napi_value>(JSC::JSValue::encode(val));
 }
 

--- a/src/bun.js/bindings/napi_handle_scope.cpp
+++ b/src/bun.js/bindings/napi_handle_scope.cpp
@@ -48,6 +48,10 @@ void NapiHandleScopeImpl::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     for (auto& handle : thisObject->m_storage) {
         visitor.append(handle);
     }
+
+    if (thisObject->m_parent) {
+        visitor.appendUnbarriered(thisObject->m_parent);
+    }
 }
 
 DEFINE_VISIT_CHILDREN(NapiHandleScopeImpl);

--- a/src/bun.js/bindings/napi_handle_scope.cpp
+++ b/src/bun.js/bindings/napi_handle_scope.cpp
@@ -1,0 +1,44 @@
+#include "napi_handle_scope.h"
+
+namespace Bun {
+
+// for CREATE_METHOD_TABLE
+namespace JSCastingHelpers = JSC::JSCastingHelpers;
+
+const JSC::ClassInfo NapiHandleScope::s_info = {
+    "NapiHandleScope"_s,
+    nullptr,
+    nullptr,
+    nullptr,
+    CREATE_METHOD_TABLE(NapiHandleScope)
+};
+
+NapiHandleScope* NapiHandleScope::create(JSC::VM& vm, JSC::Structure* structure, NapiHandleScope* parent)
+{
+    NapiHandleScope* buffer = new (NotNull, JSC::allocateCell<NapiHandleScope>(vm)) NapiHandleScope(vm, structure, parent);
+    buffer->finishCreation(vm);
+    return buffer;
+}
+
+template<typename Visitor>
+void NapiHandleScope::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    NapiHandleScope* thisObject = jsCast<NapiHandleScope*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+
+    WTF::Locker locker { thisObject->cellLock() };
+
+    for (auto& handle : thisObject->m_storage) {
+        visitor.append(handle);
+    }
+}
+
+DEFINE_VISIT_CHILDREN(NapiHandleScope);
+
+void NapiHandleScope::append(JSC::JSValue val)
+{
+    m_storage.append(JSC::WriteBarrier<JSC::Unknown>(vm(), this, val));
+}
+
+} // namespace Bun

--- a/src/bun.js/bindings/napi_handle_scope.h
+++ b/src/bun.js/bindings/napi_handle_scope.h
@@ -55,9 +55,16 @@ public:
     NapiHandleScope(Zig::GlobalObject* globalObject);
     ~NapiHandleScope();
 
+    static NapiHandleScopeImpl* push(Zig::GlobalObject* globalObject);
+    static void pop(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
+
 private:
     NapiHandleScopeImpl* m_impl;
     Zig::GlobalObject* m_globalObject;
 };
+
+extern "C" NapiHandleScopeImpl* NapiHandleScope__push(Zig::GlobalObject* globalObject);
+extern "C" void NapiHandleScope__pop(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
+extern "C" void NapiHandleScope__append(Zig::GlobalObject* globalObject, JSC::EncodedJSValue value);
 
 } // namespace Bun

--- a/src/bun.js/bindings/napi_handle_scope.h
+++ b/src/bun.js/bindings/napi_handle_scope.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "BunClientData.h"
+#include "root.h"
+
+namespace Bun {
+
+// An array of write barriers (so that newly-added objects are not lost by GC) to JSValues. Unlike
+// the V8 version, pointer stability is not required (because napi_values don't point into this
+// structure) so we can use a regular WTF::Vector
+class NapiHandleScope : public JSC::JSCell {
+public:
+    using Base = JSC::JSCell;
+
+    static NapiHandleScope* create(JSC::VM& vm, JSC::Structure* structure, NapiHandleScope* parent);
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        return JSC::Structure::create(vm, globalObject, JSC::jsNull(), JSC::TypeInfo(JSC::CellType, StructureFlags), info(), 0, 0);
+    }
+
+    template<typename, JSC::SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<NapiHandleScope, WebCore::UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForHandleScopeBuffer.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForHandleScopeBuffer = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForHandleScopeBuffer.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForHandleScopeBuffer = std::forward<decltype(space)>(space); });
+    }
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    void append(JSC::JSValue val);
+    NapiHandleScope* parent() const { return m_parent; }
+
+private:
+    NapiHandleScope* m_parent;
+    WTF::Vector<JSC::WriteBarrier<JSC::Unknown>, 16> m_storage;
+
+    NapiHandleScope(JSC::VM& vm, JSC::Structure* structure, NapiHandleScope* parent)
+        : Base(vm, structure)
+        , m_parent(parent)
+    {
+    }
+};
+
+} // namespace Bun

--- a/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
@@ -49,6 +49,7 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSNextTickQueue;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNAPIFunction;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForTTYWrapObject;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNapiHandleScopeImpl;
 #include "ZigGeneratedClasses+DOMClientIsoSubspaces.h"
     /* --- bun --- */
 

--- a/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
@@ -49,6 +49,7 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForJSNextTickQueue;
     std::unique_ptr<IsoSubspace> m_subspaceForNAPIFunction;
     std::unique_ptr<IsoSubspace> m_subspaceForTTYWrapObject;
+    std::unique_ptr<IsoSubspace> m_subspaceForNapiHandleScopeImpl;
 
 #include "ZigGeneratedClasses+DOMIsoSubspaces.h"
     /*-- BUN --*/

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1194,6 +1194,8 @@ pub const napi_async_work = struct {
     }
 
     pub fn runFromJS(this: *napi_async_work) void {
+        const handle_scope = NapiHandleScope.push(this.global, false);
+        defer handle_scope.pop(this.global);
         this.complete.?(
             this.global,
             if (this.status.load(.seq_cst) == @intFromEnum(Status.cancelled))

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -64,12 +64,54 @@ pub const Ref = opaque {
     extern fn napi_delete_reference_internal(ref: *Ref) void;
     extern fn napi_set_ref(ref: *Ref, value: JSC.JSValue) void;
 };
-pub const napi_handle_scope = napi_env;
-pub const napi_escapable_handle_scope = napi_env;
+pub const NapiHandleScope = opaque {
+    extern fn NapiHandleScope__push(globalObject: *JSC.JSGlobalObject) *NapiHandleScope;
+    extern fn NapiHandleScope__pop(globalObject: *JSC.JSGlobalObject, current: *NapiHandleScope) void;
+    extern fn NapiHandleScope__append(globalObject: *JSC.JSGlobalObject, value: JSC.JSValueReprInt) void;
+
+    pub fn push(env: napi_env) *NapiHandleScope {
+        return NapiHandleScope__push(env);
+    }
+
+    pub fn pop(self: *NapiHandleScope, env: napi_env) void {
+        NapiHandleScope__pop(env, self);
+    }
+
+    pub fn append(env: napi_env, value: JSC.JSValue) void {
+        NapiHandleScope__append(env, @intFromEnum(value));
+    }
+};
+
+pub const napi_handle_scope = *NapiHandleScope;
+
+pub const napi_escapable_handle_scope = *struct_napi_escapable_handle_scope__;
 pub const napi_callback_info = *JSC.CallFrame;
 pub const napi_deferred = *JSC.JSPromise.Strong;
 
-pub const napi_value = JSC.JSValue;
+/// To ensure napi_values are not collected prematurely after being returned into a native module,
+/// you must use these functions rather than convert between napi_value and JSC.JSValue directly
+pub const napi_value = enum(JSC.JSValueReprInt) {
+    _,
+
+    pub fn set(
+        self: *napi_value,
+        env: napi_env,
+        val: JSC.JSValue,
+    ) void {
+        NapiHandleScope.append(env, val);
+        self.* = @enumFromInt(@intFromEnum(val));
+    }
+
+    pub fn get(self: *const napi_value) JSC.JSValue {
+        return @enumFromInt(@intFromEnum(self.*));
+    }
+
+    pub fn create(env: napi_env, val: JSC.JSValue) napi_value {
+        NapiHandleScope.append(env, val);
+        return @enumFromInt(@intFromEnum(val));
+    }
+};
+
 pub const struct_napi_escapable_handle_scope__ = opaque {};
 
 const char16_t = u16;
@@ -205,29 +247,29 @@ pub const napi_type_tag = extern struct {
     upper: u64,
 };
 pub extern fn napi_get_last_error_info(env: napi_env, result: [*c][*c]const napi_extended_error_info) napi_status;
-pub export fn napi_get_undefined(_: napi_env, result_: ?*napi_value) napi_status {
+pub export fn napi_get_undefined(env: napi_env, result_: ?*napi_value) napi_status {
     log("napi_get_undefined", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsUndefined();
+    result.set(env, JSValue.jsUndefined());
     return .ok;
 }
-pub export fn napi_get_null(_: napi_env, result_: ?*napi_value) napi_status {
+pub export fn napi_get_null(env: napi_env, result_: ?*napi_value) napi_status {
     log("napi_get_null", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsNull();
+    result.set(env, JSValue.jsNull());
     return .ok;
 }
 pub extern fn napi_get_global(env: napi_env, result: *napi_value) napi_status;
-pub export fn napi_get_boolean(_: napi_env, value: bool, result_: ?*napi_value) napi_status {
+pub export fn napi_get_boolean(env: napi_env, value: bool, result_: ?*napi_value) napi_status {
     log("napi_get_boolean", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsBoolean(value);
+    result.set(env, JSValue.jsBoolean(value));
     return .ok;
 }
 pub export fn napi_create_array(env: napi_env, result_: ?*napi_value) napi_status {
@@ -235,7 +277,7 @@ pub export fn napi_create_array(env: napi_env, result_: ?*napi_value) napi_statu
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.createEmptyArray(env, 0);
+    result.set(env, JSValue.createEmptyArray(env, 0));
     return .ok;
 }
 const prefilled_undefined_args_array: [128]JSC.JSValue = brk: {
@@ -262,37 +304,33 @@ pub export fn napi_create_array_with_length(env: napi_env, length: usize, result
     }
 
     array.ensureStillAlive();
-    result.* = array;
+    result.set(env, array);
     return .ok;
 }
 pub extern fn napi_create_double(_: napi_env, value: f64, result: *napi_value) napi_status;
-pub export fn napi_create_int32(_: napi_env, value: i32, result_: ?*napi_value) napi_status {
+pub export fn napi_create_int32(env: napi_env, value: i32, result_: ?*napi_value) napi_status {
     log("napi_create_int32", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsNumber(value);
+    result.set(env, JSValue.jsNumber(value));
     return .ok;
 }
-pub export fn napi_create_uint32(_: napi_env, value: u32, result_: ?*napi_value) napi_status {
+pub export fn napi_create_uint32(env: napi_env, value: u32, result_: ?*napi_value) napi_status {
     log("napi_create_uint32", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsNumber(value);
+    result.set(env, JSValue.jsNumber(value));
     return .ok;
 }
-pub export fn napi_create_int64(_: napi_env, value: i64, result_: ?*napi_value) napi_status {
+pub export fn napi_create_int64(env: napi_env, value: i64, result_: ?*napi_value) napi_status {
     log("napi_create_int64", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsNumber(value);
+    result.set(env, JSValue.jsNumber(value));
     return .ok;
-}
-inline fn setNapiValue(result: *napi_value, value: JSValue) void {
-    value.ensureStillAlive();
-    result.* = value;
 }
 pub export fn napi_create_string_latin1(env: napi_env, str: ?[*]const u8, length: usize, result_: ?*napi_value) napi_status {
     const result: *napi_value = result_ orelse {
@@ -315,7 +353,7 @@ pub export fn napi_create_string_latin1(env: napi_env, str: ?[*]const u8, length
     log("napi_create_string_latin1: {s}", .{slice});
 
     if (slice.len == 0) {
-        setNapiValue(result, bun.String.empty.toJS(env));
+        result.set(env, bun.String.empty.toJS(env));
         return .ok;
     }
 
@@ -324,7 +362,7 @@ pub export fn napi_create_string_latin1(env: napi_env, str: ?[*]const u8, length
 
     @memcpy(bytes, slice);
 
-    setNapiValue(result, string.toJS(env));
+    result.set(env, string.toJS(env));
     return .ok;
 }
 pub export fn napi_create_string_utf8(env: napi_env, str: ?[*]const u8, length: usize, result_: ?*napi_value) napi_status {
@@ -352,7 +390,7 @@ pub export fn napi_create_string_utf8(env: napi_env, str: ?[*]const u8, length: 
     }
 
     defer string.deref();
-    setNapiValue(result, string.toJS(env));
+    result.set(env, string.toJS(env));
     return .ok;
 }
 pub export fn napi_create_string_utf16(env: napi_env, str: ?[*]const char16_t, length: usize, result_: ?*napi_value) napi_status {
@@ -377,7 +415,7 @@ pub export fn napi_create_string_utf16(env: napi_env, str: ?[*]const char16_t, l
         log("napi_create_string_utf16: {d} {any}", .{ slice.len, bun.fmt.FormatUTF16{ .buf = slice[0..@min(slice.len, 512)] } });
 
     if (slice.len == 0) {
-        setNapiValue(result, bun.String.empty.toJS(env));
+        result.set(env, bun.String.empty.toJS(env));
     }
 
     var string, const chars = bun.String.createUninitialized(.utf16, slice.len);
@@ -385,7 +423,7 @@ pub export fn napi_create_string_utf16(env: napi_env, str: ?[*]const char16_t, l
 
     @memcpy(chars, slice);
 
-    setNapiValue(result, string.toJS(env));
+    result.set(env, string.toJS(env));
     return .ok;
 }
 pub extern fn napi_create_symbol(env: napi_env, description: napi_value, result: *napi_value) napi_status;
@@ -394,44 +432,48 @@ pub extern fn napi_create_type_error(env: napi_env, code: napi_value, msg: napi_
 pub extern fn napi_create_range_error(env: napi_env, code: napi_value, msg: napi_value, result: *napi_value) napi_status;
 pub extern fn napi_typeof(env: napi_env, value: napi_value, result: *napi_valuetype) napi_status;
 pub extern fn napi_get_value_double(env: napi_env, value: napi_value, result: *f64) napi_status;
-pub export fn napi_get_value_int32(_: napi_env, value: napi_value, result_: ?*i32) napi_status {
+pub export fn napi_get_value_int32(_: napi_env, value_: napi_value, result_: ?*i32) napi_status {
     log("napi_get_value_int32", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     if (!value.isNumber()) {
         return .number_expected;
     }
     result.* = value.to(i32);
     return .ok;
 }
-pub export fn napi_get_value_uint32(_: napi_env, value: napi_value, result_: ?*u32) napi_status {
+pub export fn napi_get_value_uint32(_: napi_env, value_: napi_value, result_: ?*u32) napi_status {
     log("napi_get_value_uint32", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     if (!value.isNumber()) {
         return .number_expected;
     }
     result.* = value.to(u32);
     return .ok;
 }
-pub export fn napi_get_value_int64(_: napi_env, value: napi_value, result_: ?*i64) napi_status {
+pub export fn napi_get_value_int64(_: napi_env, value_: napi_value, result_: ?*i64) napi_status {
     log("napi_get_value_int64", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     if (!value.isNumber()) {
         return .number_expected;
     }
     result.* = value.to(i64);
     return .ok;
 }
-pub export fn napi_get_value_bool(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_get_value_bool(_: napi_env, value_: napi_value, result_: ?*bool) napi_status {
     log("napi_get_value_bool", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
 
     result.* = value.to(bool);
     return .ok;
@@ -441,8 +483,9 @@ inline fn maybeAppendNull(ptr: anytype, doit: bool) void {
         ptr.* = 0;
     }
 }
-pub export fn napi_get_value_string_latin1(env: napi_env, value: napi_value, buf_ptr_: ?[*:0]c_char, bufsize: usize, result_ptr: ?*usize) napi_status {
+pub export fn napi_get_value_string_latin1(env: napi_env, value_: napi_value, buf_ptr_: ?[*:0]c_char, bufsize: usize, result_ptr: ?*usize) napi_status {
     log("napi_get_value_string_latin1", .{});
+    const value = value_.get();
     defer value.ensureStillAlive();
     const buf_ptr = @as(?[*:0]u8, @ptrCast(buf_ptr_));
 
@@ -498,8 +541,9 @@ pub export fn napi_get_value_string_latin1(env: napi_env, value: napi_value, buf
 /// via the result parameter.
 /// The result argument is optional unless buf is NULL.
 pub extern fn napi_get_value_string_utf8(env: napi_env, value: napi_value, buf_ptr: [*c]u8, bufsize: usize, result_ptr: ?*usize) napi_status;
-pub export fn napi_get_value_string_utf16(env: napi_env, value: napi_value, buf_ptr: ?[*]char16_t, bufsize: usize, result_ptr: ?*usize) napi_status {
+pub export fn napi_get_value_string_utf16(env: napi_env, value_: napi_value, buf_ptr: ?[*]char16_t, bufsize: usize, result_ptr: ?*usize) napi_status {
     log("napi_get_value_string_utf16", .{});
+    const value = value_.get();
     defer value.ensureStillAlive();
     const str = value.toBunString(env);
     defer str.deref();
@@ -546,40 +590,44 @@ pub export fn napi_get_value_string_utf16(env: napi_env, value: napi_value, buf_
 
     return .ok;
 }
-pub export fn napi_coerce_to_bool(env: napi_env, value: napi_value, result_: ?*napi_value) napi_status {
+pub export fn napi_coerce_to_bool(env: napi_env, value_: napi_value, result_: ?*napi_value) napi_status {
     log("napi_coerce_to_bool", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.jsBoolean(value.coerce(bool, env));
+    const value = value_.get();
+    result.set(env, JSValue.jsBoolean(value.coerce(bool, env)));
     return .ok;
 }
-pub export fn napi_coerce_to_number(env: napi_env, value: napi_value, result_: ?*napi_value) napi_status {
+pub export fn napi_coerce_to_number(env: napi_env, value_: napi_value, result_: ?*napi_value) napi_status {
     log("napi_coerce_to_number", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSC.JSValue.jsNumber(JSC.C.JSValueToNumber(env.ref(), value.asObjectRef(), TODO_EXCEPTION));
+    const value = value_.get();
+    result.set(env, JSC.JSValue.jsNumber(JSC.C.JSValueToNumber(env.ref(), value.asObjectRef(), TODO_EXCEPTION)));
     return .ok;
 }
-pub export fn napi_coerce_to_object(env: napi_env, value: napi_value, result_: ?*napi_value) napi_status {
+pub export fn napi_coerce_to_object(env: napi_env, value_: napi_value, result_: ?*napi_value) napi_status {
     log("napi_coerce_to_object", .{});
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.c(JSC.C.JSValueToObject(env.ref(), value.asObjectRef(), TODO_EXCEPTION));
+    const value = value_.get();
+    result.set(env, JSValue.c(JSC.C.JSValueToObject(env.ref(), value.asObjectRef(), TODO_EXCEPTION)));
     return .ok;
 }
-pub export fn napi_get_prototype(env: napi_env, object: napi_value, result_: ?*napi_value) napi_status {
+pub export fn napi_get_prototype(env: napi_env, object_: napi_value, result_: ?*napi_value) napi_status {
     log("napi_get_prototype", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const object = object_.get();
     if (!object.isObject()) {
         return .object_expected;
     }
 
-    result.* = JSValue.c(JSC.C.JSObjectGetPrototype(env.ref(), object.asObjectRef()));
+    result.set(env, JSValue.c(JSC.C.JSObjectGetPrototype(env.ref(), object.asObjectRef())));
     return .ok;
 }
 // TODO: bind JSC::ownKeys
@@ -591,8 +639,10 @@ pub export fn napi_get_prototype(env: napi_env, object: napi_value, result_: ?*n
 
 //     result.* =
 // }
-pub export fn napi_set_element(env: napi_env, object: napi_value, index: c_uint, value: napi_value) napi_status {
+pub export fn napi_set_element(env: napi_env, object_: napi_value, index: c_uint, value_: napi_value) napi_status {
     log("napi_set_element", .{});
+    const object = object_.get();
+    const value = value_.get();
     if (!object.jsType().isIndexable()) {
         return .array_expected;
     }
@@ -601,11 +651,12 @@ pub export fn napi_set_element(env: napi_env, object: napi_value, index: c_uint,
     JSC.C.JSObjectSetPropertyAtIndex(env.ref(), object.asObjectRef(), index, value.asObjectRef(), TODO_EXCEPTION);
     return .ok;
 }
-pub export fn napi_has_element(env: napi_env, object: napi_value, index: c_uint, result_: ?*bool) napi_status {
+pub export fn napi_has_element(env: napi_env, object_: napi_value, index: c_uint, result_: ?*bool) napi_status {
     log("napi_has_element", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const object = object_.get();
 
     if (!object.jsType().isIndexable()) {
         return .array_expected;
@@ -617,19 +668,21 @@ pub export fn napi_has_element(env: napi_env, object: napi_value, index: c_uint,
 pub extern fn napi_get_element(env: napi_env, object: napi_value, index: u32, result: *napi_value) napi_status;
 pub extern fn napi_delete_element(env: napi_env, object: napi_value, index: u32, result: *napi_value) napi_status;
 pub extern fn napi_define_properties(env: napi_env, object: napi_value, property_count: usize, properties: [*c]const napi_property_descriptor) napi_status;
-pub export fn napi_is_array(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_is_array(_: napi_env, value_: napi_value, result_: ?*bool) napi_status {
     log("napi_is_array", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     result.* = value.jsType().isArray();
     return .ok;
 }
-pub export fn napi_get_array_length(env: napi_env, value: napi_value, result_: [*c]u32) napi_status {
+pub export fn napi_get_array_length(env: napi_env, value_: napi_value, result_: [*c]u32) napi_status {
     log("napi_get_array_length", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
 
     if (!value.jsType().isArray()) {
         return .array_expected;
@@ -638,22 +691,24 @@ pub export fn napi_get_array_length(env: napi_env, value: napi_value, result_: [
     result.* = @as(u32, @truncate(value.getLength(env)));
     return .ok;
 }
-pub export fn napi_strict_equals(env: napi_env, lhs: napi_value, rhs: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_strict_equals(env: napi_env, lhs_: napi_value, rhs_: napi_value, result_: ?*bool) napi_status {
     log("napi_strict_equals", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const lhs, const rhs = .{ lhs_.get(), rhs_.get() };
     // there is some nuance with NaN here i'm not sure about
     result.* = lhs.isSameValue(rhs, env);
     return .ok;
 }
 pub extern fn napi_call_function(env: napi_env, recv: napi_value, func: napi_value, argc: usize, argv: [*c]const napi_value, result: *napi_value) napi_status;
 pub extern fn napi_new_instance(env: napi_env, constructor: napi_value, argc: usize, argv: [*c]const napi_value, result_: ?*napi_value) napi_status;
-pub export fn napi_instanceof(env: napi_env, object: napi_value, constructor: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_instanceof(env: napi_env, object_: napi_value, constructor_: napi_value, result_: ?*bool) napi_status {
     log("napi_instanceof", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const object, const constructor = .{ object_.get(), constructor_.get() };
     // TODO: does this throw object_expected in node?
     result.* = object.isObject() and object.isInstanceOf(env, constructor);
     return .ok;
@@ -683,18 +738,17 @@ pub extern fn napi_reference_unref(env: napi_env, ref: *Ref, result: [*c]u32) na
 pub extern fn napi_get_reference_value(env: napi_env, ref: *Ref, result: *napi_value) napi_status;
 pub extern fn napi_get_reference_value_internal(ref: *Ref) JSC.JSValue;
 
-// JSC scans the stack
-// we don't need this
 pub export fn napi_open_handle_scope(env: napi_env, result_: ?*napi_handle_scope) napi_status {
+    _ = env; // autofix
+    _ = result_; // autofix
     log("napi_open_handle_scope", .{});
-    const result = result_ orelse {
-        return invalidArg();
-    };
-    result.* = env;
+    // const result = result_ orelse {
+    //     return invalidArg();
+    // };
+    // result.* = env;
     return .ok;
 }
-// JSC scans the stack
-// we don't need this
+
 pub export fn napi_close_handle_scope(_: napi_env, _: napi_handle_scope) napi_status {
     log("napi_close_handle_scope", .{});
     return .ok;
@@ -714,8 +768,9 @@ pub export fn napi_async_destroy(_: napi_env, _: *anyopaque) napi_status {
 }
 
 // this is just a regular function call
-pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value, func: napi_value, arg_count: usize, args: ?[*]const napi_value, result: ?*napi_value) napi_status {
+pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv_: napi_value, func_: napi_value, arg_count: usize, args: ?[*]const napi_value, maybe_result: ?*napi_value) napi_status {
     log("napi_make_callback", .{});
+    const recv, const func = .{ recv_.get(), func_.get() };
     if (func.isEmptyOrUndefinedOrNull() or !func.isCallable(env.vm())) {
         return .function_expected;
     }
@@ -732,8 +787,8 @@ pub export fn napi_make_callback(env: napi_env, _: *anyopaque, recv: napi_value,
             &.{},
     );
 
-    if (result) |result_| {
-        result_.* = res;
+    if (maybe_result) |result| {
+        result.set(env, res);
     }
 
     // TODO: this is likely incorrect
@@ -761,13 +816,14 @@ fn notImplementedYet(comptime name: []const u8) void {
     );
 }
 
-// JSC stack scanning will handle this
 pub export fn napi_open_escapable_handle_scope(env: napi_env, handle_: ?*napi_escapable_handle_scope) napi_status {
+    _ = env; // autofix
     log("napi_open_escapable_handle_scope", .{});
     const handle = handle_ orelse {
         return invalidArg();
     };
-    handle.* = env;
+    _ = handle; // autofix
+    // handle.* = env;
     return .ok;
 }
 pub export fn napi_close_escapable_handle_scope(_: napi_env, _: napi_escapable_handle_scope) napi_status {
@@ -779,7 +835,7 @@ pub export fn napi_escape_handle(_: napi_env, _: napi_escapable_handle_scope, va
     const result = result_ orelse {
         return invalidArg();
     };
-    value.ensureStillAlive();
+    // value.ensureStillAlive();
     result.* = value;
     return .ok;
 }
@@ -807,18 +863,20 @@ pub extern fn napi_throw(env: napi_env, @"error": napi_value) napi_status;
 pub extern fn napi_throw_error(env: napi_env, code: [*c]const u8, msg: [*c]const u8) napi_status;
 pub extern fn napi_throw_type_error(env: napi_env, code: [*c]const u8, msg: [*c]const u8) napi_status;
 pub extern fn napi_throw_range_error(env: napi_env, code: [*c]const u8, msg: [*c]const u8) napi_status;
-pub export fn napi_is_error(_: napi_env, value: napi_value, result: *bool) napi_status {
+pub export fn napi_is_error(_: napi_env, value_: napi_value, result: *bool) napi_status {
     log("napi_is_error", .{});
+    const value = value_.get();
     result.* = value.isAnyError();
     return .ok;
 }
 pub extern fn napi_is_exception_pending(env: napi_env, result: *bool) napi_status;
 pub extern fn napi_get_and_clear_last_exception(env: napi_env, result: *napi_value) napi_status;
-pub export fn napi_is_arraybuffer(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_is_arraybuffer(_: napi_env, value_: napi_value, result_: ?*bool) napi_status {
     log("napi_is_arraybuffer", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     result.* = !value.isNumber() and value.jsTypeLoose() == .ArrayBuffer;
     return .ok;
 }
@@ -826,8 +884,9 @@ pub extern fn napi_create_arraybuffer(env: napi_env, byte_length: usize, data: [
 
 pub extern fn napi_create_external_arraybuffer(env: napi_env, external_data: ?*anyopaque, byte_length: usize, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
 
-pub export fn napi_get_arraybuffer_info(env: napi_env, arraybuffer: napi_value, data: ?*[*]u8, byte_length: ?*usize) napi_status {
+pub export fn napi_get_arraybuffer_info(env: napi_env, arraybuffer_: napi_value, data: ?*[*]u8, byte_length: ?*usize) napi_status {
     log("napi_get_arraybuffer_info", .{});
+    const arraybuffer = arraybuffer_.get();
     const array_buffer = arraybuffer.asArrayBuffer(env) orelse return .arraybuffer_expected;
     const slice = array_buffer.slice();
     if (data) |dat|
@@ -836,18 +895,20 @@ pub export fn napi_get_arraybuffer_info(env: napi_env, arraybuffer: napi_value, 
         len.* = slice.len;
     return .ok;
 }
-pub export fn napi_is_typedarray(_: napi_env, value: napi_value, result: ?*bool) napi_status {
+pub export fn napi_is_typedarray(_: napi_env, value_: napi_value, result: ?*bool) napi_status {
     log("napi_is_typedarray", .{});
+    const value = value_.get();
     if (result != null)
         result.?.* = value.jsTypeLoose().isTypedArray();
     return if (result != null) .ok else invalidArg();
 }
-pub export fn napi_create_typedarray(env: napi_env, @"type": napi_typedarray_type, length: usize, arraybuffer: napi_value, byte_offset: usize, result_: ?*napi_value) napi_status {
+pub export fn napi_create_typedarray(env: napi_env, @"type": napi_typedarray_type, length: usize, arraybuffer_: napi_value, byte_offset: usize, result_: ?*napi_value) napi_status {
     log("napi_create_typedarray", .{});
+    const arraybuffer = arraybuffer_.get();
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSValue.c(
+    result.set(env, JSValue.c(
         JSC.C.JSObjectMakeTypedArrayWithArrayBufferAndOffset(
             env.ref(),
             @"type".toC(),
@@ -856,64 +917,74 @@ pub export fn napi_create_typedarray(env: napi_env, @"type": napi_typedarray_typ
             length,
             TODO_EXCEPTION,
         ),
-    );
+    ));
     return .ok;
 }
 pub export fn napi_get_typedarray_info(
     env: napi_env,
-    typedarray: napi_value,
-    @"type": ?*napi_typedarray_type,
-    length: ?*usize,
-    data: ?*[*]u8,
-    arraybuffer: ?*napi_value,
-    byte_offset: ?*usize,
+    typedarray_: napi_value,
+    maybe_type: ?*napi_typedarray_type,
+    maybe_length: ?*usize,
+    maybe_data: ?*[*]u8,
+    maybe_arraybuffer: ?*napi_value,
+    maybe_byte_offset: ?*usize,
 ) napi_status {
     log("napi_get_typedarray_info", .{});
+    const typedarray = typedarray_.get();
     if (typedarray.isEmptyOrUndefinedOrNull())
         return invalidArg();
     defer typedarray.ensureStillAlive();
 
     const array_buffer = typedarray.asArrayBuffer(env) orelse return invalidArg();
-    if (@"type" != null)
-        @"type".?.* = napi_typedarray_type.fromJSType(array_buffer.typed_array_type) orelse return invalidArg();
+    if (maybe_type) |@"type"|
+        @"type".* = napi_typedarray_type.fromJSType(array_buffer.typed_array_type) orelse return invalidArg();
 
     // TODO: handle detached
-    if (data != null)
-        data.?.* = array_buffer.ptr;
+    if (maybe_data) |data|
+        data.* = array_buffer.ptr;
 
-    if (length != null)
-        length.?.* = array_buffer.len;
+    if (maybe_length) |length|
+        length.* = array_buffer.len;
 
-    if (arraybuffer != null)
-        arraybuffer.?.* = JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), typedarray.asObjectRef(), null));
+    if (maybe_arraybuffer) |arraybuffer|
+        arraybuffer.set(env, JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), typedarray.asObjectRef(), null)));
 
-    if (byte_offset != null)
-        byte_offset.?.* = array_buffer.offset;
+    if (maybe_byte_offset) |byte_offset|
+        byte_offset.* = array_buffer.offset;
     return .ok;
 }
 pub extern fn napi_create_dataview(env: napi_env, length: usize, arraybuffer: napi_value, byte_offset: usize, result: *napi_value) napi_status;
-pub export fn napi_is_dataview(_: napi_env, value: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_is_dataview(_: napi_env, value_: napi_value, result_: ?*bool) napi_status {
     log("napi_is_dataview", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     result.* = !value.isEmptyOrUndefinedOrNull() and value.jsTypeLoose() == .DataView;
     return .ok;
 }
-pub export fn napi_get_dataview_info(env: napi_env, dataview: napi_value, bytelength: ?*usize, data: ?*[*]u8, arraybuffer: ?*napi_value, byte_offset: ?*usize) napi_status {
+pub export fn napi_get_dataview_info(
+    env: napi_env,
+    dataview_: napi_value,
+    maybe_bytelength: ?*usize,
+    maybe_data: ?*[*]u8,
+    maybe_arraybuffer: ?*napi_value,
+    maybe_byte_offset: ?*usize,
+) napi_status {
     log("napi_get_dataview_info", .{});
+    const dataview = dataview_.get();
     const array_buffer = dataview.asArrayBuffer(env) orelse return .object_expected;
-    if (bytelength != null)
-        bytelength.?.* = array_buffer.byte_len;
+    if (maybe_bytelength) |bytelength|
+        bytelength.* = array_buffer.byte_len;
 
-    if (data != null)
-        data.?.* = array_buffer.ptr;
+    if (maybe_data) |data|
+        data.* = array_buffer.ptr;
 
-    if (arraybuffer != null)
-        arraybuffer.?.* = JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), dataview.asObjectRef(), null));
+    if (maybe_arraybuffer) |arraybuffer|
+        arraybuffer.set(env, JSValue.c(JSC.C.JSObjectGetTypedArrayBuffer(env.ref(), dataview.asObjectRef(), null)));
 
-    if (byte_offset != null)
-        byte_offset.?.* = array_buffer.offset;
+    if (maybe_byte_offset) |byte_offset|
+        byte_offset.* = array_buffer.offset;
 
     return .ok;
 }
@@ -935,27 +1006,30 @@ pub export fn napi_create_promise(env: napi_env, deferred_: ?*napi_deferred, pro
     };
     deferred.* = bun.default_allocator.create(JSC.JSPromise.Strong) catch @panic("failed to allocate napi_deferred");
     deferred.*.* = JSC.JSPromise.Strong.init(env);
-    promise.* = deferred.*.get().asValue(env);
+    promise.set(env, deferred.*.get().asValue(env));
     return .ok;
 }
-pub export fn napi_resolve_deferred(env: napi_env, deferred: napi_deferred, resolution: napi_value) napi_status {
+pub export fn napi_resolve_deferred(env: napi_env, deferred: napi_deferred, resolution_: napi_value) napi_status {
     log("napi_resolve_deferred", .{});
+    const resolution = resolution_.get();
     var prom = deferred.get();
     prom.resolve(env, resolution);
     deferred.deinit();
     bun.default_allocator.destroy(deferred);
     return .ok;
 }
-pub export fn napi_reject_deferred(env: napi_env, deferred: napi_deferred, rejection: napi_value) napi_status {
+pub export fn napi_reject_deferred(env: napi_env, deferred: napi_deferred, rejection_: napi_value) napi_status {
     log("napi_reject_deferred", .{});
+    const rejection = rejection_.get();
     var prom = deferred.get();
     prom.reject(env, rejection);
     deferred.deinit();
     bun.default_allocator.destroy(deferred);
     return .ok;
 }
-pub export fn napi_is_promise(_: napi_env, value: napi_value, is_promise_: ?*bool) napi_status {
+pub export fn napi_is_promise(_: napi_env, value_: napi_value, is_promise_: ?*bool) napi_status {
     log("napi_is_promise", .{});
+    const value = value_.get();
     const is_promise = is_promise_ orelse {
         return invalidArg();
     };
@@ -975,14 +1049,15 @@ pub export fn napi_create_date(env: napi_env, time: f64, result_: ?*napi_value) 
         return invalidArg();
     };
     var args = [_]JSC.C.JSValueRef{JSC.JSValue.jsNumber(time).asObjectRef()};
-    result.* = JSValue.c(JSC.C.JSObjectMakeDate(env.ref(), 1, &args, TODO_EXCEPTION));
+    result.set(env, JSValue.c(JSC.C.JSObjectMakeDate(env.ref(), 1, &args, TODO_EXCEPTION)));
     return .ok;
 }
-pub export fn napi_is_date(_: napi_env, value: napi_value, is_date_: ?*bool) napi_status {
+pub export fn napi_is_date(_: napi_env, value_: napi_value, is_date_: ?*bool) napi_status {
     log("napi_is_date", .{});
     const is_date = is_date_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     is_date.* = value.jsTypeLoose() == .JSDate;
     return .ok;
 }
@@ -993,7 +1068,7 @@ pub export fn napi_create_bigint_int64(env: napi_env, value: i64, result_: ?*nap
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSC.JSValue.fromInt64NoTruncate(env, value);
+    result.set(env, JSC.JSValue.fromInt64NoTruncate(env, value));
     return .ok;
 }
 pub export fn napi_create_bigint_uint64(env: napi_env, value: u64, result_: ?*napi_value) napi_status {
@@ -1001,25 +1076,27 @@ pub export fn napi_create_bigint_uint64(env: napi_env, value: u64, result_: ?*na
     const result = result_ orelse {
         return invalidArg();
     };
-    result.* = JSC.JSValue.fromUInt64NoTruncate(env, value);
+    result.set(env, JSC.JSValue.fromUInt64NoTruncate(env, value));
     return .ok;
 }
 pub extern fn napi_create_bigint_words(env: napi_env, sign_bit: c_int, word_count: usize, words: [*c]const u64, result: *napi_value) napi_status;
 // TODO: lossless
-pub export fn napi_get_value_bigint_int64(_: napi_env, value: napi_value, result_: ?*i64, _: *bool) napi_status {
+pub export fn napi_get_value_bigint_int64(_: napi_env, value_: napi_value, result_: ?*i64, _: *bool) napi_status {
     log("napi_get_value_bigint_int64", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     result.* = value.toInt64();
     return .ok;
 }
 // TODO: lossless
-pub export fn napi_get_value_bigint_uint64(_: napi_env, value: napi_value, result_: ?*u64, _: *bool) napi_status {
+pub export fn napi_get_value_bigint_uint64(_: napi_env, value_: napi_value, result_: ?*u64, _: *bool) napi_status {
     log("napi_get_value_bigint_uint64", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     result.* = value.toUInt64NoTruncate();
     return .ok;
 }
@@ -1196,7 +1273,7 @@ pub export fn napi_create_buffer(env: napi_env, length: usize, data: ?**anyopaqu
             ptr.* = buffer.asArrayBuffer(env).?.ptr;
         }
     }
-    result.* = buffer;
+    result.set(env, buffer);
     return .ok;
 }
 pub extern fn napi_create_external_buffer(env: napi_env, length: usize, data: ?*anyopaque, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
@@ -1215,20 +1292,22 @@ pub export fn napi_create_buffer_copy(env: napi_env, length: usize, data: [*]u8,
         }
     }
 
-    result.* = buffer;
+    result.set(env, buffer);
 
     return .ok;
 }
-pub export fn napi_is_buffer(env: napi_env, value: napi_value, result_: ?*bool) napi_status {
+pub export fn napi_is_buffer(env: napi_env, value_: napi_value, result_: ?*bool) napi_status {
     log("napi_is_buffer", .{});
     const result = result_ orelse {
         return invalidArg();
     };
+    const value = value_.get();
     result.* = value.isBuffer(env);
     return .ok;
 }
-pub export fn napi_get_buffer_info(env: napi_env, value: napi_value, data: ?*[*]u8, length: ?*usize) napi_status {
+pub export fn napi_get_buffer_info(env: napi_env, value_: napi_value, data: ?*[*]u8, length: ?*usize) napi_status {
     log("napi_get_buffer_info", .{});
+    const value = value_.get();
     const array_buf = value.asArrayBuffer(env) orelse {
         // TODO: is invalid_arg what to return here?
         return .arraybuffer_expected;
@@ -1491,7 +1570,9 @@ pub const ThreadSafeFunction = struct {
                     log("call() {}", .{str});
                 }
 
-                cb.napi_threadsafe_function_call_js(globalObject, cb.js, this.ctx, task);
+                const handle_scope = NapiHandleScope.push(globalObject);
+                defer handle_scope.pop(globalObject);
+                cb.napi_threadsafe_function_call_js(globalObject, napi_value.create(globalObject, cb.js), this.ctx, task);
             },
         }
     }
@@ -1572,7 +1653,7 @@ pub const ThreadSafeFunction = struct {
 
 pub export fn napi_create_threadsafe_function(
     env: napi_env,
-    func: napi_value,
+    func_: napi_value,
     _: napi_value,
     _: napi_value,
     max_queue_size: usize,
@@ -1587,6 +1668,7 @@ pub export fn napi_create_threadsafe_function(
     const result = result_ orelse {
         return invalidArg();
     };
+    const func = func_.get();
 
     if (call_js_cb == null and (func.isEmptyOrUndefinedOrNull() or !func.isCallable(env.vm()))) {
         return napi_status.function_expected;

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -366,6 +366,28 @@ napi_value test_napi_handle_scope_nesting(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+napi_value constructor(napi_env env, napi_callback_info info) {
+  napi_value this_value;
+  assert(napi_get_cb_info(env, info, nullptr, nullptr, &this_value, nullptr) ==
+         napi_ok);
+  napi_value property_value;
+  assert(napi_create_string_utf8(env, "meow", NAPI_AUTO_LENGTH,
+                                 &property_value) == napi_ok);
+  assert(napi_set_named_property(env, this_value, "foo", property_value) ==
+         napi_ok);
+  napi_value undefined;
+  assert(napi_get_undefined(env, &undefined) == napi_ok);
+  return undefined;
+}
+
+napi_value get_class_with_constructor(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value napi_class;
+  assert(napi_define_class(env, "NapiClass", NAPI_AUTO_LENGTH, constructor,
+                           nullptr, 0, nullptr, &napi_class) == napi_ok);
+  return napi_class;
+}
+
 Napi::Value RunCallback(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::Function cb = info[0].As<Napi::Function>();
@@ -404,6 +426,8 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
               Napi::Function::New(env, test_napi_escapable_handle_scope));
   exports.Set("test_napi_handle_scope_nesting",
               Napi::Function::New(env, test_napi_handle_scope_nesting));
+  exports.Set("get_class_with_constructor",
+              Napi::Function::New(env, get_class_with_constructor));
 
   return exports;
 }

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -186,6 +186,39 @@ napi_value test_napi_handle_scope(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+napi_value test_napi_delete_property(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  napi_value object = info[0];
+  napi_valuetype type;
+  assert(napi_typeof(env, object, &type) == napi_ok);
+  assert(type == napi_object);
+
+  napi_value key;
+  assert(napi_create_string_utf8(env, "foo", 3, &key) == napi_ok);
+
+  napi_value non_configurable_key;
+  assert(napi_create_string_utf8(env, "bar", 3, &non_configurable_key) ==
+         napi_ok);
+
+  napi_value val;
+  assert(napi_create_int32(env, 42, &val) == napi_ok);
+
+  bool delete_result;
+  assert(napi_delete_property(env, object, non_configurable_key,
+                              &delete_result) == napi_ok);
+  assert(delete_result == false);
+
+  assert(napi_delete_property(env, object, key, &delete_result) == napi_ok);
+  assert(delete_result == true);
+
+  bool has_property;
+  assert(napi_has_property(env, object, key, &has_property) == napi_ok);
+  assert(has_property == false);
+
+  return ok(env);
+}
+
 Napi::Value RunCallback(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::Function cb = info[0].As<Napi::Function>();
@@ -216,6 +249,8 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
           env, test_napi_threadsafe_function_does_not_hang_after_finalize));
   exports.Set("test_napi_handle_scope",
               Napi::Function::New(env, test_napi_handle_scope));
+  exports.Set("test_napi_delete_property",
+              Napi::Function::New(env, test_napi_delete_property));
 
   return exports;
 }

--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -12,7 +12,8 @@ if (typeof fn !== "function") {
   throw new Error("Unknown test:", process.argv[2]);
 }
 const result = fn.apply(null, eval(process.argv[3] ?? "[]"));
-
-if (result) {
+if (result instanceof Promise) {
+  result.then(x => console.log("resolved to", x));
+} else if (result) {
   throw new Error(result);
 }

--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -11,7 +11,8 @@ const fn = tests[process.argv[2]];
 if (typeof fn !== "function") {
   throw new Error("Unknown test:", process.argv[2]);
 }
-const result = fn.apply(null, JSON.parse(process.argv[3] ?? "[]"));
+const result = fn.apply(null, eval(process.argv[3] ?? "[]"));
+
 if (result) {
   throw new Error(result);
 }

--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -1,4 +1,4 @@
-const tests = require("./build/Release/napitests.node");
+const tests = require("./module");
 if (process.argv[2] === "self") {
   console.log(
     tests(function (str) {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1,0 +1,9 @@
+const nativeTests = require("./build/Release/napitests.node");
+
+nativeTests.test_napi_class_constructor_handle_scope = () => {
+  const NapiClass = nativeTests.get_class_with_constructor();
+  const x = new NapiClass();
+  console.log("x.foo =", x.foo);
+};
+
+module.exports = nativeTests;

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -80,6 +80,9 @@ describe("napi", () => {
     it("keeps the parent handle scope alive", () => {
       checkSameOutput("test_napi_handle_scope_nesting", []);
     });
+    it("exists when calling a napi constructor", () => {
+      checkSameOutput("test_napi_class_constructor_handle_scope", []);
+    });
   });
 
   describe("escapable_handle_scope", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -83,6 +83,9 @@ describe("napi", () => {
     it("exists when calling a napi constructor", () => {
       checkSameOutput("test_napi_class_constructor_handle_scope", []);
     });
+    it("exists while calling a napi_async_complete_callback", () => {
+      checkSameOutput("create_promise", []);
+    });
   });
 
   describe("escapable_handle_scope", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -69,6 +69,12 @@ describe("napi", () => {
     const result = checkSameOutput("self", []);
     expect(result).toBe("hello world!");
   });
+
+  describe("handle_scope", () => {
+    it("keeps napi_values alive", () => {
+      checkSameOutput("test_napi_handle_scope", []);
+    });
+  });
 });
 
 function checkSameOutput(test: string, args: any[]) {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -79,6 +79,12 @@ describe("napi", () => {
     }, 10000);
   });
 
+  describe("escapable_handle_scope", () => {
+    it("keeps the escaped value alive in the outer scope", () => {
+      checkSameOutput("test_napi_escapable_handle_scope", []);
+    });
+  });
+
   describe("napi_delete_property", () => {
     it("returns a valid boolean", () => {
       checkSameOutput(

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -77,6 +77,9 @@ describe("napi", () => {
     it("keeps bigints alive", () => {
       checkSameOutput("test_napi_handle_scope_bigint", []);
     }, 10000);
+    it("keeps the parent handle scope alive", () => {
+      checkSameOutput("test_napi_handle_scope_nesting", []);
+    });
   });
 
   describe("escapable_handle_scope", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -71,9 +71,12 @@ describe("napi", () => {
   });
 
   describe("handle_scope", () => {
-    it("keeps napi_values alive", () => {
-      checkSameOutput("test_napi_handle_scope", []);
+    it("keeps strings alive", () => {
+      checkSameOutput("test_napi_handle_scope_string", []);
     });
+    it("keeps bigints alive", () => {
+      checkSameOutput("test_napi_handle_scope_bigint", []);
+    }, 10000);
   });
 
   describe("napi_delete_property", () => {


### PR DESCRIPTION
Draft because I have a hunch something will break when handle scopes are nested.

### What does this PR do?

We thought we wouldn't need these due to JSC's stack scanning. Turns out, NAPI modules can put `napi_value`s on the heap where the stack scanner won't see them. So we need a `napi_handle_scope` to keep them alive.

`NapiHandleScopeImpl` is a heap-allocated wrapper around `WTF::Vector<JSC::WriteBarrier<JSC::Unknown>>`. `NapiHandleScope` is an RAII helper class that opens a handle scope and closes it at the end of the C++ scope. `napi_handle_scope` and `napi_escapable_handle_scope` are both pointers to `NapiHandleScopeImpl` (which can be escapable or not).

A `NapiHandleScope` must be created whenever you start running a native function from a NAPI module:

https://github.com/oven-sh/bun/blob/7b1b0e3de8241dfc860baed64cefd3c10b8250d6/src/bun.js/bindings/BunProcess.cpp#L411-L414

https://github.com/oven-sh/bun/blob/7b1b0e3de8241dfc860baed64cefd3c10b8250d6/src/bun.js/bindings/napi.cpp#L441-L444

https://github.com/oven-sh/bun/blob/7b1b0e3de8241dfc860baed64cefd3c10b8250d6/src/napi/napi.zig#L1577-L1579

**Whenever you return a new `napi_value` to native code you must ensure it is stored in the current handle scope**. Otherwise it could get collected if the native function moves it off the stack. Use `toNapi` in C++ code or `napi_value.set`/`napi_value.create` in Zig code.

### How did you verify your code works?

I wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
    - JSValues in handle scopes are stored in write barriers under a GC-visible object stored on the global object.
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

