### PR TITLE
Fix CTRL + C behavior in `bun run` so it doesn't `^[[A`

### DIFF
--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -658,8 +658,7 @@ static struct sigaction previous_actions[NSIG];
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
     M(SIGPWR);                        \
-    M(SIGSTKFLT);                     \
-    M(SIGUNUSED);
+    M(SIGSTKFLT);
 
 #endif
 

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -624,3 +624,117 @@ extern "C" void Bun__disableSOLinger(SOCKET fd)
 }
 
 #endif
+
+// Handle signals in bun.spawnSync.
+// If we receive a signal, we want to forward the signal to the child process.
+#if OS(LINUX) || OS(DARWIN)
+#include <signal.h>
+#include <pthread.h>
+
+// Note: We only ever use bun.spawnSync on the main thread.
+extern "C" int64_t Bun__currentSyncPID = 0;
+static int Bun__pendingSignalToSend = 0;
+static struct sigaction previous_actions[NSIG];
+
+// This list of signals is copied from npm.
+// https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/workspaces/arborist/lib/signals.js#L26-L57
+#define FOR_EACH_POSIX_SIGNAL(M) \
+    M(SIGABRT);                  \
+    M(SIGALRM);                  \
+    M(SIGHUP);                   \
+    M(SIGINT);                   \
+    M(SIGTERM);                  \
+    M(SIGVTALRM);                \
+    M(SIGXCPU);                  \
+    M(SIGXFSZ);                  \
+    M(SIGUSR2);                  \
+    M(SIGTRAP);                  \
+    M(SIGSYS);                   \
+    M(SIGQUIT);                  \
+    M(SIGIOT);                   \
+    M(SIGIO);
+
+#if OS(LINUX)
+#define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
+    M(SIGPOLL);                       \
+    M(SIGPWR);                        \
+    M(SIGSTKFLT);                     \
+    M(SIGUNUSED);
+
+#endif
+
+#if OS(DARWIN)
+#define FOR_EACH_SIGNAL(M) FOR_EACH_POSIX_SIGNAL(M)
+#endif
+
+#if OS(LINUX)
+#define FOR_EACH_SIGNAL(M)   \
+    FOR_EACH_POSIX_SIGNAL(M) \
+    FOR_EACH_LINUX_ONLY_SIGNAL(M)
+#endif
+
+static void Bun__forwardSignalFromParentToChildAndRestorePreviousAction(pid_t pid, int sig)
+{
+    sigset_t restore_mask;
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, sig);
+    sigemptyset(&restore_mask);
+    sigaddset(&restore_mask, sig);
+    pthread_sigmask(SIG_BLOCK, &mask, &restore_mask);
+    kill(pid, sig);
+    pthread_sigmask(SIG_UNBLOCK, &restore_mask, nullptr);
+}
+
+extern "C" void Bun__sendPendingSignalIfNecessary()
+{
+    int sig = Bun__pendingSignalToSend;
+    Bun__pendingSignalToSend = 0;
+    int pid = Bun__currentSyncPID;
+    if (sig == 0 || pid == 0)
+        return;
+
+    Bun__forwardSignalFromParentToChildAndRestorePreviousAction(pid, sig);
+}
+
+extern "C" void Bun__registerSignalsForForwarding()
+{
+    Bun__pendingSignalToSend = 0;
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;
+    sa.sa_handler = [](int sig) {
+        if (Bun__currentSyncPID == 0) {
+            Bun__pendingSignalToSend = sig;
+            return;
+        }
+
+        Bun__forwardSignalFromParentToChildAndRestorePreviousAction(Bun__currentSyncPID, sig);
+    };
+
+#define REGISTER_SIGNAL(SIG)                                                    \
+    if (sigaction(SIG, &sa, &previous_actions[SIG]) == -1) {                    \
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Unexpected error registering signal"); \
+    }
+
+    FOR_EACH_SIGNAL(REGISTER_SIGNAL)
+
+#undef REGISTER_SIGNAL
+}
+
+extern "C" void Bun__unregisterSignalsForForwarding()
+{
+    Bun__currentSyncPID = 0;
+
+#define UNREGISTER_SIGNAL(SIG)                                                    \
+    if (sigaction(SIG, &previous_actions[SIG], NULL) == -1) {                     \
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Unexpected error unregistering signal"); \
+    }
+
+    FOR_EACH_SIGNAL(UNREGISTER_SIGNAL)
+    memset(previous_actions, 0, sizeof(previous_actions));
+#undef UNREGISTER_SIGNAL
+}
+
+#endif

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -712,9 +712,8 @@ extern "C" void Bun__registerSignalsForForwarding()
         Bun__forwardSignalFromParentToChildAndRestorePreviousAction(Bun__currentSyncPID, sig);
     };
 
-#define REGISTER_SIGNAL(SIG)                                                    \
-    if (sigaction(SIG, &sa, &previous_actions[SIG]) == -1) {                    \
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Unexpected error registering signal"); \
+#define REGISTER_SIGNAL(SIG)                                 \
+    if (sigaction(SIG, &sa, &previous_actions[SIG]) == -1) { \
     }
 
     FOR_EACH_SIGNAL(REGISTER_SIGNAL)
@@ -726,9 +725,8 @@ extern "C" void Bun__unregisterSignalsForForwarding()
 {
     Bun__currentSyncPID = 0;
 
-#define UNREGISTER_SIGNAL(SIG)                                                    \
-    if (sigaction(SIG, &previous_actions[SIG], NULL) == -1) {                     \
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Unexpected error unregistering signal"); \
+#define UNREGISTER_SIGNAL(SIG)                                \
+    if (sigaction(SIG, &previous_actions[SIG], NULL) == -1) { \
     }
 
     FOR_EACH_SIGNAL(UNREGISTER_SIGNAL)

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -763,6 +763,15 @@ pub fn updatePosixSegfaultHandler(act: ?*std.posix.Sigaction) !void {
 
 var windows_segfault_handle: ?windows.HANDLE = null;
 
+pub fn resetOnPosix() void {
+    var act = std.posix.Sigaction{
+        .handler = .{ .sigaction = handleSegfaultPosix },
+        .mask = std.posix.empty_sigset,
+        .flags = (std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND),
+    };
+    updatePosixSegfaultHandler(&act) catch {};
+}
+
 pub fn init() void {
     if (!enable) return;
     switch (bun.Environment.os) {
@@ -770,12 +779,7 @@ pub fn init() void {
             windows_segfault_handle = windows.kernel32.AddVectoredExceptionHandler(0, handleSegfaultWindows);
         },
         .mac, .linux => {
-            var act = std.posix.Sigaction{
-                .handler = .{ .sigaction = handleSegfaultPosix },
-                .mask = std.posix.empty_sigset,
-                .flags = (std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND),
-            };
-            updatePosixSegfaultHandler(&act) catch {};
+            resetOnPosix();
         },
         else => @compileError("TODO"),
     }

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -1,0 +1,35 @@
+import { test, expect, it } from "bun:test";
+import { join } from "path";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("verify that we forward SIGINT from parent to child in bun run", () => {
+  const dir = tempDirWithFiles("ctrlc", {
+    "index.js": `
+      let count = 0;
+      process.exitCode = 1;
+      process.once("SIGINT", () => {
+        process.kill(process.pid, "SIGKILL");
+      });
+      setTimeout(() => {}, 999999)
+      process.kill(process.ppid, "SIGINT");
+  `,
+    "package.json": `
+    {
+      "name": "ctrlc",
+      "scripts": {
+        "start": "${bunExe()} index.js"
+      }
+    }
+  `,
+  });
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "start"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  expect(result.exitCode).toBe(null);
+  expect(result.signalCode).toBe("SIGKILL");
+});

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -1,8 +1,8 @@
 import { test, expect, it } from "bun:test";
 import { join } from "path";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 
-test("verify that we forward SIGINT from parent to child in bun run", () => {
+test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bun run", () => {
   const dir = tempDirWithFiles("ctrlc", {
     "index.js": `
       let count = 0;


### PR DESCRIPTION
### What does this PR do?

Fix CTRL + C behavior in `bun run` so it doesn't `^[[A`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
