### PR TITLE
Add if workers spawned / terminated to crash reports

### DIFF
--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -114,6 +114,8 @@ pub const Features = struct {
     pub var binlinks: usize = 0;
     pub var builtin_modules = std.enums.EnumSet(bun.JSC.HardcodedModule).initEmpty();
     pub var standalone_executable: usize = 0;
+    pub var workers_spawned: usize = 0;
+    pub var workers_terminated: usize = 0;
 
     pub fn formatter() Formatter {
         return Formatter{};

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -214,6 +214,7 @@ pub const WebWorker = struct {
     pub fn startWithErrorHandling(
         this: *WebWorker,
     ) void {
+        bun.Analytics.Features.workers_spawned += 1;
         start(this) catch |err| {
             Output.panic("An unhandled error occurred while starting a worker: {s}\n", .{@errorName(err)});
         };
@@ -456,6 +457,7 @@ pub const WebWorker = struct {
     pub fn exitAndDeinit(this: *WebWorker) noreturn {
         JSC.markBinding(@src());
         this.setStatus(.terminated);
+        bun.Analytics.Features.workers_terminated += 1;
 
         log("[{d}] exitAndDeinit", .{this.execution_context_id});
         const cpp_worker = this.cpp_worker;


### PR DESCRIPTION
### What does this PR do?

Add if workers spawned / terminated to crash reports

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
