### PR TITLE
fix bad translation in child-process-exec-timeout-kill.test.js

### DIFF
--- a/test/js/node/test/parallel/child-process-exec-timeout-kill.test.js
+++ b/test/js/node/test/parallel/child-process-exec-timeout-kill.test.js
@@ -46,14 +46,4 @@ test("exec with timeout and killSignal", done => {
   );
 });
 
-afterAll(() => {
-  // Clean up any stale processes
-  const { execSync } = require("child_process");
-  try {
-    execSync(`pkill -f "${path.basename(__filename)}"`);
-  } catch (error) {
-    // Ignore errors, as there might not be any processes to kill
-  }
-});
-
 //<#END_FILE: test-child-process-exec-timeout-kill.js


### PR DESCRIPTION
this block was unneeded and created false negative errors in CI