### PR TITLE
fix(node:http) implement request.setTimeout and server.setTimeout

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2812,6 +2812,22 @@ declare module "bun" {
     requestIP(request: Request): SocketAddress | null;
 
     /**
+     * Reset the idleTimeout of the given Request to the number in seconds. 0 means no timeout.
+     *
+     * @example
+     * ```js
+     * export default {
+     *  async fetch(request, server) {
+     *    server.timeout(request, 60);
+     *    await Bun.sleep(30000);
+     *    return new Response("30 seconds have passed");
+     *  }
+     * }
+     * ```
+     */
+    timeout(request: Request, seconds: number): SocketAddress | null;
+
+    /**
      * Undo a call to {@link Server.unref}
      *
      * If the Server has already been stopped, this does nothing.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2825,8 +2825,7 @@ declare module "bun" {
      * }
      * ```
      */
-    timeout(request: Request, seconds: number): SocketAddress | null;
-
+    timeout(request: Request, seconds: number): void;
     /**
      * Undo a call to {@link Server.unref}
      *

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -415,6 +415,12 @@ private:
 
             /* Force close rather than gracefully shutdown and risk confusing the client with a complete download */
             AsyncSocket<SSL> *asyncSocket = (AsyncSocket<SSL> *) s;
+            // Node.js by default sclose the connection but they emit the timeout event before that
+            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) asyncSocket->getAsyncSocketData();
+
+            if (httpResponseData->onTimeout) {
+                httpResponseData->onTimeout((HttpResponse<SSL> *)s, httpResponseData->userData);
+            }
             return asyncSocket->close();
 
         });

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -586,17 +586,36 @@ public:
         httpResponseData->onAborted = handler;
         return this;
     }
+
+    HttpResponse *onTimeout(void* userData,  HttpResponseData<SSL>::OnTimeoutCallback handler) {
+        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        
+        httpResponseData->userData = userData;
+        httpResponseData->onTimeout = handler;
+        return this;
+    }
+
     HttpResponse* clearOnWritableAndAborted() {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = nullptr;
         httpResponseData->onAborted = nullptr;
+        httpResponseData->onTimeout = nullptr;
+
         return this;
     }
+
     HttpResponse* clearOnAborted() {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onAborted = nullptr;
+        return this;
+    }
+
+    HttpResponse* clearOnTimeout() {
+        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+
+        httpResponseData->onTimeout = nullptr;
         return this;
     }
     /* Attach a read handler for data sent. Will be called with FIN set true if last segment. */

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -35,6 +35,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     public:
     using OnWritableCallback = bool (*)(uWS::HttpResponse<SSL>*, uint64_t, void*);
     using OnAbortedCallback = void (*)(uWS::HttpResponse<SSL>*, void*);
+    using OnTimeoutCallback = void (*)(uWS::HttpResponse<SSL>*, void*);
     using OnDataCallback = void (*)(uWS::HttpResponse<SSL>* response, const char* chunk, size_t chunk_length, bool, void*);
     uint8_t idleTimeout = 10; // default HTTP_TIMEOUT 10 seconds
 
@@ -69,7 +70,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
 
         return ret;
     }
-
     /* Bits of status */
     enum  : int32_t{
         HTTP_STATUS_CALLED = 1, // used
@@ -86,6 +86,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     OnWritableCallback onWritable = nullptr;
     OnAbortedCallback onAborted = nullptr;
     OnDataCallback inStream = nullptr;
+    OnTimeoutCallback onTimeout = nullptr;
     /* Outgoing offset */
     uint64_t offset = 0;
 

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -133,6 +133,7 @@ pub fn SSLWrapper(comptime T: type) type {
             // The peer might continue sending data for some period of time before handling the local application's shutdown indication.
             // This will start a full shutdown process if fast_shutdown = false, we can assume that the other side will complete the 2-step shutdown ASAP.
             const ret = BoringSSL.SSL_shutdown(ssl);
+            // when doing a fast shutdown we don't need to wait for the peer to send a shutdown so we just call SSL_shutdown again
             if (fast_shutdown) {
                 // This allows for a more rapid shutdown process if the application does not wish to wait for the peer.
                 // This alternative "fast shutdown" approach should only be done if it is known that the peer will not send more data, otherwise there is a risk of an application exposing itself to a truncation attack.

--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -36,6 +36,10 @@ function generate(name) {
         fn: "doRequestIP",
         length: 1,
       },
+      timeout: {
+        fn: "doTimeout",
+        length: 2,
+      },
       port: {
         getter: "getPort",
       },

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1767,6 +1767,28 @@ pub const AnyRequestContext = struct {
         return false;
     }
 
+    pub fn enableTimeoutEvents(self: AnyRequestContext) void {
+        if (self.tagged_pointer.isNull()) {
+            return;
+        }
+
+        switch (self.tagged_pointer.tag()) {
+            @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(HTTPServer.RequestContext))) => {
+                return self.tagged_pointer.as(HTTPServer.RequestContext).setTimeoutHandler();
+            },
+            @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(HTTPSServer.RequestContext))) => {
+                return self.tagged_pointer.as(HTTPSServer.RequestContext).setTimeoutHandler();
+            },
+            @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(DebugHTTPServer.RequestContext))) => {
+                return self.tagged_pointer.as(DebugHTTPServer.RequestContext).setTimeoutHandler();
+            },
+            @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(DebugHTTPSServer.RequestContext))) => {
+                return self.tagged_pointer.as(DebugHTTPSServer.RequestContext).setTimeoutHandler();
+            },
+            else => @panic("Unexpected AnyRequestContext tag"),
+        }
+    }
+
     pub fn getRemoteSocketInfo(self: AnyRequestContext) ?uws.SocketAddress {
         if (self.tagged_pointer.isNull()) {
             return null;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2356,6 +2356,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 if (request.internal_abort_callback.trigger(globalThis)) {
                     any_js_calls = true;
                 }
+                // we can already clean this strong refs
+                request.internal_abort_callback.deinit();
                 this.request_weakref.deinit();
             }
             // if signal is not aborted, abort the signal
@@ -2425,6 +2427,8 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             if (this.request_weakref.get()) |request| {
                 request.request_context = AnyRequestContext.Null;
+                // we can already clean this strong refs
+                request.internal_abort_callback.deinit();
                 this.request_weakref.deinit();
             }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -4089,13 +4089,18 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         pub fn setTimeout(this: *RequestContext, seconds: c_uint) bool {
             if (this.resp) |resp| {
                 resp.timeout(@min(seconds, 255));
+                if (seconds > 0) {
 
-                // we only set the timeout callback if we wanna the timeout event to be triggered
-                // the connection will be closed so the abort handler will be called after the timeout
-                if (this.request_weakref.get()) |req| {
-                    if (req.internal_event_callback.hasCallback()) {
-                        this.setTimeoutHandler();
+                    // we only set the timeout callback if we wanna the timeout event to be triggered
+                    // the connection will be closed so the abort handler will be called after the timeout
+                    if (this.request_weakref.get()) |req| {
+                        if (req.internal_event_callback.hasCallback()) {
+                            this.setTimeoutHandler();
+                        }
                     }
+                } else {
+                    // if the timeout is 0, we don't need to trigger the timeout event
+                    this.clearTimeoutHandler();
                 }
                 return true;
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5817,6 +5817,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         pub const doReload = onReload;
         pub const doFetch = onFetch;
         pub const doRequestIP = JSC.wrapInstanceMethod(ThisServer, "requestIP", false);
+        pub const doTimeout = JSC.wrapInstanceMethod(ThisServer, "timeout", false);
 
         pub fn doSubscriberCount(this: *ThisServer, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
             const arguments = callframe.arguments(1);
@@ -5866,6 +5867,16 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 )
             else
                 JSValue.jsNull();
+        }
+
+        pub fn timeout(this: *ThisServer, request: *JSC.WebCore.Request, seconds: JSValue) JSC.JSValue {
+            if (!seconds.isNumber()) {
+                this.globalThis.throw("timeout() requires a number", .{});
+                return .zero;
+            }
+            const value = seconds.to(c_uint);
+            _ = request.request_context.setTimeout(value);
+            return JSValue.jsUndefined();
         }
 
         pub fn publish(this: *ThisServer, globalThis: *JSC.JSGlobalObject, topic: ZigString, message_value: JSValue, compress_value: ?JSValue, exception: JSC.C.ExceptionRef) JSValue {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2337,6 +2337,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             assert(this.server != null);
             // mark request as aborted
             this.flags.aborted = true;
+
             this.detachResponse();
             var any_js_calls = false;
             var vm = this.server.?.vm;
@@ -2350,6 +2351,13 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.deref();
             }
 
+            if (this.request_weakref.get()) |request| {
+                request.request_context = AnyRequestContext.Null;
+                if (request.internal_abort_callback.trigger(globalThis)) {
+                    any_js_calls = true;
+                }
+                this.request_weakref.deinit();
+            }
             // if signal is not aborted, abort the signal
             if (this.signal) |signal| {
                 this.signal = null;

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -1,5 +1,3 @@
-#include "JavaScriptCore/JSCJSValue.h"
-#include "bun-uws/src/HttpParser.h"
 #include "root.h"
 #include "JSDOMGlobalObjectInlines.h"
 #include "ZigGlobalObject.h"

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -23,7 +23,7 @@ using namespace JSC;
 using namespace WebCore;
 
 extern "C" uWS::HttpRequest* Request__getUWSRequest(void*);
-extern "C" void Request__setInternalAbortCallback(void*, EncodedJSValue, EncodedJSValue, JSC::JSGlobalObject*);
+extern "C" void Request__setInternalAbortCallback(void*, EncodedJSValue, JSC::JSGlobalObject*);
 
 static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject* prototype, JSObject* objectValue, JSC::InternalFieldTuple* tuple, JSC::JSGlobalObject* globalObject, JSC::VM& vm)
 {
@@ -332,12 +332,11 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPAssignAbortCallback, (JSGlobalObject * globalObje
     // This is an internal binding.
     JSValue requestValue = callFrame->uncheckedArgument(0);
     JSValue callback = callFrame->uncheckedArgument(1);
-    JSValue ctx = callFrame->uncheckedArgument(2);
 
-    ASSERT(callFrame->argumentCount() == 3);
+    ASSERT(callFrame->argumentCount() == 2);
 
     if (auto* jsRequest = jsDynamicCast<WebCore::JSRequest*>(requestValue)) {
-        Request__setInternalAbortCallback(jsRequest->wrapped(), JSValue::encode(callback), JSValue::encode(ctx), globalObject);
+        Request__setInternalAbortCallback(jsRequest->wrapped(), JSValue::encode(callback), globalObject);
     }
 
     return JSValue::encode(jsNull());

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -329,12 +329,12 @@ pub const Request = struct {
             signal.unref();
             this.signal = null;
         }
+        this.internal_abort_callback.deinit();
     }
 
     pub fn finalize(this: *Request) void {
         this.finalizeWithoutDeinit();
         _ = this.body.unref();
-        this.internal_abort_callback.deinit();
         if (this.weak_ptr_data.onFinalize()) {
             this.destroy();
         }

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -91,7 +91,10 @@ pub const Request = struct {
         globalThis: *JSC.JSGlobalObject,
     ) void {
         this.internal_event_callback = InternalJSEventCallback.init(callback, globalThis);
+        // we always have the abort event but we need to enable the timeout event as well in case of `node:http`.Server.setTimeout is set
+        this.request_context.enableTimeoutEvents();
     }
+
     pub export fn Request__setTimeout(
         this: *Request,
         seconds: JSC.JSValue,

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1338,6 +1338,38 @@ extern "C"
     }
   }
 
+  void uws_res_on_timeout(int ssl, uws_res_r res,
+                          void (*handler)(uws_res_r res, void *opcional_data),
+                          void *opcional_data)
+  {
+    if (ssl)
+    {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      auto* onTimeout = reinterpret_cast<void (*)(uWS::HttpResponse<true>*, void*)>(handler);
+      if (handler)
+      {
+        uwsRes->onTimeout(opcional_data, onTimeout);
+      }
+      else
+      {
+        uwsRes->clearOnTimeout();
+      }
+    }
+    else
+    {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      auto* onTimeout = reinterpret_cast<void (*)(uWS::HttpResponse<false>*, void*)>(handler);
+      if (handler)
+      {
+        uwsRes->onTimeout(opcional_data, onTimeout);
+      }
+      else
+      {
+        uwsRes->clearOnTimeout();
+      }
+    }
+  }
+
   void uws_res_on_data(int ssl, uws_res_r res,
                        void (*handler)(uws_res_r res, const char *chunk,
                                        size_t chunk_length, bool is_end,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2555,6 +2555,12 @@ pub const AnyResponse = union(enum) {
             .TCP => |resp| resp.clearAborted(),
         };
     }
+    pub fn clearTimeout(this: AnyResponse) void {
+        return switch (this) {
+            .SSL => |resp| resp.clearTimeout(),
+            .TCP => |resp| resp.clearTimeout(),
+        };
+    }
 
     pub fn clearOnWritable(this: AnyResponse) void {
         return switch (this) {
@@ -3076,7 +3082,22 @@ pub fn NewApp(comptime ssl: bool) type {
             pub fn clearAborted(res: *Response) void {
                 uws_res_on_aborted(ssl_flag, res.downcast(), null, null);
             }
+            pub fn onTimeout(res: *Response, comptime UserDataType: type, comptime handler: fn (UserDataType, *Response) void, opcional_data: UserDataType) void {
+                const Wrapper = struct {
+                    pub fn handle(this: *uws_res, user_data: ?*anyopaque) callconv(.C) void {
+                        if (comptime UserDataType == void) {
+                            @call(bun.callmod_inline, handler, .{ {}, castRes(this), {} });
+                        } else {
+                            @call(bun.callmod_inline, handler, .{ @as(UserDataType, @ptrCast(@alignCast(user_data.?))), castRes(this) });
+                        }
+                    }
+                };
+                uws_res_on_timeout(ssl_flag, res.downcast(), Wrapper.handle, opcional_data);
+            }
 
+            pub fn clearTimeout(res: *Response) void {
+                uws_res_on_timeout(ssl_flag, res.downcast(), null, null);
+            }
             pub fn clearOnData(res: *Response) void {
                 uws_res_on_data(ssl_flag, res.downcast(), null, null);
             }
@@ -3400,6 +3421,8 @@ extern fn uws_res_has_responded(ssl: i32, res: *uws_res) bool;
 extern fn uws_res_on_writable(ssl: i32, res: *uws_res, handler: ?*const fn (*uws_res, u64, ?*anyopaque) callconv(.C) bool, user_data: ?*anyopaque) void;
 extern fn uws_res_clear_on_writable(ssl: i32, res: *uws_res) void;
 extern fn uws_res_on_aborted(ssl: i32, res: *uws_res, handler: ?*const fn (*uws_res, ?*anyopaque) callconv(.C) void, opcional_data: ?*anyopaque) void;
+extern fn uws_res_on_timeout(ssl: i32, res: *uws_res, handler: ?*const fn (*uws_res, ?*anyopaque) callconv(.C) void, opcional_data: ?*anyopaque) void;
+
 extern fn uws_res_on_data(
     ssl: i32,
     res: *uws_res,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -3504,7 +3504,7 @@ extern fn us_socket_mark_needs_more_not_ssl(socket: ?*uws_res) void;
 
 extern fn uws_res_state(ssl: c_int, res: *const uws_res) State;
 
-pub const State = enum(i32) {
+pub const State = enum(u8) {
     HTTP_STATUS_CALLED = 1,
     HTTP_WRITE_CALLED = 2,
     HTTP_END_CALLED = 4,

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -11,6 +11,7 @@ const {
   getHeader,
   setHeader,
   assignHeaders: assignHeadersFast,
+  assignAbortCallback,
   Response,
   Request,
   Headers,
@@ -20,6 +21,7 @@ const {
   getHeader: (headers: Headers, name: string) => string | undefined;
   setHeader: (headers: Headers, name: string, value: string) => void;
   assignHeaders: (object: any, req: Request, headersTuple: any) => boolean;
+  assignAbortCallback: (req: Request, callback: () => void, ctx: any) => void;
   Response: (typeof globalThis)["Response"];
   Request: (typeof globalThis)["Request"];
   Headers: (typeof globalThis)["Headers"];
@@ -646,7 +648,7 @@ Server.prototype = {
           const prevIsNextIncomingMessageHTTPS = isNextIncomingMessageHTTPS;
           isNextIncomingMessageHTTPS = isHTTPS;
           const http_req = new RequestClass(req);
-          req.signal.addEventListener("abort", onRequestAborted.bind(http_req));
+          assignAbortCallback(req, onRequestAborted, http_req);
           isNextIncomingMessageHTTPS = prevIsNextIncomingMessageHTTPS;
 
           const upgrade = http_req.headers.upgrade;

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1290,7 +1290,8 @@ function drainHeadersIfObservable() {
 }
 
 ServerResponse.prototype._final = function (callback) {
-  const shouldEmitClose = !this[finishedSymbol];
+  const req = this.req;
+  const shouldEmitClose = req && req.emit && !this[finishedSymbol];
 
   if (!this.headersSent) {
     var data = this[firstWriteSymbol] || "";
@@ -1305,7 +1306,6 @@ ServerResponse.prototype._final = function (callback) {
       }),
     );
     if (shouldEmitClose) {
-      const req = this.req;
       req.complete = true;
       req.emit("close");
     }
@@ -1317,7 +1317,6 @@ ServerResponse.prototype._final = function (callback) {
   ensureReadableStreamController.$call(this, controller => {
     controller.end();
     if (shouldEmitClose) {
-      const req = this.req;
       req.complete = true;
       req.emit("close");
     }

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -2181,6 +2181,10 @@ function _writeHead(statusCode, reason, obj, response) {
     // consisting only of the Status-Line and optional headers, and is
     // terminated by an empty line.
     response._hasBody = false;
+    const req = response.req;
+    if (req) {
+      req.complete = true;
+    }
   }
 }
 

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -21,7 +21,7 @@ const {
   getHeader: (headers: Headers, name: string) => string | undefined;
   setHeader: (headers: Headers, name: string, value: string) => void;
   assignHeaders: (object: any, req: Request, headersTuple: any) => boolean;
-  assignAbortCallback: (req: Request, callback: () => void, ctx: any) => void;
+  assignAbortCallback: (req: Request, callback: () => void) => void;
   Response: (typeof globalThis)["Response"];
   Request: (typeof globalThis)["Request"];
   Headers: (typeof globalThis)["Headers"];
@@ -648,7 +648,7 @@ Server.prototype = {
           const prevIsNextIncomingMessageHTTPS = isNextIncomingMessageHTTPS;
           isNextIncomingMessageHTTPS = isHTTPS;
           const http_req = new RequestClass(req);
-          assignAbortCallback(req, onRequestAborted, http_req);
+          assignAbortCallback(req, onRequestAborted.bind(http_req));
           isNextIncomingMessageHTTPS = prevIsNextIncomingMessageHTTPS;
 
           const upgrade = http_req.headers.upgrade;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2038,3 +2038,29 @@ it("allow requestIP after async operation", async () => {
   expect(ip.address).toBeString();
   expect(ip.family).toBeString();
 });
+
+it("allow custom timeout per request", async () => {
+  using server = Bun.serve({
+    idleTimeout: 5,
+    port: 0,
+    async fetch(req, server) {
+      if (req.url.endsWith("/long-timeout")) {
+        server.timeout(req, 60);
+      }
+      await Bun.sleep(10000); //uWS precision is not great
+
+      return new Response("Hello, World!");
+    },
+  });
+  expect(server.timeout).toBeFunction();
+  const res = await fetch(new URL("/long-timeout", server.url.origin));
+  expect(res.status).toBe(200);
+  expect(res.text()).resolves.toBe("Hello, World!");
+
+  try {
+    await fetch(server.url.origin);
+    expect.unreachable();
+  } catch (e) {
+    expect((e as Error).code).toBe("ConnectionClosed");
+  }
+}, 30_000);

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2041,12 +2041,10 @@ it("allow requestIP after async operation", async () => {
 
 it("allow custom timeout per request", async () => {
   using server = Bun.serve({
-    idleTimeout: 5,
+    idleTimeout: 1,
     port: 0,
     async fetch(req, server) {
-      if (req.url.endsWith("/long-timeout")) {
-        server.timeout(req, 60);
-      }
+      server.timeout(req, 60);
       await Bun.sleep(10000); //uWS precision is not great
 
       return new Response("Hello, World!");
@@ -2056,11 +2054,4 @@ it("allow custom timeout per request", async () => {
   const res = await fetch(new URL("/long-timeout", server.url.origin));
   expect(res.status).toBe(200);
   expect(res.text()).resolves.toBe("Hello, World!");
-
-  try {
-    await fetch(server.url.origin);
-    expect.unreachable();
-  } catch (e) {
-    expect((e as Error).code).toBe("ConnectionClosed");
-  }
-}, 30_000);
+}, 20_000);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2351,6 +2351,7 @@ it("should emit close when connection is aborted", async () => {
       .catch(() => {});
 
     const [req, res] = await once(server, "request");
+    expect(req.complete).toBe(false);
     const closeEvent = once(req, "close");
     controller.abort();
     await closeEvent;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2321,7 +2321,7 @@ it("using node:http to do https: request fails", () => {
   });
 });
 
-it("should emit close, and complete should be true only after close", async () => {
+it("should emit close, and complete should be true only after close #13373", async () => {
   const server = http.createServer().listen(0);
   try {
     await once(server, "listening");

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2351,7 +2351,6 @@ it("should emit close when connection is aborted", async () => {
       .catch(() => {});
 
     const [req, res] = await once(server, "request");
-    expect(req.complete).toBe(false);
     const closeEvent = once(req, "close");
     controller.abort();
     await closeEvent;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3,7 +3,7 @@ import { bunExe } from "bun:harness";
 import { bunEnv, randomPort } from "harness";
 import { createTest } from "node-harness";
 import { spawnSync } from "node:child_process";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
 import nodefs, { unlinkSync } from "node:fs";
 import http, {
   Agent,
@@ -2150,51 +2150,6 @@ it("should error with faulty args", async () => {
   server.close();
 });
 
-it("should mark complete true", async () => {
-  const { promise: serve, resolve: resolveServe } = Promise.withResolvers();
-  const server = createServer(async (req, res) => {
-    let count = 0;
-    let data = "";
-    req.on("data", chunk => {
-      data += chunk.toString();
-    });
-    while (!req.complete) {
-      await Bun.sleep(100);
-      count++;
-      if (count > 10) {
-        res.writeHead(500, { "Content-Type": "text/plain" });
-        res.end("Request timeout");
-        return;
-      }
-    }
-    res.writeHead(200, { "Content-Type": "text/plain" });
-    res.end(data);
-  });
-
-  server.listen(0, () => {
-    resolveServe(`http://localhost:${server.address().port}`);
-  });
-
-  const url = await serve;
-  try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Hotel 1",
-        price: 100,
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe('{"name":"Hotel 1","price":100}');
-  } finally {
-    server.close();
-  }
-});
-
 it("should propagate exception in sync data handler", async () => {
   const { exitCode, stdout } = Bun.spawnSync({
     cmd: [bunExe(), "run", path.join(import.meta.dir, "node-http-error-in-data-handler-fixture.1.js")],
@@ -2364,4 +2319,44 @@ it("using node:http to do https: request fails", () => {
     code: "ERR_INVALID_PROTOCOL",
     message: `Protocol "https:" not supported. Expected "http:"`,
   });
+});
+
+it("should emit close, and complete should be true only after close", async () => {
+  const server = http.createServer().listen(0);
+  try {
+    await once(server, "listening");
+    fetch(`http://localhost:${server.address().port}`)
+      .then(res => res.text())
+      .catch(() => {});
+
+    const [req, res] = await once(server, "request");
+    expect(req.complete).toBe(false);
+    const closeEvent = once(req, "close");
+    res.end("hi");
+
+    await closeEvent;
+    expect(req.complete).toBe(true);
+  } finally {
+    server.closeAllConnections();
+  }
+});
+
+it("should emit close when connection is aborted", async () => {
+  const server = http.createServer().listen(0);
+  try {
+    await once(server, "listening");
+    const controller = new AbortController();
+    fetch(`http://localhost:${server.address().port}`, { signal: controller.signal })
+      .then(res => res.text())
+      .catch(() => {});
+
+    const [req, res] = await once(server, "request");
+    expect(req.complete).toBe(false);
+    const closeEvent = once(req, "close");
+    controller.abort();
+    await closeEvent;
+    expect(req.complete).toBe(true);
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/9174
This PR depends or supersede https://github.com/oven-sh/bun/pull/13738

Fix: https://github.com/oven-sh/bun/issues/13373
Fix: https://github.com/oven-sh/bun/issues/7716
Fix: https://github.com/oven-sh/bun/issues/13745 (remove default timeout on server)

Also allow setting/reseting `idleTimeout` in a per `Request` bases:

```js
serve({
  idleTimeout: 10, // 10 seconds for normal requests
  async fetch(req, server) {
    if(req.url === "/long-await-request") {
      server.timeout(req, 100); // 100 seconds for this request
      await Bun.sleep(30000); // 30 seconds
      return new Response("30s is fine now :)", { status: 200 });
    } 
    return new Response("Hello World!", { status: 200 });
  }
})
```

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
