### PR TITLE
Increase randomIntegrityAuditRate from 0.05 to 1.0 in CI

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -437,6 +437,7 @@ async function spawnBun(execPath, { args, cwd, timeout, env, stdout, stderr }) {
     BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
     BUN_DEBUG_QUIET_LOGS: "1",
     BUN_GARBAGE_COLLECTOR_LEVEL: "1",
+    BUN_JSC_randomIntegrityAuditRate: "1.0",
     BUN_ENABLE_CRASH_REPORTING: "0", // change this to '1' if https://github.com/oven-sh/bun/issues/13012 is implemented
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,


### PR DESCRIPTION
### What does this PR do?

Tell JSC to audit heap cells more frequently in CI tests, to hopefully catch more memory corruption

- [x] Code changes

### How did you verify your code works?

Ran some tests locally with the new flag and they still pass