### PR TITLE
Switch asymmetric encryption implementation to BoringSSL

### DIFF
--- a/bench/crypto/asymmetricCipher.js
+++ b/bench/crypto/asymmetricCipher.js
@@ -1,0 +1,24 @@
+import { bench, run } from "mitata";
+const crypto = require("node:crypto");
+
+const keyPair = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {
+    type: "spki",
+    format: "pem",
+  },
+  privateKeyEncoding: {
+    type: "pkcs8",
+    format: "pem",
+  },
+});
+
+// Max message size for 2048-bit RSA keys
+const plaintext = crypto.getRandomValues(Buffer.alloc(214));
+
+bench("RSA_PKCS1_OAEP_PADDING round-trip", () => {
+  const ciphertext = crypto.publicEncrypt(keyPair.publicKey, plaintext);
+  crypto.privateDecrypt(keyPair.privateKey, ciphertext);
+});
+
+await run();

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.h
@@ -40,6 +40,9 @@ public:
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::RSA_OAEP;
     static Ref<CryptoAlgorithm> create();
 
+    static ExceptionOr<Vector<uint8_t>> platformEncryptWithHash(const CryptoAlgorithmRsaOaepParams&, const CryptoKeyRSA&, const Vector<uint8_t>&, CryptoAlgorithmIdentifier hashIdentifier);
+    static ExceptionOr<Vector<uint8_t>> platformDecryptWithHash(const CryptoAlgorithmRsaOaepParams&, const CryptoKeyRSA&, const Vector<uint8_t>&, CryptoAlgorithmIdentifier hashIdentifier);
+
 private:
     CryptoAlgorithmRSA_OAEP() = default;
     CryptoAlgorithmIdentifier identifier() const final;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRsaOaepParams.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRsaOaepParams.h
@@ -37,6 +37,7 @@ class CryptoAlgorithmRsaOaepParams final : public CryptoAlgorithmParameters {
 public:
     // Use labelVector() instead of label. The label will be gone once labelVector() is called.
     mutable std::optional<BufferSource::VariantType> label;
+    size_t padding = 0; // 0 represents the default value of the API
 
     Class parametersClass() const final { return Class::RsaOaepParams; }
 

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -18,6 +18,8 @@ const {
   generateKeyPairSync,
   sign: nativeSign,
   verify: nativeVerify,
+  publicEncrypt,
+  privateDecrypt,
 } = $cpp("KeyObject.cpp", "createNodeCryptoBinding");
 
 const {
@@ -11610,16 +11612,10 @@ var require_privateDecrypt = __commonJS({
 var require_browser10 = __commonJS({
   "node_modules/public-encrypt/browser.js"(exports) {
     var publicEncrypt = require_publicEncrypt();
-    exports.publicEncrypt = function (key, buf, options) {
-      return publicEncrypt(getKeyFrom(key, "public"), buf, options);
-    };
-    var privateDecrypt = require_privateDecrypt();
-    exports.privateDecrypt = function (key, buf, options) {
-      return privateDecrypt(getKeyFrom(key, "private"), buf, options);
-    };
     exports.privateEncrypt = function (key, buf) {
       return publicEncrypt(getKeyFrom(key, "private"), buf, !0);
     };
+    var privateDecrypt = require_privateDecrypt();
     exports.publicDecrypt = function (key, buf) {
       return privateDecrypt(getKeyFrom(key, "public"), buf, !0);
     };
@@ -11721,10 +11717,8 @@ var require_crypto_browserify2 = __commonJS({
     exports.Verify = sign.Verify;
     exports.createECDH = require_browser9();
     var publicEncrypt = require_browser10();
-    exports.publicEncrypt = publicEncrypt.publicEncrypt;
     exports.privateEncrypt = publicEncrypt.privateEncrypt;
     exports.publicDecrypt = publicEncrypt.publicDecrypt;
-    exports.privateDecrypt = publicEncrypt.privateDecrypt;
     exports.getRandomValues = values => crypto.getRandomValues(values);
     var rf = require_browser11();
     exports.randomFill = rf.randomFill;
@@ -12034,7 +12028,7 @@ function _createPublicKey(key) {
         }
         return KeyObject.from(
           createPublicKey({
-            key: createPrivateKey({ key: actual_key, format: key.format, passphrase: key.passphrase }),
+            key: createPrivateKey({ key: actual_key, format: key.format || "pem", passphrase: key.passphrase }),
             format: "",
           }),
         );
@@ -12165,6 +12159,52 @@ crypto_exports.verify = function (algorithm, data, key, signature, callback) {
     }
   }
 };
+
+// We are not allowed to call createPublicKey/createPrivateKey when we're already working with a
+// KeyObject/CryptoKey of the same type (public/private).
+function toCryptoKey(key, asPublic) {
+  // Top level CryptoKey.
+  if (key instanceof KeyObject || key instanceof CryptoKey) {
+    if (asPublic && key.type === "private") {
+      return _createPublicKey(key).$bunNativePtr;
+    }
+    return key.$bunNativePtr || key;
+  }
+
+  // Nested CryptoKey.
+  if (key.key instanceof KeyObject || key.key instanceof CryptoKey) {
+    if (asPublic && key.key.type === "private") {
+      return _createPublicKey(key.key).$bunNativePtr;
+    }
+    return key.key.$bunNativePtr || key.key;
+  }
+
+  // One of string, ArrayBuffer, Buffer, TypedArray, DataView, or Object.
+  return asPublic ? _createPublicKey(key).$bunNativePtr : _createPrivateKey(key).$bunNativePtr;
+}
+
+function doAsymmetricCipher(key, message, operation, isEncrypt) {
+  // Our crypto bindings expect the key to be a `JSCryptoKey` property within an object.
+  const cryptoKey = toCryptoKey(key, isEncrypt);
+  const oaepLabel =
+    typeof key.oaepLabel === "string" ? Buffer.from(key.oaepLabel, key.encoding) : key.oaepLabel;
+  const keyObject = {
+    key: cryptoKey,
+    oaepHash: key.oaepHash,
+    oaepLabel,
+    padding: key.padding,
+  };
+  const buffer = typeof message === "string" ? Buffer.from(message, key.encoding) : message;
+  return operation(keyObject, buffer);
+}
+
+crypto_exports.publicEncrypt = function(key, message) {
+  return doAsymmetricCipher(key, message, publicEncrypt, true);
+}
+
+crypto_exports.privateDecrypt = function(key, message) {
+  return doAsymmetricCipher(key, message, privateDecrypt, false);
+}
 
 __export(crypto_exports, {
   DEFAULT_ENCODING: () => DEFAULT_ENCODING,

--- a/test/js/node/crypto/crypto-rsa.test.js
+++ b/test/js/node/crypto/crypto-rsa.test.js
@@ -1,0 +1,405 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Copied from https://github.com/nodejs/node/blob/dcc2ed944f641004c0339bf76db58ccfefedd138/test/parallel/test-crypto-rsa-dsa.js
+
+const crypto = require("crypto");
+const constants = crypto.constants;
+const fixtures = require("../test/common/fixtures");
+
+// Test certificates
+const certPem = fixtures.readKey("rsa_cert.crt");
+const keyPem = fixtures.readKey("rsa_private.pem");
+const rsaKeySize = 2048;
+const rsaPubPem = fixtures.readKey("rsa_public.pem", "ascii");
+const rsaKeyPem = fixtures.readKey("rsa_private.pem", "ascii");
+const rsaKeyPemEncrypted = fixtures.readKey("rsa_private_encrypted.pem", "ascii");
+const rsaPkcs8KeyPem = fixtures.readKey("rsa_private_pkcs8.pem");
+
+const ec = new TextEncoder();
+
+const decryptError = {
+  message: expect.any(String),
+};
+
+function getBufferCopy(buf) {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+describe("RSA encryption/decryption", () => {
+  const input = "I AM THE WALRUS";
+  const bufferToEncrypt = Buffer.from(input);
+  const bufferPassword = Buffer.from("password");
+
+  let encryptedBuffer;
+  let otherEncrypted;
+
+  beforeAll(() => {
+    encryptedBuffer = crypto.publicEncrypt(rsaPubPem, bufferToEncrypt);
+
+    const ab = getBufferCopy(ec.encode(rsaPubPem));
+    const ab2enc = getBufferCopy(bufferToEncrypt);
+
+    crypto.publicEncrypt(ab, ab2enc);
+    crypto.publicEncrypt(new Uint8Array(ab), new Uint8Array(ab2enc));
+    crypto.publicEncrypt(new DataView(ab), new DataView(ab2enc));
+    otherEncrypted = crypto.publicEncrypt(
+      {
+        key: Buffer.from(ab).toString("hex"),
+        encoding: "hex",
+      },
+      Buffer.from(ab2enc).toString("hex"),
+    );
+  });
+
+  test("privateDecrypt with rsaKeyPem", () => {
+    const decryptedBuffer = crypto.privateDecrypt(rsaKeyPem, encryptedBuffer);
+    expect(decryptedBuffer.toString()).toBe(input);
+  });
+
+  test("privateDecrypt with otherEncrypted", () => {
+    const otherDecrypted = crypto.privateDecrypt(rsaKeyPem, otherEncrypted);
+    expect(otherDecrypted.toString()).toBe(input);
+  });
+
+  test("privateDecrypt with rsaPkcs8KeyPem", () => {
+    const decryptedBuffer = crypto.privateDecrypt(rsaPkcs8KeyPem, encryptedBuffer);
+    expect(decryptedBuffer.toString()).toBe(input);
+  });
+
+  test("privateDecrypt with password", () => {
+    const decryptedBufferWithPassword = crypto.privateDecrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: "password",
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferWithPassword.toString()).toBe(input);
+
+    const otherDecryptedBufferWithPassword = crypto.privateDecrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: ec.encode("password"),
+      },
+      encryptedBuffer,
+    );
+    expect(otherDecryptedBufferWithPassword.toString()).toBe(decryptedBufferWithPassword.toString());
+  });
+
+  test("publicEncrypt and privateDecrypt with password", () => {
+    const encryptedBuffer = crypto.publicEncrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: "password",
+      },
+      bufferToEncrypt,
+    );
+
+    const decryptedBufferWithPassword = crypto.privateDecrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: "password",
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferWithPassword.toString()).toBe(input);
+  });
+
+  test("privateEncrypt and publicDecrypt with buffer password", () => {
+    const encryptedBuffer = crypto.privateEncrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: bufferPassword,
+      },
+      bufferToEncrypt,
+    );
+
+    const decryptedBufferWithPassword = crypto.publicDecrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: bufferPassword,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferWithPassword.toString()).toBe(input);
+  });
+
+  test("privateEncrypt and publicDecrypt with RSA_PKCS1_PADDING", () => {
+    const encryptedBuffer = crypto.privateEncrypt(
+      {
+        padding: crypto.constants.RSA_PKCS1_PADDING,
+        key: rsaKeyPemEncrypted,
+        passphrase: bufferPassword,
+      },
+      bufferToEncrypt,
+    );
+
+    const decryptedBufferWithPassword = crypto.publicDecrypt(
+      {
+        padding: crypto.constants.RSA_PKCS1_PADDING,
+        key: rsaKeyPemEncrypted,
+        passphrase: bufferPassword,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferWithPassword.toString()).toBe(input);
+
+    const decryptedBufferWithoutPadding = crypto.publicDecrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: bufferPassword,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferWithoutPadding.toString()).toBe(input);
+  });
+
+  test("publicEncrypt and privateDecrypt with certPem and keyPem", () => {
+    const encryptedBuffer = crypto.publicEncrypt(certPem, bufferToEncrypt);
+    const decryptedBuffer = crypto.privateDecrypt(keyPem, encryptedBuffer);
+    expect(decryptedBuffer.toString()).toBe(input);
+  });
+
+  test("publicEncrypt and privateDecrypt with keyPem", () => {
+    const encryptedBuffer = crypto.publicEncrypt(keyPem, bufferToEncrypt);
+    const decryptedBuffer = crypto.privateDecrypt(keyPem, encryptedBuffer);
+    expect(decryptedBuffer.toString()).toBe(input);
+  });
+
+  test("privateEncrypt and publicDecrypt with keyPem", () => {
+    const encryptedBuffer = crypto.privateEncrypt(keyPem, bufferToEncrypt);
+    const decryptedBuffer = crypto.publicDecrypt(keyPem, encryptedBuffer);
+    expect(decryptedBuffer.toString()).toBe(input);
+  });
+
+  test("privateDecrypt with wrong password", () => {
+    expect(() => {
+      crypto.privateDecrypt(
+        {
+          key: rsaKeyPemEncrypted,
+          passphrase: "wrong",
+        },
+        bufferToEncrypt,
+      );
+    }).toThrow(expect.objectContaining(decryptError));
+  });
+
+  test("publicEncrypt with wrong password", () => {
+    expect(() => {
+      crypto.publicEncrypt(
+        {
+          key: rsaKeyPemEncrypted,
+          passphrase: "wrong",
+        },
+        encryptedBuffer,
+      );
+    }).toThrow(expect.objectContaining(decryptError));
+  });
+
+  test("publicDecrypt with wrong password", () => {
+    const encryptedBuffer = crypto.privateEncrypt(
+      {
+        key: rsaKeyPemEncrypted,
+        passphrase: Buffer.from("password"),
+      },
+      bufferToEncrypt,
+    );
+
+    expect(() => {
+      crypto.publicDecrypt(
+        {
+          key: rsaKeyPemEncrypted,
+          passphrase: Buffer.from("wrong"),
+        },
+        encryptedBuffer,
+      );
+    }).toThrow(expect.objectContaining(decryptError));
+  });
+});
+
+function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
+  const size = padding === "RSA_NO_PADDING" ? rsaKeySize / 8 : 32;
+  const input = Buffer.allocUnsafe(size);
+  for (let i = 0; i < input.length; i++) input[i] = (i * 7 + 11) & 0xff;
+  const bufferToEncrypt = Buffer.from(input);
+
+  padding = constants[padding];
+
+    const encryptedBuffer = crypto.publicEncrypt(
+      {
+        key: rsaPubPem,
+        padding: padding,
+        oaepHash: encryptOaepHash,
+      },
+      bufferToEncrypt,
+    );
+
+    if (padding === constants.RSA_PKCS1_PADDING) {
+      expect(() => {
+        crypto.privateDecrypt(
+          {
+            key: rsaKeyPem,
+            padding: padding,
+            oaepHash: decryptOaepHash,
+          },
+          encryptedBuffer,
+        );
+      }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+
+      expect(() => {
+        crypto.privateDecrypt(
+          {
+            key: rsaPkcs8KeyPem,
+            padding: padding,
+            oaepHash: decryptOaepHash,
+          },
+          encryptedBuffer,
+        );
+      }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+    } else {
+      const decryptedBuffer = crypto.privateDecrypt(
+        {
+          key: rsaKeyPem,
+          padding: padding,
+          oaepHash: decryptOaepHash,
+        },
+        encryptedBuffer,
+      );
+      expect(decryptedBuffer).toEqual(input);
+
+      const decryptedBufferPkcs8 = crypto.privateDecrypt(
+        {
+          key: rsaPkcs8KeyPem,
+          padding: padding,
+          oaepHash: decryptOaepHash,
+        },
+        encryptedBuffer,
+      );
+      expect(decryptedBufferPkcs8).toEqual(input);
+    }
+}
+
+test(`RSA with RSA_NO_PADDING`, () => {
+  test_rsa("RSA_NO_PADDING");
+});
+
+test(`RSA with RSA_PKCS1_PADDING`, () => {
+  test_rsa("RSA_PKCS1_PADDING");
+});
+
+test(`RSA with RSA_PKCS1_OAEP_PADDING`, () => {
+  test_rsa("RSA_PKCS1_OAEP_PADDING");
+  test_rsa("RSA_PKCS1_OAEP_PADDING", undefined, "sha1");
+  test_rsa("RSA_PKCS1_OAEP_PADDING", "sha1", undefined);
+  test_rsa("RSA_PKCS1_OAEP_PADDING", "sha256", "sha256");
+  test_rsa("RSA_PKCS1_OAEP_PADDING", "sha512", "sha512");
+});
+
+test(`RSA with hash mismatch`, () => {
+  expect(() => {
+    test_rsa("RSA_PKCS1_OAEP_PADDING", "sha256", "sha512");
+  }).toThrow(expect.objectContaining(decryptError));
+});
+
+test("RSA-OAEP test vectors", () => {
+  const { decryptionTests } = JSON.parse(fixtures.readSync("rsa-oaep-test-vectors.js", "utf8"));
+
+  for (const { ct, oaepHash, oaepLabel } of decryptionTests) {
+    const label = oaepLabel ? Buffer.from(oaepLabel, "hex") : undefined;
+    const copiedLabel = oaepLabel ? getBufferCopy(label) : undefined;
+
+    const decrypted = crypto.privateDecrypt(
+      {
+        key: rsaPkcs8KeyPem,
+        oaepHash,
+        oaepLabel: oaepLabel ? label : undefined,
+      },
+      Buffer.from(ct, "hex"),
+    );
+
+    expect(decrypted.toString("utf8")).toBe("Hello Node.js");
+
+    const otherDecrypted = crypto.privateDecrypt(
+      {
+        key: rsaPkcs8KeyPem,
+        oaepHash,
+        oaepLabel: copiedLabel,
+      },
+      Buffer.from(ct, "hex"),
+    );
+
+    expect(otherDecrypted.toString("utf8")).toBe("Hello Node.js");
+  }
+});
+
+describe("Invalid oaepHash and oaepLabel options", () => {
+  const testCases = [
+    { fn: crypto.publicEncrypt, name: "publicEncrypt", key: rsaPubPem },
+    { fn: crypto.privateDecrypt, name: "privateDecrypt", key: rsaKeyPem },
+  ];
+
+  testCases.forEach(({ fn, name, key }) => {
+    test(`${name} with invalid oaepHash`, () => {
+      expect(() => {
+        fn(
+          {
+            key,
+            oaepHash: "Hello world",
+          },
+          Buffer.alloc(10),
+        );
+      }).toThrow(expect.objectContaining({
+        code: "ERR_CRYPTO_INVALID_DIGEST",
+      }));
+
+      [0, false, null, Symbol(), () => {}].forEach(oaepHash => {
+        expect(() => {
+          fn(
+            {
+              key,
+              oaepHash,
+            },
+            Buffer.alloc(10),
+          );
+        }).toThrow(expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+        }));
+      });
+    });
+
+    test(`${name} with invalid oaepLabel`, () => {
+      [0, false, null, Symbol(), () => {}, {}].forEach(oaepLabel => {
+        expect(() => {
+          fn(
+            {
+              key,
+              oaepLabel,
+            },
+            Buffer.alloc(10),
+          );
+        }).toThrow(expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+        }));
+      });
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

We port over `crypto.publicEncrypt` and `crypto.privateDecrypt` as a pair as they are interdependent. All relevant test coverage from Node.js has been ported over, with some slight changes on some of the thrown error assertions.

I had the following benchmarks on an Apple M1 Pro:

This branch:

```
benchmark                              time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------- -----------------------------
RSA_PKCS1_OAEP_PADDING round-trip     829 µs/iter       (815 µs … 939 µs)    831 µs    883 µs    939 µs
```

bun/main:

```
benchmark                              time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------- -----------------------------
RSA_PKCS1_OAEP_PADDING round-trip  27'141 µs/iter (26'762 µs … 27'931 µs) 27'255 µs 27'931 µs 27'931 µs
```

Fixes https://github.com/oven-sh/bun/issues/4859.

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)