### PR TITLE
fix(pack): don't automatically include `CHANGELOG` when `files` is populated

### DIFF
--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -334,9 +334,7 @@ pub const PackCommand = struct {
                         eql(entry_name, "LICENSE") or
                         eql(entry_name, "LICENCE") or
                         eql(entry_name, "README") or
-                        entry_name.len > "README.".len and eql(entry_name[0.."README.".len], "README.") or
-                        eql(entry_name, "CHANGELOG") or
-                        entry_name.len > "CHANGELOG.".len and eql(entry_name[0.."CHANGELOG.".len], "CHANGELOG.")))
+                        entry_name.len > "README.".len and eql(entry_name[0.."README.".len], "README.")))
                         included = true;
                 }
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -763,6 +763,49 @@ describe("bundledDependnecies", () => {
 });
 
 describe("files", () => {
+  test("CHANGELOG is not included by default", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-files-changelog",
+          version: "1.1.1",
+          files: ["lib"],
+        }),
+      ),
+      write(join(packageDir, "CHANGELOG.md"), "hello"),
+      write(join(packageDir, "lib", "index.js"), "console.log('hello ./lib/index.js')"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+    const tarball = readTarball(join(packageDir, "pack-files-changelog-1.1.1.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { "pathname": "package/package.json" },
+      { "pathname": "package/lib/index.js" },
+    ]);
+  });
+  test("cannot exclude LICENSE", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-files-license",
+          version: "1.1.1",
+          files: ["lib", "!LICENSE"],
+        }),
+      ),
+      write(join(packageDir, "LICENSE"), "hello"),
+      write(join(packageDir, "lib", "index.js"), "console.log('hello ./lib/index.js')"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+    const tarball = readTarball(join(packageDir, "pack-files-license-1.1.1.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { "pathname": "package/package.json" },
+      { "pathname": "package/LICENSE" },
+      { "pathname": "package/lib/index.js" },
+    ]);
+  });
   test("can include files and directories", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
