### PR TITLE
fix(node:http) always set headersSent to true after end

### DIFF
--- a/bench/crypto/asymmetricCipher.js
+++ b/bench/crypto/asymmetricCipher.js
@@ -1,7 +1,7 @@
 import { bench, run } from "mitata";
 const crypto = require("node:crypto");
 
-const keyPair = crypto.generateKeyPairSync('rsa', {
+const keyPair = crypto.generateKeyPairSync("rsa", {
   modulusLength: 2048,
   publicKeyEncoding: {
     type: "spki",

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -12186,8 +12186,7 @@ function toCryptoKey(key, asPublic) {
 function doAsymmetricCipher(key, message, operation, isEncrypt) {
   // Our crypto bindings expect the key to be a `JSCryptoKey` property within an object.
   const cryptoKey = toCryptoKey(key, isEncrypt);
-  const oaepLabel =
-    typeof key.oaepLabel === "string" ? Buffer.from(key.oaepLabel, key.encoding) : key.oaepLabel;
+  const oaepLabel = typeof key.oaepLabel === "string" ? Buffer.from(key.oaepLabel, key.encoding) : key.oaepLabel;
   const keyObject = {
     key: cryptoKey,
     oaepHash: key.oaepHash,
@@ -12198,13 +12197,13 @@ function doAsymmetricCipher(key, message, operation, isEncrypt) {
   return operation(keyObject, buffer);
 }
 
-crypto_exports.publicEncrypt = function(key, message) {
+crypto_exports.publicEncrypt = function (key, message) {
   return doAsymmetricCipher(key, message, publicEncrypt, true);
-}
+};
 
-crypto_exports.privateDecrypt = function(key, message) {
+crypto_exports.privateDecrypt = function (key, message) {
   return doAsymmetricCipher(key, message, privateDecrypt, false);
-}
+};
 
 __export(crypto_exports, {
   DEFAULT_ENCODING: () => DEFAULT_ENCODING,

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1324,6 +1324,7 @@ ServerResponse.prototype._final = function (callback) {
     var data = this[firstWriteSymbol] || "";
     this[firstWriteSymbol] = undefined;
     this[finishedSymbol] = true;
+    this.headersSent = true; // https://github.com/oven-sh/bun/issues/3458
     drainHeadersIfObservable.$call(this);
     this._reply(
       new Response(data, {

--- a/test/js/node/crypto/crypto-rsa.test.js
+++ b/test/js/node/crypto/crypto-rsa.test.js
@@ -244,39 +244,18 @@ function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
 
   padding = constants[padding];
 
-    const encryptedBuffer = crypto.publicEncrypt(
-      {
-        key: rsaPubPem,
-        padding: padding,
-        oaepHash: encryptOaepHash,
-      },
-      bufferToEncrypt,
-    );
+  const encryptedBuffer = crypto.publicEncrypt(
+    {
+      key: rsaPubPem,
+      padding: padding,
+      oaepHash: encryptOaepHash,
+    },
+    bufferToEncrypt,
+  );
 
-    if (padding === constants.RSA_PKCS1_PADDING) {
-      expect(() => {
-        crypto.privateDecrypt(
-          {
-            key: rsaKeyPem,
-            padding: padding,
-            oaepHash: decryptOaepHash,
-          },
-          encryptedBuffer,
-        );
-      }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
-
-      expect(() => {
-        crypto.privateDecrypt(
-          {
-            key: rsaPkcs8KeyPem,
-            padding: padding,
-            oaepHash: decryptOaepHash,
-          },
-          encryptedBuffer,
-        );
-      }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
-    } else {
-      const decryptedBuffer = crypto.privateDecrypt(
+  if (padding === constants.RSA_PKCS1_PADDING) {
+    expect(() => {
+      crypto.privateDecrypt(
         {
           key: rsaKeyPem,
           padding: padding,
@@ -284,9 +263,10 @@ function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
         },
         encryptedBuffer,
       );
-      expect(decryptedBuffer).toEqual(input);
+    }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
 
-      const decryptedBufferPkcs8 = crypto.privateDecrypt(
+    expect(() => {
+      crypto.privateDecrypt(
         {
           key: rsaPkcs8KeyPem,
           padding: padding,
@@ -294,8 +274,28 @@ function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
         },
         encryptedBuffer,
       );
-      expect(decryptedBufferPkcs8).toEqual(input);
-    }
+    }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+  } else {
+    const decryptedBuffer = crypto.privateDecrypt(
+      {
+        key: rsaKeyPem,
+        padding: padding,
+        oaepHash: decryptOaepHash,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBuffer).toEqual(input);
+
+    const decryptedBufferPkcs8 = crypto.privateDecrypt(
+      {
+        key: rsaPkcs8KeyPem,
+        padding: padding,
+        oaepHash: decryptOaepHash,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferPkcs8).toEqual(input);
+  }
 }
 
 test(`RSA with RSA_NO_PADDING`, () => {
@@ -367,9 +367,11 @@ describe("Invalid oaepHash and oaepLabel options", () => {
           },
           Buffer.alloc(10),
         );
-      }).toThrow(expect.objectContaining({
-        code: "ERR_CRYPTO_INVALID_DIGEST",
-      }));
+      }).toThrow(
+        expect.objectContaining({
+          code: "ERR_CRYPTO_INVALID_DIGEST",
+        }),
+      );
 
       [0, false, null, Symbol(), () => {}].forEach(oaepHash => {
         expect(() => {
@@ -380,9 +382,11 @@ describe("Invalid oaepHash and oaepLabel options", () => {
             },
             Buffer.alloc(10),
           );
-        }).toThrow(expect.objectContaining({
-          code: "ERR_INVALID_ARG_TYPE",
-        }));
+        }).toThrow(
+          expect.objectContaining({
+            code: "ERR_INVALID_ARG_TYPE",
+          }),
+        );
       });
     });
 
@@ -396,9 +400,11 @@ describe("Invalid oaepHash and oaepLabel options", () => {
             },
             Buffer.alloc(10),
           );
-        }).toThrow(expect.objectContaining({
-          code: "ERR_INVALID_ARG_TYPE",
-        }));
+        }).toThrow(
+          expect.objectContaining({
+            code: "ERR_INVALID_ARG_TYPE",
+          }),
+        );
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?
Split from: https://github.com/oven-sh/bun/pull/13778

Fix: https://github.com/oven-sh/bun/issues/3458
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
