### PR TITLE
feat(node:util): support array type in format for the styleText util

### DIFF
--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -389,15 +389,6 @@ describe("util", () => {
         code: "ERR_INVALID_ARG_VALUE",
       },
     );
-
-    assert.throws(
-      () => {
-        util.styleText("red", "text");
-      },
-      {
-        code: "ERR_INVALID_ARG_TYPE",
-      },
-    );
   });
 
   describe("getSystemErrorName", () => {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -341,7 +341,7 @@ describe("util", () => {
   });
 
   it("styleText", () => {
-    [undefined, null, false, 5n, 5, Symbol(), () => {}, {}, []].forEach(invalidOption => {
+    [undefined, null, false, 5n, 5, Symbol(), () => {}, {}].forEach(invalidOption => {
       assert.throws(
         () => {
           util.styleText(invalidOption, "test");
@@ -370,6 +370,34 @@ describe("util", () => {
     );
 
     assert.strictEqual(util.styleText("red", "test"), "\u001b[31mtest\u001b[39m");
+
+    assert.strictEqual(
+      util.styleText(["bold", "red"], "test"),
+      "\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m",
+    );
+
+    assert.strictEqual(
+      util.styleText(["bold", "red"], "test"),
+      util.styleText("bold", util.styleText("red", "test")),
+    );
+
+    assert.throws(
+      () => {
+        util.styleText(["invalid"], "text");
+      },
+      {
+        code: "ERR_INVALID_ARG_VALUE",
+      },
+    );
+
+    assert.throws(
+      () => {
+        util.styleText("red", "text");
+      },
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+      },
+    );
   });
 
   describe("getSystemErrorName", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This adds support for format array type in the `styleText` function from the `node:util` module. This feature is already [https://nodejs.org/api/util.html#utilstyletextformat-text-options](available) in Node.js

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests matching those from Node.js

<!-- If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
