### PR TITLE
Sqlite typescript and document improvement

### DIFF
--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -620,15 +620,16 @@ class Database {
         },
   );
 
-  query<Params, ReturnType>(sql: string): Statement<Params, ReturnType>;
-  run(
+  query<ReturnType, Params>(sql: string): Statement<ReturnType, Params>;
+
+  run<Params>(
     sql: string,
-    params?: SQLQueryBindings,
+    ...params: Params[]
   ): { lastInsertRowid: number; changes: number };
   exec = this.run;
 }
 
-class Statement<Params, ReturnType> {
+class Statement<ReturnType, Params> {
   all(params: Params): ReturnType[];
   get(params: Params): ReturnType | undefined;
   run(params: Params): {

--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -75,7 +75,7 @@ To instead throw an error when a parameter is missing and allow binding without 
 import { Database } from "bun:sqlite";
 
 const strict = new Database(
-  ":memory:", 
+  ":memory:",
   { strict: true }
 );
 
@@ -648,14 +648,15 @@ class Statement<ReturnType, Params> {
   as(Class: new () => ReturnType): this;
 }
 
-type SQLQueryBindings =
+type PrimitiveSQLQueryBindings =
   | string
   | bigint
   | TypedArray
   | number
   | boolean
-  | null
-  | Record<string, string | bigint | TypedArray | number | boolean | null>;
+  | null;
+
+type SQLQueryBindings = PrimitiveSQLQueryBindings[] | Record<string, PrimitiveSQLQueryBindings>;
 ```
 
 ### Datatypes

--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -66,7 +66,7 @@ const db = new Database("mydb.sqlite", { create: true });
 Added in Bun v1.1.14
 {% /callout %}
 
-By default, `bun:sqlite` requires binding parameters to include the `$`, `:`, or `@` prefix, and does not throw an error if a parameter is missing.
+By default, `bun:sqlite` requires binding parameters to include the `$`, `:`, or `@` prefix (see [binding values](#binding-values)), and does not throw an error if a parameter is missing.
 
 To instead throw an error when a parameter is missing and allow binding without a prefix, set `strict: true` on the `Database` constructor:
 

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -199,11 +199,13 @@ declare module "bun:sqlite" {
      * | `bigint` | `INTEGER` |
      * | `null` | `NULL` |
      */
-    run<ParamsType extends SQLQueryBindings[]>(sqlQuery: string, ...bindings: ParamsType[]): Changes;
+    run<ParamsType extends SQLQueryBindings>(sqlQuery: string, bindings: ParamsType): Changes;
+    run(sqlQuery: string, ...bindings: PrimitiveSQLQueryBindings[]): Changes;
     /**
         This is an alias of {@link Database.prototype.run}
      */
-    exec<ParamsType extends SQLQueryBindings[]>(sqlQuery: string, ...bindings: ParamsType[]): Changes;
+    exec<ParamsType extends SQLQueryBindings>(sqlQuery: string, bindings: ParamsType): Changes;
+    exec(sqlQuery: string, ...bindings: PrimitiveSQLQueryBindings[]): Changes;
 
     /**
      * Compile a SQL query and return a {@link Statement} object. This is the
@@ -229,10 +231,9 @@ declare module "bun:sqlite" {
      *
      * Under the hood, this calls `sqlite3_prepare_v3`.
      */
-    query<ReturnType, ParamsType extends SQLQueryBindings | SQLQueryBindings[]>(
+    query<ReturnType, ParamsType extends SQLQueryBindings = []>(
       sqlQuery: string,
-    ): // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
-    Statement<ReturnType, ParamsType extends any[] ? ParamsType : [ParamsType]>;
+    ): Statement<ReturnType, ParamsType>;
 
     /**
      * Compile a SQL query and return a {@link Statement} object.
@@ -254,11 +255,10 @@ declare module "bun:sqlite" {
      *
      * Under the hood, this calls `sqlite3_prepare_v3`.
      */
-    prepare<ReturnType, ParamsType extends SQLQueryBindings | SQLQueryBindings[]>(
+    prepare<ReturnType, ParamsType extends SQLQueryBindings = []>(
       sqlQuery: string,
       params?: ParamsType,
-    ): // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
-    Statement<ReturnType, ParamsType extends any[] ? ParamsType : [ParamsType]>;
+    ): Statement<ReturnType, ParamsType>;
 
     /**
      * Is the database in a transaction?
@@ -515,7 +515,7 @@ declare module "bun:sqlite" {
    * // => undefined
    * ```
    */
-  export class Statement<ReturnType = unknown, ParamsType extends SQLQueryBindings[] = any[]> implements Disposable {
+  export class Statement<ReturnType = unknown, ParamsType extends SQLQueryBindings = []> implements Disposable {
     /**
      * Creates a new prepared statement from native code.
      *
@@ -542,7 +542,8 @@ declare module "bun:sqlite" {
      * // => [{bar: "foo"}]
      * ```
      */
-    all(...params: ParamsType): ReturnType[];
+    all(params: ParamsType): ReturnType[];
+    all(...params: PrimitiveSQLQueryBindings[]): ReturnType[];
 
     /**
      * Execute the prepared statement and return **the first** result.
@@ -577,7 +578,8 @@ declare module "bun:sqlite" {
      * | `bigint` | `INTEGER` |
      * | `null` | `NULL` |
      */
-    get(...params: ParamsType): ReturnType | null;
+    get(params: ParamsType): ReturnType | null;
+    get(...params: PrimitiveSQLQueryBindings[]): ReturnType | null;
 
     /**
      * Execute the prepared statement. This returns `undefined`.
@@ -609,7 +611,8 @@ declare module "bun:sqlite" {
      * | `bigint` | `INTEGER` |
      * | `null` | `NULL` |
      */
-    run(...params: ParamsType): Changes;
+    run(params: ParamsType): Changes;
+    run(...params: PrimitiveSQLQueryBindings[]): Changes;
 
     /**
      * Execute the prepared statement and return the results as an array of arrays.
@@ -649,7 +652,8 @@ declare module "bun:sqlite" {
      * | `bigint` | `INTEGER` |
      * | `null` | `NULL` |
      */
-    values(...params: ParamsType): Array<Array<string | bigint | number | boolean | Uint8Array>>;
+    values(params: ParamsType): Array<Array<string | bigint | number | boolean | Uint8Array>>;
+    values(...params: PrimitiveSQLQueryBindings[]): Array<Array<string | bigint | number | boolean | Uint8Array>>;
 
     /**
      * The names of the columns returned by the prepared statement.
@@ -1066,14 +1070,15 @@ declare module "bun:sqlite" {
    */
   export var native: any;
 
-  export type SQLQueryBindings =
+  export type PrimitiveSQLQueryBindings =
     | string
     | bigint
     | NodeJS.TypedArray
     | number
     | boolean
-    | null
-    | Record<string, string | bigint | NodeJS.TypedArray | number | boolean | null>;
+    | null;
+
+  export type SQLQueryBindings = PrimitiveSQLQueryBindings[] | Record<string, PrimitiveSQLQueryBindings>;
 
   export default Database;
 

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -179,7 +179,7 @@ declare module "bun:sqlite" {
      * - `CREATE VIRTUAL TABLE`
      * - `CREATE TEMPORARY TABLE`
      *
-     * @param sql The SQL query to run
+     * @param sqlQuery The SQL query to run
      *
      * @param bindings Optional bindings for the query
      *
@@ -223,7 +223,7 @@ declare module "bun:sqlite" {
      * stmt.all();
      * ```
      *
-     * @param sql The SQL query to compile
+     * @param sqlQuery The SQL query to compile
      *
      * @returns `Statment` instance
      *
@@ -247,7 +247,7 @@ declare module "bun:sqlite" {
      * stmt.all("baz");
      * ```
      *
-     * @param sql The SQL query to compile
+     * @param sqlQuery The SQL query to compile
      * @param params Optional bindings for the query
      *
      * @returns `Statment` instance

--- a/packages/bun-types/test/sqlite.test.ts
+++ b/packages/bun-types/test/sqlite.test.ts
@@ -26,8 +26,7 @@ expectType<void>(runResults);
 
 const query3 = db.prepare<
   { name: string; dob: number }, // return type first
-  // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
-  [{ $id: string }]
+  { $id: string }
 >("select name, dob from users where id = $id");
 const allResults3 = query3.all({ $id: "asdf" });
 expectType<Array<{ name: string; dob: number }>>(allResults3);


### PR DESCRIPTION
### What does this PR do?
1. Makes Params generic type optional in `query` and `prepare` 
2. Fix `db.run` generic not working correctly
3. So basically there are three ways to pass the bindings
  - As separate params (with primitive types)
  - As an array (of primitive types)
  - As an object (record<string, primitive>)
  Previous types allowed for thing like an array or objects that could have caused error. (it works if there is only one object in an array but is it really clean?) now if you decide to pass multiple param or pass an array it should be from primitive types.

See the example below for better understanding.
  
```ts
import { Database } from "bun:sqlite";

const db = new Database(":memory:", { strict: true });

interface Product {
  id: number;
  title: string;
  price: number;
  [key: string]: string | number;
}

db.run(`
    CREATE TABLE IF NOT EXISTS product
    (
        id    INTEGER PRIMARY KEY,
        title TEXT,
        price REAL
    );
`);

const insertStmt = db.prepare<void, Product>(`
    INSERT INTO product(id, title, price)
    VALUES ($id, $title, $price)
`);

insertStmt.run({
  id: 1,
  title: "Product 1",
  price: 5.95,
});

// Before -> No TS error 😢
// Now -> TS2769: No overload matches this call.
db.run(
  `
    INSERT INTO product(id, title, price)
    VALUES ($id, $title, $price)
`,
  [
    {
      id: 2,
      title: "Product 2",
      price: 9.99,
    },
    {
      id: 3,
      title: "Product 3",
      price: 9.99,
    },
  ],
);

// Before -> TS2344: Type Product does not satisfy the constraint SQLQueryBindings[]
// Now -> Works 🥳
db.run<Product>(
  `
    INSERT INTO product(id, title, price)
    VALUES ($id, $title, $price)
`,
  {
    id: 4,
    title: "Product 4",
    price: 9.99,
  },
);

// Before -> TS2558: Expected 2 type arguments, but got 1
// Now -> Works 🥳
let products = db
  .query<Product>(
    `
        SELECT *
        FROM product
    `,
  )
  .all();
console.log(products);

// Before -> TS2345: Argument of type number is not assignable to parameter of type { id: number; }
// Now -> works with both 1 or {id: 1} 
const product = db
  .query<Product, { id: number }>(
    `
        SELECT *
        FROM product WHERE id = $id
    `,
  )
  .get(1);
```


- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
