### PR TITLE
Add missing timers.promises

### DIFF
--- a/bench/crypto/asymmetricCipher.js
+++ b/bench/crypto/asymmetricCipher.js
@@ -1,7 +1,7 @@
 import { bench, run } from "mitata";
 const crypto = require("node:crypto");
 
-const keyPair = crypto.generateKeyPairSync('rsa', {
+const keyPair = crypto.generateKeyPairSync("rsa", {
   modulusLength: 2048,
   publicKeyEncoding: {
     type: "spki",

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -12186,8 +12186,7 @@ function toCryptoKey(key, asPublic) {
 function doAsymmetricCipher(key, message, operation, isEncrypt) {
   // Our crypto bindings expect the key to be a `JSCryptoKey` property within an object.
   const cryptoKey = toCryptoKey(key, isEncrypt);
-  const oaepLabel =
-    typeof key.oaepLabel === "string" ? Buffer.from(key.oaepLabel, key.encoding) : key.oaepLabel;
+  const oaepLabel = typeof key.oaepLabel === "string" ? Buffer.from(key.oaepLabel, key.encoding) : key.oaepLabel;
   const keyObject = {
     key: cryptoKey,
     oaepHash: key.oaepHash,
@@ -12198,13 +12197,13 @@ function doAsymmetricCipher(key, message, operation, isEncrypt) {
   return operation(keyObject, buffer);
 }
 
-crypto_exports.publicEncrypt = function(key, message) {
+crypto_exports.publicEncrypt = function (key, message) {
   return doAsymmetricCipher(key, message, publicEncrypt, true);
-}
+};
 
-crypto_exports.privateDecrypt = function(key, message) {
+crypto_exports.privateDecrypt = function (key, message) {
   return doAsymmetricCipher(key, message, privateDecrypt, false);
-}
+};
 
 __export(crypto_exports, {
   DEFAULT_ENCODING: () => DEFAULT_ENCODING,

--- a/src/js/node/timers.ts
+++ b/src/js/node/timers.ts
@@ -1,4 +1,4 @@
-// Hardcoded module "node:timers"
+const { throwNotImplemented } = require("internal/shared");
 const { defineCustomPromisify } = require("internal/promisify");
 
 // Lazily load node:timers/promises promisified functions onto the global timers.
@@ -26,6 +26,7 @@ const { defineCustomPromisify } = require("internal/promisify");
     });
   }
 }
+var timersPromisesValue;
 
 export default {
   setTimeout,
@@ -34,4 +35,33 @@ export default {
   setImmediate,
   clearInterval,
   clearImmediate,
+  get promises() {
+    return (timersPromisesValue ??= require("node:timers/promises"));
+  },
+  set promises(value) {
+    timersPromisesValue = value;
+  },
+  active(timer) {
+    if ($isCallable(timer?.refresh)) {
+      timer.refresh();
+    } else {
+      throwNotImplemented("'timers.active'");
+    }
+  },
+  unenroll(timer) {
+    if ($isCallable(timer?.refresh)) {
+      clearTimeout(timer);
+      return;
+    }
+
+    throwNotImplemented("'timers.unenroll'");
+  },
+  enroll(timer, msecs) {
+    if ($isCallable(timer?.refresh)) {
+      timer.refresh();
+      return;
+    }
+
+    throwNotImplemented("'timers.enroll'");
+  },
 };

--- a/test/js/node/crypto/crypto-rsa.test.js
+++ b/test/js/node/crypto/crypto-rsa.test.js
@@ -244,39 +244,18 @@ function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
 
   padding = constants[padding];
 
-    const encryptedBuffer = crypto.publicEncrypt(
-      {
-        key: rsaPubPem,
-        padding: padding,
-        oaepHash: encryptOaepHash,
-      },
-      bufferToEncrypt,
-    );
+  const encryptedBuffer = crypto.publicEncrypt(
+    {
+      key: rsaPubPem,
+      padding: padding,
+      oaepHash: encryptOaepHash,
+    },
+    bufferToEncrypt,
+  );
 
-    if (padding === constants.RSA_PKCS1_PADDING) {
-      expect(() => {
-        crypto.privateDecrypt(
-          {
-            key: rsaKeyPem,
-            padding: padding,
-            oaepHash: decryptOaepHash,
-          },
-          encryptedBuffer,
-        );
-      }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
-
-      expect(() => {
-        crypto.privateDecrypt(
-          {
-            key: rsaPkcs8KeyPem,
-            padding: padding,
-            oaepHash: decryptOaepHash,
-          },
-          encryptedBuffer,
-        );
-      }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
-    } else {
-      const decryptedBuffer = crypto.privateDecrypt(
+  if (padding === constants.RSA_PKCS1_PADDING) {
+    expect(() => {
+      crypto.privateDecrypt(
         {
           key: rsaKeyPem,
           padding: padding,
@@ -284,9 +263,10 @@ function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
         },
         encryptedBuffer,
       );
-      expect(decryptedBuffer).toEqual(input);
+    }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
 
-      const decryptedBufferPkcs8 = crypto.privateDecrypt(
+    expect(() => {
+      crypto.privateDecrypt(
         {
           key: rsaPkcs8KeyPem,
           padding: padding,
@@ -294,8 +274,28 @@ function test_rsa(padding, encryptOaepHash, decryptOaepHash, exceptionThrown) {
         },
         encryptedBuffer,
       );
-      expect(decryptedBufferPkcs8).toEqual(input);
-    }
+    }).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
+  } else {
+    const decryptedBuffer = crypto.privateDecrypt(
+      {
+        key: rsaKeyPem,
+        padding: padding,
+        oaepHash: decryptOaepHash,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBuffer).toEqual(input);
+
+    const decryptedBufferPkcs8 = crypto.privateDecrypt(
+      {
+        key: rsaPkcs8KeyPem,
+        padding: padding,
+        oaepHash: decryptOaepHash,
+      },
+      encryptedBuffer,
+    );
+    expect(decryptedBufferPkcs8).toEqual(input);
+  }
 }
 
 test(`RSA with RSA_NO_PADDING`, () => {
@@ -367,9 +367,11 @@ describe("Invalid oaepHash and oaepLabel options", () => {
           },
           Buffer.alloc(10),
         );
-      }).toThrow(expect.objectContaining({
-        code: "ERR_CRYPTO_INVALID_DIGEST",
-      }));
+      }).toThrow(
+        expect.objectContaining({
+          code: "ERR_CRYPTO_INVALID_DIGEST",
+        }),
+      );
 
       [0, false, null, Symbol(), () => {}].forEach(oaepHash => {
         expect(() => {
@@ -380,9 +382,11 @@ describe("Invalid oaepHash and oaepLabel options", () => {
             },
             Buffer.alloc(10),
           );
-        }).toThrow(expect.objectContaining({
-          code: "ERR_INVALID_ARG_TYPE",
-        }));
+        }).toThrow(
+          expect.objectContaining({
+            code: "ERR_INVALID_ARG_TYPE",
+          }),
+        );
       });
     });
 
@@ -396,9 +400,11 @@ describe("Invalid oaepHash and oaepLabel options", () => {
             },
             Buffer.alloc(10),
           );
-        }).toThrow(expect.objectContaining({
-          code: "ERR_INVALID_ARG_TYPE",
-        }));
+        }).toThrow(
+          expect.objectContaining({
+            code: "ERR_INVALID_ARG_TYPE",
+          }),
+        );
       });
     });
   });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { clearInterval, clearTimeout, setInterval, setTimeout } from "node:timers";
+import { clearInterval, clearTimeout, setInterval, setTimeout, promises } from "node:timers";
 import { promisify } from "util";
 
 for (const fn of [setTimeout, setInterval]) {
@@ -51,4 +51,9 @@ it("node.js util.promisify(setImmediate) works", async () => {
       throw new Error("TestPassed");
     });
   }).toThrow("TestPassed");
+});
+
+it("timers.promises === timers/promises", async () => {
+  const ns = await import("node:timers/promises");
+  expect(ns.default).toBe(promises);
 });

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { clearInterval, clearTimeout, setInterval, setTimeout, promises } from "node:timers";
+import { clearInterval, clearTimeout, promises, setInterval, setTimeout } from "node:timers";
 import { promisify } from "util";
 
 for (const fn of [setTimeout, setInterval]) {


### PR DESCRIPTION
### What does this PR do?

Add missing timers.promises

preserved the behavior of `require("timers").promises = `

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
