### PR TITLE
fix(`node:net`, `node:tls`) add named pipe support on `node:net` and `node:tls` modules

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -730,6 +730,7 @@ pub const EventLoopTimer = struct {
         TestRunner,
         StatWatcherScheduler,
         UpgradedDuplex,
+        WrappedPipe,
 
         pub fn Type(comptime T: Tag) type {
             return switch (T) {
@@ -738,6 +739,7 @@ pub const EventLoopTimer = struct {
                 .TestRunner => JSC.Jest.TestRunner,
                 .StatWatcherScheduler => StatWatcherScheduler,
                 .UpgradedDuplex => uws.UpgradedDuplex,
+                .WrappedPipe => uws.WrappedPipe,
             };
         }
     };
@@ -799,6 +801,9 @@ pub const EventLoopTimer = struct {
                     return container.timerCallback();
                 }
                 if (comptime t.Type() == uws.UpgradedDuplex) {
+                    return container.onTimeout();
+                }
+                if (comptime t.Type() == uws.WrappedPipe) {
                     return container.onTimeout();
                 }
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -932,14 +932,18 @@ pub const Listener = struct {
         if (this.handlers.active_connections == 0) {
             this.handlers.unprotect();
             // deiniting the context will also close the listener
-            this.socket_context.?.deinit(this.ssl);
-            this.socket_context = null;
+            if (this.socket_context) |ctx| {
+                this.socket_context = null;
+                ctx.deinit(this.ssl);
+            }
             this.strong_self.clear();
             this.strong_data.clear();
         } else {
             if (force_close) {
                 // close all connections in this context and wait for them to close
-                this.socket_context.?.close(this.ssl);
+                if (this.socket_context) |ctx| {
+                    ctx.close(this.ssl);
+                }
             } else {
                 // only close the listener and wait for the connections to close by it self
                 switch (listener) {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -3833,6 +3833,7 @@ pub const WindowsNamedPipeContext = if (Environment.isWindows) struct {
         if (socket != .listener) {
             return error.InvalidOptions;
         }
+
         const this = WindowsNamedPipeContext.create(globalThis, socket);
         if (ssl_config) |ssl_options| {
             BoringSSL.load();
@@ -3850,6 +3851,12 @@ pub const WindowsNamedPipeContext = if (Environment.isWindows) struct {
         }
 
         this.uvPipe.listenNamedPipe(path, backlog, this, onClientConnect).unwrap() catch return error.FailedToBindPipe;
+        _ = uv.uv_pipe_chmod(&this.uvPipe, uv.UV_WRITABLE | uv.UV_READABLE);
+        //TODO: add readableAll and writableAll support if someone needs it
+        // if(uv.uv_pipe_chmod(&this.uvPipe, uv.UV_WRITABLE | uv.UV_READABLE) != 0) {
+        // this.closePipeAndDeinit();
+        // return error.FailedChmodPipe;
+        //}
 
         return this;
     }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -3797,8 +3797,8 @@ pub const WindowsNamedPipeContext = if (Environment.isWindows) struct {
     }
 
     fn onClientConnect(this: *WindowsNamedPipeContext, status: uv.ReturnCode) void {
-        if (status != uv.ReturnCode.zero) {
-            // connection dropped
+        if (status != uv.ReturnCode.zero or this.vm.isShuttingDown()) {
+            // connection dropped or vm is shutting down
             return;
         }
         bun.assert(this.socket == .listener);

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -3615,6 +3615,7 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
         };
 
         const client = WindowsNamedPipeContext.create(this.globalThis, socket);
+
         const result = client.named_pipe.getAcceptedBy(&this.uvPipe, this.ctx);
         if (result == .err) {
             // connection dropped

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1113,7 +1113,6 @@ pub const Listener = struct {
                 var handlers_ptr = handlers.vm.allocator.create(Handlers) catch bun.outOfMemory();
                 handlers_ptr.* = handlers;
                 handlers_ptr.is_server = false;
-                handlers_ptr.protect();
 
                 var promise = JSC.JSPromise.create(globalObject);
                 const promise_value = promise.asValue(globalObject);

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -3723,6 +3723,7 @@ pub const WindowsNamedPipeContext = if (Environment.isWindows) struct {
     };
 
     usingnamespace bun.New(WindowsNamedPipeContext);
+    const log = Output.scoped(.WindowsNamedPipeContext, false);
 
     fn onOpen(this: *WindowsNamedPipeContext) void {
         this.is_open = true;
@@ -3963,6 +3964,7 @@ pub const WindowsNamedPipeContext = if (Environment.isWindows) struct {
         return &this.named_pipe;
     }
     fn deinit(this: *WindowsNamedPipeContext) void {
+        log("deinit", .{});
         const socket = this.socket;
         this.socket = .none;
         switch (socket) {

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -59,7 +59,6 @@ pub fn SSLWrapper(comptime T: type) type {
         /// Initialize the SSLWrapper with a specific SSL_CTX*, remember to call SSL_CTX_up_ref if you want to keep the SSL_CTX alive after the SSLWrapper is deinitialized
         pub fn initWithCTX(ctx: *BoringSSL.SSL_CTX, is_client: bool, handlers: Handlers) !This {
             BoringSSL.load();
-
             const ssl = BoringSSL.SSL_new(ctx) orelse return error.OutOfMemory;
             errdefer BoringSSL.SSL_free(ssl);
 

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -2645,7 +2645,7 @@ pub fn translateUVErrorToE(code_in: anytype) bun.C.E {
         UV_EREMOTEIO => bun.C.E.REMOTEIO,
         UV_ECANCELED => bun.C.E.CANCELED,
         UV_ECHARSET => bun.C.E.CHARSET,
-        UV_EOF => bun.C.E.OF,
+        UV_EOF => bun.C.E.EOF,
         else => @enumFromInt(-code),
     };
 }
@@ -2750,7 +2750,7 @@ pub const ReturnCode = enum(c_int) {
                 UV_EREMOTEIO => @intFromEnum(bun.C.E.REMOTEIO),
                 UV_ECANCELED => @intFromEnum(bun.C.E.CANCELED),
                 UV_ECHARSET => @intFromEnum(bun.C.E.CHARSET),
-                UV_EOF => @intFromEnum(bun.C.E.OF),
+                UV_EOF => @intFromEnum(bun.C.E.EOF),
                 else => null,
             }
         else

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -1312,7 +1312,7 @@ pub const Pipe = extern struct {
     }
 
     pub fn listenNamedPipe(this: *@This(), named_pipe: []const u8, backlog: i32, context: anytype, comptime onClientConnect: *const (fn (@TypeOf(context), ReturnCode) void)) Maybe(void) {
-        if (this.bind(named_pipe, 0).asErr()) |err| {
+        if (this.bind(named_pipe, UV_PIPE_NO_TRUNCATE).asErr()) |err| {
             return .{ .err = err };
         }
         return this.listen(backlog, context, onClientConnect);
@@ -1332,8 +1332,7 @@ pub const Pipe = extern struct {
                 onConnect(@ptrCast(@alignCast(handle.data)), status);
             }
         };
-
-        if (uv_pipe_connect2(req, this, @ptrCast(name.ptr), name.len, 0, &Wrapper.uvConnectCb).toError(.connect2)) |err| {
+        if (uv_pipe_connect2(req, this, @ptrCast(name.ptr), name.len, UV_PIPE_NO_TRUNCATE, &Wrapper.uvConnectCb).toError(.connect2)) |err| {
             return .{ .err = err };
         }
         return .{ .result = {} };

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -835,6 +835,7 @@ pub const WindowsNamedPipe = if (Environment.isWindows) struct {
         onConnect(this, uv.ReturnCode.zero);
         return .{ .result = {} };
     }
+
     pub fn connect(this: *WindowsNamedPipe, path: []const u8, ssl_options: ?JSC.API.ServerConfig.SSLConfig) JSC.Maybe(void) {
         bun.assert(this.pipe != null);
         this.flags.disconnected = true;
@@ -929,7 +930,7 @@ pub const WindowsNamedPipe = if (Environment.isWindows) struct {
 
     pub fn close(this: *WindowsNamedPipe) void {
         if (this.wrapper) |*wrapper| {
-            _ = wrapper.shutdown(true);
+            _ = wrapper.shutdown(false);
         }
         this.writer.end();
     }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -549,11 +549,430 @@ pub const UpgradedDuplex = struct {
     }
 };
 
+pub const WrappedPipe = struct {
+    pub const CertError = UpgradedDuplex.CertError;
+
+    const WrapperType = SSLWrapper(*WrappedPipe);
+    const uv = bun.windows.libuv;
+    wrapper: ?WrapperType,
+    pipe: if (Environment.isWindows) ?*uv.Pipe else void, // any duplex
+
+    writer: bun.io.StreamingWriter(WrappedPipe, onWrite, onError, onWritable, onPipeClose) = .{},
+
+    incoming: bun.ByteList = .{}, // Maybe we should use IPCBuffer here as well
+    ssl_error: CertError = .{},
+    globalThis: *JSC.JSGlobalObject,
+    vm: *bun.JSC.VirtualMachine,
+    handlers: Handlers,
+    connect_req: uv.uv_connect_t = std.mem.zeroes(uv.uv_connect_t),
+
+    event_loop_timer: EventLoopTimer = .{
+        .next = .{},
+        .tag = .WrappedPipe,
+    },
+    current_timeout: u32 = 0,
+    flags: Flags = .{},
+
+    pub const Flags = packed struct {
+        disconnected: bool = true,
+        is_client: bool = false,
+        is_ssl: bool = false,
+    };
+    pub const Handlers = struct {
+        ctx: *anyopaque,
+        onOpen: *const fn (*anyopaque) void,
+        onHandshake: *const fn (*anyopaque, bool, uws.us_bun_verify_error_t) void,
+        onData: *const fn (*anyopaque, []const u8) void,
+        onClose: *const fn (*anyopaque) void,
+        onEnd: *const fn (*anyopaque) void,
+        onWritable: *const fn (*anyopaque) void,
+        onError: *const fn (*anyopaque, JSC.JSValue) void,
+        onTimeout: *const fn (*anyopaque) void,
+    };
+
+    const log = bun.Output.scoped(.WrappedPipe, false);
+
+    fn onWritable(
+        this: *WrappedPipe,
+    ) void {
+        log("onWritable", .{});
+        // flush pending data
+        this.flush();
+        // call onWritable (will flush on demand)
+        this.handlers.onWritable(this.handlers.ctx);
+    }
+
+    fn onPipeClose(this: *WrappedPipe) void {
+        log("onPipeClose", .{});
+        this.flags.disconnected = true;
+        this.pipe = null;
+        this.handlers.onClose(this.handlers.ctx);
+    }
+    fn onReadAlloc(this: *WrappedPipe, suggested_size: usize) []u8 {
+        var available = this.incoming.available();
+        if (available.len < suggested_size) {
+            this.incoming.ensureUnusedCapacity(bun.default_allocator, suggested_size) catch bun.outOfMemory();
+            available = this.incoming.available();
+        }
+        return available.ptr[0..suggested_size];
+    }
+
+    fn onRead(this: *WrappedPipe, buffer: []const u8) void {
+        log("onRead ({})", .{buffer.len});
+        this.incoming.len += @as(u32, @truncate(buffer.len));
+        bun.assert(this.incoming.len <= this.incoming.cap);
+        bun.assert(bun.isSliceInBuffer(buffer, this.incoming.allocatedSlice()));
+
+        const data = this.incoming.slice();
+
+        this.resetTimeout();
+
+        if (this.wrapper) |*wrapper| {
+            wrapper.receiveData(data);
+        } else {
+            this.handlers.onData(this.handlers.ctx, data);
+        }
+        this.incoming.len = 0;
+    }
+
+    fn onWrite(this: *WrappedPipe, amount: usize, status: bun.io.WriteStatus) void {
+        log("onWrite {d} {}", .{ amount, status });
+
+        switch (status) {
+            .pending => {},
+            .drained => {
+                // unref after sending all data
+                this.writer.source.?.pipe.unref();
+            },
+            .end_of_file => {
+                this.handlers.onEnd(this.handlers.ctx);
+            },
+        }
+    }
+
+    fn onError(this: *WrappedPipe, err: bun.sys.Error) void {
+        log("onError", .{});
+        if (this.vm.isShuttingDown()) {
+            this.writer.close();
+            return;
+        }
+        this.handlers.onError(this.handlers.ctx, err.toJSC(this.globalThis));
+    }
+
+    fn onOpen(this: *WrappedPipe) void {
+        log("onOpen", .{});
+        this.handlers.onOpen(this.handlers.ctx);
+    }
+
+    fn onData(this: *WrappedPipe, decoded_data: []const u8) void {
+        log("onData ({})", .{decoded_data.len});
+        this.handlers.onData(this.handlers.ctx, decoded_data);
+    }
+
+    fn onHandshake(this: *WrappedPipe, handshake_success: bool, ssl_error: uws.us_bun_verify_error_t) void {
+        log("onHandshake", .{});
+
+        this.ssl_error = .{
+            .error_no = ssl_error.error_no,
+            .code = if (ssl_error.code == null) "" else bun.default_allocator.dupeZ(u8, ssl_error.code[0..bun.len(ssl_error.code) :0]) catch bun.outOfMemory(),
+            .reason = if (ssl_error.reason == null) "" else bun.default_allocator.dupeZ(u8, ssl_error.reason[0..bun.len(ssl_error.reason) :0]) catch bun.outOfMemory(),
+        };
+        this.handlers.onHandshake(this.handlers.ctx, handshake_success, ssl_error);
+    }
+
+    fn onClose(this: *WrappedPipe) void {
+        log("onClose", .{});
+        defer this.deinit();
+
+        this.handlers.onClose(this.handlers.ctx);
+        // closes the underlying duplex
+        this.callWriteOrEnd(null, false);
+    }
+
+    fn callWriteOrEnd(this: *WrappedPipe, data: ?[]const u8, msg_more: bool) void {
+        if (data) |bytes| {
+            if (bytes.len > 0) {
+                // ref because we have pending data
+                this.writer.source.?.pipe.ref();
+                if (this.flags.disconnected) {
+                    // enqueue to be sent after connecting
+                    this.writer.outgoing.write(bytes) catch bun.outOfMemory();
+                } else {
+                    // write will enqueue the data if it cannot be sent
+                    _ = this.writer.write(bytes);
+                }
+            }
+        }
+
+        if (!msg_more) {
+            if (this.wrapper) |*wrapper| {
+                _ = wrapper.shutdown(false);
+            }
+            this.writer.end();
+        }
+    }
+
+    fn internalWrite(this: *WrappedPipe, encoded_data: []const u8) void {
+        this.resetTimeout();
+
+        // Possible scenarios:
+        // Scenario 1: will not write if is not connected yet but will enqueue the data
+        // Scenario 2: will not write if a exception is thrown (will be handled by onError)
+        // Scenario 3: will be queued in memory and will be flushed later
+        // Scenario 4: no write/end function exists (will be handled by onError)
+        this.callWriteOrEnd(encoded_data, true);
+    }
+
+    pub fn flush(this: *WrappedPipe) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.flush();
+        }
+        if (!this.flags.disconnected) {
+            _ = this.writer.flush();
+        }
+    }
+
+    fn onInternalReceiveData(this: *WrappedPipe, data: []const u8) void {
+        if (this.wrapper) |*wrapper| {
+            this.resetTimeout();
+            wrapper.receiveData(data);
+        }
+    }
+
+    pub fn onTimeout(this: *WrappedPipe) EventLoopTimer.Arm {
+        log("onTimeout", .{});
+
+        const has_been_cleared = this.event_loop_timer.state == .CANCELLED or this.vm.scriptExecutionStatus() != .running;
+
+        this.event_loop_timer.state = .FIRED;
+        this.event_loop_timer.heap = .{};
+
+        if (has_been_cleared) {
+            return .disarm;
+        }
+
+        this.handlers.onTimeout(this.handlers.ctx);
+
+        return .disarm;
+    }
+
+    pub fn from(
+        globalThis: *JSC.JSGlobalObject,
+        pipe: if (Environment.isWindows) *uv.Pipe else void,
+        handlers: WrappedPipe.Handlers,
+    ) !WrappedPipe {
+        if (Environment.isPosix) {
+            @compileError("WrappedPipe is not supported on POSIX systems");
+        }
+        return WrappedPipe{
+            .vm = globalThis.bunVM(),
+            .globalThis = globalThis,
+            .pipe = pipe,
+            .wrapper = null,
+            .handlers = handlers,
+        };
+    }
+    fn onConnect(this: *WrappedPipe, status: uv.ReturnCode) void {
+        if (status.errEnum()) |err| {
+            this.onError(err);
+            return;
+        }
+        this.flags.disconnected = false;
+        if (this.start(true)) {
+            if (this.isTLS()) {
+                if (this.wrapper) |*wrapper| {
+                    wrapper.start();
+                }
+            } else {
+                // trigger onOpen
+                this.onOpen();
+            }
+        }
+        this.flush();
+    }
+
+    pub fn connect(this: *WrappedPipe, path: []const u8, ssl_options: ?JSC.API.ServerConfig.SSLConfig) !void {
+        if (this.pipe == null) {
+            return bun.C.E.BADF;
+        }
+        this.flags.disconnected = true;
+        // ref because we are connecting
+        _ = this.pipe.?.ref();
+
+        if (ssl_options) |tls| {
+            this.flags.is_ssl = true;
+            this.wrapper = try WrapperType.init(tls, true, .{
+                .ctx = this,
+                .onOpen = WrappedPipe.onOpen,
+                .onHandshake = WrappedPipe.onHandshake,
+                .onData = WrappedPipe.onData,
+                .onClose = WrappedPipe.onClose,
+                .write = WrappedPipe.internalWrite,
+            });
+        }
+        return this.pipe.connect(this.connect_req, path, WrappedPipe, onConnect);
+    }
+    pub fn startTLS(this: *WrappedPipe, ssl_options: JSC.API.ServerConfig.SSLConfig, is_client: bool) !void {
+        this.flags.is_ssl = true;
+        if (this.start(is_client)) {
+            this.wrapper = try WrapperType.init(ssl_options, is_client, .{
+                .ctx = this,
+                .onOpen = WrappedPipe.onOpen,
+                .onHandshake = WrappedPipe.onHandshake,
+                .onData = WrappedPipe.onData,
+                .onClose = WrappedPipe.onClose,
+                .write = WrappedPipe.internalWrite,
+            });
+
+            this.wrapper.?.start();
+        }
+    }
+
+    pub fn start(this: *WrappedPipe, is_client: bool) bool {
+        this.flags.is_client = is_client;
+        if (this.pipe == null) {
+            return false;
+        }
+        _ = this.pipe.?.unref();
+        this.writer.setParent(this);
+        const startPipeResult = this.writer.startWithPipe(this.pipe.?);
+        if (startPipeResult == .err) {
+            this.onError(startPipeResult.getErrno());
+            return false;
+        }
+        const stream = this.writer.getStream() orelse {
+            this.onError(bun.C.E.PIPE);
+            return false;
+        };
+
+        const readStartResult = stream.readStart(this, onReadAlloc, onError, onRead);
+        if (readStartResult == .err) {
+            this.onError(startPipeResult.getErrno());
+            return false;
+        }
+        return true;
+    }
+
+    pub fn isTLS(this: *WrappedPipe) bool {
+        return this.flags.is_ssl;
+    }
+
+    pub fn encodeAndWrite(this: *WrappedPipe, data: []const u8, is_end: bool) i32 {
+        log("encodeAndWrite (len: {} - is_end: {})", .{ data.len, is_end });
+        if (this.wrapper) |*wrapper| {
+            return @as(i32, @intCast(wrapper.writeData(data) catch 0));
+        } else {
+            this.internalWrite(data);
+        }
+        return 0;
+    }
+
+    pub fn rawWrite(this: *WrappedPipe, encoded_data: []const u8, _: bool) i32 {
+        this.internalWrite(encoded_data);
+        return @intCast(encoded_data.len);
+    }
+
+    pub fn close(this: *WrappedPipe) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.shutdown(true);
+        }
+        this.writer.end();
+    }
+
+    pub fn shutdown(this: *WrappedPipe) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.shutdown(false);
+        }
+    }
+
+    pub fn shutdownRead(this: *WrappedPipe) void {
+        if (this.wrapper) |*wrapper| {
+            _ = wrapper.shutdownRead();
+        } else {
+            if (this.writer.getStream()) |stream| {
+                _ = stream.readStop();
+            }
+        }
+    }
+
+    pub fn isShutdown(this: *WrappedPipe) bool {
+        if (this.wrapper) |wrapper| {
+            return wrapper.isShutdown();
+        }
+
+        return this.flags.disconnected or this.writer.is_done;
+    }
+
+    pub fn isClosed(this: *WrappedPipe) bool {
+        if (this.wrapper) |wrapper| {
+            return wrapper.isClosed();
+        }
+        return this.flags.disconnected;
+    }
+
+    pub fn isEstablished(this: *WrappedPipe) bool {
+        return !this.isClosed();
+    }
+
+    pub fn ssl(this: *WrappedPipe) ?*BoringSSL.SSL {
+        if (this.wrapper) |wrapper| {
+            return wrapper.ssl;
+        }
+        return null;
+    }
+
+    pub fn sslError(this: *WrappedPipe) us_bun_verify_error_t {
+        return .{
+            .error_no = this.ssl_error.error_no,
+            .code = @ptrCast(this.ssl_error.code.ptr),
+            .reason = @ptrCast(this.ssl_error.reason.ptr),
+        };
+    }
+
+    pub fn resetTimeout(this: *WrappedPipe) void {
+        this.setTimeoutInMilliseconds(this.current_timeout);
+    }
+    pub fn setTimeoutInMilliseconds(this: *WrappedPipe, ms: c_uint) void {
+        if (this.event_loop_timer.state == .ACTIVE) {
+            this.vm.timer.remove(&this.event_loop_timer);
+        }
+        this.current_timeout = ms;
+
+        // if the interval is 0 means that we stop the timer
+        if (ms == 0) {
+            return;
+        }
+
+        // reschedule the timer
+        this.event_loop_timer.next = bun.timespec.msFromNow(ms);
+        this.vm.timer.insert(&this.event_loop_timer);
+    }
+    pub fn setTimeout(this: *WrappedPipe, seconds: c_uint) void {
+        log("setTimeout({d})", .{seconds});
+        this.setTimeoutInMilliseconds(seconds * 1000);
+    }
+
+    pub fn deinit(this: *WrappedPipe) void {
+        log("deinit", .{});
+        // clear the timer
+        this.setTimeout(0);
+
+        if (this.wrapper) |*wrapper| {
+            wrapper.deinit();
+            this.wrapper = null;
+        }
+        var ssl_error = this.ssl_error;
+        ssl_error.deinit();
+        this.ssl_error = .{};
+    }
+};
+
 pub const InternalSocket = union(enum) {
     done: *Socket,
     connecting: *ConnectingSocket,
     detached: void,
     upgradedDuplex: *UpgradedDuplex,
+    pipe: *WrappedPipe,
     pub fn isDetached(this: InternalSocket) bool {
         return this == .detached;
     }
@@ -582,6 +1001,9 @@ pub const InternalSocket = union(enum) {
             .upgradedDuplex => |socket| {
                 socket.close();
             },
+            .pipe => |pipe| {
+                pipe.close();
+            },
         }
     }
 
@@ -591,6 +1013,7 @@ pub const InternalSocket = union(enum) {
             .connecting => |socket| us_connecting_socket_is_closed(@intFromBool(is_ssl), socket) > 0,
             .detached => true,
             .upgradedDuplex => |socket| socket.isClosed(),
+            .pipe => |pipe| pipe.isClosed(),
         };
     }
 
@@ -600,6 +1023,7 @@ pub const InternalSocket = union(enum) {
             .connecting => null,
             .detached => null,
             .upgradedDuplex => null,
+            .pipe => null,
         };
     }
 
@@ -607,19 +1031,23 @@ pub const InternalSocket = union(enum) {
         return switch (this) {
             .done => switch (other) {
                 .done => this.done == other.done,
-                .upgradedDuplex, .connecting, .detached => false,
+                .upgradedDuplex, .connecting, .detached, .pipe => false,
             },
             .connecting => switch (other) {
-                .upgradedDuplex, .done, .detached => false,
+                .upgradedDuplex, .done, .detached, .pipe => false,
                 .connecting => this.connecting == other.connecting,
             },
             .detached => switch (other) {
                 .detached => true,
-                .upgradedDuplex, .done, .connecting => false,
+                .upgradedDuplex, .done, .connecting, .pipe => false,
             },
             .upgradedDuplex => switch (other) {
                 .upgradedDuplex => this.upgradedDuplex == other.upgradedDuplex,
-                .done, .connecting, .detached => false,
+                .done, .connecting, .detached, .pipe => false,
+            },
+            .pipe => switch (other) {
+                .pipe => this.pipe == other.pipe,
+                .done, .connecting, .detached, .upgradedDuplex => false,
             },
         };
     }
@@ -641,6 +1069,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             switch (this.socket) {
                 .done => |socket| return uws.us_socket_verify_error(comptime ssl_int, socket),
                 .upgradedDuplex => |socket| return socket.sslError(),
+                .pipe => |pipe| return pipe.sslError(),
                 .connecting, .detached => return std.mem.zeroes(us_bun_verify_error_t),
             }
         }
@@ -649,6 +1078,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             switch (this.socket) {
                 .done => |socket| return us_socket_is_established(comptime ssl_int, socket) > 0,
                 .upgradedDuplex => |socket| return socket.isEstablished(),
+                .pipe => |pipe| return pipe.isEstablished(),
                 .connecting, .detached => return false,
             }
         }
@@ -656,6 +1086,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         pub fn timeout(this: ThisSocket, seconds: c_uint) void {
             switch (this.socket) {
                 .upgradedDuplex => |socket| socket.setTimeout(seconds),
+                .pipe => |pipe| pipe.setTimeout(seconds),
                 .done => |socket| us_socket_timeout(comptime ssl_int, socket, seconds),
                 .connecting => |socket| us_connecting_socket_timeout(comptime ssl_int, socket, seconds),
                 .detached => {},
@@ -684,6 +1115,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 },
                 .detached => {},
                 .upgradedDuplex => |socket| socket.setTimeout(seconds),
+                .pipe => |pipe| pipe.setTimeout(seconds),
             }
         }
 
@@ -699,6 +1131,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 },
                 .detached => {},
                 .upgradedDuplex => |socket| socket.setTimeout(minutes * 60),
+                .pipe => |pipe| pipe.setTimeout(minutes * 60),
             }
         }
 
@@ -852,6 +1285,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .connecting => |socket| us_connecting_socket_get_native_handle(comptime ssl_int, socket),
                 .detached => null,
                 .upgradedDuplex => |socket| if (is_ssl) @as(*anyopaque, @ptrCast(socket.ssl())) else null,
+                .pipe => |socket| if (is_ssl) @as(*anyopaque, @ptrCast(socket.ssl())) else null,
             } orelse return null);
         }
 
@@ -886,6 +1320,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .connecting => |sock| us_connecting_socket_ext(comptime ssl_int, sock),
                 .detached => return null,
                 .upgradedDuplex => return null,
+                .pipe => return null,
             };
 
             return @as(*align(alignment) ContextType, @ptrCast(@alignCast(ptr)));
@@ -898,6 +1333,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .connecting => |socket| return us_connecting_socket_context(comptime ssl_int, socket),
                 .detached => return null,
                 .upgradedDuplex => return null,
+                .pipe => return null,
             }
         }
 
@@ -905,6 +1341,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             switch (this.socket) {
                 .upgradedDuplex => |socket| {
                     return socket.flush();
+                },
+                .pipe => |pipe| {
+                    return pipe.flush();
                 },
                 .done => |socket| {
                     return us_socket_flush(
@@ -920,6 +1359,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             switch (this.socket) {
                 .upgradedDuplex => |socket| {
                     return socket.encodeAndWrite(data, msg_more);
+                },
+                .pipe => |pipe| {
+                    return pipe.encodeAndWrite(data, msg_more);
                 },
                 .done => |socket| {
                     const result = us_socket_write(
@@ -957,6 +1399,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .upgradedDuplex => |socket| {
                     return socket.rawWrite(data, msg_more);
                 },
+                .pipe => |pipe| {
+                    return pipe.rawWrite(data, msg_more);
+                },
             }
         }
         pub fn shutdown(this: ThisSocket) void {
@@ -977,6 +1422,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .detached => {},
                 .upgradedDuplex => |socket| {
                     socket.shutdown();
+                },
+                .pipe => |pipe| {
+                    pipe.shutdown();
                 },
             }
         }
@@ -1001,6 +1449,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .upgradedDuplex => |socket| {
                     socket.shutdownRead();
                 },
+                .pipe => |pipe| {
+                    pipe.shutdownRead();
+                },
             }
         }
 
@@ -1021,6 +1472,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .detached => return true,
                 .upgradedDuplex => |socket| {
                     return socket.isShutdown();
+                },
+                .pipe => |pipe| {
+                    return pipe.isShutdown();
                 },
             }
         }
@@ -1051,6 +1505,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .upgradedDuplex => |socket| {
                     return socket.sslError().error_no;
                 },
+                .pipe => |pipe| {
+                    return pipe.sslError().error_no;
+                },
             }
         }
 
@@ -1069,7 +1526,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                         socket,
                     );
                 },
-                .upgradedDuplex, .connecting, .detached => return 0,
+                .pipe, .upgradedDuplex, .connecting, .detached => return 0,
             }
         }
         pub fn remoteAddress(this: ThisSocket, buf: [*]u8, length: *i32) void {
@@ -1082,7 +1539,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                         length,
                     );
                 },
-                .upgradedDuplex, .connecting, .detached => return {
+                .pipe, .upgradedDuplex, .connecting, .detached => return {
                     length.* = 0;
                 },
             }
@@ -1111,7 +1568,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     }
                     return buf[0..@intCast(length)];
                 },
-                .upgradedDuplex, .connecting, .detached => return null,
+                .pipe, .upgradedDuplex, .connecting, .detached => return null,
             }
         }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -608,6 +608,7 @@ pub const WrappedPipe = struct {
         this.pipe = null;
         this.handlers.onClose(this.handlers.ctx);
     }
+
     fn onReadAlloc(this: *WrappedPipe, suggested_size: usize) []u8 {
         var available = this.incoming.available();
         if (available.len < suggested_size) {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -651,10 +651,6 @@ pub const WrappedPipe = struct {
 
     fn onError(this: *WrappedPipe, err: bun.sys.Error) void {
         log("onError", .{});
-        if (this.vm.isShuttingDown()) {
-            this.writer.close();
-            return;
-        }
         this.handlers.onError(this.handlers.ctx, err);
     }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1179,6 +1179,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         pub fn isDetached(this: ThisSocket) bool {
             return this.socket.isDetached();
         }
+        pub fn isNamedPipe(this: ThisSocket) bool {
+            return this.socket.isNamedPipe();
+        }
         pub fn verifyError(this: ThisSocket) us_bun_verify_error_t {
             switch (this.socket) {
                 .done => |socket| return uws.us_socket_verify_error(comptime ssl_int, socket),

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1087,6 +1087,9 @@ pub const InternalSocket = union(enum) {
     pub fn isDetached(this: InternalSocket) bool {
         return this == .detached;
     }
+    pub fn isNamedPipe(this: InternalSocket) bool {
+        return this == .pipe;
+    }
     pub fn detach(this: *InternalSocket) void {
         this.* = .detached;
     }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1408,7 +1408,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .done => |socket| us_socket_get_native_handle(comptime ssl_int, socket),
                 .connecting => |socket| us_connecting_socket_get_native_handle(comptime ssl_int, socket),
                 .detached => null,
-                .upgradedDuplex => |socket| if (is_ssl) @as(*anyopaque, @ptrCast(socket.ssl())) else null,
+                .upgradedDuplex => |socket| if (is_ssl) @as(*anyopaque, @ptrCast(socket.ssl() orelse return null)) else null,
                 .pipe => |socket| if (is_ssl and Environment.isWindows) @as(*anyopaque, @ptrCast(socket.ssl() orelse return null)) else null,
             } orelse return null);
         }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -832,6 +832,8 @@ pub const WindowsNamedPipe = if (Environment.isWindows) struct {
                     },
                 };
             };
+            // ref because we are accepting will unref when wrapper deinit
+            _ = BoringSSL.SSL_CTX_up_ref(tls);
         }
         const initResult = this.pipe.?.init(this.vm.uvLoop(), false);
         if (initResult == .err) {

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -606,7 +606,6 @@ pub const WindowsNamedPipe = if (Environment.isWindows) struct {
         log("onPipeClose", .{});
         this.flags.disconnected = true;
         this.pipe = null;
-        this.writer.source = null;
         this.onClose();
     }
 

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -1157,8 +1157,9 @@ pub fn WindowsStreamingWriter(
             this.source = null;
             if (this.closed_without_reporting) {
                 this.closed_without_reporting = false;
-                onClose(this.parent);
+                return;
             }
+            onClose(this.parent);
         }
 
         pub fn startWithCurrentPipe(this: *WindowsWriter) bun.JSC.Maybe(void) {

--- a/src/js/internal/net.ts
+++ b/src/js/internal/net.ts
@@ -1,3 +1,3 @@
-const [addServerName, upgradeDuplexToTLS] = $zig("socket.zig", "createNodeTLSBinding");
+const [addServerName, upgradeDuplexToTLS, isNamedPipeSocket] = $zig("socket.zig", "createNodeTLSBinding");
 
-export default { addServerName, upgradeDuplexToTLS };
+export default { addServerName, upgradeDuplexToTLS, isNamedPipeSocket };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -21,7 +21,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 const { Duplex } = require("node:stream");
 const EventEmitter = require("node:events");
-const { addServerName, upgradeDuplexToTLS } = require("../internal/net");
+const { addServerName, upgradeDuplexToTLS, isNamedPipeSocket } = require("../internal/net");
 const { ExceptionWithHostPort } = require("internal/shared");
 const { ERR_SERVER_NOT_RUNNING } = require("internal/errors");
 
@@ -561,6 +561,11 @@ const Socket = (function (InternalSocket) {
       // start using existing connection
       try {
         if (connection) {
+          const socket = connection[bunSocketInternal];
+          if (!upgradeDuplex && socket) {
+            // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
+            upgradeDuplex = isNamedPipeSocket(socket);
+          }
           if (upgradeDuplex) {
             this.connecting = true;
             this.#upgraded = connection;
@@ -578,8 +583,6 @@ const Socket = (function (InternalSocket) {
 
             this[bunSocketInternal] = result;
           } else {
-            const socket = connection[bunSocketInternal];
-
             if (socket) {
               this.connecting = true;
               this.#upgraded = connection;

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -1169,7 +1169,7 @@ pub const E = enum(u16) {
     HWPOISON = 133,
     UNKNOWN = 134,
     CHARSET = 135,
-    OF = 136,
+    EOF = 136,
 
     UV_E2BIG = -uv.UV_E2BIG,
     UV_EACCES = -uv.UV_EACCES,

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,8 +1,10 @@
-import { Socket as _BunSocket, TCPSocketListener } from "bun";
+import { Socket as _BunSocket, resolve, TCPSocketListener } from "bun";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
-import { connect, createConnection, isIP, isIPv4, isIPv6, Server, Socket, Stream } from "net";
-import { join } from "path";
+import { connect, createServer, createConnection, isIP, isIPv4, isIPv6, Server, Socket, Stream } from "node:net";
+import { join } from "node:path";
+import { once } from "node:events";
+import { randomUUID } from "node:crypto";
 
 const socket_domain = tmpdirSync();
 
@@ -559,4 +561,43 @@ it("should not hang after destroy", async () => {
   } finally {
     server.close();
   }
+});
+
+it("should work with named pipes", async () => {
+  async function test(pipe_name: string) {
+    const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
+    const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
+    let client: ReturnType<typeof connect> | null = null;
+    let server: ReturnType<typeof createServer> | null = null;
+    try {
+      server = createServer(socket => {
+        socket.on("data", data => {
+          const message = data.toString();
+          console.log(`Message received from client: ${message}`);
+          socket.write("Goodbye World!");
+          resolveMessageReceived(message);
+        });
+      });
+
+      server.listen(pipe_name);
+      await once(server, "listening");
+
+      client = connect(pipe_name).on("data", data => {
+        const message = data.toString();
+        resolveClientReceived(message);
+      });
+
+      client?.write("Hello World!");
+      const message = await messageReceived;
+      expect(message).toBe("Hello World!");
+      const client_message = await clientReceived;
+      expect(client_message).toBe("Goodbye World!");
+    } finally {
+      client?.destroy();
+      server?.close();
+    }
+  }
+
+  await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
+  await test(`\\\\?\\pipe\\test\\${randomUUID()}`);
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,10 +1,11 @@
 import { Socket as _BunSocket, resolve, TCPSocketListener } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync, isWindows } from "harness";
+import { bunEnv, bunExe, tmpdirSync, isWindows, expectMaxObjectTypeCount } from "harness";
 import { connect, createServer, createConnection, isIP, isIPv4, isIPv6, Server, Socket, Stream } from "node:net";
 import { join } from "node:path";
 import { once } from "node:events";
 import { randomUUID } from "node:crypto";
+import { heapStats } from "bun:jsc";
 
 const socket_domain = tmpdirSync();
 
@@ -596,6 +597,7 @@ it.if(isWindows)("should work with named pipes", async () => {
   }
 
   const batch = [];
+  const before = heapStats().objectTypeCounts.TLSSocket || 0;
   for (let i = 0; i < 200; i++) {
     batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
     batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
@@ -605,4 +607,5 @@ it.if(isWindows)("should work with named pipes", async () => {
     }
   }
   await Promise.all(batch);
+  expectMaxObjectTypeCount(expect, "TCPSocket", before);
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -604,4 +604,5 @@ it.if(isWindows)("should work with named pipes", async () => {
       batch.length = 0;
     }
   }
+  await Promise.all(batch);
 });

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -6,54 +6,54 @@ import { once } from "node:events";
 import { randomUUID } from "node:crypto";
 import { heapStats } from "bun:jsc";
 
-// it.if(isWindows)("should work with named pipes and tls", async () => {
-//   async function test(pipe_name: string) {
-//     const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
-//     const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
-//     let client: ReturnType<typeof connect> | null = null;
-//     let server: ReturnType<typeof createServer> | null = null;
-//     try {
-//       server = createServer(tls, socket => {
-//         socket.on("data", data => {
-//           const message = data.toString();
-//           socket.write("Goodbye World!");
-//           resolveMessageReceived(message);
-//         });
-//       });
+it.if(isWindows)("should work with named pipes and tls", async () => {
+  async function test(pipe_name: string) {
+    const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
+    const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
+    let client: ReturnType<typeof connect> | null = null;
+    let server: ReturnType<typeof createServer> | null = null;
+    try {
+      server = createServer(tls, socket => {
+        socket.on("data", data => {
+          const message = data.toString();
+          socket.write("Goodbye World!");
+          resolveMessageReceived(message);
+        });
+      });
 
-//       server.listen(pipe_name);
-//       await once(server, "listening");
+      server.listen(pipe_name);
+      await once(server, "listening");
 
-//       client = connect({ path: pipe_name, ca: tls.cert }).on("data", data => {
-//         const message = data.toString();
-//         resolveClientReceived(message);
-//       });
+      client = connect({ path: pipe_name, ca: tls.cert }).on("data", data => {
+        const message = data.toString();
+        resolveClientReceived(message);
+      });
 
-//       client?.write("Hello World!");
-//       const message = await messageReceived;
-//       expect(message).toBe("Hello World!");
-//       const client_message = await clientReceived;
-//       expect(client_message).toBe("Goodbye World!");
-//     } finally {
-//       client?.destroy();
-//       server?.close();
-//     }
-//   }
+      client?.write("Hello World!");
+      const message = await messageReceived;
+      expect(message).toBe("Hello World!");
+      const client_message = await clientReceived;
+      expect(client_message).toBe("Goodbye World!");
+    } finally {
+      client?.destroy();
+      server?.close();
+    }
+  }
 
-//   const batch = [];
+  const batch = [];
 
-//   const before = heapStats().objectTypeCounts.TLSSocket || 0;
-//   for (let i = 0; i < 200; i++) {
-//     batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
-//     batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
-//     if (i % 50 === 0) {
-//       await Promise.all(batch);
-//       batch.length = 0;
-//     }
-//   }
-//   await Promise.all(batch);
-//   expectMaxObjectTypeCount(expect, "TLSSocket", before);
-// });
+  const before = heapStats().objectTypeCounts.TLSSocket || 0;
+  for (let i = 0; i < 200; i++) {
+    batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
+    batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
+    if (i % 50 === 0) {
+      await Promise.all(batch);
+      batch.length = 0;
+    }
+  }
+  await Promise.all(batch);
+  expectMaxObjectTypeCount(expect, "TLSSocket", before);
+});
 
 it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", async () => {
   const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -6,12 +6,61 @@ import { once } from "node:events";
 import { randomUUID } from "node:crypto";
 import { heapStats } from "bun:jsc";
 
-it.if(isWindows)("should work with named pipes and tls", async () => {
+// it.if(isWindows)("should work with named pipes and tls", async () => {
+//   async function test(pipe_name: string) {
+//     const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
+//     const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
+//     let client: ReturnType<typeof connect> | null = null;
+//     let server: ReturnType<typeof createServer> | null = null;
+//     try {
+//       server = createServer(tls, socket => {
+//         socket.on("data", data => {
+//           const message = data.toString();
+//           socket.write("Goodbye World!");
+//           resolveMessageReceived(message);
+//         });
+//       });
+
+//       server.listen(pipe_name);
+//       await once(server, "listening");
+
+//       client = connect({ path: pipe_name, ca: tls.cert }).on("data", data => {
+//         const message = data.toString();
+//         resolveClientReceived(message);
+//       });
+
+//       client?.write("Hello World!");
+//       const message = await messageReceived;
+//       expect(message).toBe("Hello World!");
+//       const client_message = await clientReceived;
+//       expect(client_message).toBe("Goodbye World!");
+//     } finally {
+//       client?.destroy();
+//       server?.close();
+//     }
+//   }
+
+//   const batch = [];
+
+//   const before = heapStats().objectTypeCounts.TLSSocket || 0;
+//   for (let i = 0; i < 200; i++) {
+//     batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
+//     batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
+//     if (i % 50 === 0) {
+//       await Promise.all(batch);
+//       batch.length = 0;
+//     }
+//   }
+//   await Promise.all(batch);
+//   expectMaxObjectTypeCount(expect, "TLSSocket", before);
+// });
+
+it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", async () => {
+  const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
+  const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
+  let client: ReturnType<typeof net.connect> | ReturnType<typeof connect> | null = null;
+  let server: ReturnType<typeof createServer> | null = null;
   async function test(pipe_name: string) {
-    const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
-    const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
-    let client: ReturnType<typeof connect> | null = null;
-    let server: ReturnType<typeof createServer> | null = null;
     try {
       server = createServer(tls, socket => {
         socket.on("data", data => {
@@ -24,11 +73,12 @@ it.if(isWindows)("should work with named pipes and tls", async () => {
       server.listen(pipe_name);
       await once(server, "listening");
 
-      client = connect({ path: pipe_name, ca: tls.cert }).on("data", data => {
+      const nonTLSClient = net.connect(pipe_name);
+      client = connect({ socket: nonTLSClient, ca: tls.cert }).on("data", data => {
         const message = data.toString();
         resolveClientReceived(message);
       });
-
+      await once(client, "secureConnect");
       client?.write("Hello World!");
       const message = await messageReceived;
       expect(message).toBe("Hello World!");
@@ -39,18 +89,8 @@ it.if(isWindows)("should work with named pipes and tls", async () => {
       server?.close();
     }
   }
-
-  const batch = [];
-
   const before = heapStats().objectTypeCounts.TLSSocket || 0;
-  for (let i = 0; i < 200; i++) {
-    batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
-    batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
-    if (i % 50 === 0) {
-      await Promise.all(batch);
-      batch.length = 0;
-    }
-  }
-  await Promise.all(batch);
+  await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
+  await test(`\\\\?\\pipe\\test\\${randomUUID()}`);
   expectMaxObjectTypeCount(expect, "TLSSocket", before);
 });

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "bun:test";
-import { tls } from "harness";
+import { tls, isWindows } from "harness";
 import { connect, createServer } from "node:tls";
 import { once } from "node:events";
 import { randomUUID } from "node:crypto";
 
-it("should work with named pipes and tls", async () => {
+it.if(isWindows)("should work with named pipes and tls", async () => {
   async function test(pipe_name: string) {
     const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
     const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -14,7 +14,6 @@ it.if(isWindows)("should work with named pipes and tls", async () => {
       server = createServer(tls, socket => {
         socket.on("data", data => {
           const message = data.toString();
-          console.log(`Message received from client: ${message}`);
           socket.write("Goodbye World!");
           resolveMessageReceived(message);
         });
@@ -39,6 +38,14 @@ it.if(isWindows)("should work with named pipes and tls", async () => {
     }
   }
 
-  await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
-  await test(`\\\\?\\pipe\\test\\${randomUUID()}`);
+  const batch = [];
+  for (let i = 0; i < 200; i++) {
+    batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
+    batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
+    if (i % 50 === 0) {
+      await Promise.all(batch);
+      batch.length = 0;
+    }
+  }
+  await Promise.all(batch);
 });

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test";
+import { tls } from "harness";
+import { connect, createServer } from "node:tls";
+import { once } from "node:events";
+import { randomUUID } from "node:crypto";
+
+it("should work with named pipes and tls", async () => {
+  async function test(pipe_name: string) {
+    const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
+    const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
+    let client: ReturnType<typeof connect> | null = null;
+    let server: ReturnType<typeof createServer> | null = null;
+    try {
+      server = createServer(tls, socket => {
+        socket.on("data", data => {
+          const message = data.toString();
+          console.log(`Message received from client: ${message}`);
+          socket.write("Goodbye World!");
+          resolveMessageReceived(message);
+        });
+      });
+
+      server.listen(pipe_name);
+      await once(server, "listening");
+
+      client = connect({ path: pipe_name, ca: tls.cert }).on("data", data => {
+        const message = data.toString();
+        resolveClientReceived(message);
+      });
+
+      client?.write("Hello World!");
+      const message = await messageReceived;
+      expect(message).toBe("Hello World!");
+      const client_message = await clientReceived;
+      expect(client_message).toBe("Goodbye World!");
+    } finally {
+      client?.destroy();
+      server?.close();
+    }
+  }
+
+  await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
+  await test(`\\\\?\\pipe\\test\\${randomUUID()}`);
+});


### PR DESCRIPTION
Fix: https://github.com/oven-sh/bun/issues/13824
Fix: https://github.com/oven-sh/bun/issues/11759
Fix: https://github.com/oven-sh/bun/issues/13042

### TODO
- [X] Connect using libuv fd
- [X] Connect using system fd
- [X] Connect using path to named pipe
- [X] Client TLS
- [x] Listen path to named pipe
- [x] Server TLS
- [x] upgradeTLS (disabled only available when using JS Wrapper)
- [x] Upgrade via `node:tls` to TLS
- [x] Tests

### What does this PR do?
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Tests
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
