### PR TITLE
Fix flaky process.cpuUsage tests

### DIFF
--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -448,7 +448,7 @@ describe("process.cpuUsage", () => {
     init.user = 1;
     const delta = process.cpuUsage(init);
     expect(delta.user).toBeGreaterThan(0);
-    expect(delta.system).toBeGreaterThan(0);
+    expect(delta.system).toBeGreaterThanOrEqual(-1);
   });
 
   it.skipIf(process.platform === "win32")("works with diff of different structure", () => {
@@ -458,7 +458,7 @@ describe("process.cpuUsage", () => {
     };
     const delta = process.cpuUsage(init);
     expect(delta.user).toBeGreaterThan(0);
-    expect(delta.system).toBeGreaterThan(0);
+    expect(delta.system).toBeGreaterThanOrEqual(-1);
   });
 
   it("throws on invalid property", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -444,11 +444,11 @@ describe("process.cpuUsage", () => {
   // Skipped on Windows because it seems UV returns { user: 15000, system: 0 } constantly
   it.skipIf(process.platform === "win32")("works with diff", () => {
     const init = process.cpuUsage();
-    init.system = 1;
-    init.user = 1;
+    init.system = 0;
+    init.user = 0;
     const delta = process.cpuUsage(init);
     expect(delta.user).toBeGreaterThan(0);
-    expect(delta.system).toBeGreaterThanOrEqual(-1);
+    expect(delta.system).toBeGreaterThanOrEqual(0);
   });
 
   it.skipIf(process.platform === "win32")("works with diff of different structure", () => {
@@ -458,7 +458,7 @@ describe("process.cpuUsage", () => {
     };
     const delta = process.cpuUsage(init);
     expect(delta.user).toBeGreaterThan(0);
-    expect(delta.system).toBeGreaterThanOrEqual(-1);
+    expect(delta.system).toBeGreaterThanOrEqual(0);
   });
 
   it("throws on invalid property", () => {


### PR DESCRIPTION
### What does this PR do?

Changes the test of `process.cpuUsage` when passing a reference point (to measure the difference in CPU usage since then) to permit 0 microseconds for the system time difference (instead of requiring it to be greater than 0). This test had been occasionally failing on Linux.

Reviewing the times this test failed, it was only ever the system time difference that failed, and it was -1 or 0 sometimes but never -2 or less. I also changed the value being compared from 1 to 0, so if the new system time is zero the difference will be 0 (0-0) instead of -1 (0-1).

Node's implementation is the same as ours: they [subtract the raw time values](https://github.com/nodejs/node/blob/2ef33af16ebc5da9bd1b7261ee88add0ae9a835a/lib/internal/process/per_thread.js#L140-L145), which come from [libuv](https://github.com/libuv/libuv/blob/44e61dab7effb739f543b8b4eee43f577bf2db49/src/unix/core.c#L995) that calls getrusage directly. So it's a little weird that this doesn't fail in their tests. Probably their CI machines are configured differently.


### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
