### PR TITLE
Fix edgecase with "os" and "cpu" in bun install

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -12924,7 +12924,7 @@ pub const PackageManager = struct {
                 if (comptime log_level.isVerbose()) {
                     const name = this.lockfile.str(&this.names[package_id]);
                     if (!meta.os.isMatch() and !meta.arch.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os & cpu mismatch", .{name});
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' cpu & os mismatch", .{name});
                     } else if (!meta.os.isMatch()) {
                         Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os mismatch", .{name});
                     } else if (!meta.arch.isMatch()) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -12924,11 +12924,11 @@ pub const PackageManager = struct {
                 if (comptime log_level.isVerbose()) {
                     const name = this.lockfile.str(&this.names[package_id]);
                     if (!meta.os.isMatch() and !meta.arch.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing package '<b>{s}<r><d>': '{s}' os and '{s}' cpu unsupported", .{ name, Npm.OperatingSystem.current_name, Npm.Architecture.current_name });
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os and cpu unsupported", .{name});
                     } else if (!meta.os.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing package '<b>{s}<r><d>': '{s}' os unsupported", .{ name, Npm.OperatingSystem.current_name });
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os unsupported", .{name});
                     } else if (!meta.arch.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing package '<b>{s}<r><d>': '{s}' cpu unsupported", .{ name, Npm.Architecture.current_name });
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' cpu unsupported", .{name});
                     }
                 }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -12924,7 +12924,7 @@ pub const PackageManager = struct {
                 if (comptime log_level.isVerbose()) {
                     const name = this.lockfile.str(&this.names[package_id]);
                     if (!meta.os.isMatch() and !meta.arch.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os and cpu unsupported", .{name});
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os & cpu unsupported", .{name});
                     } else if (!meta.os.isMatch()) {
                         Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os unsupported", .{name});
                     } else if (!meta.arch.isMatch()) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -12921,6 +12921,17 @@ pub const PackageManager = struct {
                 if (comptime log_level.showProgress()) {
                     this.node.completeOne();
                 }
+                if (comptime log_level.isVerbose()) {
+                    const name = this.lockfile.str(&this.names[package_id]);
+                    if (!meta.os.isMatch() and !meta.arch.isMatch()) {
+                        Output.prettyErrorln("<d>Skip installing package '<b>{s}<r><d>': '{s}' os and '{s}' cpu unsupported", .{ name, Npm.OperatingSystem.current_name, Npm.Architecture.current_name });
+                    } else if (!meta.os.isMatch()) {
+                        Output.prettyErrorln("<d>Skip installing package '<b>{s}<r><d>': '{s}' os unsupported", .{ name, Npm.OperatingSystem.current_name });
+                    } else if (!meta.arch.isMatch()) {
+                        Output.prettyErrorln("<d>Skip installing package '<b>{s}<r><d>': '{s}' cpu unsupported", .{ name, Npm.Architecture.current_name });
+                    }
+                }
+
                 if (comptime increment_tree_count) this.incrementTreeInstallCount(this.current_tree_id, null, !is_pending_package_install, log_level);
                 return;
             }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -12924,11 +12924,11 @@ pub const PackageManager = struct {
                 if (comptime log_level.isVerbose()) {
                     const name = this.lockfile.str(&this.names[package_id]);
                     if (!meta.os.isMatch() and !meta.arch.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os & cpu unsupported", .{name});
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os & cpu mismatch", .{name});
                     } else if (!meta.os.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os unsupported", .{name});
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' os mismatch", .{name});
                     } else if (!meta.arch.isMatch()) {
-                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' cpu unsupported", .{name});
+                        Output.prettyErrorln("<d>Skip installing '<b>{s}<r><d>' cpu mismatch", .{name});
                     }
                 }
 

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -515,23 +515,31 @@ pub fn migrateNPMLockfile(
                 .origin = if (package_id == 0) .local else .npm,
 
                 .arch = if (pkg.get("cpu")) |cpu_array| arch: {
+                    var arch = Npm.Architecture.none.negatable();
                     if (cpu_array.data != .e_array) return error.InvalidNPMLockfile;
-                    var arch: Npm.Architecture = .none;
+                    if (cpu_array.data.e_array.items.len == 0) {
+                        break :arch arch.combine();
+                    }
+
                     for (cpu_array.data.e_array.items.slice()) |item| {
                         if (item.data != .e_string) return error.InvalidNPMLockfile;
-                        arch = arch.apply(item.data.e_string.data);
+                        arch.apply(item.data.e_string.data);
                     }
-                    break :arch arch;
+                    break :arch arch.combine();
                 } else .all,
 
                 .os = if (pkg.get("os")) |cpu_array| arch: {
+                    var os = Npm.OperatingSystem.none.negatable();
                     if (cpu_array.data != .e_array) return error.InvalidNPMLockfile;
-                    var os: Npm.OperatingSystem = .none;
+                    if (cpu_array.data.e_array.items.len == 0) {
+                        break :arch .all;
+                    }
+
                     for (cpu_array.data.e_array.items.slice()) |item| {
                         if (item.data != .e_string) return error.InvalidNPMLockfile;
-                        os = os.apply(item.data.e_string.data);
+                        os.apply(item.data.e_string.data);
                     }
-                    break :arch os;
+                    break :arch os.combine();
                 } else .all,
 
                 .man_dir = String{},

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -395,16 +395,15 @@ pub const OperatingSystem = enum(u16) {
 
     pub const all_value: u16 = aix | darwin | freebsd | linux | openbsd | sunos | win32 | android;
 
+    pub const current: OperatingSystem = switch (Environment.os) {
+        .linux => @enumFromInt(linux),
+        .mac => @enumFromInt(darwin),
+        .windows => @enumFromInt(win32),
+        else => @compileError("Unsupported operating system: " ++ @tagName(Environment.os)),
+    };
+
     pub fn isMatch(this: OperatingSystem) bool {
-        if (comptime Environment.isLinux) {
-            return (@intFromEnum(this) & linux) != 0;
-        } else if (comptime Environment.isMac) {
-            return (@intFromEnum(this) & darwin) != 0;
-        } else if (comptime Environment.isWindows) {
-            return (@intFromEnum(this) & win32) != 0;
-        } else {
-            return false;
-        }
+        return (@intFromEnum(this) & @intFromEnum(current)) != 0;
     }
 
     pub inline fn has(this: OperatingSystem, other: u16) bool {
@@ -421,6 +420,13 @@ pub const OperatingSystem = enum(u16) {
         .{ "win32", win32 },
         .{ "android", android },
     });
+
+    pub const current_name = switch (Environment.os) {
+        .linux => "linux",
+        .mac => "darwin",
+        .windows => "win32",
+        else => @compileError("Unsupported operating system: " ++ @tagName(current)),
+    };
 
     pub fn negatable(this: OperatingSystem) Negatable(OperatingSystem) {
         return .{ .added = this, .removed = .none };
@@ -465,6 +471,9 @@ pub const Libc = enum(u8) {
         return .{ .added = this, .removed = .none };
     }
 
+    // TODO:
+    pub const current: Libc = @intFromEnum(glibc);
+
     const JSC = bun.JSC;
     pub fn jsFunctionLibcIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) JSC.JSValue {
         const args = callframe.arguments(1);
@@ -502,6 +511,18 @@ pub const Architecture = enum(u16) {
 
     pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64;
 
+    pub const current: Architecture = switch (Environment.arch) {
+        .arm64 => @enumFromInt(arm64),
+        .x64 => @enumFromInt(x64),
+        else => @compileError("Specify architecture: " ++ Environment.arch),
+    };
+
+    pub const current_name = switch (Environment.arch) {
+        .arm64 => "arm64",
+        .x64 => "x64",
+        else => @compileError("Unsupported architecture: " ++ @tagName(current)),
+    };
+
     pub const NameMap = bun.ComptimeStringMap(u16, .{
         .{ "arm", arm },
         .{ "arm64", arm64 },
@@ -521,13 +542,7 @@ pub const Architecture = enum(u16) {
     }
 
     pub fn isMatch(this: Architecture) bool {
-        if (comptime Environment.isAarch64) {
-            return (@intFromEnum(this) & arm64) != 0;
-        } else if (comptime Environment.isX64) {
-            return (@intFromEnum(this) & x64) != 0;
-        } else {
-            return false;
-        }
+        return @intFromEnum(this) & @intFromEnum(current) != 0;
     }
 
     pub fn negatable(this: Architecture) Negatable(Architecture) {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -320,6 +320,63 @@ const ExternVersionMap = extern struct {
     }
 };
 
+fn Negatable(comptime T: type) type {
+    return struct {
+        added: T = T.none,
+        removed: T = T.none,
+        had_any: bool = false,
+
+        // https://github.com/pnpm/pnpm/blob/1f228b0aeec2ef9a2c8577df1d17186ac83790f9/config/package-is-installable/src/checkPlatform.ts#L56-L86
+        // https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/node_modules/npm-install-checks/lib/index.js#L2-L96
+        pub fn combine(this: Negatable(T)) T {
+            const added = if (this.had_any) T.all_value else @intFromEnum(this.added);
+            const removed = @intFromEnum(this.removed);
+
+            // If none were added or removed, all are allowed
+            if (added == 0 and removed == 0) {
+                // []
+                return T.all;
+            }
+
+            // If none were added, but some were removed, return the inverse of the removed
+            if (added == 0 and removed != 0) {
+                // ["!linux", "!darwin"]
+                return @enumFromInt(T.all_value & ~removed);
+            }
+
+            if (removed == 0) {
+                // ["linux", "darwin"]
+                return @enumFromInt(added);
+            }
+
+            // - ["linux", "!darwin"]
+            return @enumFromInt(added & ~removed);
+        }
+
+        pub fn apply(this: *Negatable(T), str: []const u8) void {
+            if (str.len == 0) {
+                return;
+            }
+
+            if (strings.eqlComptime(str, "any")) {
+                this.had_any = true;
+                return;
+            }
+
+            const is_not = str[0] == '!';
+            const offset: usize = @intFromBool(is_not);
+
+            const field: u16 = T.NameMap.get(str[offset..]) orelse return;
+
+            if (is_not) {
+                this.* = .{ .added = this.added, .removed = @enumFromInt(@intFromEnum(this.removed) | field) };
+            } else {
+                this.* = .{ .added = @enumFromInt(@intFromEnum(this.added) | field), .removed = this.removed };
+            }
+        }
+    };
+}
+
 /// https://nodejs.org/api/os.html#osplatform
 pub const OperatingSystem = enum(u16) {
     none = 0,
@@ -365,31 +422,35 @@ pub const OperatingSystem = enum(u16) {
         .{ "android", android },
     });
 
-    pub fn apply(this_: OperatingSystem, str: []const u8) OperatingSystem {
-        if (str.len == 0) {
-            return this_;
+    pub fn negatable(this: OperatingSystem) Negatable(OperatingSystem) {
+        return .{ .added = this, .removed = .none };
+    }
+
+    const JSC = bun.JSC;
+    pub fn jsFunctionOperatingSystemIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) JSC.JSValue {
+        const args = callframe.arguments(1);
+        var operating_system = negatable(.none);
+        var iter = args.ptr[0].arrayIterator(globalObject);
+        while (iter.next()) |item| {
+            const slice = item.toSlice(globalObject, bun.default_allocator);
+            defer slice.deinit();
+            operating_system.apply(slice.slice());
+            if (globalObject.hasException()) return .zero;
         }
-        const this = @intFromEnum(this_);
-
-        const is_not = str[0] == '!';
-        const offset: usize = if (str[0] == '!') 1 else 0;
-
-        const field: u16 = NameMap.get(str[offset..]) orelse return this_;
-
-        if (is_not) {
-            return @as(OperatingSystem, @enumFromInt(this & ~field));
-        } else {
-            return @as(OperatingSystem, @enumFromInt(this | field));
-        }
+        if (globalObject.hasException()) return .zero;
+        return JSC.JSValue.jsBoolean(operating_system.combine().isMatch());
     }
 };
 
 pub const Libc = enum(u8) {
     none = 0,
+    all = all_value,
     _,
 
     pub const glibc: u8 = 1 << 1;
     pub const musl: u8 = 1 << 2;
+
+    pub const all_value: u8 = glibc | musl;
 
     pub const NameMap = bun.ComptimeStringMap(u8, .{
         .{ "glibc", glibc },
@@ -400,22 +461,23 @@ pub const Libc = enum(u8) {
         return (@intFromEnum(this) & other) != 0;
     }
 
-    pub fn apply(this_: Libc, str: []const u8) Libc {
-        if (str.len == 0) {
-            return this_;
+    pub fn negatable(this: Libc) Negatable(Libc) {
+        return .{ .added = this, .removed = .none };
+    }
+
+    const JSC = bun.JSC;
+    pub fn jsFunctionLibcIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) JSC.JSValue {
+        const args = callframe.arguments(1);
+        var libc = negatable(.none);
+        var iter = args.ptr[0].arrayIterator(globalObject);
+        while (iter.next()) |item| {
+            const slice = item.toSlice(globalObject, bun.default_allocator);
+            defer slice.deinit();
+            libc.apply(slice.slice());
+            if (globalObject.hasException()) return .zero;
         }
-        const this = @intFromEnum(this_);
-
-        const is_not = str[0] == '!';
-        const offset: usize = if (str[0] == '!') 1 else 0;
-
-        const field: u8 = NameMap.get(str[offset..]) orelse return this_;
-
-        if (is_not) {
-            return @as(Libc, @enumFromInt(this & ~field));
-        } else {
-            return @as(Libc, @enumFromInt(this | field));
-        }
+        if (globalObject.hasException()) return .zero;
+        return JSC.JSValue.jsBoolean(libc.combine().isMatch());
     }
 };
 
@@ -468,25 +530,26 @@ pub const Architecture = enum(u16) {
         }
     }
 
-    pub fn apply(this_: Architecture, str: []const u8) Architecture {
-        if (str.len == 0) {
-            return this_;
+    pub fn negatable(this: Architecture) Negatable(Architecture) {
+        return .{ .added = this, .removed = .none };
+    }
+
+    const JSC = bun.JSC;
+    pub fn jsFunctionArchitectureIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) JSC.JSValue {
+        const args = callframe.arguments(1);
+        var architecture = negatable(.none);
+        var iter = args.ptr[0].arrayIterator(globalObject);
+        while (iter.next()) |item| {
+            const slice = item.toSlice(globalObject, bun.default_allocator);
+            defer slice.deinit();
+            architecture.apply(slice.slice());
+            if (globalObject.hasException()) return .zero;
         }
-        const this = @intFromEnum(this_);
-
-        const is_not = str[0] == '!';
-        const offset: usize = if (str[0] == '!') 1 else 0;
-        const input = str[offset..];
-
-        const field: u16 = NameMap.get(input) orelse return this_;
-
-        if (is_not) {
-            return @as(Architecture, @enumFromInt(this & ~field));
-        } else {
-            return @as(Architecture, @enumFromInt(this | field));
-        }
+        if (globalObject.hasException()) return .zero;
+        return JSC.JSValue.jsBoolean(architecture.combine().isMatch());
     }
 };
+
 const BigExternalString = Semver.BigExternalString;
 
 pub const PackageVersion = extern struct {
@@ -592,7 +655,8 @@ pub const PackageManifest = struct {
 
     pub const Serializer = struct {
         // - version 3: added serialization of registry url. it's used to invalidate when it changes
-        pub const version = "bun-npm-manifest-cache-v0.0.3\n";
+        // - version 4: fixed bug with cpu & os tag not being added correctly
+        pub const version = "bun-npm-manifest-cache-v0.0.4\n";
         const header_bytes: string = "#!/usr/bin/env bun\n" ++ version;
 
         pub const sizes = blk: {
@@ -1466,70 +1530,70 @@ pub const PackageManifest = struct {
 
                     var package_version: PackageVersion = empty_version;
 
-                    if (prop.value.?.asProperty("cpu")) |cpu| {
-                        package_version.cpu = Architecture.all;
+                    if (prop.value.?.asProperty("cpu")) |cpu_q| {
+                        var cpu = Architecture.none.negatable();
 
-                        switch (cpu.expr.data) {
+                        switch (cpu_q.expr.data) {
                             .e_array => |arr| {
                                 const items = arr.slice();
                                 if (items.len > 0) {
-                                    package_version.cpu = Architecture.none;
                                     for (items) |item| {
                                         if (item.asString(allocator)) |cpu_str_| {
-                                            package_version.cpu = package_version.cpu.apply(cpu_str_);
+                                            cpu.apply(cpu_str_);
                                         }
                                     }
                                 }
                             },
                             .e_string => |stri| {
-                                package_version.cpu = Architecture.apply(Architecture.none, stri.data);
+                                cpu.apply(stri.data);
                             },
                             else => {},
                         }
+                        package_version.cpu = cpu.combine();
                     }
 
-                    if (prop.value.?.asProperty("os")) |os| {
-                        package_version.os = OperatingSystem.all;
+                    if (prop.value.?.asProperty("os")) |os_q| {
+                        var os = OperatingSystem.none.negatable();
 
-                        switch (os.expr.data) {
+                        switch (os_q.expr.data) {
                             .e_array => |arr| {
                                 const items = arr.slice();
                                 if (items.len > 0) {
-                                    package_version.os = OperatingSystem.none;
                                     for (items) |item| {
                                         if (item.asString(allocator)) |cpu_str_| {
-                                            package_version.os = package_version.os.apply(cpu_str_);
+                                            os.apply(cpu_str_);
                                         }
                                     }
                                 }
                             },
                             .e_string => |stri| {
-                                package_version.os = OperatingSystem.apply(OperatingSystem.none, stri.data);
+                                os.apply(stri.data);
                             },
                             else => {},
                         }
+                        package_version.os = os.combine();
                     }
 
                     if (prop.value.?.asProperty("libc")) |libc| {
-                        package_version.libc = Libc.none;
+                        var libc_ = Libc.none.negatable();
 
                         switch (libc.expr.data) {
                             .e_array => |arr| {
                                 const items = arr.slice();
                                 if (items.len > 0) {
-                                    package_version.libc = Libc.none;
                                     for (items) |item| {
                                         if (item.asString(allocator)) |libc_str_| {
-                                            package_version.libc = package_version.libc.apply(libc_str_);
+                                            libc_.apply(libc_str_);
                                         }
                                     }
                                 }
                             },
                             .e_string => |stri| {
-                                package_version.libc = Libc.apply(.none, stri.data);
+                                libc_.apply(stri.data);
                             },
                             else => {},
                         }
+                        package_version.libc = libc_.combine();
                     }
 
                     if (prop.value.?.asProperty("hasInstallScript")) |has_install_script| {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -114,3 +114,15 @@ export const npmTag: (
   $newZigFunction("dependency.zig", "Version.Tag.inferFromJS", 1);
 
 export const readTarball: (tarball: string) => any = $newZigFunction("pack_command.zig", "bindings.jsReadTarball", 1);
+
+export const isArchitectureMatch: (architecture: string[]) => boolean = $newZigFunction(
+  "npm.zig",
+  "Architecture.jsFunctionArchitectureIsMatch",
+  1,
+);
+
+export const isOperatingSystemMatch: (operatingSystem: string[]) => boolean = $newZigFunction(
+  "npm.zig",
+  "OperatingSystem.jsFunctionOperatingSystemIsMatch",
+  1,
+);

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -874,34 +874,30 @@ pub const PackageJSON = struct {
                     }
                 }
                 if (json.get("cpu")) |os_field| {
-                    var first = true;
                     if (os_field.asArray()) |array_const| {
                         var array = array_const;
+                        var arch = Architecture.none.negatable();
                         while (array.next()) |item| {
                             if (item.asString(bun.default_allocator)) |str| {
-                                if (first) {
-                                    package_json.arch = Architecture.none;
-                                    first = false;
-                                }
-                                package_json.arch = package_json.arch.apply(str);
+                                arch.apply(str);
                             }
                         }
+
+                        package_json.arch = arch.combine();
                     }
                 }
 
                 if (json.get("os")) |os_field| {
-                    var first = true;
                     var tmp = os_field.asArray();
                     if (tmp) |*array| {
+                        var os = OperatingSystem.none.negatable();
                         while (array.next()) |item| {
                             if (item.asString(bun.default_allocator)) |str| {
-                                if (first) {
-                                    package_json.os = OperatingSystem.none;
-                                    first = false;
-                                }
-                                package_json.os = package_json.os.apply(str);
+                                os.apply(str);
                             }
                         }
+
+                        package_json.os = os.combine();
                     }
                 }
 

--- a/test/cli/install/architecture-match.test.ts
+++ b/test/cli/install/architecture-match.test.ts
@@ -1,0 +1,64 @@
+import { isArchitectureMatch, isOperatingSystemMatch } from "bun:internal-for-testing";
+import "harness";
+
+import { test, expect, describe } from "bun:test";
+
+describe("isArchitectureMatch", () => {
+  const trues = [
+    [],
+    ["any"],
+    ["any", process.arch],
+    [process.arch],
+    ["!ia32"],
+    ["!ia32", process.arch],
+    ["ia32", process.arch],
+    ["!mips", "!ia32"],
+  ];
+  const falses = [
+    ["ia32"],
+    ["any", "!" + process.arch],
+    ["!" + process.arch],
+    ["!ia32", "!" + process.arch],
+    ["!" + process.arch, process.arch],
+  ];
+  for (let arch of trues) {
+    test(`${arch} === true`, () => {
+      expect(isArchitectureMatch(arch)).toBe(true);
+    });
+  }
+  for (let arch of falses) {
+    test(`${arch} === false`, () => {
+      expect(isArchitectureMatch(arch)).toBe(false);
+    });
+  }
+});
+
+describe("isOperatingSystemMatch", () => {
+  const trues = [
+    [],
+    ["any"],
+    ["any", process.platform],
+    [process.platform],
+    ["!sunos"],
+    ["!sunos", process.platform],
+    ["sunos", process.platform],
+    ["!aix", "!sunos"],
+  ];
+  const falses = [
+    ["aix"],
+    ["any", "!" + process.platform],
+    ["!" + process.platform],
+    ["!sunos", "!" + process.platform],
+    ["!" + process.platform, process.platform],
+  ];
+  for (let os of trues) {
+    test(`${os} === true`, () => {
+      expect(isOperatingSystemMatch(os)).toBe(true);
+    });
+  }
+  for (let os of falses) {
+    test(`${os} === false`, () => {
+      expect(isOperatingSystemMatch(os)).toBe(false);
+    });
+  }
+});

--- a/test/cli/install/architecture-match.test.ts
+++ b/test/cli/install/architecture-match.test.ts
@@ -1,7 +1,7 @@
 import { isArchitectureMatch, isOperatingSystemMatch } from "bun:internal-for-testing";
 import "harness";
 
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 describe("isArchitectureMatch", () => {
   const trues = [

--- a/test/cli/install/architecture-match.test.ts
+++ b/test/cli/install/architecture-match.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, test } from "bun:test";
 
 describe("isArchitectureMatch", () => {
   const trues = [
+    ["wombo.com", "any"],
+    ["wombo.com", process.arch],
     [],
     ["any"],
     ["any", process.arch],
@@ -15,6 +17,7 @@ describe("isArchitectureMatch", () => {
     ["!mips", "!ia32"],
   ];
   const falses = [
+    ["wombo.com"],
     ["ia32"],
     ["any", "!" + process.arch],
     ["!" + process.arch],
@@ -43,6 +46,7 @@ describe("isOperatingSystemMatch", () => {
     ["!sunos", process.platform],
     ["sunos", process.platform],
     ["!aix", "!sunos"],
+    ["wombo.com", "!aix"],
   ];
   const falses = [
     ["aix"],


### PR DESCRIPTION
### What does this PR do?

A `"cpu"` field in package.json like `["!ia32", "!arm"]` was treated as equivalent to specifying no CPU is ever supported, which means the package would never be installed. This is incorrect.

We were also not handling `"any"` correctly.

References:
- https://github.com/pnpm/pnpm/blob/1f228b0aeec2ef9a2c8577df1d17186ac83790f9/config/package-is-installable/src/checkPlatform.ts#L56-L86
- https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/node_modules/npm-install-checks/lib/index.js#L2-L96

Now we get all the fields that were added and all the fields that were removed, and only combine the two if both were present

This bumps the manifest cache version because the data needs to be regenerated since we were storing incorrect values for `"os"`, `"cpu"`. Technically, we need to also bump the lockfiles to handle this correctly...which is not great. I'm not doing that in this PR.

### How did you verify your code works?

There are unit tests