### PR TITLE
Add the missing 'linked' option to `--sourcemap` in `bun build --help`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -242,7 +242,7 @@ pub const Arguments = struct {
         clap.parseParam("--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\"") catch unreachable,
         clap.parseParam("--outdir <STR>                   Default to \"dist\" if multiple files") catch unreachable,
         clap.parseParam("--outfile <STR>                  Write to a file") catch unreachable,
-        clap.parseParam("--sourcemap <STR>?               Build with sourcemaps - 'inline', 'external', or 'none'") catch unreachable,
+        clap.parseParam("--sourcemap <STR>?               Build with sourcemaps - 'linked', 'inline', 'external', or 'none'") catch unreachable,
         clap.parseParam("--format <STR>                   Specifies the module format to build to. Only \"esm\" is supported.") catch unreachable,
         clap.parseParam("--root <STR>                     Root directory used for multiple entry points") catch unreachable,
         clap.parseParam("--splitting                      Enable code splitting") catch unreachable,


### PR DESCRIPTION
### What does this PR do?

Adds the missing 'linked' option (introduced by #13349) to `--sourcemap` param in the `bun build --help`

- [x] Documentation
- [ ] Code changes