### PR TITLE
Attempt to fix spawn-streaming-stdin.test.ts on Windows

### DIFF
--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -3,9 +3,9 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, dumpStats, expectMaxObjectTypeCount, getMaxFD } from "harness";
 import { join } from "path";
 
-const N = 100;
+const N = 50;
 const concurrency = 16;
-const delay = 8 * 12;
+const delay = 150;
 
 test("spawn can write to stdin multiple chunks", async () => {
   const interval = setInterval(dumpStats, 1000).unref();


### PR DESCRIPTION
### What does this PR do?

`spawn-streaming-stdin.test.ts` has been failing on Windows because sometimes chunks of input get merged, and the test expects to receive more than one chunk. I tried to fix this by increasing the delay between chunks, and I decreased the number of iterations

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)