### PR TITLE
fix `hot/hot.test.ts`

### DIFF
--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, existsSync } from "fs";
-import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -487,7 +487,7 @@ throw new Error('0');`,
       stderr: "inherit",
       stdin: "ignore",
     });
-    while (!existsSync(hotRunnerRoot)) {}
+    await waitForFileToExist(hotRunnerRoot, 5);
     await using runner = spawn({
       cmd: [bunExe(), "--hot", "run", hotRunnerRoot],
       env: bunEnv,
@@ -577,7 +577,7 @@ throw new Error('0');`,
       stderr: "ignore",
       stdin: "ignore",
     });
-    while (!existsSync(hotRunnerRoot)) {}
+    await waitForFileToExist(hotRunnerRoot, 5);
     await using runner = spawn({
       cmd: [
         //

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -487,7 +487,7 @@ throw new Error('0');`,
       stderr: "inherit",
       stdin: "ignore",
     });
-    await waitForFileToExist(hotRunnerRoot, 5);
+    waitForFileToExist(hotRunnerRoot, 20);
     await using runner = spawn({
       cmd: [bunExe(), "--hot", "run", hotRunnerRoot],
       env: bunEnv,
@@ -577,7 +577,7 @@ throw new Error('0');`,
       stderr: "ignore",
       stdin: "ignore",
     });
-    await waitForFileToExist(hotRunnerRoot, 5);
+    waitForFileToExist(hotRunnerRoot, 20);
     await using runner = spawn({
       cmd: [
         //

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, existsSync } from "fs";
+import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isDebug, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, existsSync } from "fs";
 import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
 import { join } from "path";
 
@@ -487,6 +487,7 @@ throw new Error('0');`,
       stderr: "inherit",
       stdin: "ignore",
     });
+    while (!existsSync(hotRunnerRoot)) {}
     await using runner = spawn({
       cmd: [bunExe(), "--hot", "run", hotRunnerRoot],
       env: bunEnv,
@@ -576,6 +577,7 @@ throw new Error('0');`,
       stderr: "ignore",
       stdin: "ignore",
     });
+    while (!existsSync(hotRunnerRoot)) {}
     await using runner = spawn({
       cmd: [
         //

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -35,7 +35,7 @@ for (const dir of ["dir", "©️"]) {
       await updateFile(i);
     }
     rmSync(path);
-  });
+  }, 10000);
 }
 
 afterEach(() => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,7 +1,7 @@
-import { gc as bunGC, spawnSync, unsafe, which } from "bun";
+import { gc as bunGC, spawnSync, unsafe, which, sleep } from "bun";
 import { heapStats } from "bun:jsc";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { readFile, readlink, writeFile } from "fs/promises";
+import { readFile, readlink, writeFile, exists } from "fs/promises";
 import fs, { closeSync, openSync } from "node:fs";
 import os from "node:os";
 import { dirname, isAbsolute, join } from "path";
@@ -1284,3 +1284,9 @@ Object.defineProperty(globalThis, "gc", {
   enumerable: false,
   configurable: true,
 });
+
+export async function waitForFileToExist(path: string, interval: number) {
+  while (!(await exists(path))) {
+    await sleep(interval);
+  }
+}

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,7 +1,7 @@
-import { gc as bunGC, sleep, spawnSync, unsafe, which } from "bun";
+import { gc as bunGC, sleepSync, spawnSync, unsafe, which } from "bun";
 import { heapStats } from "bun:jsc";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { exists, readFile, readlink, writeFile } from "fs/promises";
+import { readFile, readlink, writeFile } from "fs/promises";
 import fs, { closeSync, openSync } from "node:fs";
 import os from "node:os";
 import { dirname, isAbsolute, join } from "path";
@@ -1285,8 +1285,8 @@ Object.defineProperty(globalThis, "gc", {
   configurable: true,
 });
 
-export async function waitForFileToExist(path: string, interval: number) {
-  while (!(await exists(path))) {
-    await sleep(interval);
+export function waitForFileToExist(path: string, interval: number) {
+  while (!fs.existsSync(path)) {
+    sleepSync(interval);
   }
 }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1,7 +1,7 @@
-import { gc as bunGC, spawnSync, unsafe, which, sleep } from "bun";
+import { gc as bunGC, sleep, spawnSync, unsafe, which } from "bun";
 import { heapStats } from "bun:jsc";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { readFile, readlink, writeFile, exists } from "fs/promises";
+import { exists, readFile, readlink, writeFile } from "fs/promises";
 import fs, { closeSync, openSync } from "node:fs";
 import os from "node:os";
 import { dirname, isAbsolute, join } from "path";


### PR DESCRIPTION
### What does this PR do?
work in progress
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
