### PR TITLE
Make NAPI garbage collection tests faster

### DIFF
--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -11,7 +11,18 @@ const fn = tests[process.argv[2]];
 if (typeof fn !== "function") {
   throw new Error("Unknown test:", process.argv[2]);
 }
-const result = fn.apply(null, eval(process.argv[3] ?? "[]"));
+
+// pass GC runner as first argument
+const result = fn.apply(null, [
+  () => {
+    if (process.isBun) {
+      Bun.gc(true);
+    } else if (global.gc) {
+      global.gc();
+    }
+  },
+  ...eval(process.argv[3] ?? "[]"),
+]);
 if (result instanceof Promise) {
   result.then(x => console.log("resolved to", x));
 } else if (result) {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -135,7 +135,13 @@ function checkSameOutput(test: string, args: any[] | string) {
 
 function runOn(executable: string, test: string, args: any[] | string) {
   const exec = spawnSync({
-    cmd: [executable, join(__dirname, "napi-app/main.js"), test, typeof args == "string" ? args : JSON.stringify(args)],
+    cmd: [
+      executable,
+      "--expose-gc",
+      join(__dirname, "napi-app/main.js"),
+      test,
+      typeof args == "string" ? args : JSON.stringify(args),
+    ],
     env: bunEnv,
   });
   const errs = exec.stderr.toString();


### PR DESCRIPTION
### What does this PR do?

Some of the NAPI tests need to check that an object is not freed after garbage collection runs. Previously, they would perform lots of allocations to try to force GC to run. Now, they all take a callback from JS which in turn calls `Bun.gc` to deterministically run the collector. This makes those tests much faster.

### How did you verify your code works?

I ran the new tests while reintroducing several GC-related bugs one at a time and each bug was consistently caught by all the tests that were intended to catch it.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
