### PR TITLE
Fix ReadFileUV not reading to the end of a non-regular file on Windows

### DIFF
--- a/src/bun.js/webcore/blob/ReadFile.zig
+++ b/src/bun.js/webcore/blob/ReadFile.zig
@@ -730,7 +730,9 @@ pub const ReadFileUV = struct {
     }
 
     pub fn queueRead(this: *ReadFileUV) void {
-        if (this.remainingBuffer().len > 0 and this.errno == null and !this.read_eof) {
+        // if not a regular file, buffer capacity is arbitrary, and running out doesn't mean we're
+        // at the end of the file
+        if ((this.remainingBuffer().len > 0 or !this.is_regular_file) and this.errno == null and !this.read_eof) {
             log("ReadFileUV.queueRead - this.remainingBuffer().len = {d}", .{this.remainingBuffer().len});
 
             if (!this.is_regular_file) {

--- a/test/regression/issue/07500/07500.fixture.js
+++ b/test/regression/issue/07500/07500.fixture.js
@@ -1,1 +1,18 @@
-console.write(await Bun.stdin.text());
+const input = await Bun.stdin.text();
+
+if (process.platform == "win32") {
+  // powershell unavoidably appends \r\n to text sent from a powershell command (like Get-Content)
+  // to an external program (like bun)
+  // https://github.com/PowerShell/PowerShell/issues/5974
+  // so we have to remove it
+  // for sanity check that it actually ends in \r\n
+  const CR = "\r".charCodeAt(0);
+  const LF = "\n".charCodeAt(0);
+  if (input.charCodeAt(input.length - 2) !== CR || input.charCodeAt(input.length - 1) !== LF) {
+    throw new Error(`input of ${input.length} bytes does not end in CRLF`);
+  }
+  const trimmed = input.substring(0, input.length - 2);
+  console.write(trimmed);
+} else {
+  console.write(input);
+}

--- a/test/regression/issue/07500/07500.test.ts
+++ b/test/regression/issue/07500/07500.test.ts
@@ -10,7 +10,8 @@ test("7500 - Bun.stdin.text() doesn't read all data", async () => {
     .split(" ")
     .join("\n");
   await Bun.write(filename, text);
-  const cat = isWindows ? "Get-Content" : "cat";
+  // -Raw on windows makes it output a single string instead of an array of lines
+  const cat = isWindows ? "Get-Content -Raw" : "cat";
   const bunCommand = `${bunExe()} ${join(import.meta.dir, "07500.fixture.js")}`;
   const shellCommand = `${cat} ${filename} | ${bunCommand}`.replace(/\\/g, "\\\\");
 
@@ -27,7 +28,7 @@ test("7500 - Bun.stdin.text() doesn't read all data", async () => {
     throw new Error(proc.stdout.toString());
   }
 
-  const output = proc.stdout.toString().replaceAll("\r\n", "\n");
+  const output = proc.stdout.toString();
   if (output !== text) {
     expect(output).toHaveLength(text.length);
     throw new Error("Output didn't match!\n");


### PR DESCRIPTION
### What does this PR do?

Previously, ReadFileUV would sometimes read only one chunk of data when reading a non-regular file (like stdin), rather than reading the whole file. Now, it does read the whole file, and the test for it is more consistent.

### How did you verify your code works?

I made changes to the regression test for #7500 so that it consistently fails using the old version of Bun on a Windows test machine. Previously, that test would sometimes fail in CI but I couldn't get it to fail on my own machine. The new test consistently passes on the new ReadFile.zig code.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
