### PR TITLE
fixes --conditions for bun test

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -567,7 +567,7 @@ pub const Arguments = struct {
 
         ctx.passthrough = args.remaining();
 
-        if (cmd == .AutoCommand or cmd == .RunCommand or cmd == .BuildCommand) {
+        if (cmd == .AutoCommand or cmd == .RunCommand or cmd == .BuildCommand or cmd == .TestCommand) {
             if (args.options("--conditions").len > 0) {
                 opts.conditions = args.options("--conditions");
             }

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -54,6 +54,7 @@ beforeAll(() => {
   });
 
   writeFileSync(`${dir}/test.js`, `import {foo} from 'custom/test';\nconsole.log(foo);`);
+  writeFileSync(`${dir}/test.test.js`, `import {foo} from 'custom/test';\nconsole.log(foo);`);
   writeFileSync(`${dir}/test.cjs`, `const {foo} = require("custom2/test");\nconsole.log(foo);`);
   writeFileSync(
     `${dir}/multiple-conditions.js`,
@@ -79,6 +80,17 @@ beforeAll(() => {
 it("custom condition 'import' in package.json resolves", async () => {
   const { exitCode, stdout } = Bun.spawnSync({
     cmd: [bunExe(), "--conditions=first", `${dir}/test.js`],
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  expect(exitCode).toBe(0);
+  expect(stdout.toString("utf8")).toBe("1\n");
+});
+
+it("custom condition 'import' in package.json resolves in bun test", async () => {
+  const { exitCode, stdout } = Bun.spawnSync({
+    cmd: [bunExe(), "test", "--conditions=first", `${dir}/test.test.js`],
     env: bunEnv,
     cwd: import.meta.dir,
   });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
this PR fixes https://github.com/oven-sh/bun/issues/12545 and https://github.com/oven-sh/bun/issues/10036 - both of which described an issue where the `--conditions` flag did not have any effect when running`bun test`.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
