### PR TITLE
Don't panic when a package.json manifest registry api name doesn't match the local name

### DIFF
--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1308,19 +1308,19 @@ pub const PackageManifest = struct {
             .string_pool = string_pool,
         };
 
-        if (json.asProperty("name")) |name_q| {
-            const received_name = name_q.expr.asString(allocator) orelse return null;
-
-            // If this manifest is coming from the default registry, make sure it's the expected one. If it's not
-            // from the default registry we don't check because the registry might have a different name in the manifest.
-            // https://githun.com/oven-sh/bun/issues/4925
-            if (scope.url_hash == Registry.default_url_hash and !strings.eqlLong(expected_name, received_name, true)) {
-                Output.panic("<r>internal: <red>Package name mismatch.<r> Expected <b>\"{s}\"<r> but received <red>\"{s}\"<r>", .{ expected_name, received_name });
-                return null;
+        if (PackageManager.verbose_install) {
+            if (json.asProperty("name")) |name_q| {
+                const received_name = name_q.expr.asString(allocator) orelse return null;
+                // If this manifest is coming from the default registry, make sure it's the expected one. If it's not
+                // from the default registry we don't check because the registry might have a different name in the manifest.
+                // https://github.com/oven-sh/bun/issues/4925
+                if (scope.url_hash == Registry.default_url_hash and !strings.eqlLong(expected_name, received_name, true)) {
+                    Output.warn("Package name mismatch. Expected <b>\"{s}\"<r> but received <red>\"{s}\"<r>", .{ expected_name, received_name });
+                }
             }
-
-            string_builder.count(expected_name);
         }
+
+        string_builder.count(expected_name);
 
         if (json.asProperty("modified")) |name_q| {
             const field = name_q.expr.asString(allocator) orelse return null;


### PR DESCRIPTION
### What does this PR do?

Don't panic when a package.json manifest registry api name doesn't match the local name



### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
