### PR TITLE
Micro-optimize `path.resolve()`, `path.resolve("")`

### DIFF
--- a/bench/snippets/path-resolve.mjs
+++ b/bench/snippets/path-resolve.mjs
@@ -3,6 +3,8 @@ import { posix } from "path";
 
 const pathConfigurations = [
   "",
+  ".",
+  "./",
   ["", ""].join("|"),
   ["./abc.js"].join("|"),
   ["foo/bar", "/tmp/file/", "..", "a/../subfile"].join("|"),

--- a/bench/snippets/process-cwd.mjs
+++ b/bench/snippets/process-cwd.mjs
@@ -1,0 +1,7 @@
+import { bench, run } from "mitata";
+
+bench("process.cwd()", () => {
+  process.cwd();
+});
+
+await run();

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2835,22 +2835,33 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessTitle,
 #endif
 }
 
-JSC_DEFINE_HOST_FUNCTION(Process_functionCwd,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+static inline JSValue getCachedCwd(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();
-    auto* processObject = jsCast<Process*>(defaultGlobalObject(globalObject)->processObject());
     auto scope = DECLARE_THROW_SCOPE(vm);
+
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L142-L146
+    auto* processObject = jsCast<Process*>(defaultGlobalObject(globalObject)->processObject());
     if (auto* cached = processObject->cachedCwd()) {
-        return JSValue::encode(cached);
+        return cached;
     }
 
     auto cwd = Bun__Process__getCwd(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     JSString* cwdStr = jsCast<JSString*>(JSValue::decode(cwd));
     processObject->setCachedCwd(vm, cwdStr);
-    return JSValue::encode(cwdStr);
+    RELEASE_AND_RETURN(scope, cwdStr);
+}
+
+extern "C" EncodedJSValue Process__getCachedCwd(JSC::JSGlobalObject* globalObject)
+{
+    return JSValue::encode(getCachedCwd(globalObject));
+}
+
+JSC_DEFINE_HOST_FUNCTION(Process_functionCwd,
+    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    return JSValue::encode(getCachedCwd(globalObject));
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionReallyKill,


### PR DESCRIPTION
### What does this PR do?

Micro-optimize `path.resolve()`, `path.resolve("")` on posix by returning the same JSString* as process.cwd(), so we avoid unnecessarily creating a string

### How did you verify your code works?

