### PR TITLE
Increase timeouts for shell-hang.test.ts

### DIFF
--- a/test/js/bun/shell/shell-hang.test.ts
+++ b/test/js/bun/shell/shell-hang.test.ts
@@ -22,7 +22,7 @@ describe("fail", () => {
     fixture => {
       expect([path.join(import.meta.dir, fixture)]).not.toRun();
     },
-    500,
+    700,
   );
 });
 
@@ -32,6 +32,6 @@ describe("pass", () => {
     fixture => {
       expect([path.join(import.meta.dir, fixture)]).toRun();
     },
-    500,
+    700,
   );
 });


### PR DESCRIPTION
### What does this PR do?

Increases the timeout for each test in `shell-hang.test.ts` from 500ms to 700ms. Those subtests rarely take ~650ms to run (as opposed to typical values of 60-80ms) in our Windows CI. I believe this can probably be attributed to background tasks or other OS interference, as I was able to easily make those tests take 300ms or more by running them with background tasks active on the same computer.

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
