### PR TITLE
Support reading from user's .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+; registry=https://registry.npmjs.org/
+registry=https://npm.pkg.github.com

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:22.04
+RUN apt update && \
+    apt install -y python3 pip curl git unzip wget ccache ninja-build cargo nodejs && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install cmake && \
+    curl -fsSL https://bun.sh/install | bash && \
+    ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
+    git clone https://github.com/oven-sh/bun.git
+RUN apt install -y lsb-release wget software-properties-common gnupg
+RUN wget https://apt.llvm.org/llvm.sh -O - | bash -s -- 16 all
+WORKDIR /bun
+# RUN apt update && \
+#     apt install -y curl wget lsb-release software-properties-common cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils && \
+#     wget https://apt.llvm.org/llvm.sh -O - | bash -s -- 16 all && \
+#     curl -fsSL https://bun.sh/install | bash && \
+#     ln -s /root/.bun/bin/bun /usr/local/bin/bun
+
+
+# WORKDIR /bun
+
+
+# 1  ls
+#    2  bun run build
+#    3  apt update
+#    4  apt install build-essential libtool autoconf unzip wget
+#    5  bun run build
+#    6  version=3.28
+#    7  build=1
+#    8  ## don't modify from here
+#    9  mkdir ~/temp
+#   10  cd ~/temp
+#   11  wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
+#   12  tar -xzvf cmake-$version.$build.tar.gz
+#   13  cd cmake-$version.$build/
+#   14  ./bootstrap
+#   15  make -j$(nproc)
+#   16  apt install -y libssl-dev
+#   17  make -j$(nproc)
+#   18  ./bootstrap
+#   19  nproc
+#   20  make -j$(nproc)
+#   21  make install
+#   22  cmake --version
+#   23  cd /bun
+#   24  bun run build
+#   25  build/bun-debug
+#   26  ls
+#   27  cd build
+#   28  ls
+#   29  ls -la
+#   30  cd debug
+#   31  ls
+#   32  ls -la
+#   33  ./bun-debug
+#   34  ./bun-debug -version
+#   35  cd ../..
+#   36  bun-debug
+#   37  ./bun-debug
+#   38  ./build/debug/bun-debug test cli/install/registry
+#   39  ./build/debug/bun-debug test cli/install/registry > test.log
+#   40  ls -la
+#   41  rmdir .npmrc
+#   42  ls -la
+#   43  cat .npmc

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,84 @@
+services:
+  rebuild:
+    build:
+      dockerfile: builder.Dockerfile
+    command: bash
+    stdin_open: true # docker run -i
+    tty: true # docker run -t
+    volumes:
+      - ./src/ini.zig:/bun/src/ini.zig
+      - ./src/install/install.zig:/bun/src/install/install.zig
+      - ./test/cli/install/registry/bun-install-registry.test.ts:/bun/test/cli/install/registry/bun-install-registry.test.ts
+      - ./scripts/runner.node.mjs:/bun/scripts/runner.node.mjs
+      # - ./npmrc_usr:/root/.npmrc
+      # - ./npmrc_prj:/bun/.npmrc
+
+  baseline:
+    build:
+      dockerfile: builder.Dockerfile
+    command: bash
+    stdin_open: true # docker run -i
+    tty: true # docker run -t
+
+
+  # test:
+  #   image: bun-rebuild:latest
+  #   command: ./build/bun-debug --version
+  #   depends_on:
+  #     rebuild:
+  #       condition: service_completed_successfully
+#     1  apt install curl wget lsb-release software-properties-common cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
+#     2  apt update
+#     3  mkdir code
+#     4  cd code
+#     5  apt install git
+#     6  git clone https://github.com/oven-sh/bun.git
+#     7  cd bun
+#     8  ls
+#     9  apt install curl wget lsb-release software-properties-common cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
+#    10  which clang-16
+#    11  wget https://apt.llvm.org/llvm.sh -O - | bash -s -- 16 all
+#    12  which clang-16
+#    13  bun setup
+#    14  curl -fsSL https://bun.sh/install | bash
+#    15  bun setup
+#    16  source /root/.bashrc
+#    17  bun setup
+#    18  hash
+#    19  bun
+#    20  bun setup
+#    21  build/bun-debug --version
+#    22  apt install vim
+#    23  vim src/ini.zig
+#    24  vim src/ini.zig
+#    25  bun run build
+#    26  bun run build
+#    27  bun setup
+#    28  cat src/ini.zig | grep "cwd"
+#    29  vim src/ini.zig
+#    30  bun run build
+#    31  ls
+#    32  ./build/bun-debug --version
+#    33  bun setup
+#    34  bun run build
+#    35  touch /root/.npmrc
+#    36  echo "registry=https://nexus.ssvc.uncd.io/repository/npmjs/" > /root/.npmrc
+#    37  bun install lodash
+#    38  ./build/bun-debug install lodash
+#    39  cp /root/.npmrc ./.npmrc
+#    40  ./build/bun-debug install lodash
+#    41  ./build/bun-debug install lodash
+#    42  ls
+#    43  rm -rf node_modules
+#    44  ./build/bun-debug install lodash
+#    45  ./build/bun-debug uninstall lodash
+#    46  ./build/bun-debug install lodash
+#    47  ls
+#    48  cat .npmrc
+#    49  mv .npmrc /root/
+#    50  ./build/bun-debug install lodash
+#    51  ./build/bun-debug uninstall lodash
+#    52  bun run build
+#    53  bun run build
+#    54  bun run build
+#    55  history

--- a/npmrc_prj
+++ b/npmrc_prj
@@ -1,0 +1,2 @@
+; registry=https://registry.npmjs.org/
+; registry=https://npm.pkg.github.com

--- a/nvmrc_usr
+++ b/nvmrc_usr
@@ -1,0 +1,2 @@
+; registry=https://registry.npmjs.org/
+; registry=https://npm.pkg.github.com

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -574,7 +574,7 @@ pub const IniTestingAPIs = struct {
 
         const install = allocator.create(bun.Schema.Api.BunInstall) catch bun.outOfMemory();
         install.* = std.mem.zeroes(bun.Schema.Api.BunInstall);
-        loadNpmrc(allocator, install, env, false, &log, &source) catch {
+        loadNpmrc(allocator, install, env, false, ".npmrc", &log, &source) catch {
             return log.toJS(globalThis, allocator, "error");
         };
 
@@ -878,35 +878,36 @@ pub fn loadNpmrcFromFile(
     install: *bun.Schema.Api.BunInstall,
     env: *bun.DotEnv.Loader,
     auto_loaded: bool,
+    npmrc_path: [:0]const u8,
 ) void {
     var log = bun.logger.Log.init(allocator);
     defer log.deinit();
-    const npmrc_file = switch (bun.sys.openat(bun.FD.cwd(), ".npmrc", bun.O.RDONLY, 0)) {
+    const npmrc_file = switch (bun.sys.openat(bun.FD.cwd(), npmrc_path, bun.O.RDONLY, 0)) {
         .result => |fd| fd,
         .err => |err| {
             if (auto_loaded) return;
             Output.prettyErrorln("{}\nwhile opening .npmrc \"{s}\"", .{
                 err,
-                ".npmrc",
+                npmrc_path,
             });
             Global.exit(1);
         },
     };
     defer _ = bun.sys.close(npmrc_file);
 
-    const source = switch (bun.sys.File.toSource(".npmrc", allocator)) {
+    const source = switch (bun.sys.File.toSource(npmrc_path, allocator)) {
         .result => |s| s,
         .err => |e| {
             Output.prettyErrorln("{}\nwhile reading .npmrc \"{s}\"", .{
                 e,
-                ".npmrc",
+                npmrc_path,
             });
             Global.exit(1);
         },
     };
     defer allocator.free(source.contents);
 
-    loadNpmrc(allocator, install, env, auto_loaded, &log, &source) catch {
+    loadNpmrc(allocator, install, env, auto_loaded, npmrc_path, &log, &source) catch {
         if (log.errors == 1)
             Output.warn("Encountered an error while reading <b>.npmrc<r>:\n", .{})
         else
@@ -920,10 +921,11 @@ pub fn loadNpmrc(
     install: *bun.Schema.Api.BunInstall,
     env: *bun.DotEnv.Loader,
     auto_loaded: bool,
+    npmrc_path: [:0]const u8,
     log: *bun.logger.Log,
     source: *const bun.logger.Source,
 ) !void {
-    var parser = bun.ini.Parser.init(allocator, ".npmrc", source.contents, env);
+    var parser = bun.ini.Parser.init(allocator, npmrc_path, source.contents, env);
     defer parser.deinit();
     parser.parse(parser.arena.allocator()) catch |e| {
         if (e == error.ParserError) {
@@ -933,13 +935,13 @@ pub fn loadNpmrc(
         if (auto_loaded) {
             Output.warn("{}\nwhile reading .npmrc \"{s}\"", .{
                 e,
-                ".npmrc",
+                npmrc_path,
             });
             return;
         }
         Output.prettyErrorln("{}\nwhile reading .npmrc \"{s}\"", .{
             e,
-            ".npmrc",
+            npmrc_path,
         });
         Global.exit(1);
     };

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8458,6 +8458,31 @@ pub const PackageManager = struct {
         try env.load(entries_option.entries, &[_][]u8{}, .production, false);
 
         initializeStore();
+        if (bun.getenvZ("XDG_CONFIG_HOME") orelse bun.getenvZ(bun.DotEnv.home_env)) |data_dir| {
+            var buf: bun.PathBuffer = undefined;
+            var parts = [_]string{
+                "./.npmrc",
+            };
+
+            bun.ini.loadNpmrcFromFile(
+                ctx.allocator,
+                ctx.install orelse brk: {
+                    const install_ = ctx.allocator.create(Api.BunInstall) catch bun.outOfMemory();
+                    install_.* = std.mem.zeroes(Api.BunInstall);
+                    ctx.install = install_;
+                    break :brk install_;
+                },
+                env,
+                true,
+                Path.joinAbsStringBufZ(
+                    data_dir,
+                    &buf,
+                    &parts,
+                    .auto,
+                ),
+            );
+        }
+
         bun.ini.loadNpmrcFromFile(
             ctx.allocator,
             ctx.install orelse brk: {
@@ -8468,6 +8493,7 @@ pub const PackageManager = struct {
             },
             env,
             true,
+            ".npmrc",
         );
 
         var cpu_count = @as(u32, @truncate(((try std.Thread.getCpuCount()) + 1)));


### PR DESCRIPTION
### What does this PR do?

This PR expands upon PR https://github.com/oven-sh/bun/pull/11979 to add support for reading [per-user](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#files) .npmrc files in addition to `per-project` .npmrc files.

Configuration in project .npmrc files will be combined with configuration in user .npmrc files.  If a specific configuration is defined in both, the project configuration is used.