### PR TITLE
fix: use Bun's Fetch interface for fetch

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3170,7 +3170,7 @@ declare module "bun" {
    */
   function openInEditor(path: string, options?: EditorOptions): void;
 
-  const fetch: typeof globalThis.fetch & {
+  const fetch: Fetch & {
     preconnect(url: string): void;
   };
 


### PR DESCRIPTION
Allows TypeScript to use Bun's FetchRequestInit instead of Node's RequestInit in fetch request options.

### What does this PR do?

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I modified the `.d.ts` file directly in my own project's `node_modules` and verified the type is recognized correctly in VSCode.

### Additional Info

This previously existing similar type probably supports, `fetch` to be of `Fetch`, hence made this change
https://github.com/oven-sh/bun/blob/3d68a9483fbb69b7ac4dd9c686658ec14a6674e4/packages/bun-types/globals.d.ts#L945

Fixes #13827