### PR TITLE
disable most DOMJIT

### DIFF
--- a/src/bun.js/bindings/ZigGeneratedCode.cpp
+++ b/src/bun.js/bindings/ZigGeneratedCode.cpp
@@ -15,18 +15,18 @@ using namespace WebCore;
 
 /* -- BEGIN DOMCall DEFINITIONS -- */
 
-BUN_DECLARE_HOST_FUNCTION(FFI__ptr__slowpathWrapper);
-extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(FFI__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, JSC::JSUint8Array*));
+// BUN_DECLARE_HOST_FUNCTION(FFI__ptr__slowpathWrapper);
+// extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(FFI__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, JSC::JSUint8Array*));
 
-JSC_DEFINE_JIT_OPERATION(FFI__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, JSC::JSUint8Array* arg1))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { FFI__ptr__fastpath(lexicalGlobalObject, thisValue, arg1) };
-}
+// JSC_DEFINE_JIT_OPERATION(FFI__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, JSC::JSUint8Array* arg1))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { FFI__ptr__fastpath(lexicalGlobalObject, thisValue, arg1) };
+// }
 JSC_DEFINE_HOST_FUNCTION(FFI__ptr__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return FFI__ptr__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -35,19 +35,27 @@ JSC_DEFINE_HOST_FUNCTION(FFI__ptr__slowpathWrapper, (JSC::JSGlobalObject * globa
 extern "C" void FFI__ptr__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_ptr_signature(
-        FFI__ptr__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecDoubleReal,
-        JSC::SpecUint8Array);
+    // static const JSC::DOMJIT::Signature DOMJIT_ptr_signature(
+    //     FFI__ptr__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecDoubleReal,
+    //     JSC::SpecUint8Array);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     1,
+    //     String("ptr"_s),
+    //     FFI__ptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, FFI__ptr__slowpathWrapper,
+    //     &DOMJIT_ptr_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         1,
         String("ptr"_s),
-        FFI__ptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, FFI__ptr__slowpathWrapper,
-        &DOMJIT_ptr_signature);
+        FFI__ptr__slowpathWrapper,
+        ImplementationVisibility::Public,
+        NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "ptr"_s),
@@ -57,15 +65,15 @@ extern "C" void FFI__ptr__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSV
 BUN_DECLARE_HOST_FUNCTION(Reader__u8__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__u8__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__u8__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__u8__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__u8__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__u8__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__u8__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__u8__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -74,20 +82,29 @@ JSC_DEFINE_HOST_FUNCTION(Reader__u8__slowpathWrapper, (JSC::JSGlobalObject * glo
 extern "C" void Reader__u8__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_u8_signature(
-        Reader__u8__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt32Only,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_u8_signature(
+    //     Reader__u8__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt32Only,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("u8"_s),
+    //     Reader__u8__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u8__slowpathWrapper,
+    //     &DOMJIT_u8_signature);
+
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("u8"_s),
-        Reader__u8__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u8__slowpathWrapper,
-        &DOMJIT_u8_signature);
+        Reader__u8__slowpathWrapper,
+        ImplementationVisibility::Public,
+        NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "u8"_s),
@@ -97,15 +114,15 @@ extern "C" void Reader__u8__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJ
 BUN_DECLARE_HOST_FUNCTION(Reader__u16__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__u16__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__u16__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__u16__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__u16__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__u16__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__u16__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__u16__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -114,20 +131,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__u16__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__u16__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_u16_signature(
-        Reader__u16__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt32Only,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_u16_signature(
+    //     Reader__u16__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt32Only,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("u16"_s),
+    //     Reader__u16__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u16__slowpathWrapper,
+    //     &DOMJIT_u16_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("u16"_s),
-        Reader__u16__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u16__slowpathWrapper,
-        &DOMJIT_u16_signature);
+        Reader__u16__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "u16"_s),
@@ -137,15 +160,15 @@ extern "C" void Reader__u16__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 BUN_DECLARE_HOST_FUNCTION(Reader__u32__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__u32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__u32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__u32__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__u32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__u32__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__u32__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__u32__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -154,20 +177,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__u32__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__u32__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_u32_signature(
-        Reader__u32__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt32Only,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_u32_signature(
+    //     Reader__u32__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt32Only,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("u32"_s),
+    //     Reader__u32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u32__slowpathWrapper,
+    //     &DOMJIT_u32_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("u32"_s),
-        Reader__u32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u32__slowpathWrapper,
-        &DOMJIT_u32_signature);
+        Reader__u32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "u32"_s),
@@ -177,15 +206,15 @@ extern "C" void Reader__u32__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 BUN_DECLARE_HOST_FUNCTION(Reader__ptr__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__ptr__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__ptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__ptr__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__ptr__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__ptr__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -194,20 +223,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__ptr__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__ptr__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_ptr_signature(
-        Reader__ptr__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt52Any,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_ptr_signature(
+    //     Reader__ptr__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("ptr"_s),
+    //     Reader__ptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__ptr__slowpathWrapper,
+    //     &DOMJIT_ptr_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("ptr"_s),
-        Reader__ptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__ptr__slowpathWrapper,
-        &DOMJIT_ptr_signature);
+        Reader__ptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "ptr"_s),
@@ -217,15 +252,15 @@ extern "C" void Reader__ptr__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 BUN_DECLARE_HOST_FUNCTION(Reader__i8__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__i8__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__i8__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__i8__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__i8__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__i8__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__i8__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__i8__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -234,20 +269,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__i8__slowpathWrapper, (JSC::JSGlobalObject * glo
 extern "C" void Reader__i8__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_i8_signature(
-        Reader__i8__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt32Only,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_i8_signature(
+    //     Reader__i8__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt32Only,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("i8"_s),
+    //     Reader__i8__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i8__slowpathWrapper,
+    //     &DOMJIT_i8_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("i8"_s),
-        Reader__i8__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i8__slowpathWrapper,
-        &DOMJIT_i8_signature);
+        Reader__i8__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "i8"_s),
@@ -257,15 +298,15 @@ extern "C" void Reader__i8__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJ
 BUN_DECLARE_HOST_FUNCTION(Reader__i16__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__i16__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__i16__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__i16__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__i16__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__i16__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__i16__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__i16__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -274,20 +315,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__i16__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__i16__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_i16_signature(
-        Reader__i16__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt32Only,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_i16_signature(
+    //     Reader__i16__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt32Only,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("i16"_s),
+    //     Reader__i16__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i16__slowpathWrapper,
+    //     &DOMJIT_i16_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("i16"_s),
-        Reader__i16__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i16__slowpathWrapper,
-        &DOMJIT_i16_signature);
+        Reader__i16__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "i16"_s),
@@ -297,15 +344,15 @@ extern "C" void Reader__i16__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 BUN_DECLARE_HOST_FUNCTION(Reader__i32__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__i32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__i32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__i32__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__i32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__i32__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__i32__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__i32__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -314,20 +361,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__i32__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__i32__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_i32_signature(
-        Reader__i32__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt32Only,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_i32_signature(
+    //     Reader__i32__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt32Only,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("i32"_s),
+    //     Reader__i32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i32__slowpathWrapper,
+    //     &DOMJIT_i32_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("i32"_s),
-        Reader__i32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i32__slowpathWrapper,
-        &DOMJIT_i32_signature);
+        Reader__i32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "i32"_s),
@@ -337,15 +390,15 @@ extern "C" void Reader__i32__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 BUN_DECLARE_HOST_FUNCTION(Reader__i64__slowpathWrapper);
 extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__i64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__i64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__i64__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__i64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__i64__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__i64__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__i64__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -354,20 +407,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__i64__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__i64__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_i64_signature(
-        Reader__i64__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecHeapTop,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_i64_signature(
+    //     Reader__i64__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecHeapTop,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("i64"_s),
+    //     Reader__i64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i64__slowpathWrapper,
+    //     &DOMJIT_i64_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("i64"_s),
-        Reader__i64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__i64__slowpathWrapper,
-        &DOMJIT_i64_signature);
+        Reader__i64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "i64"_s),
@@ -375,17 +434,17 @@ extern "C" void Reader__i64__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 }
 
 BUN_DECLARE_HOST_FUNCTION(Reader__u64__slowpathWrapper);
-extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__u64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
+// extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__u64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__u64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__u64__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__u64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__u64__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__u64__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__u64__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -394,20 +453,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__u64__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__u64__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_u64_signature(
-        Reader__u64__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecHeapTop,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_u64_signature(
+    //     Reader__u64__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecHeapTop,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("u64"_s),
+    //     Reader__u64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u64__slowpathWrapper,
+    //     &DOMJIT_u64_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("u64"_s),
-        Reader__u64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__u64__slowpathWrapper,
-        &DOMJIT_u64_signature);
+        Reader__u64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "u64"_s),
@@ -415,17 +480,17 @@ extern "C" void Reader__u64__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 }
 
 BUN_DECLARE_HOST_FUNCTION(Reader__intptr__slowpathWrapper);
-extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__intptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
+// extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__intptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__intptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__intptr__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__intptr__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__intptr__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__intptr__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__intptr__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -434,20 +499,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__intptr__slowpathWrapper, (JSC::JSGlobalObject *
 extern "C" void Reader__intptr__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_intptr_signature(
-        Reader__intptr__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecInt52Any,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_intptr_signature(
+    //     Reader__intptr__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("intptr"_s),
+    //     Reader__intptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__intptr__slowpathWrapper,
+    //     &DOMJIT_intptr_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("intptr"_s),
-        Reader__intptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__intptr__slowpathWrapper,
-        &DOMJIT_intptr_signature);
+        Reader__intptr__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "intptr"_s),
@@ -455,17 +526,17 @@ extern "C" void Reader__intptr__put(JSC::JSGlobalObject* globalObject, JSC::Enco
 }
 
 BUN_DECLARE_HOST_FUNCTION(Reader__f32__slowpathWrapper);
-extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__f32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
+// extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__f32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__f32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__f32__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__f32__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__f32__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__f32__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__f32__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -474,20 +545,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__f32__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__f32__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_f32_signature(
-        Reader__f32__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecDoubleReal,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_f32_signature(
+    //     Reader__f32__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecDoubleReal,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("f32"_s),
+    //     Reader__f32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__f32__slowpathWrapper,
+    //     &DOMJIT_f32_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("f32"_s),
-        Reader__f32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__f32__slowpathWrapper,
-        &DOMJIT_f32_signature);
+        Reader__f32__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "f32"_s),
@@ -495,17 +572,17 @@ extern "C" void Reader__f32__put(JSC::JSGlobalObject* globalObject, JSC::Encoded
 }
 
 BUN_DECLARE_HOST_FUNCTION(Reader__f64__slowpathWrapper);
-extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__f64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
+// extern "C" JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(Reader__f64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t, int32_t));
 
-JSC_DEFINE_JIT_OPERATION(Reader__f64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { Reader__f64__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
-}
+// JSC_DEFINE_JIT_OPERATION(Reader__f64__fastpathWrapper, EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int64_t arg1, int32_t arg2))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     return { Reader__f64__fastpath(lexicalGlobalObject, thisValue, arg1, arg2) };
+// }
 JSC_DEFINE_HOST_FUNCTION(Reader__f64__slowpathWrapper, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* frame))
 {
     return Reader__f64__slowpath(globalObject, JSValue::encode(frame->thisValue()), reinterpret_cast<JSC::EncodedJSValue*>(frame->addressOfArgumentsStart()), frame->argumentCount());
@@ -514,20 +591,26 @@ JSC_DEFINE_HOST_FUNCTION(Reader__f64__slowpathWrapper, (JSC::JSGlobalObject * gl
 extern "C" void Reader__f64__put(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value)
 {
     JSC::JSObject* thisObject = JSC::jsCast<JSC::JSObject*>(JSC::JSValue::decode(value));
-    static const JSC::DOMJIT::Signature DOMJIT_f64_signature(
-        Reader__f64__fastpathWrapper,
-        thisObject->classInfo(),
-        JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
-        JSC::SpecDoubleReal,
-        JSC::SpecInt52Any,
-        JSC::SpecInt32Only);
+    // static const JSC::DOMJIT::Signature DOMJIT_f64_signature(
+    //     Reader__f64__fastpathWrapper,
+    //     thisObject->classInfo(),
+    //     JSC::DOMJIT::Effect::forReadWrite(JSC::DOMJIT::HeapRange::top(), JSC::DOMJIT::HeapRange::top()),
+    //     JSC::SpecDoubleReal,
+    //     JSC::SpecInt52Any,
+    //     JSC::SpecInt32Only);
+    // JSFunction* function = JSFunction::create(
+    //     globalObject->vm(),
+    //     globalObject,
+    //     2,
+    //     String("f64"_s),
+    //     Reader__f64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__f64__slowpathWrapper,
+    //     &DOMJIT_f64_signature);
     JSFunction* function = JSFunction::create(
         globalObject->vm(),
         globalObject,
         2,
         String("f64"_s),
-        Reader__f64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic, Reader__f64__slowpathWrapper,
-        &DOMJIT_f64_signature);
+        Reader__f64__slowpathWrapper, ImplementationVisibility::Public, NoIntrinsic);
     thisObject->putDirect(
         globalObject->vm(),
         Identifier::fromString(globalObject->vm(), "f64"_s),

--- a/src/bun.js/bindings/webcore/JSTextEncoder.cpp
+++ b/src/bun.js/bindings/webcore/JSTextEncoder.cpp
@@ -73,10 +73,10 @@ extern "C" size_t TextEncoder__encodeInto8(const LChar* stringPtr, size_t string
 extern "C" size_t TextEncoder__encodeInto16(const UChar* stringPtr, size_t stringLen, void* ptr, size_t len);
 extern "C" JSC::EncodedJSValue TextEncoder__encodeRopeString(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSString* str);
 
-extern "C" {
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(jsTextEncoderEncodeWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject*, JSTextEncoder*, DOMJIT::IDLJSArgumentType<IDLDOMString>));
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(jsTextEncoderPrototypeFunction_encodeIntoWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSTextEncoder* castedThis, DOMJIT::IDLJSArgumentType<IDLDOMString> source, DOMJIT::IDLJSArgumentType<IDLUint8Array> destination));
-}
+// extern "C" {
+// static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(jsTextEncoderEncodeWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject*, JSTextEncoder*, DOMJIT::IDLJSArgumentType<IDLDOMString>));
+// static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(jsTextEncoderPrototypeFunction_encodeIntoWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSTextEncoder* castedThis, DOMJIT::IDLJSArgumentType<IDLDOMString> source, DOMJIT::IDLJSArgumentType<IDLUint8Array> destination));
+// }
 
 template<> TextEncoder::EncodeIntoResult convertDictionary<TextEncoder::EncodeIntoResult>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
@@ -214,90 +214,92 @@ template<> void JSTextEncoderDOMConstructor::initializeProperties(VM& vm, JSDOMG
     putDirect(vm, vm.propertyNames->prototype, JSTextEncoder::prototype(vm, globalObject), JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete);
 }
 
-static const JSC::DOMJIT::Signature DOMJITSignatureForJSTextEncoderEncodeWithoutTypeCheck(
-    jsTextEncoderEncodeWithoutTypeCheck,
-    JSTextEncoder::info(),
-    // https://github.com/oven-sh/bun/issues/9226
-    // It's not totally clear what the correct side effects are for this function, so we just make it conservative for now.
-    JSC::DOMJIT::Effect {},
-    DOMJIT::IDLResultTypeFilter<IDLUint8Array>::value,
-    DOMJIT::IDLArgumentTypeFilter<IDLDOMString>::value);
+// static const JSC::DOMJIT::Signature DOMJITSignatureForJSTextEncoderEncodeWithoutTypeCheck(
+//     jsTextEncoderEncodeWithoutTypeCheck,
+//     JSTextEncoder::info(),
+//     // https://github.com/oven-sh/bun/issues/9226
+//     // It's not totally clear what the correct side effects are for this function, so we just make it conservative for now.
+//     JSC::DOMJIT::Effect {},
+//     DOMJIT::IDLResultTypeFilter<IDLUint8Array>::value,
+//     DOMJIT::IDLArgumentTypeFilter<IDLDOMString>::value);
 
-static const JSC::DOMJIT::Signature DOMJITSignatureForJSTextEncoderEncodeIntoWithoutTypeCheck(
-    jsTextEncoderPrototypeFunction_encodeIntoWithoutTypeCheck,
-    JSTextEncoder::info(),
+// static const JSC::DOMJIT::Signature DOMJITSignatureForJSTextEncoderEncodeIntoWithoutTypeCheck(
+//     jsTextEncoderPrototypeFunction_encodeIntoWithoutTypeCheck,
+//     JSTextEncoder::info(),
 
-    JSC::DOMJIT::Effect {},
-    // JSC::DOMJIT::Effect::forReadWriteKinds(encodeIntoRead, encodeIntoWrite),
-    DOMJIT::IDLResultTypeFilter<IDLObject>::value,
-    DOMJIT::IDLArgumentTypeFilter<IDLDOMString>::value,
-    DOMJIT::IDLArgumentTypeFilter<IDLUint8Array>::value);
+//     JSC::DOMJIT::Effect {},
+//     // JSC::DOMJIT::Effect::forReadWriteKinds(encodeIntoRead, encodeIntoWrite),
+//     DOMJIT::IDLResultTypeFilter<IDLObject>::value,
+//     DOMJIT::IDLArgumentTypeFilter<IDLDOMString>::value,
+//     DOMJIT::IDLArgumentTypeFilter<IDLUint8Array>::value);
 
 /* Hash table for prototype */
 
 static const HashTableValue JSTextEncoderPrototypeTableValues[] = {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTextEncoderConstructor, 0 } },
     { "encoding"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsTextEncoder_encoding, 0 } },
-    { "encode"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DOMJITFunction), NoIntrinsic, { HashTableValue::DOMJITFunctionType, jsTextEncoderPrototypeFunction_encode, &DOMJITSignatureForJSTextEncoderEncodeWithoutTypeCheck } },
-    { "encodeInto"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DOMJITFunction), NoIntrinsic, { HashTableValue::DOMJITFunctionType, jsTextEncoderPrototypeFunction_encodeInto, &DOMJITSignatureForJSTextEncoderEncodeIntoWithoutTypeCheck } },
+    // { "encode"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DOMJITFunction), NoIntrinsic, { HashTableValue::DOMJITFunctionType, jsTextEncoderPrototypeFunction_encode, &DOMJITSignatureForJSTextEncoderEncodeWithoutTypeCheck } },
+    // { "encodeInto"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DOMJITFunction), NoIntrinsic, { HashTableValue::DOMJITFunctionType, jsTextEncoderPrototypeFunction_encodeInto, &DOMJITSignatureForJSTextEncoderEncodeIntoWithoutTypeCheck } },
+    { "encode"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTextEncoderPrototypeFunction_encode, 1 } },
+    { "encodeInto"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTextEncoderPrototypeFunction_encodeInto, 2 } },
 };
 
-JSC_DEFINE_JIT_OPERATION(jsTextEncoderEncodeWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSTextEncoder* castedThis, DOMJIT::IDLJSArgumentType<IDLDOMString> input))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    JSC::EncodedJSValue res;
-    String str;
-    if (input->is8Bit()) {
-        if (input->isRope()) {
-            GCDeferralContext gcDeferralContext(vm);
-            auto encodedValue = TextEncoder__encodeRopeString(lexicalGlobalObject, input);
-            if (!JSC::JSValue::decode(encodedValue).isUndefined()) {
-                RELEASE_AND_RETURN(throwScope, { encodedValue });
-            }
-        }
+// JSC_DEFINE_JIT_OPERATION(jsTextEncoderEncodeWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSTextEncoder* castedThis, DOMJIT::IDLJSArgumentType<IDLDOMString> input))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     auto throwScope = DECLARE_THROW_SCOPE(vm);
+//     JSC::EncodedJSValue res;
+//     String str;
+//     if (input->is8Bit()) {
+//         if (input->isRope()) {
+//             GCDeferralContext gcDeferralContext(vm);
+//             auto encodedValue = TextEncoder__encodeRopeString(lexicalGlobalObject, input);
+//             if (!JSC::JSValue::decode(encodedValue).isUndefined()) {
+//                 RELEASE_AND_RETURN(throwScope, { encodedValue });
+//             }
+//         }
 
-        str = input->value(lexicalGlobalObject);
-        res = TextEncoder__encode8(lexicalGlobalObject, str.span8().data(), str.length());
-    } else {
-        str = input->value(lexicalGlobalObject);
-        res = TextEncoder__encode16(lexicalGlobalObject, str.span16().data(), str.length());
-    }
+//         str = input->value(lexicalGlobalObject);
+//         res = TextEncoder__encode8(lexicalGlobalObject, str.span8().data(), str.length());
+//     } else {
+//         str = input->value(lexicalGlobalObject);
+//         res = TextEncoder__encode16(lexicalGlobalObject, str.span16().data(), str.length());
+//     }
 
-    if (UNLIKELY(JSC::JSValue::decode(res).isObject() && JSC::JSValue::decode(res).getObject()->isErrorInstance())) {
-        throwScope.throwException(lexicalGlobalObject, JSC::JSValue::decode(res));
-        return { encodedJSValue() };
-    }
+//     if (UNLIKELY(JSC::JSValue::decode(res).isObject() && JSC::JSValue::decode(res).getObject()->isErrorInstance())) {
+//         throwScope.throwException(lexicalGlobalObject, JSC::JSValue::decode(res));
+//         return { encodedJSValue() };
+//     }
 
-    RELEASE_AND_RETURN(throwScope, { res });
-}
+//     RELEASE_AND_RETURN(throwScope, { res });
+// }
 
-JSC_DEFINE_JIT_OPERATION(jsTextEncoderPrototypeFunction_encodeIntoWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSTextEncoder* castedThis, DOMJIT::IDLJSArgumentType<IDLDOMString> sourceStr, DOMJIT::IDLJSArgumentType<IDLUint8Array> destination))
-{
-    VM& vm = JSC::getVM(lexicalGlobalObject);
-    IGNORE_WARNINGS_BEGIN("frame-address")
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    IGNORE_WARNINGS_END
-    JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    String source = sourceStr->value(lexicalGlobalObject);
-    size_t res = 0;
-    if (!source.is8Bit()) {
-        res = TextEncoder__encodeInto16(source.span16().data(), source.length(), destination->vector(), destination->byteLength());
-    } else {
-        res = TextEncoder__encodeInto8(source.span8().data(), source.length(), destination->vector(), destination->byteLength());
-    }
+// JSC_DEFINE_JIT_OPERATION(jsTextEncoderPrototypeFunction_encodeIntoWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSTextEncoder* castedThis, DOMJIT::IDLJSArgumentType<IDLDOMString> sourceStr, DOMJIT::IDLJSArgumentType<IDLUint8Array> destination))
+// {
+//     VM& vm = JSC::getVM(lexicalGlobalObject);
+//     IGNORE_WARNINGS_BEGIN("frame-address")
+//     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+//     IGNORE_WARNINGS_END
+//     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+//     String source = sourceStr->value(lexicalGlobalObject);
+//     size_t res = 0;
+//     if (!source.is8Bit()) {
+//         res = TextEncoder__encodeInto16(source.span16().data(), source.length(), destination->vector(), destination->byteLength());
+//     } else {
+//         res = TextEncoder__encodeInto8(source.span8().data(), source.length(), destination->vector(), destination->byteLength());
+//     }
 
-    Bun::GlobalScope* globalScope = reinterpret_cast<Bun::GlobalScope*>(lexicalGlobalObject);
-    auto* result = JSC::constructEmptyObject(vm, globalScope->encodeIntoObjectStructure());
-    result->putDirectOffset(vm, 0, JSC::jsNumber(static_cast<uint32_t>(res)));
-    result->putDirectOffset(vm, 1, JSC::jsNumber(static_cast<uint32_t>(res >> 32)));
+//     Bun::GlobalScope* globalScope = reinterpret_cast<Bun::GlobalScope*>(lexicalGlobalObject);
+//     auto* result = JSC::constructEmptyObject(vm, globalScope->encodeIntoObjectStructure());
+//     result->putDirectOffset(vm, 0, JSC::jsNumber(static_cast<uint32_t>(res)));
+//     result->putDirectOffset(vm, 1, JSC::jsNumber(static_cast<uint32_t>(res >> 32)));
 
-    return { JSValue::encode(result) };
-}
+//     return { JSValue::encode(result) };
+// }
 
 const ClassInfo JSTextEncoderPrototype::s_info = { "TextEncoder"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTextEncoderPrototype) };
 

--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -102,7 +102,21 @@ export function define(
     estimatedSize,
     structuredClone,
     values,
-    klass: Object.fromEntries(Object.entries(klass).sort(([a], [b]) => a.localeCompare(b))),
-    proto: Object.fromEntries(Object.entries(proto).sort(([a], [b]) => a.localeCompare(b))),
+    klass: Object.fromEntries(
+      Object.entries(klass)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => {
+          v.DOMJIT = undefined;
+          return [k, v];
+        }),
+    ),
+    proto: Object.fromEntries(
+      Object.entries(proto)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => {
+          v.DOMJIT = undefined;
+          return [k, v];
+        }),
+    ),
   };
 }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -172,6 +172,10 @@ JSC_DEFINE_JIT_OPERATION(${DOMJITName(
 
 function zigExportName(to: Map<string, string>, symbolName: (name: string) => string, prop) {
   var { defaultValue, getter, setter, accessor, fn, DOMJIT, cache } = prop;
+
+  // TODO: bring DOMJIT back
+  DOMJIT = undefined;
+
   const exportNames = {
     getter: "",
     setter: "",
@@ -226,6 +230,9 @@ function propRow(
     builtin,
     writable = false,
   } = (defaultPropertyAttributes ? Object.assign({}, defaultPropertyAttributes, prop) : prop) as any;
+
+  // TODO: bring DOMJIT back
+  DOMJIT = undefined;
 
   var extraPropertyAttributes = "";
   if (!enumerable) {
@@ -858,6 +865,9 @@ function renderDecls(symbolName, typeName, proto, supportsObjectCreate = false) 
         "\n",
       );
 
+      // TODO: bring DOMJIT back
+      proto[name].DOMJIT = undefined;
+
       if (proto[name].DOMJIT) {
         rows.push(
           DOMJITFunctionDeclaration(
@@ -1139,22 +1149,21 @@ JSC_DEFINE_HOST_FUNCTION(${symbolName(typeName, name)}Callback, (JSGlobalObject 
     ASSERT_WITH_MESSAGE(!JSValue::decode(result).isEmpty() or DECLARE_CATCH_SCOPE(vm).exception() != 0, \"${typeName}.${proto[name].fn} returned an empty value without an exception\");
 
     ${
-      !proto[name].DOMJIT
-        ? ""
-        : `
-    JSValue decoded = JSValue::decode(result);
-    if (thisObject->m_${fn}_expectedResultType) {
-      if (decoded.isCell() && !decoded.isEmpty()) {
-        ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
-        ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().value() == decoded.asCell()->type(), "DOMJIT function return type changed!");
-      } else {
-        ASSERT_WITH_MESSAGE(!thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
-      }
-    } else if (!decoded.isEmpty()) {
-      thisObject->m_${fn}_expectedResultType = decoded.isCell()
-        ? std::optional<JSC::JSType>(decoded.asCell()->type())
-        : std::optional<JSC::JSType>(std::nullopt);
-    }`
+      // TODO: bring DOMJIT back
+      !proto[name].DOMJIT ? "" : ""
+      // JSValue decoded = JSValue::decode(result);
+      // if (thisObject->m_${fn}_expectedResultType) {
+      //   if (decoded.isCell() && !decoded.isEmpty()) {
+      //     ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
+      //     ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().value() == decoded.asCell()->type(), "DOMJIT function return type changed!");
+      //   } else {
+      //     ASSERT_WITH_MESSAGE(!thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
+      //   }
+      // } else if (!decoded.isEmpty()) {
+      //   thisObject->m_${fn}_expectedResultType = decoded.isCell()
+      //     ? std::optional<JSC::JSType>(decoded.asCell()->type())
+      //     : std::optional<JSC::JSType>(std::nullopt);
+      // }`
     }
 
     return result;
@@ -1304,7 +1313,11 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
           })
           .join("\n")}
 
-        ${domJITTypeCheckFields(proto, klass)}
+        ${
+          // TODO: bring DOMJIT back
+          // domJITTypeCheckFields(proto, klass)
+          ""
+        }
 
         ${weakOwner}
 
@@ -1741,7 +1754,11 @@ const JavaScriptCoreBindings = struct {
     {
       const exportNames = name => zigExportName(exports, name => protoSymbolName(typeName, name), proto[name]);
       for (const name in proto) {
-        const { getter, setter, accessor, fn, this: thisValue = false, cache, DOMJIT } = proto[name];
+        const { getter, setter, accessor, fn, this: thisValue = false, cache } = proto[name];
+
+        // TODO: bring DOMJIT back
+        const DOMJIT = undefined;
+
         const names = exportNames(name);
         if (names.getter) {
           output += `
@@ -1786,7 +1803,11 @@ const JavaScriptCoreBindings = struct {
     {
       const exportNames = name => zigExportName(exports, name => classSymbolName(typeName, name), klass[name]);
       for (const name in klass) {
-        const { getter, setter, accessor, fn, this: thisValue = true, cache, DOMJIT } = klass[name];
+        const { getter, setter, accessor, fn, this: thisValue = true, cache } = klass[name];
+
+        // TODO: bring DOMJIT back
+        const DOMJIT = undefined;
+
         const names = exportNames(name);
         if (names.getter) {
           output += `

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -172,10 +172,6 @@ JSC_DEFINE_JIT_OPERATION(${DOMJITName(
 
 function zigExportName(to: Map<string, string>, symbolName: (name: string) => string, prop) {
   var { defaultValue, getter, setter, accessor, fn, DOMJIT, cache } = prop;
-
-  // TODO: bring DOMJIT back
-  DOMJIT = undefined;
-
   const exportNames = {
     getter: "",
     setter: "",
@@ -230,9 +226,6 @@ function propRow(
     builtin,
     writable = false,
   } = (defaultPropertyAttributes ? Object.assign({}, defaultPropertyAttributes, prop) : prop) as any;
-
-  // TODO: bring DOMJIT back
-  DOMJIT = undefined;
 
   var extraPropertyAttributes = "";
   if (!enumerable) {
@@ -865,9 +858,6 @@ function renderDecls(symbolName, typeName, proto, supportsObjectCreate = false) 
         "\n",
       );
 
-      // TODO: bring DOMJIT back
-      proto[name].DOMJIT = undefined;
-
       if (proto[name].DOMJIT) {
         rows.push(
           DOMJITFunctionDeclaration(
@@ -1149,21 +1139,22 @@ JSC_DEFINE_HOST_FUNCTION(${symbolName(typeName, name)}Callback, (JSGlobalObject 
     ASSERT_WITH_MESSAGE(!JSValue::decode(result).isEmpty() or DECLARE_CATCH_SCOPE(vm).exception() != 0, \"${typeName}.${proto[name].fn} returned an empty value without an exception\");
 
     ${
-      // TODO: bring DOMJIT back
-      !proto[name].DOMJIT ? "" : ""
-      // JSValue decoded = JSValue::decode(result);
-      // if (thisObject->m_${fn}_expectedResultType) {
-      //   if (decoded.isCell() && !decoded.isEmpty()) {
-      //     ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
-      //     ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().value() == decoded.asCell()->type(), "DOMJIT function return type changed!");
-      //   } else {
-      //     ASSERT_WITH_MESSAGE(!thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
-      //   }
-      // } else if (!decoded.isEmpty()) {
-      //   thisObject->m_${fn}_expectedResultType = decoded.isCell()
-      //     ? std::optional<JSC::JSType>(decoded.asCell()->type())
-      //     : std::optional<JSC::JSType>(std::nullopt);
-      // }`
+      !proto[name].DOMJIT
+        ? ""
+        : `
+    JSValue decoded = JSValue::decode(result);
+    if (thisObject->m_${fn}_expectedResultType) {
+      if (decoded.isCell() && !decoded.isEmpty()) {
+        ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
+        ASSERT_WITH_MESSAGE(thisObject->m_${fn}_expectedResultType.value().value() == decoded.asCell()->type(), "DOMJIT function return type changed!");
+      } else {
+        ASSERT_WITH_MESSAGE(!thisObject->m_${fn}_expectedResultType.value().has_value(), "DOMJIT function return type changed!");
+      }
+    } else if (!decoded.isEmpty()) {
+      thisObject->m_${fn}_expectedResultType = decoded.isCell()
+        ? std::optional<JSC::JSType>(decoded.asCell()->type())
+        : std::optional<JSC::JSType>(std::nullopt);
+    }`
     }
 
     return result;
@@ -1313,11 +1304,7 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
           })
           .join("\n")}
 
-        ${
-          // TODO: bring DOMJIT back
-          // domJITTypeCheckFields(proto, klass)
-          ""
-        }
+        ${domJITTypeCheckFields(proto, klass)}
 
         ${weakOwner}
 
@@ -1754,11 +1741,7 @@ const JavaScriptCoreBindings = struct {
     {
       const exportNames = name => zigExportName(exports, name => protoSymbolName(typeName, name), proto[name]);
       for (const name in proto) {
-        const { getter, setter, accessor, fn, this: thisValue = false, cache } = proto[name];
-
-        // TODO: bring DOMJIT back
-        const DOMJIT = undefined;
-
+        const { getter, setter, accessor, fn, this: thisValue = false, cache, DOMJIT } = proto[name];
         const names = exportNames(name);
         if (names.getter) {
           output += `
@@ -1803,11 +1786,7 @@ const JavaScriptCoreBindings = struct {
     {
       const exportNames = name => zigExportName(exports, name => classSymbolName(typeName, name), klass[name]);
       for (const name in klass) {
-        const { getter, setter, accessor, fn, this: thisValue = true, cache } = klass[name];
-
-        // TODO: bring DOMJIT back
-        const DOMJIT = undefined;
-
+        const { getter, setter, accessor, fn, this: thisValue = true, cache, DOMJIT } = klass[name];
         const names = exportNames(name);
         if (names.getter) {
           output += `


### PR DESCRIPTION
### What does this PR do?
fixes #14001 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
