### PR TITLE
fix snapshot regression

### DIFF
--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -140,48 +140,32 @@ pub const Snapshots = struct {
 
         // TODO: when common js transform changes, keep this updated or add flag to support this version
 
-        const export_default = brk: {
-            for (ast.parts.slice()) |part| {
-                for (part.stmts) |stmt| {
-                    if (stmt.data == .s_export_default and stmt.data.s_export_default.value == .expr) {
-                        break :brk stmt.data.s_export_default.value.expr;
-                    }
-                }
-            }
-
-            return;
-        };
-
-        if (export_default.data == .e_call) {
-            const function_call = export_default.data.e_call;
-            if (function_call.args.len == 2 and function_call.args.ptr[0].data == .e_function) {
-                const arg_function_stmts = function_call.args.ptr[0].data.e_function.func.body.stmts;
-                for (arg_function_stmts) |stmt| {
-                    switch (stmt.data) {
-                        .s_expr => |expr| {
-                            if (expr.value.data == .e_binary and expr.value.data.e_binary.op == .bin_assign) {
-                                const left = expr.value.data.e_binary.left;
-                                if (left.data == .e_index and left.data.e_index.index.data == .e_string and left.data.e_index.target.data == .e_identifier) {
-                                    const target: js_ast.E.Identifier = left.data.e_index.target.data.e_identifier;
-                                    var index: *js_ast.E.String = left.data.e_index.index.data.e_string;
-                                    if (target.ref.eql(exports_ref) and expr.value.data.e_binary.right.data == .e_string) {
-                                        const key = index.slice(this.allocator);
-                                        var value_string = expr.value.data.e_binary.right.data.e_string;
-                                        const value = value_string.slice(this.allocator);
-                                        defer {
-                                            if (!index.isUTF8()) this.allocator.free(key);
-                                            if (!value_string.isUTF8()) this.allocator.free(value);
-                                        }
-                                        const value_clone = try this.allocator.alloc(u8, value.len);
-                                        bun.copy(u8, value_clone, value);
-                                        const name_hash = bun.hash(key);
-                                        try this.values.put(name_hash, value_clone);
+        for (ast.parts.slice()) |part| {
+            for (part.stmts) |stmt| {
+                switch (stmt.data) {
+                    .s_expr => |expr| {
+                        if (expr.value.data == .e_binary and expr.value.data.e_binary.op == .bin_assign) {
+                            const left = expr.value.data.e_binary.left;
+                            if (left.data == .e_index and left.data.e_index.index.data == .e_string and left.data.e_index.target.data == .e_identifier) {
+                                const target: js_ast.E.Identifier = left.data.e_index.target.data.e_identifier;
+                                var index: *js_ast.E.String = left.data.e_index.index.data.e_string;
+                                if (target.ref.eql(exports_ref) and expr.value.data.e_binary.right.data == .e_string) {
+                                    const key = index.slice(this.allocator);
+                                    var value_string = expr.value.data.e_binary.right.data.e_string;
+                                    const value = value_string.slice(this.allocator);
+                                    defer {
+                                        if (!index.isUTF8()) this.allocator.free(key);
+                                        if (!value_string.isUTF8()) this.allocator.free(value);
                                     }
+                                    const value_clone = try this.allocator.alloc(u8, value.len);
+                                    bun.copy(u8, value_clone, value);
+                                    const name_hash = bun.hash(key);
+                                    try this.values.put(name_hash, value_clone);
                                 }
                             }
-                        },
-                        else => {},
-                    }
+                        }
+                    },
+                    else => {},
                 }
             }
         }

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -15,7 +15,7 @@ TN:
 SF:demo2.ts
 FNF:2
 FNH:1
-DA:2,26
+DA:2,28
 DA:4,10
 DA:6,10
 DA:9,0

--- a/test/regression/issue/14029.test.ts
+++ b/test/regression/issue/14029.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "bun:test";
+import { join } from "path";
+import { tmpdirSync, bunExe, bunEnv } from "harness";
+
+test("snapshots will recognize existing entries", async () => {
+  const testDir = tmpdirSync();
+  await Bun.write(
+    join(testDir, "test.test.js"),
+    `
+  test("snapshot test", () => {
+    expect("foo").toMatchSnapshot();
+  });
+  `,
+  );
+
+  let proc = Bun.spawnSync({
+    cmd: [bunExe(), "test", "./test.test.js"],
+    cwd: testDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(proc.stderr.toString()).toContain("1 added");
+  expect(proc.exitCode).toBe(0);
+
+  const newSnapshot = await Bun.file(join(testDir, "__snapshots__", "test.test.js.snap")).text();
+
+  // Run the same test, make sure another entry isn't added
+  proc = Bun.spawnSync({
+    cmd: [bunExe(), "test", "./test.test.js"],
+    cwd: testDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(proc.stderr.toString()).not.toContain("1 added");
+  expect(proc.exitCode).toBe(0);
+
+  expect(newSnapshot).toBe(await Bun.file(join(testDir, "__snapshots__", "test.test.js.snap")).text());
+});


### PR DESCRIPTION
### What does this PR do?
fixes #14029 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
