### PR TITLE
Experiment: Add `buffer` type and inline pointer

### DIFF
--- a/docs/api/ffi.md
+++ b/docs/api/ffi.md
@@ -110,6 +110,7 @@ The following `FFIType` values are supported.
 
 | `FFIType`  | C Type         | Aliases                     |
 | ---------- | -------------- | --------------------------- |
+| buffer     | `char*`        |                             |
 | cstring    | `char*`        |                             |
 | function   | `(void*)(*)()` | `fn`, `callback`            |
 | ptr        | `void*`        | `pointer`, `void*`, `char*` |
@@ -129,6 +130,8 @@ The following `FFIType` values are supported.
 | char       | `char`         |                             |
 | napi_env   | `napi_env`     |                             |
 | napi_value | `napi_value`   |                             |
+
+Note: `buffer` arguments must be a `TypedArray` or `DataView`.
 
 ## Strings
 

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -340,6 +340,7 @@ declare module "bun:ffi" {
 
     napi_env = 18,
     napi_value = 19,
+    buffer = 20,
   }
 
   type Pointer = number & { __pointer__: null };
@@ -377,6 +378,7 @@ declare module "bun:ffi" {
     [FFIType.function]: Pointer | JSCallback; // cannot be null
     [FFIType.napi_env]: unknown;
     [FFIType.napi_value]: unknown;
+    [FFIType.buffer]: NodeJS.TypedArray | DataView;
   }
   interface FFITypeToReturnsType {
     [FFIType.char]: number;
@@ -411,6 +413,7 @@ declare module "bun:ffi" {
     [FFIType.function]: Pointer | null;
     [FFIType.napi_env]: unknown;
     [FFIType.napi_value]: unknown;
+    [FFIType.buffer]: NodeJS.TypedArray | DataView;
   }
   interface FFITypeStringToType {
     ["char"]: FFIType.char;
@@ -445,6 +448,7 @@ declare module "bun:ffi" {
     ["callback"]: FFIType.pointer; // for now
     ["napi_env"]: never;
     ["napi_value"]: unknown;
+    ["buffer"]: FFIType.buffer;
   }
 
   type FFITypeOrString = FFIType | keyof FFITypeStringToType;

--- a/src/bun.js/api/FFI.h
+++ b/src/bun.js/api/FFI.h
@@ -35,7 +35,7 @@ typedef _Bool bool;
 
 #ifndef SRC_JS_NATIVE_API_TYPES_H_
 typedef struct napi_env__ *napi_env;
-typedef struct napi_value__ *napi_value;
+typedef int64_t napi_value;
 typedef enum {
   napi_ok,
   napi_invalid_arg,
@@ -74,14 +74,14 @@ void NapiHandleScope__pop(void* jsGlobalObject, void* handleScope);
 // begin with a 15-bit pattern within the range 0x0002..0xFFFC.
 #define DoubleEncodeOffsetBit 49
 #define DoubleEncodeOffset    (1ll << DoubleEncodeOffsetBit)
-#define OtherTag              0x2
-#define BoolTag               0x4
-#define UndefinedTag          0x8
+#define OtherTag              0x2ll
+#define BoolTag               0x4ll
+#define UndefinedTag          0x8ll
 #define TagValueFalse            (OtherTag | BoolTag | false)
 #define TagValueTrue             (OtherTag | BoolTag | true)
 #define TagValueUndefined        (OtherTag | UndefinedTag)
 #define TagValueNull             (OtherTag)
-#define NotCellMask  NumberTag | OtherTag
+#define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
 #define MAX_INT32 2147483648
 #define MAX_INT52 9007199254740991
@@ -171,6 +171,11 @@ static int32_t JSVALUE_TO_INT32(EncodedJSValue val) __attribute__((__always_inli
 static float JSVALUE_TO_FLOAT(EncodedJSValue val) __attribute__((__always_inline__));
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) __attribute__((__always_inline__));
 static bool JSVALUE_TO_BOOL(EncodedJSValue val) __attribute__((__always_inline__));
+static uint8_t GET_JSTYPE(EncodedJSValue val) __attribute__((__always_inline__));
+static bool JSTYPE_IS_TYPED_ARRAY(uint8_t type) __attribute__((__always_inline__));
+static bool JSCELL_IS_TYPED_ARRAY(EncodedJSValue val) __attribute__((__always_inline__));
+static void* JSVALUE_TO_TYPED_ARRAY_VECTOR(EncodedJSValue val) __attribute__((__always_inline__));
+static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) __attribute__((__always_inline__));
 
 static bool JSVALUE_IS_CELL(EncodedJSValue val) {
   return !(val.asInt64 & NotCellMask);
@@ -184,6 +189,25 @@ static bool JSVALUE_IS_NUMBER(EncodedJSValue val) {
   return val.asInt64 & NumberTag;
 }
 
+static uint8_t GET_JSTYPE(EncodedJSValue val) {
+  return *(uint8_t*)((uint8_t*)val.asPtr + JSCell__offsetOfType);
+}
+
+static bool JSTYPE_IS_TYPED_ARRAY(uint8_t type) {
+  return type >= JSTypeArrayBufferViewMin && type <= JSTypeArrayBufferViewMax;
+}
+
+static bool JSCELL_IS_TYPED_ARRAY(EncodedJSValue val) {
+  return JSVALUE_IS_CELL(val) && JSTYPE_IS_TYPED_ARRAY(GET_JSTYPE(val));
+}
+
+static void* JSVALUE_TO_TYPED_ARRAY_VECTOR(EncodedJSValue val) {
+  return *(void**)((char*)val.asPtr + JSArrayBufferView__offsetOfVector);
+}
+
+static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
+  return *(uint64_t*)((char*)val.asPtr + JSArrayBufferView__offsetOfLength);
+}
 
 // JSValue numbers-as-pointers are represented as a 52-bit integer
 // Previously, the pointer was stored at the end of the 64-bit value
@@ -193,6 +217,11 @@ static bool JSVALUE_IS_NUMBER(EncodedJSValue val) {
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
   if (val.asInt64 == TagValueNull)
     return 0;
+
+  if (JSCELL_IS_TYPED_ARRAY(val)) {
+      return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
+  }
+
   val.asInt64 -= DoubleEncodeOffset;
   size_t ptr = (size_t)val.asDouble;
   return (void*)ptr;
@@ -273,6 +302,10 @@ static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) {
 
   if (JSVALUE_IS_NUMBER(value)) {
     return (uint64_t)JSVALUE_TO_DOUBLE(value);
+  }
+
+  if (JSCELL_IS_TYPED_ARRAY(value)) {
+    return (uint64_t)JSVALUE_TO_TYPED_ARRAY_LENGTH(value);
   }
 
   return JSVALUE_TO_UINT64_SLOW(value);

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -76,6 +76,24 @@ const IOTask = JSC.IOTask;
 const TCC = @import("../../tcc.zig");
 extern fn pthread_jit_write_protect_np(enable: bool) callconv(.C) void;
 
+const Offsets = extern struct {
+    JSArrayBufferView__offsetOfLength: u32,
+    JSArrayBufferView__offsetOfByteOffset: u32,
+    JSArrayBufferView__offsetOfVector: u32,
+    JSCell__offsetOfType: u32,
+
+    extern "C" var Bun__FFI__offsets: Offsets;
+    extern "C" fn Bun__FFI__ensureOffsetsAreLoaded() void;
+    fn loadOnce() void {
+        Bun__FFI__ensureOffsetsAreLoaded();
+    }
+    var once = std.once(loadOnce);
+    pub fn get() *const Offsets {
+        once.call();
+        return &Bun__FFI__offsets;
+    }
+};
+
 pub const FFI = struct {
     dylib: ?std.DynLib = null,
     relocated_bytes_to_free: ?[]u8 = null,
@@ -1361,6 +1379,11 @@ pub const FFI = struct {
             return ZigString.static("Cannot return napi_env to JavaScript").toErrorInstance(global);
         }
 
+        if (return_type == .buffer) {
+            abi_types.clearAndFree(allocator);
+            return ZigString.static("Cannot return a buffer to JavaScript (since byteLength and byteOffset are unknown)").toErrorInstance(global);
+        }
+
         if (function.threadsafe and return_type != ABIType.void) {
             abi_types.clearAndFree(allocator);
             return ZigString.static("Threadsafe functions must return void").toErrorInstance(global);
@@ -1542,14 +1565,7 @@ pub const FFI = struct {
             }
 
             _ = TCC.tcc_set_output_type(state, TCC.TCC_OUTPUT_MEMORY);
-            const Sizes = @import("../bindings/sizes.zig");
 
-            var symbol_buf: [256]u8 = undefined;
-            TCC.tcc_define_symbol(
-                state,
-                "Bun_FFI_PointerOffsetToArgumentsList",
-                std.fmt.bufPrintZ(&symbol_buf, "{d}", .{Sizes.Bun_FFI_PointerOffsetToArgumentsList}) catch unreachable,
-            );
             CompilerRT.define(state);
 
             // TCC.tcc_define_symbol(
@@ -2064,7 +2080,7 @@ pub const FFI = struct {
         function = 17,
         napi_env = 18,
         napi_value = 19,
-
+        buffer = 20,
         pub const max = @intFromEnum(ABIType.napi_value);
 
         /// Types that we can directly pass through as an `int64_t`
@@ -2104,6 +2120,8 @@ pub const FFI = struct {
             .{ "uint64_t", ABIType.uint64_t },
             .{ "uint8_t", ABIType.uint8_t },
             .{ "usize", ABIType.uint64_t },
+            .{ "size_t", ABIType.uint64_t },
+            .{ "buffer", ABIType.buffer },
             .{ "void*", ABIType.ptr },
             .{ "ptr", ABIType.ptr },
             .{ "pointer", ABIType.ptr },
@@ -2219,6 +2237,9 @@ pub const FFI = struct {
                         try writer.writeAll(".asNapiValue");
                         return;
                     },
+                    .buffer => {
+                        try writer.writeAll("JSVALUE_TO_TYPED_ARRAY_VECTOR(");
+                    },
                 }
                 // if (self.fromi64) {
                 //     try writer.writeAll("EncodedJSValue{ ");
@@ -2274,6 +2295,9 @@ pub const FFI = struct {
                     .napi_value => {
                         try writer.print("((EncodedJSValue) {{.asNapiValue = {s} }} )", .{self.symbol});
                     },
+                    .buffer => {
+                        try writer.writeAll("0");
+                    },
                 }
             }
         };
@@ -2302,7 +2326,7 @@ pub const FFI = struct {
 
         pub fn typenameLabel(this: ABIType) []const u8 {
             return switch (this) {
-                .function, .cstring, .ptr => "void*",
+                .buffer, .function, .cstring, .ptr => "void*",
                 .bool => "bool",
                 .int8_t => "int8_t",
                 .uint8_t => "uint8_t",
@@ -2345,6 +2369,7 @@ pub const FFI = struct {
                 .void => "void",
                 .napi_env => "napi_env",
                 .napi_value => "napi_value",
+                .buffer => "buffer",
             };
         }
     };
@@ -2423,6 +2448,40 @@ const CompilerRT = struct {
             // there
             _ = TCC.tcc_compile_string(state, @embedFile(("libtcc1.c")));
         }
+
+        const Sizes = @import("../bindings/sizes.zig");
+        var symbol_buf: [256]u8 = undefined;
+        TCC.tcc_define_symbol(
+            state,
+            "Bun_FFI_PointerOffsetToArgumentsList",
+            std.fmt.bufPrintZ(&symbol_buf, "{d}", .{Sizes.Bun_FFI_PointerOffsetToArgumentsList}) catch unreachable,
+        );
+        const offsets = Offsets.get();
+        TCC.tcc_define_symbol(
+            state,
+            "JSArrayBufferView__offsetOfLength",
+            std.fmt.bufPrintZ(&symbol_buf, "{d}", .{offsets.JSArrayBufferView__offsetOfLength}) catch unreachable,
+        );
+        TCC.tcc_define_symbol(
+            state,
+            "JSArrayBufferView__offsetOfVector",
+            std.fmt.bufPrintZ(&symbol_buf, "{d}", .{offsets.JSArrayBufferView__offsetOfVector}) catch unreachable,
+        );
+        TCC.tcc_define_symbol(
+            state,
+            "JSCell__offsetOfType",
+            std.fmt.bufPrintZ(&symbol_buf, "{d}", .{offsets.JSCell__offsetOfType}) catch unreachable,
+        );
+        TCC.tcc_define_symbol(
+            state,
+            "JSTypeArrayBufferViewMin",
+            std.fmt.bufPrintZ(&symbol_buf, "{d}", .{@intFromEnum(JSC.JSValue.JSType.min_typed_array)}) catch unreachable,
+        );
+        TCC.tcc_define_symbol(
+            state,
+            "JSTypeArrayBufferViewMax",
+            std.fmt.bufPrintZ(&symbol_buf, "{d}", .{@intFromEnum(JSC.JSValue.JSType.max_typed_array)}) catch unreachable,
+        );
     }
 
     pub fn inject(state: *TCC.TCCState) void {

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -3676,6 +3676,9 @@ pub const JSValue = enum(JSValueReprInt) {
         JSAsJSONType = 0b11110000 | 1,
         _,
 
+        pub const min_typed_array: JSType = .Int8Array;
+        pub const max_typed_array: JSType = .DataView;
+
         pub fn canGet(this: JSType) bool {
             return switch (this) {
                 .Array,

--- a/src/bun.js/bindings/ffi.cpp
+++ b/src/bun.js/bindings/ffi.cpp
@@ -1,0 +1,17 @@
+#include "root.h"
+
+typedef struct FFIFields {
+    uint32_t JSArrayBufferView__offsetOfLength;
+    uint32_t JSArrayBufferView__offsetOfByteOffset;
+    uint32_t JSArrayBufferView__offsetOfVector;
+    uint32_t JSCell__offsetOfType;
+} FFIFields;
+extern "C" FFIFields Bun__FFI__offsets = { 0 };
+
+extern "C" void Bun__FFI__ensureOffsetsAreLoaded()
+{
+    Bun__FFI__offsets.JSArrayBufferView__offsetOfLength = JSC::JSArrayBufferView::offsetOfLength();
+    Bun__FFI__offsets.JSArrayBufferView__offsetOfByteOffset = JSC::JSArrayBufferView::offsetOfByteOffset();
+    Bun__FFI__offsets.JSArrayBufferView__offsetOfVector = JSC::JSArrayBufferView::offsetOfVector();
+    Bun__FFI__offsets.JSCell__offsetOfType = JSC::JSCell::typeInfoTypeOffset();
+}

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -294,7 +294,7 @@ Object.defineProperty(globalThis, "__GlobalBunFFIPtrFunctionForWrapper", {
   enumerable: false,
   configurable: true,
 });
-Object.defineProperty(ArrayBuffer.$isView, "__GlobalBunFFIPtrArrayBufferViewFn", {
+Object.defineProperty(globalThis, "__GlobalBunFFIPtrArrayBufferViewFn", {
   value: ArrayBuffer.$isView,
   enumerable: false,
   configurable: true,

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -295,9 +295,12 @@ Object.defineProperty(globalThis, "__GlobalBunFFIPtrFunctionForWrapper", {
   configurable: true,
 });
 Object.defineProperty(globalThis, "__GlobalBunFFIPtrArrayBufferViewFn", {
-  value: ArrayBuffer.$isView,
+  value: function isTypedArrayView(val) {
+    return $isTypedArrayView(val);
+  },
   enumerable: false,
   configurable: true,
+  writable: true,
 });
 
 ffiWrappers[FFIType.cstring] = ffiWrappers[FFIType.pointer] = `{

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -214,10 +214,6 @@ ffiWrappers[FFIType.u64_fast] = `{
     return val;
   }
 
-  if (__GlobalBunFFIPtrArrayBufferViewFn(val)) {
-    return val;
-  }
-
   return !val ? 0 : +val || 0;
 }`;
 
@@ -242,20 +238,12 @@ ffiWrappers[FFIType.uint64_t] = `{
     return val <= 0 ? BigInt(0) : BigInt(val || 0);
   }
 
-  if (__GlobalBunFFIPtrArrayBufferViewFn(val)) {
-    return val;
-  }
-
   return BigInt(+val || 0);
 }`;
 
 ffiWrappers[FFIType.u64_fast] = `{
   if (typeof val === "bigint") {
     if (val <= BigInt(Number.MAX_SAFE_INTEGER) && val >= BigInt(0)) return Number(val);
-    return val;
-  }
-
-  if (__GlobalBunFFIPtrArrayBufferViewFn(val)) {
     return val;
   }
 
@@ -300,7 +288,6 @@ Object.defineProperty(globalThis, "__GlobalBunFFIPtrArrayBufferViewFn", {
   },
   enumerable: false,
   configurable: true,
-  writable: true,
 });
 
 ffiWrappers[FFIType.cstring] = ffiWrappers[FFIType.pointer] = `{

--- a/test/js/bun/ffi/cc-fixture.c
+++ b/test/js/bun/ffi/cc-fixture.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #endif
 
+#include <stdint.h>
+
 #if __has_include(<node/node_api.h>)
 
 #include <node/node_api.h>
@@ -19,6 +21,8 @@ napi_value napi_main(napi_env env) {
 }
 
 #endif
+
+uint8_t lastByte(uint8_t *arr, size_t len) { return arr[len - 1]; }
 
 int main() {
 

--- a/test/js/bun/ffi/cc-fixture.js
+++ b/test/js/bun/ffi/cc-fixture.js
@@ -35,6 +35,6 @@ if (napi_main(null) !== "Hello, Napi!") {
   throw new Error("napi_main() !== Hello, Napi!");
 }
 
-if (lastByte(bytes, bytes) !== 42) {
+if (lastByte(bytes, bytes.byteLength) !== 42) {
   throw new Error("lastByte(bytes, bytes.length) !== 42");
 }

--- a/test/js/bun/ffi/cc-fixture.js
+++ b/test/js/bun/ffi/cc-fixture.js
@@ -1,7 +1,10 @@
 import { cc } from "bun:ffi";
 import fixture from "./cc-fixture.c" with { type: "file" };
+let bytes = new Uint8Array(64);
+bytes[bytes.length - 1] = 42;
+
 const {
-  symbols: { napi_main, main },
+  symbols: { napi_main, main, lastByte },
 } = cc({
   source: fixture,
   define: {
@@ -9,6 +12,10 @@ const {
   },
 
   symbols: {
+    "lastByte": {
+      args: ["ptr", "uint64_t"],
+      returns: "uint8_t",
+    },
     "napi_main": {
       args: ["napi_env"],
       returns: "napi_value",
@@ -26,4 +33,8 @@ if (main() !== 42) {
 
 if (napi_main(null) !== "Hello, Napi!") {
   throw new Error("napi_main() !== Hello, Napi!");
+}
+
+if (lastByte(bytes, bytes) !== 42) {
+  throw new Error("lastByte(bytes, bytes.length) !== 42");
 }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
