### PR TITLE
Allow TCP connections for BUN_INSPECT_NOTIFY

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -45,6 +45,7 @@ export default function (
         unix: path.resolve(notifyUrl.substring("unix://".length)),
       });
     } else {
+      const { hostname, port } = new URL(notifyUrl);
       notify({
         hostname,
         port: port && port !== "0" ? Number(port) : undefined,

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -38,10 +38,11 @@ export default function (
 
   const notifyUrl = process.env["BUN_INSPECT_NOTIFY"] || "";
   if (notifyUrl) {
-    const { hostname, port, pathname, protocol } = new URL(notifyUrl);
-    if (protocol.startsWith("unix")) {
+    if (notifyUrl.startsWith("unix://")) {
+      const path = require("node:path");
       notify({
-        unix: pathname,
+        // This is actually a filesystem path, not a URL.
+        unix: path.resolve(notifyUrl.substring("unix://".length)),
       });
     } else {
       notify({


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
