### PR TITLE
Keep event loop alive when refConcurrently has been called

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1288,8 +1288,14 @@ pub const EventLoop = struct {
         _ = this.tickConcurrentWithCount();
     }
 
+    /// Check whether refConcurrently has been called but the change has not yet been applied to the
+    /// underlying event loop's `active` counter
+    pub fn hasPendingRefs(this: *const EventLoop) bool {
+        return this.concurrent_ref.load(.seq_cst) > 0;
+    }
+
     fn updateCounts(this: *EventLoop) void {
-        const delta = this.concurrent_ref.swap(0, .monotonic);
+        const delta = this.concurrent_ref.swap(0, .seq_cst);
         const loop = this.virtual_machine.event_loop_handle.?;
         if (comptime Environment.isWindows) {
             if (delta > 0) {
@@ -1642,14 +1648,13 @@ pub const EventLoop = struct {
     }
 
     pub fn refConcurrently(this: *EventLoop) void {
-        // TODO maybe this should be AcquireRelease
-        _ = this.concurrent_ref.fetchAdd(1, .monotonic);
+        _ = this.concurrent_ref.fetchAdd(1, .seq_cst);
         this.wakeup();
     }
 
     pub fn unrefConcurrently(this: *EventLoop) void {
         // TODO maybe this should be AcquireRelease
-        _ = this.concurrent_ref.fetchSub(1, .monotonic);
+        _ = this.concurrent_ref.fetchSub(1, .seq_cst);
         this.wakeup();
     }
 };

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -935,9 +935,12 @@ pub const VirtualMachine = struct {
 
     pub fn isEventLoopAlive(vm: *const VirtualMachine) bool {
         return vm.unhandled_error_counter == 0 and
-            (vm.event_loop_handle.?.isActive() or
-            vm.active_tasks + vm.event_loop.tasks.count + vm.event_loop.immediate_tasks.count + vm.event_loop.next_immediate_tasks.count > 0 or
-            vm.event_loop.hasPendingRefs());
+            (@intFromBool(vm.event_loop_handle.?.isActive()) +
+            vm.active_tasks +
+            vm.event_loop.tasks.count +
+            vm.event_loop.immediate_tasks.count +
+            vm.event_loop.next_immediate_tasks.count +
+            @intFromBool(vm.event_loop.hasPendingRefs()) > 0);
     }
 
     pub fn wakeup(this: *VirtualMachine) void {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -936,7 +936,8 @@ pub const VirtualMachine = struct {
     pub fn isEventLoopAlive(vm: *const VirtualMachine) bool {
         return vm.unhandled_error_counter == 0 and
             (vm.event_loop_handle.?.isActive() or
-            vm.active_tasks + vm.event_loop.tasks.count + vm.event_loop.immediate_tasks.count + vm.event_loop.next_immediate_tasks.count > 0);
+            vm.active_tasks + vm.event_loop.tasks.count + vm.event_loop.immediate_tasks.count + vm.event_loop.next_immediate_tasks.count > 0 or
+            vm.event_loop.hasPendingRefs());
     }
 
     pub fn wakeup(this: *VirtualMachine) void {

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -4,6 +4,9 @@
             "target_name": "napitests",
             "cflags!": ["-fno-exceptions"],
             "cflags_cc!": ["-fno-exceptions"],
+            "xcode_settings": {
+                "OTHER_CFLAGS": ["-mmacosx-version-min=11.0.0"],
+            },
             "msvs_settings": {
                 "VCCLCompilerTool": {
                     "ExceptionHandling": "0",

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -4,9 +4,6 @@
             "target_name": "napitests",
             "cflags!": ["-fno-exceptions"],
             "cflags_cc!": ["-fno-exceptions"],
-            "xcode_settings": {
-                "OTHER_CFLAGS": ["-mmacosx-version-min=11.0.0"],
-            },
             "msvs_settings": {
                 "VCCLCompilerTool": {
                     "ExceptionHandling": "0",

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <iostream>
-#include <semaphore>
 #include <thread>
 
 napi_value fail(napi_env env, const char *msg) {

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <iostream>
 #include <semaphore>
+#include <thread>
 
 napi_value fail(napi_env env, const char *msg) {
   napi_value result;
@@ -374,29 +375,12 @@ struct AsyncWorkData {
   int result;
   napi_deferred deferred;
   napi_async_work work;
-  // if nonnull, promise resolves to the result of calling tsfn
-  napi_threadsafe_function tsfn;
-  // if tsfn is nonnull, used to signal from tsfn_callback() to execute()
-  std::binary_semaphore result_ready;
 
-  AsyncWorkData()
-      : result(0), deferred(nullptr), work(nullptr), tsfn(nullptr),
-        result_ready(0) {}
+  AsyncWorkData() : result(0), deferred(nullptr), work(nullptr) {}
 
   static void execute(napi_env env, void *data) {
     AsyncWorkData *async_work_data = reinterpret_cast<AsyncWorkData *>(data);
-
-    if (async_work_data->tsfn) {
-      // nonblocking means it will return an error if the threadsafe function's
-      // queue is full, which it should never do because we only use it once and
-      // we init with a capacity of 1
-      assert(napi_call_threadsafe_function(async_work_data->tsfn, nullptr,
-                                           napi_tsfn_nonblocking) == napi_ok);
-      // block until the callback finishes
-      async_work_data->result_ready.acquire();
-    } else {
-      async_work_data->result = 42;
-    }
+    async_work_data->result = 42;
   }
 
   static void complete(napi_env env, napi_status status, void *data) {
@@ -411,36 +395,7 @@ struct AsyncWorkData {
     assert(napi_resolve_deferred(env, async_work_data->deferred, result) ==
            napi_ok);
     assert(napi_delete_async_work(env, async_work_data->work) == napi_ok);
-    if (async_work_data->tsfn) {
-      assert(napi_release_threadsafe_function(async_work_data->tsfn,
-                                              napi_tsfn_abort) == napi_ok);
-    }
     delete async_work_data;
-  }
-
-  static void tsfn_callback(napi_env env, napi_value js_callback, void *context,
-                            void *data) {
-    // env and js_callback are "NULL if the thread-safe function is being torn
-    // down and data may need to be freed." our data is freed in complete so we
-    // don't care.
-    printf("tsfn_callback\n");
-    if (!env || !js_callback) {
-      return;
-    }
-    AsyncWorkData *async_work_data = reinterpret_cast<AsyncWorkData *>(context);
-
-    napi_value recv;
-    assert(napi_get_undefined(env, &recv) == napi_ok);
-
-    napi_value js_result;
-    assert(napi_call_function(env, recv, js_callback, 0, nullptr, &js_result) ==
-           napi_ok);
-    // js function should return an integer
-    assert(napi_get_value_int32(env, js_result, &async_work_data->result) ==
-           napi_ok);
-
-    // signal that we are done
-    async_work_data->result_ready.release();
   }
 };
 
@@ -459,20 +414,88 @@ napi_value create_promise(const Napi::CallbackInfo &info) {
                                 AsyncWorkData::execute, AsyncWorkData::complete,
                                 data, &data->work) == napi_ok);
 
-  if (info.Length() == 2) {
-    // argument 0 to this function is a callback to run GC
-    // argument 1 to this function, if present, is a JS callback to determine
-    // the resolved value
-    assert(napi_create_threadsafe_function(
-               env, info[1], nullptr, resource_name,
-               // max_queue_size, initial_thread_count
-               1, 1,
-               // thread_finalize_data, thread_finalize_cb
-               nullptr, nullptr, data, AsyncWorkData::tsfn_callback,
-               &data->tsfn) == napi_ok);
+  assert(napi_queue_async_work(env, data->work) == napi_ok);
+  return promise;
+}
+
+struct ThreadsafeFunctionData {
+  napi_threadsafe_function tsfn;
+  napi_deferred deferred;
+
+  static void thread_entry(ThreadsafeFunctionData *data) {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(10ms);
+    // nonblocking means it will return an error if the threadsafe function's
+    // queue is full, which it should never do because we only use it once and
+    // we init with a capacity of 1
+    assert(napi_call_threadsafe_function(data->tsfn, nullptr,
+                                         napi_tsfn_nonblocking) == napi_ok);
   }
 
-  assert(napi_queue_async_work(env, data->work) == napi_ok);
+  static void tsfn_finalize_callback(napi_env env, void *finalize_data,
+                                     void *finalize_hint) {
+    printf("tsfn_finalize_callback\n");
+    ThreadsafeFunctionData *data =
+        reinterpret_cast<ThreadsafeFunctionData *>(finalize_data);
+    delete data;
+  }
+
+  static void tsfn_callback(napi_env env, napi_value js_callback, void *context,
+                            void *data) {
+    // context == ThreadsafeFunctionData pointer
+    // data == nullptr
+    printf("tsfn_callback\n");
+    ThreadsafeFunctionData *tsfn_data =
+        reinterpret_cast<ThreadsafeFunctionData *>(context);
+
+    napi_value recv;
+    assert(napi_get_undefined(env, &recv) == napi_ok);
+
+    // call our JS function with undefined for this and no arguments
+    napi_value js_result;
+    assert(napi_call_function(env, recv, js_callback, 0, nullptr, &js_result) ==
+           napi_ok);
+
+    // resolve the promise with the return value of the JS function
+    assert(napi_resolve_deferred(env, tsfn_data->deferred, js_result) ==
+           napi_ok);
+
+    // clean up the threadsafe function
+    assert(napi_release_threadsafe_function(tsfn_data->tsfn, napi_tsfn_abort) ==
+           napi_ok);
+  }
+};
+
+napi_value
+create_promise_with_threadsafe_function(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  ThreadsafeFunctionData *tsfn_data = new ThreadsafeFunctionData;
+
+  napi_value async_resource_name;
+  assert(napi_create_string_utf8(
+             env, "napitests::create_promise_with_threadsafe_function",
+             NAPI_AUTO_LENGTH, &async_resource_name) == napi_ok);
+
+  // this is called directly, without the GC callback, so argument 0 is a JS
+  // callback used to resolve the promise
+  assert(napi_create_threadsafe_function(
+             env, info[0], nullptr, async_resource_name,
+             // max_queue_size, initial_thread_count
+             1, 1,
+             // thread_finalize_data, thread_finalize_cb
+             tsfn_data, ThreadsafeFunctionData::tsfn_finalize_callback,
+             // context
+             tsfn_data, ThreadsafeFunctionData::tsfn_callback,
+             &tsfn_data->tsfn) == napi_ok);
+  // create a promise we can return to JS and put the deferred counterpart in
+  // tsfn_data
+  napi_value promise;
+  assert(napi_create_promise(env, &tsfn_data->deferred, &promise) == napi_ok);
+
+  // spawn and release std::thread
+  std::thread secondary_thread(ThreadsafeFunctionData::thread_entry, tsfn_data);
+  secondary_thread.detach();
+  // return the promise to javascript
   return promise;
 }
 
@@ -575,6 +598,9 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
   exports.Set("get_class_with_constructor",
               Napi::Function::New(env, get_class_with_constructor));
   exports.Set("create_promise", Napi::Function::New(env, create_promise));
+  exports.Set(
+      "create_promise_with_threadsafe_function",
+      Napi::Function::New(env, create_promise_with_threadsafe_function));
   exports.Set("test_napi_ref", Napi::Function::New(env, test_napi_ref));
   exports.Set("create_ref_with_finalizer",
               Napi::Function::New(env, create_ref_with_finalizer));

--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -20,6 +20,7 @@ const result = fn.apply(null, [
     } else if (global.gc) {
       global.gc();
     }
+    console.log("GC did run");
   },
   ...eval(process.argv[3] ?? "[]"),
 ]);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -25,10 +25,9 @@ nativeTests.test_napi_handle_scope_finalizer = async () => {
 };
 
 nativeTests.test_promise_with_threadsafe_function = async () => {
-  // when we provide a function for the second argument, create_promise returns a promise that calls
-  // our function from another thread (via napi_threadsafe_function) and resolves with its return
-  // value
   await new Promise(resolve => setTimeout(resolve, 1));
+  // create_promise_with_threadsafe_function returns a promise that calls our function from another
+  // thread (via napi_threadsafe_function) and resolves with its return value
   return await nativeTests.create_promise_with_threadsafe_function(() => 1234);
 };
 

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -24,4 +24,11 @@ nativeTests.test_napi_handle_scope_finalizer = async () => {
   }
 };
 
+nativeTests.create_promise_with_js_callback = async () => {
+  // when we provide a function for the second argument, create_promise returns a promise that calls
+  // our function from another thread (via napi_threadsafe_function) and resolves with its return
+  // value
+  return await nativeTests.create_promise(null, () => 1234);
+};
+
 module.exports = nativeTests;

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -24,11 +24,12 @@ nativeTests.test_napi_handle_scope_finalizer = async () => {
   }
 };
 
-nativeTests.create_promise_with_js_callback = async () => {
+nativeTests.test_promise_with_threadsafe_function = async () => {
   // when we provide a function for the second argument, create_promise returns a promise that calls
   // our function from another thread (via napi_threadsafe_function) and resolves with its return
   // value
-  return await nativeTests.create_promise(null, () => 1234);
+  await new Promise(resolve => setTimeout(resolve, 1));
+  return await nativeTests.create_promise_with_threadsafe_function(() => 1234);
 };
 
 module.exports = nativeTests;

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -122,7 +122,7 @@ describe("napi", () => {
   });
 
   describe("napi_threadsafe_function", () => {
-    it("can be used to create a promise", () => {
+    it("keeps the event loop alive without async_work", () => {
       checkSameOutput("test_promise_with_threadsafe_function", []);
     });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -60,11 +60,6 @@ describe("napi", () => {
     });
   });
 
-  it("threadsafe function does not hang on finalize", () => {
-    const result = checkSameOutput("test_napi_threadsafe_function_does_not_hang_after_finalize", []);
-    expect(result).toBe("success!");
-  });
-
   it("#1288", async () => {
     const result = checkSameOutput("self", []);
     expect(result).toBe("hello world!");
@@ -127,8 +122,13 @@ describe("napi", () => {
   });
 
   describe("napi_threadsafe_function", () => {
-    it("can call a JS callback via a native callback", () => {
-      checkSameOutput("create_promise_with_js_callback", []);
+    it("can be used to create a promise", () => {
+      checkSameOutput("test_promise_with_threadsafe_function", []);
+    });
+
+    it("does not hang on finalize", () => {
+      const result = checkSameOutput("test_napi_threadsafe_function_does_not_hang_after_finalize", []);
+      expect(result).toBe("success!");
     });
   });
 });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -125,6 +125,12 @@ describe("napi", () => {
       checkSameOutput("test_napi_handle_scope_finalizer", []);
     });
   });
+
+  describe("napi_threadsafe_function", () => {
+    it("can call a JS callback via a native callback", () => {
+      checkSameOutput("create_promise_with_js_callback", []);
+    });
+  });
 });
 
 function checkSameOutput(test: string, args: any[] | string) {


### PR DESCRIPTION
### What does this PR do?

`refConcurrently` and `unrefConcurrently` increment an atomic counter which is later used to ref or unref the event loop on the main thread. Previously, if `refConcurrently` had been called but the ref had not yet been applied by `updateCounts`, the event loop could exit early. Now we check if there are any pending refs when determining whether to exit.

Fixes #13938.

### How did you verify your code works?

Extended the NAPI tests to cover `napi_threadsafe_function` used without `napi_async_work`, which is what Prisma does that triggered this bug.

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)