### PR TITLE
docs: add ccache for Windows System Dependencies

### DIFF
--- a/docs/project/building-windows.md
+++ b/docs/project/building-windows.md
@@ -67,6 +67,7 @@ After Visual Studio, you need the following:
 - Perl
 - Ruby
 - Node.js
+- Ccache
 
 {% callout %}
 **Note** – The Zig compiler is automatically downloaded, installed, and updated by the building process.
@@ -78,12 +79,12 @@ After Visual Studio, you need the following:
 
 ```ps1#WinGet
 ## Select "Add LLVM to the system PATH for all users" in the LLVM installer
-> winget install -i LLVM.LLVM -v 18.1.8 && winget install GoLang.Go Rustlang.Rustup NASM.NASM StrawberryPerl.StrawberryPerl RubyInstallerTeam.Ruby.3.2 OpenJS.NodeJS.LTS
+> winget install -i LLVM.LLVM -v 18.1.8 && winget install GoLang.Go Rustlang.Rustup NASM.NASM StrawberryPerl.StrawberryPerl RubyInstallerTeam.Ruby.3.2 OpenJS.NodeJS.LTS Ccache.Ccache
 ```
 
 ```ps1#Scoop
 > irm https://get.scoop.sh | iex
-> scoop install nodejs-lts go rust nasm ruby perl
+> scoop install nodejs-lts go rust nasm ruby perl ccache
 # scoop seems to be buggy if you install llvm and the rest at the same time
 > scoop install llvm@18.1.8
 ```


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

add ccache for Windows build system dependencies,
if ccache not installed on windows, cmake will complain about this:
```
CMake Error at cmake/Globals.cmake:279 (message):
  Command not found: "ccache"
Call Stack (most recent call first):
  cmake/tools/SetupCcache.cmake:8 (find_command)
  CMakeLists.txt:21 (include)
```

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Here's the package link
https://winstall.app/apps/Ccache.Ccache
https://github.com/ScoopInstaller/Main/blob/master/bucket/ccache.json








