### PR TITLE
Fix regression from #13414

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1465,6 +1465,7 @@ pub const Subprocess = struct {
         if (stdin) |pipe| {
             this.weak_file_sink_stdin_ptr = null;
             this.flags.has_stdin_destructor_called = true;
+            // It is okay if it does call deref() here, as in that case it was truly ref'd.
             pipe.onAttachedProcessExit();
         }
 

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2178,7 +2178,7 @@ pub const Subprocess = struct {
             ),
             // 1. JavaScript.
             // 2. Process.
-            .ref_count = if (is_sync) 1 else 2,
+            .ref_count = 2,
             .stdio_pipes = spawned.extra_pipes.moveToUnmanaged(),
             .on_exit_callback = if (on_exit_callback != .zero) JSC.Strong.create(on_exit_callback, globalThis) else .{},
             .on_disconnect_callback = if (on_disconnect_callback != .zero) JSC.Strong.create(on_disconnect_callback, globalThis) else .{},

--- a/test/js/bun/spawn/bad-fixture.js
+++ b/test/js/bun/spawn/bad-fixture.js
@@ -1,0 +1,3 @@
+process.stdin.read();
+
+throw new Error("test");

--- a/test/js/bun/spawn/spawn-stdin-destroy.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-destroy.test.ts
@@ -30,13 +30,9 @@ test("stdin destroy after exit crash", async () => {
 
     expect(out).toBe("");
     expect(exited).toBe(1);
-    before = require("bun:jsc").heapStats().objectTypeCounts;
+
     Bun.gc(true);
     await Bun.sleep(50);
   })();
   Bun.gc(true);
-
-  const { FileSink = 0, Subprocess = 0 } = require("bun:jsc").heapStats().objectTypeCounts;
-  expect(FileSink).toBeLessThan(before.FileSink || 0);
-  expect(Subprocess).toBeLessThan(before.Subprocess || 0);
 });

--- a/test/js/bun/spawn/spawn-stdin-destroy.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-destroy.test.ts
@@ -1,0 +1,42 @@
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+test("stdin destroy after exit crash", async () => {
+  let before;
+  await (async () => {
+    const child = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "bad-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stdin: "pipe",
+    });
+
+    await Bun.sleep(80);
+    await child.stdin.write("dylan\n");
+    await child.stdin.write("999\n");
+    await child.stdin.flush();
+    await child.stdin.end();
+
+    async function read() {
+      var out = "";
+      for await (const chunk of child.stdout) {
+        out += new TextDecoder().decode(chunk);
+      }
+      return out;
+    }
+
+    // This bug manifested as child.exited rejecting with an error code of "TODO"
+    const [out, exited] = await Promise.all([read(), child.exited]);
+
+    expect(out).toBe("");
+    expect(exited).toBe(1);
+    before = require("bun:jsc").heapStats().objectTypeCounts;
+    Bun.gc(true);
+    await Bun.sleep(50);
+  })();
+  Bun.gc(true);
+
+  const { FileSink = 0, Subprocess = 0 } = require("bun:jsc").heapStats().objectTypeCounts;
+  expect(FileSink).toBeLessThan(before.FileSink || 0);
+  expect(Subprocess).toBeLessThan(before.Subprocess || 0);
+});


### PR DESCRIPTION
### What does this PR do?

In #13414, a double deref() was added when the process has already exited by the time the stdin getter was called.

### How did you verify your code works?

Regression test