### PR TITLE
Fix unbalanced ref count involving file descriptors passed to Bun.connect

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -368,7 +368,7 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, un
     return new_p;
 }
 
-void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
+int us_poll_start_rc(struct us_poll_t *p, struct us_loop_t *loop, int events) {
     p->state.poll_type = us_internal_poll_type(p) | ((events & LIBUS_SOCKET_READABLE) ? POLL_TYPE_POLLING_IN : 0) | ((events & LIBUS_SOCKET_WRITABLE) ? POLL_TYPE_POLLING_OUT : 0);
 
 #ifdef LIBUS_USE_EPOLL
@@ -379,9 +379,14 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
     do {
         ret = epoll_ctl(loop->fd, EPOLL_CTL_ADD, p->state.fd, &event);
     } while (IS_EINTR(ret));
+    return ret;
 #else
-    kqueue_change(loop->fd, p->state.fd, 0, events, p);
+    return kqueue_change(loop->fd, p->state.fd, 0, events, p);
 #endif
+}
+
+void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
+    us_poll_start_rc(p, loop, events);
 }
 
 void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -371,7 +371,7 @@ void us_poll_init(us_poll_r p, LIBUS_SOCKET_DESCRIPTOR fd, int poll_type);
 
 /* Start, change and stop polling for events */
 void us_poll_start(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
-/* Returns 0 if successful, else -1 */
+/* Returns 0 if successful */
 int us_poll_start_rc(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
 void us_poll_change(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
 void us_poll_stop(us_poll_r p, struct us_loop_t *loop) nonnull_fn_decl;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -371,6 +371,8 @@ void us_poll_init(us_poll_r p, LIBUS_SOCKET_DESCRIPTOR fd, int poll_type);
 
 /* Start, change and stop polling for events */
 void us_poll_start(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
+/* Returns 0 if successful, else -1 */
+int us_poll_start_rc(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
 void us_poll_change(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
 void us_poll_stop(us_poll_r p, struct us_loop_t *loop) nonnull_fn_decl;
 

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -21,7 +21,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <errno.h>
 
 #ifndef WIN32
@@ -310,7 +309,11 @@ struct us_socket_t *us_socket_from_fd(struct us_socket_context_t *ctx, int socke
 #else
     struct us_poll_t *p1 = us_create_poll(ctx->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p1, fd, POLL_TYPE_SOCKET);
-    us_poll_start(p1, ctx->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
+    int rc = us_poll_start_rc(p1, ctx->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
+    if (rc != 0) {
+        us_poll_free(p1, ctx->loop);
+        return 0;
+    }
 
     struct us_socket_t *s = (struct us_socket_t *) p1;
     s->context = ctx;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1356,6 +1356,9 @@ fn NewSocket(comptime ssl: bool) type {
         pub fn doConnect(this: *This, connection: Listener.UnixOrHost) !void {
             bun.assert(this.socket_context != null);
             this.ref();
+            errdefer {
+                this.deref();
+            }
 
             switch (connection) {
                 .host => |c| {
@@ -1374,9 +1377,6 @@ fn NewSocket(comptime ssl: bool) type {
                     );
                 },
                 .fd => |f| {
-                    errdefer {
-                        this.deref();
-                    }
                     const socket = This.Socket.fromFd(this.socket_context.?, f, This, this, null) orelse return error.ConnectionFailed;
                     this.onOpen(socket);
                 },

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1236,46 +1236,30 @@ pub const Listener = struct {
         const promise_value = promise.asValue(globalObject);
         handlers_ptr.promise.set(globalObject, promise_value);
 
-        if (ssl_enabled) {
-            var tls = TLSSocket.new(.{
-                .handlers = handlers_ptr,
-                .this_value = .zero,
-                .socket = TLSSocket.Socket.detached,
-                .connection = connection,
-                .protos = if (protos) |p| (bun.default_allocator.dupe(u8, p) catch bun.outOfMemory()) else null,
-                .server_name = server_name,
-                .socket_context = socket_context, // owns the socket context
-            });
+        switch (ssl_enabled) {
+            inline else => |is_ssl_enabled| {
+                const SocketType = NewSocket(is_ssl_enabled);
+                var socket = SocketType.new(.{
+                    .handlers = handlers_ptr,
+                    .this_value = .zero,
+                    .socket = SocketType.Socket.detached,
+                    .connection = connection,
+                    .protos = if (protos) |p| (bun.default_allocator.dupe(u8, p) catch bun.outOfMemory()) else null,
+                    .server_name = server_name,
+                    .socket_context = socket_context, // owns the socket context
+                });
 
-            TLSSocket.dataSetCached(tls.getThisValue(globalObject), globalObject, default_data);
+                SocketType.dataSetCached(socket.getThisValue(globalObject), globalObject, default_data);
 
-            tls.doConnect(connection) catch {
-                tls.handleConnectError(@intFromEnum(if (port == null) bun.C.SystemErrno.ENOENT else bun.C.SystemErrno.ECONNREFUSED));
+                socket.doConnect(connection) catch {
+                    socket.handleConnectError(@intFromEnum(if (port == null) bun.C.SystemErrno.ENOENT else bun.C.SystemErrno.ECONNREFUSED));
+                    return promise_value;
+                };
+
+                socket.poll_ref.ref(handlers.vm);
+
                 return promise_value;
-            };
-
-            tls.poll_ref.ref(handlers.vm);
-
-            return promise_value;
-        } else {
-            var tcp = TCPSocket.new(.{
-                .handlers = handlers_ptr,
-                .this_value = .zero,
-                .socket = TCPSocket.Socket.detached,
-                .connection = null,
-                .protos = null,
-                .server_name = null,
-                .socket_context = socket_context, // owns the socket context
-            });
-
-            TCPSocket.dataSetCached(tcp.getThisValue(globalObject), globalObject, default_data);
-            tcp.doConnect(connection) catch {
-                tcp.handleConnectError(@intFromEnum(if (port == null) bun.C.SystemErrno.ENOENT else bun.C.SystemErrno.ECONNREFUSED));
-                return promise_value;
-            };
-            tcp.poll_ref.ref(handlers.vm);
-
-            return promise_value;
+            },
         }
     }
 };
@@ -1371,9 +1355,10 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn doConnect(this: *This, connection: Listener.UnixOrHost) !void {
             bun.assert(this.socket_context != null);
+            this.ref();
+
             switch (connection) {
                 .host => |c| {
-                    this.ref();
                     this.socket = try This.Socket.connectAnon(
                         normalizeHost(c.host),
                         c.port,
@@ -1382,8 +1367,6 @@ fn NewSocket(comptime ssl: bool) type {
                     );
                 },
                 .unix => |u| {
-                    this.ref();
-
                     this.socket = try This.Socket.connectUnixAnon(
                         u,
                         this.socket_context.?,
@@ -1391,6 +1374,9 @@ fn NewSocket(comptime ssl: bool) type {
                     );
                 },
                 .fd => |f| {
+                    errdefer {
+                        this.deref();
+                    }
                     const socket = This.Socket.fromFd(this.socket_context.?, f, This, this, null) orelse return error.ConnectionFailed;
                     this.onOpen(socket);
                 },
@@ -1469,10 +1455,14 @@ fn NewSocket(comptime ssl: bool) type {
 
         fn handleConnectError(this: *This, errno: c_int) void {
             log("onConnectError({d}, {})", .{ errno, this.ref_count });
+            // Ensure the socket is still alive for any defer's we have
+            this.ref();
+            defer this.deref();
+
             const needs_deref = !this.socket.isDetached();
             this.socket = Socket.detached;
-            defer if (needs_deref) this.deref();
             defer this.markInactive();
+            defer if (needs_deref) this.deref();
 
             const handlers = this.handlers;
             const vm = handlers.vm;
@@ -1500,6 +1490,11 @@ fn NewSocket(comptime ssl: bool) type {
 
             if (callback == .zero) {
                 if (handlers.promise.trySwap()) |promise| {
+                    if (this.this_value != .zero) {
+                        this.this_value = .zero;
+                    }
+                    this.has_pending_activity.store(false, .release);
+
                     // reject the promise on connect() error
                     const err_value = err.toErrorInstance(globalObject);
                     promise.asPromise().?.rejectOnNextTick(globalObject, err_value);
@@ -1509,6 +1504,9 @@ fn NewSocket(comptime ssl: bool) type {
             }
 
             const this_value = this.getThisValue(globalObject);
+            this.this_value = .zero;
+            this.has_pending_activity.store(false, .release);
+
             const err_value = err.toErrorInstance(globalObject);
             const result = callback.call(globalObject, this_value, &[_]JSValue{
                 this_value,
@@ -1524,7 +1522,6 @@ fn NewSocket(comptime ssl: bool) type {
                 var promise = val.asPromise().?;
                 const err_ = err.toErrorInstance(globalObject);
                 promise.rejectOnNextTickAsHandled(globalObject, err_);
-                this.has_pending_activity.store(false, .release);
             }
         }
         pub fn onConnectError(this: *This, _: Socket, errno: c_int) void {
@@ -1566,6 +1563,10 @@ fn NewSocket(comptime ssl: bool) type {
         }
 
         pub fn onOpen(this: *This, socket: Socket) void {
+            // Ensure the socket remains alive until this is finished
+            this.ref();
+            defer this.deref();
+
             log("onOpen {} {}", .{ this.socket.isDetached(), this.ref_count });
             // update the internal socket instance to the one that was just connected
             // This socket must be replaced because the previous one is a connecting socket not a uSockets socket
@@ -1664,6 +1665,9 @@ fn NewSocket(comptime ssl: bool) type {
             JSC.markBinding(@src());
             log("onEnd", .{});
             if (this.socket.isDetached()) return;
+            // Ensure the socket remains alive until this is finished
+            this.ref();
+            defer this.deref();
 
             const handlers = this.handlers;
 
@@ -4120,4 +4124,26 @@ pub fn createNodeTLSBinding(global: *JSC.JSGlobalObject) JSC.JSValue {
         JSC.JSFunction.create(global, "upgradeDuplexToTLS", JSC.toJSHostFunction(jsUpgradeDuplexToTLS), 2, .{}),
         JSC.JSFunction.create(global, "isNamedPipeSocket", JSC.toJSHostFunction(jsIsNamedPipeSocket), 1, .{}),
     });
+}
+
+pub fn jsCreateSocketPair(global: *JSC.JSGlobalObject, _: *JSC.CallFrame) callconv(JSC.conv) JSValue {
+    JSC.markBinding(@src());
+
+    if (Environment.isWindows) {
+        global.throw("Not implemented on Windows", .{});
+        return .zero;
+    }
+
+    var fds_: [2]std.c.fd_t = .{ 0, 0 };
+    const rc = std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds_);
+    if (rc != 0) {
+        const err = bun.sys.Error.fromCode(bun.C.getErrno(rc), .socketpair);
+        global.throwValue(err.toJSC(global));
+        return .zero;
+    }
+
+    const array = JSC.JSValue.createEmptyArray(global, 2);
+    array.putIndex(global, 0, JSC.jsNumber(fds_[0]));
+    array.putIndex(global, 1, JSC.jsNumber(fds_[1]));
+    return array;
 }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2125,6 +2125,11 @@ pub const Subprocess = struct {
             },
         });
 
+        const posix_ipc_fd = if (Environment.isPosix and !is_sync and maybe_ipc_mode != null)
+            spawned.extra_pipes.items[@intCast(ipc_channel)]
+        else
+            bun.invalid_fd;
+
         // When run synchronously, subprocess isn't garbage collected
         subprocess.* = Subprocess{
             .globalThis = globalThis,
@@ -2184,7 +2189,7 @@ pub const Subprocess = struct {
                 if (uws.us_socket_from_fd(
                     jsc_vm.rareData().spawnIPCContext(jsc_vm),
                     @sizeOf(*Subprocess),
-                    spawned.extra_pipes.items[@intCast(ipc_channel)].cast(),
+                    posix_ipc_fd.cast(),
                 )) |socket| {
                     posix_ipc_info = IPC.Socket.from(socket);
                     subprocess.ipc_data = .{

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1823,18 +1823,18 @@ pub const Subprocess = struct {
                     if (args.getTruthy(globalThis, "ipc")) |val| {
                         if (val.isCell() and val.isCallable(globalThis.vm())) {
                             maybe_ipc_mode = ipc_mode: {
-                                if (args.get(globalThis, "serialization")) |mode_val| {
+                                if (args.getTruthy(globalThis, "serialization")) |mode_val| {
                                     if (mode_val.isString()) {
-                                        const mode_str = mode_val.toBunString(globalThis);
-                                        defer mode_str.deref();
-                                        const slice = mode_str.toUTF8(bun.default_allocator);
-                                        defer slice.deinit();
-                                        break :ipc_mode IPC.Mode.fromString(slice.slice()) orelse {
-                                            globalThis.throwInvalidArguments("serialization must be \"json\" or \"advanced\"", .{});
+                                        break :ipc_mode IPC.Mode.fromJS(globalThis, mode_val) orelse {
+                                            if (!globalThis.hasException()) {
+                                                globalThis.throwInvalidArguments("serialization must be \"json\" or \"advanced\"", .{});
+                                            }
                                             return .zero;
                                         };
                                     } else {
-                                        globalThis.throwInvalidArguments("serialization must be a 'string'", .{});
+                                        if (!globalThis.hasException()) {
+                                            globalThis.throwInvalidArgumentType("spawn", "serialization", "string");
+                                        }
                                         return .zero;
                                     }
                                 }
@@ -2086,13 +2086,35 @@ pub const Subprocess = struct {
             } else {},
         };
 
+        var spawned = switch (bun.spawn.spawnProcess(
+            &spawn_options,
+            @ptrCast(argv.items.ptr),
+            @ptrCast(env_array.items.ptr),
+        ) catch |err| {
+            spawn_options.deinit();
+            globalThis.throwError(err, ": failed to spawn process");
+
+            return .zero;
+        }) {
+            .err => |err| {
+                spawn_options.deinit();
+                globalThis.throwValue(err.toJSC(globalThis));
+                return .zero;
+            },
+            .result => |result| result,
+        };
+
+        const loop = jsc_vm.eventLoop();
+
+        const process = spawned.toProcess(loop, is_sync);
+
         var subprocess = Subprocess.new(.{
             .globalThis = globalThis,
-            .process = undefined,
+            .process = process,
             .pid_rusage = null,
-            .stdin = undefined,
-            .stdout = undefined,
-            .stderr = undefined,
+            .stdin = .{ .ignore = {} },
+            .stdout = .{ .ignore = {} },
+            .stderr = .{ .ignore = {} },
             .stdio_pipes = .{},
             .on_exit_callback = .{},
             .on_disconnect_callback = .{},
@@ -2103,51 +2125,10 @@ pub const Subprocess = struct {
             },
         });
 
-        var spawned = switch (bun.spawn.spawnProcess(
-            &spawn_options,
-            @ptrCast(argv.items.ptr),
-            @ptrCast(env_array.items.ptr),
-        ) catch |err| {
-            subprocess.deref();
-            spawn_options.deinit();
-            globalThis.throwError(err, ": failed to spawn process");
-
-            return .zero;
-        }) {
-            .err => |err| {
-                subprocess.deref();
-                spawn_options.deinit();
-                globalThis.throwValue(err.toJSC(globalThis));
-                return .zero;
-            },
-            .result => |result| result,
-        };
-
-        var posix_ipc_info: if (Environment.isPosix) IPC.Socket else void = undefined;
-        if (Environment.isPosix and !is_sync) {
-            if (maybe_ipc_mode != null) {
-                posix_ipc_info = IPC.Socket.from(
-                    // we initialize ext later in the function
-                    uws.us_socket_from_fd(
-                        jsc_vm.rareData().spawnIPCContext(jsc_vm),
-                        @sizeOf(*Subprocess),
-                        spawned.extra_pipes.items[@intCast(ipc_channel)].cast(),
-                    ) orelse {
-                        subprocess.deref();
-                        spawn_options.deinit();
-                        globalThis.throw("failed to create socket pair", .{});
-                        return .zero;
-                    },
-                );
-            }
-        }
-
-        const loop = jsc_vm.eventLoop();
-
         // When run synchronously, subprocess isn't garbage collected
         subprocess.* = Subprocess{
             .globalThis = globalThis,
-            .process = spawned.toProcess(loop, is_sync),
+            .process = process,
             .pid_rusage = null,
             .stdin = Writable.init(
                 stdio[0],
@@ -2156,6 +2137,7 @@ pub const Subprocess = struct {
                 spawned.stdin,
             ) catch {
                 globalThis.throwOutOfMemory();
+                subprocess.deref();
                 return .zero;
             },
             .stdout = Readable.init(
@@ -2182,16 +2164,10 @@ pub const Subprocess = struct {
             .stdio_pipes = spawned.extra_pipes.moveToUnmanaged(),
             .on_exit_callback = if (on_exit_callback != .zero) JSC.Strong.create(on_exit_callback, globalThis) else .{},
             .on_disconnect_callback = if (on_disconnect_callback != .zero) JSC.Strong.create(on_disconnect_callback, globalThis) else .{},
-            .ipc_data = if (!is_sync)
-                if (maybe_ipc_mode) |ipc_mode|
-                    if (Environment.isWindows) .{
-                        .mode = ipc_mode,
-                    } else .{
-                        .socket = posix_ipc_info,
-                        .mode = ipc_mode,
-                    }
-                else
-                    null
+            .ipc_data = if (!is_sync and comptime Environment.isWindows)
+                if (maybe_ipc_mode) |ipc_mode| .{
+                    .mode = ipc_mode,
+                } else null
             else
                 null,
             .ipc_callback = if (ipc_callback != .zero) JSC.Strong.create(ipc_callback, globalThis) else .{},
@@ -2201,6 +2177,23 @@ pub const Subprocess = struct {
         };
 
         subprocess.process.setExitHandler(subprocess);
+
+        var posix_ipc_info: if (Environment.isPosix) IPC.Socket else void = undefined;
+        if (Environment.isPosix and !is_sync) {
+            if (maybe_ipc_mode) |mode| {
+                if (uws.us_socket_from_fd(
+                    jsc_vm.rareData().spawnIPCContext(jsc_vm),
+                    @sizeOf(*Subprocess),
+                    spawned.extra_pipes.items[@intCast(ipc_channel)].cast(),
+                )) |socket| {
+                    posix_ipc_info = IPC.Socket.from(socket);
+                    subprocess.ipc_data = .{
+                        .socket = posix_ipc_info,
+                        .mode = mode,
+                    };
+                }
+            }
+        }
 
         if (subprocess.ipc_data) |*ipc_data| {
             if (Environment.isPosix) {

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -30,9 +30,8 @@ pub const Mode = enum {
         .{ "json", .json },
     });
 
-    pub fn fromString(s: []const u8) ?Mode {
-        return Map.get(s);
-    }
+    pub const fromJS = Map.fromJS;
+    pub const fromString = Map.get;
 };
 
 pub const DecodedIPCMessage = union(enum) {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -126,3 +126,5 @@ export const isOperatingSystemMatch: (operatingSystem: string[]) => boolean = $n
   "OperatingSystem.jsFunctionOperatingSystemIsMatch",
   1,
 );
+
+export const createSocketPair: () => [number, number] = $newZigFunction("socket.zig", "jsCreateSocketPair", 0);

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -435,10 +435,10 @@ function test(label: string, fn: (ws: WebSocket, done: (err?: unknown) => void) 
 }
 
 async function listen(): Promise<URL> {
-  const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
+  const pathname = path.resolve(import.meta.dir, "../../web/websocket/websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();
   const server = spawn({
-    cmd: [nodeExe() ?? bunExe(), pathname],
+    cmd: [bunExe(), pathname],
     cwd: import.meta.dir,
     env: bunEnv,
     stdout: "inherit",

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -261,21 +261,27 @@ function test(label: string, fn: (ws: WebSocket, done: (err?: unknown) => void) 
 
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
+  const { promise, resolve, reject } = Promise.withResolvers();
   const server = spawn({
     cmd: [nodeExe() ?? bunExe(), pathname],
     cwd: import.meta.dir,
     env: bunEnv,
-    stderr: "ignore",
-    stdout: "pipe",
+    stdout: "inherit",
+    stderr: "inherit",
+    serialization: "json",
+    ipc(message) {
+      const url = message?.href;
+      if (url) {
+        try {
+          resolve(new URL(url));
+        } catch (error) {
+          reject(error);
+        }
+      }
+    },
   });
+
   servers.push(server);
-  for await (const chunk of server.stdout) {
-    const text = new TextDecoder().decode(chunk);
-    try {
-      return new URL(text);
-    } catch {
-      throw new Error(`Invalid URL: '${text}'`);
-    }
-  }
-  throw new Error("No URL found?");
+
+  return await promise;
 }

--- a/test/js/web/websocket/websocket-server-echo.mjs
+++ b/test/js/web/websocket/websocket-server-echo.mjs
@@ -10,7 +10,7 @@ const wss = new WebSocketServer({
 server.on("listening", () => {
   const { address, port, family } = server.address();
   const { href } = new URL(family === "IPv6" ? `ws://[${address}]:${port}` : `ws://${address}:${port}`);
-  console.log(href);
+  process.send({ href });
   console.error("Listening:", href);
 });
 


### PR DESCRIPTION
### What does this PR do?

This does four things:
1) Fix unbalanced ref count with file descriptors passed to Bun.connect leading to a null-pointer dereference (discovered via undefined behavior sanitizer https://github.com/ziglang/zig/issues/21495)
2) When passing an invalid file descriptor to Bun.connect, we now throw an error appropriately instead of opening a socket that will never receive an event.
3) Fix a potential UAF in connectError when markInactive is called after deref() 
4) Avoid allocating a Subprocess until after it has spawned successfully, and remove a few usages of `undefined`

### How did you verify your code works?

There are a few new tests, along with an internal binding for `socketpair` to make it easier to test the file descriptor scenarios