### PR TITLE
Use callbacks instead of a promise that calls a callback for node:fs functions that expect callbacks

### DIFF
--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -95,7 +95,7 @@ fn call(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
             var callback_argument = JSC.JSValue.zero;
             if (this.is_callback_api) {
                 if (arguments_slice.len > 0) {
-                    callback_argument = arguments_slice[arguments_slice.len - 1];
+                    callback_argument = arguments_slice[arguments_slice.len - 1].withAsyncContextIfNeeded(globalObject);
                     arguments_slice = arguments_slice[0 .. arguments_slice.len - 1];
                 }
             }

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1,7 +1,9 @@
 // Hardcoded module "node:fs/promises"
 import type { Dirent } from "fs";
 const EventEmitter = require("node:events");
-const fs = $zig("node_fs_binding.zig", "createBinding");
+const internalBinding = $zig("node_fs_binding.zig", "createBinding");
+
+const { 0: fs, 1: fsCallbacks } = internalBinding;
 const constants = $processBindingConstants.fs;
 
 var PromisePrototypeFinally = Promise.prototype.finally; //TODO
@@ -151,6 +153,7 @@ const private_symbols = {
   kFd,
   FileHandle: null,
   fs,
+  fsCallbacks,
 };
 
 const _readFile = fs.readFile.bind(fs);

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -11068,7 +11068,7 @@ pub const Interpreter = struct {
                             vm,
                             bun.ArenaAllocator.init(bun.default_allocator),
                             this,
-                            false,
+                            null,
                         );
                     } else {
                         _ = JSC.Node.ShellAsyncCpTask.createMini(


### PR DESCRIPTION
### What does this PR do?

This fixes a hypothetical execution-order bug in node:fs

Callbacks run before promises.

Since all the node:fs callback functions are currently implemented as wrappers around promises, that means we're delaying execution to the end of the current task. Since these are top-level tasks it should normally not make a difference, but in theory - maybe it could? 

This works by making the API for callback-taking functions the same as promise-taking functions and then we don't need to care which is which most of the time

### How did you verify your code works?

Untested, but wrote most of the code. Probably doesn't compile.