### PR TITLE
[install.sh] Try use busybox's unzip

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -53,8 +53,14 @@ success() {
     echo -e "${Green}$@ ${Color_Off}"
 }
 
-command -v unzip >/dev/null ||
+uzip=
+if command -v unzip >/dev/null; then
+    uzip=unzip
+elif command -v busybox >/dev/null; then
+    unzip="busybox unzip"
+else
     error 'unzip is required to install bun'
+fi
 
 if [[ $# -gt 2 ]]; then
     error 'Too many arguments, only 2 are allowed. The first can be a specific tag of bun to install. (e.g. "bun-v0.1.4") The second can be a build variant of bun to install. (e.g. "debug-info")'
@@ -134,7 +140,7 @@ fi
 curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri" ||
     error "Failed to download bun from \"$bun_uri\""
 
-unzip -oqd "$bin_dir" "$exe.zip" ||
+$uzip -oqd "$bin_dir" "$exe.zip" ||
     error 'Failed to extract bun'
 
 mv "$bin_dir/bun-$target/$exe_name" "$exe" ||


### PR DESCRIPTION
### What does this PR do?

Try use busybox's unzip instead of infozip

<!-- **Please explain what your changes do**, example: -->
https://discord.com/channels/876711213126520882/876711213126520885/1287567969496469617
> Jarred:
IIRC, we use the default installed unzip
macOS comes with unzip as well

But with Debian doesn't by default. WSL comes with Debian by default also
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
