### PR TITLE
fix(install): relative paths to tarballs in workspaces

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -841,15 +841,19 @@ pub fn isRootDependency(this: *const Lockfile, manager: *PackageManager, id: Dep
 /// Is this a direct dependency of any workspace (including workspace root)?
 /// TODO make this faster by caching the workspace package ids
 pub fn isWorkspaceDependency(this: *const Lockfile, id: DependencyID) bool {
+    return getWorkspacePkgIfWorkspaceDep(this, id) != invalid_package_id;
+}
+
+pub fn getWorkspacePkgIfWorkspaceDep(this: *const Lockfile, id: DependencyID) PackageID {
     const packages = this.packages.slice();
     const resolutions = packages.items(.resolution);
     const dependencies_lists = packages.items(.dependencies);
-    for (resolutions, dependencies_lists) |resolution, dependencies| {
+    for (resolutions, dependencies_lists, 0..) |resolution, dependencies, pkg_id| {
         if (resolution.tag != .workspace and resolution.tag != .root) continue;
-        if (dependencies.contains(id)) return true;
+        if (dependencies.contains(id)) return @intCast(pkg_id);
     }
 
-    return false;
+    return invalid_package_id;
 }
 
 /// Does this tree id belong to a workspace (including workspace root)?

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2,6 +2,7 @@ import { file, write } from "bun";
 import { install_test_helpers } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { cp } from "fs/promises";
 import { bunExe, bunEnv as env, runBunInstall, tmpdirSync, toMatchNodeModulesAt } from "harness";
 import { join } from "path";
 const { parseLockfile } = install_test_helpers;
@@ -507,4 +508,83 @@ test("cwd in workspace script is not the symlink path on windows", async () => {
   await runBunInstall(env, packageDir);
 
   expect(await file(join(packageDir, "node_modules", "pkg1", "cwd")).text()).toBe(join(packageDir, "pkg1"));
+});
+
+describe("relative tarballs", async () => {
+  test("from package.json", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["pkgs/*"],
+        }),
+      ),
+      write(
+        join(packageDir, "pkgs", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "qux": "../../qux-0.0.2.tgz",
+          },
+        }),
+      ),
+      cp(join(import.meta.dir, "qux-0.0.2.tgz"), join(packageDir, "qux-0.0.2.tgz")),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    expect(await file(join(packageDir, "node_modules", "qux", "package.json")).json()).toMatchObject({
+      name: "qux",
+      version: "0.0.2",
+    });
+  });
+  test("from cli", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["pkgs/*"],
+        }),
+      ),
+      write(
+        join(packageDir, "pkgs", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+        }),
+      ),
+      cp(join(import.meta.dir, "qux-0.0.2.tgz"), join(packageDir, "qux-0.0.2.tgz")),
+    ]);
+
+    const { stderr, exited } = Bun.spawn({
+      cmd: [bunExe(), "install", "../../qux-0.0.2.tgz"],
+      cwd: join(packageDir, "pkgs", "pkg1"),
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await Bun.readableStreamToText(stderr);
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("failed to resolve");
+    expect(await exited).toBe(0);
+
+    const results = await Promise.all([
+      file(join(packageDir, "node_modules", "qux", "package.json")).json(),
+      file(join(packageDir, "pkgs", "pkg1", "package.json")).json(),
+    ]);
+
+    expect(results[0]).toMatchObject({
+      name: "qux",
+      version: "0.0.2",
+    });
+
+    expect(results[1]).toMatchObject({
+      name: "pkg1",
+      dependencies: {
+        qux: "../../qux-0.0.2.tgz",
+      },
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
fixes #7608 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test for relative paths in package.json and from cli
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
