### PR TITLE
Switch RSA asymmetric sign implementation to BoringSSL

### DIFF
--- a/bench/crypto/asymmetricSign.js
+++ b/bench/crypto/asymmetricSign.js
@@ -1,0 +1,24 @@
+import { bench, run } from "mitata";
+const crypto = require("node:crypto");
+
+const keyPair = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: {
+    type: "spki",
+    format: "pem",
+  },
+  privateKeyEncoding: {
+    type: "pkcs8",
+    format: "pem",
+  },
+});
+
+// Max message size for 2048-bit RSA keys
+const plaintext = crypto.getRandomValues(Buffer.alloc(245));
+
+bench("RSA sign RSA_PKCS1_PADDING round-trip", () => {
+  const sig = crypto.privateEncrypt(keyPair.privateKey, plaintext);
+  crypto.publicDecrypt(keyPair.publicKey, sig);
+});
+
+await run();

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
@@ -40,9 +40,11 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSignNoAlgorithm(const CryptoKeyRSA&, size_t padding, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformSignWithAlgorithm(const CryptoKeyRSA&, CryptoAlgorithmIdentifier, const Vector<uint8_t>&);
 
     static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformVerifyRecover(const CryptoKeyRSA&, size_t padding, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerifyWithAlgorithm(const CryptoKeyRSA&, CryptoAlgorithmIdentifier, const Vector<uint8_t>&, const Vector<uint8_t>&);
 
 private:

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
@@ -33,13 +33,8 @@
 
 namespace WebCore {
 
-static ExceptionOr<Vector<uint8_t>> signWithEVP_MD(const CryptoKeyRSA& key, const EVP_MD* md, const Vector<uint8_t>& data)
+static ExceptionOr<Vector<uint8_t>> signWithEVP_MD(const CryptoKeyRSA& key, const EVP_MD* md, size_t padding, const Vector<uint8_t>& data)
 {
-
-    std::optional<Vector<uint8_t>> digest = calculateDigest(md, data);
-    if (!digest)
-        return Exception { OperationError };
-
     auto ctx = EvpPKeyCtxPtr(EVP_PKEY_CTX_new(key.platformKey(), nullptr));
     if (!ctx)
         return Exception { OperationError };
@@ -47,22 +42,34 @@ static ExceptionOr<Vector<uint8_t>> signWithEVP_MD(const CryptoKeyRSA& key, cons
     if (EVP_PKEY_sign_init(ctx.get()) <= 0)
         return Exception { OperationError };
 
-    if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_PADDING) <= 0)
+    if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), padding) <= 0)
         return Exception { OperationError };
 
-    if (EVP_PKEY_CTX_set_signature_md(ctx.get(), md) <= 0)
-        return Exception { OperationError };
+    auto toSign = data;
+    if (md) {
+        if (EVP_PKEY_CTX_set_signature_md(ctx.get(), md) <= 0)
+            return Exception { OperationError };
+        std::optional<Vector<uint8_t>> digest = calculateDigest(md, data);
+        if (!digest)
+            return Exception { OperationError };
+        toSign = std::move(digest.value());
+    }
 
     size_t signatureLen;
-    if (EVP_PKEY_sign(ctx.get(), nullptr, &signatureLen, digest->data(), digest->size()) <= 0)
+    if (EVP_PKEY_sign(ctx.get(), nullptr, &signatureLen, toSign.data(), toSign.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> signature(signatureLen);
-    if (EVP_PKEY_sign(ctx.get(), signature.data(), &signatureLen, digest->data(), digest->size()) <= 0)
+    if (EVP_PKEY_sign(ctx.get(), signature.data(), &signatureLen, toSign.data(), toSign.size()) <= 0)
         return Exception { OperationError };
     signature.shrink(signatureLen);
 
     return signature;
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignNoAlgorithm(const CryptoKeyRSA& key, size_t padding, const Vector<uint8_t>& data)
+{
+    return signWithEVP_MD(key, nullptr, padding, data);
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithAlgorithm(const CryptoKeyRSA& key, CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>& data)
@@ -72,7 +79,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSignWithA
     if (!md)
         return Exception { NotSupportedError };
 
-    return signWithEVP_MD(key, md, data);
+    return signWithEVP_MD(key, md, RSA_PKCS1_PADDING, data);
 }
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(const CryptoKeyRSA& key, const Vector<uint8_t>& data)
 {
@@ -80,7 +87,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformSign(cons
     if (!md)
         return Exception { NotSupportedError };
 
-    return signWithEVP_MD(key, md, data);
+    return signWithEVP_MD(key, md, RSA_PKCS1_PADDING, data);
 }
 
 static ExceptionOr<bool> verifyWithEVP_MD(const CryptoKeyRSA& key, const EVP_MD* md, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
@@ -123,6 +130,30 @@ ExceptionOr<bool> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerify(const CryptoK
         return Exception { NotSupportedError };
 
     return verifyWithEVP_MD(key, md, signature, data);
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerifyRecover(const CryptoKeyRSA& key, size_t padding, const Vector<uint8_t>& signature)
+{
+    auto ctx = EvpPKeyCtxPtr(EVP_PKEY_CTX_new(key.platformKey(), nullptr));
+    if (!ctx)
+        return Exception { OperationError };
+
+    if (EVP_PKEY_verify_recover_init(ctx.get()) <= 0)
+        return Exception { OperationError };
+
+    if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), padding) <= 0)
+        return Exception { OperationError };
+
+    size_t plaintextLen;
+    if (EVP_PKEY_verify_recover(ctx.get(), nullptr, &plaintextLen, signature.data(), signature.size()) <= 0)
+        return Exception { OperationError };
+
+    Vector<uint8_t> plaintext(plaintextLen);
+    if (EVP_PKEY_verify_recover(ctx.get(), plaintext.data(), &plaintextLen, signature.data(), signature.size()) <= 0)
+        return Exception { OperationError };
+    plaintext.shrink(plaintextLen);
+
+    return plaintext;
 }
 
 } // namespace WebCore

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -20,6 +20,8 @@ const {
   verify: nativeVerify,
   publicEncrypt,
   privateDecrypt,
+  privateEncrypt,
+  publicDecrypt,
 } = $cpp("KeyObject.cpp", "createNodeCryptoBinding");
 
 const {
@@ -11441,186 +11443,7 @@ var require_browser9 = __commonJS({
   },
 });
 
-// node_modules/public-encrypt/mgf.js
-var require_mgf = __commonJS({
-  "node_modules/public-encrypt/mgf.js"(exports, module) {
-    var createHash = require_browser2(),
-      Buffer2 = require_safe_buffer().Buffer;
-    module.exports = function (seed, len) {
-      for (var t = Buffer2.alloc(0), i = 0, c; t.length < len; )
-        (c = i2ops(i++)), (t = Buffer2.concat([t, createHash("sha1").update(seed).update(c).digest()]));
-      return t.slice(0, len);
-    };
-    function i2ops(c) {
-      var out = Buffer2.allocUnsafe(4);
-      return out.writeUInt32BE(c, 0), out;
-    }
-  },
-});
-
-// node_modules/public-encrypt/xor.js
-var require_xor = __commonJS({
-  "node_modules/public-encrypt/xor.js"(exports, module) {
-    module.exports = function (a, b) {
-      for (var len = a.length, i = -1; ++i < len; ) a[i] ^= b[i];
-      return a;
-    };
-  },
-});
-
-// node_modules/public-encrypt/node_modules/bn.js/lib/bn.js
-var require_bn7 = require_bn;
-
 const { CryptoHasher } = globalThis.Bun;
-
-// node_modules/public-encrypt/withPublic.js
-var require_withPublic = __commonJS({
-  "node_modules/public-encrypt/withPublic.js"(exports, module) {
-    var BN = require_bn7(),
-      Buffer2 = require_safe_buffer().Buffer;
-    function withPublic(paddedMsg, key) {
-      return Buffer2.from(paddedMsg.toRed(BN.mont(key.modulus)).redPow(new BN(key.publicExponent)).fromRed().toArray());
-    }
-    module.exports = withPublic;
-  },
-});
-
-// node_modules/public-encrypt/publicEncrypt.js
-var require_publicEncrypt = __commonJS({
-  "node_modules/public-encrypt/publicEncrypt.js"(exports, module) {
-    var parseKeys = require_parse_asn1(),
-      randomBytes = require_browser(),
-      createHash = require_browser2(),
-      mgf = require_mgf(),
-      xor = require_xor(),
-      BN = require_bn7(),
-      withPublic = require_withPublic(),
-      crt = require_browserify_rsa(),
-      Buffer2 = require_safe_buffer().Buffer;
-    module.exports = function (publicKey, msg, reverse) {
-      var padding;
-      publicKey.padding ? (padding = publicKey.padding) : reverse ? (padding = 1) : (padding = 4);
-      var key = parseKeys(publicKey),
-        paddedMsg;
-      if (padding === 4) paddedMsg = oaep(key, msg);
-      else if (padding === 1) paddedMsg = pkcs1(key, msg, reverse);
-      else if (padding === 3) {
-        if (((paddedMsg = new BN(msg)), paddedMsg.cmp(key.modulus) >= 0)) throw new Error("data too long for modulus");
-      } else throw new Error("unknown padding");
-      return reverse ? crt(paddedMsg, key) : withPublic(paddedMsg, key);
-    };
-    function oaep(key, msg) {
-      var k = key.modulus.byteLength(),
-        mLen = msg.length,
-        iHash = createHash("sha1").update(Buffer2.alloc(0)).digest(),
-        hLen = iHash.length,
-        hLen2 = 2 * hLen;
-      if (mLen > k - hLen2 - 2) throw new Error("message too long");
-      var ps = Buffer2.alloc(k - mLen - hLen2 - 2),
-        dblen = k - hLen - 1,
-        seed = randomBytes(hLen),
-        maskedDb = xor(Buffer2.concat([iHash, ps, Buffer2.alloc(1, 1), msg], dblen), mgf(seed, dblen)),
-        maskedSeed = xor(seed, mgf(maskedDb, hLen));
-      return new BN(Buffer2.concat([Buffer2.alloc(1), maskedSeed, maskedDb], k));
-    }
-    function pkcs1(key, msg, reverse) {
-      var mLen = msg.length,
-        k = key.modulus.byteLength();
-      if (mLen > k - 11) throw new Error("message too long");
-      var ps;
-      return (
-        reverse ? (ps = Buffer2.alloc(k - mLen - 3, 255)) : (ps = nonZero(k - mLen - 3)),
-        new BN(Buffer2.concat([Buffer2.from([0, reverse ? 1 : 2]), ps, Buffer2.alloc(1), msg], k))
-      );
-    }
-    function nonZero(len) {
-      for (var out = Buffer2.allocUnsafe(len), i = 0, cache = randomBytes(len * 2), cur = 0, num; i < len; )
-        cur === cache.length && ((cache = randomBytes(len * 2)), (cur = 0)),
-          (num = cache[cur++]),
-          num && (out[i++] = num);
-      return out;
-    }
-  },
-});
-
-// node_modules/public-encrypt/privateDecrypt.js
-var require_privateDecrypt = __commonJS({
-  "node_modules/public-encrypt/privateDecrypt.js"(exports, module) {
-    var parseKeys = require_parse_asn1(),
-      mgf = require_mgf(),
-      xor = require_xor(),
-      BN = require_bn7(),
-      crt = require_browserify_rsa(),
-      createHash = require_browser2(),
-      withPublic = require_withPublic(),
-      Buffer2 = require_safe_buffer().Buffer;
-    module.exports = function (privateKey, enc, reverse) {
-      var padding;
-      privateKey.padding ? (padding = privateKey.padding) : reverse ? (padding = 1) : (padding = 4);
-      var key = parseKeys(privateKey),
-        k = key.modulus.byteLength();
-      if (enc.length > k || new BN(enc).cmp(key.modulus) >= 0) throw new Error("decryption error");
-      var msg;
-      reverse ? (msg = withPublic(new BN(enc), key)) : (msg = crt(enc, key));
-      var zBuffer = Buffer2.alloc(k - msg.length);
-      if (((msg = Buffer2.concat([zBuffer, msg], k)), padding === 4)) return oaep(key, msg);
-      if (padding === 1) return pkcs1(key, msg, reverse);
-      if (padding === 3) return msg;
-      throw new Error("unknown padding");
-    };
-    function oaep(key, msg) {
-      var k = key.modulus.byteLength(),
-        iHash = createHash("sha1").update(Buffer2.alloc(0)).digest(),
-        hLen = iHash.length;
-      if (msg[0] !== 0) throw new Error("decryption error");
-      var maskedSeed = msg.slice(1, hLen + 1),
-        maskedDb = msg.slice(hLen + 1),
-        seed = xor(maskedSeed, mgf(maskedDb, hLen)),
-        db = xor(maskedDb, mgf(seed, k - hLen - 1));
-      if (compare(iHash, db.slice(0, hLen))) throw new Error("decryption error");
-      for (var i = hLen; db[i] === 0; ) i++;
-      if (db[i++] !== 1) throw new Error("decryption error");
-      return db.slice(i);
-    }
-    function pkcs1(key, msg, reverse) {
-      for (var p1 = msg.slice(0, 2), i = 2, status = 0; msg[i++] !== 0; )
-        if (i >= msg.length) {
-          status++;
-          break;
-        }
-      var ps = msg.slice(2, i - 1);
-      if (
-        (((p1.toString("hex") !== "0002" && !reverse) || (p1.toString("hex") !== "0001" && reverse)) && status++,
-        ps.length < 8 && status++,
-        status)
-      )
-        throw new Error("decryption error");
-      return msg.slice(i);
-    }
-    function compare(a, b) {
-      (a = Buffer2.from(a)), (b = Buffer2.from(b));
-      var dif = 0,
-        len = a.length;
-      a.length !== b.length && (dif++, (len = Math.min(a.length, b.length)));
-      for (var i = -1; ++i < len; ) dif += a[i] ^ b[i];
-      return dif;
-    }
-  },
-});
-
-// node_modules/public-encrypt/browser.js
-var require_browser10 = __commonJS({
-  "node_modules/public-encrypt/browser.js"(exports) {
-    var publicEncrypt = require_publicEncrypt();
-    exports.privateEncrypt = function (key, buf) {
-      return publicEncrypt(getKeyFrom(key, "private"), buf, !0);
-    };
-    var privateDecrypt = require_privateDecrypt();
-    exports.publicDecrypt = function (key, buf) {
-      return privateDecrypt(getKeyFrom(key, "public"), buf, !0);
-    };
-  },
-});
 
 // node_modules/randomfill/browser.js
 var require_browser11 = __commonJS({
@@ -11716,9 +11539,6 @@ var require_crypto_browserify2 = __commonJS({
     exports.createVerify = sign.createVerify;
     exports.Verify = sign.Verify;
     exports.createECDH = require_browser9();
-    var publicEncrypt = require_browser10();
-    exports.privateEncrypt = publicEncrypt.privateEncrypt;
-    exports.publicDecrypt = publicEncrypt.publicDecrypt;
     exports.getRandomValues = values => crypto.getRandomValues(values);
     var rf = require_browser11();
     exports.randomFill = rf.randomFill;
@@ -12203,6 +12023,21 @@ crypto_exports.publicEncrypt = function (key, message) {
 
 crypto_exports.privateDecrypt = function (key, message) {
   return doAsymmetricCipher(key, message, privateDecrypt, false);
+};
+
+function doAsymmetricSign(key, message, operation, isEncrypt) {
+  // Our crypto bindings expect the key to be a `JSCryptoKey` property within an object.
+  const cryptoKey = toCryptoKey(key, isEncrypt);
+  const buffer = typeof message === "string" ? Buffer.from(message, key.encoding) : message;
+  return operation(cryptoKey, buffer, key.padding);
+}
+
+crypto_exports.privateEncrypt = function (key, message) {
+  return doAsymmetricSign(key, message, privateEncrypt, false);
+};
+
+crypto_exports.publicDecrypt = function (key, message) {
+  return doAsymmetricSign(key, message, publicDecrypt, true);
 };
 
 __export(crypto_exports, {


### PR DESCRIPTION
### What does this PR do?

We port over the remaining `crypto.privateEncrypt` and `crypto.publicDecrypt`, allowing us to get rid of the browserify `public-encrypt` dependency implementing them. All relevant test coverage from Node.js was already ported over, which we still adhere to.

I had the following benchmarks on an Apple M1 Pro:

This branch:

```
benchmark                                  time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------------- -----------------------------
RSA sign RSA_PKCS1_PADDING round-trip     832 µs/iter       (816 µs … 915 µs)    834 µs    893 µs    915 µs
```

bun/main:

```
benchmark                                  time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------------- -----------------------------
RSA sign RSA_PKCS1_PADDING round-trip  26'997 µs/iter (26'657 µs … 27'551 µs) 27'119 µs 27'551 µs 27'551 µs
```

Fixes https://github.com/oven-sh/bun/issues/6076.

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)