### PR TITLE
add missing defers to JSBundler.Plugin.hasAnyMatches

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -967,6 +967,8 @@ pub const JSBundler = struct {
             else
                 bun.String.createUTF8(path.namespace);
             const path_string = bun.String.createUTF8(path.text);
+            defer namespace_string.deref();
+            defer path_string.deref();
             return JSBundlerPlugin__anyMatches(this, &namespace_string, &path_string, is_onLoad);
         }
 


### PR DESCRIPTION
this one i wasnt 100% confident on but the three functions below it all follow a similar pattern and do the defers on their strings