### PR TITLE
fix small leak in node:process.execArgv getter

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1875,6 +1875,7 @@ pub const Process = struct {
 
         var args = std.ArrayList(bun.String).initCapacity(temp_alloc, bun.argv.len - 1) catch bun.outOfMemory();
         defer args.deinit();
+        defer for (args.items) |*arg| arg.deref();
 
         var seen_run = false;
         var prev: ?[]const u8 = null;


### PR DESCRIPTION
this getter is cached so the blast radius is small but this patch still frees up the stray `bun.String` instances created during the initial call