### PR TITLE
Fix zig build

### DIFF
--- a/cmake/Globals.cmake
+++ b/cmake/Globals.cmake
@@ -129,7 +129,13 @@ else()
   set(WARNING WARNING)
 endif()
 
-optionx(VENDOR_PATH FILEPATH "The path to the vendor directory" DEFAULT ${CWD}/vendor)
+if(CI)
+  set(DEFAULT_VENDOR_PATH ${CACHE_PATH}/vendor)
+else()
+  set(DEFAULT_VENDOR_PATH ${CWD}/vendor)
+endif()
+
+optionx(VENDOR_PATH FILEPATH "The path to the vendor directory" DEFAULT ${DEFAULT_VENDOR_PATH})
 optionx(TMP_PATH FILEPATH "The path to the temporary directory" DEFAULT ${BUILD_PATH}/tmp)
 
 optionx(FRESH BOOL "Set when --fresh is used" DEFAULT OFF)

--- a/cmake/scripts/DownloadUrl.cmake
+++ b/cmake/scripts/DownloadUrl.cmake
@@ -125,7 +125,5 @@ else()
   file(RENAME ${DOWNLOAD_TMP_FILE} ${DOWNLOAD_PATH})
 endif()
 
-get_filename_component(DOWNLOAD_FILENAME ${DOWNLOAD_PATH} NAME)
-message(STATUS "Saved ${DOWNLOAD_FILENAME}")
-
 file(REMOVE_RECURSE ${DOWNLOAD_TMP_PATH})
+message(STATUS "Saved ${DOWNLOAD_PATH}")

--- a/cmake/scripts/DownloadZig.cmake
+++ b/cmake/scripts/DownloadZig.cmake
@@ -89,7 +89,7 @@ endif()
 
 file(REMOVE_RECURSE ${ZIG_PATH}/lib)
 
-# Use copy_directory instead of file(COPY) because there were
+# Use copy_directory instead of file(RENAME) because there were
 # race conditions in CI where some files were not copied.
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${ZIG_REPOSITORY_PATH}/lib ${ZIG_PATH}/lib)
 

--- a/cmake/scripts/DownloadZig.cmake
+++ b/cmake/scripts/DownloadZig.cmake
@@ -89,7 +89,24 @@ if(NOT ZIG_REPOSITORY_RESULT EQUAL 0)
 endif()
 
 file(REMOVE_RECURSE ${ZIG_PATH}/lib)
-file(RENAME ${ZIG_PATH}/tmp/lib ${ZIG_PATH}/lib)
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND}
+      -E sleep 3
+)
+
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND}
+      -E copy_directory ${ZIG_PATH}/tmp/lib ${ZIG_PATH}/lib
+)
+
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND}
+      -E sleep 3
+)
+
 file(REMOVE_RECURSE ${ZIG_PATH}/tmp)
 message(STATUS "Saved ${ZIG_PATH}/lib")
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn as nodeSpawn } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, mkdirSync, cpSync, chmodSync } from "node:fs";
-import { basename, join, relative, resolve } from "node:path";
+import { existsSync, readFileSync, mkdirSync, cpSync, chmodSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
 
 // https://cmake.org/cmake/help/latest/manual/cmake.1.html#generate-a-project-buildsystem
 const generateFlags = [
@@ -57,32 +57,32 @@ async function build(args) {
   const cacheRead = isCacheReadEnabled();
   const cacheWrite = isCacheWriteEnabled();
   if (cacheRead || cacheWrite) {
-  //   const cachePath = getCachePath();
-  //   if (cacheRead && !existsSync(cachePath)) {
-  //     const mainCachePath = getCachePath(getDefaultBranch());
-  //     if (existsSync(mainCachePath)) {
-  //       mkdirSync(cachePath, { recursive: true });
-  //       try {
-  //         cpSync(mainCachePath, cachePath, { recursive: true, force: true });
-  //       } catch (error) {
-  //         const { code } = error;
-  //         switch (code) {
-  //           case "EPERM":
-  //           case "EACCES":
-  //             try {
-  //               chmodSync(mainCachePath, 0o777);
-  //               cpSync(mainCachePath, cachePath, { recursive: true, force: true });
-  //             } catch (error) {
-  //               console.warn("Failed to copy cache with permissions fix", error);
-  //             }
-  //             break;
-  //           default:
-  //             console.warn("Failed to copy cache", error);
-  //         }
-  //       }
-  //     }
-  //   }
-    // generateOptions["-DCACHE_PATH"] = cmakePath(cachePath);
+    const cachePath = getCachePath();
+    if (cacheRead && !existsSync(cachePath)) {
+      const mainCachePath = getCachePath(getDefaultBranch());
+      if (existsSync(mainCachePath)) {
+        mkdirSync(cachePath, { recursive: true });
+        try {
+          cpSync(mainCachePath, cachePath, { recursive: true, force: true });
+        } catch (error) {
+          const { code } = error;
+          switch (code) {
+            case "EPERM":
+            case "EACCES":
+              try {
+                chmodSync(mainCachePath, 0o777);
+                cpSync(mainCachePath, cachePath, { recursive: true, force: true });
+              } catch (error) {
+                console.warn("Failed to copy cache with permissions fix", error);
+              }
+              break;
+            default:
+              console.warn("Failed to copy cache", error);
+          }
+        }
+      }
+    }
+    generateOptions["-DCACHE_PATH"] = cmakePath(cachePath);
     generateOptions["--fresh"] = undefined;
     if (cacheRead && cacheWrite) {
       generateOptions["-DCACHE_STRATEGY"] = "read-write";


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
