### PR TITLE
Rewrite crypto.{randomBytes,randomFill} implementation in Zig

### DIFF
--- a/bench/crypto/randomBytes.js
+++ b/bench/crypto/randomBytes.js
@@ -1,0 +1,36 @@
+import { bench, run } from "mitata";
+const crypto = require("node:crypto");
+
+bench("randomBytes 64B", () => {
+  crypto.randomBytes(64);
+});
+
+bench("randomBytes 256B", () => {
+  crypto.randomBytes(256);
+});
+
+bench("randomBytes 1K", () => {
+  crypto.randomBytes(1024);
+});
+
+bench("randomBytes 4K", () => {
+  crypto.randomBytes(4096);
+});
+
+bench("randomBytes 16K", () => {
+  crypto.randomBytes(16384);
+});
+
+bench("randomBytes 64K", () => {
+  crypto.randomBytes(65536);
+});
+
+bench("randomBytes 256K", () => {
+  crypto.randomBytes(262144);
+});
+
+bench("randomBytes 1M", () => {
+  crypto.randomBytes(1048576);
+});
+
+await run();

--- a/bench/crypto/randomFill.js
+++ b/bench/crypto/randomFill.js
@@ -1,0 +1,38 @@
+import { bench, run } from "mitata";
+const crypto = require("node:crypto");
+
+const buffer = Buffer.alloc(1048576);
+
+bench("randomFillSync 64B", () => {
+  crypto.randomFillSync(buffer, 0, 64);
+});
+
+bench("randomFillSync 256B", () => {
+  crypto.randomFillSync(buffer, 0, 256);
+});
+
+bench("randomFillSync 1K", () => {
+  crypto.randomFillSync(buffer, 0, 1024);
+});
+
+bench("randomFillSync 4K", () => {
+  crypto.randomFillSync(buffer, 0, 4096);
+});
+
+bench("randomFillSync 16K", () => {
+  crypto.randomFillSync(buffer, 0, 16384);
+});
+
+bench("randomFillSync 64K", () => {
+  crypto.randomFillSync(buffer, 0, 65536);
+});
+
+bench("randomFillSync 256K", () => {
+  crypto.randomFillSync(buffer, 0, 262144);
+});
+
+bench("randomFillSync 1M", () => {
+  crypto.randomFillSync(buffer, 0, 1048576);
+});
+
+await run();

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -12,6 +12,30 @@ const EVP = Crypto.EVP;
 const PBKDF2 = EVP.PBKDF2;
 const JSValue = JSC.JSValue;
 const validators = @import("./util/validators.zig");
+
+fn randomBytes(globalThis: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) JSC.JSValue {
+    const arguments = callFrame.arguments(1).slice();
+
+    if (!arguments[0].isNumber())
+        return globalThis.throwInvalidArgumentTypeValue("size", "non-negative number", arguments[0]);
+
+    const size = arguments[0].to(i64);
+    if (size < 0 or size > std.math.maxInt(i32))
+        return globalThis.throwInvalidArgumentRangeValue("size", "must be within range [0, 2147483647]", size);
+
+    const jsBuffer = JSC.JSValue.createUninitializedUint8Array(globalThis, @intCast(size));
+    if (globalThis.hasException())
+        return .zero;
+
+    if (size > 0) {
+        if (jsBuffer.asArrayBuffer(globalThis)) |jsArrayBuffer| {
+            bun.randomData(globalThis, jsArrayBuffer.slice());
+        }
+    }
+
+    return jsBuffer;
+}
+
 fn randomInt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
     const arguments = callframe.arguments(2).slice();
 
@@ -36,6 +60,67 @@ fn randomInt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSV
     }
 
     return JSC.JSValue.jsNumberFromInt64(std.crypto.random.intRangeLessThan(i64, min, max));
+}
+
+fn randomFill(globalThis: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) JSC.JSValue {
+    const arguments = callFrame.arguments(3).slice();
+
+    const jsBuffer = arguments[0];
+    const buffer = jsBuffer.asArrayBuffer(globalThis) orelse {
+        return globalThis.throwInvalidArgumentTypeValue(
+            "buffer",
+            "Buffer or array-like object",
+            arguments[0],
+        );
+    };
+    const slice = buffer.slice();
+
+    if (!arguments[1].isUndefined() and !arguments[1].isNumber())
+        return globalThis.throwInvalidArgumentTypeValue("offset", "non-negative number", arguments[1]);
+    if (!arguments[2].isUndefined() and !arguments[2].isNumber())
+        return globalThis.throwInvalidArgumentTypeValue("size", "non-negative number", arguments[2]);
+
+    var offset: u32 = 0;
+    if (arguments[1].isNumber()) {
+        const offset_i64 = arguments[1].to(i64);
+        if (offset_i64 < 0 or offset_i64 > std.math.maxInt(i32)) {
+            return globalThis.throwInvalidArgumentRangeValue(
+                "offset",
+                "It must be within range [0, 2147483647]",
+                offset_i64,
+            );
+        }
+        if (offset_i64 > slice.len) {
+            globalThis.throw("offset ({}) overflows the buffer's length", .{offset_i64});
+            return .zero;
+        }
+        offset = @intCast(offset_i64);
+    }
+
+    var size: u32 = @as(u32, @intCast(slice.len)) - offset;
+    if (arguments[2].isNumber()) {
+        const size_i64 = arguments[2].to(i64);
+        if (size_i64 < 0 or size_i64 > std.math.maxInt(i32)) {
+            return globalThis.throwInvalidArgumentRangeValue(
+                "size",
+                "It must be within range [0, 2147483647]",
+                size_i64,
+            );
+        }
+        if (size_i64 + offset > slice.len) {
+            globalThis.throw("size ({}) with offset ({}) overflows the buffer's length", .{
+                size_i64,
+                offset
+            });
+            return .zero;
+        }
+        size = @intCast(size_i64);
+    }
+
+    if (size > 0)
+        bun.randomData(globalThis, slice[offset..offset+size]);
+
+    return jsBuffer;
 }
 
 fn pbkdf2(
@@ -88,14 +173,18 @@ fn pbkdf2Sync(
 
 const jsPbkdf2 = JSC.toJSHostFunction(pbkdf2);
 const jsPbkdf2Sync = JSC.toJSHostFunction(pbkdf2Sync);
+const jsRandomBytes = JSC.toJSHostFunction(randomBytes);
 const jsRandomInt = JSC.toJSHostFunction(randomInt);
+const jsRandomFill = JSC.toJSHostFunction(randomFill);
 
 pub fn createNodeCryptoBindingZig(global: *JSC.JSGlobalObject) JSC.JSValue {
-    const crypto = JSC.JSValue.createEmptyObject(global, 3);
+    const crypto = JSC.JSValue.createEmptyObject(global, 5);
 
     crypto.put(global, bun.String.init("pbkdf2"), JSC.JSFunction.create(global, "pbkdf2", jsPbkdf2, 5, .{}));
     crypto.put(global, bun.String.init("pbkdf2Sync"), JSC.JSFunction.create(global, "pbkdf2Sync", jsPbkdf2Sync, 5, .{}));
+    crypto.put(global, bun.String.init("randomBytes"), JSC.JSFunction.create(global, "randomBytes", jsRandomBytes, 1, .{}));
     crypto.put(global, bun.String.init("randomInt"), JSC.JSFunction.create(global, "randomInt", jsRandomInt, 2, .{}));
+    crypto.put(global, bun.String.init("randomFill"), JSC.JSFunction.create(global, "randomFill", jsRandomFill, 3, .{}));
 
     return crypto;
 }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -604,6 +604,22 @@ pub fn rand(bytes: []u8) void {
     _ = BoringSSL.RAND_bytes(bytes.ptr, bytes.len);
 }
 
+pub fn randomData(
+    globalThis: *JSC.JSGlobalObject,
+    slice: []u8,
+) void {
+    switch (slice.len) {
+        0 => {},
+        // 256 bytes or less we reuse from the same cache as UUID generation.
+        1...JSC.RareData.EntropyCache.size / 8 => {
+            copy(u8, slice, globalThis.bunVM().rareData().entropySlice(slice.len));
+        },
+        else => {
+            rand(slice);
+        },
+    }
+}
+
 pub const ObjectPool = @import("./pool.zig").ObjectPool;
 
 pub fn assertNonBlocking(fd: anytype) void {

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "bun:test";
-import { randomInt } from "crypto";
+import { randomBytes, randomInt, randomFill, randomFillSync } from "crypto";
+
+describe("randomBytes args validation", async() => {
+  it("size should be > 0 and <= 2147483647", () => {
+    expect(() => randomBytes(-1)).toThrow(RangeError);
+    expect(() => randomBytes(2147483648)).toThrow(RangeError);
+
+    const buffer = randomBytes(16);
+    expect(buffer.length).toBe(16);
+  });
+});
 
 describe("randomInt args validation", async () => {
   it("default min is 0 so max should be greater than 0", () => {
@@ -27,5 +37,51 @@ describe("randomInt args validation", async () => {
 
   it("accept large negative numbers", () => {
     expect(() => randomInt(-Number.MAX_SAFE_INTEGER, -Number.MAX_SAFE_INTEGER + 1)).not.toThrow(RangeError);
+  });
+});
+
+describe("randomFillSync args validation", async() => {
+  const buffer = Buffer.alloc(16);
+
+  it("buffer should be a Buffer or array-like object", () => {
+    expect(() => randomFillSync(0, 0, 0)).toThrow(TypeError);
+    expect(() => randomFillSync("hello", 0, 0)).toThrow(TypeError);
+    expect(() => randomFillSync(Buffer.alloc(16), 0, 0)).not.toThrow();
+    expect(() => randomFillSync(new Uint32Array(4), 0, 0)).not.toThrow();
+  });
+
+  it("offset should be > 0 and <= 2147483647", () => {
+    expect(() => randomFillSync(buffer, -1, 0)).toThrow(RangeError);
+    expect(() => randomFillSync(buffer, 2147483648, 0)).toThrow(RangeError);
+    expect(() => randomFillSync(buffer, buffer, 0)).toThrow(TypeError);
+  });
+
+  it("size should be > 0 and <= 2147483647", () => {
+    expect(() => randomFillSync(buffer, 0, -1)).toThrow(RangeError);
+    expect(() => randomFillSync(buffer, 0, 2147483648)).toThrow(RangeError);
+    expect(() => randomFillSync(buffer, 0, buffer)).toThrow(TypeError);
+  });
+
+  it("offset/size should be within buffer range", () => {
+    expect(() => randomFillSync(buffer, buffer.length + 1, 0)).toThrow();
+    expect(() => randomFillSync(buffer, buffer.length, 1)).toThrow();
+  });
+});
+
+describe("randomFill args validation", async() => {
+  it("callback should be a function", () => {
+    expect(() => randomFill(Buffer.alloc(16), 0, buffer.length, buffer)).toThrow();
+  });
+
+  it("callback only", () => {
+    randomFill(Buffer.alloc(16), function(err, buffer) {
+      expect(buffer).not.toEqual(Buffer.alloc(16));
+    });
+  });
+
+  it("callback with offset only", () => {
+    randomFill(Buffer.alloc(16), 0, function(err, buffer) {
+      expect(buffer).not.toEqual(Buffer.alloc(16));
+    });
   });
 });


### PR DESCRIPTION
This moves most of the validation logic for both of these functions to happen natively. Ultimately, we want the node crypto library to be a thin wrapper over native implementations. The actual randomness generation for both was already covered by native code with `getRandomValues`. This is still the case, but now we invoke the underlying randomness generator behind `getRandomValues` from a native context.

The new implementation of `randomFill` is more efficient as we were previously allocating a new random buffer and copying over the bytes. This is no longer the case -- we now mutate the buffer directly natively.

These changes had the following result (on an Apple M1 Pro):

```
benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
randomBytes 64B        34.6 ns/iter     (31.11 ns … 366 ns)  31.74 ns  59.12 ns    276 ns
randomBytes 256B      77.96 ns/iter     (70.64 ns … 374 ns)  74.38 ns    260 ns    343 ns
randomBytes 1K          372 ns/iter       (335 ns … 746 ns)    359 ns    700 ns    746 ns
randomBytes 4K          891 ns/iter     (801 ns … 1'174 ns)  1'005 ns  1'131 ns  1'174 ns
randomBytes 16K       2'660 ns/iter   (2'560 ns … 3'214 ns)  2'683 ns  2'994 ns  3'214 ns
randomBytes 64K      10'092 ns/iter     (8'625 ns … 678 µs)  9'000 ns 33'708 ns    378 µs
randomBytes 256K     39'682 ns/iter    (34'333 ns … 674 µs) 35'375 ns 71'083 ns    542 µs
randomBytes 1M          157 µs/iter     (137 µs … 1'345 µs)    142 µs    597 µs    824 µs
randomFillSync 64B    24.21 ns/iter    (22.99 ns … 73.4 ns)  23.17 ns  37.82 ns  44.41 ns
randomFillSync 256B   63.55 ns/iter   (61.12 ns … 91.04 ns)  62.38 ns  76.88 ns  81.85 ns
randomFillSync 1K       307 ns/iter       (272 ns … 364 ns)    313 ns    338 ns    364 ns
randomFillSync 4K       755 ns/iter       (720 ns … 796 ns)    768 ns    788 ns    796 ns
randomFillSync 16K    2'328 ns/iter   (2'219 ns … 2'422 ns)  2'367 ns  2'420 ns  2'422 ns
randomFillSync 64K    8'715 ns/iter   (8'435 ns … 8'849 ns)  8'793 ns  8'842 ns  8'849 ns
randomFillSync 256K  37'038 ns/iter (34'708 ns … 71'250 ns) 36'334 ns 64'500 ns 66'000 ns
randomFillSync 1M       144 µs/iter       (137 µs … 193 µs)    142 µs    171 µs    185 µs
```

bun/main:

```
benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
randomBytes 64B       33.65 ns/iter     (30.15 ns … 363 ns)  31.15 ns  58.65 ns    283 ns
randomBytes 256B      78.38 ns/iter     (70.66 ns … 393 ns)  75.99 ns    265 ns    355 ns
randomBytes 1K          388 ns/iter       (345 ns … 844 ns)    376 ns    708 ns    844 ns
randomBytes 4K          907 ns/iter     (807 ns … 1'357 ns)    988 ns  1'229 ns  1'357 ns
randomBytes 16K       2'686 ns/iter   (2'564 ns … 3'172 ns)  2'714 ns  2'979 ns  3'172 ns
randomBytes 64K      10'118 ns/iter     (8'625 ns … 681 µs)  9'042 ns 33'125 ns    389 µs
randomBytes 256K     39'792 ns/iter    (34'416 ns … 643 µs) 35'875 ns 73'875 ns    508 µs
randomBytes 1M          159 µs/iter     (137 µs … 1'313 µs)    143 µs    621 µs    862 µs
randomFillSync 64B       59 ns/iter     (54.14 ns … 375 ns)  55.79 ns  99.47 ns    331 ns
randomFillSync 256B     107 ns/iter     (98.82 ns … 414 ns)    105 ns    286 ns    395 ns
randomFillSync 1K       416 ns/iter       (378 ns … 766 ns)    403 ns    730 ns    766 ns
randomFillSync 4K       992 ns/iter     (900 ns … 1'294 ns)  1'101 ns  1'253 ns  1'294 ns
randomFillSync 16K    2'944 ns/iter   (2'851 ns … 3'393 ns)  2'970 ns  3'054 ns  3'393 ns
randomFillSync 64K   11'014 ns/iter     (9'666 ns … 648 µs)  9'917 ns 34'542 ns    380 µs
randomFillSync 256K  50'979 ns/iter  (39'416 ns … 1'276 µs) 39'958 ns    405 µs  1'162 µs
randomFillSync 1M       198 µs/iter     (156 µs … 1'538 µs)    164 µs  1'146 µs  1'280 µs
```