### PR TITLE
types: clarified parameter name

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2282,7 +2282,7 @@ declare module "bun" {
      */
     development?: boolean;
 
-    error?: (this: Server, request: ErrorLike) => Response | Promise<Response> | undefined | Promise<undefined>;
+    error?: (this: Server, error: ErrorLike) => Response | Promise<Response> | undefined | Promise<undefined>;
 
     /**
      * Uniquely identify a server instance with an ID


### PR DESCRIPTION
### What does this PR do?

Tweaks TypeScript definitions to provide a clearer name for an error parameter. The current name seems accidental.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
