### PR TITLE
Propagate exceptions in napi_run_script

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2593,9 +2593,15 @@ extern "C" napi_status napi_run_script(napi_env env, napi_value script,
 
     JSC::SourceCode sourceCode = makeSource(code, SourceOrigin(), SourceTaintedOrigin::Untainted);
 
-    JSValue value = JSC::evaluate(globalObject, sourceCode, globalObject->globalThis());
+    NakedPtr<Exception> returnedException;
+    JSValue value = JSC::evaluate(globalObject, sourceCode, globalObject->globalThis(), returnedException);
 
-    if (throwScope.exception() || value.isEmpty()) {
+    if (returnedException) {
+        throwScope.throwException(globalObject, returnedException);
+        RELEASE_AND_RETURN(throwScope, napi_generic_failure);
+    }
+
+    if (value.isEmpty()) {
         return napi_generic_failure;
     }
 

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -555,6 +555,13 @@ napi_value was_finalize_called(const Napi::CallbackInfo &info) {
   return ret;
 }
 
+napi_value eval_wrapper(const Napi::CallbackInfo &info) {
+  napi_value ret = nullptr;
+  // info[0] is the GC callback
+  (void)napi_run_script(info.Env(), info[1], &ret);
+  return ret;
+}
+
 Napi::Value RunCallback(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   // this function is invoked without the GC callback
@@ -605,6 +612,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
               Napi::Function::New(env, create_ref_with_finalizer));
   exports.Set("was_finalize_called",
               Napi::Function::New(env, was_finalize_called));
+  exports.Set("eval_wrapper", Napi::Function::New(env, eval_wrapper));
 
   return exports;
 }

--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -14,6 +14,8 @@ if (typeof fn !== "function") {
 
 // pass GC runner as first argument
 try {
+  // napi.test.ts:147 tries to read this variable and shouldn't be able to
+  let shouldNotExist = 5;
   const result = fn.apply(null, [
     () => {
       if (process.isBun) {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -142,6 +142,10 @@ describe("napi", () => {
     it("propagates exceptions", () => {
       checkSameOutput("eval_wrapper", ["(()=>{ throw new TypeError('oops'); })()"]);
     });
+    it("cannot see locals from around its invocation", () => {
+      // variable is declared on main.js:18, but it should not be in scope for the eval'd code
+      checkSameOutput("eval_wrapper", ["shouldNotExist"]);
+    });
   });
 });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -131,6 +131,18 @@ describe("napi", () => {
       expect(result).toBe("success!");
     });
   });
+
+  describe("napi_run_script", () => {
+    it("evaluates a basic expression", () => {
+      checkSameOutput("eval_wrapper", ["5 * (1 + 2)"]);
+    });
+    it("provides the right this value", () => {
+      checkSameOutput("eval_wrapper", ["this === global"]);
+    });
+    it("propagates exceptions", () => {
+      checkSameOutput("eval_wrapper", ["(()=>{ throw new TypeError('oops'); })()"]);
+    });
+  });
 });
 
 function checkSameOutput(test: string, args: any[] | string) {


### PR DESCRIPTION
### What does this PR do?

Fixes `napi_run_script` to not swallow exceptions thrown by the eval'd script

### How did you verify your code works?

Updated napi tests to cover `napi_run_script` in some edge cases + normal cases.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)