### PR TITLE
cmake: only run prettier explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,4 +46,7 @@ include(BuildBun)
 include(RunClangFormat)
 include(RunClangTidy)
 include(RunZigFormat)
-include(RunPrettier)
+
+if (ENABLE_PRETTIER)
+  include(RunPrettier)
+endif()

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -91,6 +91,8 @@ if(LINUX)
   optionx(ENABLE_VALGRIND BOOL "If Valgrind support should be enabled" DEFAULT OFF)
 endif()
 
+optionx(ENABLE_PRETTIER BOOL "If prettier should be ran" DEFAULT OFF)
+
 if(USE_VALGRIND AND NOT USE_BASELINE)
   message(WARNING "If valgrind is enabled, baseline must also be enabled")
   setx(USE_BASELINE ON)

--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
     "zig-format": "bun run cmake --target zig-format",
     "zig-format:check": "bun run cmake --target zig-format-check",
     "zig-format:diff": "bun run cmake --target zig-format-diff",
-    "prettier": "bun run cmake --target prettier",
-    "prettier:check": "bun run cmake --target prettier-check",
-    "prettier:extra": "bun run cmake --target prettier-extra",
-    "prettier:diff": "bun run cmake --target prettier-diff"
+    "prettier": "bun run cmake -DENABLE_PRETTIER=ON --target prettier",
+    "prettier:check": "bun run cmake -DENABLE_PRETTIER=ON --target prettier-check",
+    "prettier:extra": "bun run cmake -DENABLE_PRETTIER=ON --target prettier-extra",
+    "prettier:diff": "bun run cmake -DENABLE_PRETTIER=ON --target prettier-diff"
   }
 }


### PR DESCRIPTION
greatly speeds up `bun run build`

before `-- Configuring done (84.8s)`
after `-- Configuring done (8.7s)`
