### PR TITLE
Introduce bytecode caching, polish `"cjs"` bundler output format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ BUN_RELEASE_BIN = $(PACKAGE_DIR)/bun
 PRETTIER ?= $(shell which prettier 2>/dev/null || echo "./node_modules/.bin/prettier")
 ESBUILD = "$(shell which esbuild 2>/dev/null || echo "./node_modules/.bin/esbuild")"
 DSYMUTIL ?= $(shell which dsymutil 2>/dev/null || which dsymutil-15 2>/dev/null)
-WEBKIT_DIR ?= $(realpath src/bun.js/WebKit)
+WEBKIT_DIR ?= $(realpath vendor/WebKit)
 WEBKIT_RELEASE_DIR ?= $(WEBKIT_DIR)/WebKitBuild/Release
 WEBKIT_DEBUG_DIR ?= $(WEBKIT_DIR)/WebKitBuild/Debug
 WEBKIT_RELEASE_DIR_LTO ?= $(WEBKIT_DIR)/WebKitBuild/ReleaseLTO
@@ -138,7 +138,7 @@ endif
 SED = $(shell which gsed 2>/dev/null || which sed 2>/dev/null)
 
 BUN_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-BUN_DEPS_DIR ?= $(shell pwd)/src/deps
+BUN_DEPS_DIR ?= $(shell pwd)/vendor
 BUN_DEPS_OUT_DIR ?= $(shell pwd)/build/bun-deps
 CPU_COUNT = 2
 ifeq ($(OS_NAME),darwin)
@@ -689,19 +689,10 @@ assert-deps:
 	@test $(shell cargo --version | awk '{print $$2}' | cut -d. -f2) -gt 57 || (echo -e "ERROR: cargo version must be at least 1.57."; exit 1)
 	@echo "You have the dependencies installed! Woo"
 
-# the following allows you to run `make submodule` to update or init submodules. but we will exclude webkit
-# unless you explicitly clone it yourself (a huge download)
-SUBMODULE_NAMES=$(shell cat .gitmodules | grep 'path = ' | awk '{print $$3}')
-ifeq ("$(wildcard src/bun.js/WebKit/.git)", "")
-	SUBMODULE_NAMES := $(filter-out src/bun.js/WebKit, $(SUBMODULE_NAMES))
-endif
 
 .PHONY: init-submodules
 init-submodules: submodule # (backwards-compatibility alias)
 
-.PHONY: submodule
-submodule: ## to init or update all submodules
-	git submodule update --init --recursive --progress --depth=1 --checkout $(SUBMODULE_NAMES)
 
 .PHONY: build-obj
 build-obj:
@@ -804,7 +795,7 @@ cls:
 	@echo -e "\n\n---\n\n"
 
 jsc-check:
-	@ls $(JSC_BASE_DIR)  >/dev/null 2>&1 || (echo -e "Failed to access WebKit build. Please compile the WebKit submodule using the Dockerfile at $(shell pwd)/src/javascript/WebKit/Dockerfile and then copy from /output in the Docker container to $(JSC_BASE_DIR). You can override the directory via JSC_BASE_DIR. \n\n 	DOCKER_BUILDKIT=1 docker build -t bun-webkit $(shell pwd)/src/bun.js/WebKit -f $(shell pwd)/src/bun.js/WebKit/Dockerfile --progress=plain\n\n 	docker container create bun-webkit\n\n 	# Get the container ID\n	docker container ls\n\n 	docker cp DOCKER_CONTAINER_ID_YOU_JUST_FOUND:/output $(JSC_BASE_DIR)" && exit 1)
+	@ls $(JSC_BASE_DIR)  >/dev/null 2>&1 || (echo -e "Failed to access WebKit build. Please compile the WebKit submodule using the Dockerfile at $(shell pwd)/src/javascript/WebKit/Dockerfile and then copy from /output in the Docker container to $(JSC_BASE_DIR). You can override the directory via JSC_BASE_DIR. \n\n 	DOCKER_BUILDKIT=1 docker build -t bun-webkit $(shell pwd)/vendor/WebKit -f $(shell pwd)/vendor/WebKit/Dockerfile --progress=plain\n\n 	docker container create bun-webkit\n\n 	# Get the container ID\n	docker container ls\n\n 	docker cp DOCKER_CONTAINER_ID_YOU_JUST_FOUND:/output $(JSC_BASE_DIR)" && exit 1)
 	@ls $(JSC_INCLUDE_DIR)  >/dev/null 2>&1 || (echo "Failed to access WebKit include directory at $(JSC_INCLUDE_DIR)." && exit 1)
 	@ls $(JSC_LIB)  >/dev/null 2>&1 || (echo "Failed to access WebKit lib directory at $(JSC_LIB)." && exit 1)
 
@@ -945,7 +936,7 @@ jsc-bindings: headers bindings
 
 .PHONY: clone-submodules
 clone-submodules:
-	git -c submodule."src/bun.js/WebKit".update=none submodule update --init --recursive --depth=1 --progress
+	git -c submodule."vendor/WebKit".update=none submodule update --init --recursive --depth=1 --progress
 
 
 .PHONY: headers
@@ -1379,7 +1370,7 @@ jsc-build-linux-compile-config-debug:
 			$(WEBKIT_DEBUG_DIR)
 
 # If you get "Error: could not load cache"
-# run  rm -rf src/bun.js/WebKit/CMakeCache.txt
+# run  rm -rf vendor/WebKit/CMakeCache.txt
 .PHONY: jsc-build-linux-compile-build
 jsc-build-linux-compile-build:
 		mkdir -p $(WEBKIT_RELEASE_DIR)  && \
@@ -1414,7 +1405,7 @@ jsc-build-copy-debug:
 	cp $(WEBKIT_DEBUG_DIR)/lib/libbmalloc.a $(BUN_DEPS_OUT_DIR)/libbmalloc.a
 
 clean-jsc:
-	cd src/bun.js/WebKit && rm -rf **/CMakeCache.txt **/CMakeFiles && rm -rf src/bun.js/WebKit/WebKitBuild
+	cd vendor/WebKit && rm -rf **/CMakeCache.txt **/CMakeFiles && rm -rf vendor/WebKit/WebKitBuild
 clean-bindings:
 	rm -rf $(OBJ_DIR)/*.o $(DEBUG_OBJ_DIR)/*.o $(DEBUG_OBJ_DIR)/webcore/*.o $(DEBUG_BINDINGS_OBJ) $(OBJ_DIR)/webcore/*.o $(BINDINGS_OBJ) $(OBJ_DIR)/*.d $(DEBUG_OBJ_DIR)/*.d
 

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ SED = $(shell which gsed 2>/dev/null || which sed 2>/dev/null)
 
 BUN_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BUN_DEPS_DIR ?= $(shell pwd)/vendor
-BUN_DEPS_OUT_DIR ?= $(shell pwd)/build/bun-deps
+BUN_DEPS_OUT_DIR ?= $(shell pwd)/build/release
 CPU_COUNT = 2
 ifeq ($(OS_NAME),darwin)
 CPU_COUNT = $(shell sysctl -n hw.logicalcpu)
@@ -1256,7 +1256,7 @@ jsc-build-mac-compile:
 			-DENABLE_STATIC_JSC=ON \
 			-DENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE=ON \
 			-DALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS=ON \
-			-DCMAKE_BUILD_TYPE=Release \
+			-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 			-DUSE_THIN_ARCHIVES=OFF \
 			-DBUN_FAST_TLS=ON \
 			-DENABLE_FTL_JIT=ON \
@@ -1268,7 +1268,7 @@ jsc-build-mac-compile:
 			$(WEBKIT_DIR) \
 			$(WEBKIT_RELEASE_DIR) && \
 	CFLAGS="$(CFLAGS) -ffat-lto-objects" CXXFLAGS="$(CXXFLAGS)  -ffat-lto-objects" \
-		cmake --build $(WEBKIT_RELEASE_DIR) --config Release --target jsc
+		cmake --build $(WEBKIT_RELEASE_DIR) --config RelWithDebInfo --target jsc
 
 .PHONY: jsc-build-mac-compile-lto
 jsc-build-mac-compile-lto:

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 4a2db3254a9535949a5d5380eb58cf0f77c8e15a)
+  set(WEBKIT_VERSION 76798f7b2fb287ee9f1ecce98bae895a2d026d93)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -110,7 +110,7 @@ bun build --compile --minify --sourcemap --bytecode ./path/to/my/app.ts --outfil
 
 Bytecode compilation moves moves parsing overhead for large input files from runtime to bundle time. Your app starts faster, in exchange for making the `bun build` command a little slower. It doesn't obscure source code.
 
-**Experimental:** Bytecode compilation is an experimental feature introduced in Bun v1.1.30
+**Experimental:** Bytecode compilation is an experimental feature introduced in Bun v1.1.30. Only `cjs` format is supported (which means no top-level-await). Let us know if you run into any issues!
 
 ### What do these flags do?
 

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -102,13 +102,17 @@ bun build --compile --minify --sourcemap ./path/to/my/app.ts --outfile myapp
 
 ### Bytecode compilation
 
-To improve startup time further, you can enable bytecode compilation:
+To improve startup time, enable bytecode compilation:
 
 ```sh
 bun build --compile --minify --sourcemap --bytecode ./path/to/my/app.ts --outfile myapp
 ```
 
-Bytecode compilation moves moves parsing overhead for large input files from runtime to bundle time. Your app starts faster, in exchange for making the `bun build` command a little slower. It doesn't obscure source code.
+Using bytecode compilation, `tsc` starts 2x faster:
+
+{% image src="https://github.com/user-attachments/assets/dc8913db-01d2-48f8-a8ef-ac4e984f9763" width="689" /%}
+
+Bytecode compilation moves parsing overhead for large input files from runtime to bundle time. Your app starts faster, in exchange for making the `bun build` command a little slower. It doesn't obscure source code.
 
 **Experimental:** Bytecode compilation is an experimental feature introduced in Bun v1.1.30. Only `cjs` format is supported (which means no top-level-await). Let us know if you run into any issues!
 

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -100,11 +100,25 @@ When deploying to production, we recommend the following:
 bun build --compile --minify --sourcemap ./path/to/my/app.ts --outfile myapp
 ```
 
-**What do these flags do?**
+### Bytecode compilation
+
+To improve startup time further, you can enable bytecode compilation:
+
+```sh
+bun build --compile --minify --sourcemap --bytecode ./path/to/my/app.ts --outfile myapp
+```
+
+Bytecode compilation moves moves parsing overhead for large input files from runtime to bundle time. Your app starts faster, in exchange for making the `bun build` command a little slower. It doesn't obscure source code.
+
+**Experimental:** Bytecode compilation is an experimental feature introduced in Bun v1.1.30
+
+### What do these flags do?
 
 The `--minify` argument optimizes the size of the transpiled output code. If you have a large application, this can save megabytes of space. For smaller applications, it might still improve start time a little.
 
 The `--sourcemap` argument embeds a sourcemap compressed with zstd, so that errors & stacktraces point to their original locations instead of the transpiled location. Bun will automatically decompress & resolve the sourcemap when an error occurs.
+
+The `--bytecode` argument enables bytecode compilation. Every time you run JavaScript code in Bun, JavaScriptCore (the engine) will compile your source code into bytecode. We can move this parsing work from runtime to bundle time, saving you startup time.
 
 ## Worker
 

--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -330,6 +330,8 @@ Depending on the target, Bun will apply different module resolution rules and op
 
   If any entrypoints contains a Bun shebang (`#!/usr/bin/env bun`) the bundler will default to `target: "bun"` instead of `"browser"`.
 
+  When using `target: "bun"` and `format: "cjs"` together, the `// @bun @bun-cjs` pragma is added and the CommonJS wrapper function is not compatible with Node.js.
+
 ---
 
 - `node`
@@ -1158,7 +1160,7 @@ Each artifact also contains the following properties:
 ---
 
 - `bytecode`
-- Generate bytecode for any JavaScript/TypeScript entrypoints. Only supported for `"cjs"` format, only supports `"target": "bun"` and dependent on a matching version of Bun. This adds a corresponding `.jsc` file for each entrypoint.
+- Generate bytecode for any JavaScript/TypeScript entrypoints. Only supported for `"cjs"` format, only supports `"target": "bun"` and dependent on a matching version of Bun. This adds a corresponding `.jsc` file for each entrypoint
 
 ---
 

--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -1160,7 +1160,7 @@ Each artifact also contains the following properties:
 ---
 
 - `bytecode`
-- Generate bytecode for any JavaScript/TypeScript entrypoints. Only supported for `"cjs"` format, only supports `"target": "bun"` and dependent on a matching version of Bun. This adds a corresponding `.jsc` file for each entrypoint
+- Generate bytecode for any JavaScript/TypeScript entrypoints. This can greatly improve startup times for large applications. Only supported for `"cjs"` format, only supports `"target": "bun"` and dependent on a matching version of Bun. This adds a corresponding `.jsc` file for each entrypoint
 
 ---
 

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -59,7 +59,7 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 - `--format`
 - `--format`
-- Bun only supports `"esm"` currently but other module formats are planned. esbuild defaults to `"iife"`.
+- Bun supports `"esm"` and `"cjs"` currently, but more module formats are planned. esbuild defaults to `"iife"`.
 
 ---
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1815,7 +1815,7 @@ declare module "bun" {
     path: string;
     loader: Loader;
     hash: string | null;
-    kind: "entry-point" | "chunk" | "asset" | "sourcemap";
+    kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode";
     sourcemap: BuildArtifact | null;
   }
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1497,13 +1497,35 @@ declare module "bun" {
     kind: ImportKind;
   }
 
-  type ModuleFormat = "esm"; // later: "cjs", "iife"
-
   interface BuildConfig {
     entrypoints: string[]; // list of file path
     outdir?: string; // output directory
     target?: Target; // default: "browser"
-    format?: ModuleFormat; // later: "cjs", "iife"
+    /**
+     * Output module format. Top-level await is only supported for `"esm"`.
+     *
+     * Can be:
+     * - `"esm"`
+     * - `"cjs"` (**experimental**)
+     * - `"iife"` (**experimental**)
+     *
+     * @default "esm"
+     */
+    format?: /**
+
+     * ECMAScript Module format
+     */
+    | "esm"
+      /**
+       * CommonJS format
+       * **Experimental**
+       */
+      | "cjs"
+      /**
+       * IIFE format
+       * **Experimental**
+       */
+      | "iife";
     naming?:
       | string
       | {
@@ -1561,6 +1583,18 @@ declare module "bun" {
     //       /** Only works when runtime=automatic */
     //       importSource?: string; // default: "react"
     //     };
+
+    /**
+     * Generate bytecode for the output. This can dramatically improve cold
+     * start times, but will make the final output larger and slightly increase
+     * memory usage.
+     *
+     * Bytecode is currently only supported for CommonJS (`format: "cjs"`).
+     *
+     * Must be `target: "bun"`
+     * @default false
+     */
+    bytecode?: boolean;
   }
 
   namespace Password {

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -75,8 +75,10 @@ pub const StandaloneModuleGraph = struct {
         name: Schema.StringPointer = .{},
         contents: Schema.StringPointer = .{},
         sourcemap: Schema.StringPointer = .{},
+        bytecode: Schema.StringPointer = .{},
         encoding: Encoding = .latin1,
         loader: bun.options.Loader = .file,
+        module_format: ModuleFormat = .none,
     };
 
     pub const Encoding = enum(u8) {
@@ -88,6 +90,12 @@ pub const StandaloneModuleGraph = struct {
         utf8 = 2,
     };
 
+    pub const ModuleFormat = enum(u8) {
+        none = 0,
+        esm = 1,
+        cjs = 2,
+    };
+
     pub const File = struct {
         name: []const u8 = "",
         loader: bun.options.Loader,
@@ -96,6 +104,8 @@ pub const StandaloneModuleGraph = struct {
         cached_blob: ?*bun.JSC.WebCore.Blob = null,
         encoding: Encoding = .binary,
         wtf_string: bun.String = bun.String.empty,
+        bytecode: []u8 = "",
+        module_format: ModuleFormat = .none,
 
         pub fn lessThanByIndex(ctx: []const File, lhs_i: u32, rhs_i: u32) bool {
             const lhs = ctx[lhs_i];
@@ -225,7 +235,7 @@ pub const StandaloneModuleGraph = struct {
         };
 
         const modules_list_bytes = sliceTo(raw_bytes, offsets.modules_ptr);
-        const modules_list = std.mem.bytesAsSlice(CompiledModuleGraphFile, modules_list_bytes);
+        const modules_list: []align(1) const CompiledModuleGraphFile = std.mem.bytesAsSlice(CompiledModuleGraphFile, modules_list_bytes);
 
         if (offsets.entry_point_id > modules_list.len) {
             return error.@"Corrupted module graph: entry point ID is greater than module list count";
@@ -246,6 +256,8 @@ pub const StandaloneModuleGraph = struct {
                         } }
                     else
                         .none,
+                    .bytecode = if (module.bytecode.length > 0) @constCast(sliceTo(raw_bytes, module.bytecode)) else &.{},
+                    .module_format = module.module_format,
                 },
             );
         }
@@ -271,14 +283,14 @@ pub const StandaloneModuleGraph = struct {
         return bytes[ptr.offset..][0..ptr.length :0];
     }
 
-    pub fn toBytes(allocator: std.mem.Allocator, prefix: []const u8, output_files: []const bun.options.OutputFile) ![]u8 {
+    pub fn toBytes(allocator: std.mem.Allocator, prefix: []const u8, output_files: []const bun.options.OutputFile, output_format: bun.options.Format) ![]u8 {
         var serialize_trace = bun.tracy.traceNamed(@src(), "StandaloneModuleGraph.serialize");
         defer serialize_trace.end();
 
         var entry_point_id: ?usize = null;
         var string_builder = bun.StringBuilder{};
         var module_count: usize = 0;
-        for (output_files, 0..) |output_file, i| {
+        for (output_files) |output_file| {
             string_builder.countZ(output_file.dest_path);
             string_builder.countZ(prefix);
             if (output_file.value == .buffer) {
@@ -288,10 +300,13 @@ pub const StandaloneModuleGraph = struct {
                     // the exact amount is not possible without allocating as it
                     // involves a JSON parser.
                     string_builder.cap += output_file.value.buffer.bytes.len * 2;
+                } else if (output_file.output_kind == .bytecode) {
+                    // Allocate up to 128 byte alignment for bytecode
+                    string_builder.cap += (output_file.value.buffer.bytes.len + 127) / 128 * 128;
                 } else {
                     if (entry_point_id == null) {
                         if (output_file.output_kind == .@"entry-point") {
-                            entry_point_id = i;
+                            entry_point_id = module_count;
                         }
                     }
 
@@ -320,7 +335,7 @@ pub const StandaloneModuleGraph = struct {
         defer source_map_arena.deinit();
 
         for (output_files) |output_file| {
-            if (output_file.output_kind == .sourcemap) {
+            if (!output_file.output_kind.isFileInStandaloneMode()) {
                 continue;
             }
 
@@ -329,6 +344,22 @@ pub const StandaloneModuleGraph = struct {
             }
 
             const dest_path = bun.strings.removeLeadingDotSlash(output_file.dest_path);
+
+            const bytecode: StringPointer = brk: {
+                if (output_file.bytecode_index != std.math.maxInt(u32)) {
+                    // Use up to 64 byte alignment for bytecode
+                    // Not aligning it correctly will cause a runtime assertion error.
+                    const bytecode = output_files[output_file.bytecode_index].value.buffer.bytes;
+                    const aligned = std.mem.alignInSlice(string_builder.writable(), 64).?;
+                    @memcpy(aligned[0..bytecode.len], bytecode[0..bytecode.len]);
+                    const offset = @intFromPtr(aligned.ptr) - @intFromPtr(string_builder.ptr.?);
+                    const len = bytecode.len;
+                    string_builder.len += len;
+                    break :brk StringPointer{ .offset = @truncate(offset), .length = @truncate(len) };
+                } else {
+                    break :brk .{};
+                }
+            };
 
             var module = CompiledModuleGraphFile{
                 .name = string_builder.fmtAppendCountZ("{s}{s}", .{
@@ -341,7 +372,14 @@ pub const StandaloneModuleGraph = struct {
                     .js, .jsx, .ts, .tsx => .latin1,
                     else => .binary,
                 },
+                .module_format = if (output_file.loader.isJavaScriptLike()) switch (output_format) {
+                    .cjs => .cjs,
+                    .esm => .esm,
+                    else => .none,
+                } else .none,
+                .bytecode = bytecode,
             };
+
             if (output_file.source_map_index != std.math.maxInt(u32)) {
                 defer source_map_header_list.clearRetainingCapacity();
                 defer source_map_string_list.clearRetainingCapacity();
@@ -619,8 +657,9 @@ pub const StandaloneModuleGraph = struct {
         module_prefix: []const u8,
         outfile: []const u8,
         env: *bun.DotEnv.Loader,
+        output_format: bun.options.Format,
     ) !void {
-        const bytes = try toBytes(allocator, module_prefix, output_files);
+        const bytes = try toBytes(allocator, module_prefix, output_files, output_format);
         if (bytes.len == 0) return;
 
         const fd = inject(

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -3,7 +3,8 @@
 /// Version 4: TypeScript enums are properly handled + more constant folding
 /// Version 5: `require.main === module` no longer marks a module as CJS
 /// Version 6: `use strict` is preserved in CommonJS modules when at the top of the file
-const expected_version = 6;
+/// Version 7: Several bundler changes that are likely to impact the runtime as well.
+const expected_version = 7;
 
 const bun = @import("root").bun;
 const std = @import("std");

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -166,7 +166,7 @@ pub const JSBundler = struct {
             if (try config.getOwnOptionalEnum(globalThis, "target", options.Target)) |target| {
                 this.target = target;
 
-                if (this.target != .bun and this.bytecode) {
+                if (target != .bun and this.bytecode) {
                     globalThis.throwInvalidArguments("target must be 'bun' when bytecode is true", .{});
                     return error.JSError;
                 }
@@ -203,8 +203,8 @@ pub const JSBundler = struct {
             if (try config.getOwnOptionalEnum(globalThis, "format", options.Format)) |format| {
                 this.format = format;
 
-                if (this.bytecode and !(this.format == .esm or this.format == .cjs)) {
-                    globalThis.throwInvalidArguments("format must be 'esm' or 'cjs' when bytecode is true", .{});
+                if (this.bytecode and format != .cjs) {
+                    globalThis.throwInvalidArguments("format must be 'cjs' when bytecode is true. Eventually we'll add esm support as well.", .{});
                     return error.JSError;
                 }
             }

--- a/src/bun.js/bindings/CommonJSModuleRecord.cpp
+++ b/src/bun.js/bindings/CommonJSModuleRecord.cpp
@@ -763,7 +763,7 @@ void populateESMExports(
     bool ignoreESModuleAnnotation)
 {
     auto& vm = globalObject->vm();
-    Identifier esModuleMarker = builtinNames(vm).__esModulePublicName();
+    const Identifier& esModuleMarker = builtinNames(vm).__esModulePublicName();
 
     // Bun's intepretation of the "__esModule" annotation:
     //

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -194,6 +194,10 @@ Structure* createMemoryFootprintStructure(JSC::VM& vm, JSC::JSGlobalObject* glob
 extern "C" WebCore::Worker* WebWorker__getParentWorker(void*);
 
 #ifndef BUN_WEBKIT_VERSION
+#ifndef ASSERT_ENABLED
+#warning "BUN_WEBKIT_VERSION is not defined. WebKit's cmakeconfig.h is supposed to define that. If you're building a release build locally, ignore this warning. If you're seeing this warning in CI, please file an issue."
+#endif
+
 #define WEBKIT_BYTECODE_CACHE_HASH_KEY __TIMESTAMP__
 #else
 #define WEBKIT_BYTECODE_CACHE_HASH_KEY BUN_WEBKIT_VERSION

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -149,6 +149,7 @@
 #include "ErrorCode.h"
 #include "v8/shim/GlobalInternals.h"
 #include "EventLoopTask.h"
+#include <JavaScriptCore/JSCBytecodeCacheVersion.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JavaScriptCore/RemoteInspectorServer.h"
@@ -191,6 +192,23 @@ static bool has_loaded_jsc = false;
 Structure* createMemoryFootprintStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
 
 extern "C" WebCore::Worker* WebWorker__getParentWorker(void*);
+
+#ifndef BUN_WEBKIT_VERSION
+#define WEBKIT_BYTECODE_CACHE_HASH_KEY __TIMESTAMP__
+#else
+#define WEBKIT_BYTECODE_CACHE_HASH_KEY BUN_WEBKIT_VERSION
+#endif
+static consteval unsigned getWebKitBytecodeCacheVersion()
+{
+    return WTF::SuperFastHash::computeHash(WEBKIT_BYTECODE_CACHE_HASH_KEY);
+}
+#undef WEBKIT_BYTECODE_CACHE_HASH_KEY
+
+extern "C" unsigned getJSCBytecodeCacheVersion()
+{
+    return getWebKitBytecodeCacheVersion();
+}
+
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode)
 {
     // NOLINTBEGIN
@@ -222,6 +240,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         JSC::Options::evalMode() = evalMode;
         JSC::Options::usePromiseTryMethod() = true;
         JSC::Options::useRegExpEscape() = true;
+        JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
 #ifdef BUN_DEBUG
         JSC::Options::showPrivateScriptsInStackTraces() = true;

--- a/src/bun.js/bindings/ZigSourceProvider.h
+++ b/src/bun.js/bindings/ZigSourceProvider.h
@@ -45,9 +45,9 @@ public:
     unsigned hash() const override;
     StringView source() const override { return StringView(m_source.get()); }
 
-    RefPtr<JSC::CachedBytecode> cachedBytecode()
+    RefPtr<JSC::CachedBytecode> cachedBytecode() const final
     {
-        return nullptr;
+        return m_cachedBytecode.copyRef();
     };
 
     void updateCache(const UnlinkedFunctionExecutable* executable, const SourceCode&,

--- a/src/bun.js/bindings/ZigSourceProvider.h
+++ b/src/bun.js/bindings/ZigSourceProvider.h
@@ -43,7 +43,7 @@ public:
         bool isBuiltIn = false);
     ~SourceProvider();
     unsigned hash() const override;
-    StringView source() const override { return StringView(m_source.get()); }
+    StringView source() const override;
 
     RefPtr<JSC::CachedBytecode> cachedBytecode() const final
     {

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -105,6 +105,83 @@ pub const JSObject = extern struct {
     };
 };
 
+pub const CachedBytecode = opaque {
+    extern fn generateCachedModuleByteCodeFromSourceCode(sourceProviderURL: *bun.String, input_code: [*]const u8, inputSourceCodeSize: usize, outputByteCode: *?[*]u8, outputByteCodeSize: *usize, cached_bytecode: *?*CachedBytecode) bool;
+    extern fn generateCachedCommonJSProgramByteCodeFromSourceCode(sourceProviderURL: *bun.String, input_code: [*]const u8, inputSourceCodeSize: usize, outputByteCode: *?[*]u8, outputByteCodeSize: *usize, cached_bytecode: *?*CachedBytecode) bool;
+
+    pub fn generateForESM(sourceProviderURL: *bun.String, input: []const u8) ?struct { []const u8, *CachedBytecode } {
+        var this: ?*CachedBytecode = null;
+
+        var input_code_size: usize = 0;
+        var input_code_ptr: ?[*]u8 = null;
+        if (generateCachedModuleByteCodeFromSourceCode(sourceProviderURL, input.ptr, input.len, &input_code_ptr, &input_code_size, &this)) {
+            return .{ input_code_ptr.?[0..input_code_size], this.? };
+        }
+
+        return null;
+    }
+
+    pub fn generateForCJS(sourceProviderURL: *bun.String, input: []const u8) ?struct { []const u8, *CachedBytecode } {
+        var this: ?*CachedBytecode = null;
+        var input_code_size: usize = 0;
+        var input_code_ptr: ?[*]u8 = null;
+        if (generateCachedCommonJSProgramByteCodeFromSourceCode(sourceProviderURL, input.ptr, input.len, &input_code_ptr, &input_code_size, &this)) {
+            return .{ input_code_ptr.?[0..input_code_size], this.? };
+        }
+
+        return null;
+    }
+
+    extern "C" fn CachedBytecode__deref(this: *CachedBytecode) void;
+    pub fn deref(this: *CachedBytecode) void {
+        return CachedBytecode__deref(this);
+    }
+
+    pub fn generate(format: bun.options.Format, input: []const u8, source_provider_url: *bun.String) ?struct { []const u8, *CachedBytecode } {
+        return switch (format) {
+            .esm => generateForESM(source_provider_url, input),
+            .cjs => generateForCJS(source_provider_url, input),
+            else => null,
+        };
+    }
+
+    pub const VTable = &std.mem.Allocator.VTable{
+        .alloc = struct {
+            pub fn alloc(ctx: *anyopaque, len: usize, ptr_align: u8, ret_addr: usize) ?[*]u8 {
+                _ = ctx; // autofix
+                _ = len; // autofix
+                _ = ptr_align; // autofix
+                _ = ret_addr; // autofix
+                @panic("Unexpectedly called CachedBytecode.alloc");
+            }
+        }.alloc,
+        .resize = struct {
+            pub fn resize(ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, ret_addr: usize) bool {
+                _ = ctx; // autofix
+                _ = buf; // autofix
+                _ = buf_align; // autofix
+                _ = new_len; // autofix
+                _ = ret_addr; // autofix
+                return false;
+            }
+        }.resize,
+        .free = struct {
+            pub fn free(ctx: *anyopaque, buf: []u8, buf_align: u8, _: usize) void {
+                _ = buf; // autofix
+                _ = buf_align; // autofix
+                CachedBytecode__deref(@ptrCast(ctx));
+            }
+        }.free,
+    };
+
+    pub fn allocator(this: *CachedBytecode) std.mem.Allocator {
+        return .{
+            .ptr = this,
+            .vtable = VTable,
+        };
+    }
+};
+
 /// Prefer using bun.String instead of ZigString in new code.
 pub const ZigString = extern struct {
     /// This can be a UTF-16, Latin1, or UTF-8 string.

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -215,6 +215,8 @@ pub const ResolvedSource = extern struct {
     /// This is for source_code
     source_code_needs_deref: bool = true,
     already_bundled: bool = false,
+    bytecode_cache: ?[*]u8 = null,
+    bytecode_cache_size: usize = 0,
 
     pub const Tag = @import("ResolvedSourceTag").ResolvedSourceTag;
 };

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -101,6 +101,8 @@ typedef struct ResolvedSource {
     uint32_t tag;
     bool needsDeref;
     bool already_bundled;
+    uint8_t* bytecode_cache;
+    size_t bytecode_cache_size;
 } ResolvedSource;
 static const uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2747,12 +2747,12 @@ pub const VirtualMachine = struct {
                 return promise;
             }
 
-            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(main_file_name)) orelse return error.JSError;
+            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.fromBytes(this.main)) orelse return error.JSError;
             this.pending_internal_promise = promise;
             JSC.JSValue.fromCell(promise).ensureStillAlive();
             return promise;
         } else {
-            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(this.main)) orelse return error.JSError;
+            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.fromBytes(this.main)) orelse return error.JSError;
             this.pending_internal_promise = promise;
             JSC.JSValue.fromCell(promise).ensureStillAlive();
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2747,7 +2747,7 @@ pub const VirtualMachine = struct {
                 return promise;
             }
 
-            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.fromBytes(this.main)) orelse return error.JSError;
+            const promise = JSModuleLoader.loadAndEvaluateModule(this.global, &String.init(main_file_name)) orelse return error.JSError;
             this.pending_internal_promise = promise;
             JSC.JSValue.fromCell(promise).ensureStillAlive();
             return promise;

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -585,7 +585,7 @@ pub const RuntimeTranspilerStore = struct {
                     .already_bundled = true,
                     .hash = 0,
                     .bytecode_cache = if (bytecode_slice.len > 0) bytecode_slice.ptr else null,
-                    .bytecode_cache_size = if (bytecode_slice.len > 0) bytecode_slice.len else 0,
+                    .bytecode_cache_size = bytecode_slice.len,
                     .is_commonjs_module = parse_result.already_bundled.isCommonJS(),
                 };
                 this.resolved_source.source_code.ensureHash();

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -576,6 +576,7 @@ pub const RuntimeTranspilerStore = struct {
 
             if (parse_result.already_bundled != .none) {
                 const duped = String.createUTF8(specifier);
+                const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                 this.resolved_source = ResolvedSource{
                     .allocator = null,
                     .source_code = bun.String.createLatin1(parse_result.source.contents),
@@ -583,8 +584,9 @@ pub const RuntimeTranspilerStore = struct {
                     .source_url = duped.createIfDifferent(path.text),
                     .already_bundled = true,
                     .hash = 0,
-                    .bytecode_cache = if (parse_result.already_bundled == .bytecode) parse_result.already_bundled.bytecode.ptr else null,
-                    .bytecode_cache_size = if (parse_result.already_bundled == .bytecode) parse_result.already_bundled.bytecode.len else 0,
+                    .bytecode_cache = if (bytecode_slice.len > 0) bytecode_slice.ptr else null,
+                    .bytecode_cache_size = if (bytecode_slice.len > 0) bytecode_slice.len else 0,
+                    .is_commonjs_module = parse_result.already_bundled.isCommonJS(),
                 };
                 this.resolved_source.source_code.ensureHash();
                 return;
@@ -1765,6 +1767,7 @@ pub const ModuleLoader = struct {
                 }
 
                 if (parse_result.already_bundled != .none) {
+                    const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                     return ResolvedSource{
                         .allocator = null,
                         .source_code = bun.String.createLatin1(parse_result.source.contents),
@@ -1772,8 +1775,9 @@ pub const ModuleLoader = struct {
                         .source_url = input_specifier.createIfDifferent(path.text),
                         .already_bundled = true,
                         .hash = 0,
-                        .bytecode_cache = if (parse_result.already_bundled == .bytecode) parse_result.already_bundled.bytecode.ptr else null,
-                        .bytecode_cache_size = if (parse_result.already_bundled == .bytecode) parse_result.already_bundled.bytecode.len else 0,
+                        .bytecode_cache = if (bytecode_slice.len > 0) bytecode_slice.ptr else null,
+                        .bytecode_cache_size = if (bytecode_slice.len > 0) bytecode_slice.len else 0,
+                        .is_commonjs_module = parse_result.already_bundled.isCommonJS(),
                     };
                 }
 

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2578,6 +2578,9 @@ pub const ModuleLoader = struct {
                     .source_url = specifier.dupeRef(),
                     .hash = 0,
                     .source_code_needs_deref = false,
+                    .bytecode_cache = if (file.bytecode.len > 0) file.bytecode.ptr else null,
+                    .bytecode_cache_size = file.bytecode.len,
+                    .is_commonjs_module = file.module_format == .cjs,
                 };
             }
         }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3821,4 +3821,4 @@ pub fn WeakPtr(comptime T: type, comptime weakable_field: std.meta.FieldEnum(T))
     };
 }
 
-pub const bytecode_extension = ".bun";
+pub const bytecode_extension = ".jsc";

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3820,3 +3820,5 @@ pub fn WeakPtr(comptime T: type, comptime weakable_field: std.meta.FieldEnum(T))
         }
     };
 }
+
+pub const bytecode_extension = ".bun";

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3254,7 +3254,7 @@ pub const ParseTask = struct {
         opts.features.allow_runtime = !source.index.isRuntime();
         opts.features.unwrap_commonjs_to_esm = output_format == .esm and FeatureFlags.unwrap_commonjs_to_esm;
         opts.features.use_import_meta_require = target.isBun();
-        opts.features.top_level_await = true;
+        opts.features.top_level_await = output_format == .esm or output_format == .internal_kit_dev;
         opts.features.auto_import_jsx = task.jsx.parse and bundler.options.auto_import_jsx;
         opts.features.trim_unused_imports = loader.isTypeScript() or (bundler.options.trim_unused_imports orelse false);
         opts.features.inlining = bundler.options.minify_syntax;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3242,25 +3242,28 @@ pub const ParseTask = struct {
         else
             bundler.options.target;
 
+        const output_format = bundler.options.output_format;
+
         var opts = js_parser.Parser.Options.init(task.jsx, loader);
         opts.bundle = true;
         opts.warn_about_unbundled_modules = false;
         opts.macro_context = &this.data.macro_context;
         opts.package_version = task.package_version;
 
-        opts.features.auto_polyfill_require = bundler.options.output_format == .esm and !target.isBun();
+        opts.features.auto_polyfill_require = output_format == .esm and !target.isBun();
         opts.features.allow_runtime = !source.index.isRuntime();
+        opts.features.unwrap_commonjs_to_esm = output_format == .esm and FeatureFlags.unwrap_commonjs_to_esm;
         opts.features.use_import_meta_require = target.isBun();
         opts.features.top_level_await = true;
         opts.features.auto_import_jsx = task.jsx.parse and bundler.options.auto_import_jsx;
         opts.features.trim_unused_imports = loader.isTypeScript() or (bundler.options.trim_unused_imports orelse false);
         opts.features.inlining = bundler.options.minify_syntax;
-        opts.output_format = bundler.options.output_format;
+        opts.output_format = output_format;
         opts.features.minify_syntax = bundler.options.minify_syntax;
         opts.features.minify_identifiers = bundler.options.minify_identifiers;
         opts.features.emit_decorator_metadata = bundler.options.emit_decorator_metadata;
         opts.features.unwrap_commonjs_packages = bundler.options.unwrap_commonjs_packages;
-        opts.features.hot_module_reloading = bundler.options.output_format == .internal_kit_dev and !source.index.isRuntime();
+        opts.features.hot_module_reloading = output_format == .internal_kit_dev and !source.index.isRuntime();
         opts.features.react_fast_refresh = target == .browser and
             bundler.options.react_fast_refresh and
             loader.isJSX() and

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3760,6 +3760,8 @@ pub const JSMeta = struct {
 
 pub const Graph = struct {
     generate_bytecode_cache: bool = false,
+
+    // TODO: consider removing references to this in favor of bundler.options.code_splitting
     code_splitting: bool = false,
 
     pool: *ThreadPool,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -828,10 +828,7 @@ pub const Arguments = struct {
                         bun.Output.warn("--format={s} is for debugging only, and may experience breaking changes at any moment", .{format_str});
                         bun.Output.flush();
                     },
-                    .cjs => {
-                        bun.Output.warn("--format={s} is highly experimental and may experience breaking changes at any moment", .{format_str});
-                        bun.Output.flush();
-                    },
+                    .cjs => {},
                     else => {},
                 }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -237,6 +237,7 @@ pub const Arguments = struct {
 
     const build_only_params = [_]ParamType{
         clap.parseParam("--compile                        Generate a standalone Bun executable containing your bundled code") catch unreachable,
+        clap.parseParam("--bytecode                       Use a bytecode cache") catch unreachable,
         clap.parseParam("--watch                          Automatically restart the process on file change") catch unreachable,
         clap.parseParam("--no-clear-screen                Disable clearing the terminal screen on reload when --watch is enabled") catch unreachable,
         clap.parseParam("--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\"") catch unreachable,
@@ -725,6 +726,7 @@ pub const Arguments = struct {
 
         if (cmd == .BuildCommand) {
             ctx.bundler_options.transform_only = args.flag("--no-bundle");
+            ctx.bundler_options.bytecode = args.flag("--bytecode");
 
             if (args.option("--public-path")) |public_path| {
                 ctx.bundler_options.public_path = public_path;
@@ -1344,6 +1346,7 @@ pub const Command = struct {
             ignore_dce_annotations: bool = false,
             emit_dce_annotations: bool = true,
             output_format: options.Format = .esm,
+            bytecode: bool = false,
         };
 
         pub fn create(allocator: std.mem.Allocator, log: *logger.Log, comptime command: Command.Tag) anyerror!Context {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -834,7 +834,11 @@ pub const Arguments = struct {
                         bun.Output.warn("--format={s} is for debugging only, and may experience breaking changes at any moment", .{format_str});
                         bun.Output.flush();
                     },
-                    .cjs => {},
+                    .cjs => {
+                        if (ctx.args.target == null) {
+                            ctx.args.target = .node;
+                        }
+                    },
                     else => {},
                 }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -791,6 +791,11 @@ pub const Arguments = struct {
 
                 if (opts.target.? == .bun)
                     ctx.debug.run_in_bun = opts.target.? == .bun;
+
+                if (opts.target.? != .bun and ctx.bundler_options.bytecode) {
+                    Output.errGeneric("target must be 'bun' when bytecode is true. Received: {s}", .{@tagName(opts.target.?)});
+                    Global.exit(1);
+                }
             }
 
             if (args.flag("--watch")) {
@@ -843,6 +848,10 @@ pub const Arguments = struct {
                 }
 
                 ctx.bundler_options.output_format = format;
+                if (format != .cjs and ctx.bundler_options.bytecode) {
+                    Output.errGeneric("format must be 'cjs' when bytecode is true. Eventually we'll add esm support as well.", .{});
+                    Global.exit(1);
+                }
             }
 
             if (args.flag("--splitting")) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -829,12 +829,8 @@ pub const Arguments = struct {
                         bun.Output.flush();
                     },
                     .cjs => {
-                        // Make this a soft error in debug to allow experimenting with these flags.
-                        const function = if (Environment.isDebug) Output.debugWarn else Output.errGeneric;
-                        function("Format '{s}' are not implemented", .{@tagName(format)});
-                        if (!Environment.isDebug) {
-                            Global.crash();
-                        }
+                        bun.Output.warn("--format={s} is highly experimental and may experience breaking changes at any moment", .{format_str});
+                        bun.Output.flush();
                     },
                     else => {},
                 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -731,6 +731,7 @@ pub const Arguments = struct {
             // TODO: support --format=esm
             if (ctx.bundler_options.bytecode) {
                 ctx.bundler_options.output_format = .cjs;
+                ctx.args.target = .bun;
             }
 
             if (args.option("--public-path")) |public_path| {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -728,6 +728,11 @@ pub const Arguments = struct {
             ctx.bundler_options.transform_only = args.flag("--no-bundle");
             ctx.bundler_options.bytecode = args.flag("--bytecode");
 
+            // TODO: support --format=esm
+            if (ctx.bundler_options.bytecode) {
+                ctx.bundler_options.output_format = .cjs;
+            }
+
             if (args.option("--public-path")) |public_path| {
                 ctx.bundler_options.public_path = public_path;
             }

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -42,7 +42,7 @@ pub const BuildCommand = struct {
         Global.configureAllocator(.{ .long_running = true });
         const allocator = ctx.allocator;
         var log = ctx.log;
-        if (ctx.bundler_options.compile) {
+        if (ctx.bundler_options.compile or ctx.bundler_options.bytecode) {
             // set this early so that externals are set up correctly and define is right
             ctx.args.target = .bun;
         }

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -96,12 +96,15 @@ pub const BuildCommand = struct {
         this_bundler.options.minify_identifiers = ctx.bundler_options.minify_identifiers;
         this_bundler.options.emit_dce_annotations = ctx.bundler_options.emit_dce_annotations;
         this_bundler.options.ignore_dce_annotations = ctx.bundler_options.ignore_dce_annotations;
+
         this_bundler.options.output_dir = ctx.bundler_options.outdir;
         this_bundler.options.output_format = ctx.bundler_options.output_format;
 
         if (ctx.bundler_options.output_format == .internal_kit_dev) {
             this_bundler.options.tree_shaking = false;
         }
+
+        this_bundler.options.bytecode = ctx.bundler_options.bytecode;
 
         if (ctx.bundler_options.compile) {
             if (ctx.bundler_options.code_splitting) {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -392,6 +392,7 @@ pub const BuildCommand = struct {
                             this_bundler.options.public_path,
                             outfile,
                             this_bundler.env,
+                            this_bundler.options.output_format,
                         );
                         const compiled_elapsed = @divTrunc(@as(i64, @truncate(std.time.nanoTimestamp() - bundled_end)), @as(i64, std.time.ns_per_ms));
                         const compiled_elapsed_digit_count: isize = switch (compiled_elapsed) {

--- a/src/js/builtins/Module.ts
+++ b/src/js/builtins/Module.ts
@@ -76,9 +76,7 @@ export function overridableRequire(this: CommonJSModuleRecord, id: string) {
     // If we can pull out a ModuleNamespaceObject, let's do it.
     if (esm?.evaluated && (esm.state ?? 0) >= $ModuleReady) {
       const namespace = Loader.getModuleNamespaceObject(esm!.module);
-      return (mod.exports =
-        // if they choose a module
-        namespace.__esModule ? namespace : Object.create(namespace, { __esModule: { value: true } }));
+      return (mod.exports = namespace);
     }
   }
 

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -7496,9 +7496,14 @@ pub const Part = struct {
 };
 
 pub const Result = union(enum) {
-    already_bundled: void,
+    already_bundled: AlreadyBundled,
     cached: void,
     ast: Ast,
+
+    pub const AlreadyBundled = enum {
+        bun,
+        bytecode,
+    };
 };
 
 pub const StmtOrExpr = union(enum) {

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -7502,7 +7502,9 @@ pub const Result = union(enum) {
 
     pub const AlreadyBundled = enum {
         bun,
+        bun_cjs,
         bytecode,
+        bytecode_cjs,
     };
 };
 

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6977,8 +6977,7 @@ pub const BundledAst = struct {
         force_cjs_to_esm: bool = false,
         has_lazy_export: bool = false,
         commonjs_module_exports_assigned_deoptimized: bool = false,
-
-        _: u1 = 0,
+        has_explicit_use_strict_directive: bool = false,
     };
 
     pub const empty = BundledAst.init(Ast.empty);
@@ -7028,6 +7027,7 @@ pub const BundledAst = struct {
             .force_cjs_to_esm = this.flags.force_cjs_to_esm,
             .has_lazy_export = this.flags.has_lazy_export,
             .commonjs_module_exports_assigned_deoptimized = this.flags.commonjs_module_exports_assigned_deoptimized,
+            .directive = if (this.flags.has_explicit_use_strict_directive) "use strict" else null,
         };
     }
 
@@ -7080,6 +7080,7 @@ pub const BundledAst = struct {
                 .force_cjs_to_esm = ast.force_cjs_to_esm,
                 .has_lazy_export = ast.has_lazy_export,
                 .commonjs_module_exports_assigned_deoptimized = ast.commonjs_module_exports_assigned_deoptimized,
+                .has_explicit_use_strict_directive = strings.eqlComptime(ast.directive orelse "", "use strict"),
             },
         };
     }

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -175,7 +175,9 @@ fn NewLexer_(
         bun_pragma: enum {
             none,
             bun,
+            bun_cjs,
             bytecode,
+            bytecode_cjs,
         } = .none,
         source_mapping_url: ?js_ast.Span = null,
         number: f64 = 0.0,
@@ -2027,7 +2029,7 @@ fn NewLexer_(
                                         // }
                                     }
 
-                                    if (strings.hasPrefixWithWordBoundary(chunk, "bun")) {
+                                    if (lexer.bun_pragma == .none and strings.hasPrefixWithWordBoundary(chunk, "bun")) {
                                         lexer.bun_pragma = .bun;
                                     } else if (strings.hasPrefixWithWordBoundary(chunk, "jsx")) {
                                         if (PragmaArg.scan(.skip_space_first, lexer.start + i + 1, "jsx", chunk)) |span| {
@@ -2049,8 +2051,10 @@ fn NewLexer_(
                                         if (PragmaArg.scan(.no_space_first, lexer.start + i + 1, " sourceMappingURL=", chunk)) |span| {
                                             lexer.source_mapping_url = span;
                                         }
-                                    } else if (lexer.bun_pragma == .bun and strings.hasPrefixWithWordBoundary(chunk, "bytecode")) {
-                                        lexer.bun_pragma = .bytecode;
+                                    } else if ((lexer.bun_pragma == .bun or lexer.bun_pragma == .bun_cjs) and strings.hasPrefixWithWordBoundary(chunk, "bytecode")) {
+                                        lexer.bun_pragma = if (lexer.bun_pragma == .bun) .bytecode else .bytecode_cjs;
+                                    } else if ((lexer.bun_pragma == .bytecode or lexer.bun_pragma == .bun) and strings.hasPrefixWithWordBoundary(chunk, "bun-cjs")) {
+                                        lexer.bun_pragma = if (lexer.bun_pragma == .bytecode) .bytecode_cjs else .bun_cjs;
                                     }
                                 },
                                 else => {},
@@ -2080,7 +2084,7 @@ fn NewLexer_(
                             }
                         }
 
-                        if (strings.hasPrefixWithWordBoundary(chunk, "bun")) {
+                        if (lexer.bun_pragma == .none and strings.hasPrefixWithWordBoundary(chunk, "bun")) {
                             lexer.bun_pragma = .bun;
                         } else if (strings.hasPrefixWithWordBoundary(chunk, "jsx")) {
                             if (PragmaArg.scan(.skip_space_first, lexer.start + i + 1, "jsx", chunk)) |span| {
@@ -2102,8 +2106,10 @@ fn NewLexer_(
                             if (PragmaArg.scan(.no_space_first, lexer.start + i + 1, " sourceMappingURL=", chunk)) |span| {
                                 lexer.source_mapping_url = span;
                             }
-                        } else if (lexer.bun_pragma == .bun and strings.hasPrefixWithWordBoundary(chunk, "bytecode")) {
-                            lexer.bun_pragma = .bytecode;
+                        } else if ((lexer.bun_pragma == .bun or lexer.bun_pragma == .bun_cjs) and strings.hasPrefixWithWordBoundary(chunk, "bytecode")) {
+                            lexer.bun_pragma = if (lexer.bun_pragma == .bun) .bytecode else .bytecode_cjs;
+                        } else if ((lexer.bun_pragma == .bytecode or lexer.bun_pragma == .bun) and strings.hasPrefixWithWordBoundary(chunk, "bun-cjs")) {
+                            lexer.bun_pragma = if (lexer.bun_pragma == .bytecode) .bytecode_cjs else .bun_cjs;
                         }
                     },
                     else => {},

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -2895,6 +2895,7 @@ pub const Parser = struct {
         warn_about_unbundled_modules: bool = true,
 
         module_type: options.ModuleType = .unknown,
+        output_format: options.Format = .esm,
 
         transform_only: bool = false,
 
@@ -3231,6 +3232,8 @@ pub const Parser = struct {
                 .already_bundled = switch (p.lexer.bun_pragma) {
                     .bun => .bun,
                     .bytecode => .bytecode,
+                    .bytecode_cjs => .bytecode_cjs,
+                    .bun_cjs => .bun_cjs,
                     else => unreachable,
                 },
             };
@@ -17641,7 +17644,7 @@ fn NewParser_(
         /// If --target=bun, this does nothing.
         fn recordUsageOfRuntimeRequire(p: *P) void {
             // target bun does not have __require
-            if (!p.options.features.use_import_meta_require) {
+            if (p.options.features.auto_polyfill_require) {
                 bun.assert(p.options.features.allow_runtime);
 
                 p.ensureRequireSymbol();
@@ -17650,9 +17653,7 @@ fn NewParser_(
         }
 
         fn ignoreUsageOfRuntimeRequire(p: *P) void {
-            if (!p.options.features.use_import_meta_require and
-                p.options.features.allow_runtime)
-            {
+            if (p.options.features.auto_polyfill_require) {
                 bun.assert(p.runtime_imports.__require != null);
                 p.ignoreUsage(p.runtimeIdentifierRef(logger.Loc.Empty, "__require"));
                 p.symbols.items[p.require_ref.innerIndex()].use_count_estimate -|= 1;

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -23516,6 +23516,7 @@ fn NewParser_(
                 .export_keyword = p.esm_export_keyword,
                 .top_level_symbols_to_parts = top_level_symbols_to_parts,
                 .char_freq = p.computeCharacterFrequency(),
+                .directive = if (p.module_scope.strict_mode == .explicit_strict_mode) "use strict" else null,
 
                 // Assign slots to symbols in nested scopes. This is some precomputation for
                 // the symbol renaming pass that will happen later in the linker. It's done

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3226,9 +3226,13 @@ pub const Parser = struct {
         }
 
         // Detect a leading "// @bun" pragma
-        if (p.lexer.bun_pragma and p.options.features.dont_bundle_twice) {
+        if (p.lexer.bun_pragma != .none and p.options.features.dont_bundle_twice) {
             return js_ast.Result{
-                .already_bundled = {},
+                .already_bundled = switch (p.lexer.bun_pragma) {
+                    .bun => .bun,
+                    .bytecode => .bytecode,
+                    else => unreachable,
+                },
             };
         }
 

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -5344,9 +5344,8 @@ fn NewParser_(
             }
         }
 
-        pub fn shouldUnwrapCommonJSToESM(p: *P) bool {
-            // hot module loading opts out of this because we want to produce a cjs bundle at the end
-            return FeatureFlags.unwrap_commonjs_to_esm and !p.options.features.hot_module_reloading;
+        pub inline fn shouldUnwrapCommonJSToESM(p: *const P) bool {
+            return p.options.features.unwrap_commonjs_to_esm;
         }
 
         fn isBindingUsed(p: *P, binding: Binding, default_export_ref: Ref) bool {

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1939,6 +1939,7 @@ fn NewPrinter(
 
             assert(p.import_records.len > import_record_index);
             const record = p.importRecord(import_record_index);
+            const module_type = p.options.module_type;
 
             if (comptime is_bun_platform) {
                 // "bun" is not a real module. It's just globalThis.Bun.
@@ -1962,13 +1963,13 @@ fn NewPrinter(
                     },
                     .bun_test => {
                         if (record.kind == .dynamic) {
-                            if (p.options.module_type == .cjs) {
+                            if (module_type == .cjs) {
                                 p.print("Promise.resolve(globalThis.Bun.jest(__filename))");
                             } else {
                                 p.print("Promise.resolve(globalThis.Bun.jest(import.meta.path))");
                             }
                         } else if (record.kind == .require) {
-                            if (p.options.module_type == .cjs) {
+                            if (module_type == .cjs) {
                                 p.print("globalThis.Bun.jest(__filename)");
                             } else {
                                 p.print("globalThis.Bun.jest(import.meta.path)");
@@ -2027,7 +2028,7 @@ fn NewPrinter(
                 }
 
                 if (p.options.input_files_for_kit) |input_files| {
-                    bun.assert(p.options.module_type == .internal_kit_dev);
+                    bun.assert(module_type == .internal_kit_dev);
                     p.printSpaceBeforeIdentifier();
                     p.printSymbol(p.options.commonjs_module_ref);
                     p.print(".require(");
@@ -2070,7 +2071,7 @@ fn NewPrinter(
                 }
 
                 if (wrap_with_to_esm) {
-                    if (p.options.module_type.isESM()) {
+                    if (module_type.isESM()) {
                         p.print(",");
                         p.printSpace();
                         p.print("1");
@@ -2097,7 +2098,9 @@ fn NewPrinter(
                     }
                 }
 
-                if (p.options.module_type == .internal_kit_dev) {
+                const wrap_with_to_esm = record.wrap_with_to_esm;
+
+                if (module_type == .internal_kit_dev) {
                     p.printSpaceBeforeIdentifier();
                     p.printSymbol(p.options.commonjs_module_ref);
                     if (record.tag == .builtin)
@@ -2112,9 +2115,13 @@ fn NewPrinter(
                     }
                     p.print(")");
                     return;
+                } else if (wrap_with_to_esm) {
+                    p.printSpaceBeforeIdentifier();
+                    p.printSymbol(p.options.to_esm_ref);
+                    p.print("(");
                 }
 
-                if (p.options.module_type == .esm and is_bun_platform) {
+                if (module_type == .esm and is_bun_platform) {
                     p.print("import.meta.require");
                 } else if (p.options.require_ref) |ref| {
                     p.printSymbol(ref);
@@ -2125,6 +2132,10 @@ fn NewPrinter(
                 p.print("(");
                 p.printImportRecordPath(record);
                 p.print(")");
+
+                if (wrap_with_to_esm) {
+                    p.print(")");
+                }
                 return;
             }
 
@@ -6059,7 +6070,7 @@ pub fn printAst(
     var module_scope = tree.module_scope;
     if (opts.minify_identifiers) {
         const allocator = opts.allocator;
-        var reserved_names = try rename.computeInitialReservedNames(allocator);
+        var reserved_names = try rename.computeInitialReservedNames(allocator, opts.module_type);
         for (module_scope.children.slice()) |child| {
             child.parent = &module_scope;
         }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1830,6 +1830,7 @@ pub const OutputFile = struct {
     hash: u64 = 0,
     is_executable: bool = false,
     source_map_index: u32 = std.math.maxInt(u32),
+    bytecode_index: u32 = std.math.maxInt(u32),
     output_kind: JSC.API.BuildArtifact.OutputKind = .chunk,
     dest_path: []const u8 = "",
 
@@ -1934,6 +1935,7 @@ pub const OutputFile = struct {
         input_loader: Loader,
         hash: ?u64 = null,
         source_map_index: ?u32 = null,
+        bytecode_index: ?u32 = null,
         output_path: string,
         size: ?usize = null,
         input_path: []const u8 = "",
@@ -1968,6 +1970,7 @@ pub const OutputFile = struct {
             .size_without_sourcemap = options.display_size,
             .hash = options.hash orelse 0,
             .output_kind = options.output_kind,
+            .bytecode_index = options.bytecode_index orelse std.math.maxInt(u32),
             .source_map_index = options.source_map_index orelse std.math.maxInt(u32),
             .is_executable = options.is_executable,
             .value = switch (options.data) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -599,6 +599,10 @@ pub const Format = enum {
         return this == .esm;
     }
 
+    pub inline fn isAlwaysStrictMode(this: Format) bool {
+        return this == .esm;
+    }
+
     pub const Map = bun.ComptimeStringMap(Format, .{
         .{ "esm", .esm },
         .{ "cjs", .cjs },

--- a/src/options.zig
+++ b/src/options.zig
@@ -1484,6 +1484,7 @@ pub const BundleOptions = struct {
 
     ignore_dce_annotations: bool = false,
     emit_dce_annotations: bool = false,
+    bytecode: bool = false,
 
     code_coverage: bool = false,
     debugger: bool = false,

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -260,6 +260,7 @@ pub const Runtime = struct {
         unwrap_commonjs_packages: []const string = &.{},
 
         commonjs_at_runtime: bool = false,
+        unwrap_commonjs_to_esm: bool = bun.FeatureFlags.unwrap_commonjs_to_esm,
 
         emit_decorator_metadata: bool = false,
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -260,7 +260,7 @@ pub const Runtime = struct {
         unwrap_commonjs_packages: []const string = &.{},
 
         commonjs_at_runtime: bool = false,
-        unwrap_commonjs_to_esm: bool = bun.FeatureFlags.unwrap_commonjs_to_esm,
+        unwrap_commonjs_to_esm: bool = false,
 
         emit_decorator_metadata: bool = false,
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -240,6 +240,8 @@ pub const Runtime = struct {
         /// Use `import.meta.require()` instead of require()?
         /// This is only supported with --target=bun
         use_import_meta_require: bool = false,
+
+        /// Allow runtime usage of require(), converting `require` into `__require`
         auto_polyfill_require: bool = false,
 
         replace_exports: ReplaceableExport.Map = .{},

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -240,6 +240,7 @@ pub const Runtime = struct {
         /// Use `import.meta.require()` instead of require()?
         /// This is only supported with --target=bun
         use_import_meta_require: bool = false,
+        auto_polyfill_require: bool = false,
 
         replace_exports: ReplaceableExport.Map = .{},
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -4,6 +4,34 @@ import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import path, { join } from "path";
 
 describe("Bun.build", () => {
+  test("bytecode works", async () => {
+    const dir = tempDirWithFiles("bun-build-api-bytecode", {
+      "package.json": `{}`,
+      "index.ts": `
+        export function hello() {
+          return "world";
+        }
+
+        console.log(hello());
+      `,
+      out: {
+        "hmm.js": "hmm",
+      },
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "index.ts")],
+      outdir: join(dir, "out"),
+      target: "bun",
+      bytecode: true,
+    });
+
+    expect(build.outputs).toHaveLength(2);
+    expect(build.outputs[0].kind).toBe("entry-point");
+    expect(build.outputs[1].kind).toBe("bytecode");
+    expect([build.outputs[0].path]).toRun("world\n");
+  });
+
   test("passing undefined doesnt segfault", () => {
     try {
       // @ts-ignore

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -13,6 +13,27 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  itBundled("compile/HelloWorldBytecode", {
+    compile: true,
+    bytecode: true,
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("Hello, world!");
+      `,
+    },
+    run: {
+      stdout: "Hello, world!",
+      stderr: [
+        "[Disk Cache] Cache hit for sourceCode",
+
+        // TODO: remove this line once bun:main is removed.
+        "[Disk Cache] Cache miss for sourceCode",
+      ].join("\n"),
+      env: {
+        BUN_JSC_verboseDiskCache: "1",
+      },
+    },
+  });
   // https://github.com/oven-sh/bun/issues/8697
   itBundled("compile/EmbeddedFileOutfile", {
     compile: true,
@@ -65,6 +86,43 @@ describe("bundler", () => {
     entryPointsRaw: ["./entry.ts", "./worker.ts"],
     outfile: "dist/out",
     run: { stdout: "Hello, world!\nWorker loaded!\n", file: "dist/out", setCwd: true },
+  });
+  itBundled("compile/WorkerRelativePathTSExtensionBytecode", {
+    compile: true,
+    bytecode: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import {rmSync} from 'fs';
+        // Verify we're not just importing from the filesystem
+        rmSync("./worker.ts", {force: true});
+        console.log("Hello, world!");
+        new Worker("./worker.ts");
+      `,
+      "/worker.ts": /* js */ `
+        console.log("Worker loaded!");
+    `.trim(),
+    },
+    entryPointsRaw: ["./entry.ts", "./worker.ts"],
+    outfile: "dist/out",
+    run: {
+      stdout: "Hello, world!\nWorker loaded!\n",
+      file: "dist/out",
+      setCwd: true,
+      stderr: [
+        "[Disk Cache] Cache hit for sourceCode",
+
+        // TODO: remove this line once bun:main is removed.
+        "[Disk Cache] Cache miss for sourceCode",
+
+        "[Disk Cache] Cache hit for sourceCode",
+
+        // TODO: remove this line once bun:main is removed.
+        "[Disk Cache] Cache miss for sourceCode",
+      ].join("\n"),
+      env: {
+        BUN_JSC_verboseDiskCache: "1",
+      },
+    },
   });
   itBundled("compile/Bun.embeddedFiles", {
     compile: true,
@@ -188,10 +246,25 @@ describe("bundler", () => {
     },
     run: { stdout: "ok" },
   });
-  itBundled("compile/ReactSSR", {
-    install: ["react@next", "react-dom@next"],
-    files: {
-      "/entry.tsx": /* tsx */ `
+
+  for (const additionalOptions of [
+    { bytecode: true, minify: true, format: "cjs" },
+    { format: "cjs" },
+    { format: "cjs", minify: true },
+    { format: "esm" },
+    { format: "esm", minify: true },
+  ]) {
+    const { bytecode = false, format, minify = false } = additionalOptions;
+    const NODE_ENV = minify ? "'production'" : undefined;
+    itBundled.only("compile/ReactSSR" + (bytecode ? "+bytecode" : "") + "+" + format + (minify ? "+minify" : ""), {
+      install: ["react@next", "react-dom@next"],
+      format,
+      minifySyntax: minify,
+      minifyIdentifiers: minify,
+      minifyWhitespace: minify,
+      define: NODE_ENV ? { "process.env.NODE_ENV": NODE_ENV } : undefined,
+      files: {
+        "/entry.tsx": /* tsx */ `
         import React from "react";
         import { renderToReadableStream } from "react-dom/server";
 
@@ -210,23 +283,37 @@ describe("bundler", () => {
           </html>
         );
 
-        const port = 0;
-        using server = Bun.serve({
-          port,
-          async fetch(req) {
-            return new Response(await renderToReadableStream(<App />), headers);
-          },
-        });
-        const res = await fetch(server.url);
-        if (res.status !== 200) throw "status error";
-        console.log(await res.text());
+        async function main() {
+          const port = 0;
+          using server = Bun.serve({
+            port,
+            async fetch(req) {
+              return new Response(await renderToReadableStream(<App />), headers);
+            },
+          });
+          const res = await fetch(server.url);
+          if (res.status !== 200) throw "status error";
+          console.log(await res.text());
+        }
+
+        main();
       `,
-    },
-    run: {
-      stdout: "<!DOCTYPE html><html><head></head><body><h1>Hello World</h1><p>This is an example.</p></body></html>",
-    },
-    compile: true,
-  });
+      },
+      run: {
+        stdout: "<!DOCTYPE html><html><head></head><body><h1>Hello World</h1><p>This is an example.</p></body></html>",
+        stderr: bytecode
+          ? "[Disk Cache] Cache hit for sourceCode\n[Disk Cache] Cache miss for sourceCode\n"
+          : undefined,
+        env: bytecode
+          ? {
+              BUN_JSC_verboseDiskCache: "1",
+            }
+          : undefined,
+      },
+      compile: true,
+      bytecode,
+    });
+  }
   itBundled("compile/DynamicRequire", {
     files: {
       "/entry.tsx": /* tsx */ `

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -256,7 +256,7 @@ describe("bundler", () => {
   ]) {
     const { bytecode = false, format, minify = false } = additionalOptions;
     const NODE_ENV = minify ? "'production'" : undefined;
-    itBundled.only("compile/ReactSSR" + (bytecode ? "+bytecode" : "") + "+" + format + (minify ? "+minify" : ""), {
+    itBundled("compile/ReactSSR" + (bytecode ? "+bytecode" : "") + "+" + format + (minify ? "+minify" : ""), {
       install: ["react@next", "react-dom@next"],
       format,
       minifySyntax: minify,

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1446,6 +1446,7 @@ describe("bundler", () => {
     format: "cjs",
     treeShaking: true,
     bundling: false,
+    todo: true,
   });
   itBundled("dce/TreeShakingNoBundleIIFE", {
     files: {
@@ -1459,6 +1460,7 @@ describe("bundler", () => {
     format: "iife",
     treeShaking: true,
     bundling: false,
+    todo: true,
   });
   itBundled("dce/TreeShakingInESMWrapper", {
     files: {
@@ -1687,6 +1689,7 @@ describe("bundler", () => {
       `,
     },
     format: "iife",
+    todo: true,
     dce: true,
   });
   itBundled("dce/RemoveUnusedImports", {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1318,7 +1318,7 @@ describe("bundler", () => {
         console.log('writeFileSync' in fs, readFileSync, 'writeFileSync' in defaultValue)
       `,
     },
-    target: "node",
+    target: "bun",
     format: "cjs",
     run: {
       stdout: "true [Function: readFileSync] true",
@@ -4632,18 +4632,18 @@ describe("bundler", () => {
   });
   // TODO: this is hard to test since bun runtime doesn't support require.main and require.cache
   // i'm not even sure what we want our behavior to be for this case.
-  // itBundled("default/RequireMainCacheCommonJS", {
-  //   files: {
-  //     "/entry.js": /* js */ `
-  //       console.log('is main:', require.main === module)
-  //       console.log(require('./is-main'))
-  //       console.log('cache:', require.cache);
-  //     `,
-  //     "/is-main.js": `module.exports = require.main === module`,
-  //   },
-  //   format: "cjs",
-  //   platform: "node",
-  // });
+  itBundled("default/RequireMainCacheCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log('is main:', require.main === module)
+        console.log(require('./is-main'))
+        console.log('cache:', require.cache);
+      `,
+      "/is-main.js": `module.exports = require.main === module`,
+    },
+    format: "cjs",
+    platform: "node",
+  });
   itBundled("default/ExternalES6ConvertedToCommonJS", {
     todo: true,
     files: {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2581,6 +2581,7 @@ describe("bundler", () => {
     minifySyntax: true,
     minifyWhitespace: true,
     bundling: false,
+    todo: true,
     onAfterBundle(api) {
       assert(api.readFile("/out.js").includes('"use strict";'), '"use strict"; was emitted');
     },

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -3431,6 +3431,7 @@ describe("bundler", () => {
       `,
     },
     format: "iife",
+    todo: true,
     bundleErrors: {
       "/entry.js": ['Top-level await is currently not supported with the "iife" output format'],
     },
@@ -3453,6 +3454,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+    todo: true,
     bundleErrors: {
       "/entry.js": ['Top-level await is currently not supported with the "cjs" output format'],
     },

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -432,7 +432,6 @@ describe("bundler", () => {
 
   // Use "eval" to access CommonJS variables
   itBundled("extra/CJSEval1", {
-    todo: true,
     files: {
       "in.js": `if (require('./eval').foo !== 123) throw 'fail'`,
       "eval.js": `exports.foo=234;eval('exports.foo = 123')`,
@@ -440,7 +439,6 @@ describe("bundler", () => {
     run: true,
   });
   itBundled("extra/CJSEval2", {
-    todo: true,
     files: {
       "in.js": `if (require('./eval').foo !== 123) throw 'fail'`,
       "eval.js": `module.exports={foo:234};eval('module.exports = {foo: 123}')`,

--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -561,6 +561,7 @@ describe("bundler", () => {
     format: "iife",
   });
   itBundled("importstar/ExportSelfIIFEWithName", {
+    todo: true,
     files: {
       "/entry.js": /* js */ `
         export const foo = 123
@@ -603,6 +604,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+
     runtimeFiles: {
       "/test.js": /* js */ `
         console.log(JSON.stringify(require("./out.js")));
@@ -622,6 +624,7 @@ describe("bundler", () => {
     },
     minifyIdentifiers: true,
     format: "cjs",
+
     run: {
       stdout: '{"foo":123}',
     },
@@ -635,6 +638,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+
     runtimeFiles: {
       "/test.js": /* js */ `
         console.log('2', JSON.stringify(require("./out.js")));
@@ -776,6 +780,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+
     runtimeFiles: {
       "/test.js": /* js */ `
         const foo = require('./out.js')
@@ -795,6 +800,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+
     run: {
       stdout: '{"foo":123}',
     },
@@ -808,6 +814,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+
     run: {
       stdout: '{"foo":123}',
     },
@@ -818,6 +825,7 @@ describe("bundler", () => {
       "/foo.js": `exports.foo = 123`,
     },
     format: "cjs",
+
     runtimeFiles: {
       "/test.js": /* js */ `
         const foo = require('./out.js')
@@ -860,6 +868,7 @@ describe("bundler", () => {
       "/foo.js": `exports.foo = 123`,
     },
     format: "cjs",
+
     runtimeFiles: {
       "/test.js": /* js */ `
         const foo = require('./out.js')
@@ -879,6 +888,7 @@ describe("bundler", () => {
       "/foo.js": `exports.foo = 123`,
     },
     format: "cjs",
+
     runtimeFiles: {
       "/test.js": /* js */ `
         const foo = require('./out.js')
@@ -1025,6 +1035,7 @@ describe("bundler", () => {
       `,
     },
     format: "cjs",
+
     dce: true,
     runtimeFiles: {
       "/test.js": /* js */ `
@@ -1052,6 +1063,7 @@ describe("bundler", () => {
     },
   });
   itBundled("importstar/ReExportStarExternalIIFE", {
+    todo: true,
     files: {
       "/entry.js": `export * from "foo"`,
     },
@@ -1098,6 +1110,7 @@ describe("bundler", () => {
     },
     external: ["foo"],
     format: "cjs",
+
     runtimeFiles: {
       "/node_modules/foo/index.js": /* js */ `
         module.exports = { bar: 'bar', foo: 'foo' }
@@ -1361,7 +1374,7 @@ describe("bundler", () => {
       ],
     },
   });
-  itBundled("importstar/ReExportStarEntryPointAndInnerFile", {
+  itBundled("importstar/ReExportStarEntryPointAndInnerFileExternal", {
     files: {
       "/entry.js": /* js */ `
         export * from 'a'
@@ -1373,13 +1386,38 @@ describe("bundler", () => {
     format: "cjs",
     external: ["a", "b"],
     runtimeFiles: {
+      "/test.js": /* js */ `
+      console.log(JSON.stringify(require('./out.js')))
+      `,
       "/node_modules/a/index.js": /* js */ `
-        export const a = 123;
-      `,
+       export const a = 123;
+     `,
       "/node_modules/b/index.js": /* js */ `
-        export const b = 456;
+       export const b = 456;
+     `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: '{"inner":{"b":456},"a":123,"b":456}',
+    },
+  });
+  itBundled("importstar/ReExportStarEntryPointAndInnerFile", {
+    files: {
+      "/entry.js": /* js */ `
+        export * from 'a'
+        import * as inner from './inner.js'
+        export { inner }
       `,
-
+      "/inner.js": `export * from 'b'`,
+      "/node_modules/a/index.js": /* js */ `
+      export const a = 123;
+    `,
+      "/node_modules/b/index.js": /* js */ `
+      export const b = 456;
+    `,
+    },
+    format: "cjs",
+    runtimeFiles: {
       "/test.js": /* js */ `
         console.log(JSON.stringify(require('./out.js')))
       `,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -469,13 +469,14 @@ function expectBundled(
 
   // Resolve defaults for options and some related things
   bundling ??= true;
-  target ??= "browser";
 
   if (bytecode) {
     format ??= "cjs";
+    target ??= "bun";
   }
 
   format ??= "esm";
+  target ??= "browser";
 
   entryPoints ??= entryPointsRaw ? [] : [Object.keys(files)[0]];
   if (run === true) run = {};

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -479,9 +479,7 @@ function expectBundled(
   if (bundling === false && entryPoints.length > 1) {
     throw new Error("bundling:false only supports a single entry point");
   }
-  if (!ESBUILD && (format === "cjs" || format === "iife")) {
-    throw new Error(`format ${format} not implemented in bun build`);
-  }
+
   if (!ESBUILD && metafile) {
     throw new Error("metafile not implemented in bun build");
   }
@@ -1546,7 +1544,7 @@ for (const [key, blob] of build.outputs) {
     return testRef(id, opts);
   })();
 }
-
+let anyOnly = false;
 /** Shorthand for test and expectBundled. See `expectBundled` for what this does.
  */
 export function itBundled(
@@ -1584,6 +1582,17 @@ export function itBundled(
   }
   return ref;
 }
+itBundled.only = (id: string, opts: BundlerTestInput) => {
+  const { it } = testForFile(currentFile ?? callerSourceOrigin());
+
+  it.only(
+    id,
+    () => expectBundled(id, opts as any),
+    // sourcemap code is slow
+    isDebug ? Infinity : opts.snapshotSourceMap ? 30_000 : undefined,
+  );
+};
+
 itBundled.skip = (id: string, opts: BundlerTestInput) => {
   if (FILTER && !filterMatches(id)) {
     return testRef(id, opts);

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1539,7 +1539,7 @@ for (const [key, blob] of build.outputs) {
               console.log(result);
               console.log(`---`);
             }
-            expect(result).toMatch(out);
+            expect(result).toMatch(expected);
           }
         }
 

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -326,6 +326,7 @@ export interface BundlerTestRunOptions {
   bunArgs?: string[];
   /** match exact stdout */
   stdout?: string | RegExp;
+  stderr?: string;
   /** partial match stdout (toContain()) */
   partialStdout?: string;
   /** match exact error message, example "ReferenceError: Can't find variable: bar" */
@@ -444,6 +445,7 @@ function expectBundled(
     unsupportedJSFeatures,
     useDefineForClassFields,
     ignoreDCEAnnotations,
+    bytecode = false,
     emitDCEAnnotations,
     // @ts-expect-error
     _referenceFn,
@@ -468,7 +470,13 @@ function expectBundled(
   // Resolve defaults for options and some related things
   bundling ??= true;
   target ??= "browser";
+
+  if (bytecode) {
+    format ??= "cjs";
+  }
+
   format ??= "esm";
+
   entryPoints ??= entryPointsRaw ? [] : [Object.keys(files)[0]];
   if (run === true) run = {};
   if (metafile === true) metafile = "/metafile.json";
@@ -511,6 +519,9 @@ function expectBundled(
     if (unsupportedLoaderTypes.length) {
       throw new Error(`loader '${unsupportedLoaderTypes.join("', '")}' not implemented in bun build`);
     }
+  }
+  if (ESBUILD && bytecode) {
+    throw new Error("bytecode not implemented in esbuild");
   }
   if (ESBUILD && skipOnEsbuild) {
     return testRef(id, opts);
@@ -658,6 +669,7 @@ function expectBundled(
               // mainFields && `--main-fields=${mainFields}`,
               loader && Object.entries(loader).map(([k, v]) => ["--loader", `${k}:${v}`]),
               publicPath && `--public-path=${publicPath}`,
+              bytecode && "--bytecode",
             ]
           : [
               ESBUILD_PATH,
@@ -961,6 +973,7 @@ function expectBundled(
           sourcemap: sourceMap,
           splitting,
           target,
+          bytecode,
           publicPath,
           emitDCEAnnotations,
           ignoreDCEAnnotations,
@@ -1417,7 +1430,6 @@ for (const [key, blob] of build.outputs) {
         } else {
           throw new Error(prefix + "run.file is required when there is more than one entrypoint.");
         }
-
         const args = [
           ...(compile ? [] : [(run.runtime ?? "bun") === "bun" ? bunExe() : "node"]),
           ...(run.bunArgs ?? []),
@@ -1429,6 +1441,7 @@ for (const [key, blob] of build.outputs) {
           cmd: args,
           env: {
             ...bunEnv,
+            ...(run.env || {}),
             FORCE_COLOR: "0",
             IS_TEST_RUNNER: "1",
           },
@@ -1502,28 +1515,31 @@ for (const [key, blob] of build.outputs) {
           run.validate({ stderr: stderr.toUnixString(), stdout: stdout.toUnixString() });
         }
 
-        if (run.stdout !== undefined) {
-          const result = stdout!.toUnixString().trim();
-          if (typeof run.stdout === "string") {
-            const expected = dedent(run.stdout).trim();
+        for (let [name, expected, out] of [
+          ["stdout", run.stdout, stdout],
+          ["stderr", run.stderr, stderr],
+        ].filter(([, v]) => v !== undefined)) {
+          const result = out!.toUnixString().trim();
+          if (typeof expected === "string") {
+            expected = dedent(expected).trim();
             if (expected !== result) {
               console.log(`runtime failed file: ${file}`);
-              console.log(`reference stdout:`);
+              console.log(`${name} output:`);
               console.log(result);
               console.log(`---`);
-              console.log(`expected stdout:`);
+              console.log(`expected ${name}:`);
               console.log(expected);
               console.log(`---`);
             }
             expect(result).toBe(expected);
           } else {
-            if (!run.stdout.test(result)) {
+            if (!expected.test(result)) {
               console.log(`runtime failed file: ${file}`);
-              console.log(`reference stdout:`);
+              console.log(`${name} output:`);
               console.log(result);
               console.log(`---`);
             }
-            expect(result).toMatch(run.stdout);
+            expect(result).toMatch(out);
           }
         }
 


### PR DESCRIPTION
### What does this PR do?

This adds a new `--bytecode` flag, and `// @bun @bun-cjs` comment that marks a file as already transpiled with CommonJS. 

```
bun build --compile --bytecode <script>
bun build --target=bun --bytecode --outdir=out <script>
```

2x faster `tsc --help`

![image](https://github.com/user-attachments/assets/c0dbdeb5-ae79-4da5-87a0-4e2f8142f63e)

When you use `--bytecode` without `--compile`, it adds `.jsc` files which contain the compiled bytecode. When the bytecode is unable to be loaded, it uses the source code. Bytecode compilation currently has no impact on async functions and no impact on ESM.

### How did you verify your code works?

Added tests.