### PR TITLE
Experiment: statically override malloc on Windows & Linux

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -899,6 +899,36 @@ else()
     -Wl,--wrap=mknodat
     -Wl,--wrap=statx
     -Wl,--wrap=fmod
+    -Wl,--wrap=_expand
+    -Wl,--wrap=_msize
+    -Wl,--wrap=aligned_alloc
+    -Wl,--wrap=aligned_offset_recalloc
+    -Wl,--wrap=aligned_recalloc
+    -Wl,--wrap=calloc
+    -Wl,--wrap=cfree
+    -Wl,--wrap=dupenv_s
+    -Wl,--wrap=free
+    -Wl,--wrap=free_aligned
+    -Wl,--wrap=free_size
+    -Wl,--wrap=free_size_aligned
+    -Wl,--wrap=malloc
+    -Wl,--wrap=malloc_good_size
+    -Wl,--wrap=malloc_size
+    -Wl,--wrap=malloc_usable_size
+    -Wl,--wrap=mbsdup
+    -Wl,--wrap=memalign
+    -Wl,--wrap=posix_memalign
+    -Wl,--wrap=pvalloc
+    -Wl,--wrap=realloc
+    -Wl,--wrap=reallocarr
+    -Wl,--wrap=reallocarray
+    -Wl,--wrap=realpath
+    -Wl,--wrap=recalloc
+    -Wl,--wrap=strdup
+    -Wl,--wrap=strndup
+    -Wl,--wrap=valloc
+    -Wl,--wrap=wcsdup
+    -Wl,--wrap=wdupenv_s
     -Wl,--compress-debug-sections=zlib
     -Wl,-z,lazy
     -Wl,-z,norelro

--- a/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
+++ b/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
@@ -11,43 +11,43 @@
 
 extern "C" {
 
-char* strdup(const char* s) { return mi_strdup(s); }
-char* strndup(const char* s, size_t n) { return mi_strndup(s, n); }
-char* realpath(const char* f, char* n) { return mi_realpath(f, n); }
+char* wrap_strdup(const char* s) { return mi_strdup(s); }
+char* wrap_strndup(const char* s, size_t n) { return mi_strndup(s, n); }
+char* wrap_realpath(const char* f, char* n) { return mi_realpath(f, n); }
 
-void* malloc(size_t n) { return mi_malloc(n); }
-void* calloc(size_t n, size_t c) { return mi_calloc(n, c); }
-void* realloc(void* p, size_t n) { return mi_realloc(p, n); }
-void free(void* p) { mi_free(p); }
+void* wrap_malloc(size_t n) { return mi_malloc(n); }
+void* wrap_calloc(size_t n, size_t c) { return mi_calloc(n, c); }
+void* wrap_realloc(void* p, size_t n) { return mi_realloc(p, n); }
+void wrap_free(void* p) { mi_free(p); }
 
-void cfree(void* p) { mi_cfree(p); }
-void* _expand(void* p, size_t newsize) { return mi__expand(p, newsize); }
-size_t _msize(const void* p) { return mi_malloc_size(p); }
-void* recalloc(void* p, size_t newcount, size_t size) { return mi_recalloc(p, newcount, size); }
+void wrap_cfree(void* p) { mi_cfree(p); }
+void* wrap__expand(void* p, size_t newsize) { return mi__expand(p, newsize); }
+size_t wrap__msize(const void* p) { return mi_malloc_size(p); }
+void* wrap_recalloc(void* p, size_t newcount, size_t size) { return mi_recalloc(p, newcount, size); }
 
-size_t malloc_size(const void* p) { return mi_malloc_size(p); }
-size_t malloc_good_size(size_t size) { return mi_malloc_good_size(size); }
-size_t malloc_usable_size(const void* p) { return mi_malloc_usable_size(p); }
+size_t wrap_malloc_size(const void* p) { return mi_malloc_size(p); }
+size_t wrap_malloc_good_size(size_t size) { return mi_malloc_good_size(size); }
+size_t wrap_malloc_usable_size(const void* p) { return mi_malloc_usable_size(p); }
 
-int posix_memalign(void** p, size_t alignment, size_t size) { return mi_posix_memalign(p, alignment, size); }
-void* memalign(size_t alignment, size_t size) { return mi_memalign(alignment, size); }
-void* valloc(size_t size) { return mi_valloc(size); }
-void* pvalloc(size_t size) { return mi_pvalloc(size); }
-void* aligned_alloc(size_t alignment, size_t size) { return mi_aligned_alloc(alignment, size); }
+int wrap_posix_memalign(void** p, size_t alignment, size_t size) { return mi_posix_memalign(p, alignment, size); }
+void* wrap_memalign(size_t alignment, size_t size) { return mi_memalign(alignment, size); }
+void* wrap_valloc(size_t size) { return mi_valloc(size); }
+void* wrap_pvalloc(size_t size) { return mi_pvalloc(size); }
+void* wrap_aligned_alloc(size_t alignment, size_t size) { return mi_aligned_alloc(alignment, size); }
 
-void* reallocarray(void* p, size_t count, size_t size) { return mi_reallocarray(p, count, size); }
-int reallocarr(void* p, size_t count, size_t size) { return mi_reallocarr(p, count, size); }
-void* aligned_recalloc(void* p, size_t newcount, size_t size, size_t alignment) { return mi_aligned_recalloc(p, newcount, size, alignment); }
-void* aligned_offset_recalloc(void* p, size_t newcount, size_t size, size_t alignment, size_t offset) { return mi_aligned_offset_recalloc(p, newcount, size, alignment, offset); }
+void* wrap_reallocarray(void* p, size_t count, size_t size) { return mi_reallocarray(p, count, size); }
+int wrap_reallocarr(void* p, size_t count, size_t size) { return mi_reallocarr(p, count, size); }
+void* wrap_aligned_recalloc(void* p, size_t newcount, size_t size, size_t alignment) { return mi_aligned_recalloc(p, newcount, size, alignment); }
+void* wrap_aligned_offset_recalloc(void* p, size_t newcount, size_t size, size_t alignment, size_t offset) { return mi_aligned_offset_recalloc(p, newcount, size, alignment, offset); }
 
-unsigned short* wcsdup(const unsigned short* s) { return mi_wcsdup(s); }
-unsigned char* mbsdup(const unsigned char* s) { return mi_mbsdup(s); }
-int dupenv_s(char** buf, size_t* size, const char* name) { return mi_dupenv_s(buf, size, name); }
-int wdupenv_s(unsigned short** buf, size_t* size, const unsigned short* name) { return mi_wdupenv_s(buf, size, name); }
+unsigned short* wrap_wcsdup(const unsigned short* s) { return mi_wcsdup(s); }
+unsigned char* wrap_mbsdup(const unsigned char* s) { return mi_mbsdup(s); }
+int wrap_dupenv_s(char** buf, size_t* size, const char* name) { return mi_dupenv_s(buf, size, name); }
+int wrap_wdupenv_s(unsigned short** buf, size_t* size, const unsigned short* name) { return mi_wdupenv_s(buf, size, name); }
 
-void free_size(void* p, size_t size) { mi_free_size(p, size); }
-void free_size_aligned(void* p, size_t size, size_t alignment) { mi_free_size_aligned(p, size, alignment); }
-void free_aligned(void* p, size_t alignment) { mi_free_aligned(p, alignment); }
+void wrap_free_size(void* p, size_t size) { mi_free_size(p, size); }
+void wrap_free_size_aligned(void* p, size_t size, size_t alignment) { mi_free_size_aligned(p, size, alignment); }
+void wrap_free_aligned(void* p, size_t alignment) { mi_free_aligned(p, alignment); }
 }
 
 void* operator new(size_t size) { return mi_new(size); }

--- a/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
+++ b/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
@@ -10,8 +10,21 @@
 #include <mimalloc.h>
 
 extern "C" {
+
+char* strdup(const char* s) { return mi_strdup(s); }
+char* strndup(const char* s, size_t n) { return mi_strndup(s, n); }
+char* realpath(const char* f, char* n) { return mi_realpath(f, n); }
+
+void* malloc(size_t n) { return mi_malloc(n); }
+void* calloc(size_t n, size_t c) { return mi_calloc(n, c); }
+void* realloc(void* p, size_t n) { return mi_realloc(p, n); }
+void free(void* p) { mi_free(p); }
+
 void cfree(void* p) { mi_cfree(p); }
 void* _expand(void* p, size_t newsize) { return mi__expand(p, newsize); }
+size_t _msize(const void* p) { return mi_malloc_size(p); }
+void* recalloc(void* p, size_t newcount, size_t size) { return mi_recalloc(p, newcount, size); }
+
 size_t malloc_size(const void* p) { return mi_malloc_size(p); }
 size_t malloc_good_size(size_t size) { return mi_malloc_good_size(size); }
 size_t malloc_usable_size(const void* p) { return mi_malloc_usable_size(p); }

--- a/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
+++ b/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
@@ -11,43 +11,43 @@
 
 extern "C" {
 
-char* wrap_strdup(const char* s) { return mi_strdup(s); }
-char* wrap_strndup(const char* s, size_t n) { return mi_strndup(s, n); }
-char* wrap_realpath(const char* f, char* n) { return mi_realpath(f, n); }
+char* __wrap_strdup(const char* s) { return mi_strdup(s); }
+char* __wrap_strndup(const char* s, size_t n) { return mi_strndup(s, n); }
+char* __wrap_realpath(const char* f, char* n) { return mi_realpath(f, n); }
 
-void* wrap_malloc(size_t n) { return mi_malloc(n); }
-void* wrap_calloc(size_t n, size_t c) { return mi_calloc(n, c); }
-void* wrap_realloc(void* p, size_t n) { return mi_realloc(p, n); }
-void wrap_free(void* p) { mi_free(p); }
+void* __wrap_malloc(size_t n) { return mi_malloc(n); }
+void* __wrap_calloc(size_t n, size_t c) { return mi_calloc(n, c); }
+void* __wrap_realloc(void* p, size_t n) { return mi_realloc(p, n); }
+void __wrap_free(void* p) { mi_free(p); }
 
-void wrap_cfree(void* p) { mi_cfree(p); }
-void* wrap__expand(void* p, size_t newsize) { return mi__expand(p, newsize); }
-size_t wrap__msize(const void* p) { return mi_malloc_size(p); }
-void* wrap_recalloc(void* p, size_t newcount, size_t size) { return mi_recalloc(p, newcount, size); }
+void __wrap_cfree(void* p) { mi_cfree(p); }
+void* __wrap__expand(void* p, size_t newsize) { return mi__expand(p, newsize); }
+size_t __wrap__msize(const void* p) { return mi_malloc_size(p); }
+void* __wrap_recalloc(void* p, size_t newcount, size_t size) { return mi_recalloc(p, newcount, size); }
 
-size_t wrap_malloc_size(const void* p) { return mi_malloc_size(p); }
-size_t wrap_malloc_good_size(size_t size) { return mi_malloc_good_size(size); }
-size_t wrap_malloc_usable_size(const void* p) { return mi_malloc_usable_size(p); }
+size_t __wrap_malloc_size(const void* p) { return mi_malloc_size(p); }
+size_t __wrap_malloc_good_size(size_t size) { return mi_malloc_good_size(size); }
+size_t __wrap_malloc_usable_size(const void* p) { return mi_malloc_usable_size(p); }
 
-int wrap_posix_memalign(void** p, size_t alignment, size_t size) { return mi_posix_memalign(p, alignment, size); }
-void* wrap_memalign(size_t alignment, size_t size) { return mi_memalign(alignment, size); }
-void* wrap_valloc(size_t size) { return mi_valloc(size); }
-void* wrap_pvalloc(size_t size) { return mi_pvalloc(size); }
-void* wrap_aligned_alloc(size_t alignment, size_t size) { return mi_aligned_alloc(alignment, size); }
+int __wrap_posix_memalign(void** p, size_t alignment, size_t size) { return mi_posix_memalign(p, alignment, size); }
+void* __wrap_memalign(size_t alignment, size_t size) { return mi_memalign(alignment, size); }
+void* __wrap_valloc(size_t size) { return mi_valloc(size); }
+void* __wrap_pvalloc(size_t size) { return mi_pvalloc(size); }
+void* __wrap_aligned_alloc(size_t alignment, size_t size) { return mi_aligned_alloc(alignment, size); }
 
-void* wrap_reallocarray(void* p, size_t count, size_t size) { return mi_reallocarray(p, count, size); }
-int wrap_reallocarr(void* p, size_t count, size_t size) { return mi_reallocarr(p, count, size); }
-void* wrap_aligned_recalloc(void* p, size_t newcount, size_t size, size_t alignment) { return mi_aligned_recalloc(p, newcount, size, alignment); }
-void* wrap_aligned_offset_recalloc(void* p, size_t newcount, size_t size, size_t alignment, size_t offset) { return mi_aligned_offset_recalloc(p, newcount, size, alignment, offset); }
+void* __wrap_reallocarray(void* p, size_t count, size_t size) { return mi_reallocarray(p, count, size); }
+int __wrap_reallocarr(void* p, size_t count, size_t size) { return mi_reallocarr(p, count, size); }
+void* __wrap_aligned_recalloc(void* p, size_t newcount, size_t size, size_t alignment) { return mi_aligned_recalloc(p, newcount, size, alignment); }
+void* __wrap_aligned_offset_recalloc(void* p, size_t newcount, size_t size, size_t alignment, size_t offset) { return mi_aligned_offset_recalloc(p, newcount, size, alignment, offset); }
 
-unsigned short* wrap_wcsdup(const unsigned short* s) { return mi_wcsdup(s); }
-unsigned char* wrap_mbsdup(const unsigned char* s) { return mi_mbsdup(s); }
-int wrap_dupenv_s(char** buf, size_t* size, const char* name) { return mi_dupenv_s(buf, size, name); }
-int wrap_wdupenv_s(unsigned short** buf, size_t* size, const unsigned short* name) { return mi_wdupenv_s(buf, size, name); }
+unsigned short* __wrap_wcsdup(const unsigned short* s) { return mi_wcsdup(s); }
+unsigned char* __wrap_mbsdup(const unsigned char* s) { return mi_mbsdup(s); }
+int __wrap_dupenv_s(char** buf, size_t* size, const char* name) { return mi_dupenv_s(buf, size, name); }
+int __wrap_wdupenv_s(unsigned short** buf, size_t* size, const unsigned short* name) { return mi_wdupenv_s(buf, size, name); }
 
-void wrap_free_size(void* p, size_t size) { mi_free_size(p, size); }
-void wrap_free_size_aligned(void* p, size_t size, size_t alignment) { mi_free_size_aligned(p, size, alignment); }
-void wrap_free_aligned(void* p, size_t alignment) { mi_free_aligned(p, alignment); }
+void __wrap_free_size(void* p, size_t size) { mi_free_size(p, size); }
+void __wrap_free_size_aligned(void* p, size_t size, size_t alignment) { mi_free_size_aligned(p, size, alignment); }
+void __wrap_free_aligned(void* p, size_t alignment) { mi_free_aligned(p, alignment); }
 }
 
 void* operator new(size_t size) { return mi_new(size); }

--- a/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
+++ b/src/bun.js/bindings/mimalloc-override-linux-windows.cpp
@@ -1,0 +1,58 @@
+// Statically override malloc and free with mimalloc on Linux and Windows. This
+// in theory should work because we statically link the vc runtime on Windows.
+//
+// We don't do this on macOS because system libraries expect the system malloc
+// and free. The proper way to override malloc and free on macOS is to use
+// either dyld OR to use malloc_zone_register().
+
+#if defined(WIN32) || defined(__linux__)
+
+#include <mimalloc.h>
+
+extern "C" {
+void cfree(void* p) { mi_cfree(p); }
+void* _expand(void* p, size_t newsize) { return mi__expand(p, newsize); }
+size_t malloc_size(const void* p) { return mi_malloc_size(p); }
+size_t malloc_good_size(size_t size) { return mi_malloc_good_size(size); }
+size_t malloc_usable_size(const void* p) { return mi_malloc_usable_size(p); }
+
+int posix_memalign(void** p, size_t alignment, size_t size) { return mi_posix_memalign(p, alignment, size); }
+void* memalign(size_t alignment, size_t size) { return mi_memalign(alignment, size); }
+void* valloc(size_t size) { return mi_valloc(size); }
+void* pvalloc(size_t size) { return mi_pvalloc(size); }
+void* aligned_alloc(size_t alignment, size_t size) { return mi_aligned_alloc(alignment, size); }
+
+void* reallocarray(void* p, size_t count, size_t size) { return mi_reallocarray(p, count, size); }
+int reallocarr(void* p, size_t count, size_t size) { return mi_reallocarr(p, count, size); }
+void* aligned_recalloc(void* p, size_t newcount, size_t size, size_t alignment) { return mi_aligned_recalloc(p, newcount, size, alignment); }
+void* aligned_offset_recalloc(void* p, size_t newcount, size_t size, size_t alignment, size_t offset) { return mi_aligned_offset_recalloc(p, newcount, size, alignment, offset); }
+
+unsigned short* wcsdup(const unsigned short* s) { return mi_wcsdup(s); }
+unsigned char* mbsdup(const unsigned char* s) { return mi_mbsdup(s); }
+int dupenv_s(char** buf, size_t* size, const char* name) { return mi_dupenv_s(buf, size, name); }
+int wdupenv_s(unsigned short** buf, size_t* size, const unsigned short* name) { return mi_wdupenv_s(buf, size, name); }
+
+void free_size(void* p, size_t size) { mi_free_size(p, size); }
+void free_size_aligned(void* p, size_t size, size_t alignment) { mi_free_size_aligned(p, size, alignment); }
+void free_aligned(void* p, size_t alignment) { mi_free_aligned(p, alignment); }
+}
+
+void* operator new(size_t size) { return mi_new(size); }
+void* operator new[](size_t size) { return mi_new(size); }
+void* operator new(size_t size, std::align_val_t alignment) { return mi_new_aligned(size, static_cast<size_t>(alignment)); }
+void* operator new[](size_t size, std::align_val_t alignment) { return mi_new_aligned(size, static_cast<size_t>(alignment)); }
+void* operator new(size_t size, const std::nothrow_t&) noexcept { return mi_new_nothrow(size); }
+void* operator new[](size_t size, const std::nothrow_t&) noexcept { return mi_new_nothrow(size); }
+void* operator new(size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(size, static_cast<size_t>(alignment)); }
+void* operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(size, static_cast<size_t>(alignment)); }
+
+void operator delete(void* p) noexcept { mi_free(p); }
+void operator delete[](void* p) noexcept { mi_free(p); }
+void operator delete(void* p, std::align_val_t) noexcept { mi_free(p); }
+void operator delete[](void* p, std::align_val_t) noexcept { mi_free(p); }
+void operator delete(void* p, size_t) noexcept { mi_free(p); }
+void operator delete[](void* p, size_t) noexcept { mi_free(p); }
+void operator delete(void* p, size_t, std::align_val_t) noexcept { mi_free(p); }
+void operator delete[](void* p, size_t, std::align_val_t) noexcept { mi_free(p); }
+
+#endif


### PR DESCRIPTION
### What does this PR do?

On Linux, we are importing the libc free and libc malloc symbols

What if we don't do that

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
