### PR TITLE
Tweak how we do symbol versioning for glibc

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -879,26 +879,33 @@ else()
     -Wl,--as-needed
     -Wl,--gc-sections
     -Wl,-z,stack-size=12800000
-    -Wl,--wrap=fcntl
-    -Wl,--wrap=fcntl64
-    -Wl,--wrap=stat64
-    -Wl,--wrap=pow
+    -Wl,--wrap=cosf
     -Wl,--wrap=exp
     -Wl,--wrap=expf
-    -Wl,--wrap=log
-    -Wl,--wrap=log2
-    -Wl,--wrap=lstat
-    -Wl,--wrap=stat64
-    -Wl,--wrap=stat
+    -Wl,--wrap=fcntl
+    -Wl,--wrap=fcntl64
+    -Wl,--wrap=fmod
+    -Wl,--wrap=fmodf
     -Wl,--wrap=fstat
-    -Wl,--wrap=fstatat
-    -Wl,--wrap=lstat64
     -Wl,--wrap=fstat64
+    -Wl,--wrap=fstatat
     -Wl,--wrap=fstatat64
+    -Wl,--wrap=log
+    -Wl,--wrap=log10f
+    -Wl,--wrap=log2
+    -Wl,--wrap=log2f
+    -Wl,--wrap=logf
+    -Wl,--wrap=lstat
+    -Wl,--wrap=lstat64
     -Wl,--wrap=mknod
     -Wl,--wrap=mknodat
+    -Wl,--wrap=pow
+    -Wl,--wrap=sincosf
+    -Wl,--wrap=sinf
+    -Wl,--wrap=stat
+    -Wl,--wrap=stat64
     -Wl,--wrap=statx
-    -Wl,--wrap=fmod
+    -Wl,--wrap=tanf
     -Wl,--compress-debug-sections=zlib
     -Wl,-z,lazy
     -Wl,-z,norelro

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -197,13 +197,13 @@ int __wrap_fcntl64(int fd, int cmd, ...)
         return fcntl(fd, cmd, *(struct f_owner_ex**)arg);
 
 #ifdef F_OFD_GETLK
-    // Commands that take a struct f_owner_exlock *
+    // Commands that take a struct flock *
     case F_OFD_GETLK:
     case F_OFD_SETLK:
     case F_OFD_SETLKW:
-        arg = va_arg(ap, struct f_owner_exlock**);
+        arg = va_arg(ap, struct flock**);
         va_end(ap);
-        return fcntl(fd, cmd, *(struct f_owner_exlock**)arg);
+        return fcntl(fd, cmd, *(struct flock**)arg);
 #endif
 
     default:

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -76,7 +76,6 @@ __asm__(".symver cosf,cosf@GLIBC_2.2.5");
 __asm__(".symver exp,exp@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");
 __asm__(".symver fcntl,fcntl@GLIBC_2.2.5");
-__asm__(".symver fcntl64,fcntl64@GLIBC_2.2.5");
 __asm__(".symver fmod,fmod@GLIBC_2.2.5");
 __asm__(".symver fmodf,fmodf@GLIBC_2.2.5");
 __asm__(".symver log,log@GLIBC_2.2.5");
@@ -93,7 +92,6 @@ __asm__(".symver cosf,cosf@GLIBC_2.17");
 __asm__(".symver exp,exp@GLIBC_2.17");
 __asm__(".symver expf,expf@GLIBC_2.17");
 __asm__(".symver fcntl,fcntl@GLIBC_2.17");
-__asm__(".symver fcntl64,fcntl64@GLIBC_2.17");
 __asm__(".symver fmod,fmod@GLIBC_2.17");
 __asm__(".symver fmodf,fmodf@GLIBC_2.17");
 __asm__(".symver log,log@GLIBC_2.17");
@@ -130,6 +128,41 @@ float BUN_WRAP_GLIBC_SYMBOL(tanf)(float);
 int BUN_WRAP_GLIBC_SYMBOL(fcntl)(int, int, ...);
 int BUN_WRAP_GLIBC_SYMBOL(fcntl64)(int, int, ...);
 void BUN_WRAP_GLIBC_SYMBOL(sincosf)(float, float*, float*);
+}
+
+extern "C" {
+int __wrap_fcntl(int fd, int cmd, ...)
+{
+    va_list args;
+    va_start(args, cmd);
+    void* arg = va_arg(args, void*);
+    va_end(args);
+    return fcntl(fd, cmd, arg);
+}
+
+int __wrap_fcntl64(int fd, int cmd, ...)
+{
+    va_list args;
+    va_start(args, cmd);
+    void* arg = va_arg(args, void*);
+    va_end(args);
+    return fcntl(fd, cmd, arg);
+}
+
+double __wrap_exp(double x) { return exp(x); }
+double __wrap_fmod(double x, double y) { return fmod(x, y); }
+double __wrap_log(double x) { return log(x); }
+double __wrap_log2(double x) { return log2(x); }
+double __wrap_pow(double x, double y) { return pow(x, y); }
+float __wrap_cosf(float x) { return cosf(x); }
+float __wrap_expf(float x) { return expf(x); }
+float __wrap_fmodf(float x, float y) { return fmodf(x, y); }
+float __wrap_log10f(float x) { return log10f(x); }
+float __wrap_log2f(float x) { return log2f(x); }
+float __wrap_logf(float x) { return logf(x); }
+float __wrap_sinf(float x) { return sinf(x); }
+float __wrap_tanf(float x) { return tanf(x); }
+void __wrap_sincosf(float x, float* sin_x, float* cos_x) { sincosf(x, sin_x, cos_x); }
 }
 
 // ban statx, for now

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -75,6 +75,8 @@ extern "C" int kill(int pid, int sig)
 __asm__(".symver cosf,cosf@GLIBC_2.2.5");
 __asm__(".symver exp,exp@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");
+__asm__(".symver fcntl,fcntl@GLIBC_2.2.5");
+__asm__(".symver fcntl64,fcntl64@GLIBC_2.2.5");
 __asm__(".symver fmod,fmod@GLIBC_2.2.5");
 __asm__(".symver fmodf,fmodf@GLIBC_2.2.5");
 __asm__(".symver log,log@GLIBC_2.2.5");
@@ -86,12 +88,12 @@ __asm__(".symver pow,pow@GLIBC_2.2.5");
 __asm__(".symver sincosf,sincosf@GLIBC_2.2.5");
 __asm__(".symver sinf,sinf@GLIBC_2.2.5");
 __asm__(".symver tanf,tanf@GLIBC_2.2.5");
-__asm__(".symver fcntl,fcntl@GLIBC_2.2.5");
-__asm__(".symver fcntl64,fcntl64@GLIBC_2.2.5");
 #elif defined(__aarch64__)
 __asm__(".symver cosf,cosf@GLIBC_2.17");
 __asm__(".symver exp,exp@GLIBC_2.17");
 __asm__(".symver expf,expf@GLIBC_2.17");
+__asm__(".symver fcntl,fcntl@GLIBC_2.17");
+__asm__(".symver fcntl64,fcntl64@GLIBC_2.17");
 __asm__(".symver fmod,fmod@GLIBC_2.17");
 __asm__(".symver fmodf,fmodf@GLIBC_2.17");
 __asm__(".symver log,log@GLIBC_2.17");
@@ -103,8 +105,6 @@ __asm__(".symver pow,pow@GLIBC_2.17");
 __asm__(".symver sincosf,sincosf@GLIBC_2.17");
 __asm__(".symver sinf,sinf@GLIBC_2.17");
 __asm__(".symver tanf,tanf@GLIBC_2.17");
-__asm__(".symver fcntl,fcntl@GLIBC_2.17");
-__asm__(".symver fcntl64,fcntl64@GLIBC_2.17");
 #endif
 
 #if defined(__x86_64__) || defined(__aarch64__)
@@ -114,22 +114,22 @@ __asm__(".symver fcntl64,fcntl64@GLIBC_2.17");
 #endif
 
 extern "C" {
-float BUN_WRAP_GLIBC_SYMBOL(cosf)(float);
 double BUN_WRAP_GLIBC_SYMBOL(exp)(double);
-float BUN_WRAP_GLIBC_SYMBOL(expf)(float);
 double BUN_WRAP_GLIBC_SYMBOL(fmod)(double, double);
-float BUN_WRAP_GLIBC_SYMBOL(fmodf)(float, float);
 double BUN_WRAP_GLIBC_SYMBOL(log)(double);
-float BUN_WRAP_GLIBC_SYMBOL(log10f)(float);
 double BUN_WRAP_GLIBC_SYMBOL(log2)(double);
+double BUN_WRAP_GLIBC_SYMBOL(pow)(double, double);
+float BUN_WRAP_GLIBC_SYMBOL(cosf)(float);
+float BUN_WRAP_GLIBC_SYMBOL(expf)(float);
+float BUN_WRAP_GLIBC_SYMBOL(fmodf)(float, float);
+float BUN_WRAP_GLIBC_SYMBOL(log10f)(float);
 float BUN_WRAP_GLIBC_SYMBOL(log2f)(float);
 float BUN_WRAP_GLIBC_SYMBOL(logf)(float);
-double BUN_WRAP_GLIBC_SYMBOL(pow)(double, double);
-void BUN_WRAP_GLIBC_SYMBOL(sincosf)(float, float*, float*);
 float BUN_WRAP_GLIBC_SYMBOL(sinf)(float);
 float BUN_WRAP_GLIBC_SYMBOL(tanf)(float);
 int BUN_WRAP_GLIBC_SYMBOL(fcntl)(int, int, ...);
 int BUN_WRAP_GLIBC_SYMBOL(fcntl64)(int, int, ...);
+void BUN_WRAP_GLIBC_SYMBOL(sincosf)(float, float*, float*);
 }
 
 // ban statx, for now

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -54,12 +54,15 @@ extern "C" int kill(int pid, int sig)
 // if linux
 #if defined(__linux__)
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <fcntl.h>
 #include <dlfcn.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <math.h>
 #include <stdarg.h>
+#include <errno.h>
+#include <math.h>
 
 #ifndef _STAT_VER
 #if defined(__aarch64__)


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
