### PR TITLE
fix 14248

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2251,6 +2251,7 @@ pub const E = struct {
     pub const String = struct {
         // A version of this where `utf8` and `value` are stored in a packed union, with len as a single u32 was attempted.
         // It did not improve benchmarks. Neither did converting this from a heap-allocated type to a stack-allocated type.
+        // TODO: change this to *const anyopaque and change all uses to either .slice8() or .slice16()
         data: []const u8 = "",
         prefer_template: bool = false,
 
@@ -2344,6 +2345,11 @@ pub const E = struct {
                 init(utf8)
             else
                 init(bun.strings.toUTF16AllocForReal(allocator, utf8, false, false) catch bun.outOfMemory());
+        }
+
+        pub fn slice8(this: *const String) []const u8 {
+            bun.assert(!this.is_utf16);
+            return this.data;
         }
 
         pub fn slice16(this: *const String) []const u16 {
@@ -5895,9 +5901,10 @@ pub const Expr = struct {
                 .e_undefined => std.math.nan(f64),
                 .e_string => |str| {
                     if (str.next != null) return null;
+                    if (!str.isUTF8()) return null;
 
                     // +'1' => 1
-                    return stringToEquivalentNumberValue(str.data);
+                    return stringToEquivalentNumberValue(str.slice8());
                 },
                 .e_boolean => @as(f64, if (data.e_boolean.value) 1.0 else 0.0),
                 .e_number => data.e_number.value,
@@ -5905,9 +5912,10 @@ pub const Expr = struct {
                     .e_number => |num| num.value,
                     .e_string => |str| {
                         if (str.next != null) return null;
+                        if (!str.isUTF8()) return null;
 
                         // +'1' => 1
-                        return stringToEquivalentNumberValue(str.data);
+                        return stringToEquivalentNumberValue(str.slice8());
                     },
                     else => null,
                 },

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -467,4 +467,26 @@ describe("bundler", () => {
       api.expectFile("/out.js").not.toContain("module");
     },
   });
+  itBundled("minify/ConstantFoldingUnaryPlusString", {
+    files: {
+      "/entry.ts": `
+        // supported
+        capture(+'1.0');
+        capture(+'-123.567');
+        capture(+'8.325');
+        capture(+'100000000');
+        capture(+'\\u0030\\u002e\\u0031');
+        capture(+'\\x30\\x2e\\x31');
+      `,
+    },
+    minifySyntax: true,
+    capture: [
+      "1",
+      "-123.567",
+      "8.325",
+      "1e8",
+      "+\"0.1\"",
+      "+\"0.1\"",
+    ],
+  });
 });

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -475,6 +475,7 @@ describe("bundler", () => {
         capture(+'-123.567');
         capture(+'8.325');
         capture(+'100000000');
+        // unsupported
         capture(+'\\u0030\\u002e\\u0031');
         capture(+'\\x30\\x2e\\x31');
       `,
@@ -485,6 +486,7 @@ describe("bundler", () => {
       "-123.567",
       "8.325",
       "1e8",
+      // untouched
       "+\"0.1\"",
       "+\"0.1\"",
     ],


### PR DESCRIPTION
Fixes #14248

Escaped UTF-16 data was being interpreted as unescaped UTF-8

This bug reveals that `E.String` is too unsafe, specifically `data`. I have left a TODO comment for when I reduce `E.String`'s memory footprint to also make it harder to mis-interpret the underlying bytes.