### PR TITLE
Make import.meta.require act as e_require_ref

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -18780,6 +18780,10 @@ fn NewParser_(
                     if (strings.eqlComptime(name, "main")) {
                         return p.valueForImportMetaMain(false, target.loc);
                     }
+
+                    if (strings.eqlComptime(name, "require")) {
+                        return p.valueForRequire(target.loc);
+                    }
                 },
                 .e_require_call_target => {
                     if (strings.eqlComptime(name, "main")) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1870,6 +1870,22 @@ describe("bundler", () => {
     target: "bun",
     run: { stdout: `123` },
   });
+  itBundled('edgecase/RebundleImportMetaRequire', {
+    // We don't officially support people manually using import.meta.require,
+    // however it is very easy to handle, and has caused issues when bundles
+    // are fed back into `bun build`. See https://github.com/oven-sh/bun/issues/9416
+    files: {
+      '/entry.js': `
+        console.log(import.meta.require('node:fs'));
+      `,
+    },
+    outfile: 'out.mjs',
+    target: 'node',
+    run: { runtime: 'node' }, // will throw since they do not have import.meta.require
+    onAfterBundle(api) {
+      api.expectFile('/out.mjs').not.toInclude('import.meta.require');
+    },
+  });
   itBundled("edgecase/Latin1StringKeyBrowser", {
     files: {
       "/entry.ts": `

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -443,6 +443,9 @@ describe("bundler", () => {
         capture(!!(require.main !== module)); 
         capture(!!(require.main == module)); 
         capture(!!(require.main != module)); 
+
+        capture(import.meta.require.main === module); 
+        capture(import.meta.require.main !== module); 
       `,
     },
     outfile: "/out.js",
@@ -455,6 +458,8 @@ describe("bundler", () => {
       "import.meta.main",
       "!import.meta.main",
       "import.meta.main",
+      "import.meta.main",
+      "!import.meta.main",
       "import.meta.main",
       "!import.meta.main",
       "import.meta.main",


### PR DESCRIPTION
Fixes #9416

`import.meta.require` will turn into the require ref