### PR TITLE
cli:test: skip printing successes when in debug mode and BUN_DEBUG_jest=1

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -175,9 +175,18 @@ pub const CommandLineReporter = struct {
 
         var this: *CommandLineReporter = @fieldParentPtr("callback", cb);
 
-        writeTestStatusLine(.pass, &writer);
-
-        printTestLine(label, elapsed_ns, parent, false, writer);
+        const debug_jest = blk: {
+            if (bun.getenvZ("BUN_DEBUG_jest")) |env| {
+                if (strings.eqlComptime(env, "1")) {
+                    break :blk true;
+                }
+            }
+            break :blk false;
+        };
+        if (bun.Environment.isRelease or !debug_jest) {
+            writeTestStatusLine(.pass, &writer);
+            printTestLine(label, elapsed_ns, parent, false, writer);
+        }
 
         this.jest.tests.items(.status)[id] = TestRunner.Test.Status.pass;
         this.summary.pass += 1;

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -175,15 +175,7 @@ pub const CommandLineReporter = struct {
 
         var this: *CommandLineReporter = @fieldParentPtr("callback", cb);
 
-        const debug_jest = blk: {
-            if (bun.getenvZ("BUN_DEBUG_jest")) |env| {
-                if (strings.eqlComptime(env, "1")) {
-                    break :blk true;
-                }
-            }
-            break :blk false;
-        };
-        if (bun.Environment.isRelease or !debug_jest) {
+        if (bun.Environment.isRelease or !Output.Scoped(.jest, false).isVisible()) {
             writeTestStatusLine(.pass, &writer);
             printTestLine(label, elapsed_ns, parent, false, writer);
         }


### PR DESCRIPTION
this greatly reduces the noise when developing by reducing the amount of redundant information printed when developing bun itself

below is the result shown in the debugger output

<img width="610" alt="image" src="https://github.com/user-attachments/assets/8eb8549b-67ae-45e6-af55-c3ac6a3d4bd3">

and run manually in the terminal

<img width="605" alt="image" src="https://github.com/user-attachments/assets/49ea20fc-065e-473b-9a26-296ee9a3b348">

been using this as a local patch for quite some time and thought to finally upstream