### PR TITLE
node: lowercase primitive expectations of ERR_INVALID_ARG_TYPE

### DIFF
--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -655,7 +655,7 @@ var require_assertion_error = __commonJS({
       function AssertionError2(options) {
         var _this;
         if ((_classCallCheck(this, AssertionError2), _typeof(options) !== "object" || options === null))
-          throw new ERR_INVALID_ARG_TYPE("options", "Object", options);
+          throw new ERR_INVALID_ARG_TYPE("options", "object", options);
         var message = options.message,
           operator = options.operator,
           stackStartFn = options.stackStartFn,
@@ -1083,7 +1083,7 @@ var require_assert = __commonJS({
           : expected.$call({}, actual) === !0;
     }
     function getActual(fn) {
-      if (typeof fn != "function") throw new ERR_INVALID_ARG_TYPE("fn", "Function", fn);
+      if (typeof fn != "function") throw new ERR_INVALID_ARG_TYPE("fn", "function", fn);
       try {
         fn();
       } catch (e) {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1293,7 +1293,7 @@ class ChildProcess extends EventEmitter {
       options = undefined;
     } else if (options !== undefined) {
       if (typeof options !== "object" || options === null) {
-        throw ERR_INVALID_ARG_TYPE("options", "Object", options);
+        throw ERR_INVALID_ARG_TYPE("options", "object", options);
       }
     }
 
@@ -1765,7 +1765,7 @@ class AbortError extends Error {
   name = "AbortError";
   constructor(message = "The operation was aborted", options = undefined) {
     if (options !== undefined && typeof options !== "object") {
-      throw ERR_INVALID_ARG_TYPE("options", "Object", options);
+      throw ERR_INVALID_ARG_TYPE("options", "object", options);
     }
     super(message, options);
   }

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -482,7 +482,7 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
 class AbortError extends Error {
   constructor(message = "The operation was aborted", options = undefined) {
     if (options !== undefined && typeof options !== "object") {
-      throw ERR_INVALID_ARG_TYPE("options", "Object", options);
+      throw ERR_INVALID_ARG_TYPE("options", "object", options);
     }
     super(message, options);
     this.code = "ABORT_ERR";

--- a/src/js/node/trace_events.ts
+++ b/src/js/node/trace_events.ts
@@ -14,7 +14,7 @@ function ERR_INVALID_ARG_TYPE(name, type, value) {
 function createTracing(opts) {
   if (typeof opts !== "object" || opts == null) {
     // @ts-ignore
-    throw new ERR_INVALID_ARG_TYPE("options", "Object", opts);
+    throw new ERR_INVALID_ARG_TYPE("options", "object", opts);
   }
 
   // TODO: validate categories

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -137,15 +137,15 @@ var log = function log() {
 };
 var inherits = function inherits(ctor, superCtor) {
   if (ctor === undefined || ctor === null) {
-    throw ERR_INVALID_ARG_TYPE("ctor", "Function", ctor);
+    throw ERR_INVALID_ARG_TYPE("ctor", "function", ctor);
   }
 
   if (superCtor === undefined || superCtor === null) {
-    throw ERR_INVALID_ARG_TYPE("superCtor", "Function", superCtor);
+    throw ERR_INVALID_ARG_TYPE("superCtor", "function", superCtor);
   }
 
   if (superCtor.prototype === undefined) {
-    throw ERR_INVALID_ARG_TYPE("superCtor.prototype", "Object", superCtor.prototype);
+    throw ERR_INVALID_ARG_TYPE("superCtor.prototype", "object", superCtor.prototype);
   }
   ctor.super_ = superCtor;
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);


### PR DESCRIPTION
will make https://github.com/oven-sh/bun/pull/14177 have to do less work, node does this conversion internally but there's no reason not to only send the correct expecteds