### PR TITLE
Rename internal NapiHandleScope push/pop methods to open/close

### DIFF
--- a/src/bun.js/api/FFI.h
+++ b/src/bun.js/api/FFI.h
@@ -60,8 +60,8 @@ typedef enum {
   napi_detachable_arraybuffer_expected,
   napi_would_deadlock // unused
 } napi_status;
-void* NapiHandleScope__push(void* jsGlobalObject, bool detached);
-void NapiHandleScope__pop(void* jsGlobalObject, void* handleScope);
+void* NapiHandleScope__open(void* jsGlobalObject, bool detached);
+void NapiHandleScope__close(void* jsGlobalObject, void* handleScope);
 #endif
 
 

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -1800,7 +1800,7 @@ pub const FFI = struct {
 
             if (this.needsHandleScope()) {
                 try writer.writeAll(
-                    \\  void* handleScope = NapiHandleScope__push(JS_GLOBAL_OBJECT, false);
+                    \\  void* handleScope = NapiHandleScope__open(JS_GLOBAL_OBJECT, false);
                     \\
                 );
             }
@@ -1913,7 +1913,7 @@ pub const FFI = struct {
 
             if (this.needsHandleScope()) {
                 try writer.writeAll(
-                    \\  NapiHandleScope__pop(JS_GLOBAL_OBJECT, handleScope);
+                    \\  NapiHandleScope__close(JS_GLOBAL_OBJECT, handleScope);
                     \\
                 );
             }
@@ -2487,8 +2487,8 @@ const CompilerRT = struct {
     pub fn inject(state: *TCC.TCCState) void {
         _ = TCC.tcc_add_symbol(state, "memset", &memset);
         _ = TCC.tcc_add_symbol(state, "memcpy", &memcpy);
-        _ = TCC.tcc_add_symbol(state, "NapiHandleScope__push", &bun.JSC.napi.NapiHandleScope.NapiHandleScope__push);
-        _ = TCC.tcc_add_symbol(state, "NapiHandleScope__pop", &bun.JSC.napi.NapiHandleScope.NapiHandleScope__pop);
+        _ = TCC.tcc_add_symbol(state, "NapiHandleScope__open", &bun.JSC.napi.NapiHandleScope.NapiHandleScope__open);
+        _ = TCC.tcc_add_symbol(state, "NapiHandleScope__close", &bun.JSC.napi.NapiHandleScope.NapiHandleScope__close);
 
         _ = TCC.tcc_add_symbol(
             state,

--- a/src/bun.js/bindings/napi_handle_scope.h
+++ b/src/bun.js/bindings/napi_handle_scope.h
@@ -61,18 +61,18 @@ private:
     NapiHandleScopeImpl(JSC::VM& vm, JSC::Structure* structure, NapiHandleScopeImpl* parent, bool escapable);
 };
 
-// Wrapper class used to push a new handle scope and pop it when this instance goes out of scope
+// Wrapper class used to open a new handle scope and close it when this instance goes out of scope
 class NapiHandleScope {
 public:
     NapiHandleScope(Zig::GlobalObject* globalObject);
     ~NapiHandleScope();
 
     // Create a new handle scope in the given environment
-    static NapiHandleScopeImpl* push(Zig::GlobalObject* globalObject, bool escapable);
+    static NapiHandleScopeImpl* open(Zig::GlobalObject* globalObject, bool escapable);
 
-    // Pop the most recently created handle scope in the given environment and restore the old one.
+    // Closes the most recently created handle scope in the given environment and restores the old one.
     // Asserts that `current` is the active handle scope.
-    static void pop(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
+    static void close(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
 
 private:
     NapiHandleScopeImpl* m_impl;
@@ -80,11 +80,11 @@ private:
 };
 
 // Create a new handle scope in the given environment
-extern "C" NapiHandleScopeImpl* NapiHandleScope__push(Zig::GlobalObject* globalObject, bool escapable);
+extern "C" NapiHandleScopeImpl* NapiHandleScope__open(Zig::GlobalObject* globalObject, bool escapable);
 
 // Pop the most recently created handle scope in the given environment and restore the old one.
 // Asserts that `current` is the active handle scope.
-extern "C" void NapiHandleScope__pop(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
+extern "C" void NapiHandleScope__close(Zig::GlobalObject* globalObject, NapiHandleScopeImpl* current);
 
 // Store a value in the active handle scope in the given environment
 extern "C" void NapiHandleScope__append(Zig::GlobalObject* globalObject, JSC::EncodedJSValue value);


### PR DESCRIPTION
### What does this PR do?

Renames `NapiHandleScope::push`, `NapiHandleScope::pop`, `NapiHandleScope__push`, and `NapiHandleScope__pop` to use `open` and `close` instead of `push` and `pop`. The new names are consistent with public NAPI functions that work with handle scopes.

### How did you verify your code works?

Re-ran existing NAPI and FFI tests.
