### PR TITLE
Update CONTRIBUTING.md, fix #14225

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,34 +116,18 @@ $ export PATH="$PATH:/usr/lib/llvm16/bin"
 
 ## Building Bun
 
-After cloning the repository, run the following command to run the first build. This may take a while as it will clone submodules and build dependencies.
-
-```bash
-$ bun setup
-```
-
-The binary will be located at `./build/bun-debug`. It is recommended to add this to your `$PATH`. To verify the build worked, let's print the version number on the development build of Bun.
-
-```bash
-$ build/bun-debug --version
-x.y.z_debug
-```
-
-To rebuild, you can invoke `bun run build`
+After cloning the repository, run the following command to build. This may take a while as it will clone submodules and build dependencies.
 
 ```bash
 $ bun run build
 ```
 
-These two scripts, `setup` and `build`, are aliases to do roughly the following:
+The binary will be located at `./build/debug/bun-debug`. It is recommended to add this to your `$PATH`. To verify the build worked, let's print the version number on the development build of Bun.
 
 ```bash
-$ ./scripts/setup.sh
-$ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
-$ ninja -C build # 'bun run build' runs just this
+$ build/debug/bun-debug --version
+x.y.z_debug
 ```
-
-Advanced users can pass CMake flags to customize the build.
 
 ## VSCode
 


### PR DESCRIPTION
`setup.sh` was removed in #13427. Updated the doc accordingly.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
