### PR TITLE
node:stream: fix setDefaultHighWaterMark

### DIFF
--- a/src/js/node/stream.ts
+++ b/src/js/node/stream.ts
@@ -617,14 +617,9 @@ var require_validators = __commonJS({
       ArrayPrototypeIncludes,
       ArrayPrototypeJoin,
       ArrayPrototypeMap,
-      NumberIsInteger,
-      NumberMAX_SAFE_INTEGER,
-      NumberMIN_SAFE_INTEGER,
       NumberParseInt,
       RegExpPrototypeTest,
       String: String2,
-      StringPrototypeToUpperCase,
-      StringPrototypeTrim,
     } = require_primordials();
     var {
       hideStackFrames,
@@ -2121,49 +2116,6 @@ var require_from = __commonJS({
   },
 });
 
-var require_state = __commonJS({
-  "node_modules/readable-stream/lib/internal/streams/state.js"(exports, module) {
-    "use strict";
-
-    const { MathFloor, NumberIsInteger } = require_primordials();
-    const { ERR_INVALID_ARG_VALUE } = require_errors().codes;
-    let defaultHighWaterMarkBytes = 16 * 1024;
-    let defaultHighWaterMarkObjectMode = 16;
-    function highWaterMarkFrom(options, isDuplex, duplexKey) {
-      return options.highWaterMark != null ? options.highWaterMark : isDuplex ? options[duplexKey] : null;
-    }
-    function getDefaultHighWaterMark(objectMode) {
-      return objectMode ? defaultHighWaterMarkObjectMode : defaultHighWaterMarkBytes;
-    }
-    function setDefaultHighWaterMark(objectMode, value) {
-      validateInteger(value, "value", 0);
-      if (objectMode) {
-        defaultHighWaterMarkObjectMode = value;
-      } else {
-        defaultHighWaterMarkBytes = value;
-      }
-    }
-    function getHighWaterMark(state, options, duplexKey, isDuplex) {
-      const hwm = highWaterMarkFrom(options, isDuplex, duplexKey);
-      if (hwm != null) {
-        if (!NumberIsInteger(hwm) || hwm < 0) {
-          const name = isDuplex ? `options.${duplexKey}` : "options.highWaterMark";
-          throw new ERR_INVALID_ARG_VALUE(name, hwm);
-        }
-        return MathFloor(hwm);
-      }
-
-      // Default value
-      return getDefaultHighWaterMark(state.objectMode);
-    }
-    module.exports = {
-      getHighWaterMark,
-      getDefaultHighWaterMark,
-      setDefaultHighWaterMark,
-    };
-  },
-});
-
 var _ReadableFromWeb;
 var _ReadableFromWebForUndici;
 
@@ -2190,8 +2142,6 @@ var require_readable = __commonJS({
     var { Stream, prependListener } = require_legacy();
 
     const BufferList = $cpp("JSBufferList.cpp", "getBufferList");
-
-    const { getHighWaterMark, getDefaultHighWaterMark } = require_state();
 
     const { AbortError } = require_errors();
 

--- a/test/js/node/test/parallel/stream-set-default-hwm.test.js
+++ b/test/js/node/test/parallel/stream-set-default-hwm.test.js
@@ -1,0 +1,42 @@
+//#FILE: test-stream-set-default-hwm.js
+//#SHA1: bc1189f9270a4b5463d8421ef234fc7baaad667f
+//-----------------
+"use strict";
+
+const { setDefaultHighWaterMark, getDefaultHighWaterMark, Writable, Readable, Transform } = require("stream");
+
+test("setDefaultHighWaterMark and getDefaultHighWaterMark for object mode", () => {
+  expect(getDefaultHighWaterMark(false)).not.toBe(32 * 1000);
+  setDefaultHighWaterMark(false, 32 * 1000);
+  expect(getDefaultHighWaterMark(false)).toBe(32 * 1000);
+});
+
+test("setDefaultHighWaterMark and getDefaultHighWaterMark for non-object mode", () => {
+  expect(getDefaultHighWaterMark(true)).not.toBe(32);
+  setDefaultHighWaterMark(true, 32);
+  expect(getDefaultHighWaterMark(true)).toBe(32);
+});
+
+test("Writable stream uses new default high water mark", () => {
+  const w = new Writable({
+    write() {},
+  });
+  expect(w.writableHighWaterMark).toBe(32 * 1000);
+});
+
+test("Readable stream uses new default high water mark", () => {
+  const r = new Readable({
+    read() {},
+  });
+  expect(r.readableHighWaterMark).toBe(32 * 1000);
+});
+
+test("Transform stream uses new default high water mark for both readable and writable", () => {
+  const t = new Transform({
+    transform() {},
+  });
+  expect(t.writableHighWaterMark).toBe(32 * 1000);
+  expect(t.readableHighWaterMark).toBe(32 * 1000);
+});
+
+//<#END_FILE: test-stream-set-default-hwm.js


### PR DESCRIPTION
localized function implementation was interfering with functions of the same name in global scope

global scoped functions exist at b/L2001-2026