### PR TITLE
On test timeout, kill any spawned processes

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1449,7 +1449,7 @@ pub const Subprocess = struct {
         defer this.deref();
         defer this.disconnectIPC(true);
 
-        jsc_vm.onProcessExit(process);
+        jsc_vm.onSubprocessExit(process);
 
         var stdin: ?*JSC.WebCore.FileSink = this.weak_file_sink_stdin_ptr;
         var existing_stdin_value = JSC.JSValue.zero;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -2326,7 +2326,7 @@ pub const Subprocess = struct {
                 abort_signal = null;
             }
             if (!subprocess.process.hasExited()) {
-                jsc_vm.onProcessSpawn(subprocess.process);
+                jsc_vm.onSubprocessSpawn(subprocess.process);
             }
             return out;
         }
@@ -2350,7 +2350,7 @@ pub const Subprocess = struct {
         }
 
         if (!subprocess.process.hasExited()) {
-            jsc_vm.onProcessSpawn(subprocess.process);
+            jsc_vm.onSubprocessSpawn(subprocess.process);
         }
 
         while (subprocess.hasPendingActivityNonThreadsafe()) {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -761,7 +761,7 @@ const AutoKiller = struct {
             this.processes.put(bun.default_allocator, process, {}) catch {};
     }
 
-    pub fn onProcessExit(this: *AutoKiller, process: *bun.spawn.Process) void {
+    pub fn onSubprocessExit(this: *AutoKiller, process: *bun.spawn.Process) void {
         if (this.ever_enabled)
             _ = this.processes.swapRemove(process);
     }
@@ -957,7 +957,7 @@ pub const VirtualMachine = struct {
         this.auto_killer.onSpawnProcess(process);
     }
 
-    pub fn onProcessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {
+    pub fn onSubprocessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {
         this.auto_killer.onProcessExit(process);
     }
 

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -700,6 +700,76 @@ const body_value_pool_size = if (bun.heap_breakdown.enabled) 0 else 256;
 pub const BodyValueRef = bun.HiveRef(JSC.WebCore.Body.Value, body_value_pool_size);
 const BodyValueHiveAllocator = bun.HiveArray(BodyValueRef, body_value_pool_size).Fallback;
 
+const AutoKiller = struct {
+    const log = Output.scoped(.AutoKiller, true);
+    processes: std.AutoArrayHashMapUnmanaged(*bun.spawn.Process, void) = .{},
+    enabled: bool = false,
+    ever_enabled: bool = false,
+
+    pub fn enable(this: *AutoKiller) void {
+        this.enabled = true;
+        this.ever_enabled = true;
+    }
+
+    pub fn disable(this: *AutoKiller) void {
+        this.enabled = false;
+    }
+
+    pub const Result = struct {
+        processes: u32 = 0,
+
+        pub fn format(self: @This(), comptime _: []const u8, _: anytype, writer: anytype) !void {
+            switch (self.processes) {
+                0 => {},
+                1 => {
+                    try writer.writeAll("killed 1 dangling process");
+                },
+                else => {
+                    try std.fmt.format(writer, "killed {d} dangling processes", .{self.processes});
+                },
+            }
+        }
+    };
+
+    pub fn kill(this: *AutoKiller) Result {
+        return .{
+            .processes = this.killProcesses(),
+        };
+    }
+
+    fn killProcesses(this: *AutoKiller) u32 {
+        var count: u32 = 0;
+        while (this.processes.popOrNull()) |process| {
+            if (!process.key.hasExited()) {
+                log("process.kill {d}", .{process.key.pid});
+                count += @as(u32, @intFromBool(process.key.kill(bun.SignalCode.default) == .result));
+            }
+        }
+        return count;
+    }
+
+    pub fn clear(this: *AutoKiller) void {
+        if (this.processes.capacity() > 256) {
+            this.processes.clearAndFree(bun.default_allocator);
+        }
+
+        this.processes.clearRetainingCapacity();
+    }
+
+    pub fn onSpawnProcess(this: *AutoKiller, process: *bun.spawn.Process) void {
+        if (this.enabled)
+            this.processes.put(bun.default_allocator, process, {}) catch {};
+    }
+
+    pub fn onProcessExit(this: *AutoKiller, process: *bun.spawn.Process) void {
+        _ = this.processes.swapRemove(process);
+    }
+
+    pub fn deinit(this: *AutoKiller) void {
+        this.processes.deinit(bun.default_allocator);
+    }
+};
+
 /// TODO: rename this to ScriptExecutionContext
 /// This is the shared global state for a single JS instance execution
 /// Today, Bun is one VM per thread, so the name "VirtualMachine" sort of makes sense
@@ -765,6 +835,9 @@ pub const VirtualMachine = struct {
     macro_entry_points: std.AutoArrayHashMap(i32, *MacroEntryPoint),
     macro_mode: bool = false,
     no_macros: bool = false,
+    auto_killer: AutoKiller = .{
+        .enabled = false,
+    },
 
     has_any_macro_remappings: bool = false,
     is_from_devserver: bool = false,
@@ -877,6 +950,14 @@ pub const VirtualMachine = struct {
 
     pub fn getTLSRejectUnauthorized(this: *const VirtualMachine) bool {
         return this.default_tls_reject_unauthorized orelse this.bundler.env.getTLSRejectUnauthorized();
+    }
+
+    pub fn onProcessSpawn(this: *VirtualMachine, process: *bun.spawn.Process) void {
+        if (this.auto_killer.ever_enabled) this.auto_killer.onSpawnProcess(process);
+    }
+
+    pub fn onProcessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {
+        if (this.auto_killer.ever_enabled) this.auto_killer.onProcessExit(process);
     }
 
     pub fn getVerboseFetch(this: *VirtualMachine) bun.http.HTTPVerboseLevel {
@@ -2561,6 +2642,8 @@ pub const VirtualMachine = struct {
 
     // TODO:
     pub fn deinit(this: *VirtualMachine) void {
+        this.auto_killer.deinit();
+
         if (source_code_printer) |print| {
             print.getMutableBuffer().deinit();
             print.ctx.written = &.{};

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -958,7 +958,7 @@ pub const VirtualMachine = struct {
     }
 
     pub fn onSubprocessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {
-        this.auto_killer.onProcessExit(process);
+        this.auto_killer.onSubprocessExit(process);
     }
 
     pub fn getVerboseFetch(this: *VirtualMachine) bun.http.HTTPVerboseLevel {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -756,7 +756,7 @@ const AutoKiller = struct {
         this.processes.clearRetainingCapacity();
     }
 
-    pub fn onSpawnProcess(this: *AutoKiller, process: *bun.spawn.Process) void {
+    pub fn onSubprocessSpawn(this: *AutoKiller, process: *bun.spawn.Process) void {
         if (this.enabled)
             this.processes.put(bun.default_allocator, process, {}) catch {};
     }
@@ -953,8 +953,8 @@ pub const VirtualMachine = struct {
         return this.default_tls_reject_unauthorized orelse this.bundler.env.getTLSRejectUnauthorized();
     }
 
-    pub fn onProcessSpawn(this: *VirtualMachine, process: *bun.spawn.Process) void {
-        this.auto_killer.onSpawnProcess(process);
+    pub fn onSubprocessSpawn(this: *VirtualMachine, process: *bun.spawn.Process) void {
+        this.auto_killer.onSubprocessSpawn(process);
     }
 
     pub fn onSubprocessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -762,7 +762,8 @@ const AutoKiller = struct {
     }
 
     pub fn onProcessExit(this: *AutoKiller, process: *bun.spawn.Process) void {
-        _ = this.processes.swapRemove(process);
+        if (this.ever_enabled)
+            _ = this.processes.swapRemove(process);
     }
 
     pub fn deinit(this: *AutoKiller) void {
@@ -953,11 +954,11 @@ pub const VirtualMachine = struct {
     }
 
     pub fn onProcessSpawn(this: *VirtualMachine, process: *bun.spawn.Process) void {
-        if (this.auto_killer.ever_enabled) this.auto_killer.onSpawnProcess(process);
+        this.auto_killer.onSpawnProcess(process);
     }
 
     pub fn onProcessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {
-        if (this.auto_killer.ever_enabled) this.auto_killer.onProcessExit(process);
+        this.auto_killer.onProcessExit(process);
     }
 
     pub fn getVerboseFetch(this: *VirtualMachine) bun.http.HTTPVerboseLevel {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -149,8 +149,12 @@ pub const TestRunner = struct {
         this.has_pending_tests = false;
         this.pending_test = null;
 
+        const vm = JSC.VirtualMachine.get();
+        vm.auto_killer.clear();
+        vm.auto_killer.disable();
+
         // disable idling
-        JSC.VirtualMachine.get().wakeup();
+        vm.wakeup();
     }
 
     pub fn drain(this: *TestRunner) void {
@@ -1410,7 +1414,7 @@ pub const TestRunnerTask = struct {
         }
 
         this.sync_state = .pending;
-
+        jsc_vm.auto_killer.enable();
         var result = TestScope.run(&test_, this);
 
         if (this.describe.tests.items.len > test_id) {
@@ -1429,7 +1433,6 @@ pub const TestRunnerTask = struct {
                 // Let's allow any pending work to run, and then move on to the next test.
                 this.continueRunningTestsAfterMicrotasksRun();
             }
-
             return true;
         }
 
@@ -1551,8 +1554,22 @@ pub const TestRunnerTask = struct {
         describe.tests.items[test_id] = test_;
 
         if (from == .timeout) {
-            const err = this.globalThis.createErrorInstance("Test {} timed out after {d}ms", .{ bun.fmt.quote(test_.label), test_.timeout_millis });
-            _ = this.globalThis.bunVM().uncaughtException(this.globalThis, err, true);
+            const vm = this.globalThis.bunVM();
+            const cancel_result = vm.auto_killer.kill();
+
+            const err = brk: {
+                if (cancel_result.processes > 0) {
+                    switch (Output.enable_ansi_colors_stdout) {
+                        inline else => |enable_ansi_colors| {
+                            break :brk this.globalThis.createErrorInstance(comptime Output.prettyFmt("Test {} timed out after {d}ms <r><d>({})<r>", enable_ansi_colors), .{ bun.fmt.quote(test_.label), test_.timeout_millis, cancel_result });
+                        },
+                    }
+                } else {
+                    break :brk this.globalThis.createErrorInstance("Test {} timed out after {d}ms", .{ bun.fmt.quote(test_.label), test_.timeout_millis });
+                }
+            };
+
+            _ = vm.uncaughtException(this.globalThis, err, true);
         }
 
         checkAssertionsCounter(result);
@@ -1620,6 +1637,7 @@ pub const TestRunnerTask = struct {
             .pending => @panic("Unexpected pending test"),
         }
         describe.onTestComplete(globalThis, test_id, result == .skip or (!Jest.runner.?.test_options.run_todo and result == .todo));
+
         Jest.runner.?.runNextTest();
     }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1213,6 +1213,7 @@ pub const TestCommand = struct {
                     if (reporter.jest.bail == reporter.summary.fail) {
                         reporter.printSummary();
                         Output.prettyError("\nBailed out after {d} failure{s}<r>\n", .{ reporter.jest.bail, if (reporter.jest.bail == 1) "" else "s" });
+
                         Global.exit(1);
                     }
 
@@ -1287,6 +1288,10 @@ pub const TestCommand = struct {
                 Output.prettyErrorln("<r>\n::endgroup::\n", .{});
                 Output.flush();
             }
+
+            // Ensure these never linger across files.
+            vm.auto_killer.clear();
+            vm.auto_killer.disable();
         }
 
         if (is_last) {

--- a/test/cli/test/process-kill-fixture-sync.ts
+++ b/test/cli/test/process-kill-fixture-sync.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("test timeout kills dangling processes", async () => {
+  Bun.spawnSync({
+    cmd: [bunExe(), "--eval", "Bun.sleepSync(500); console.log('This should not be printed!');"],
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+    env: bunEnv,
+  });
+}, 10);
+
+test("slow test after test timeout", async () => {
+  await Bun.sleep(100);
+  console.log("Ran slow test");
+}, 200);

--- a/test/cli/test/process-kill-fixture.ts
+++ b/test/cli/test/process-kill-fixture.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("test timeout kills dangling processes", async () => {
+  Bun.spawn({
+    cmd: [bunExe(), "--eval", "Bun.sleepSync(50); console.log('This should not be printed!');"],
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+    env: bunEnv,
+  });
+  await Bun.sleep(5);
+}, 1);
+
+test("slow test after test timeout", async () => {
+  await Bun.sleep(100);
+  console.log("Ran slow test");
+}, 200);

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+test.each([true, false])("processes get killed", async sync => {
+  const { exited, stdout, stderr } = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "test",
+      path.join(import.meta.dir, sync ? "process-kill-fixture-sync.ts" : "process-kill-fixture.ts"),
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "inherit",
+    env: bunEnv,
+  });
+  const [out, err, exitCode] = await Promise.all([new Response(stdout).text(), new Response(stderr).text(), exited]);
+  console.log(out);
+  console.log(err);
+  // TODO: figure out how to handle terminatio nexception from spawn sync properly.
+  expect(exitCode).not.toBe(0);
+  expect(out).not.toContain("This should not be printed!");
+  expect(err).toContain("killed 1 dangling process");
+});

--- a/test/integration/next-pages/test/dev-server-puppeteer.ts
+++ b/test/integration/next-pages/test/dev-server-puppeteer.ts
@@ -37,6 +37,17 @@ const b = await launch({
   ],
 });
 
+process.on("beforeExit", async reason => {
+  await b?.close?.();
+});
+
+process.once("SIGTERM", () => {
+  b?.close?.();
+  setTimeout(() => {
+    process.exit(0);
+  }, 100);
+});
+
 async function main() {
   const p = await b.newPage();
   console.error("Loaded puppeteer");


### PR DESCRIPTION
### What does this PR do?

Test timeouts in `bun test` throw a special kind of exception that cannot be caught

This is a reliable way to cancel a test, but it means means cleanup functions don't work. Normally, this is mostly okay - but there are situations where this causes problems:
- Spawned processes do not get killed. On Linux and macOS, this causes dangling processes to hang around forever


### How did you verify your code works?

There is a test