### PR TITLE
hoisting of exports when there is top level using

### DIFF
--- a/src/ast/base.zig
+++ b/src/ast/base.zig
@@ -114,7 +114,7 @@ pub const Ref = packed struct(u64) {
         allocated_name,
         source_contents_slice,
         symbol,
-    } = .invalid,
+    },
 
     source_index: Int = 0,
 

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -22865,13 +22865,21 @@ fn NewParser_(
                 var end: u32 = 0;
                 for (stmts) |stmt| {
                     switch (stmt.data) {
-                        .s_directive,
-                        .s_import,
-                        .s_export_from,
-                        .s_export_star,
-                        => {
+                        .s_directive, .s_import, .s_export_from, .s_export_star => {
                             // These can't go in a try/catch block
                             result.append(stmt) catch bun.outOfMemory();
+                            continue;
+                        },
+
+                        .s_class => {
+                            if (stmt.data.s_class.is_export) {
+                                // can't go in try/catch; hoist out
+                                result.append(stmt) catch bun.outOfMemory();
+                                continue;
+                            }
+                        },
+
+                        .s_export_default => {
                             continue;
                         },
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1883,23 +1883,53 @@ describe("bundler", () => {
     target: "browser",
     run: { stdout: `123` },
   });
-  itBundled('edgecase/UninitializedVariablesMoved', {
+  itBundled("edgecase/UninitializedVariablesMoved", {
     files: {
-      '/entry.ts': `
+      "/entry.ts": `
         await import('./b.js');
       `,
-      '/b.js': `
+      "/b.js": `
         export var a = 32;
         export var b;
         (function (c) {
             c.d = 1;
         })(b ?? {});
         +a;
-      `
+      `,
     },
-    minifySyntax:true,
+    minifySyntax: true,
     run: true, // pass if no thrown error
-  })
+  });
+  itBundled("edgecase/UsingExportDefault", {
+    files: {
+      "/entry.ts": `
+        using a = {
+          [Symbol.dispose]: () => { 
+            console.info("Disposing");
+          }
+        };
+        export default {};
+      `,
+    },
+    run: {
+      stdout: "Disposing",
+    },
+  });
+  itBundled("edgecase/UsingExport", {
+    files: {
+      "/entry.ts": `
+        export class A {
+          [Symbol.dispose](){
+            console.info("Disposing");
+          }
+        }
+        using a = new A();
+      `,
+    },
+    run: {
+      stdout: "Disposing",
+    },
+  });
 
   // TODO(@paperdave): test every case of this. I had already tested it manually, but it may break later
   const requireTranspilationListESM = [

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2010,16 +2010,21 @@ describe("bundler", () => {
   itBundled("edgecase/UsingExportFails", {
     files: {
       "/entry.ts": `
+        import a from "./import.ts";
+        console.log(a.ok);
+      `,
+      "/import.ts": `
         using a = {
           [Symbol.dispose]: () => {
             console.log("Disposing");
-          }
+          },
+          ok: true,
         };
         export default a;
       `,
     },
     run: {
-      stdout: "Disposing",
+      stdout: "Disposing\ntrue",
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
fixes #13734 (and #14098 which actually was its own fix) - exported classes and export default were not hoisted properly and instead ended up inside the generated try/catch block.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
