### PR TITLE
remove bun pack in favor of bun pm pack

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1169,7 +1169,6 @@ pub const HelpCommand = struct {
         \\  <b><blue>remove<r>    <d>{s:<16}<r>     Remove a dependency from package.json <d>(bun rm)<r>
         \\  <b><blue>update<r>    <d>{s:<16}<r>     Update outdated dependencies
         \\  <b><blue>outdated<r>                       Display latest versions of outdated dependencies
-        \\  <b><blue>pack<r>                           Archive the current workspace package
         \\  <b><blue>link<r>      <d>[\<package\>]<r>          Register or link a local npm package
         \\  <b><blue>unlink<r>                         Unregister a local npm package
         \\  <b><blue>patch <d>\<pkg\><r>                    Prepare a package for patching


### PR DESCRIPTION
### What does this PR do?

Removes pack from base bun
```
  install                        Install dependencies for a package.json (bun i)
  add       @shumai/shumai       Add a dependency to package.json (bun a)
  remove    @parcel/core         Remove a dependency from package.json (bun rm)
  update    hono                 Update outdated dependencies
  outdated                       Display latest versions of outdated dependencies
  pack                           Archive the current workspace package
  link      [<package>]          Register or link a local npm package
  unlink                         Unregister a local npm package
  patch <pkg>                    Prepare a package for patching
  pm <subcommand>                Additional package management utilities
```

- [x] Code changes

`bun pack` was a legacy option that did not work but still appeared in the help panel, this just removes it, `bun pm pack` still works as normal
