### PR TITLE
add docs for `bun publish`

### DIFF
--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -1,8 +1,11 @@
 ## `bun publish`
 
-To publish a package to the npm registry, use `bun publish`. `bun publish` will automatically pack your package into a tarball and send it off to the configured npm registry from your config files.
+Use `bun publish` to publish a package to the npm registry.
+
+`bun publish` will automatically pack your package into a tarball, strip workspace protocols from the `package.json` (resolving versions if necessary), and publish to the registry specified in your configuration files. Both `bunfig.toml` and `.npmrc` files are supported.
 
 ```sh
+## Publishing the package from the current working directory
 $ bun publish
 
 ## Output
@@ -97,4 +100,4 @@ Enter OTP: 123456
 
 ### `--gzip-level`
 
-Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball path argument.
+Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball path argument. Values range from `0` to `9` (default is `9`).

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -1,6 +1,6 @@
 ## `bun publish`
 
-To publish a package to the npm registry, use `bun publish`. `bun publish` will automatically pack your package into a tarball and send it off to to the configured npm registry from your config files.
+To publish a package to the npm registry, use `bun publish`. `bun publish` will automatically pack your package into a tarball and send it off to the configured npm registry from your config files.
 
 ```sh
 $ bun publish

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -98,6 +98,14 @@ Enter OTP: 123456
 ...
 ```
 
+### `--otp`
+
+Provide a one-time password directly to the CLI. If the password is valid, this will skip the extra prompt for a one-time password before publishing. Example usage:
+
+```sh
+$ bun publish --otp 123456
+```
+
 ### `--gzip-level`
 
 Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball path argument. Values range from `0` to `9` (default is `9`).

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -1,0 +1,100 @@
+## `bun publish`
+
+To publish a package to the npm registry, use `bun publish`. `bun publish` will automatically pack your package into a tarball and send it off to to the configured npm registry from your config files.
+
+```sh
+$ bun publish
+
+## Output
+bun publish v1.1.30 (ca7428e9)
+
+packed 203B package.json
+packed 224B README.md
+packed 30B index.ts
+packed 0.64KB tsconfig.json
+
+Total files: 4
+Shasum: 79e2b4377b63f4de38dc7ea6e5e9dbee08311a69
+Integrity: sha512-6QSNlDdSwyG/+[...]X6wXHriDWr6fA==
+Unpacked size: 1.1KB
+Packed size: 0.76KB
+Tag: latest
+Access: default
+Registry: http://localhost:4873/
+
+ + publish-1@1.0.0
+```
+
+Alternatively, you can pack and publish your package separately by using `bun pm pack` followed by `bun publish` with the path to the output tarball.
+
+```sh
+$ bun pm pack
+...
+$ bun publish ./package.tgz
+```
+
+{% callout %}
+**Note** - `bun publish` will not run lifecycle scripts (`prepublishOnly/prepack/prepare/postpack/publish/postpublish`) if a tarball path is provided. Scripts will only be run if the package is packed by `bun publish`.
+{% /callout %}
+
+## Flags
+
+### `--access`
+
+The `--access` flag can be used to set the access level of the package being published. The access level can be one of `public` or `restricted`. Uscoped packages are always public, and attempting to publish an unscoped package with `--access restricted` will result in an error.
+
+```sh
+$ bun publish --access public
+```
+
+`--access` can also be set in the `publishConfig` field of your `package.json`.
+
+```json
+{
+  "publishConfig": {
+    "access": "restricted"
+  }
+}
+```
+
+### `--tag`
+
+Set the tag of the package version being published. By default, the tag is `latest`. The initial version of a package is always given the `latest` tag in addition to the specified tag.
+
+```sh
+$ bun publish --tag alpha
+```
+
+`--tag` can also be set in the `publishConfig` field of your `package.json`.
+
+```json
+{
+  "publishConfig": {
+    "tag": "next"
+  }
+}
+```
+
+### `--dry-run`
+
+The `--dry-run` flag can be used to simulate the publish process without actually publishing the package. This is useful for verifying the contents of the published package without actually publishing the package.
+
+```sh
+$ bun publish --dry-run
+```
+
+### `--auth-type`
+
+If you have 2FA enabled for your npm account, `bun publish` will prompt you for a one-time password. This can be done through a browser or the CLI. The `--auth-type` flag can be used to tell the npm registry which method you prefer. The possible values are `web` and `legacy`, with `web` being the default.
+
+```sh
+$ bun publish --auth-type legacy
+...
+This operation requires a one-time password.
+Enter OTP: 123456
+...
+```
+
+### `--gzip-level`
+
+Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball path argument.

--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -164,6 +164,9 @@ export default {
     page("cli/update", "`bun update`", {
       description: "Update your project's dependencies.",
     }),
+    page("cli/publish", "`bun publish`", {
+      description: "Publish your package to an npm registry.",
+    }),
     page("cli/outdated", "`bun outdated`", {
       description: "Check for outdated dependencies.",
     }),

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -1330,7 +1330,7 @@ pub const FetchHeaders = opaque {
     pub fn createFromPicoHeaders(
         pico_headers: anytype,
     ) *FetchHeaders {
-        const out = PicoHeaders{ .ptr = pico_headers.ptr, .len = pico_headers.len };
+        const out = PicoHeaders{ .ptr = pico_headers.list.ptr, .len = pico_headers.list.len };
         const result = shim.cppFn("createFromPicoHeaders_", .{
             &out,
         });

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1996,7 +1996,7 @@ pub const Example = struct {
 
         var is_expected_content_type = false;
         var content_type: string = "";
-        for (response.headers) |header| {
+        for (response.headers.list) |header| {
             if (strings.eqlCaseInsensitiveASCII(header.name, "content-type", true)) {
                 content_type = header.value;
 

--- a/src/deps/picohttp.zig
+++ b/src/deps/picohttp.zig
@@ -6,6 +6,8 @@ const Match = ExactSizeMatcher(2);
 const Output = bun.Output;
 const Environment = bun.Environment;
 const StringBuilder = bun.StringBuilder;
+const string = bun.string;
+const strings = bun.strings;
 
 const fmt = std.fmt;
 
@@ -14,6 +16,19 @@ const assert = bun.assert;
 pub const Header = struct {
     name: []const u8,
     value: []const u8,
+
+    pub const List = struct {
+        list: []Header = &.{},
+
+        pub fn get(this: *const List, name: string) ?string {
+            for (this.list) |header| {
+                if (strings.eqlCaseInsensitiveASCII(header.name, name, true)) {
+                    return header.value;
+                }
+            }
+            return null;
+        }
+    };
 
     pub fn isMultiline(self: Header) bool {
         return @intFromPtr(self.name.ptr) == 0;
@@ -216,7 +231,7 @@ pub const Response = struct {
     minor_version: usize = 0,
     status_code: u32 = 0,
     status: []const u8 = "",
-    headers: []Header = &.{},
+    headers: Header.List = .{},
     bytes_read: c_int = 0,
 
     pub fn format(self: Response, comptime _: []const u8, _: fmt.FormatOptions, writer: anytype) !void {
@@ -234,7 +249,7 @@ pub const Response = struct {
                 self.status,
             },
         );
-        for (self.headers) |header| {
+        for (self.headers.list) |header| {
             if (Output.enable_ansi_colors_stderr) {
                 _ = try writer.write(Output.prettyFmt("<r><d>[fetch]<r> ", true));
             }
@@ -247,7 +262,7 @@ pub const Response = struct {
     pub fn count(this: *const Response, builder: *StringBuilder) void {
         builder.count(this.status);
 
-        for (this.headers) |header| {
+        for (this.headers.list) |header| {
             header.count(builder);
         }
     }
@@ -256,11 +271,11 @@ pub const Response = struct {
         var that = this.*;
         that.status = builder.append(this.status);
 
-        for (this.headers, 0..) |header, i| {
+        for (this.headers.list, 0..) |header, i| {
             headers[i] = header.clone(builder);
         }
 
-        that.headers = headers[0..this.headers.len];
+        that.headers.list = headers[0..this.headers.list.len];
 
         return that;
     }
@@ -297,7 +312,7 @@ pub const Response = struct {
                 .minor_version = @as(usize, @intCast(minor_version)),
                 .status_code = @as(u32, @intCast(status_code)),
                 .status = status,
-                .headers = src[0..@min(num_headers, src.len)],
+                .headers = .{ .list = src[0..@min(num_headers, src.len)] },
                 .bytes_read = rc,
             },
         };

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -517,7 +517,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 return;
             }
 
-            for (response.headers) |header| {
+            for (response.headers.list) |header| {
                 switch (header.name.len) {
                     "Connection".len => {
                         if (connection_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Connection", false)) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9617,14 +9617,14 @@ pub const PackageManager = struct {
 
                     const outro_text =
                         \\<b>Examples:<r>
-                        \\  <d>Publish the package in the current working directory with public access.<r>
+                        \\  <d>Display files that would be published, without publishing to the registry.<r>
+                        \\  <b><green>bun publish --dry-run<r>  
+                        \\
+                        \\  <d>Publish the current package with public access.<r>
                         \\  <b><green>bun publish --access public<r>
                         \\
-                        \\  <d>Publish a pre-existing package tarball.<r>
-                        \\  <b><green>bun publish ./path/to/tarball.tgz<r>
-                        \\
-                        \\  <d>Publish with tag 'next'.<r>
-                        \\  <b><green>bun publish --tag next<r>
+                        \\  <d>Publish a pre-existing package tarball with tag 'next'.<r>
+                        \\  <b><green>bun publish ./path/to/tarball.tgz --tag next<r>
                         \\
                     ;
 

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -249,7 +249,7 @@ pub const Registry = struct {
 
         var newly_last_modified: string = "";
         var new_etag: string = "";
-        for (response.headers) |header| {
+        for (response.headers.list) |header| {
             if (!(header.name.len == "last-modified".len or header.name.len == "etag".len)) continue;
 
             const hashed = HTTPClient.hashHeaderName(header.name);

--- a/src/output.zig
+++ b/src/output.zig
@@ -1004,12 +1004,12 @@ pub const DebugTimer = struct {
     }
 };
 
-/// Print a blue note message
+/// Print a blue note message to stderr
 pub inline fn note(comptime fmt: []const u8, args: anytype) void {
     prettyErrorln("<blue>note<r><d>:<r> " ++ fmt, args);
 }
 
-/// Print a yellow warning message
+/// Print a yellow warning message to stderr
 pub inline fn warn(comptime fmt: []const u8, args: anytype) void {
     prettyErrorln("<yellow>warn<r><d>:<r> " ++ fmt, args);
 }


### PR DESCRIPTION
### What does this PR do?
- adds docs for `bun publish`
- prints messages from `npm-notice` header
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
adds tests for otp failure and `npm-notice`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
