### PR TITLE
add missing docs for new bun pm commands

### DIFF
--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -138,3 +138,5 @@ To print the default trusted dependencies list:
 ```bash
 $ bun pm default-trusted
 ```
+
+see the current list on GitHub [here](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt)

--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -1,5 +1,22 @@
 The `bun pm` command group provides a set of utilities for working with Bun's package manager.
 
+## pack
+
+To create a tarball of the current workspace:
+
+```bash
+$ bun pm pack
+```
+
+Options for the `pack` command:
+
+- `--dry-run`: Perform all tasks except writing the tarball to disk.
+- `--destination`: Specify the directory where the tarball will be saved.
+- `--ignore-scripts`: Skip running pre/postpack and prepare scripts.
+- `--gzip-level`: Set a custom compression level for gzip, ranging from 0 to 9 (default is 9).
+
+## bin
+
 To print the path to the `bin` directory for the local project:
 
 ```bash
@@ -13,6 +30,8 @@ To print the path to the global `bin` directory:
 $ bun pm bin -g
 <$HOME>/.bun/bin
 ```
+
+## ls
 
 To print a list of installed dependencies in the current project and their resolved versions, excluding their dependencies.
 
@@ -45,6 +64,28 @@ $ bun pm ls --all
 ├── ...
 ```
 
+## hash
+
+To generate and print the hash of the current lockfile:
+
+```bash
+$ bun pm hash
+```
+
+To print the string used to hash the lockfile:
+
+```bash
+$ bun pm hash-string
+```
+
+To print the hash stored in the current lockfile:
+
+```bash
+$ bun pm hash-print
+```
+
+## cache
+
 To print the path to Bun's global module cache:
 
 ```bash
@@ -57,16 +98,43 @@ To clear Bun's global module cache:
 $ bun pm cache rm
 ```
 
-## List global installs
+## migrate
 
-To list all globally installed packages:
+To migrate another package manager's lockfile without installing anything:
 
 ```bash
-$ bun pm ls -g
+$ bun pm migrate
 ```
 
-To list all globally installed packages, including nth-order dependencies:
+## untrusted
+
+To print current untrusted dependencies with scripts:
 
 ```bash
-$ bun pm ls -g --all
+$ bun pm untrusted
+
+./node_modules/@biomejs/biome @1.8.3
+ » [postinstall]: node scripts/postinstall.js
+
+These dependencies had their lifecycle scripts blocked during install.
+```
+
+## trust
+
+To run scripts for untrusted dependencies and add to `trustedDependencies`:
+
+```bash
+$ bun pm trust <names>
+```
+
+Options for the `trust` command:
+
+- `--all`: Trust all untrusted dependencies.
+
+## default-trusted
+
+To print the default trusted dependencies list:
+
+```bash
+$ bun pm default-trusted
 ```

--- a/docs/guides/install/trusted.md
+++ b/docs/guides/install/trusted.md
@@ -17,7 +17,7 @@ If you are seeing one of the following errors, you are probably trying to use a 
 
 ---
 
-To tell Bun to allow lifecycle scripts for a particular package, add the package to `trustedDependencies` in your package.json.
+To allow Bun to execute lifecycle scripts for a specific package, add the package to `trustedDependencies` in your package.json file. You can do this automatically by running the command `bun pm trust <package names>`.
 
 {% callout %}
 Note that this only allows lifecycle scripts for the specific package listed in `trustedDependencies`, _not_ the dependencies of that dependency!

--- a/docs/guides/install/trusted.md
+++ b/docs/guides/install/trusted.md
@@ -17,7 +17,7 @@ If you are seeing one of the following errors, you are probably trying to use a 
 
 ---
 
-To allow Bun to execute lifecycle scripts for a specific package, add the package to `trustedDependencies` in your package.json file. You can do this automatically by running the command `bun pm trust <package names>`.
+To allow Bun to execute lifecycle scripts for a specific package, add the package to `trustedDependencies` in your package.json file. You can do this automatically by running the command `bun pm trust <pkg>`.
 
 {% callout %}
 Note that this only allows lifecycle scripts for the specific package listed in `trustedDependencies`, _not_ the dependencies of that dependency!


### PR DESCRIPTION
### What does this PR do?

Adds missing documentation to https://bun.sh/docs/cli/pm

adds docs for 

- pack
- hash + (hash-string, hash-print)
- cache
- migrate
- untrusted
- trust
- default-trusted