### PR TITLE
fix #14338: WebSocket doesn't emit error before close

### DIFF
--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -1280,73 +1280,73 @@ void WebSocket::didFailWithErrorCode(int32_t code)
     // invalid_response
     case 1: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Invalid response");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // expected_101_status_code
     case 2: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Expected 101 status code");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // missing_upgrade_header
     case 3: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Missing upgrade header");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // missing_connection_header
     case 4: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Missing connection header");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // missing_websocket_accept_header
     case 5: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Missing websocket accept header");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // invalid_upgrade_header
     case 6: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Invalid upgrade header");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // invalid_connection_header
     case 7: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Invalid connection header");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // invalid_websocket_version
     case 8: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Invalid websocket version");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // mismatch_websocket_accept_header
     case 9: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Mismatch websocket accept header");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // missing_client_protocol
     case 10: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Missing client protocol");
-        didReceiveClose(CleanStatus::Clean, 1002, message);
+        didReceiveClose(CleanStatus::Clean, 1002, message, true);
         break;
     }
     // mismatch_client_protocol
     case 11: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Mismatch client protocol");
-        didReceiveClose(CleanStatus::Clean, 1002, message);
+        didReceiveClose(CleanStatus::Clean, 1002, message, true);
         break;
     }
     // timeout
     case 12: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Timeout");
-        didReceiveClose(CleanStatus::Clean, 1013, message);
+        didReceiveClose(CleanStatus::Clean, 1013, message, true);
         break;
     }
     // closed
@@ -1358,7 +1358,7 @@ void WebSocket::didFailWithErrorCode(int32_t code)
     // failed_to_write
     case 14: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Failed to write");
-        didReceiveClose(CleanStatus::NotClean, 1006, message);
+        didReceiveClose(CleanStatus::NotClean, 1006, message, true);
         break;
     }
     // failed_to_connect
@@ -1370,7 +1370,7 @@ void WebSocket::didFailWithErrorCode(int32_t code)
     // headers_too_large
     case 16: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Headers too large");
-        didReceiveClose(CleanStatus::NotClean, 1007, message);
+        didReceiveClose(CleanStatus::NotClean, 1007, message, true);
         break;
     }
     // ended
@@ -1383,61 +1383,61 @@ void WebSocket::didFailWithErrorCode(int32_t code)
     // failed_to_allocate_memory
     case 18: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Failed to allocate memory");
-        didReceiveClose(CleanStatus::NotClean, 1001, message);
+        didReceiveClose(CleanStatus::NotClean, 1001, message, true);
         break;
     }
     // control_frame_is_fragmented
     case 19: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Protocol error - control frame is fragmented");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // invalid_control_frame
     case 20: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Protocol error - invalid control frame");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // compression_unsupported
     case 21: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Compression not implemented yet");
-        didReceiveClose(CleanStatus::Clean, 1011, message);
+        didReceiveClose(CleanStatus::Clean, 1011, message, true);
         break;
     }
     // unexpected_mask_from_server
     case 22: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Protocol error - unexpected mask from server");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // expected_control_frame
     case 23: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Protocol error - expected control frame");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // unsupported_control_frame
     case 24: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Protocol error - unsupported control frame");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // unexpected_opcode
     case 25: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Protocol error - unexpected opcode");
-        didReceiveClose(CleanStatus::NotClean, 1002, message);
+        didReceiveClose(CleanStatus::NotClean, 1002, message, true);
         break;
     }
     // invalid_utf8
     case 26: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("Server sent invalid UTF8");
-        didReceiveClose(CleanStatus::NotClean, 1003, message);
+        didReceiveClose(CleanStatus::NotClean, 1003, message, true);
         break;
     }
     // tls_handshake_failed
     case 27: {
         static NeverDestroyed<String> message = MAKE_STATIC_STRING_IMPL("TLS handshake failed");
-        didReceiveClose(CleanStatus::NotClean, 1015, message);
+        didReceiveClose(CleanStatus::NotClean, 1015, message, true);
         break;
     }
     }

--- a/src/bun.js/bindings/webcore/WebSocket.h
+++ b/src/bun.js/bindings/webcore/WebSocket.h
@@ -184,7 +184,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError = false);
+    void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool wasError = false);
     void didUpdateBufferedAmount(unsigned bufferedAmount);
     void didStartClosingHandshake();
 

--- a/test/js/web/websocket/websocket-error.test.ts
+++ b/test/js/web/websocket/websocket-error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+describe("WebSocket error", () => {
+  // regression test for https://github.com/oven-sh/bun/issues/14338
+  test("should throw websocket connection error", async () => {
+    const server = Bun.serve({
+      fetch: () => new Response,
+    });
+
+    let errorCount = 0;
+    await new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${server.port}`);
+      ws.addEventListener("open", reject);
+      ws.addEventListener("error", (e) => {
+        errorCount += 1;
+      });
+      ws.addEventListener("close", resolve);
+    });
+    expect(errorCount).toBe(1);
+
+    server.stop();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This should fix: #14338

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
