### PR TITLE
Return undefined from napi_get_property when property does not exist

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -702,7 +702,7 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
     JSC::EnsureStillAliveScope ensureAlive2(keyProp);
     auto scope = DECLARE_CATCH_SCOPE(vm);
     *result = toNapi(target->get(globalObject, keyProp.toPropertyKey(globalObject)), globalObject);
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     scope.clearException();
     return napi_ok;
@@ -887,7 +887,7 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
     *result = toNapi(target->get(globalObject, name), globalObject);
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     scope.clearException();
     return napi_ok;

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -701,7 +701,7 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
     auto keyProp = toJS(key);
     JSC::EnsureStillAliveScope ensureAlive2(keyProp);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    *result = toNapi(target->getIfPropertyExists(globalObject, keyProp.toPropertyKey(globalObject)), globalObject);
+    *result = toNapi(target->get(globalObject, keyProp.toPropertyKey(globalObject)), globalObject);
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     scope.clearException();
@@ -886,7 +886,7 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     PROPERTY_NAME_FROM_UTF8(name);
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    *result = toNapi(target->getIfPropertyExists(globalObject, name), globalObject);
+    *result = toNapi(target->get(globalObject, name), globalObject);
     RETURN_IF_EXCEPTION(scope, napi_generic_failure);
 
     scope.clearException();

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -646,6 +646,43 @@ napi_value eval_wrapper(const Napi::CallbackInfo &info) {
   return ret;
 }
 
+// perform_get(object, key)
+napi_value perform_get(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value obj = info[0];
+  napi_value key = info[1];
+  napi_status status;
+  napi_value value;
+
+  // if key is a string, try napi_get_named_property
+  napi_valuetype type;
+  assert(napi_typeof(env, key, &type) == napi_ok);
+  if (type == napi_string) {
+    char buf[1024];
+    assert(napi_get_value_string_utf8(env, key, buf, 1024, nullptr) == napi_ok);
+    status = napi_get_named_property(env, obj, buf, &value);
+    printf("get_named_property status = %d\n", status);
+    if (status == napi_ok) {
+      assert(value != nullptr);
+      assert(napi_typeof(env, value, &type) == napi_ok);
+      printf("value type = %d\n", type);
+    } else {
+      return ok(env);
+    }
+  }
+
+  status = napi_get_property(env, obj, key, &value);
+  printf("get_property status = %d\n", status);
+  if (status == napi_ok) {
+    assert(value != nullptr);
+    assert(napi_typeof(env, value, &type) == napi_ok);
+    printf("value type = %d\n", type);
+    return value;
+  } else {
+    return ok(env);
+  }
+}
+
 Napi::Value RunCallback(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   // this function is invoked without the GC callback
@@ -699,6 +736,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
   exports.Set("call_and_get_exception",
               Napi::Function::New(env, call_and_get_exception));
   exports.Set("eval_wrapper", Napi::Function::New(env, eval_wrapper));
+  exports.Set("perform_get", Napi::Function::New(env, perform_get));
 
   return exports;
 }

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -661,7 +661,9 @@ napi_value perform_get(const Napi::CallbackInfo &info) {
     char buf[1024];
     assert(napi_get_value_string_utf8(env, key, buf, 1024, nullptr) == napi_ok);
     status = napi_get_named_property(env, obj, buf, &value);
-    printf("get_named_property status = %d\n", status);
+    printf("get_named_property status is pending_exception or generic_failure "
+           "= %d\n",
+           status == napi_pending_exception || status == napi_generic_failure);
     if (status == napi_ok) {
       assert(value != nullptr);
       assert(napi_typeof(env, value, &type) == napi_ok);
@@ -672,7 +674,8 @@ napi_value perform_get(const Napi::CallbackInfo &info) {
   }
 
   status = napi_get_property(env, obj, key, &value);
-  printf("get_property status = %d\n", status);
+  printf("get_property status is pending_exception or generic_failure  = %d\n",
+         status == napi_pending_exception || status == napi_generic_failure);
   if (status == napi_ok) {
     assert(value != nullptr);
     assert(napi_typeof(env, value, &type) == napi_ok);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -56,6 +56,14 @@ nativeTests.test_get_property = () => {
     {
       set foo(newValue) {},
     },
+    new Proxy(
+      {},
+      {
+        get(_target, key) {
+          throw new Error(`proxy get ${key}`);
+        },
+      },
+    ),
   ];
   const keys = [
     "foo",

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -44,4 +44,43 @@ nativeTests.test_get_exception = (_, value) => {
   }
 };
 
+nativeTests.test_get_property = () => {
+  const objects = [
+    {},
+    { foo: "bar" },
+    {
+      get foo() {
+        throw new Error("get foo");
+      },
+    },
+    {
+      set foo(newValue) {},
+    },
+  ];
+  const keys = [
+    "foo",
+    {
+      toString() {
+        throw new Error("toString");
+      },
+    },
+    {
+      [Symbol.toPrimitive]() {
+        throw new Error("Symbol.toPrimitive");
+      },
+    },
+  ];
+
+  for (const object of objects) {
+    for (const key of keys) {
+      try {
+        const ret = nativeTests.perform_get(object, key);
+        console.log("native function returned", ret);
+      } catch (e) {
+        console.log("threw", e.toString());
+      }
+    }
+  }
+};
+
 module.exports = nativeTests;

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -275,6 +275,12 @@ describe("napi", () => {
       checkSameOutput("eval_wrapper", ["shouldNotExist"]);
     });
   });
+
+  describe("napi_get_named_property", () => {
+    it("handles edge cases", () => {
+      checkSameOutput("test_get_property", []);
+    });
+  });
 });
 
 function checkSameOutput(test: string, args: any[] | string) {


### PR DESCRIPTION
needs more testing

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
