### PR TITLE
Fix v8::Object::Set edge cases

### DIFF
--- a/src/bun.js/bindings/v8/V8Object.cpp
+++ b/src/bun.js/bindings/v8/V8Object.cpp
@@ -50,13 +50,11 @@ Maybe<bool> Object::Set(Local<Context> context, Local<Value> key, Local<Value> v
     RETURN_IF_EXCEPTION(scope, Nothing<bool>());
 
     if (!object->put(object, globalObject, identifier, v, slot)) {
-        scope.clearExceptionExceptTermination();
-        return Nothing<bool>();
+        RETURN_IF_EXCEPTION(scope, Nothing<bool>());
+        // TODO(@190n): this is reached. object->put can return false without throwing an exception.
+        ASSERT_NOT_REACHED();
     }
-    if (scope.exception()) {
-        scope.clearException();
-        return Nothing<bool>();
-    }
+    RETURN_IF_EXCEPTION(scope, Nothing<bool>());
     return Just(true);
 }
 

--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -248,6 +248,22 @@ void test_v8_object(const FunctionCallbackInfo<Value> &info) {
   return ok(info);
 }
 
+void set_field_from_js(const FunctionCallbackInfo<Value> &info) {
+  Isolate *isolate = info.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+
+  Local<Object> obj = info[0].As<Object>();
+  Local<Value> key = info[1];
+  Local<Number> value = Number::New(isolate, 321.0);
+  Maybe<bool> ret = obj->Set(context, key, value);
+  LOG_EXPR(ret.IsJust());
+  if (ret.IsJust()) {
+    LOG_EXPR(ret.ToChecked());
+  }
+
+  return ok(info);
+}
+
 void test_v8_array_new(const FunctionCallbackInfo<Value> &info) {
   Isolate *isolate = info.GetIsolate();
 
@@ -483,6 +499,7 @@ void initialize(Local<Object> exports, Local<Value> module,
                   test_v8_string_write_utf8);
   NODE_SET_METHOD(exports, "test_v8_external", test_v8_external);
   NODE_SET_METHOD(exports, "test_v8_object", test_v8_object);
+  NODE_SET_METHOD(exports, "set_field_from_js", set_field_from_js);
   NODE_SET_METHOD(exports, "test_v8_array_new", test_v8_array_new);
   NODE_SET_METHOD(exports, "test_v8_object_template", test_v8_object_template);
   NODE_SET_METHOD(exports, "create_function_with_data",

--- a/test/v8/v8-module/module.js
+++ b/test/v8/v8-module/module.js
@@ -2,6 +2,7 @@ module.exports = debugMode => {
   const nativeModule = require(`./build/${debugMode ? "Debug" : "Release"}/v8tests`);
   return {
     ...nativeModule,
+
     test_v8_global() {
       console.log(nativeModule.global_get());
       nativeModule.global_set(123);
@@ -12,12 +13,60 @@ module.exports = debugMode => {
       }
       console.log(JSON.stringify(nativeModule.global_get()));
     },
+
     test_v8_function_template() {
       const f = nativeModule.create_function_with_data();
       if (process.isBun) {
         Bun.gc(true);
       }
       console.log(f());
+    },
+
+    test_v8_object_set_failure() {
+      const object = {};
+      const key = {
+        toString() {
+          throw new Error("thrown by key.toString()");
+        },
+      };
+
+      try {
+        nativeModule.set_field_from_js(object, key);
+        console.log("no error while setting with key that throws in toString()");
+      } catch (e) {
+        console.log(e.toString());
+      }
+
+      const setterThrows = new Proxy(object, {
+        set(obj, prop, value) {
+          throw new Error(`proxy setting ${prop} to ${value}`);
+        },
+      });
+
+      try {
+        nativeModule.set_field_from_js(setterThrows, "xyz");
+        console.log("no error while setting on Proxy that throws");
+      } catch (e) {
+        console.log(e.toString());
+      }
+
+      console.log("after setting, object.xyz is", object.xyz);
+
+      const onlyGetter = {
+        get foo() {
+          return 5;
+        },
+      };
+
+      try {
+        nativeModule.set_field_from_js(onlyGetter, "foo");
+        // apparently this is expected in node
+        console.log("no error while setting a key that only has a getter");
+      } catch (e) {
+        console.log(e.toString());
+      }
+
+      console.log("after setting, onlyGetter.foo is", onlyGetter.foo);
     },
   };
 };

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -139,6 +139,9 @@ describe("Object", () => {
   it("can create an object and set properties", () => {
     checkSameOutput("test_v8_object", []);
   });
+  it("can handle failure in Set()", () => {
+    checkSameOutput("test_v8_object_set_failure", []);
+  });
 });
 describe("Array", () => {
   // v8::Array::New is broken as it still tries to reinterpret locals as JSValues


### PR DESCRIPTION
still some errors -- I just opened this PR to make sure I don't forget about this branch

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
