### PR TITLE
add `bun pm whoami`

### DIFF
--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -64,6 +64,14 @@ $ bun pm ls --all
 ├── ...
 ```
 
+## whoami
+
+Print your npm username. Requires you to be logged in (`bunx npm login`) with credentials in either `bunfig.toml` or `.npmrc`:
+
+```bash
+$ bun pm whoami
+```
+
 ## hash
 
 To generate and print the hash of the current lockfile:

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -110,6 +110,7 @@ pub const PackageManagerCommand = struct {
             \\  <d>└<r>  <cyan>-g<r>                     print the <b>global<r> path to bin folder
             \\  bun pm <b>ls<r>                 list the dependency tree according to the current lockfile
             \\  <d>└<r>  <cyan>--all<r>                  list the entire dependency tree according to the current lockfile
+            \\  bun pm <b>whoami<r>             print the current npm username
             \\  bun pm <b>hash<r>               generate & print the hash of the current lockfile
             \\  bun pm <b>hash-string<r>        print the string used to hash the lockfile
             \\  bun pm <b>hash-print<r>         print the hash stored in the current lockfile

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -159,9 +159,14 @@ pub const PackageManagerCommand = struct {
                     error.OutOfMemory => bun.outOfMemory(),
                     error.NeedAuth => {
                         Output.errGeneric("missing authentication (run <cyan>`bunx npm login`<r>)", .{});
-                        Global.crash();
+                    },
+                    error.ProbablyInvalidAuth => {
+                        Output.errGeneric("failed to authenticate with registry '{}'", .{
+                            bun.fmt.redactedNpmUrl(pm.options.scope.url.href),
+                        });
                     },
                 }
+                Global.crash();
             };
             Output.println("{s}", .{username});
             Global.exit(0);

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -586,7 +586,14 @@ pub const PublishCommand = struct {
                 if (!prompt_for_otp) {
                     // general error
                     const otp_response = false;
-                    return handleResponseErrors(directory_publish, ctx, &req, &res, &response_buf, otp_response);
+                    try Npm.responseError(
+                        ctx.allocator,
+                        &req,
+                        &res,
+                        .{ ctx.package_name, ctx.package_version },
+                        &response_buf,
+                        otp_response,
+                    );
                 }
 
                 // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
@@ -637,7 +644,14 @@ pub const PublishCommand = struct {
                 switch (otp_res.status_code) {
                     400...std.math.maxInt(@TypeOf(otp_res.status_code)) => {
                         const otp_response = true;
-                        return handleResponseErrors(directory_publish, ctx, &otp_req, &otp_res, &response_buf, otp_response);
+                        try Npm.responseError(
+                            ctx.allocator,
+                            &otp_req,
+                            &otp_res,
+                            .{ ctx.package_name, ctx.package_version },
+                            &response_buf,
+                            otp_response,
+                        );
                     },
                     else => {
                         // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
@@ -652,60 +666,6 @@ pub const PublishCommand = struct {
             },
             else => {},
         }
-    }
-
-    fn handleResponseErrors(
-        comptime directory_publish: bool,
-        ctx: *const Context(directory_publish),
-        req: *const http.AsyncHTTP,
-        res: *const bun.picohttp.Response,
-        response_body: *MutableString,
-        comptime otp_response: bool,
-    ) OOM!void {
-        const message = message: {
-            const source = logger.Source.initPathString("???", response_body.list.items);
-            const json = JSON.parseUTF8(&source, ctx.manager.log, ctx.allocator) catch |err| {
-                switch (err) {
-                    error.OutOfMemory => |oom| return oom,
-                    else => break :message null,
-                }
-            };
-
-            // I don't think we should make this check, I cannot find code in npm
-            // that does this
-            // if (comptime otp_response) {
-            //     if (json.get("success")) |success_expr| {
-            //         if (success_expr.asBool()) |successful| {
-            //             if (successful) {
-            //                 // possible to hit this with otp responses
-            //                 return;
-            //             }
-            //         }
-            //     }
-            // }
-
-            const @"error", _ = try json.getString(ctx.allocator, "error") orelse break :message null;
-            break :message @"error";
-        };
-
-        Output.prettyErrorln("\n<red>{d}<r>{s}{s}: {s}\n", .{
-            res.status_code,
-            if (res.status.len > 0) " " else "",
-            res.status,
-            bun.fmt.redactedNpmUrl(req.url.href),
-        });
-
-        if (message) |msg| {
-            if (comptime otp_response) {
-                if (res.status_code == 401 and strings.containsComptime(msg, "You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.")) {
-                    Output.prettyErrorln("\n - Received invalid OTP", .{});
-                    Global.crash();
-                }
-            }
-            Output.prettyErrorln("\n - {s}", .{msg});
-        }
-
-        Global.crash();
     }
 
     const GetOTPError = OOM || error{};
@@ -874,7 +834,14 @@ pub const PublishCommand = struct {
                     },
                     else => {
                         const otp_response = false;
-                        try handleResponseErrors(directory_publish, ctx, &req, &res, response_buf, otp_response);
+                        try Npm.responseError(
+                            ctx.allocator,
+                            &req,
+                            &res,
+                            .{ ctx.package_name, ctx.package_version },
+                            response_buf,
+                            otp_response,
+                        );
                     },
                 }
             }

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -439,16 +439,13 @@ pub const Parser = struct {
             }
 
             const env_var = val[i + 2 .. j];
-            const expanded = this.expandEnvVar(env_var);
+            // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/workspaces/config/lib/env-replace.js#L6
+            const expanded = this.env.get(env_var) orelse return null;
             unesc.appendSlice(expanded) catch bun.outOfMemory();
 
             return j;
         }
         return null;
-    }
-
-    fn expandEnvVar(this: *Parser, name: []const u8) []const u8 {
-        return this.env.get(name) orelse "";
     }
 
     fn singleStrRope(ropealloc: Allocator, str: []const u8) *Rope {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -40,6 +40,7 @@ const Npm = @This();
 
 const WhoamiError = OOM || error{
     NeedAuth,
+    ProbablyInvalidAuth,
 };
 
 pub fn whoami(allocator: std.mem.Allocator, manager: *PackageManager) WhoamiError!string {
@@ -183,8 +184,8 @@ pub fn whoami(allocator: std.mem.Allocator, manager: *PackageManager) WhoamiErro
     };
 
     const username, _ = try json.getString(allocator, "username") orelse {
-        Output.errGeneric("response JSON missing username string field", .{});
-        Global.crash();
+        // no username, invalid auth probably
+        return error.ProbablyInvalidAuth;
     };
     return username;
 }

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -19,7 +19,7 @@ const Bin = @import("./bin.zig").Bin;
 const Environment = bun.Environment;
 const Aligner = @import("./install.zig").Aligner;
 const HTTPClient = bun.http;
-const json_parser = bun.JSON;
+const JSON = bun.JSON;
 const default_allocator = bun.default_allocator;
 const IdentityContext = @import("../identity_context.zig").IdentityContext;
 const ArrayIdentityContext = @import("../identity_context.zig").ArrayIdentityContext;
@@ -31,8 +31,211 @@ const VersionSlice = @import("./install.zig").VersionSlice;
 const ObjectPool = @import("../pool.zig").ObjectPool;
 const Api = @import("../api/schema.zig").Api;
 const DotEnv = @import("../env_loader.zig");
+const http = bun.http;
+const OOM = bun.OOM;
+const Global = bun.Global;
+const PublishCommand = bun.CLI.PublishCommand;
 
 const Npm = @This();
+
+const WhoamiError = OOM || error{
+    NeedAuth,
+};
+
+pub fn whoami(allocator: std.mem.Allocator, manager: *PackageManager) WhoamiError!string {
+    const registry = manager.options.scope;
+
+    if (registry.user.len > 0) {
+        const sep = strings.indexOfChar(registry.user, ':').?;
+        return registry.user[0..sep];
+    }
+
+    if (registry.url.username.len > 0) return registry.url.username;
+
+    if (registry.token.len == 0) {
+        return error.NeedAuth;
+    }
+
+    const auth_type = if (manager.options.publish_config.auth_type) |auth_type| @tagName(auth_type) else "web";
+    const ci_name = bun.detectCI();
+
+    var print_buf = std.ArrayList(u8).init(allocator);
+    defer print_buf.deinit();
+    var print_writer = print_buf.writer();
+
+    var headers: http.HeaderBuilder = .{};
+
+    {
+        headers.count("accept", "*/*");
+        headers.count("accept-encoding", "gzip,deflate");
+
+        try print_writer.print("Bearer {s}", .{registry.token});
+        headers.count("authorization", print_buf.items);
+        print_buf.clearRetainingCapacity();
+
+        // no otp needed, just use auth-type from options
+        headers.count("npm-auth-type", auth_type);
+        headers.count("npm-command", "whoami");
+
+        try print_writer.print("{s} {s} {s} workspaces/{}{s}{s}", .{
+            Global.user_agent,
+            Global.os_name,
+            Global.arch_name,
+            // TODO: figure out how npm determines workspaces=true
+            false,
+            if (ci_name != null) " ci/" else "",
+            ci_name orelse "",
+        });
+        headers.count("user-agent", print_buf.items);
+        print_buf.clearRetainingCapacity();
+
+        headers.count("Connection", "keep-alive");
+        headers.count("Host", registry.url.host);
+    }
+
+    try headers.allocate(allocator);
+
+    {
+        headers.append("accept", "*/*");
+        headers.append("accept-encoding", "gzip/deflate");
+
+        try print_writer.print("Bearer {s}", .{registry.token});
+        headers.append("authorization", print_buf.items);
+        print_buf.clearRetainingCapacity();
+
+        headers.append("npm-auth-type", auth_type);
+        headers.append("npm-command", "whoami");
+
+        try print_writer.print("{s} {s} {s} workspaces/{}{s}{s}", .{
+            Global.user_agent,
+            Global.os_name,
+            Global.arch_name,
+            false,
+            if (ci_name != null) " ci/" else "",
+            ci_name orelse "",
+        });
+        headers.append("user-agent", print_buf.items);
+        print_buf.clearRetainingCapacity();
+
+        headers.append("Connection", "keep-alive");
+        headers.append("Host", registry.url.host);
+    }
+
+    try print_writer.print("{s}/-/whoami", .{
+        strings.withoutTrailingSlash(registry.url.href),
+    });
+
+    var response_buf = try MutableString.init(allocator, 1024);
+
+    const url = URL.parse(print_buf.items);
+
+    var req = http.AsyncHTTP.initSync(
+        allocator,
+        .GET,
+        url,
+        headers.entries,
+        headers.content.ptr.?[0..headers.content.len],
+        &response_buf,
+        "",
+        null,
+        null,
+        .follow,
+    );
+
+    const res = req.sendSync() catch |err| {
+        switch (err) {
+            error.OutOfMemory => |oom| return oom,
+            else => {
+                Output.err(err, "whoami request failed to send", .{});
+                Global.crash();
+            },
+        }
+    };
+
+    if (res.status_code >= 400) {
+        const otp_response = false;
+        try responseError(
+            allocator,
+            &req,
+            &res,
+            null,
+            &response_buf,
+            otp_response,
+        );
+    }
+
+    if (res.headers.getIfOtherIsAbsent("npm-notice", "x-local-cache")) |notice| {
+        Output.printError("\n", .{});
+        Output.note("{s}", .{notice});
+        Output.flush();
+    }
+
+    var log = logger.Log.init(allocator);
+    const source = logger.Source.initPathString("???", response_buf.list.items);
+    const json = JSON.parseUTF8(&source, &log, allocator) catch |err| {
+        switch (err) {
+            error.OutOfMemory => |oom| return oom,
+            else => {
+                Output.err(err, "failed to parse '/-/whoami' response body as JSON", .{});
+                Global.crash();
+            },
+        }
+    };
+
+    const username, _ = try json.getString(allocator, "username") orelse {
+        Output.errGeneric("response JSON missing username string field", .{});
+        Global.crash();
+    };
+    return username;
+}
+
+pub fn responseError(
+    allocator: std.mem.Allocator,
+    req: *const http.AsyncHTTP,
+    res: *const bun.picohttp.Response,
+    // `<name>@<version>`
+    pkg_id: ?struct { string, string },
+    response_body: *MutableString,
+    comptime otp_response: bool,
+) OOM!noreturn {
+    const message = message: {
+        var log = logger.Log.init(allocator);
+        const source = logger.Source.initPathString("???", response_body.list.items);
+        const json = JSON.parseUTF8(&source, &log, allocator) catch |err| {
+            switch (err) {
+                error.OutOfMemory => |oom| return oom,
+                else => break :message null,
+            }
+        };
+
+        const @"error", _ = try json.getString(allocator, "error") orelse break :message null;
+        break :message @"error";
+    };
+
+    Output.prettyErrorln("\n<red>{d}<r>{s}{s}: {s}\n", .{
+        res.status_code,
+        if (res.status.len > 0) " " else "",
+        res.status,
+        bun.fmt.redactedNpmUrl(req.url.href),
+    });
+
+    if (res.status_code == 404 and pkg_id != null) {
+        const package_name, const package_version = pkg_id.?;
+        Output.prettyErrorln("\n - '{s}@{s}' does not exist in this registry", .{ package_name, package_version });
+    } else {
+        if (message) |msg| {
+            if (comptime otp_response) {
+                if (res.status_code == 401 and strings.containsComptime(msg, "You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.")) {
+                    Output.prettyErrorln("\n - Received invalid OTP", .{});
+                    Global.crash();
+                }
+            }
+            Output.prettyErrorln("\n - {s}", .{msg});
+        }
+    }
+
+    Global.crash();
+}
 
 pub const Registry = struct {
     pub const default_url = "https://registry.npmjs.org/";
@@ -52,6 +255,9 @@ pub const Registry = struct {
         url: URL,
         url_hash: u64,
         token: string = "",
+
+        // username and password combo, `user:pass`
+        user: string = "",
 
         pub fn hash(str: string) u64 {
             return String.Builder.stringHash(str);
@@ -82,6 +288,7 @@ pub const Registry = struct {
 
             var url = URL.parse(registry.url);
             var auth: string = "";
+            var user: []u8 = "";
             var needs_normalize = false;
 
             if (registry.token.len == 0) {
@@ -176,12 +383,12 @@ pub const Registry = struct {
 
                     if (registry.username.len > 0 and registry.password.len > 0 and auth.len == 0) {
                         var output_buf = try allocator.alloc(u8, registry.username.len + registry.password.len + 1 + std.base64.standard.Encoder.calcSize(registry.username.len + registry.password.len + 1));
-                        var input_buf = output_buf[0 .. registry.username.len + registry.password.len + 1];
-                        @memcpy(input_buf[0..registry.username.len], registry.username);
-                        input_buf[registry.username.len] = ':';
-                        @memcpy(input_buf[registry.username.len + 1 ..][0..registry.password.len], registry.password);
-                        output_buf = output_buf[input_buf.len..];
-                        auth = std.base64.standard.Encoder.encode(output_buf, input_buf);
+                        user = output_buf[0 .. registry.username.len + registry.password.len + 1];
+                        @memcpy(user[0..registry.username.len], registry.username);
+                        user[registry.username.len] = ':';
+                        @memcpy(user[registry.username.len + 1 ..][0..registry.password.len], registry.password);
+                        output_buf = output_buf[user.len..];
+                        auth = std.base64.standard.Encoder.encode(output_buf, user);
                         break :outer;
                     }
                 }
@@ -207,6 +414,7 @@ pub const Registry = struct {
                 .url_hash = url_hash,
                 .token = registry.token,
                 .auth = auth,
+                .user = user,
             };
         }
     };
@@ -1280,7 +1488,7 @@ pub const PackageManifest = struct {
         defer bun.JSAst.Stmt.Data.Store.memory_allocator.?.pop();
         var arena = bun.ArenaAllocator.init(allocator);
         defer arena.deinit();
-        const json = json_parser.parseUTF8(
+        const json = JSON.parseUTF8(
             &source,
             log,
             arena.allocator(),

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -600,6 +600,28 @@ describe("whoami", async () => {
     expect(err).not.toContain("error:");
     expect(await exited).toBe(0);
   });
+  test("only .npmrc", async () => {
+    const token = await generateRegistryUser("whoami-npmrc", "whoami-npmrc");
+    const npmrc = `
+    //localhost:${port}/:_authToken=${token}
+    registry=http://localhost:${port}/`;
+    await Promise.all([
+      write(join(packageDir, "package.json"), JSON.stringify({ name: "whoami-pkg", version: "1.1.1" })),
+      write(join(packageDir, ".npmrc"), npmrc),
+    ]);
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "whoami"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const out = await Bun.readableStreamToText(stdout);
+    expect(out).toBe("whoami-npmrc\n");
+    const err = await Bun.readableStreamToText(stderr);
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  });
   test("not logged in", async () => {
     await write(join(packageDir, "package.json"), JSON.stringify({ name: "whoami-pkg", version: "1.1.1" }));
     const { stdout, stderr, exited } = spawn({

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -63,7 +63,7 @@ hello = \${LOL}
 hello = \${oooooooooooooooogaboga}
       `,
       env: {},
-      expected: { hello: "" },
+      expected: { hello: "${oooooooooooooooogaboga}" },
     });
 
     envVarTest({


### PR DESCRIPTION
### What does this PR do?
Adds `bun pm whoami` for printing npm username. Reads from either `bunfig.toml` or `.npmrc`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests for no authentication, invalid authentication, bunfig, and .npmrc.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
