### PR TITLE
--footer esbuild & rollup style!

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -1092,7 +1092,7 @@ $ bun build ./index.tsx --outdir ./out --loader .png:dataurl --loader .txt:file
 
 ### `banner`
 
-A banner to be added to the final bundle, this can be a directive like "use client" for react or a comment block such as a license for the code. 
+A banner to be added to the final bundle, this can be a directive like "use client" for react or a comment block such as a license for the code.
 
 {% codetabs %}
 
@@ -1108,11 +1108,29 @@ await Bun.build({
 $ bun build ./index.tsx --outdir ./out --banner "\"use client\";"
 ```
 
+### `footer`
+
+A footer to be added to the final bundle, this can be something like a comment block for a license or just a fun easter egg.
+
+{% codetabs %}
+
+```ts#JavaScript
+await Bun.build({
+  entrypoints: ['./index.tsx'],
+  outdir: './out',
+  footer: '// built with love in SF'
+})
+```
+
+```bash#CLI
+$ bun build ./index.tsx --outdir ./out --footer="// built with love in SF"
+```
+
 {% /codetabs %}
 
 ### `experimentalCss`
 
-Whether to enable *experimental* support for bundling CSS files. Defaults to `false`.
+Whether to enable _experimental_ support for bundling CSS files. Defaults to `false`.
 
 This supports bundling CSS files imported from JS, as well as CSS entrypoints.
 

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -153,13 +153,13 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 ---
 
-- `--banner:js`
+- `--banner`
 - `--banner`
 - Only applies to js bundles
 
 ---
 
-- `--footer:js`
+- `--footer`
 - `--footer`
 - Only applies to js bundles
 

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -201,12 +201,6 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 ---
 
-- `--footer`
-- n/a
-- Not supported
-
----
-
 - `--global-name`
 - n/a
 - Not applicable, Bun does not support `iife` output at this time

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -153,8 +153,14 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 
 ---
 
+- `--banner:js`
 - `--banner`
-- `--banner`
+- Only applies to js bundles
+
+---
+
+- `--footer:js`
+- `--footer`
 - Only applies to js bundles
 
 ---

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1599,6 +1599,12 @@ declare module "bun" {
      * Add a banner to the bundled code such as "use client";
      */
     banner?: string;
+    /**
+     * Add a footer to the bundled code such as a comment block like
+     *
+     * `// made with bun!`
+     */
+    footer?: string;
 
     /**
      * **Experimental**

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -73,6 +73,7 @@ pub const JSBundler = struct {
         format: options.Format = .esm,
         bytecode: bool = false,
         banner: OwnedString = OwnedString.initEmpty(bun.default_allocator),
+        footer: OwnedString = OwnedString.initEmpty(bun.default_allocator),
         experimental_css: bool = false,
 
         pub const List = bun.StringArrayHashMapUnmanaged(Config);
@@ -188,6 +189,11 @@ pub const JSBundler = struct {
             if (try config.getOwnOptional(globalThis, "banner", ZigString.Slice)) |slice| {
                 defer slice.deinit();
                 try this.banner.appendSliceExact(slice.slice());
+            }
+
+            if (try config.getOwnOptional(globalThis, "footer", ZigString.Slice)) |slice| {
+                defer slice.deinit();
+                try this.footer.appendSliceExact(slice.slice());
             }
 
             if (config.getOwnTruthy(globalThis, "sourcemap")) |source_map_js| {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -876,6 +876,7 @@ pub const BundleV2 = struct {
         this.linker.options.ignore_dce_annotations = bundler.options.ignore_dce_annotations;
 
         this.linker.options.banner = bundler.options.banner;
+        this.linker.options.footer = bundler.options.footer;
 
         this.linker.options.experimental_css = bundler.options.experimental_css;
 
@@ -1478,6 +1479,7 @@ pub const BundleV2 = struct {
             bundler.options.ignore_dce_annotations = config.ignore_dce_annotations;
             bundler.options.experimental_css = config.experimental_css;
             bundler.options.banner = config.banner.toOwnedSlice();
+            bundler.options.footer = config.footer.toOwnedSlice();
 
             bundler.configureLinker();
             try bundler.configureDefines();
@@ -4602,6 +4604,7 @@ pub const LinkerContext = struct {
         minify_syntax: bool = false,
         minify_identifiers: bool = false,
         banner: []const u8 = "",
+        footer: []const u8 = "",
         experimental_css: bool = false,
         source_maps: options.SourceMapOption = .none,
         target: options.Target = .browser,
@@ -8977,7 +8980,16 @@ pub const LinkerContext = struct {
         j.ensureNewlineAtEnd();
         // TODO: maybeAppendLegalComments
 
-        // TODO: footer
+        if (c.options.footer.len > 0) {
+            if (newline_before_comment) {
+                j.pushStatic("\n");
+                line_offset.advance("\n");
+            }
+            j.pushStatic(ctx.c.options.footer);
+            line_offset.advance(ctx.c.options.footer);
+            j.pushStatic("\n");
+            line_offset.advance("\n");
+        }
 
         chunk.intermediate_output = c.breakOutputIntoPieces(
             worker.allocator,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -263,6 +263,7 @@ pub const Arguments = struct {
         clap.parseParam("--outfile <STR>                  Write to a file") catch unreachable,
         clap.parseParam("--sourcemap <STR>?               Build with sourcemaps - 'linked', 'inline', 'external', or 'none'") catch unreachable,
         clap.parseParam("--banner <STR>                   Add a banner to the bundled output such as \"use client\"; for a bundle being used with RSCs") catch unreachable,
+        clap.parseParam("--footer <STR>                   Add a footer to the bundled output such as // built with bun!") catch unreachable,
         clap.parseParam("--format <STR>                   Specifies the module format to build to. Only \"esm\" is supported.") catch unreachable,
         clap.parseParam("--root <STR>                     Root directory used for multiple entry points") catch unreachable,
         clap.parseParam("--splitting                      Enable code splitting") catch unreachable,
@@ -781,6 +782,10 @@ pub const Arguments = struct {
 
             if (args.option("--banner")) |banner| {
                 ctx.bundler_options.banner = banner;
+            }
+
+            if (args.option("--footer")) |footer| {
+                ctx.bundler_options.footer = footer;
             }
 
             const experimental_css = args.flag("--experimental-css");
@@ -1408,6 +1413,7 @@ pub const Command = struct {
             output_format: options.Format = .esm,
             bytecode: bool = false,
             banner: []const u8 = "",
+            footer: []const u8 = "",
             experimental_css: bool = false,
         };
 

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -98,6 +98,8 @@ pub const BuildCommand = struct {
         this_bundler.options.ignore_dce_annotations = ctx.bundler_options.ignore_dce_annotations;
 
         this_bundler.options.banner = ctx.bundler_options.banner;
+        this_bundler.options.footer = ctx.bundler_options.footer;
+
         this_bundler.options.experimental_css = ctx.bundler_options.experimental_css;
 
         this_bundler.options.output_dir = ctx.bundler_options.outdir;

--- a/test/bundler/bundler_footer.test.ts
+++ b/test/bundler/bundler_footer.test.ts
@@ -1,0 +1,29 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  itBundled("footer/CommentFooter", {
+    footer: "// developed with love in SF",
+    files: {
+      "/a.js": `console.log("Hello, world!")`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain("// developed with love in SF");
+    },
+  });
+  itBundled("footer/MultilineFooter", {
+    footer: `/**
+ * This is copyright of [...] ${new Date().getFullYear()}
+ * do not redistribute without consent of [...]
+*/`,
+    files: {
+      "index.js": `console.log("Hello, world!")`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain(`/**
+ * This is copyright of [...] ${new Date().getFullYear()}
+ * do not redistribute without consent of [...]
+*/`);
+    },
+  });
+});

--- a/test/bundler/bundler_footer.test.ts
+++ b/test/bundler/bundler_footer.test.ts
@@ -8,7 +8,7 @@ describe("bundler", () => {
       "/a.js": `console.log("Hello, world!")`,
     },
     onAfterBundle(api) {
-      api.expectFile("out.js").toContain("// developed with love in SF");
+      api.expectFile("out.js").toEndWith('// developed with love in SF"\n');
     },
   });
   itBundled("footer/MultilineFooter", {
@@ -20,10 +20,10 @@ describe("bundler", () => {
       "index.js": `console.log("Hello, world!")`,
     },
     onAfterBundle(api) {
-      api.expectFile("out.js").toContain(`/**
+      api.expectFile("out.js").toEndWith(`/**
  * This is copyright of [...] ${new Date().getFullYear()}
  * do not redistribute without consent of [...]
-*/`);
+*/\"\n`);
     },
   });
 });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -146,6 +146,7 @@ export interface BundlerTestInput {
   alias?: Record<string, string>;
   assetNaming?: string;
   banner?: string;
+  footer?: string;
   define?: Record<string, string | number>;
 
   /** Use for resolve custom conditions */
@@ -416,6 +417,7 @@ function expectBundled(
     external,
     packages,
     files,
+    footer,
     format,
     globalName,
     inject,
@@ -666,6 +668,7 @@ function expectBundled(
               serverComponents && "--server-components",
               outbase && `--root=${outbase}`,
               banner && `--banner="${banner}"`, // TODO: --banner-css=*
+              footer && `--footer="${footer}"`,
               ignoreDCEAnnotations && `--ignore-dce-annotations`,
               emitDCEAnnotations && `--emit-dce-annotations`,
               // inject && inject.map(x => ["--inject", path.join(root, x)]),
@@ -710,6 +713,7 @@ function expectBundled(
               metafile && `--metafile=${metafile}`,
               sourceMap && `--sourcemap=${sourceMap}`,
               banner && `--banner:js=${banner}`,
+              footer && `--footer:js=${footer}`,
               legalComments && `--legal-comments=${legalComments}`,
               ignoreDCEAnnotations && `--ignore-annotations`,
               splitting && `--splitting`,


### PR DESCRIPTION
### What does this PR do?

This implements the --footer flag for `bun build` adds the footer field to bun.d.ts BuildOptions, implements footer additions into the bundler and shifting the source-map start point to work correctly with footers

- [x] Documentation
- [x] Types changes
- [x] Code changes

### How did you verify your code works?

Automated tests in + hand testing of sourcemap compatibility

- [x] I included a test for the new code, or existing tests cover it
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

### Examples

```ts
const enum LogLevel {
  INFO,
  WARN,
  ERROR,
}

function log(data: string, level: LogLevel) {
  switch (level) {
    case LogLevel.INFO:
      console.log(data);
      break;
    case LogLevel.WARN:
      console.warn(data);
      break;
    case LogLevel.ERROR:
      console.error(data);
      break;
  }
}

log("Hey what's good, not this it's broken", LogLevel.ERROR);
```

```
bun build index.ts --outdir=./dist --minify --footer="// made with love in SF" --sourcemap="external"
```
```ts
await Bun.build({
  entrypoints: ["./index.ts"],
  outdir: "./dist",
  minify: true,
  sourcemap: "linked",
  footer: "// made with love in SF",
});
```
Both of these result in
```js
function e(o,s){switch(s){case 0:console.log(o);break;case 1:console.warn(o);break;case 2:console.error(o);break}}e("Hey what's good, not this it's broken",2);

// made with love in SF

//# debugId=D6C4F8A4A7CB8B9F64756E2164756E21
//# sourceMappingURL=index.js.map
```
```map.js
{
  "version": 3,
  "sources": ["../index.ts"],
  "sourcesContent": [
    "const enum LogLevel {\n  INFO,\n  WARN,\n  ERROR,\n}\n\nfunction log(data: string, level: LogLevel) {\n  switch (level) {\n    case LogLevel.INFO:\n      console.log(data);\n      break;\n    case LogLevel.WARN:\n      console.warn(data);\n      break;\n    case LogLevel.ERROR:\n      console.error(data);\n      break;\n  }\n}\n\nlog(\"Hey what's good, not this it's broken\", LogLevel.ERROR);\n"
  ],
  "mappings": "AAMA,SAAS,CAAG,CAAC,EAAc,EAAiB,CAC1C,OAAQ,OACD,GACH,QAAQ,IAAI,CAAI,EAChB,UACG,GACH,QAAQ,KAAK,CAAI,EACjB,UACG,GACH,QAAQ,MAAM,CAAI,EAClB,OAIN,EAAI,wCAAyC,CAAc",
  "debugId": "D6C4F8A4A7CB8B9F64756E2164756E21",
  "names": []
}
```

This also allows nice things like automatic copyright statements

```ts
await Bun.build({
  entrypoints: ["./index.ts"],
  outdir: "./dist",
  minify: true,
  sourcemap: "linked",
  footer: `/**
 * This is copyright of [...] ${new Date().getFullYear()}
 * do not redistribute without consent of [...]
*/`,
});
```

```js
function e(o,s){switch(s){case 0:console.log(o);break;case 1:console.warn(o);break;case 2:console.error(o);break}}e("Hey what's good, not this it's broken",2);

/**
 * This is copyright of [...] 2024
 * do not redistribute without consent of [...]
*/

//# debugId=49D4166E8D5C94DD64756E2164756E21
//# sourceMappingURL=index.js.map
```

