### PR TITLE
remove redundant lines from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    // "skipLibCheck": true,
-    "allowJs": true
   },
   "include": [".", "packages/bun-types/index.d.ts"],
   "exclude": [


### PR DESCRIPTION
### What does this PR do?

- [ ] Documentation or TypeScript types
- [X] Code changes

**What**:

- Removes two lines from `compilerOptions` in the root `tsconfig.json`:
  - `// "skipLibCheck": true,`
  - `"allowJs": true`

**Why**:

- Afaict these lines have no effect, they're already defined in [tsconfig.base.json](https://github.com/oven-sh/bun/blame/main/tsconfig.base.json) which this file extends:
  - `"allowJs": true,`
  - `"skipLibCheck": true,`

**Why not / other considerations**:

- Unlikely:
  - it's decided that `skipLibCheck: false` and `allowJs: false` are better base configuration values
  - all the tsconfigs that extend `tsconfig.base.json` ([search link](https://github.com/search?q=repo%3Aoven-sh%2Fbun%20tsconfig.base.json&type=code)) are reviewed for whether they should use the new values or explicitly overwrite them with the old ones
  - the values don't get overwritten in `tsconfig.json`
  - it turns out these were important to some group of people in ways tests didn't catch
- I don't think there's any issues with how this change interacts with the [jsconfig](https://github.com/oven-sh/bun/blob/main/jsconfig.json) but I could be wrong

### How did you verify your code works?

Read the code on github and thought through possible issues. I did not run automated tests.

