### PR TITLE
docs(bundler): add missing `codetabs` closing tag

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -1108,6 +1108,8 @@ await Bun.build({
 $ bun build ./index.tsx --outdir ./out --banner "\"use client\";"
 ```
 
+{% /codetabs %}
+
 ### `footer`
 
 A footer to be added to the final bundle, this can be something like a comment block for a license or just a fun easter egg.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types
- [ ] Code changes

<!-- ### How did you verify your code works?

 **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

rn:
![image](https://github.com/user-attachments/assets/60718e04-b362-4fd1-98ff-2894f6192422)

