### PR TITLE
enable iterator-helpers in webkit

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -245,6 +245,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         JSC::Options::evalMode() = evalMode;
         JSC::Options::usePromiseTryMethod() = true;
         JSC::Options::useRegExpEscape() = true;
+        JSC::Options::useIteratorHelpers() = true;
         JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
 #ifdef BUN_DEBUG


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/14426

before

```c
❯ ./build/debug/bun-debug --print '[1,2,3][Symbol.iterator]().toArray()'
1 | [1,2,3][Symbol.iterator]().toArray()
                               ^
TypeError: [1, 2, 3][Symbol.iterator]().toArray is not a function. (In '[1, 2, 3][Symbol.iterator]().toArray()', '[1, 2, 3][Symbol.iterator]().toArray' is undefined)
      at /Users/meghandenny/src/bun/[eval]:1:28
      at asyncFunctionResume (1:11)
      at promiseReactionJobWithoutPromiseUnwrapAsyncContext (1:11)
      at promiseReactionJob (1:11)
```

after

```c
❯ ./build/debug/bun-debug --print '[1,2,3][Symbol.iterator]().toArray()'
[ 1, 2, 3 ]
```
