### PR TITLE
Update tsconfig-for-init.json

### DIFF
--- a/src/cli/tsconfig-for-init.json
+++ b/src/cli/tsconfig-for-init.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Enable latest features
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",
@@ -9,7 +9,8 @@
     "allowJs": true,
 
     // Bundler mode
-    "moduleResolution": "bundler",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,


### PR DESCRIPTION
- Change moduleResolution to "Node" to match bun's runtime behavior.

to showcase why this change is important:

```ts
import vite from "vite";
// TS (with Node moduleResolution): Module '"/home/hussein/test/node_modules/vite/dist/node/index"' has no default export.
// TS (with Bundler moduleResolution): it gives you no error which is false!
// Bun: SyntaxError: Missing 'default' export in module '/home/hussein/test/node_modules/vite/dist/node/index.js'.
console.log(vite);
```

and this edge case:

```ts
import urlcat from "urlcat";
// TS (with Bundler moduleResolution): Could not find a declaration file for module 'urlcat'. '/home/hussein/test/node_modules/urlcat/dist/index.mjs' implicitly has an 'any' type.
// in Bun, it works with any moduleResolution. But we need "Node" moduleResolution to remove the TS error.
console.log(urlcat);
```

it matches Bun ✅

- Remove "DOM" lib since Bun is for backend (navigator.userAgent etc. will remain)
- Add resolveJsonModule to allow .json imports in TypeScript

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
