### PR TITLE
docs: `--conditions` flag

### DIFF
--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -238,6 +238,30 @@ If `exports` is not defined, Bun falls back to `"module"` (ESM imports only) the
 }
 ```
 
+### Custom conditions
+
+The `--conditions` flag allows you to specify a list of conditions to use when resolving packages from package.json `"exports"`.
+
+This flag is supported in both `bun build` and Bun's runtime.
+
+```sh
+# Use it with bun build:
+$ bun build --conditions="react-server" --target=bun ./app/foo/route.js
+
+# Use it with bun's runtime:
+$ bun --conditions="react-server" ./app/foo/route.js
+```
+
+You can also use `conditions` programmatically with `Bun.build`:
+
+```js
+await Bun.build({
+  conditions: ["react-server"],
+  target: "bun",
+  entryPoints: ["./app/foo/route.js"],
+});
+```
+
 ## Path re-mapping
 
 In the spirit of treating TypeScript as a first-class citizen, the Bun runtime will re-map import paths according to the [`compilerOptions.paths`](https://www.typescriptlang.org/tsconfig#paths) field in `tsconfig.json`. This is a major divergence from Node.js, which doesn't support any form of import path re-mapping.


### PR DESCRIPTION
I think this is the best place to document this old feature:  
https://bun.sh/blog/bun-v1.0.30#new-flag-conditions (most is copied from the changelog)

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
