### PR TITLE
Fix console.table for numeric keys

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -342,7 +342,7 @@ const TablePrinter = struct {
             //  - otherwise: iterate the object properties, and create the columns on-demand
             if (!this.properties.isUndefined()) {
                 for (columns.items[1..]) |*column| {
-                    if (row_value.getWithString(this.globalObject, column.name)) |value| {
+                    if (row_value.getOwn(this.globalObject, column.name)) |value| {
                         column.width = @max(column.width, this.getWidthForValue(value));
                     }
                 }
@@ -436,7 +436,7 @@ const TablePrinter = struct {
                     value = row_value;
                 }
             } else if (row_value.isObject()) {
-                value = row_value.getWithString(this.globalObject, col.name) orelse JSValue.zero;
+                value = row_value.getOwn(this.globalObject, col.name) orelse JSValue.zero;
             }
 
             if (value.isEmpty()) {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3712,23 +3712,6 @@ JSC__JSValue JSC__JSValue__getIfPropertyExistsImpl(JSC__JSValue JSValue0,
     return JSC::JSValue::encode(Bun::getIfPropertyExistsPrototypePollutionMitigation(vm, globalObject, object, property));
 }
 
-extern "C" JSC__JSValue JSC__JSValue__getIfPropertyExistsImplString(JSC__JSValue JSValue0, JSC__JSGlobalObject* globalObject, BunString* propertyName)
-{
-    ASSERT_NO_PENDING_EXCEPTION(globalObject);
-    JSValue value = JSC::JSValue::decode(JSValue0);
-    JSC::JSObject* object = value.getObject();
-    if (UNLIKELY(!object))
-        return JSValue::encode({});
-
-    JSC::VM& vm = globalObject->vm();
-
-    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::String(""_s) : propertyName->toWTFString(BunString::ZeroCopy);
-    auto identifier = JSC::Identifier::fromString(vm, propertyNameString);
-    auto property = JSC::PropertyName(identifier);
-
-    return JSC::JSValue::encode(Bun::getIfPropertyExistsPrototypePollutionMitigation(vm, globalObject, object, property));
-}
-
 extern "C" JSC__JSValue JSC__JSValue__getOwn(JSC__JSValue JSValue0, JSC__JSGlobalObject* globalObject, BunString* propertyName)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5275,14 +5275,6 @@ pub const JSValue = enum(JSValueReprInt) {
         return if (value.isEmpty()) null else value;
     }
 
-    extern fn JSC__JSValue__getIfPropertyExistsImplString(value: JSValue, globalObject: *JSGlobalObject, propertyName: [*c]const bun.String) JSValue;
-
-    pub fn getWithString(this: JSValue, global: *JSGlobalObject, property_name: anytype) ?JSValue {
-        var property_name_str = bun.String.init(property_name);
-        const value = JSC__JSValue__getIfPropertyExistsImplString(this, global, &property_name_str);
-        return if (@intFromEnum(value) != 0) value else return null;
-    }
-
     extern fn JSC__JSValue__getOwn(value: JSValue, globalObject: *JSGlobalObject, propertyName: [*c]const bun.String) JSValue;
 
     /// Get *own* property value (i.e. does not resolve property in the prototype chain)

--- a/test/js/bun/console/__snapshots__/console-table.test.ts.snap
+++ b/test/js/bun/console/__snapshots__/console-table.test.ts.snap
@@ -194,3 +194,12 @@ exports[`console.table expected output for: properties - interesting character 1
 └───┴────────┘
 "
 `;
+
+exports[`console.table expected output for: number keys 1`] = `
+"┌──────┬─────┬─────┐
+│      │ 10  │ 100 │
+├──────┼─────┼─────┤
+│ test │ 123 │ 154 │
+└──────┴─────┴─────┘
+"
+`;

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -134,6 +134,14 @@ describe("console.table", () => {
         ],
       },
     ],
+    [
+      "number keys",
+      {
+        args: () => [
+          {test: {"10": 123, "100": 154}},
+        ],
+      },
+    ],
   ])("expected output for: %s", (label, { args }) => {
     const { stdout } = spawnSync({
       cmd: [bunExe(), `${import.meta.dir}/console-table-run.ts`, args.toString()],


### PR DESCRIPTION
### What does this PR do?

Fixes #14415

Previously, `getWithString` was called for each property key, but getWithString calls getIfPropertyExistsPrototypePollutionMitigation which asserts the key is not an index key. Presumably, getWithString used to work here before the prototype pollution mitigation in 1.1.20.

With this change, properties that aren't an own property are no longer included in `console.table`

```js
class A {
    constructor(cond) {
        this.a = 1;
        this.b = 2;
    }
}
class B {
    constructor(cond) {
        this.a = 1;
    }
    get b() { return 128; }
}

console.table({a: new A(), b: new B()});
```

Previously, this logged the value of b for both classes, but the one with the getter had the table printed wrong:

```
┌───┬───┬───┐
│   │ a │ b │
├───┼───┼───┤
│ a │ 1 │ 2 │
│ b │ 1 │ 128 │
└───┴───┴───┘
```

Now, it does not log the b with the getter:

```
┌───┬───┬───┐
│   │ a │ b │
├───┼───┼───┤
│ a │ 1 │ 2 │
│ b │ 1 │   │
└───┴───┴───┘
```

This also removes the bindings for getWithString as this was the only place they were used.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

- [ ] N/A I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] N/A JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
