### PR TITLE
fix label in 3-typescript-bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
@@ -1,6 +1,6 @@
 name: 🇹 TypeScript Type Bug Report
 description: Report an issue with TypeScript types
-labels: [bug, typescript]
+labels: [bug, types]
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
`typescript` label is being deprecated and meant for parser/transpiler bugs but we already have `transpiler`

`types` is the correct label for this template