### PR TITLE
streams.test.js: skip failing macos test

### DIFF
--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -7,12 +7,10 @@ import {
   readableStreamToText,
 } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { tmpdirSync } from "harness";
+import { tmpdirSync, isWindows, isMacOS } from "harness";
 import { mkfifo } from "mkfifo";
 import { createReadStream, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-
-const isWindows = process.platform === "win32";
 
 it("TransformStream", async () => {
   // https://developer.mozilla.org/en-US/docs/Web/API/TransformStream
@@ -427,7 +425,7 @@ it("ReadableStream.prototype.values", async () => {
   expect(chunks.join("")).toBe("helloworld");
 });
 
-it.skipIf(isWindows)("Bun.file() read text from pipe", async () => {
+it.todoIf(isWindows || isMacOS)("Bun.file() read text from pipe", async () => {
   const fifoPath = join(tmpdirSync(), "bun-streams-test-fifo");
   try {
     unlinkSync(fifoPath);


### PR DESCRIPTION
was going to make a tracking issue but its already marked todo on windows and also fails locally
will come back and mark a bunch of existing `.todoIf`/`.skipIf` issues at once