### PR TITLE
Remove duplicate in import-json.md

### DIFF
--- a/docs/guides/runtime/import-json.md
+++ b/docs/guides/runtime/import-json.md
@@ -27,16 +27,6 @@ data.version; // => "1.0.0"
 data.author.name; // => "John Dough"
 ```
 
-Bun also supports [Import Attributes](https://github.com/tc39/proposal-import-attributes/) and [JSON modules](https://github.com/tc39/proposal-json-modules) syntax.
-
-```ts
-import data from "./package.json" with { type: "json" };
-
-data.name; // => "bun"
-data.version; // => "1.0.0"
-data.author.name; // => "John Dough"
-```
-
 ---
 
 Bun also supports [Import Attributes](https://github.com/tc39/proposal-import-attributes/) and [JSON modules](https://github.com/tc39/proposal-json-modules) syntax.


### PR DESCRIPTION
### What does this PR do?

This removes a duplicated paragraph in `docs/guides/runtime/import-json.md`

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
