### PR TITLE
fix(parser): uncaught mismatch between JSX opening/closing tags

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -530,7 +530,8 @@ const JSXTag = struct {
     };
     data: Data,
     range: logger.Range,
-    name: string = "",
+    /// Empty string for fragments.
+    name: string,
 
     pub fn parse(comptime P: type, p: *P) anyerror!JSXTag {
         const loc = p.lexer.loc();
@@ -559,6 +560,7 @@ const JSXTag = struct {
                     .data = name,
                 }, loc) },
                 .range = tag_range,
+                .name = name,
             };
         }
 
@@ -15778,7 +15780,7 @@ fn NewParser_(
                         const end_tag = try JSXTag.parse(P, p);
 
                         if (!strings.eql(end_tag.name, tag.name)) {
-                            try p.log.addRangeErrorFmt(p.source, end_tag.range, p.allocator, "Expected closing tag \\</{s}> to match opening tag \\<{s}>", .{
+                            try p.log.addRangeErrorFmt(p.source, end_tag.range, p.allocator, "Expected closing tag \\</{s}\\> to match opening tag \\<{s}\\>", .{
                                 end_tag.name,
                                 tag.name,
                             });

--- a/test/regression/issue/14477/14477.test.ts
+++ b/test/regression/issue/14477/14477.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+import fs from "fs";
+
+test("JSXElement with mismatched closing tags produces a syntax error", async () => {
+  const files = await fs.promises.readdir(import.meta.dir);
+  const fixtures = files.filter(file => !file.endsWith(".test.ts")).map(fixture => join(import.meta.dir, fixture));
+
+  const bakery = fixtures.map(
+    fixture =>
+      Bun.spawn({
+        cmd: [bunExe(), fixture],
+        cwd: import.meta.dir,
+        stdio: ["inherit", "inherit", "inherit"],
+        env: bunEnv,
+      }).exited,
+  );
+
+  // all subprocesses should fail.
+  const exited = await Promise.all(bakery);
+  expect(exited).toEqual(Array.from({ length: fixtures.length }, () => 1));
+});

--- a/test/regression/issue/14477/builtin-mismatch.tsx
+++ b/test/regression/issue/14477/builtin-mismatch.tsx
@@ -1,0 +1,1 @@
+console.log(<div></p>);

--- a/test/regression/issue/14477/component-mismatch.tsx
+++ b/test/regression/issue/14477/component-mismatch.tsx
@@ -1,0 +1,2 @@
+
+console.log(<Foo></Bar>);

--- a/test/regression/issue/14477/non-identifier-mismatch.tsx
+++ b/test/regression/issue/14477/non-identifier-mismatch.tsx
@@ -1,0 +1,3 @@
+// mismatch where openening tag is not a valid IdentifierName, but is a valid
+// JSXIdentifierName
+console.log(<div-:button></p>);


### PR DESCRIPTION
### What does this PR do?
> Closes #14477

Fixes a bug where mismatched identifiers in JSX opening/closing tags were not being caught.
```jsx
console.log(<div></p>);
//                 ^ now reports a syntax error here
```
I also noticed that the stylized tags in the relevant error message were missing a `>`, so I fixed that too.

Before:
```
Bun v1.1.31-debug+6b8fd718c (macOS arm64)
1 | console.log(<div></p>);
                       ^
error: Expected closing tag </p to match opening tag <div
    at /Users/donisaac/Documents/projects/experiments/bun/test/regression/issue/14477/builtin-mismatch.tsx:1:20
```

After:
```
Bun v1.1.31-debug+6b8fd718c (macOS arm64)
1 | console.log(<div></p>);
                       ^
error: Expected closing tag </p> to match opening tag <div>
    at /Users/donisaac/Documents/projects/experiments/bun/test/regression/issue/14477/builtin-mismatch.tsx:1:20
```

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I added regression test cases to `test/regression/issue/14477/14477.test.ts`. It tests for all branches in `JSXTag.parse` that initialize a new `JSXTag`:
1. Fragments (no `name`)
2. Builtins and webcomponents (`<button` and `<Foo-:Bar`)
3. Custom React components (`<MyComponent`)

<!-- If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->
<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
