### PR TITLE
Fix several bugs when printing exceptions from Error.captureStackTrace

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 4bfe7524240e026c8af66d53d314ac2711339e40)
+  set(WEBKIT_VERSION 12e2f46fb01f7c5cf5a992b9414ddfaab32b7110)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 01ac6a63449713c5b7cf38fb03628283041f63be)
+  set(WEBKIT_VERSION 4bfe7524240e026c8af66d53d314ac2711339e40)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/src/bun.js/bindings/ErrorStackTrace.h
+++ b/src/bun.js/bindings/ErrorStackTrace.h
@@ -46,13 +46,13 @@ public:
 
 private:
     JSC::VM& m_vm;
-    JSC::JSCell* m_callee;
+    JSC::JSCell* m_callee { nullptr };
 
     // May be null
     JSC::CallFrame* m_callFrame;
 
     // May be null
-    JSC::CodeBlock* m_codeBlock;
+    JSC::CodeBlock* m_codeBlock { nullptr };
     JSC::BytecodeIndex m_bytecodeIndex;
 
     // Lazy-initialized
@@ -96,8 +96,40 @@ public:
     SourcePositions* getSourcePositions();
 
     bool isWasmFrame() const { return m_isWasmFrame; }
-    bool isEval() const { return m_codeBlock && (JSC::EvalCode == m_codeBlock->codeType()); }
-    bool isConstructor() const { return m_codeBlock && (JSC::CodeForConstruct == m_codeBlock->specializationKind()); }
+    bool isEval()
+    {
+        if (m_codeBlock) {
+            if (m_codeBlock->codeType() == JSC::EvalCode) {
+                return true;
+            }
+            auto* executable = m_codeBlock->ownerExecutable();
+            if (!executable) {
+                return false;
+            }
+
+            switch (executable->evalContextType()) {
+            case JSC::EvalContextType::None: {
+                return false;
+            }
+            case JSC::EvalContextType::FunctionEvalContext:
+            case JSC::EvalContextType::InstanceFieldEvalContext:
+                return true;
+            }
+        }
+
+        if (m_callee && m_callee->inherits<JSC::JSFunction>()) {
+            auto* function = jsCast<JSC::JSFunction*>(m_callee);
+            if (function->isHostFunction()) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+    bool isConstructor() const
+    {
+        return m_codeBlock && (JSC::CodeForConstruct == m_codeBlock->specializationKind());
+    }
 
 private:
     ALWAYS_INLINE String retrieveSourceURL();
@@ -130,9 +162,16 @@ public:
     {
     }
 
+    JSCStackTrace(WTF::Vector<JSCStackFrame>&& frames)
+        : m_frames(WTFMove(frames))
+    {
+    }
+
     size_t size() const { return m_frames.size(); }
     bool isEmpty() const { return m_frames.isEmpty(); }
     JSCStackFrame& at(size_t i) { return m_frames.at(i); }
+
+    WTF::Vector<JSCStackFrame>&& frames() { return WTFMove(m_frames); }
 
     static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames);
 
@@ -145,6 +184,7 @@ public:
      *
      * Return value must remain stack allocated. */
     static JSCStackTrace captureCurrentJSStackTrace(Zig::GlobalObject* globalObject, JSC::CallFrame* callFrame, size_t frameLimit, JSC::JSValue caller);
+    static void getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit);
 
     /* In JSC, JSC::Exception points to the actual value that was thrown, usually
      * a JSC::ErrorInstance (but could be any JSValue). In v8, on the other hand,

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -583,8 +583,10 @@ WTF::String Bun::formatStackTrace(
                 }
             }
 
-            // If it's not a Zig::GlobalObject, don't bother source-mapping it.
-            if (globalObject == lexicalGlobalObject && globalObject) {
+            bool isDefinitelyNotRunninginNodeVMGlobalObject = (globalObject == lexicalGlobalObject && globalObject);
+
+            bool isDefaultGlobalObjectInAFinalizer = (globalObject && !lexicalGlobalObject && !errorInstance);
+            if (isDefinitelyNotRunninginNodeVMGlobalObject || isDefaultGlobalObjectInAFinalizer) {
                 // https://github.com/oven-sh/bun/issues/3595
                 if (!sourceURLForFrame.isEmpty()) {
                     remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -373,6 +373,7 @@ public:
     }
 
     bool asyncHooksNeedsCleanup = false;
+    bool isInsideErrorPrepareStackTraceCallback = false;
 
     /**
      * WARNING: You must update visitChildrenImpl() if you add a new field.

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -191,8 +191,7 @@ public:
 
     void clearDOMGuardedObjects();
 
-    static void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, JSC::JSArray* callSites);
-    void formatStackTrace(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites, JSValue prepareStack = JSC::jsUndefined());
+    static void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, MarkedArgumentBuffer& callSites);
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, JSC::Exception*);
     static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -584,6 +584,7 @@ public:
     LazyProperty<JSGlobalObject, JSObject> m_navigatorObject;
     LazyProperty<JSGlobalObject, JSObject> m_performanceObject;
     LazyProperty<JSGlobalObject, JSObject> m_processObject;
+    LazyProperty<JSGlobalObject, CustomGetterSetter> m_lazyStackCustomGetterSetter;
 
     bool hasOverridenModuleResolveFilenameFunction = false;
 

--- a/src/bun.js/bindings/v8-capture-stack-fixture.cjs
+++ b/src/bun.js/bindings/v8-capture-stack-fixture.cjs
@@ -1,0 +1,15 @@
+let e = new Error();
+
+const { noInline } = require("bun:jsc");
+
+function sloppyWrapperFn() {
+  sloppyFn();
+}
+noInline(sloppyWrapperFn);
+
+function sloppyFn() {
+  Error.captureStackTrace(e);
+  module.exports = e.stack;
+}
+noInline(sloppyFn);
+sloppyWrapperFn();

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3358,6 +3358,7 @@ pub const VirtualMachine = struct {
         if (frames.len == 0) return;
 
         var top = &frames[0];
+        var top_frame_is_builtin = false;
         if (this.hide_bun_stackframes) {
             for (frames) |*frame| {
                 if (frame.source_url.hasPrefixComptime("bun:") or
@@ -3365,10 +3366,12 @@ pub const VirtualMachine = struct {
                     frame.source_url.isEmpty() or
                     frame.source_url.eqlComptime("native"))
                 {
+                    top_frame_is_builtin = true;
                     continue;
                 }
 
                 top = frame;
+                top_frame_is_builtin = false;
                 break;
             }
         }
@@ -3417,8 +3420,14 @@ pub const VirtualMachine = struct {
                     }
                 }
 
+                if (top_frame_is_builtin) {
+                    // Avoid printing "export default 'native'"
+                    break :code ZigString.Slice.empty;
+                }
+
                 var log = logger.Log.init(bun.default_allocator);
                 defer log.deinit();
+
                 var original_source = fetchWithoutOnLoadPlugins(this, this.global, top.source_url, bun.String.empty, &log, .print_source) catch return;
                 must_reset_parser_arena_later.* = true;
                 break :code original_source.source_code.toUTF8(bun.default_allocator);

--- a/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
@@ -430,6 +430,9 @@ test("no assertion failures", () => {
     }
   }
   const customError = new CustomError("bar");
+  customError.stack;
+  delete customError.originalLine;
+  delete customError.originalColumn;
   assert.strictEqual(util.format(customError), customError.stack.replace(/^Error/, "Custom$&")); //! temp bug workaround
   // Doesn't capture stack trace
   function BadCustomError(msg) {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -586,6 +586,7 @@ test("Error.captureStackTrace updates the stack property each call, even if Erro
   let error = new Error();
   const firstStack = error.stack;
   Error.prepareStackTrace = function (err, stack) {
+    expect(err.stack).not.toBe(firstStack);
     didCallPrepareStackTrace = true;
     return stack;
   };

--- a/test/js/node/v8/error-prepare-stack-default-fixture.js
+++ b/test/js/node/v8/error-prepare-stack-default-fixture.js
@@ -5,20 +5,38 @@ const orig = Error.prepareStackTrace;
 Error.prepareStackTrace = (err, stack) => {
   return orig(err, stack);
 };
+var stack2, stack;
 
-const err = new Error();
-Error.captureStackTrace(err);
-const stack = err.stack;
+function twoWrapperLevel() {
+  const err = new Error();
+  Error.captureStackTrace(err);
+  stack = err.stack;
 
-Error.prepareStackTrace = undefined;
-const err2 = new Error();
-Error.captureStackTrace(err2);
-const stack2 = err2.stack;
+  Error.prepareStackTrace = undefined;
+  const err2 = new Error();
+  Error.captureStackTrace(err2);
+  stack2 = err2.stack;
+}
 
-const stackIgnoringLineAndColumn = stack.replaceAll(":10:24", "N");
-const stack2IgnoringLineAndColumn = stack2.replaceAll(":15:24", "N");
+function oneWrapperLevel() {
+  // ...
+  var a = 123;
+  globalThis.a = a;
+  // ---
+
+  twoWrapperLevel();
+}
+
+oneWrapperLevel();
+
+// The native line column numbers might differ a bit here.
+const stackIgnoringLineAndColumn = stack.replaceAll(":12:26", ":NN:NN").replaceAll(/native:.*$/gm, "native)");
+const stack2IgnoringLineAndColumn = stack2.replaceAll(":17:26", ":NN:NN").replaceAll(/native:.*$/gm, "native)");
 if (stackIgnoringLineAndColumn !== stack2IgnoringLineAndColumn) {
+  console.log("\n-----\n");
   console.log(stackIgnoringLineAndColumn);
+  console.log("\n-----\n");
   console.log(stack2IgnoringLineAndColumn);
+  console.log("\n-----\n");
   throw new Error("Stacks are different");
 }

--- a/test/regression/issue/013880-fixture.cjs
+++ b/test/regression/issue/013880-fixture.cjs
@@ -1,0 +1,15 @@
+function a() {
+  try {
+    new Function("throw new Error(1)")();
+  } catch (e) {
+    console.log(Error.prepareStackTrace);
+    console.log(e.stack);
+  }
+}
+
+Error.prepareStackTrace = function abc() {
+  console.log("trigger");
+  a();
+};
+
+new Error().stack;

--- a/test/regression/issue/013880.test.ts
+++ b/test/regression/issue/013880.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "bun:test";
+
+test("regression", () => {
+  expect(() => require("./013880-fixture.cjs")).not.toThrow();
+});


### PR DESCRIPTION
### What does this PR do?

- This makes it so `Error.captureStackTrace` runs `Error.prepareStackTrace` lazily (excluding the case where a non-Error object is passed), which should both improve performance by not calling it until error.stack is accessed, and align the behavior with V8/Node (Node makes this a getter/setter, we don't do that and instead the Error object overrides `[[Put]]`)  
- This fixes some cases where the CallSite objects would return "native" or "unknown" for the source URL when it definitely should not have been doing that. 
- This fixes the really annoying `export default "native"` or `export defalut "node:fs"` source code preview bug
- The makes the `isEval` function in the CallSite array object work slightly more often
- This regresses the `getThis()` function, as JSC::StackFrame does not persist the `this` value. I could not find many usages of this on GitHub. We will see if anyone complains.
- This fixes an infinite loop when throwing an error inside an Error.prepareStackTrace function fixes #13880

This makes it so we show the source code preview more often for top-level exceptions:

```ts
bun test v1.1.30 (29e1ba04)

test/js/third_party/postgres/postgres.test.ts:
766 |     query.execute()
767 |   }
768 | 
769 |   function ErrorResponse(x) {
770 |     query && (query.cursorFn || query.describeFirst) && write(Sync)
771 |     const error = Errors.postgres(parseError(x))
          ^
PostgresError: connection is insecure (try using `sslmode=require`)
      at /Users/jarred/Code/bun/test/node_modules/postgres/src/connection.js:771:5
✗ postgres > should connect using TLS [240.85ms]
766 |     query.execute()
767 |   }
768 | 
769 |   function ErrorResponse(x) {
770 |     query && (query.cursorFn || query.describeFirst) && write(Sync)
771 |     const error = Errors.postgres(parseError(x))
          ^
PostgresError: connection is insecure (try using `sslmode=require`)
      at /Users/jarred/Code/bun/test/node_modules/postgres/src/connection.js:771:5
✗ postgres > should insert, select and delete [144.82ms]

 0 pass
 2 fail
```

Previously:
```ts
❯ bun test postgres.test
bun test v1.1.31-canary.32 (183a8f61)

test/js/third_party/postgres/postgres.test.ts:
PostgresError: connection is insecure (try using `sslmode=require`)
✗ postgres > should connect using TLS [141.69ms]
PostgresError: connection is insecure (try using `sslmode=require`)
✗ postgres > should insert, select and delete [127.80ms]

 0 pass
 2 fail
Ran 2 tests across 1 files. [387.00ms]
```

### How did you verify your code works?

There are updated tests.

Haven't figured out how to write a test for the `export default "native"` issue, not sure yet how to minimally reproduce that.