### PR TITLE
Next.js dev server now runs on Bun

### DIFF
--- a/docs/guides/ecosystem/nextjs.md
+++ b/docs/guides/ecosystem/nextjs.md
@@ -2,12 +2,6 @@
 name: Build an app with Next.js and Bun
 ---
 
-{% callout %}
-The Next.js [App Router](https://nextjs.org/docs/app) currently relies on Node.js APIs that Bun does not yet implement. The guide below uses Bun to initialize a project and install dependencies, but it uses Node.js to run the dev server.
-{% /callout %}
-
----
-
 Initialize a Next.js app with `create-next-app`. This automatically installs dependencies using `npm`.
 
 ```sh


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This removes the note `The Next.js [App Router](https://nextjs.org/docs/app) currently relies on Node.js APIs that Bun does not yet implement. The guide below uses Bun to initialize a project and install dependencies, but it uses Node.js to run the dev server.` since Bun now can run Next.js dev server using app router with `--bun` flag. (even with `next dev --turbo`)

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I'm running three websites using Bun & Next.js on Vercel, and running dev server, `bun run --bun build`, and deploying on Vercel using bun works fine.

I don't see error message when using `--bun` that says worker.stdin, worker.stdout, and worker.stderr are needed.

Bun 1.1.30
Darwin 24.0.0
Next.js 14.2.15

Vercel Deployment log:
```
...
+ First Load JS shared by all            87.1 kB
...
○  (Static)  prerendered as static content
Traced Next.js server files in: 36.017ms
Created all serverless functions in: 86.188ms
Collected static files (public/, static/, .next/static): 10.557ms
Build Completed in /vercel/output [31s]
Deploying outputs...
Deployment completed
Uploading build cache [143.62 MB]...
Build cache uploaded: 2.049s
```

Edit: Here are some logs on local machine
```
my-app on  main via ⬢ v20.18.0 via 🍞 v1.1.30
➜ bun run --bun dev
$ next dev
  ▲ Next.js 14.2.15
  - Local:        http://localhost:3000

 ✓ Starting...
 ✓ Ready in 2.2s
 ○ Compiling / ...
 ✓ Compiled / in 1513ms (546 modules)
 GET / 200 in 1688ms
 ✓ Compiled in 185ms (254 modules)
 ✓ Compiled /favicon.ico in 403ms (305 modules)
 GET /favicon.ico 200 in 457ms
^C
```

```
my-app on  main via ⬢ v20.18.0 via 🍞 v1.1.30
➜ bun run --bun build
$ next build
  ▲ Next.js 14.2.15

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (5/5)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    5.26 kB        92.3 kB
└ ○ /_not-found                          873 B            88 kB
+ First Load JS shared by all            87.1 kB
  ├ chunks/117-9d7f1cd31c438fde.js       31.6 kB
  ├ chunks/fd9d1056-aa94ea5c2eabf904.js  53.6 kB
  └ other shared chunks (total)          1.85 kB


○  (Static)  prerendered as static content
```
