### PR TITLE
node:child_process: 'ineherit' stdio should make getters be null

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1121,8 +1121,6 @@ class ChildProcess extends EventEmitter {
             if (autoResume) pipe.resume();
             return pipe;
           }
-          case "inherit":
-            return process[fdToStdioName(i)] || null;
           case "destroyed":
             return new ShimmedStdioOutStream();
           default:

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -279,6 +279,33 @@ describe("spawn()", () => {
     const { stdout } = spawnSync("bun", ["-v"], { encoding: "utf8" });
     expect(isValidSemver(stdout.trim())).toBe(true);
   });
+
+  describe("stdio", () => {
+    it("ignore", () => {
+      const child = spawn(bunExe(), ["-v"], { stdio: "ignore" });
+      expect(!!child).toBe(true);
+      expect(child.stdout).toBeNull();
+      expect(child.stderr).toBeNull();
+    });
+    it("inherit", () => {
+      const child = spawn(bunExe(), ["-v"], { stdio: "inherit" });
+      expect(!!child).toBe(true);
+      expect(child.stdout).toBeNull();
+      expect(child.stderr).toBeNull();
+    });
+    it("pipe", () => {
+      const child = spawn(bunExe(), ["-v"], { stdio: "pipe" });
+      expect(!!child).toBe(true);
+      expect(child.stdout).not.toBeNull();
+      expect(child.stderr).not.toBeNull();
+    });
+    it.todo("overlapped", () => {
+      const child = spawn(bunExe(), ["-v"], { stdio: "overlapped" });
+      expect(!!child).toBe(true);
+      expect(child.stdout).not.toBeNull();
+      expect(child.stderr).not.toBeNull();
+    });
+  });
 });
 
 describe("execFile()", () => {


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/14554

<img width="1830" alt="image" src="https://github.com/user-attachments/assets/41396e55-63ae-4953-b2ed-9872ba7f1524">

will leave as draft until i add a test and CI passes

----

```js
import child_process from "node:child_process";

const res = child_process.spawn("ls", {
  stdio: "inherit",
});
console.log(res.stderr);
```

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/a3026795-4c7e-49f1-84e7-410b59cfd28a">
