### PR TITLE
 fix h2 tests failures

### DIFF
--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -60,7 +60,7 @@ function validateLinkHeaderValue(hints) {
 hideFromStack(validateLinkHeaderValue);
 // TODO: do it in NodeValidator.cpp
 function validateObject(value, name) {
-  if (typeof value !== "object") throw ERR_INVALID_ARG_TYPE(name, "object", value);
+  if (typeof value !== "object") throw $ERR_INVALID_ARG_TYPE(name, "object", value);
 }
 hideFromStack(validateObject);
 

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -1,5 +1,5 @@
 const { hideFromStack } = require("internal/shared");
-
+const { ArrayIsArray } = require("internal/primordials");
 const RegExpPrototypeExec = RegExp.prototype.exec;
 
 const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
@@ -28,6 +28,7 @@ function validateLinkHeaderFormat(value, name) {
     );
   }
 }
+
 function validateLinkHeaderValue(hints) {
   if (typeof hints === "string") {
     validateLinkHeaderFormat(hints, "hints");

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -58,8 +58,14 @@ function validateLinkHeaderValue(hints) {
   );
 }
 hideFromStack(validateLinkHeaderValue);
+// TODO: do it in NodeValidator.cpp
+function validateObject(value, name) {
+  if (typeof value !== "object") throw ERR_INVALID_ARG_TYPE(name, "object", value);
+}
+hideFromStack(validateObject);
 
 export default {
+  validateObject: validateObject,
   validateLinkHeaderValue: validateLinkHeaderValue,
   checkIsHttpToken: checkIsHttpToken,
   /** `(value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER)` */

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1703,11 +1703,12 @@ class Http2Stream extends Duplex {
     if ((this[bunHTTP2StreamStatus] & StreamState.Closed) === 0) {
       const session = this[bunHTTP2Session];
       assertSession(session);
+      code = code || 0;
       validateInteger(code, "code", 0, 13);
       this.rstCode = code;
       markStreamClosed(this);
 
-      session[bunHTTP2Native]?.rstStream(this.#id, code || 0);
+      session[bunHTTP2Native]?.rstStream(this.#id, code);
       this[bunHTTP2Session] = null;
     }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Existing tests
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
