### PR TITLE
use `memset_patternN` in `Buffer.fill`

### DIFF
--- a/bench/snippets/buffer-fill.mjs
+++ b/bench/snippets/buffer-fill.mjs
@@ -1,0 +1,15 @@
+import { bench, run } from "./runner.mjs";
+
+for (let size of [32, 2048, 1024 * 16, 1024 * 1024 * 2, 1024 * 1024 * 16]) {
+  for (let fillSize of [4, 8, 16, 11]) {
+    const buffer = Buffer.allocUnsafe(size);
+
+    const pattern = "x".repeat(fillSize);
+
+    bench(`Buffer.fill ${size} bytes with ${fillSize} byte value`, () => {
+      buffer.fill(pattern);
+    });
+  }
+}
+
+await run();

--- a/src/bun.js/node/buffer.zig
+++ b/src/bun.js/node/buffer.zig
@@ -55,22 +55,10 @@ pub const BufferVectorized = struct {
                 @memset(buf, buf[0]);
                 return true;
             },
-            4 => if (comptime Environment.isMac) {
-                const pattern = buf[0..4];
+            inline 4, 8, 16 => |n| if (comptime Environment.isMac) {
+                const pattern = buf[0..n];
                 buf = buf[pattern.len..];
-                bun.C.memset_pattern4(buf.ptr, pattern.ptr, buf.len);
-                return true;
-            },
-            8 => if (comptime Environment.isMac) {
-                const pattern = buf[0..8];
-                buf = buf[pattern.len..];
-                bun.C.memset_pattern8(buf.ptr, pattern.ptr, buf.len);
-                return true;
-            },
-            16 => if (comptime Environment.isMac) {
-                const pattern = buf[0..16];
-                buf = buf[pattern.len..];
-                bun.C.memset_pattern16(buf.ptr, pattern.ptr, buf.len);
+                @field(bun.C, bun.fmt.comptimePrint("memset_pattern{d}", .{n}))(buf.ptr, pattern.ptr, buf.len);
                 return true;
             },
             else => {},

--- a/src/bun.js/node/buffer.zig
+++ b/src/bun.js/node/buffer.zig
@@ -80,13 +80,13 @@ pub const BufferVectorized = struct {
         buf = buf[written..];
 
         while (buf.len >= contents.len) {
-            @memcpy(buf[0..contents.len], contents);
+            bun.copy(u8, buf, contents);
             buf = buf[contents.len..];
             contents.len *= 2;
         }
 
         if (buf.len > 0) {
-            @memcpy(buf, contents[0..buf.len]);
+            bun.copy(u8, buf, contents[0..buf.len]);
         }
 
         return true;

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -888,3 +888,7 @@ pub const CLOCK_THREAD_CPUTIME_ID = 1;
 pub const netdb = @cImport({
     @cInclude("netdb.h");
 });
+
+pub extern fn memset_pattern4(buf: [*]u8, pattern: [*]const u8, len: usize) void;
+pub extern fn memset_pattern8(buf: [*]u8, pattern: [*]const u8, len: usize) void;
+pub extern fn memset_pattern16(buf: [*]u8, pattern: [*]const u8, len: usize) void;

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -8210,12 +8210,8 @@ it("should ensure read permissions of all extracted files", async () => {
 
   await runBunInstall(env, package_dir);
 
-  expect((await stat(join(package_dir, "node_modules", "pkg-only-owner", "package.json"))).mode & 0o666).toBe(
-    isWindows ? 0o666 : 0o644,
-  );
-  expect((await stat(join(package_dir, "node_modules", "pkg-only-owner", "src", "index.js"))).mode & 0o666).toBe(
-    isWindows ? 0o666 : 0o644,
-  );
+  expect((await stat(join(package_dir, "node_modules", "pkg-only-owner", "package.json"))).mode & 0o444).toBe(0o444);
+  expect((await stat(join(package_dir, "node_modules", "pkg-only-owner", "src", "index.js"))).mode & 0o444).toBe(0o444);
 });
 
 it("should handle @scoped name that contains tilde, issue#7045", async () => {


### PR DESCRIPTION
### What does this PR do?

Before:
```
❯ bun /Users/dylan/code/bun/bench/snippets/buffer-fill.mjs
cpu: Apple M1 Max
runtime: bun 1.1.30 (arm64-darwin)

benchmark                                          time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------------------------- -----------------------------
Buffer.fill 32 bytes with 4 byte value          25.51 ns/iter   (24.36 ns … 51.63 ns)   25.9 ns  29.52 ns  30.23 ns
Buffer.fill 32 bytes with 8 byte value          19.79 ns/iter   (18.05 ns … 29.24 ns)  19.56 ns   24.7 ns  26.19 ns
Buffer.fill 32 bytes with 16 byte value         15.44 ns/iter   (15.15 ns … 21.93 ns)  15.51 ns  17.53 ns  18.36 ns
Buffer.fill 32 bytes with 11 byte value         19.38 ns/iter   (18.62 ns … 29.44 ns)  19.56 ns  21.87 ns   22.9 ns
Buffer.fill 2048 bytes with 4 byte value        75.03 ns/iter   (66.63 ns … 86.33 ns)  75.71 ns  81.61 ns   84.2 ns
Buffer.fill 2048 bytes with 8 byte value         64.2 ns/iter  (59.37 ns … 448.25 ns)  60.92 ns 183.53 ns 257.21 ns
Buffer.fill 2048 bytes with 16 byte value       56.88 ns/iter   (55.89 ns … 65.98 ns)   57.1 ns  62.32 ns  63.14 ns
Buffer.fill 2048 bytes with 11 byte value       67.37 ns/iter   (65.98 ns … 77.59 ns)  68.06 ns  72.23 ns  73.41 ns
Buffer.fill 16384 bytes with 4 byte value       253.1 ns/iter (238.01 ns … 306.48 ns) 254.21 ns 277.29 ns 277.69 ns
Buffer.fill 16384 bytes with 8 byte value      245.86 ns/iter (232.36 ns … 269.86 ns) 248.37 ns 260.68 ns 263.39 ns
Buffer.fill 16384 bytes with 16 byte value     242.69 ns/iter (229.21 ns … 250.71 ns) 245.08 ns 249.44 ns 250.02 ns
Buffer.fill 16384 bytes with 11 byte value        250 ns/iter (243.79 ns … 264.95 ns) 251.09 ns 261.87 ns  263.7 ns
Buffer.fill 2097152 bytes with 4 byte value     36.78 µs/iter   (35.88 µs … 71.83 µs)  36.92 µs  40.33 µs  42.17 µs
Buffer.fill 2097152 bytes with 8 byte value      36.4 µs/iter      (35 µs … 93.96 µs)  36.42 µs  41.71 µs  42.83 µs
Buffer.fill 2097152 bytes with 16 byte value    35.99 µs/iter   (35.13 µs … 62.58 µs)     36 µs  38.83 µs  40.46 µs
Buffer.fill 2097152 bytes with 11 byte value    35.17 µs/iter   (34.29 µs … 68.75 µs)  35.04 µs  41.25 µs  42.92 µs
Buffer.fill 16777216 bytes with 4 byte value   459.35 µs/iter (410.13 µs … 558.08 µs) 475.38 µs 514.38 µs 526.79 µs
Buffer.fill 16777216 bytes with 8 byte value   471.42 µs/iter    (438.75 µs … 580 µs)  478.5 µs 530.96 µs 547.08 µs
Buffer.fill 16777216 bytes with 16 byte value  463.69 µs/iter (435.75 µs … 522.29 µs) 468.92 µs 497.17 µs 503.21 µs
Buffer.fill 16777216 bytes with 11 byte value  460.78 µs/iter     (414 µs … 654.5 µs)    468 µs 558.88 µs 578.25 µs
```

After:
```
❯ ./build/release/bun /Users/dylan/code/bun/bench/snippets/buffer-fill.mjs
cpu: Apple M1 Max
runtime: bun 1.1.31 (arm64-darwin)

benchmark                                          time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------------------------- -----------------------------
Buffer.fill 32 bytes with 4 byte value          19.61 ns/iter    (18.9 ns … 24.89 ns)  19.57 ns  22.37 ns  23.15 ns
Buffer.fill 32 bytes with 8 byte value          17.81 ns/iter   (16.73 ns … 31.59 ns)   17.6 ns  21.53 ns  22.71 ns
Buffer.fill 32 bytes with 16 byte value         14.13 ns/iter   (13.88 ns … 24.08 ns)  14.07 ns  16.13 ns   16.9 ns
Buffer.fill 32 bytes with 11 byte value         19.03 ns/iter    (18.62 ns … 27.8 ns)  18.86 ns  22.32 ns  22.89 ns
Buffer.fill 2048 bytes with 4 byte value        36.91 ns/iter  (35.69 ns … 345.48 ns)  36.15 ns  42.69 ns  44.08 ns
Buffer.fill 2048 bytes with 8 byte value        35.23 ns/iter   (34.66 ns … 60.75 ns)  35.11 ns  39.97 ns     42 ns
Buffer.fill 2048 bytes with 16 byte value       34.75 ns/iter    (34.25 ns … 43.4 ns)  34.69 ns  38.99 ns  40.24 ns
Buffer.fill 2048 bytes with 11 byte value       73.45 ns/iter   (72.39 ns … 90.92 ns)  73.46 ns   78.9 ns  80.79 ns
Buffer.fill 16384 bytes with 4 byte value      181.37 ns/iter  (179.1 ns … 200.78 ns) 181.72 ns 194.29 ns 196.05 ns
Buffer.fill 16384 bytes with 8 byte value      178.02 ns/iter  (176.37 ns … 194.8 ns) 178.23 ns 190.41 ns 193.99 ns
Buffer.fill 16384 bytes with 16 byte value     177.86 ns/iter  (176.53 ns … 187.2 ns) 178.36 ns 183.72 ns 184.47 ns
Buffer.fill 16384 bytes with 11 byte value     260.66 ns/iter (235.24 ns … 812.54 ns) 254.61 ns 732.31 ns 799.64 ns
Buffer.fill 2097152 bytes with 4 byte value     34.17 µs/iter     (33 µs … 246.79 µs)  33.79 µs   41.5 µs  44.58 µs
Buffer.fill 2097152 bytes with 8 byte value     33.97 µs/iter  (33.08 µs … 117.75 µs)  33.75 µs  40.17 µs  42.08 µs
Buffer.fill 2097152 bytes with 16 byte value    33.79 µs/iter      (33 µs … 50.71 µs)  33.71 µs  36.96 µs  38.46 µs
Buffer.fill 2097152 bytes with 11 byte value     35.7 µs/iter   (34.88 µs … 55.33 µs)  35.71 µs     39 µs  41.42 µs
Buffer.fill 16777216 bytes with 4 byte value   272.61 µs/iter    (268.08 µs … 848 µs) 269.83 µs 319.63 µs 334.13 µs
Buffer.fill 16777216 bytes with 8 byte value   270.25 µs/iter (267.46 µs … 334.83 µs) 269.67 µs 292.08 µs 297.46 µs
Buffer.fill 16777216 bytes with 16 byte value  270.97 µs/iter (268.58 µs … 374.13 µs) 270.17 µs 297.96 µs 301.63 µs
Buffer.fill 16777216 bytes with 11 byte value  485.21 µs/iter   (438.13 µs … 2.95 ms) 469.88 µs   1.03 ms    1.6 ms
```

Byte length of 11 is also tested to show results when `memset_patternN` isn't used.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Existing tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
