### PR TITLE
Force the c-ares libdir to always be 'lib'

### DIFF
--- a/cmake/targets/BuildCares.cmake
+++ b/cmake/targets/BuildCares.cmake
@@ -18,6 +18,7 @@ register_cmake_command(
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DCARES_SHARED=OFF
     -DCARES_BUILD_TOOLS=OFF # this was set to ON?
+    -DCMAKE_INSTALL_LIBDIR=lib
   LIB_PATH
     lib
   LIBRARIES


### PR DESCRIPTION
Otherwise, on systems whose libdir is 'lib64', libcares.a can't be located. This was already fixed a few years ago in the Makefile (9a7333dd5e9d34d26aa94a771f7d3c142809f054) but never got added to the CMake scripts.

### How did you verify your code works?

Manual testing (i.e. Bun won't build for me without this).