### PR TITLE
flush entire immediate queue

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1356,9 +1356,8 @@ pub const EventLoop = struct {
         var ctx = this.virtual_machine;
         var loop = this.usocketsLoop();
 
-        while (this.flushImmediateQueue()) {
-            this.tickImmediateTasks(ctx);
-        }
+        this.flushImmediateQueue();
+        this.tickImmediateTasks(ctx);
 
         if (comptime Environment.isPosix) {
             // Some tasks need to keep the event loop alive for one more tick.
@@ -1395,28 +1394,24 @@ pub const EventLoop = struct {
             ctx.timer.drainTimers(ctx);
         }
 
-        while (this.flushImmediateQueue()) {
-            this.tickImmediateTasks(ctx);
-        }
+        this.flushImmediateQueue();
+        this.tickImmediateTasks(ctx);
 
         ctx.onAfterEventLoop();
     }
 
-    pub fn flushImmediateQueue(this: *EventLoop) bool {
+    pub fn flushImmediateQueue(this: *EventLoop) void {
         // If we can get away with swapping the queues, do that rather than copying the data
         if (this.immediate_tasks.count > 0) {
             this.immediate_tasks.write(this.next_immediate_tasks.readableSlice(0)) catch unreachable;
             this.next_immediate_tasks.head = 0;
             this.next_immediate_tasks.count = 0;
-            return true;
         } else if (this.next_immediate_tasks.count > 0) {
             const prev_immediate = this.immediate_tasks;
             const next_immediate = this.next_immediate_tasks;
             this.immediate_tasks = next_immediate;
             this.next_immediate_tasks = prev_immediate;
-            return true;
         }
-        return false;
     }
 
     pub fn tickPossiblyForever(this: *EventLoop) void {
@@ -1454,9 +1449,8 @@ pub const EventLoop = struct {
     pub fn autoTickActive(this: *EventLoop) void {
         var loop = this.usocketsLoop();
         var ctx = this.virtual_machine;
-        while (this.flushImmediateQueue()) {
-            this.tickImmediateTasks(ctx);
-        }
+        this.flushImmediateQueue();
+        this.tickImmediateTasks(ctx);
 
         if (comptime Environment.isPosix) {
             const pending_unref = ctx.pending_unref_counter;
@@ -1479,9 +1473,8 @@ pub const EventLoop = struct {
             ctx.timer.drainTimers(ctx);
         }
 
-        while (this.flushImmediateQueue()) {
-            this.tickImmediateTasks(ctx);
-        }
+        this.flushImmediateQueue();
+        this.tickImmediateTasks(ctx);
         ctx.onAfterEventLoop();
     }
 

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1356,8 +1356,9 @@ pub const EventLoop = struct {
         var ctx = this.virtual_machine;
         var loop = this.usocketsLoop();
 
-        this.flushImmediateQueue();
-        this.tickImmediateTasks(ctx);
+        while (this.flushImmediateQueue()) {
+            this.tickImmediateTasks(ctx);
+        }
 
         if (comptime Environment.isPosix) {
             // Some tasks need to keep the event loop alive for one more tick.
@@ -1394,22 +1395,28 @@ pub const EventLoop = struct {
             ctx.timer.drainTimers(ctx);
         }
 
-        this.flushImmediateQueue();
+        while (this.flushImmediateQueue()) {
+            this.tickImmediateTasks(ctx);
+        }
+
         ctx.onAfterEventLoop();
     }
 
-    pub fn flushImmediateQueue(this: *EventLoop) void {
+    pub fn flushImmediateQueue(this: *EventLoop) bool {
         // If we can get away with swapping the queues, do that rather than copying the data
         if (this.immediate_tasks.count > 0) {
             this.immediate_tasks.write(this.next_immediate_tasks.readableSlice(0)) catch unreachable;
             this.next_immediate_tasks.head = 0;
             this.next_immediate_tasks.count = 0;
+            return true;
         } else if (this.next_immediate_tasks.count > 0) {
             const prev_immediate = this.immediate_tasks;
             const next_immediate = this.next_immediate_tasks;
             this.immediate_tasks = next_immediate;
             this.next_immediate_tasks = prev_immediate;
+            return true;
         }
+        return false;
     }
 
     pub fn tickPossiblyForever(this: *EventLoop) void {
@@ -1447,8 +1454,9 @@ pub const EventLoop = struct {
     pub fn autoTickActive(this: *EventLoop) void {
         var loop = this.usocketsLoop();
         var ctx = this.virtual_machine;
-        this.flushImmediateQueue();
-        this.tickImmediateTasks(ctx);
+        while (this.flushImmediateQueue()) {
+            this.tickImmediateTasks(ctx);
+        }
 
         if (comptime Environment.isPosix) {
             const pending_unref = ctx.pending_unref_counter;
@@ -1471,7 +1479,9 @@ pub const EventLoop = struct {
             ctx.timer.drainTimers(ctx);
         }
 
-        this.flushImmediateQueue();
+        while (this.flushImmediateQueue()) {
+            this.tickImmediateTasks(ctx);
+        }
         ctx.onAfterEventLoop();
     }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1244,7 +1244,7 @@ pub const TestCommand = struct {
                 vm.eventLoop().tick();
 
                 var prev_unhandled_count = vm.unhandled_error_counter;
-                while (vm.active_tasks > 0) : (_ = vm.eventLoop().flushImmediateQueue()) {
+                while (vm.active_tasks > 0) : (vm.eventLoop().flushImmediateQueue()) {
                     if (!jest.Jest.runner.?.has_pending_tests) {
                         jest.Jest.runner.?.drain();
                     }
@@ -1264,9 +1264,8 @@ pub const TestCommand = struct {
                     }
                 }
 
-                while (vm.eventLoop().flushImmediateQueue()) {
-                    vm.eventLoop().tickImmediateTasks(vm);
-                }
+                vm.eventLoop().flushImmediateQueue();
+                vm.eventLoop().tickImmediateTasks(vm);
 
                 switch (vm.aggressive_garbage_collection) {
                     .none => {},

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1244,7 +1244,7 @@ pub const TestCommand = struct {
                 vm.eventLoop().tick();
 
                 var prev_unhandled_count = vm.unhandled_error_counter;
-                while (vm.active_tasks > 0) : (vm.eventLoop().flushImmediateQueue()) {
+                while (vm.active_tasks > 0) : (_ = vm.eventLoop().flushImmediateQueue()) {
                     if (!jest.Jest.runner.?.has_pending_tests) {
                         jest.Jest.runner.?.drain();
                     }
@@ -1264,7 +1264,9 @@ pub const TestCommand = struct {
                     }
                 }
 
-                vm.eventLoop().flushImmediateQueue();
+                while (vm.eventLoop().flushImmediateQueue()) {
+                    vm.eventLoop().tickImmediateTasks(vm);
+                }
 
                 switch (vm.aggressive_garbage_collection) {
                     .none => {},


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
