### PR TITLE
fix(install): Skip optional dependencies if false in bunfig.toml

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -4201,6 +4201,8 @@ pub const PackageManager = struct {
             };
         } else if (behavior.isPeer() and !install_peer) {
             return null;
+        } else if (behavior.isOptional() and !this.options.remote_package_features.optional_dependencies) {
+            return null;
         }
 
         // appendPackage sets the PackageID on the package


### PR DESCRIPTION
### What does this PR do?

Closes #14619
Closes #7274

Checks the optional dependency feature in `bunfig.toml` before creating any network tasks and installing the dependency, but still lists it as optional in the lockfile.

- [x] Code changes
- [x] Ran `bun-debug install` with the reproduction example in https://github.com/oven-sh/bun/issues/14619
