### PR TITLE
fix one of the failure checks in expectBundled.ts

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1520,7 +1520,7 @@ for (const [key, blob] of build.outputs) {
             }
           }
         } else if (!success) {
-          if (run.exitCode) {
+          if (run.exitCode != null) {
             expect([exitCode, signalCode]).toEqual([run.exitCode, undefined]);
           } else {
             throw new Error(prefix + "Runtime failed\n" + stdout!.toUnixString() + "\n" + stderr!.toUnixString());


### PR DESCRIPTION
`.exitCode` is `BundlerTestRunOptions.exitCode?: number | undefined`
this if statement looks to be wanting to check for undefined but `0` is also a falsey value

this fixes a logic bug in that if statement
and will additionally help us debug a windows ci failure in `test/bundler/bundler_compile.test.ts`