### PR TITLE
bun-types: add missing options to DigestEncoding

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3231,7 +3231,7 @@ declare module "bun" {
   }
   const unsafe: Unsafe;
 
-  type DigestEncoding = "hex" | "base64";
+  type DigestEncoding = "utf8" | "ucs2" | "utf16le" | "latin1" | "ascii" | "base64" | "base64url" | "hex";
 
   /**
    * Are ANSI colors enabled for stdin and stdout?


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/14651

list defined in native at https://github.com/oven-sh/bun/blob/bun-v1.1.31/src/bun.js/node/types.zig#L597