### PR TITLE
fix(CryptoHasher): throw error if `update` or `digest` are called after `digest`

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -3186,6 +3186,10 @@ pub const Crypto = struct {
             }
 
             pub fn update(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) JSC.JSValue {
+                if (this.digested) {
+                    globalThis.ERR_INVALID_STATE(name ++ " hasher already digested, create a new instance to update", .{}).throw();
+                    return .zero;
+                }
                 const thisValue = callframe.this();
                 const input = callframe.argument(0);
                 const buffer = JSC.Node.BlobOrStringOrBuffer.fromJS(globalThis, globalThis.bunVM().allocator, input) orelse {
@@ -3208,7 +3212,7 @@ pub const Crypto = struct {
                 output: ?JSC.Node.StringOrBuffer,
             ) JSC.JSValue {
                 if (this.digested) {
-                    globalThis.ERR_INVALID_STATE(name ++ " already digested, create a new " ++ name ++ " hasher to digest again", .{}).throw();
+                    globalThis.ERR_INVALID_STATE(name ++ " hasher already digested, create a new instance to digest again", .{}).throw();
                     return .zero;
                 }
                 if (output) |*string_or_buffer| {

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -84,6 +84,28 @@ describe("Hash is consistent", () => {
 
   const inputs = [...sourceInputs, ...sourceInputs.map(x => new Blob([x]))];
 
+  for (let algorithm of [
+    Bun.SHA1,
+    Bun.SHA224,
+    Bun.SHA256,
+    Bun.SHA384,
+    Bun.SHA512,
+    Bun.SHA512_256,
+    Bun.MD4,
+    Bun.MD5,
+  ] as const) {
+    test(`second digest should throw an error ${algorithm.name}`, () => {
+      const hasher = new algorithm().update("hello");
+      hasher.digest();
+      expect(() => hasher.digest()).toThrow(
+        `${algorithm.name} hasher already digested, create a new instance to digest again`,
+      );
+      expect(() => hasher.update("world")).toThrow(
+        `${algorithm.name} hasher already digested, create a new instance to update`,
+      );
+    });
+  }
+
   for (let algorithm of ["sha1", "sha256", "sha512", "md5"] as const) {
     describe(algorithm, () => {
       const Class = globalThis.Bun[algorithm.toUpperCase() as "SHA1" | "SHA256" | "SHA512" | "MD5"];


### PR DESCRIPTION
### What does this PR do?
Prevents crashing if the hasher is already digested.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test for each algorithm
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
