### PR TITLE
Implement crypto.hash()

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -2645,7 +2645,7 @@ pub const Crypto = struct {
                     inline else => |*str| {
                         defer str.deinit();
                         const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                            globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str.slice()});
+                            globalThis.ERR_INVALID_ARG_VALUE("Unknown encoding: {s}", .{str.slice()}).throw();
                             return JSC.JSValue.zero;
                         };
 
@@ -2833,7 +2833,7 @@ pub const Crypto = struct {
                     inline else => |*str| {
                         defer str.deinit();
                         const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                            globalThis.throwInvalidArguments("Unknown encoding: {}", .{str.*});
+                            globalThis.ERR_INVALID_ARG_VALUE("Unknown encoding: {s}", .{str.slice()}).throw();
                             return JSC.JSValue.zero;
                         };
 
@@ -2964,8 +2964,16 @@ pub const Crypto = struct {
                 switch (string_or_buffer) {
                     inline else => |*str| {
                         defer str.deinit();
-                        globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str.slice()});
-                        return JSC.JSValue.zero;
+                        const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
+                            globalThis.ERR_INVALID_ARG_VALUE("Unknown encoding: {s}", .{str.slice()}).throw();
+                            return JSC.JSValue.zero;
+                        };
+
+                        if (encoding == .buffer) {
+                            return hashByNameInnerToBytes(globalThis, Algorithm, input, null);
+                        }
+
+                        return hashByNameInnerToString(globalThis, Algorithm, input, encoding);
                     },
                     .buffer => |buffer| {
                         return hashByNameInnerToBytes(globalThis, Algorithm, input, buffer.buffer);
@@ -2973,6 +2981,23 @@ pub const Crypto = struct {
                 }
             }
             return hashByNameInnerToBytes(globalThis, Algorithm, input, null);
+        }
+
+        fn hashByNameInnerToString(globalThis: *JSGlobalObject, comptime Algorithm: type, input: JSC.Node.BlobOrStringOrBuffer, encoding: JSC.Node.Encoding) JSC.JSValue {
+            defer input.deinit();
+
+            if (input == .blob and input.blob.isBunFile()) {
+                globalThis.throw("Bun.file() is not supported here yet (it needs an async version)", .{});
+                return .zero;
+            }
+
+            var h = Algorithm.init(.{});
+            h.update(input.slice());
+
+            var out: [digestLength(Algorithm)]u8 = undefined;
+            h.final(&out);
+
+            return encoding.encodeWithSize(globalThis, digestLength(Algorithm), &out);
         }
 
         fn hashByNameInnerToBytes(globalThis: *JSGlobalObject, comptime Algorithm: type, input: JSC.Node.BlobOrStringOrBuffer, output: ?JSC.ArrayBuffer) JSC.JSValue {
@@ -3156,7 +3181,7 @@ pub const Crypto = struct {
                         inline else => |*str| {
                             defer str.deinit();
                             const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                                globalThis.throwInvalidArguments("Unknown encoding: {s}", .{str.slice()});
+                                globalThis.ERR_INVALID_ARG_VALUE("Unknown encoding: {s}", .{str.slice()}).throw();
                                 return JSC.JSValue.zero;
                             };
 
@@ -3220,7 +3245,7 @@ pub const Crypto = struct {
                         inline else => |*str| {
                             defer str.deinit();
                             const encoding = JSC.Node.Encoding.from(str.slice()) orelse {
-                                globalThis.throwInvalidArguments("Unknown encoding: \"{s}\"", .{str.slice()});
+                                globalThis.ERR_INVALID_ARG_VALUE("Unknown encoding: {s}", .{str.slice()}).throw();
                                 return JSC.JSValue.zero;
                             };
 

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1221,9 +1221,10 @@ pub const Crypto = struct {
         pub usingnamespace bun.New(@This());
 
         pub fn init(algorithm: EVP.Algorithm, key: []const u8) ?*HMAC {
+            const md = algorithm.md() orelse return null;
             var ctx: BoringSSL.HMAC_CTX = undefined;
             BoringSSL.HMAC_CTX_init(&ctx);
-            if (BoringSSL.HMAC_Init_ex(&ctx, key.ptr, @intCast(key.len), algorithm.md(), null) != 1) {
+            if (BoringSSL.HMAC_Init_ex(&ctx, key.ptr, @intCast(key.len), md, null) != 1) {
                 BoringSSL.HMAC_CTX_cleanup(&ctx);
                 return null;
             }
@@ -2714,7 +2715,7 @@ pub const Crypto = struct {
                                     BoringSSL.ERR_clear_error();
                                     globalThis.throwValue(instance);
                                 } else {
-                                    globalThis.throwTODO("HMAC is not supported for this algorithm");
+                                    globalThis.throwTODO("HMAC is not supported for this algorithm yet");
                                 }
                             }
                             return null;

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -1204,7 +1204,11 @@ pub fn wrapStaticMethod(
                     },
                     ?JSC.Node.StringOrBuffer => {
                         if (iter.nextEat()) |arg| {
-                            args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse {
+                            args[i] = JSC.Node.StringOrBuffer.fromJS(globalThis.ptr(), iter.arena.allocator(), arg) orelse brk: {
+                                if (arg == .undefined) {
+                                    break :brk null;
+                                }
+
                                 globalThis.throwInvalidArguments("expected string or buffer", .{});
                                 iter.deinit();
                                 return JSC.JSValue.zero;

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -4,7 +4,7 @@ var __getOwnPropNames = Object.getOwnPropertyNames;
 const StreamModule = require("node:stream");
 const BufferModule = require("node:buffer");
 const StringDecoder = require("node:string_decoder").StringDecoder;
-
+const { CryptoHasher } = Bun;
 const {
   symmetricKeySize,
   asymmetricKeyDetails,
@@ -11443,8 +11443,6 @@ var require_browser9 = __commonJS({
   },
 });
 
-const { CryptoHasher } = globalThis.Bun;
-
 // node_modules/randomfill/browser.js
 var require_browser11 = __commonJS({
   "node_modules/randomfill/browser.js"(exports) {
@@ -11560,8 +11558,7 @@ var require_crypto_browserify2 = __commonJS({
 // crypto.js
 var crypto_exports = require_crypto_browserify2();
 
-var DEFAULT_ENCODING = "buffer",
-  getRandomValues = array => crypto.getRandomValues(array),
+var getRandomValues = array => crypto.getRandomValues(array),
   randomUUID = () => crypto.randomUUID(),
   timingSafeEqual =
     "timingSafeEqual" in crypto
@@ -11578,7 +11575,7 @@ var DEFAULT_ENCODING = "buffer",
     "scryptSync" in crypto
       ? (password, salt, keylen, options) => {
           let res = crypto.scryptSync(password, salt, keylen, options);
-          return DEFAULT_ENCODING !== "buffer" ? new Buffer(res).toString(DEFAULT_ENCODING) : new Buffer(res);
+          return new Buffer(res);
         }
       : void 0,
   scrypt =
@@ -11592,11 +11589,7 @@ var DEFAULT_ENCODING = "buffer",
           }
           try {
             let result = crypto.scryptSync(password, salt, keylen, options);
-            process.nextTick(
-              callback,
-              null,
-              DEFAULT_ENCODING !== "buffer" ? new Buffer(result).toString(DEFAULT_ENCODING) : new Buffer(result),
-            );
+            process.nextTick(callback, null, new Buffer(result));
           } catch (err2) {
             throw err2;
           }
@@ -12040,18 +12033,19 @@ crypto_exports.publicDecrypt = function (key, message) {
   return doAsymmetricSign(key, message, publicDecrypt, true);
 };
 
-__export(crypto_exports, {
-  DEFAULT_ENCODING: () => DEFAULT_ENCODING,
-  getRandomValues: () => getRandomValues,
-  randomUUID: () => randomUUID,
-  randomInt: () => randomInt,
-  getCurves: () => getCurves,
-  scrypt: () => scrypt,
-  scryptSync: () => scryptSync,
-  timingSafeEqual: () => timingSafeEqual,
-  webcrypto: () => webcrypto,
-  subtle: () => _subtle,
-});
+crypto_exports.hash = function hash(algorithm, input, outputEncoding = "hex") {
+  return CryptoHasher.hash(algorithm, input, outputEncoding);
+};
+
+crypto_exports.getRandomValues = getRandomValues;
+crypto_exports.randomUUID = randomUUID;
+crypto_exports.randomInt = randomInt;
+crypto_exports.getCurves = getCurves;
+crypto_exports.scrypt = scrypt;
+crypto_exports.scryptSync = scryptSync;
+crypto_exports.timingSafeEqual = timingSafeEqual;
+crypto_exports.webcrypto = webcrypto;
+crypto_exports.subtle = _subtle;
 
 export default crypto_exports;
 /*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -189,7 +189,7 @@ describe("CryptoHasher", () => {
     describe(algorithm, () => {
       for (let encoding of ["hex", "base64", "buffer", undefined, "base64url"] as const) {
         describe(encoding || "default", () => {
-          test.only("instance", () => {
+          test("instance", () => {
             const hasher = new Bun.CryptoHasher(algorithm || undefined);
             hasher.update("hello");
             expect(hasher.digest(encoding)).toEqual(Bun.CryptoHasher.hash(algorithm, "hello", encoding));

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { withoutAggressiveGC } from "harness";
 
 test("Bun.file in CryptoHasher is not supported yet", () => {
   expect(() => Bun.SHA1.hash(Bun.file(import.meta.path))).toThrow();
@@ -144,6 +145,66 @@ describe("Hash is consistent", () => {
           }
         }
       });
+    });
+  }
+});
+
+describe("CryptoHasher", () => {
+  const algorithms = [
+    "blake2b256",
+    "blake2b512",
+    "ripemd160",
+    "rmd160",
+    "md4",
+    "md5",
+    "sha1",
+    "sha128",
+    "sha224",
+    "sha256",
+    "sha384",
+    "sha512",
+    "sha-1",
+    "sha-224",
+    "sha-256",
+    "sha-384",
+    "sha-512",
+    "sha-512/224",
+    "sha-512_224",
+    "sha-512224",
+    "sha512-224",
+    "sha-512/256",
+    "sha-512_256",
+    "sha-512256",
+    "sha512-256",
+    "sha384",
+    "sha3-224",
+    "sha3-256",
+    "sha3-384",
+    "sha3-512",
+    "shake128",
+    "shake256",
+  ] as const;
+
+  for (let algorithm of algorithms) {
+    describe(algorithm, () => {
+      for (let encoding of ["hex", "base64", "buffer", undefined, "base64url"] as const) {
+        describe(encoding || "default", () => {
+          test.only("instance", () => {
+            const hasher = new Bun.CryptoHasher(algorithm || undefined);
+            hasher.update("hello");
+            expect(hasher.digest(encoding)).toEqual(Bun.CryptoHasher.hash(algorithm, "hello", encoding));
+          });
+
+          test("consistent", () => {
+            const first = Bun.CryptoHasher.hash(algorithm, "hello", encoding);
+            withoutAggressiveGC(() => {
+              for (let i = 0; i < 100; i++) {
+                expect(Bun.CryptoHasher.hash(algorithm, "hello", encoding)).toStrictEqual(first);
+              }
+            });
+          });
+        });
+      }
     });
   }
 });

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -58,8 +58,18 @@ describe("HMAC", () => {
     });
   }
 
-  test("ripemd160 is not supported", () => {
-    expect(() => new Bun.CryptoHasher("ripemd160", "key")).toThrow();
+  const unsupported = [
+    ["sha3-224"],
+    ["sha3-256"],
+    ["sha3-384"],
+    ["sha3-512"],
+    ["shake128"],
+    ["shake256"],
+    ["ripemd160"],
+  ] as const;
+  test.each(unsupported)("%s is not supported", algorithm => {
+    expect(() => new Bun.CryptoHasher(algorithm, "key")).toThrow();
+    expect(() => new Bun.CryptoHasher(algorithm)).not.toThrow();
   });
 });
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -17,7 +17,6 @@ afterEach(() => gc());
  * 1. First we run them with native Buffer.write
  * 2. Then we run them with Node.js' implementation of Buffer.write, calling out to Bun's implementation of utf8Write, asciiWrite, latin1Write, base64Write, base64urlWrite, ucs2Write, utf16leWrite, utf16beWrite, etc.
  *
- *
  */
 const NumberIsInteger = Number.isInteger;
 class ERR_INVALID_ARG_TYPE extends TypeError {

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -1,0 +1,87 @@
+import { expect, test, describe } from "bun:test";
+import crypto from "crypto";
+import { readFileSync } from "fs";
+import { path } from "../test/common/fixtures";
+
+describe("crypto.hash", () => {
+  test("throws for invalid arguments", () => {
+    ([undefined, null, true, 1, () => {}, {}] as const).forEach(invalid => {
+      expect(() => crypto.hash(invalid, "test")).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    });
+
+    [undefined, null, true, 1, () => {}, {}].forEach(invalid => {
+      expect(() => crypto.hash("sha1", invalid)).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    });
+
+    [null, true, 1, () => {}, {}].forEach(invalid => {
+      expect(() => crypto.hash("sha1", "test", invalid)).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    });
+
+    expect(() => crypto.hash("sha1", "test", "not an encoding")).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_VALUE",
+      }),
+    );
+  });
+  const input = readFileSync(path("utf8_test_text.txt"));
+  [
+    "blake2b256",
+    "blake2b512",
+    "ripemd160",
+    "rmd160",
+    "md4",
+    "md5",
+    "sha1",
+    "sha128",
+    "sha224",
+    "sha256",
+    "sha384",
+    "sha512",
+    "sha-1",
+    "sha-224",
+    "sha-256",
+    "sha-384",
+    "sha-512",
+    "sha-512/224",
+    "sha-512_224",
+    "sha-512224",
+    "sha512-224",
+    "sha-512/256",
+    "sha-512_256",
+    "sha-512256",
+    "sha512-256",
+    "sha384",
+    "sha3-224",
+    "sha3-256",
+    "sha3-384",
+    "sha3-512",
+    "shake128",
+    "shake256",
+  ].forEach(method => {
+    test(`output matches crypto.createHash(${method})`, () => {
+      for (const outputEncoding of ["buffer", "hex", "base64", undefined]) {
+        const oldDigest = crypto
+          .createHash(method)
+          .update(input)
+          .digest(outputEncoding || "hex");
+        const digestFromBuffer = crypto.hash(method, input, outputEncoding);
+        expect(digestFromBuffer).toEqual(oldDigest);
+
+        const digestFromString = crypto.hash(method, input.toString(), outputEncoding);
+        expect(digestFromString).toEqual(oldDigest);
+      }
+    });
+  });
+});


### PR DESCRIPTION

### What does this PR do?

Implement crypto.hash()

Fixes https://github.com/oven-sh/bun/issues/14650
Fixes https://github.com/oven-sh/bun/issues/14616
Fixes #14684 

@nektro when you added CryptoHash implementations for the non-boringssl algorithms, it seems you forgot to make the string encoded versions work.

### How did you verify your code works?

Tests copied from Node + additional tests for our own implementation.