### PR TITLE
tls(Server) fix connectionListener and make alpnProtocol more compatible with node.js

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1301,7 +1301,7 @@ fn selectALPNCallback(
         // in a useful ALPN response as part of the Server Hello message.
         // We now return SSL_TLSEXT_ERR_ALERT_FATAL in that case as per Section 3.2
         // of RFC 7301, which causes a fatal no_application_protocol alert.
-        return if(status == BoringSSL.OPENSSL_NPN_NEGOTIATED) BoringSSL.SSL_TLSEXT_ERR_OK else BoringSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
+        return if (status == BoringSSL.OPENSSL_NPN_NEGOTIATED) BoringSSL.SSL_TLSEXT_ERR_OK else BoringSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
     } else {
         return BoringSSL.SSL_TLSEXT_ERR_NOACK;
     }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1296,8 +1296,6 @@ fn selectALPNCallback(
             return BoringSSL.SSL_TLSEXT_ERR_NOACK;
         }
         const status = BoringSSL.SSL_select_next_proto(bun.cast([*c][*c]u8, out), outlen, protos.ptr, @as(c_uint, @intCast(protos.len)), in, inlen);
-        const log = Output.scoped(.Socket, false);
-        log("alpnProtocol {s} status {}", .{in[0..inlen], status});
         // Previous versions of Node.js returned SSL_TLSEXT_ERR_NOACK if no protocol
         // match was found. This would neither cause a fatal alert nor would it result
         // in a useful ALPN response as part of the Server Hello message.
@@ -2583,7 +2581,6 @@ fn NewSocket(comptime ssl: bool) type {
 
             BoringSSL.SSL_get0_alpn_selected(ssl_ptr, &alpn_proto, &alpn_proto_len);
             if (alpn_proto == null or alpn_proto_len == 0) {
-                log("no alpnProtocol", .{});
                 return JSValue.jsBoolean(false);
             }
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1295,17 +1295,15 @@ fn selectALPNCallback(
         if (protos.len == 0) {
             return BoringSSL.SSL_TLSEXT_ERR_NOACK;
         }
-
         const status = BoringSSL.SSL_select_next_proto(bun.cast([*c][*c]u8, out), outlen, protos.ptr, @as(c_uint, @intCast(protos.len)), in, inlen);
-
+        const log = Output.scoped(.Socket, false);
+        log("alpnProtocol {s} status {}", .{in[0..inlen], status});
         // Previous versions of Node.js returned SSL_TLSEXT_ERR_NOACK if no protocol
         // match was found. This would neither cause a fatal alert nor would it result
         // in a useful ALPN response as part of the Server Hello message.
         // We now return SSL_TLSEXT_ERR_ALERT_FATAL in that case as per Section 3.2
         // of RFC 7301, which causes a fatal no_application_protocol alert.
-        const expected = if (comptime BoringSSL.OPENSSL_NPN_NEGOTIATED == 1) BoringSSL.SSL_TLSEXT_ERR_OK else BoringSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
-
-        return if (status == expected) 1 else 0;
+        return if(status == BoringSSL.OPENSSL_NPN_NEGOTIATED) BoringSSL.SSL_TLSEXT_ERR_OK else BoringSSL.SSL_TLSEXT_ERR_ALERT_FATAL;
     } else {
         return BoringSSL.SSL_TLSEXT_ERR_NOACK;
     }
@@ -2585,6 +2583,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             BoringSSL.SSL_get0_alpn_selected(ssl_ptr, &alpn_proto, &alpn_proto_len);
             if (alpn_proto == null or alpn_proto_len == 0) {
+                log("no alpnProtocol", .{});
                 return JSValue.jsBoolean(false);
             }
 

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3274,9 +3274,9 @@ class Http2SecureServer extends tls.Server {
     //TODO: add 'http/1.1' on ALPNProtocols list after allowHTTP1 support
     if (typeof options === "function") {
       onRequestHandler = options;
-      options = { ALPNProtocols: ["h2", "H2"] };
+      options = { ALPNProtocols: ["h2"] };
     } else if (options == null || typeof options == "object") {
-      options = { ...options, ALPNProtocols: ["h2", "H2"] };
+      options = { ...options, ALPNProtocols: ["h2"] };
     } else {
       throw $ERR_INVALID_ARG_TYPE("options must be an object");
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3274,9 +3274,9 @@ class Http2SecureServer extends tls.Server {
     //TODO: add 'http/1.1' on ALPNProtocols list after allowHTTP1 support
     if (typeof options === "function") {
       onRequestHandler = options;
-      options = { ALPNProtocols: ["h2"] };
+      options = { ALPNProtocols: ["h2", "H2"] };
     } else if (options == null || typeof options == "object") {
-      options = { ...options, ALPNProtocols: ["h2"] };
+      options = { ...options, ALPNProtocols: ["h2", "H2"] };
     } else {
       throw $ERR_INVALID_ARG_TYPE("options must be an object");
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -331,7 +331,10 @@ const Socket = (function (InternalSocket) {
         } else {
           self.authorized = true;
         }
-        server[bunSocketServerOptions]?.connectionListener?.$call(server, self);
+        const connectionListener = server[bunSocketServerOptions]?.connectionListener;
+        if (typeof connectionListener == "function") {
+          connectionListener.$call(server, self);
+        }
         server.emit("secureConnection", self);
         // after secureConnection event we emmit secure and secureConnect
         self.emit("secure", self);

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -330,6 +330,7 @@ const TLSSocket = (function (InternalTLSSocket) {
     #socket;
     #checkServerIdentity;
     #session;
+    alpnProtocol = null;
 
     constructor(socket, options) {
       super(socket instanceof InternalTCPSocket ? options : options || socket);
@@ -501,10 +502,6 @@ const TLSSocket = (function (InternalTLSSocket) {
     }
     getX509Certificate() {
       throw Error("Not implented in Bun yet");
-    }
-
-    get alpnProtocol() {
-      return this[bunSocketInternal]?.alpnProtocol;
     }
 
     [buntls](port, host) {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -664,7 +664,7 @@ it("tls.rootCertificates should exists", () => {
   expect(typeof rootCertificates[0]).toBe("string");
 });
 
-it("connectionListener should emit the right amount of times", async () => {
+it("connectionListener should emit the right amount of times, and with alpnProtocol available", async () => {
   let count = 0;
   const promises = [];
   const server: Server = createServer(

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -667,10 +667,17 @@ it("tls.rootCertificates should exists", () => {
 it("connectionListener should emit the right amount of times", async () => {
   let count = 0;
   const promises = [];
-  const server: Server = createServer(COMMON_CERT, socket => {
-    count++;
-    socket.end();
-  });
+  const server: Server = createServer(
+    {
+      ...COMMON_CERT,
+      ALPNProtocols: ["bun"],
+    },
+    socket => {
+      count++;
+      expect(socket.alpnProtocol).toBe("bun");
+      socket.end();
+    },
+  );
   server.setMaxListeners(100);
 
   server.listen(0);
@@ -683,6 +690,7 @@ it("connectionListener should emit the right amount of times", async () => {
         ca: COMMON_CERT.cert,
         rejectUnauthorized: false,
         port: server.address().port,
+        ALPNProtocols: ["bun"],
       },
       () => {
         socket.on("close", resolve);

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import type { PeerCertificate } from "tls";
 import tls, { connect, createServer, rootCertificates, Server, TLSSocket } from "tls";
+import { once } from "node:events";
 
 const { describe, expect, it, createCallCheckCtx } = createTest(import.meta.path);
 
@@ -661,4 +662,36 @@ it("tls.rootCertificates should exists", () => {
   expect(rootCertificates).toBeInstanceOf(Array);
   expect(rootCertificates.length).toBeGreaterThan(0);
   expect(typeof rootCertificates[0]).toBe("string");
+});
+
+it("connectionListener should emit the right amount of times", async () => {
+  let count = 0;
+  const promises = [];
+  const server: Server = createServer(COMMON_CERT, socket => {
+    count++;
+    socket.end();
+  });
+  server.setMaxListeners(100);
+
+  server.listen(0);
+  await once(server, "listening");
+  for (let i = 0; i < 50; i++) {
+    const { promise, resolve } = Promise.withResolvers();
+    promises.push(promise);
+    const socket = connect(
+      {
+        ca: COMMON_CERT.cert,
+        rejectUnauthorized: false,
+        port: server.address().port,
+      },
+      () => {
+        socket.on("close", resolve);
+        socket.resume();
+        socket.end();
+      },
+    );
+  }
+
+  await Promise.all(promises);
+  expect(count).toBe(50);
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test added.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
