### PR TITLE
Update instructions to run a `bun` application via `pm2` with the use…

### DIFF
--- a/docs/guides/ecosystem/pm2.md
+++ b/docs/guides/ecosystem/pm2.md
@@ -37,7 +37,10 @@ Alternatively, you can create a PM2 configuration file. Create a file named `pm2
 module.exports = {
   name: "app", // Name of your application
   script: "index.ts", // Entry point of your application
-  interpreter: "~/.bun/bin/bun", // Path to the Bun interpreter
+  interpreter: "bun", // Bun interpreter
+  env: {
+    PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`, // Add "~/.bun/bin/bun" to PATH
+  }
 };
 ```
 


### PR DESCRIPTION
… of `pm2.config.js`

pm2 will not run unless the bun executable is in the path

### What does this PR do?

This PR updates the pm2.config.js file to make sure pm2 can find bun in the PATH.
