### PR TITLE
feat: install specific version of Bun by `bun upgrade <version>`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,8 +134,16 @@ Save the file. You'll need to open a new shell/terminal window for the changes t
 
 Once installed, the binary can upgrade itself.
 
+To upgrade to the latest version:
+
 ```sh
 $ bun upgrade
+```
+
+To intsall a specific version of Bun:
+
+```sh
+$ bun upgrade <version | canary | stable >
 ```
 
 {% callout %}
@@ -150,7 +158,7 @@ $ bun upgrade
 Bun automatically releases an (untested) canary build on every commit to `main`. To upgrade to the latest canary build:
 
 ```sh
-$ bun upgrade --canary
+$ bun upgrade canary
 ```
 
 The canary build is useful for testing new features and bug fixes before they're released in a stable build. To help the Bun team fix bugs faster, canary builds automatically upload crash reports to Bun's team.
@@ -158,7 +166,7 @@ The canary build is useful for testing new features and bug fixes before they're
 [View canary build](https://github.com/oven-sh/bun/releases/tag/canary)
 
 {% callout %}
-**Note** — To switch back to a stable release from canary, run `bun upgrade --stable`.
+**Note** — To switch back to a stable release from canary, run `bun upgrade stable`.
 {% /callout %}
 
 ## Installing older versions of Bun

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -19,9 +19,9 @@ beforeEach(async () => {
   copyFileSync(bunExe(), execPath);
 });
 
-it("two invalid arguments, should display error message and suggest command", async () => {
+it("two or more arguments, should display error message and suggest command", async () => {
   const { stderr } = spawn({
-    cmd: [execPath, "upgrade", "bun-types", "--dev"],
+    cmd: [execPath, "upgrade", "foo", "bar"],
     cwd,
     stdout: null,
     stdin: "pipe",
@@ -30,13 +30,15 @@ it("two invalid arguments, should display error message and suggest command", as
   });
 
   const err = await new Response(stderr).text();
-  expect(err.split(/\r?\n/)).toContain("error: This command updates Bun itself, and does not take package names.");
-  expect(err.split(/\r?\n/)).toContain("note: Use `bun update bun-types --dev` instead.");
+  expect(err.split(/\r?\n/)).toContain("error: Invalid number of arguments.");
+  expect(err.split(/\r?\n/)).toContain(
+    "note: Run `bun upgrade` with `<version>`, `stable`,  `canary`, or no argument for latest version.",
+  );
 });
 
-it("two invalid arguments flipped, should display error message and suggest command", async () => {
+it("zero arguments and one invalid option, should display error message", async () => {
   const { stderr } = spawn({
-    cmd: [execPath, "upgrade", "--dev", "bun-types"],
+    cmd: [execPath, "upgrade", "--foo"],
     cwd,
     stdout: null,
     stdin: "pipe",
@@ -45,13 +47,12 @@ it("two invalid arguments flipped, should display error message and suggest comm
   });
 
   const err = await new Response(stderr).text();
-  expect(err.split(/\r?\n/)).toContain("error: This command updates Bun itself, and does not take package names.");
-  expect(err.split(/\r?\n/)).toContain("note: Use `bun update --dev bun-types` instead.");
+  expect(err.split(/\r?\n/)).toContain("error: `bun upgrade` only accepts `--profile` as an option.");
 });
 
-it("one invalid argument, should display error message and suggest command", async () => {
+it("one valid argument and one invalid option, should display error message", async () => {
   const { stderr } = spawn({
-    cmd: [execPath, "upgrade", "bun-types"],
+    cmd: [execPath, "upgrade", "stable", "--foo"],
     cwd,
     stdout: null,
     stdin: "pipe",
@@ -60,11 +61,10 @@ it("one invalid argument, should display error message and suggest command", asy
   });
 
   const err = await new Response(stderr).text();
-  expect(err.split(/\r?\n/)).toContain("error: This command updates Bun itself, and does not take package names.");
-  expect(err.split(/\r?\n/)).toContain("note: Use `bun update bun-types` instead.");
+  expect(err.split(/\r?\n/)).toContain("error: `bun upgrade` only accepts `--profile` as an option.");
 });
 
-it("one valid argument, should succeed", async () => {
+it("one valid options, should succeed", async () => {
   const { stderr } = spawn({
     cmd: [execPath, "upgrade", "--help"],
     cwd,
@@ -78,22 +78,6 @@ it("one valid argument, should succeed", async () => {
   // Should not contain error message
   expect(err.split(/\r?\n/)).not.toContain("error: This command updates bun itself, and does not take package names.");
   expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --help` instead.");
-});
-
-it("two valid argument, should succeed", async () => {
-  const { stderr } = spawn({
-    cmd: [execPath, "upgrade", "--stable", "--profile"],
-    cwd,
-    stdout: null,
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-
-  const err = await new Response(stderr).text();
-  // Should not contain error message
-  expect(err.split(/\r?\n/)).not.toContain("error: This command updates Bun itself, and does not take package names.");
-  expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --stable --profile` instead.");
 });
 
 it("zero arguments, should succeed", async () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
A specific version of Bun can be installed by the command `bun upgrade
<version>`. Installing canary and stable builds is now done by
`bun upgrade <canary|stable>.

By the way, what does `bun upgrade --profile` do? The `--profile` option should be documented.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
