### PR TITLE
pm: BrokenPipe is not fatal when printing the lockfile

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1276,7 +1276,11 @@ pub const Printer = struct {
         }
 
         const writer = Output.writer();
-        try printWithLockfile(allocator, lockfile, format, @TypeOf(writer), writer);
+        printWithLockfile(allocator, lockfile, format, @TypeOf(writer), writer) catch |err| switch (err) {
+            error.OutOfMemory => bun.outOfMemory(),
+            error.BrokenPipe => {},
+            else => |e| return e,
+        };
         Output.flush();
     }
 


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/5828