### PR TITLE
Reduce default max network connection limit from 256 to 48 in bun install

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1,10 +1,10 @@
-// Default to a maximum of 48 simultaneous HTTP requests for bun install if no proxy is specified
+// Default to a maximum of 64 simultaneous HTTP requests for bun install if no proxy is specified
 // if a proxy IS specified, default to 16
 // https://github.com/npm/cli/issues/7072
 // https://pnpm.io/npmrc#network-concurrency (pnpm defaults to 16)
 // https://yarnpkg.com/configuration/yarnrc#networkConcurrency (defaults to 50)
 const default_max_simultaneous_requests_for_bun_install = 48;
-const default_max_simultaneous_requests_for_bun_install_for_proxies = 16;
+const default_max_simultaneous_requests_for_bun_install_for_proxies = 64;
 
 const bun = @import("root").bun;
 const FeatureFlags = bun.FeatureFlags;
@@ -8769,7 +8769,7 @@ pub const PackageManager = struct {
                 break :brk @max(network_concurrency, 1);
             }
 
-            // If any HTTP proxy is set, reduce the default limit to 16 from 48.
+            // If any HTTP proxy is set, use a diferent limit
             if (env.has("http_proxy") or env.has("https_proxy") or env.has("HTTPS_PROXY") or env.has("HTTP_PROXY")) {
                 break :brk default_max_simultaneous_requests_for_bun_install_for_proxies;
             }

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -222,6 +222,7 @@ pub const PatchTask = struct {
                         dep_id,
                         pkg,
                         this.callback.calc_hash.name_and_version_hash,
+                        .allow_authorization,
                     ) orelse unreachable;
                     if (manager.getPreinstallState(pkg.meta.id) == .extract) {
                         manager.setPreinstallState(pkg.meta.id, manager.lockfile, .extracting);

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -222,7 +222,10 @@ pub const PatchTask = struct {
                         dep_id,
                         pkg,
                         this.callback.calc_hash.name_and_version_hash,
-                        .allow_authorization,
+                        switch (pkg.resolution.tag) {
+                            .npm => .allow_authorization,
+                            else => .no_authorization,
+                        },
                     ) orelse unreachable;
                     if (manager.getPreinstallState(pkg.meta.id) == .extract) {
                         manager.setPreinstallState(pkg.meta.id, manager.lockfile, .extracting);

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -4,6 +4,7 @@ import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs
 import { bunExe, bunEnv as env, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join, relative } from "path";
 import {
+  check_npm_auth_type,
   dummyAfterAll,
   dummyAfterEach,
   dummyBeforeAll,
@@ -509,6 +510,93 @@ it("should add exact version with -E", async () => {
       2,
     ),
   );
+  await access(join(package_dir, "bun.lockb"));
+});
+
+it("should add dependency with package.json in it and http tarball", async () => {
+  check_npm_auth_type.check = false;
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.headers.get("Authorization")) {
+        return new Response("bad request", { status: 400 });
+      }
+
+      return new Response(Bun.file(join(__dirname, "baz-0.0.3.tgz")));
+    },
+  });
+  const urls: string[] = [];
+  setHandler(
+    dummyRegistry(urls, {
+      "0.0.3": {
+        bin: {
+          "baz-run": "index.js",
+        },
+      },
+      "0.0.5": {
+        bin: {
+          "baz-run": "index.js",
+        },
+      },
+    }),
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+
+      dependencies: {
+        booop: `${server.url.href}/booop-0.0.1.tgz`,
+      },
+    }),
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "bap@npm:baz@0.0.5"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      "BUN_CONFIG_TOKEN": "npm_******",
+    },
+  });
+  const err = await new Response(stderr).text();
+  expect(err).not.toContain("error:");
+  expect(err).toContain("Saved lockfile");
+  const out = await new Response(stdout).text();
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+    expect.stringContaining("bun add v1."),
+    "",
+    expect.stringContaining("+ booop@http://"),
+    "",
+    "installed bap@0.0.5 with binaries:",
+    " - baz-run",
+    "",
+    "2 packages installed",
+  ]);
+  expect(await exited).toBe(0);
+  expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.5.tgz`]);
+  expect(requested).toBe(2);
+  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "bap", "booop"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", "bap"))).toEqual(["index.js", "package.json"]);
+  expect(await file(join(package_dir, "node_modules", "bap", "package.json")).json()).toEqual({
+    name: "baz",
+    version: "0.0.5",
+    bin: {
+      "baz-exec": "index.js",
+    },
+  });
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      bap: "npm:baz@0.0.5",
+      booop: `${server.url.href}/booop-0.0.1.tgz`,
+    },
+  });
   await access(join(package_dir, "bun.lockb"));
 });
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -67,6 +67,136 @@ afterAll(dummyAfterAll);
 beforeEach(dummyBeforeEach);
 afterEach(dummyAfterEach);
 
+for (let input of ["abcdef", "65537", "-1"]) {
+  it(`bun install --network-concurrency=${input} fails`, async () => {
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls));
+    await writeFile(
+      join(package_dir, "package.json"),
+      `
+{
+  "name": "foo",
+  "version": "0.0.1",
+  "dependencies": {
+    "bar": "^1"
+  }
+}`,
+    );
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--network-concurrency", "abcdef"],
+      cwd: package_dir,
+      stdout: "inherit",
+      stdin: "inherit",
+      stderr: "pipe",
+      env,
+    });
+    const err = await new Response(stderr).text();
+    expect(err).toContain("Expected --network-concurrency to be a number between 0 and 65535");
+    expect(await exited).toBe(1);
+    expect(urls).toBeEmpty();
+  });
+}
+
+it("bun install --network-concurrency=5 doesnt go over 5 concurrent requests", async () => {
+  const urls: string[] = [];
+  let maxConcurrentRequests = 0;
+  let concurrentRequestCounter = 0;
+  let totalRequests = 0;
+  setHandler(async function (request) {
+    concurrentRequestCounter++;
+    totalRequests++;
+    try {
+      await Bun.sleep(10);
+      maxConcurrentRequests = Math.max(maxConcurrentRequests, concurrentRequestCounter);
+
+      if (concurrentRequestCounter > 20) {
+        throw new Error("Too many concurrent requests");
+      }
+    } finally {
+      concurrentRequestCounter--;
+    }
+
+    return new Response("404", { status: 404 });
+  });
+  await writeFile(
+    join(package_dir, "package.json"),
+    `
+{
+  "name": "foo",
+  "version": "0.0.1",
+  "dependencies": {
+    "bar1": "^1",
+    "bar2": "^1",
+    "bar3": "^1",
+    "bar4": "^1",
+    "bar5": "^1",
+    "bar6": "^1",
+    "bar7": "^1",
+    "bar8": "^1",
+    "bar9": "^1",
+    "bar10": "^1",
+    "bar11": "^1",
+    "bar12": "^1",
+    "bar13": "^1",
+    "bar14": "^1",
+    "bar15": "^1",
+    "bar16": "^1",
+    "bar17": "^1",
+    "bar18": "^1",
+    "bar19": "^1",
+    "bar20": "^1",
+    "bar21": "^1",
+    "bar22": "^1",
+    "bar23": "^1",
+    "bar24": "^1",
+    "bar25": "^1",
+    "bar26": "^1",
+    "bar27": "^1",
+    "bar28": "^1",
+    "bar29": "^1",
+    "bar30": "^1",
+    "bar31": "^1",
+    "bar32": "^1",
+    "bar33": "^1",
+    "bar34": "^1",
+    "bar35": "^1",
+    "bar36": "^1",
+    "bar37": "^1",
+    "bar38": "^1",
+    "bar39": "^1",
+    "bar40": "^1",
+    "bar41": "^1",
+    "bar42": "^1",
+    "bar43": "^1",
+    "bar44": "^1",
+    "bar45": "^1",
+    "bar46": "^1",
+    "bar47": "^1",
+    "bar48": "^1",
+    "bar49": "^1",
+    "bar50": "^1",
+    "bar51": "^1",
+  }
+}`,
+  );
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--network-concurrency", "5"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err = await new Response(stderr).text();
+  expect(await exited).toBe(1);
+  expect(urls).toBeEmpty();
+  expect(maxConcurrentRequests).toBeLessThanOrEqual(5);
+  expect(totalRequests).toBe(51);
+
+  expect(err).toContain("failed to resolve");
+  expect(await new Response(stdout).text()).toEqual(expect.stringContaining("bun install v1."));
+});
+
 it("should not error when package.json has comments and trailing commas", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
@@ -74,13 +204,12 @@ it("should not error when package.json has comments and trailing commas", async 
     join(package_dir, "package.json"),
     `
     {
-      // such comment!
       "name": "foo",
-      /** even multi-line comment!! */
       "version": "0.0.1",
       "dependencies": {
         "bar": "^1",
       },
+      
     }
 `,
   );

--- a/test/cli/install/dummy.registry.ts
+++ b/test/cli/install/dummy.registry.ts
@@ -24,6 +24,7 @@ let server: Server;
 export let package_dir: string;
 export let requested: number;
 export let root_url: string;
+export let check_npm_auth_type = { check: true };
 export function dummyRegistry(urls: string[], info: any = { "0.0.2": {} }, numberOfTimesTo500PerURL = 0) {
   let retryCountsByURL = new Map<string, number>();
   const _handler: Handler = async request => {
@@ -50,7 +51,9 @@ export function dummyRegistry(urls: string[], info: any = { "0.0.2": {} }, numbe
     expect(request.headers.get("accept")).toBe(
       "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
     );
-    expect(request.headers.get("npm-auth-type")).toBe(null);
+    if (check_npm_auth_type.check) {
+      expect(request.headers.get("npm-auth-type")).toBe(null);
+    }
     expect(await request.text()).toBe("");
 
     const name = url.slice(url.indexOf("/", root_url.length) + 1);


### PR DESCRIPTION
### What does this PR do?

This reduces the default max HTTP/HTTPS connection limit from 256 to 48 in bun install.

256 simultaneous HTTP requests is more than enough to saturate networks

When using a proxy, the default limit is 16 instead of 48.

Fixes https://github.com/oven-sh/bun/issues/4066

We already automatically adjust when there's a network error

### How did you verify your code works?

There are tests