### PR TITLE
docs: fix missing code highlight in spawn.md

### DIFF
--- a/docs/api/spawn.md
+++ b/docs/api/spawn.md
@@ -179,7 +179,7 @@ proc.kill(); // specify an exit code
 
 The parent `bun` process will not terminate until all child processes have exited. Use `proc.unref()` to detach the child process from the parent.
 
-```
+```ts
 const proc = Bun.spawn(["bun", "--version"]);
 proc.unref();
 ```


### PR DESCRIPTION
### What does this PR do?

Minor fix, while browsing the docs for the Bun.spawn API, noticed code block isn't highlighted properly.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes


