### PR TITLE
Update SvelteKit usage guide

### DIFF
--- a/docs/guides/ecosystem/sveltekit.md
+++ b/docs/guides/ecosystem/sveltekit.md
@@ -2,56 +2,62 @@
 name: Build an app with SvelteKit and Bun
 ---
 
-Use `bun create` to scaffold your app with the `svelte` package. Answer the prompts to select a template and set up your development environment.
+Use `sv create my-app` to create a SvelteKit project with SvelteKit CLI. Answer the prompts to select a template and set up your development environment.
 
 ```sh
-$ bun create svelte@latest my-app
-┌  Welcome to SvelteKit!
+$ bunx sv create my-app
+┌  Welcome to the Svelte CLI! (v0.5.7)
 │
-◇  Which Svelte app template?
-│  SvelteKit demo app
+◇  Which template would you like?
+│  SvelteKit demo
 │
-◇  Add type checking with TypeScript?
-│  Yes, using TypeScript syntax
+◇  Add type checking with Typescript?
+│  Yes, using Typescript syntax
 │
-◇  Select additional options (use arrow keys/space bar)
-│  None
+◆  Project created
 │
-└  Your project is ready!
-
-✔ Typescript
-  Inside Svelte components, use <script lang="ts">
-
-Install community-maintained integrations:
-  https://github.com/svelte-add/svelte-add
+◇  What would you like to add to your project?
+│  none
+│
+◇  Which package manager do you want to install dependencies with?
+│  bun
+│
+◇  Successfully installed dependencies
+│
+◇  Project next steps ─────────────────────────────────────────────────────╮
+│                                                                          │
+│  1: cd my-app                                                            │
+│  2: git init && git add -A && git commit -m "Initial commit" (optional)  │
+│  3: bun run dev -- --open                                                │
+│                                                                          │
+│  To close the dev server, hit Ctrl-C                                     │
+│                                                                          │
+│  Stuck? Visit us at https://svelte.dev/chat                              │
+│                                                                          │
+├──────────────────────────────────────────────────────────────────────────╯
+│
+└  You're all set!
 ```
 
 ---
 
-Once the project is initialized, `cd` into the new project and install dependencies.
-
-```sh
-$ cd my-app
-$ bun install
-```
-
----
+Once the project is initialized, `cd` into the new project. You don't need to run 'bun install' since the dependencies are already installed.
 
 Then start the development server with `bun --bun run dev`.
 
 To run the dev server with Node.js instead of Bun, you can omit the `--bun` flag.
 
 ```sh
+$ cd my-app
 $ bun --bun run dev
   $ vite dev
-
   Forced re-optimization of dependencies
-
-    VITE v4.4.9  ready in 895 ms
-
+  
+    VITE v5.4.10  ready in 424 ms
+  
     ➜  Local:   http://localhost:5173/
     ➜  Network: use --host to expose
-    ➜  press h to show help
+    ➜  press h + enter to show help
 ```
 
 ---
@@ -75,16 +81,22 @@ Now, make the following changes to your `svelte.config.js`.
 ```ts-diff
 - import adapter from "@sveltejs/adapter-auto";
 + import adapter from "svelte-adapter-bun";
-  import { vitePreprocess } from "@sveltejs/kit/vite";
+  import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
   /** @type {import('@sveltejs/kit').Config} */
   const config = {
-    kit: {
-      adapter: adapter(),
-    },
-    preprocess: vitePreprocess(),
+  	// Consult https://svelte.dev/docs/kit/integrations#preprocessors
+  	// for more information about preprocessors
+  	preprocess: vitePreprocess(),
+  
+  	kit: {
+  		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
+  		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+  		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
+  		adapter: adapter()
+  	}
   };
-
+  
   export default config;
 ```
 
@@ -93,28 +105,21 @@ Now, make the following changes to your `svelte.config.js`.
 To build a production bundle:
 
 ```sh
-$ bun run build
- $ vite build
-
-vite v4.4.9 building SSR bundle for production...
-transforming (60) node_modules/@sveltejs/kit/src/utils/escape.js
-
-✓ 98 modules transformed.
-Generated an empty chunk: "entries/endpoints/waitlist/_server.ts".
-
-vite v4.4.9 building for production...
-✓ 92 modules transformed.
-Generated an empty chunk: "7".
-.svelte-kit/output/client/_app/version.json      0.03 kB │ gzip:  0.05 kB
-
-...
-
-.svelte-kit/output/server/index.js               86.47 kB
-
-Run npm run preview to preview your production build locally.
-
-> Using svelte-adapter-bun
-  ✔ Start server with: bun ./build/index.js
-  ✔ done
-✓ built in 7.81s
+$ bun --bun run build
+  $ vite build
+  vite v5.4.10 building SSR bundle for production...
+  "confetti" is imported from external module "@neoconfetti/svelte" but never used in "src/routes/sverdle/+page.svelte".
+  ✓ 130 modules transformed.
+  vite v5.4.10 building for production...
+  ✓ 148 modules transformed.
+  ...
+  ✓ built in 231ms
+  ...
+  ✓ built in 899ms
+  
+  Run npm run preview to preview your production build locally.
+  
+  > Using svelte-adapter-bun
+    ✔ Start server with: bun ./build/index.js
+    ✔ done
 ```


### PR DESCRIPTION
`create-svelte` is now deprecated. New projects should be created from SvelteKit CLI('sv')

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
