### PR TITLE
bun-install-registry.test.ts: remove ini format hint here

### DIFF
--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -419,7 +419,7 @@ registry = http://localhost:${port}/
             .join("\n")
         : "";
 
-      const ini = /* ini */ `
+      const ini = `
 registry = http://localhost:${port}/
 ${Object.keys(opts)
   .map(


### PR DESCRIPTION
having the format hint in this particular block messes up the coloring of the rest of the file

before

<img width="970" alt="image" src="https://github.com/user-attachments/assets/b9a2f5a0-4f53-4710-b7ce-724662bfa5bd">

after

<img width="970" alt="image" src="https://github.com/user-attachments/assets/dfefcb80-6f0d-4527-bc4f-fc26a77c3638">
