### PR TITLE
Revert "ci: merge clang-format and clang-tidy into single pipeline"

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,41 @@
+name: clang-format
+
+permissions:
+  contents: write
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+
+env:
+  BUN_VERSION: "1.1.27"
+  LLVM_VERSION: "18.1.8"
+  LLVM_VERSION_MAJOR: "18"
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install LLVM
+        run: |
+          curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s -- ${{ env.LLVM_VERSION_MAJOR }} all
+      - name: Clang Format
+        env:
+          LLVM_VERSION: ${{ env.LLVM_VERSION }}
+        run: |
+          bun run clang-format
+      - name: Commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "`bun run clang-format`"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: clang
+name: clang-tidy
 
 permissions:
   contents: write
@@ -15,8 +15,8 @@ env:
   LLVM_VERSION_MAJOR: "18"
 
 jobs:
-  clang:
-    name: clang
+  clang-tidy:
+    name: clang-tidy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,11 +30,6 @@ jobs:
       - name: Install LLVM
         run: |
           curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s -- ${{ env.LLVM_VERSION_MAJOR }} all
-      - name: Clang Format
-        env:
-          LLVM_VERSION: ${{ env.LLVM_VERSION }}
-        run: |
-          bun run clang-format
       - name: Clang Tidy
         env:
           LLVM_VERSION: ${{ env.LLVM_VERSION }}
@@ -43,4 +38,4 @@ jobs:
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "`bun run clang-format`"
+          commit_message: "`bun run clang-tidy`"


### PR DESCRIPTION
Reverts oven-sh/bun#14798

`clang-tidy` takes prohibitively longer to run than `clang-format` so we don't actually want to do this and make tidy block format from finishing.