### PR TITLE
bun:test: implement `test.failing` and the `retry` option

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -301,6 +301,21 @@ declare module "bun:test" {
    * @param milliseconds the number of milliseconds for the default timeout
    */
   export function setDefaultTimeout(milliseconds: number): void;
+
+  // TODO: the usages below can be replaced with `Test` once https://github.com/oven-sh/bun/issues/10885 is resolved.
+  type TestFunc = (
+    label: string,
+    fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
+    /**
+     * - If a `number`, sets the timeout for the test in milliseconds.
+     * - If an `object`, sets the options for the test.
+     *   - `timeout` sets the timeout for the test in milliseconds.
+     *   - `retry` sets the number of times to retry the test if it fails.
+     *   - `repeats` sets the number of times to repeat the test, regardless of whether it passed or failed.
+     */
+    options?: number | TestOptions,
+  ) => void;
+
   export interface TestOptions {
     /**
      * Sets the timeout for the test in milliseconds.
@@ -326,6 +341,7 @@ declare module "bun:test" {
      */
     repeats?: number;
   }
+
   /**
    * Runs a test.
    *
@@ -367,11 +383,7 @@ declare module "bun:test" {
      * @param fn the test function
      * @param options the test timeout or options
      */
-    only(
-      label: string,
-      fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
-      options?: number | TestOptions,
-    ): void;
+    only: TestFunc;
     /**
      * Skips this test.
      *
@@ -379,11 +391,7 @@ declare module "bun:test" {
      * @param fn the test function
      * @param options the test timeout or options
      */
-    skip(
-      label: string,
-      fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
-      options?: number | TestOptions,
-    ): void;
+    skip: TestFunc;
     /**
      * Marks this test as to be written or to be fixed.
      *
@@ -396,11 +404,7 @@ declare module "bun:test" {
      * @param fn the test function
      * @param options the test timeout or options
      */
-    todo(
-      label: string,
-      fn?: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
-      options?: number | TestOptions,
-    ): void;
+    todo: TestFunc;
     /**
      * Runs this test, if `condition` is true.
      *
@@ -408,37 +412,19 @@ declare module "bun:test" {
      *
      * @param condition if the test should run
      */
-    if(
-      condition: boolean,
-    ): (
-      label: string,
-      fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
-      options?: number | TestOptions,
-    ) => void;
+    if(condition: boolean): TestFunc;
     /**
      * Skips this test, if `condition` is true.
      *
      * @param condition if the test should be skipped
      */
-    skipIf(
-      condition: boolean,
-    ): (
-      label: string,
-      fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
-      options?: number | TestOptions,
-    ) => void;
+    skipIf(condition: boolean): TestFunc;
     /**
      * Marks this test as to be written or to be fixed, if `condition` is true.
      *
      * @param condition if the test should be marked TODO
      */
-    todoIf(
-      condition: boolean,
-    ): (
-      label: string,
-      fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
-      options?: number | TestOptions,
-    ) => void;
+    todoIf(condition: boolean): TestFunc;
     /**
      * Returns a function that runs for each item in `table`.
      *
@@ -457,7 +443,7 @@ declare module "bun:test" {
      * Use `test.failing` when you are writing a test and expecting it to fail.
      * If `failing` test will throw any errors then it will pass. If it does not throw it will fail.
      */
-    failing: Test;
+    failing: TestFunc;
   }
   /**
    * Runs a test.

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -453,6 +453,11 @@ declare module "bun:test" {
     each<T>(
       table: T[],
     ): (label: string, fn: (...args: T[]) => void | Promise<unknown>, options?: number | TestOptions) => void;
+    /**
+     * Use `test.failing` when you are writing a test and expecting it to fail.
+     * If `failing` test will throw any errors then it will pass. If it does not throw it will fail.
+     */
+    failing: Test;
   }
   /**
    * Runs a test.

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -79,8 +79,7 @@ threadlocal var stdout_lock_count: u16 = 0;
 
 /// https://console.spec.whatwg.org/#formatter
 pub fn messageWithTypeAndLevel(
-    //console_: ConsoleObject.Type,
-    _: ConsoleObject.Type,
+    console: *ConsoleObject,
     message_type: MessageType,
     //message_level: u32,
     level: MessageLevel,
@@ -91,8 +90,6 @@ pub fn messageWithTypeAndLevel(
     if (comptime is_bindgen) {
         return;
     }
-
-    var console = global.bunVM().console;
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
@@ -3439,7 +3436,7 @@ pub fn takeHeapSnapshot(
 ) callconv(JSC.conv) void {
     // TODO: this does an extra JSONStringify and we don't need it to!
     var snapshot: [1]JSValue = .{globalThis.generateHeapSnapshot()};
-    ConsoleObject.messageWithTypeAndLevel(undefined, MessageType.Log, MessageLevel.Debug, globalThis, &snapshot, 1);
+    globalThis.bunVM().console.messageWithTypeAndLevel(.Log, .Debug, globalThis, &snapshot, 1);
 }
 pub fn timeStamp(
     // console

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -4597,8 +4597,7 @@ pub const JSValue = enum(JSValueReprInt) {
         message_type: ConsoleObject.MessageType,
         message_level: ConsoleObject.MessageLevel,
     ) void {
-        JSC.ConsoleObject.messageWithTypeAndLevel(
-            undefined,
+        globalObject.bunVM().console.messageWithTypeAndLevel(
             message_type,
             message_level,
             globalObject,

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1857,8 +1857,8 @@ inline fn createScope(
 inline fn createIfScope(
     globalThis: *JSGlobalObject,
     callframe: *CallFrame,
-    comptime property: [:0]const u8,
     comptime signature: string,
+    comptime property: [:0]const u8,
     comptime Scope: type,
     comptime tag: Tag,
 ) JSValue {
@@ -2151,8 +2151,8 @@ fn eachBind(
 fn createEach(
     globalThis: *JSGlobalObject,
     callframe: *CallFrame,
-    comptime property: [:0]const u8,
     comptime signature: string,
+    comptime property: [:0]const u8,
     comptime is_test: bool,
 ) JSValue {
     const arguments = callframe.arguments(1);

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1172,6 +1172,7 @@ pub const DescribeScope = struct {
                     Jest.runner.?.reportFailure(i + this.test_id_start, source.path.text, tests[i].label, 0, 0, this);
                     i += 1;
                 }
+                this.tests.clearAndFree(allocator);
                 this.pending_tests.deinit(allocator);
                 return;
             }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -846,6 +846,92 @@ describe("bun test", () => {
     });
     test.todo("check formatting for %p", () => {});
   });
+  describe(".failing", () => {
+    test("expect good fail", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          test.failing("the", () => {
+            expect(6).toBe(6);
+          });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 0 pass\n 1 fail\n 1 expect() calls\nRan 1 tests across 1 files. `);
+    });
+    test("expect bad pass", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          test.failing("the", () => {
+            expect(5).toBe(6);
+          });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 1 pass\n 0 fail\n 1 expect() calls\nRan 1 tests across 1 files. `);
+    });
+    test("done good fail", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          test.failing("the", done => {
+            done();
+          });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 0 pass\n 1 fail\nRan 1 tests across 1 files. `);
+    });
+    test("done bad pass", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          test.failing("the", done => {
+            done(42);
+          });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 1 pass\n 0 fail\nRan 1 tests across 1 files. `);
+    });
+    test("async good fail", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          test.failing("the", async () => {
+            await Promise.resolve(42);
+          });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 0 pass\n 1 fail\nRan 1 tests across 1 files. `);
+    });
+    test("aysnc bad pass", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          test.failing("the", async () => {
+            await Promise.reject(42);
+          });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 1 pass\n 0 fail\nRan 1 tests across 1 files. `);
+    });
+  });
 
   test("path to a non-test.ts file will work", () => {
     const stderr = runTest({

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -932,6 +932,53 @@ describe("bun test", () => {
       expect(stderr).toContain(` 1 pass\n 0 fail\nRan 1 tests across 1 files. `);
     });
   });
+  describe("{ retry }", () => {
+    test("basic", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          let j = 0;
+          test("the", async () => {
+            expect(j++).toEqual(1);
+          }, { retry: 1 });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 1 pass\n 0 fail\n 2 expect() calls\nRan 1 tests across 1 files. `);
+    });
+    test("not enough", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          let j = 0;
+          test("the", async () => {
+            expect(j++).toEqual(1);
+          }, { retry: 0 });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 0 pass\n 1 fail\n 1 expect() calls\nRan 1 tests across 1 files. `);
+    });
+    test("not enough again", () => {
+      const stderr = runTest({
+        args: [],
+        input: [
+          `
+          import { test, expect } from "bun:test";
+          let j = 0;
+          test("the", async () => {
+            expect(j++).toEqual(5);
+          }, { retry: 3 });
+          `,
+        ],
+      });
+      expect(stderr).toContain(` 0 pass\n 1 fail\n 4 expect() calls\nRan 1 tests across 1 files. `);
+    });
+  });
 
   test("path to a non-test.ts file will work", () => {
     const stderr = runTest({


### PR DESCRIPTION
for tests that are flaky instead of broken, using this should be much better than disabling them outright

related: https://github.com/oven-sh/bun/issues/1825
fixes #15887