### PR TITLE
Attempt CI fix

### DIFF
--- a/.buildkite/scripts/prepare-build.sh
+++ b/.buildkite/scripts/prepare-build.sh
@@ -99,7 +99,10 @@ assert_curl
 assert_node
 assert_release
 assert_canary
-
+# If is Windows x64, run scripts/disk-space.ps1
+if [ -n "$BUILDKITE_AGENT_META_DATA_OS" ] && [ "$BUILDKITE_AGENT_META_DATA_OS" == "windows" ]; then
+  run_command powershell ".buildkite/scripts/disk-space.ps1"
+fi
 run_command node ".buildkite/ci.mjs"
 
 if [ -f ".buildkite/ci.yml" ]; then

--- a/scripts/disk-space.ps1
+++ b/scripts/disk-space.ps1
@@ -25,14 +25,14 @@ foreach ($path in $buildkitePaths) {
 # Clear package manager caches
 Write-Host "Cleaning package manager caches..."
 # NuGet
-Remove-Item -Path "$env:USERPROFILE\.nuget\packages\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:USERPROFILE\.nuget\packages" -Recurse -Force -ErrorAction SilentlyContinue
 # npm
-Remove-Item -Path "$env:USERPROFILE\AppData\Roaming\npm-cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:USERPROFILE\AppData\Roaming\npm-cache" -Recurse -Force -ErrorAction SilentlyContinue
 # yarn
-Remove-Item -Path "$env:USERPROFILE\AppData\Local\Yarn\Cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:USERPROFILE\AppData\Local\Yarn\Cache" -Recurse -Force -ErrorAction SilentlyContinue
 # bun
-Remove-Item -Path "$env:AppData\bun\install\cache\*" -Recurse -Force -ErrorAction SilentlyContinue
-Remove-Item -Path "$env:LocalAppData\bun\install\cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:AppData\bun\install\cache" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:LocalAppData\bun\install\cache" -Recurse -Force -ErrorAction SilentlyContinue
 
 # Clean Docker
 Write-Host "Cleaning Docker resources..."

--- a/scripts/disk-space.ps1
+++ b/scripts/disk-space.ps1
@@ -1,0 +1,57 @@
+# Get initial free space for comparison
+$beforeFree = (Get-WmiObject Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace / 1GB
+
+Write-Host "Starting disk cleanup..."
+Write-Host "Initial free space: $([math]::Round($beforeFree, 2)) GB"
+
+# Clear Windows Temp folders
+Write-Host "Cleaning Windows temp folders..."
+Remove-Item -Path "C:\Windows\Temp\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:TEMP\*" -Recurse -Force -ErrorAction SilentlyContinue
+
+# Clear BuildKite artifacts and caches
+Write-Host "Cleaning BuildKite artifacts..."
+$buildkitePaths = @(
+    "C:\BuildKite\builds",
+    "C:\BuildKite\artifacts",
+    "$env:USERPROFILE\.buildkite-agent\artifacts"
+)
+foreach ($path in $buildkitePaths) {
+    if (Test-Path $path) {
+        Remove-Item -Path "$path\*" -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Clear package manager caches
+Write-Host "Cleaning package manager caches..."
+# NuGet
+Remove-Item -Path "$env:USERPROFILE\.nuget\packages\*" -Recurse -Force -ErrorAction SilentlyContinue
+# npm
+Remove-Item -Path "$env:USERPROFILE\AppData\Roaming\npm-cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+# yarn
+Remove-Item -Path "$env:USERPROFILE\AppData\Local\Yarn\Cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+# bun
+Remove-Item -Path "$env:AppData\bun\install\cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:LocalAppData\bun\install\cache\*" -Recurse -Force -ErrorAction SilentlyContinue
+
+# Clean Docker
+Write-Host "Cleaning Docker resources..."
+if (Get-Command docker -ErrorAction SilentlyContinue) {
+    docker system prune -af
+}
+
+# Empty Recycle Bin
+Write-Host "Emptying Recycle Bin..."
+Clear-RecycleBin -Force -ErrorAction SilentlyContinue
+
+# Run Windows Disk Cleanup utility
+Write-Host "Running Windows Disk Cleanup..."
+cleanmgr /sagerun:1 /autoclean
+
+# Get final free space and calculate difference
+$afterFree = (Get-WmiObject Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace / 1GB
+$spaceRecovered = $afterFree - $beforeFree
+
+Write-Host "`nCleanup completed!"
+Write-Host "Final free space: $([math]::Round($afterFree, 2)) GB"
+Write-Host "Space recovered: $([math]::Round($spaceRecovered, 2)) GB"

--- a/scripts/disk-space.ps1
+++ b/scripts/disk-space.ps1
@@ -6,8 +6,8 @@ Write-Host "Initial free space: $([math]::Round($beforeFree, 2)) GB"
 
 # Clear Windows Temp folders
 Write-Host "Cleaning Windows temp folders..."
-Remove-Item -Path "C:\Windows\Temp\*" -Recurse -Force -ErrorAction SilentlyContinue
-Remove-Item -Path "$env:TEMP\*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "C:\Windows\Temp\" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path "$env:TEMP\" -Recurse -Force -ErrorAction SilentlyContinue
 
 # Clear BuildKite artifacts and caches
 Write-Host "Cleaning BuildKite artifacts..."
@@ -18,7 +18,7 @@ $buildkitePaths = @(
 )
 foreach ($path in $buildkitePaths) {
     if (Test-Path $path) {
-        Remove-Item -Path "$path\*" -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path "$path\" -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
