### PR TITLE
`EventEmitter.name` should be `"EventEmitter"` instead of `"EventEmitter2"`

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -24,7 +24,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const { ERR_INVALID_ARG_TYPE } = require("internal/errors");
-const { throwNotImplemented } = require("internal/shared");
 const {
   validateObject,
   validateInteger,
@@ -62,6 +61,7 @@ const EventEmitter = function EventEmitter(opts) {
     this.emit = emitWithRejectionCapture;
   }
 };
+Object.defineProperty(EventEmitter, "name", { value: "EventEmitter", configurable: true });
 const EventEmitterPrototype = (EventEmitter.prototype = {});
 
 EventEmitterPrototype._events = undefined;

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -878,3 +878,7 @@ test("getEventListeners", () => {
   target.dispatchEvent(new Event("hey"));
   expect(getEventListeners(target, "hey").length).toBe(0);
 });
+
+test("EventEmitter.name", () => {
+  expect(EventEmitter.name).toBe("EventEmitter");
+});


### PR DESCRIPTION


### What does this PR do?

EventEmitter.name should be `"EventEmitter"` instead of `"EventEmitter2"`

Symbol renaming

### How did you verify your code works?

Test