### PR TITLE
fix(shell): add event loop task for `yes`

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -394,6 +394,7 @@ const ShellTouchTask = bun.shell.Interpreter.Builtin.Touch.ShellTouchTask;
 const ShellCpTask = bun.shell.Interpreter.Builtin.Cp.ShellCpTask;
 const ShellCondExprStatTask = bun.shell.Interpreter.CondExpr.ShellCondExprStatTask;
 const ShellAsync = bun.shell.Interpreter.Async;
+const ShellYesTask = bun.shell.Interpreter.Builtin.Yes.YesTask;
 // const ShellIOReaderAsyncDeinit = bun.shell.Interpreter.IOReader.AsyncDeinit;
 const ShellIOReaderAsyncDeinit = bun.shell.Interpreter.AsyncDeinitReader;
 const ShellIOWriterAsyncDeinit = bun.shell.Interpreter.AsyncDeinitWriter;
@@ -478,8 +479,8 @@ pub const Task = TaggedPointerUnion(.{
     ShellCondExprStatTask,
     ShellAsync,
     ShellAsyncSubprocessDone,
+    ShellYesTask,
     TimerObject,
-    bun.shell.Interpreter.Builtin.Yes.YesTask,
     ProcessWaiterThreadTask,
     RuntimeTranspilerStore,
     ServerAllConnectionsClosedTask,
@@ -932,6 +933,10 @@ pub const EventLoop = struct {
                 @field(Task.Tag, typeBaseName(@typeName(ShellAsync))) => {
                     var shell_ls_task: *ShellAsync = task.get(ShellAsync).?;
                     shell_ls_task.runFromMainThread();
+                },
+                @field(Task.Tag, typeBaseName(@typeName(ShellYesTask))) => {
+                    var shell_yes_task: *ShellYesTask = task.get(ShellYesTask).?;
+                    shell_yes_task.runFromMainThread();
                 },
                 @field(Task.Tag, typeBaseName(@typeName(ShellAsyncSubprocessDone))) => {
                     var shell_ls_task: *ShellAsyncSubprocessDone = task.get(ShellAsyncSubprocessDone).?;


### PR DESCRIPTION
### What does this PR do?
Adds missing task for `yes` builtin.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Not sure how to test this other than spawning a process and checking for exit code 0.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
