### PR TITLE
Draft: Fix 12509: Match webpack/babel - evaluate dirname/filename at runtime when doing a build

### DIFF
--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1368,7 +1368,7 @@ pub const Bundler = struct {
 
                 opts.tree_shaking = bundler.options.tree_shaking;
                 opts.features.inlining = bundler.options.inlining;
-
+                opts.target = bundler.options.target;
                 opts.filepath_hash_for_hmr = file_hash orelse 0;
                 opts.features.auto_import_jsx = bundler.options.auto_import_jsx;
                 opts.warn_about_unbundled_modules = !target.isBun();

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3749,7 +3749,7 @@ pub const ParseTask = struct {
             bundler.options.react_fast_refresh and
             loader.isJSX() and
             !source.path.isNodeModule();
-
+        opts.target = target;
         opts.features.server_components = if (bundler.options.server_components) switch (target) {
             .browser => .client_side,
             else => switch (use_directive) {

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3508,7 +3508,7 @@ pub const Parser = struct {
         //    var __dirname = "foo/bar"
         //    var __filename = "foo/bar/baz.js"
         //
-        if (p.options.target == Target.browse) {
+        if (p.options.target == Target.browser or !p.options.transform_only) {
             if (uses_dirname or uses_filename) {
                 const count = @as(usize, @intFromBool(uses_dirname)) + @as(usize, @intFromBool(uses_filename));
                 var declared_symbols = DeclaredSymbol.List.initCapacity(p.allocator, count) catch unreachable;

--- a/test/bundler/dirname-inline.test.ts
+++ b/test/bundler/dirname-inline.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeAll } from "bun:test";
+import { writeFileSync } from "fs";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { join } from "path";
+
+describe("Server side cases", ()=>{
+  let temp_dir: string
+  beforeAll(()=>{
+    temp_dir = tmpdirSync();
+    const fdata=`
+      import {readFileSync} from "fs"
+      console.log(__dirname)
+      console.log(readFileSync)
+    `
+    writeFileSync(join(temp_dir, "index.ts"), fdata, "utf-8");
+  })
+  it("target bun no bundle", async ()=>{
+    const out = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--target=bun", "--no-bundle", join(temp_dir, "index.ts")],
+      cwd: import.meta.dir,
+      env: bunEnv,
+      stderr: "inherit",
+      stdin: Bun.file("/dev/null"),
+    });
+    const text = out.stdout.toString()
+    expect(text.includes("__dirname =")).toBe(false)
+  })
+
+  it("target bun bundle", async ()=>{
+    const out = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--target=bun", join(temp_dir, "index.ts")],
+      cwd: import.meta.dir,
+      env: bunEnv,
+      stderr: "inherit",
+      stdin: Bun.file("/dev/null"),
+    });
+    const text = out.stdout.toString()
+    expect(text.includes("__dirname =")).toBe(false)
+  })
+
+  it("target browser", async ()=>{
+    const out = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--target=browser", join(temp_dir, "index.ts")],
+      cwd: import.meta.dir,
+      env: bunEnv,
+      stderr: "inherit",
+      stdin: Bun.file("/dev/null"),
+    });
+    const text = out.stdout.toString()
+    expect(text.includes("__dirname =")).toBe(true)
+  })
+  
+})


### PR DESCRIPTION
### What does this PR do?

Fixes #12509
Fixes #13921
Fixes #4216

This PR tries to correctly evaluate ```__dirname``` and ```__filename``` whenever possible.

Rather than almost always inlining them to the current source path. This PR changes the behavior to only do that on "run" not build since it doesn't match the behavior of webpack or babel and was bugged in the above issue.

Webpack:
	target browser: inline __dirname
	target esm: convert to esm compat

In webpack you can control the values or preserve them but this is the default.

Babel: 
	always preserve no matter the module target
	



### How did you verify your code works?

I wrote test cases




- [ X ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ X ] I included a test for the new code, or an existing test covers it
- [ X ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)





