### PR TITLE
chore(console.dir): added jsdoc

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1657,33 +1657,33 @@ declare global {
     countReset(label?: string): void;
     debug(...data: any[]): void;
     /**
-		 * Uses `node:util` -> `inspect()` on `obj` and prints the resulting string to `stdout`.
-		 * This function bypasses any custom `inspect()` function defined on `obj`.
-		 * 
-		 * Below function logs an object and shows all data of object.
-		 * 
-		 * With the option `depth` you can specify how deep the inspection will go.
-		 * ```ts
-		 * console.dir(
-		 * 	{ 
-		 * 		a: { 
-		 * 			b: { 
-		 * 				c: { 
-		 * 					d: { 
-		 * 						e: { 
-		 * 							f: { 
-		 * 								g: 'deep dive' 
-		 * 							} 
-		 * 						} 
-		 * 					} 
-		 * 				} 
-		 * 			} 
-		 * 		} 
-		 * 	}, 
-		 * 	{ depth: Infinity }
-		 * );
-		 * ```
-		 */
+     * Uses `node:util` -> `inspect()` on `obj` and prints the resulting string to `stdout`.
+     * This function bypasses any custom `inspect()` function defined on `obj`.
+     * 
+     * Below function logs an object and shows all data of object.
+     * 
+     * With the option `depth` you can specify how deep the inspection will go.
+     * ```ts
+     * console.dir(
+     * 	{ 
+     * 		a: { 
+     * 			b: { 
+     * 				c: { 
+     * 					d: { 
+     * 						e: { 
+     * 							f: { 
+     * 								g: 'deep dive' 
+     * 							} 
+     * 						} 
+     * 					} 
+     * 				} 
+     * 			} 
+     * 		} 
+     * 	}, 
+     * 	{ depth: Infinity }
+     * );
+     * ```
+     */
     dir(obj: any, options?: InspectOptions): void;
     dirxml(...data: any[]): void;
     /**

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1,4 +1,5 @@
 export {};
+import { InspectOptions } from "node:util";
 
 type _ReadableStream<T> = typeof globalThis extends {
   onerror: any;
@@ -1655,7 +1656,35 @@ declare global {
     count(label?: string): void;
     countReset(label?: string): void;
     debug(...data: any[]): void;
-    dir(item?: any, options?: any): void;
+    /**
+		 * Uses `node:util` -> `inspect()` on `obj` and prints the resulting string to `stdout`.
+		 * This function bypasses any custom `inspect()` function defined on `obj`.
+		 * 
+		 * Below function logs an object and shows all data of object.
+		 * 
+		 * With the option `depth` you can specify how deep the inspection will go.
+		 * ```ts
+		 * console.dir(
+		 * 	{ 
+		 * 		a: { 
+		 * 			b: { 
+		 * 				c: { 
+		 * 					d: { 
+		 * 						e: { 
+		 * 							f: { 
+		 * 								g: 'deep dive' 
+		 * 							} 
+		 * 						} 
+		 * 					} 
+		 * 				} 
+		 * 			} 
+		 * 		} 
+		 * 	}, 
+		 * 	{ depth: Infinity }
+		 * );
+		 * ```
+		 */
+    dir(obj: any, options?: InspectOptions): void;
     dirxml(...data: any[]): void;
     /**
      * Log to stderr in your terminal


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
