### PR TITLE
ci: Reuse build artifacts from previous build if only tests change

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -97,14 +97,16 @@ async function getBuildIdWithArtifacts() {
       return;
     }
 
-    const { prev_branch_build: lastBuild, steps } = await response.json();
+    const { state, prev_branch_build: lastBuild, steps } = await response.json();
     if (depth++) {
-      const buildSteps = steps.filter(({ label }) => label.endsWith("build-bun"));
-      if (buildSteps.length) {
-        if (buildSteps.every(({ outcome }) => outcome === "passed")) {
-          break;
+      if (state === "failed" || state === "passed") {
+        const buildSteps = steps.filter(({ label }) => label.endsWith("build-bun"));
+        if (buildSteps.length) {
+          if (buildSteps.every(({ outcome }) => outcome === "passed")) {
+            break;
+          }
+          return;
         }
-        return;
       }
     }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -407,18 +407,25 @@ function getPipeline(buildId) {
       ...buildPlatforms.map(platform => {
         const { os, arch, baseline } = platform;
 
-        return {
-          key: getKey(platform),
-          group: getLabel(platform),
-          steps: [
+        let steps = [
+          ...testPlatforms
+            .filter(platform => platform.os === os && platform.arch === arch && baseline === platform.baseline)
+            .map(platform => getTestBunStep(platform)),
+        ];
+
+        if (!buildId) {
+          steps.unshift(
             getBuildVendorStep(platform),
             getBuildCppStep(platform),
             getBuildZigStep(platform),
             getBuildBunStep(platform),
-            ...testPlatforms
-              .filter(platform => platform.os === os && platform.arch === arch && baseline === platform.baseline)
-              .map(platform => getTestBunStep(platform)),
-          ],
+          );
+        }
+
+        return {
+          key: getKey(platform),
+          group: getLabel(platform),
+          steps,
         };
       }),
     ],

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -115,7 +115,7 @@ async function getBuildIdWithArtifacts() {
     }
 
     buildId = lastBuild["number"];
-    url = url.replace(/\/builds\/[0-9]+/, `/builds/${buildId}`);
+    buildUrl = buildUrl.replace(/\/builds\/[0-9]+/, `/builds/${buildId}`);
   }
 
   return buildId;

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -73,20 +73,16 @@ async function getChangedFiles() {
   }
 }
 
-function getBuildNumber() {
-  return getEnv("BUILDKITE_BUILD_NUMBER");
-}
-
 function getBuildUrl() {
   return getEnv("BUILDKITE_BUILD_URL");
 }
 
 async function getBuildIdWithArtifacts() {
   let depth = 0;
-  let buildUrl = getBuildUrl();
+  let url = getBuildUrl();
 
-  while (buildUrl) {
-    const response = await fetch(`${buildUrl}.json`, {
+  while (url) {
+    const response = await fetch(`${url}.json`, {
       headers: {
         "Accept": "application/json",
       },
@@ -113,7 +109,7 @@ async function getBuildIdWithArtifacts() {
       return;
     }
 
-    buildUrl = buildUrl.replace(/\/builds\/[0-9]+/, `/builds/${lastBuild["number"]}`);
+    url = url.replace(/\/builds\/[0-9]+/, `/builds/${lastBuild["number"]}`);
   }
 }
 
@@ -436,7 +432,6 @@ function getPipeline(buildId) {
 
 async function main() {
   console.log("Checking environment...");
-  console.log(" - Build Id:", getBuildId());
   console.log(" - Repository:", getRepository());
   console.log(" - Branch:", getBranch());
   console.log(" - Commit:", getCommit());

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -60,7 +60,7 @@ function isPullRequest() {
 async function getChangedFiles() {
   const repository = getRepository();
   const head = getCommit();
-  const base = isMainBranch() ? `${head}^1` : getMainBranch();
+  const base = `${head}^1`;
 
   try {
     const response = await fetch(`https://api.github.com/repos/${repository}/compare/${base}...${head}`);

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -134,6 +134,10 @@ function toYaml(obj, indent = 0) {
   let result = "";
 
   for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) {
+      continue;
+    }
+
     if (value === null) {
       result += `${spaces}${key}: null\n`;
       continue;

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -73,7 +73,7 @@ async function getChangedFiles() {
   }
 }
 
-function getBuildId() {
+function getBuildNumber() {
   return getEnv("BUILDKITE_BUILD_NUMBER");
 }
 
@@ -83,7 +83,6 @@ function getBuildUrl() {
 
 async function getBuildIdWithArtifacts() {
   let depth = 0;
-  let buildId = getBuildId();
   let buildUrl = getBuildUrl();
 
   while (buildUrl) {
@@ -97,13 +96,13 @@ async function getBuildIdWithArtifacts() {
       return;
     }
 
-    const { state, prev_branch_build: lastBuild, steps } = await response.json();
+    const { id, state, prev_branch_build: lastBuild, steps } = await response.json();
     if (depth++) {
       if (state === "failed" || state === "passed") {
         const buildSteps = steps.filter(({ label }) => label.endsWith("build-bun"));
         if (buildSteps.length) {
           if (buildSteps.every(({ outcome }) => outcome === "passed")) {
-            break;
+            return id;
           }
           return;
         }
@@ -114,11 +113,8 @@ async function getBuildIdWithArtifacts() {
       return;
     }
 
-    buildId = lastBuild["number"];
-    buildUrl = buildUrl.replace(/\/builds\/[0-9]+/, `/builds/${buildId}`);
+    buildUrl = buildUrl.replace(/\/builds\/[0-9]+/, `/builds/${lastBuild["number"]}`);
   }
-
-  return buildId;
 }
 
 function isDocumentation(filename) {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1010,9 +1010,16 @@ async function getExecPathFromBuildKite(target) {
 
   const releasePath = join(cwd, "release");
   mkdirSync(releasePath, { recursive: true });
+
+  const args = ["artifact", "download", "**", releasePath, "--step", target];
+  const buildId = process.env["BUILDKITE_ARTIFACT_BUILD_ID"];
+  if (buildId) {
+    args.push("--build", buildId);
+  }
+
   await spawnSafe({
     command: "buildkite-agent",
-    args: ["artifact", "download", "**", releasePath, "--step", target],
+    args,
   });
 
   let zipPath;

--- a/test/js/bun/console/bun-inspect-table.test.ts
+++ b/test/js/bun/console/bun-inspect-table.test.ts
@@ -37,7 +37,7 @@ describe("inspect.table (ansi)", () => {
 });
 
 const withProperties = [
-  [{ a: 1, b: 3 }, ["b"]],
+  [{ a: 1, b: 2 }, ["b"]],
   [{ a: 1, b: 2 }, ["a"]],
 ];
 

--- a/test/js/bun/console/bun-inspect-table.test.ts
+++ b/test/js/bun/console/bun-inspect-table.test.ts
@@ -37,7 +37,7 @@ describe("inspect.table (ansi)", () => {
 });
 
 const withProperties = [
-  [{ a: 1, b: 2 }, ["b"]],
+  [{ a: 1, b: 3 }, ["b"]],
   [{ a: 1, b: 2 }, ["a"]],
 ];
 


### PR DESCRIPTION
### What does this PR do?

When the CI pipeline is being generated, it will detect if only tests were changed. It will then look for previous builds from that branch. Instead of re-building Bun, it will downloads the artifacts from the previous build and run the tests.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
