### PR TITLE
Fix napi property methods on non-objects

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -598,15 +598,16 @@ extern "C" napi_status napi_set_property(napi_env env, napi_value target,
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
-    auto* object = targetValue.getObject();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto* object = targetValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     auto keyProp = toJS(key);
 
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     PutPropertySlot slot(object, false);
 
     Identifier identifier = keyProp.toPropertyKey(globalObject);
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     JSValue jsValue = toJS(value);
 
@@ -637,15 +638,13 @@ extern "C" napi_status napi_has_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
-    auto* target = toJS(object).getObject();
-    if (!target) {
-        return napi_object_expected;
-    }
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto* target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     auto keyProp = toJS(key);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     *result = target->hasProperty(globalObject, keyProp.toPropertyKey(globalObject));
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     scope.clearException();
     return napi_ok;
@@ -693,16 +692,14 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* target = toJS(object).getObject();
-    if (!target) {
-        return napi_object_expected;
-    }
+    auto* target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
     JSC::EnsureStillAliveScope ensureAlive(target);
 
     auto keyProp = toJS(key);
     JSC::EnsureStillAliveScope ensureAlive2(keyProp);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     *result = toNapi(target->get(globalObject, keyProp.toPropertyKey(globalObject)), globalObject);
     RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
@@ -717,16 +714,14 @@ extern "C" napi_status napi_delete_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* target = toJS(object).getObject();
-    if (!target) {
-        return napi_object_expected;
-    }
+    auto* target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     auto keyProp = toJS(key);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     auto deleteResult = target->deleteProperty(globalObject, keyProp.toPropertyKey(globalObject));
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     if (LIKELY(result)) {
         *result = deleteResult;
@@ -746,16 +741,14 @@ extern "C" napi_status napi_has_own_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* target = toJS(object).getObject();
-    if (!target) {
-        return napi_object_expected;
-    }
+    auto* target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     auto keyProp = toJS(key);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     *result = target->hasOwnProperty(globalObject, JSC::PropertyName(keyProp.toPropertyKey(globalObject)));
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     scope.clearException();
     return napi_ok;
@@ -768,11 +761,10 @@ extern "C" napi_status napi_set_named_property(napi_env env, napi_value object,
     NAPI_PREMABLE
 
     auto globalObject = toJS(env);
-    auto target = toJS(object).getObject();
     auto& vm = globalObject->vm();
-    if (UNLIKELY(!target)) {
-        return napi_object_expected;
-    }
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     if (UNLIKELY(utf8name == nullptr || !*utf8name || !value)) {
         return napi_invalid_arg;
@@ -785,11 +777,10 @@ extern "C" napi_status napi_set_named_property(napi_env env, napi_value object,
     auto nameStr = WTF::String::fromUTF8({ utf8name, strlen(utf8name) });
     auto identifier = JSC::Identifier::fromString(vm, WTFMove(nameStr));
 
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     PutPropertySlot slot(target, true);
 
     target->put(target, globalObject, identifier, jsValue, slot);
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
     scope.clearException();
     return napi_ok;
 }
@@ -851,18 +842,16 @@ extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    JSObject* target = toJS(object).getObject();
-    if (UNLIKELY(!target)) {
-        return napi_object_expected;
-    }
+    JSObject* target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     PROPERTY_NAME_FROM_UTF8(name);
 
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     PropertySlot slot(target, PropertySlot::InternalMethodType::HasProperty);
     *result = target->getPropertySlot(globalObject, name, slot);
-    RETURN_IF_EXCEPTION(scope, napi_generic_failure);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     scope.clearException();
     return napi_ok;
@@ -880,14 +869,12 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     auto globalObject = toJS(env);
     auto& vm = globalObject->vm();
 
-    JSObject* target = toJS(object).getObject();
-    if (UNLIKELY(!target)) {
-        return napi_object_expected;
-    }
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    JSObject* target = toJS(object).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     PROPERTY_NAME_FROM_UTF8(name);
 
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     *result = toNapi(target->get(globalObject, name), globalObject);
     RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -64,6 +64,8 @@ nativeTests.test_get_property = () => {
         },
       },
     ),
+    5,
+    "hello",
   ];
   const keys = [
     "foo",
@@ -77,6 +79,8 @@ nativeTests.test_get_property = () => {
         throw new Error("Symbol.toPrimitive");
       },
     },
+    "toString",
+    "slice",
   ];
 
   for (const object of objects) {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -66,6 +66,7 @@ nativeTests.test_get_property = () => {
     ),
     5,
     "hello",
+    // TODO(@190n) test null and undefined here on the napi fix branch
   ];
   const keys = [
     "foo",


### PR DESCRIPTION
### What does this PR do?

All Node-API functions that access properties would previously return an error if the parameter was not an object. Now, they convert the parameter to an object first. This matches Node.js's behavior, and enables stuff like [getting the `slice` method on a string](
https://github.com/tree-sitter/node-tree-sitter/blob/9743116fd3368d8130778f555a9763ed6f362325/src/parser.cc#L131-L133). This and #14915 make tree-sitter work.

### How did you verify your code works?

Tested along with the existing Node-API tests. I tested this works on numbers and strings.

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)