### PR TITLE
Inline `process.versions.bun` in `bun build --compile`

### DIFF
--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -36,6 +36,7 @@ pub const BuildCommand = struct {
     const compile_define_keys = &.{
         "process.platform",
         "process.arch",
+        "process.versions.bun",
     };
 
     pub fn exec(ctx: Command.Context) !void {
@@ -250,6 +251,7 @@ pub const BuildCommand = struct {
                     null,
                 null,
                 this_bundler.options.define.drop_debugger,
+                false,
             );
 
             try bun.bake.addImportMetaDefines(allocator, this_bundler.options.define, .development, .server);

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -251,7 +251,6 @@ pub const BuildCommand = struct {
                     null,
                 null,
                 this_bundler.options.define.drop_debugger,
-                false,
             );
 
             try bun.bake.addImportMetaDefines(allocator, this_bundler.options.define, .development, .server);

--- a/src/compile_target.zig
+++ b/src/compile_target.zig
@@ -429,6 +429,8 @@ pub fn defineValues(this: *const CompileTarget) []const []const u8 {
                         .arm64 => "\"arm64\"",
                         else => @compileError("TODO"),
                     },
+
+                    "\"" ++ Global.package_json_version ++ "\"",
                 };
             }.values,
             else => @panic("TODO"),

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -14,6 +14,21 @@ describe.todoIf(isFlaky && isWindows)("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  itBundled("compile/HelloWorldWithProcessVersionsBun", {
+    compile: true,
+    files: {
+      [`/${process.platform}-${process.arch}.js`]: "module.exports = process.versions.bun;",
+      "/entry.ts": /* js */ `
+        process.exitCode = 1;
+        process.versions.bun = "bun!";
+        if (process.versions.bun === "bun!") throw new Error("fail");
+        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version.replaceAll("-debug", "")}") {
+          process.exitCode = 0;
+        }
+      `,
+    },
+    run: { exitCode: 0 },
+  });
   itBundled("compile/HelloWorldBytecode", {
     compile: true,
     bytecode: true,


### PR DESCRIPTION
### What does this PR do?

Inline `process.versions.bun` in `bun build --compile`

This makes detecting if the compiled executable is Bun more statically analyzable.

For example, tree-sitter has this line:

```js
const binding = require("node-gyp-build")(__dirname);
```

This code is very difficult for `bun build --compile` to support.

Instead, they could do:
```js
const binding = typeof process.versions.bun === "string" ?  
  require(`./prebuilds/${process.platform}-${process.arch}.node`) : 
  require("node-gyp-build")(__dirname);
```

This allows `bun build --compile` to work with it.

### How did you verify your code works?

There is a test