### PR TITLE
fix(net) fix bytesWritten drain

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1474,6 +1474,11 @@ fn NewSocket(comptime ssl: bool) type {
             if (vm.isShuttingDown()) {
                 return;
             }
+
+            this.internalFlush();
+            // is not writable if we have buffered data
+            if (this.buffered_data_for_node_net.len > 0) return;
+
             vm.eventLoop().enter();
             defer vm.eventLoop().exit();
 
@@ -2363,15 +2368,10 @@ fn NewSocket(comptime ssl: bool) type {
             };
         }
 
-        pub fn flush(
-            this: *This,
-            _: *JSC.JSGlobalObject,
-            _: *JSC.CallFrame,
-        ) JSValue {
-            JSC.markBinding(@src());
+        fn internalFlush(this: *This) JSValue {
             if (this.buffered_data_for_node_net.len > 0) {
                 const written: usize = @intCast(@max(this.socket.write(this.buffered_data_for_node_net.slice(), false), 0));
-
+                this.bytes_written += written;
                 if (written > 0) {
                     if (this.buffered_data_for_node_net.len > written) {
                         const remaining = this.buffered_data_for_node_net.slice()[written..];
@@ -2385,6 +2385,15 @@ fn NewSocket(comptime ssl: bool) type {
             }
 
             this.socket.flush();
+        }
+
+        pub fn flush(
+            this: *This,
+            _: *JSC.JSGlobalObject,
+            _: *JSC.CallFrame,
+        ) JSValue {
+            JSC.markBinding(@src());
+            this.internalFlush();
 
             return JSValue.jsUndefined();
         }
@@ -2705,6 +2714,12 @@ fn NewSocket(comptime ssl: bool) type {
             _: *JSC.JSGlobalObject,
         ) JSValue {
             return JSC.JSValue.jsNumber(this.bytes_written + this.buffered_data_for_node_net.len);
+        }
+        pub fn getBufferedQueueSize(
+            this: *This,
+            _: *JSC.JSGlobalObject,
+        ) JSValue {
+            return JSC.JSValue.jsNumber(this.buffered_data_for_node_net.len);
         }
         pub fn getALPNProtocol(
             this: *This,

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1474,10 +1474,11 @@ fn NewSocket(comptime ssl: bool) type {
             if (vm.isShuttingDown()) {
                 return;
             }
-
+            this.ref();
+            defer this.deref();
             this.internalFlush();
-            // is not writable if we have buffered data
-            if (this.buffered_data_for_node_net.len > 0) return;
+            // is not writable if we have buffered data or if we are already detached
+            if (this.buffered_data_for_node_net.len > 0 and this.socket.isDetached()) return;
 
             vm.eventLoop().enter();
             defer vm.eventLoop().exit();

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1478,7 +1478,7 @@ fn NewSocket(comptime ssl: bool) type {
             defer this.deref();
             this.internalFlush();
             // is not writable if we have buffered data or if we are already detached
-            if (this.buffered_data_for_node_net.len > 0 and this.socket.isDetached()) return;
+            if (this.buffered_data_for_node_net.len > 0 or this.socket.isDetached()) return;
 
             vm.eventLoop().enter();
             defer vm.eventLoop().exit();

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -2368,7 +2368,7 @@ fn NewSocket(comptime ssl: bool) type {
             };
         }
 
-        fn internalFlush(this: *This) JSValue {
+        fn internalFlush(this: *This) void {
             if (this.buffered_data_for_node_net.len > 0) {
                 const written: usize = @intCast(@max(this.socket.write(this.buffered_data_for_node_net.slice(), false), 0));
                 this.bytes_written += written;
@@ -2715,12 +2715,7 @@ fn NewSocket(comptime ssl: bool) type {
         ) JSValue {
             return JSC.JSValue.jsNumber(this.bytes_written + this.buffered_data_for_node_net.len);
         }
-        pub fn getBufferedQueueSize(
-            this: *This,
-            _: *JSC.JSGlobalObject,
-        ) JSValue {
-            return JSC.JSValue.jsNumber(this.buffered_data_for_node_net.len);
-        }
+
         pub fn getALPNProtocol(
             this: *This,
             globalObject: *JSC.JSGlobalObject,

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -83,9 +83,6 @@ function generate(ssl) {
       alpnProtocol: {
         getter: "getALPNProtocol",
       },
-      bytesWritten: {
-        getter: "getBytesWritten",
-      },
       write: {
         fn: "write",
         length: 3,
@@ -169,7 +166,9 @@ function generate(ssl) {
       bytesWritten: {
         getter: "getBytesWritten",
       },
-
+      bufferedQueueSize: {
+        getter: "getBufferedQueueSize",
+      },
       setServername: {
         fn: "setServername",
         length: 1,

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -166,9 +166,6 @@ function generate(ssl) {
       bytesWritten: {
         getter: "getBytesWritten",
       },
-      bufferedQueueSize: {
-        getter: "getBufferedQueueSize",
-      },
       setServername: {
         fn: "setServername",
         length: 1,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -861,23 +861,11 @@ const Socket = (function (InternalSocket) {
         return;
       }
 
-      const writeResult = socket.$write(chunk, encoding);
+      const success = socket.$write(chunk, encoding);
       this[kBytesWritten] = socket.bytesWritten;
-      switch (writeResult) {
-        case -1:
-          // dropped
-          this.#writeCallback = callback;
-          this._pendingEncoding = encoding;
-          this._pendingData = chunk;
-          break;
-        default:
-          // written or buffered by the socket
-          if (socket.bufferedQueueSize === 0) {
-            callback();
-            return;
-          }
-      }
-      if (this.#writeCallback) {
+      if (success) {
+        callback();
+      } else if (this.#writeCallback) {
         callback(new Error("overlapping _write()"));
       } else {
         this.#writeCallback = callback;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -241,7 +241,7 @@ const Socket = (function (InternalSocket) {
       if (callback) {
         const writeChunk = self._pendingData;
 
-        if (socket.$write(writeChunk || "", "utf8")) {
+        if (!writeChunk || socket.$write(writeChunk || "", self._pendingEncoding || "utf8")) {
           self._pendingData = self.#writeCallback = null;
           callback(null);
         } else {
@@ -856,16 +856,28 @@ const Socket = (function (InternalSocket) {
       if (!socket) {
         // detached but connected? wait for the socket to be attached
         this.#writeCallback = callback;
-        this._pendingEncoding = "buffer";
-        this._pendingData = Buffer.from(chunk, encoding);
+        this._pendingEncoding = encoding;
+        this._pendingData = chunk;
         return;
       }
 
-      const success = socket?.$write(chunk, encoding);
+      const writeResult = socket.$write(chunk, encoding);
       this[kBytesWritten] = socket.bytesWritten;
-      if (success) {
-        callback();
-      } else if (this.#writeCallback) {
+      switch (writeResult) {
+        case -1:
+          // dropped
+          this.#writeCallback = callback;
+          this._pendingEncoding = encoding;
+          this._pendingData = chunk;
+          break;
+        default:
+          // written or buffered by the socket
+          if (socket.bufferedQueueSize === 0) {
+            callback();
+            return;
+          }
+      }
+      if (this.#writeCallback) {
         callback(new Error("overlapping _write()"));
       } else {
         this.#writeCallback = callback;


### PR DESCRIPTION
Makes sure that the drain callback is only called after internal buffer is empty, and account for the written bytes inside flush.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Manually
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
