### PR TITLE
Fix #14865

### DIFF
--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -126,7 +126,7 @@ var ResponsePrototype = Response.prototype;
 const kUrl = Symbol("kUrl");
 
 class Request extends WebRequest {
-  [kUrl]: string;
+  [kUrl]?: string;
 
   constructor(input, init) {
     // node-fetch is relaxed with the URL, for example, it allows "/" as a valid URL.
@@ -137,12 +137,11 @@ class Request extends WebRequest {
       this[kUrl] = input;
     } else {
       super(input, init);
-      this[kUrl] = input.url;
     }
   }
 
   get url() {
-    return this[kUrl];
+    return this[kUrl] ?? super.url;
   }
 }
 

--- a/test/regression/issue/014865.test.ts
+++ b/test/regression/issue/014865.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "bun:test";
+import { Request } from "node-fetch";
+
+test("node fetch Request URL field is set even with a valid URL", () => {
+  expect(new Request("/").url).toBe("/");
+  expect(new Request("https://bun.sh/").url).toBe("https://bun.sh/");
+  expect(new Request(new URL("https://bun.sh/")).url).toBe("https://bun.sh/");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #14865

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
