### PR TITLE
Never try using epoll_pwait2 on old linux kernels

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -158,6 +158,8 @@ static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
     return ret;
 }
 
+extern int Bun__isEpollPwait2SupportedOnLinuxKernel();
+
 #endif
 
 /* Loop */
@@ -172,6 +174,13 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 
 #ifdef LIBUS_USE_EPOLL
     loop->fd = epoll_create1(EPOLL_CLOEXEC);
+
+    if (has_epoll_pwait2 == -1) {
+        if (Bun__isEpollPwait2SupportedOnLinuxKernel() == 0) {
+            has_epoll_pwait2 = 0;
+        } 
+    }
+
 #else
     loop->fd = kqueue();
 #endif

--- a/src/analytics/analytics_thread.zig
+++ b/src/analytics/analytics_thread.zig
@@ -336,6 +336,25 @@ pub const GenerateHeader = struct {
             return linux_kernel_version;
         }
 
+        export fn Bun__isEpollPwait2SupportedOnLinuxKernel() i32 {
+            if (comptime !Environment.isLinux) {
+                return 0;
+            }
+
+            // https://man.archlinux.org/man/epoll_pwait2.2.en#HISTORY
+            const min_epoll_pwait2 = Semver.Version{
+                .major = 5,
+                .minor = 11,
+                .patch = 0,
+            };
+
+            return switch (kernelVersion().order(min_epoll_pwait2, "", "")) {
+                .gt => 1,
+                .eq => 1,
+                .lt => 0,
+            };
+        }
+
         fn forLinux() Analytics.Platform {
             linux_os_name = std.mem.zeroes(@TypeOf(linux_os_name));
 


### PR DESCRIPTION
### What does this PR do?

Never try using epoll_pwait2 on old linux kernels

This fixes an issue impacting RHEL 8

### How did you verify your code works?

