### PR TITLE
[VSCode extension] Add `[eval with bun]` code lens on untitled, unsaved scratch JavaScript files

### DIFF
--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -114,6 +114,14 @@
         "category": "Bun",
         "enablement": "!inDebugMode",
         "icon": "$(debug-alt)"
+      },
+      {
+        "command": "extension.bun.runUnsavedCode",
+        "title": "Run Unsaved Code with Bun",
+        "shortTitle": "Run with Bun",
+        "category": "Bun",
+        "enablement": "!inDebugMode && resourceLangId =~ /^(javascript|typescript|javascriptreact|typescriptreact)$/ && !isInDiffEditor && resourceScheme == 'untitled'",
+        "icon": "$(play-circle)"
       }
     ],
     "menus": {
@@ -137,6 +145,20 @@
         {
           "command": "extension.bun.debugFile",
           "when": "resourceLangId == javascript || resourceLangId == javascriptreact || resourceLangId == typescript || resourceLangId == typescriptreact"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "extension.bun.runUnsavedCode",
+          "when": "resourceLangId =~ /^(javascript|typescript|javascriptreact|typescriptreact)$/ && !isInDiffEditor && resourceScheme == 'untitled'",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "extension.bun.runUnsavedCode",
+          "when": "resourceLangId =~ /^(javascript|typescript|javascriptreact|typescriptreact)$/ && !isInDiffEditor && resourceScheme == 'untitled'",
+          "group": "1_run"
         }
       ]
     },

--- a/packages/bun-vscode/src/extension.ts
+++ b/packages/bun-vscode/src/extension.ts
@@ -1,14 +1,52 @@
 import * as vscode from "vscode";
-import { registerDebugger } from "./features/debug";
+import { registerDebugger, debugCommand } from "./features/debug";
 import { registerBunlockEditor } from "./features/lockfile";
 import { registerPackageJsonProviders } from "./features/tasks/package.json";
 import { registerTaskProvider } from "./features/tasks/tasks";
+
+async function runUnsavedCode() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !editor.document.isUntitled) {
+    return;
+  }
+
+  const document = editor.document;
+  if (!["javascript", "typescript", "javascriptreact", "typescriptreact"].includes(document.languageId)) {
+    return;
+  }
+
+  const code = document.getText();
+  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
+
+  // Get the actual untitled document name
+  const untitledName = `untitled:${document.uri.path}`;
+
+  // Create a temporary debug session without saving
+  await vscode.debug.startDebugging(
+    undefined,
+    {
+      type: "bun",
+      name: "Run Unsaved Code",
+      request: "launch",
+      program: "-", // Special flag to indicate stdin input
+      __code: code, // Pass the code through configuration
+      __untitledName: untitledName, // Pass the untitled document name
+      cwd, // Pass the current working directory
+    },
+    {
+      suppressSaveBeforeStart: true, // This prevents the save dialog
+    },
+  );
+}
 
 export function activate(context: vscode.ExtensionContext) {
   registerBunlockEditor(context);
   registerDebugger(context);
   registerTaskProvider(context);
   registerPackageJsonProviders(context);
+
+  // Only register for text editors
+  context.subscriptions.push(vscode.commands.registerTextEditorCommand("extension.bun.runUnsavedCode", runUnsavedCode));
 }
 
 export function deactivate() {}

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -1,8 +1,9 @@
-import { DebugSession } from "@vscode/debugadapter";
+import { DebugSession, OutputEvent } from "@vscode/debugadapter";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import * as vscode from "vscode";
 import {
-  DAP,
+  type DAP,
   DebugAdapter,
   getAvailablePort,
   getRandomId,
@@ -45,6 +46,10 @@ const adapters = new Map<string, FileDebugSession>();
 
 export function registerDebugger(context: vscode.ExtensionContext, factory?: vscode.DebugAdapterDescriptorFactory) {
   context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      ["javascript", "typescript", "javascriptreact", "typescriptreact"],
+      new BunCodeLensProvider(),
+    ),
     vscode.commands.registerCommand("extension.bun.runFile", runFileCommand),
     vscode.commands.registerCommand("extension.bun.debugFile", debugFileCommand),
     vscode.debug.registerDebugConfigurationProvider(
@@ -144,7 +149,15 @@ class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
       target = DEBUG_CONFIGURATION;
     }
 
-    // If the configuration is missing a default property, copy it from the template.
+    if (config.program === "-" && config.__code) {
+      const code = config.__code;
+      delete config.__code;
+
+      config.stdin = code;
+      config.program = "-";
+      config.__skipValidation = true;
+    }
+
     for (const [key, value] of Object.entries(target)) {
       if (config[key] === undefined) {
         config[key] = value;
@@ -165,7 +178,7 @@ class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
     session: vscode.DebugSession,
   ): Promise<vscode.ProviderResult<vscode.DebugAdapterDescriptor>> {
     const { configuration } = session;
-    const { request, url } = configuration;
+    const { request, url, __untitledName } = configuration;
 
     if (request === "attach") {
       for (const [adapterUrl, adapter] of adapters) {
@@ -175,32 +188,105 @@ class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory 
       }
     }
 
-    const adapter = new FileDebugSession(session.id);
+    const adapter = new FileDebugSession(session.id, __untitledName);
     await adapter.initialize();
     return new vscode.DebugAdapterInlineImplementation(adapter);
   }
 }
 
+interface DebugProtocolResponse extends DAP.Response {
+  body?: {
+    source?: {
+      path?: string;
+    };
+    breakpoints?: Array<{
+      source?: {
+        path?: string;
+      };
+      verified?: boolean;
+    }>;
+  };
+}
+
+interface DebugProtocolEvent extends DAP.Event {
+  body?: {
+    source?: {
+      path?: string;
+    };
+  };
+}
+
+interface RuntimeConsoleAPICalledEvent {
+  type: string;
+  args: Array<{
+    type: string;
+    value: any;
+  }>;
+}
+
+interface RuntimeExceptionThrownEvent {
+  exceptionDetails: {
+    text: string;
+    exception?: {
+      description?: string;
+    };
+  };
+}
+
 class FileDebugSession extends DebugSession {
   adapter: DebugAdapter;
   sessionId?: string;
+  untitledDocPath?: string;
+  bunEvalPath?: string;
 
-  constructor(sessionId?: string) {
+  constructor(sessionId?: string, untitledDocPath?: string) {
     super();
     this.sessionId = sessionId;
+    this.untitledDocPath = untitledDocPath;
+
+    if (untitledDocPath) {
+      const cwd = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath ?? process.cwd();
+      this.bunEvalPath = join(cwd, "[eval]");
+    }
   }
 
   async initialize() {
     const uniqueId = this.sessionId ?? Math.random().toString(36).slice(2);
-    let url;
-    if (process.platform === "win32") {
-      url = `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`;
+    const url =
+      process.platform === "win32"
+        ? `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`
+        : `ws+unix://${tmpdir()}/${uniqueId}.sock`;
+
+    const { untitledDocPath, bunEvalPath } = this;
+    this.adapter = new DebugAdapter(url, untitledDocPath, bunEvalPath);
+
+    if (untitledDocPath) {
+      this.adapter.on("Adapter.response", (response: DebugProtocolResponse) => {
+        if (response.body?.source?.path === bunEvalPath) {
+          response.body.source.path = untitledDocPath;
+        }
+        if (Array.isArray(response.body?.breakpoints)) {
+          for (const bp of response.body.breakpoints) {
+            if (bp.source?.path === bunEvalPath) {
+              bp.source.path = untitledDocPath;
+              bp.verified = true;
+            }
+          }
+        }
+        this.sendResponse(response);
+      });
+
+      this.adapter.on("Adapter.event", (event: DebugProtocolEvent) => {
+        if (event.body?.source?.path === bunEvalPath) {
+          event.body.source.path = untitledDocPath;
+        }
+        this.sendEvent(event);
+      });
     } else {
-      url = `ws+unix://${tmpdir()}/${uniqueId}.sock`;
+      this.adapter.on("Adapter.response", response => this.sendResponse(response));
+      this.adapter.on("Adapter.event", event => this.sendEvent(event));
     }
-    this.adapter = new DebugAdapter(url);
-    this.adapter.on("Adapter.response", response => this.sendResponse(response));
-    this.adapter.on("Adapter.event", event => this.sendEvent(event));
+
     this.adapter.on("Adapter.reverseRequest", ({ command, arguments: args }) =>
       this.sendRequest(command, args, 5000, () => {}),
     );
@@ -212,6 +298,15 @@ class FileDebugSession extends DebugSession {
     const { type } = message;
 
     if (type === "request") {
+      const { untitledDocPath, bunEvalPath } = this;
+      const { command } = message;
+      if (untitledDocPath && (command === "setBreakpoints" || command === "breakpointLocations")) {
+        const args = message.arguments as any;
+        if (args.source?.path === untitledDocPath) {
+          args.source.path = bunEvalPath;
+        }
+      }
+
       this.adapter.emit("Adapter.request", message);
     } else {
       throw new Error(`Not supported: ${type}`);
@@ -272,4 +367,93 @@ function getRuntime(scope?: vscode.ConfigurationScope): string {
 
 function getConfig<T>(path: string, scope?: vscode.ConfigurationScope) {
   return vscode.workspace.getConfiguration("bun", scope).get<T>(path);
+}
+
+export async function runUnsavedCode() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !editor.document.isUntitled) return;
+
+  const code = editor.document.getText();
+  const startTime = performance.now();
+
+  try {
+    // Start debugging
+    await vscode.debug.startDebugging(undefined, {
+      ...DEBUG_CONFIGURATION,
+      program: "-",
+      __code: code,
+      __untitledName: editor.document.uri.toString(),
+      console: "debugConsole",
+      internalConsoleOptions: "openOnSessionStart",
+    });
+
+    // Find our debug session instance
+    const debugSession = Array.from(adapters.values()).find(
+      adapter => adapter.sessionId === vscode.debug.activeDebugSession?.id,
+    );
+
+    if (debugSession) {
+      // Wait for both the inspector to connect AND the adapter to be initialized
+      await new Promise<void>(resolve => {
+        let inspectorConnected = false;
+        let adapterInitialized = false;
+
+        const checkDone = () => {
+          if (inspectorConnected && adapterInitialized) {
+            resolve();
+          }
+        };
+
+        debugSession.adapter.once("Inspector.connected", () => {
+          inspectorConnected = true;
+          checkDone();
+        });
+
+        debugSession.adapter.once("Adapter.initialized", () => {
+          adapterInitialized = true;
+          checkDone();
+        });
+      });
+
+      // Now wait for debug session to complete
+      await new Promise<void>(resolve => {
+        const disposable = vscode.debug.onDidTerminateDebugSession(() => {
+          const duration = (performance.now() - startTime).toFixed(1);
+          debugSession.sendEvent(new OutputEvent(`✓ Code execution completed in ${duration}ms\n`));
+          disposable.dispose();
+          resolve();
+        });
+      });
+    }
+  } catch (err) {
+    if (vscode.debug.activeDebugSession) {
+      const duration = (performance.now() - startTime).toFixed(1);
+      const errorSession = adapters.get(vscode.debug.activeDebugSession.id);
+      errorSession?.sendEvent(
+        new OutputEvent(`✕ Error after ${duration}ms: ${err instanceof Error ? err.message : String(err)}\n`),
+      );
+    }
+  }
+}
+
+const languageIds = ["javascript", "typescript", "javascriptreact", "typescriptreact"];
+
+class BunCodeLensProvider implements vscode.CodeLensProvider {
+  async provideCodeLenses(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
+    if (!document.isUntitled || document.isClosed || document.lineCount === 0) return [];
+    if (!languageIds.includes(document.languageId)) {
+      return [];
+    }
+
+    // Create a range at position 0,0 with zero width
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+
+    return [
+      new vscode.CodeLens(range, {
+        title: "eval with bun",
+        command: "extension.bun.runUnsavedCode",
+        tooltip: "Run this unsaved, scratch file with Bun",
+      }),
+    ];
+  }
 }


### PR DESCRIPTION
### What does this PR do?

This adds a `eval with bun` code lens on untitled unsaved scratch JavaScript files

![okkk](https://github.com/user-attachments/assets/29e6c098-c004-4863-ab9d-90e92f495c6f)


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
