### PR TITLE
remove checks for self closing tags

### DIFF
--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -29,7 +29,6 @@ pub const StrictModeReservedWords = tables.StrictModeReservedWords;
 pub const PropertyModifierKeyword = tables.PropertyModifierKeyword;
 pub const TypescriptStmtKeyword = tables.TypescriptStmtKeyword;
 pub const TypeScriptAccessibilityModifier = tables.TypeScriptAccessibilityModifier;
-pub const ChildlessJSXTags = tables.ChildlessJSXTags;
 
 fn notimpl() noreturn {
     Output.panic("not implemented yet!", .{});

--- a/src/js_lexer_tables.zig
+++ b/src/js_lexer_tables.zig
@@ -552,26 +552,6 @@ pub const TypescriptStmtKeyword = enum {
     });
 };
 
-//  Error: meta is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
-pub const ChildlessJSXTags = ComptimeStringMap(void, .{
-    .{ "area", void },
-    .{ "base", void },
-    .{ "br", void },
-    .{ "col", void },
-    .{ "embed", void },
-    .{ "hr", void },
-    .{ "img", void },
-    .{ "input", void },
-    .{ "keygen", void },
-    .{ "link", void },
-    .{ "menuitem", void },
-    .{ "meta", void },
-    .{ "param", void },
-    .{ "source", void },
-    .{ "track", void },
-    .{ "wbr", void },
-});
-
 // In a microbenchmark, this outperforms
 pub const jsxEntity = ComptimeStringMap(CodePoint, .{
     .{ "Aacute", @as(CodePoint, 0x00C1) },

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -16345,24 +16345,7 @@ fn NewParser_(
 
                             const runtime = if (p.options.jsx.runtime == .automatic) options.JSX.Runtime.automatic else options.JSX.Runtime.classic;
                             const is_key_after_spread = e_.flags.contains(.is_key_after_spread);
-                            var children_count = e_.children.len;
-
-                            const is_childless_tag = FeatureFlags.react_specific_warnings and children_count > 0 and
-                                tag.data == .e_string and tag.data.e_string.isUTF8() and js_lexer.ChildlessJSXTags.has(tag.data.e_string.slice(p.allocator));
-
-                            children_count = if (is_childless_tag) 0 else children_count;
-
-                            if (children_count != e_.children.len) {
-                                // Error: meta is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
-                                // ^ from react-dom
-                                p.log.addWarningFmt(
-                                    p.source,
-                                    tag.loc,
-                                    p.allocator,
-                                    "\\<{s} /> is a void element and must not have \"children\"",
-                                    .{tag.data.e_string.slice(p.allocator)},
-                                ) catch {};
-                            }
+                            const children_count = e_.children.len;
 
                             // TODO: maybe we should split these into two different AST Nodes
                             // That would reduce the amount of allocations a little

--- a/test/regression/issue/14515.test.tsx
+++ b/test/regression/issue/14515.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+
+export function Input(a: InlineInputAttrs, ch: DocumentFragment) {
+  const o_model = a.model
+  const nullable = (a.type||'').indexOf('null') > -1
+
+  return <input>
+      {$on('input', (ev) => {
+        var v = ev.currentTarget.value
+        if (nullable && v === '') {
+          o_model.set(null!)
+        } else {
+          // @ts-ignore typescript is confused by the type of o_model, rightly so.
+          o_model.set(to_obs(v))
+        }
+      })}
+
+    </input>
+
+}
+
+function _pad(n: number) {
+  return (n < 10 ? ('0' + n) : n)
+}
+
+function _iso_date(d: Date) {
+  return `${d.getFullYear()}-${_pad(d.getMonth()+1)}-${_pad(d.getDate())}`
+}
+
+test("runs without crashing", () => { })


### PR DESCRIPTION
### What does this PR do?

This fixes #14515 by simply stopping the checks with self-closing tags in jsx, as it should not be bun's responsibility to do so. I can update the tests, but I'm not familiar with the structure, can I just drop a jsx or tsx file in `tests/snippets` ?

This is just code removal and very little is touched in the .zig. The use case I give in #14515 passes.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
