### PR TITLE
Fix typo for configuring specific registry

### DIFF
--- a/docs/install/npmrc.md
+++ b/docs/install/npmrc.md
@@ -39,7 +39,7 @@ The equivalent `bunfig.toml` option is to add a key in [`install.scopes`](https:
 myorg = "http://localhost:4873/"
 ```
 
-### `//<registry_url>/:<key>=<value>`: Confgure options for a specific registry
+### `//<registry_url>/:<key>=<value>`: Configure options for a specific registry
 
 Allows you to set options for a specific registry:
 


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the **`.npmrc` Support** docs