### PR TITLE
Fix prototypical inheritance issue in node:zlib and add a `$toClass` helper

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3443,6 +3443,42 @@ JSC_DEFINE_CUSTOM_SETTER(EventSource_setter,
     return true;
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionToClass, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    // Mimick the behavior of class Foo {} for a regular JSFunction.
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto target = callFrame->argument(0).toObject(globalObject);
+    auto name = callFrame->argument(1);
+    JSObject* base = callFrame->argument(2).getObject();
+    JSObject* prototypeBase = nullptr;
+    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+
+    if (!base) {
+        base = globalObject->functionPrototype();
+    } else if (auto proto = base->getIfPropertyExists(globalObject, vm.propertyNames->prototype)) {
+        if (auto protoObject = proto.getObject()) {
+            prototypeBase = protoObject;
+        }
+    } else {
+        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        JSC::throwTypeError(globalObject, scope, "Base class must have a prototype property"_s);
+        return encodedJSValue();
+    }
+
+    JSObject* prototype = prototypeBase ? JSC::constructEmptyObject(globalObject, prototypeBase) : JSC::constructEmptyObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+
+    prototype->structure()->setMayBePrototype(true);
+    prototype->putDirect(vm, vm.propertyNames->constructor, target, PropertyAttribute::DontEnum | 0);
+
+    target->setPrototypeDirect(vm, base);
+    target->putDirect(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | 0);
+    target->putDirect(vm, vm.propertyNames->name, name, PropertyAttribute::DontEnum | 0);
+
+    return JSValue::encode(jsUndefined());
+}
+
 EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
 {
     JSC::VM& vm = this->vm();
@@ -3544,6 +3580,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         GlobalPropertyInfo(builtinNames.requireMapPrivateName(), this->requireMap(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | 0),
         GlobalPropertyInfo(builtinNames.TextEncoderStreamEncoderPrivateName(), JSTextEncoderStreamEncoderConstructor(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | 0),
         GlobalPropertyInfo(builtinNames.makeErrorWithCodePrivateName(), JSFunction::create(vm, this, 2, String(), jsFunctionMakeErrorWithCode, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
+        GlobalPropertyInfo(builtinNames.toClassPrivateName(), JSFunction::create(vm, this, 1, String(), jsFunctionToClass, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
     };
     addStaticGlobals(staticGlobals, std::size(staticGlobals));
 

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -546,3 +546,16 @@ declare interface Error {
  */
 declare function $ERR_INVALID_ARG_TYPE(argName: string, expectedType: string, actualValue: string): TypeError;
 declare function $ERR_INVALID_ARG_TYPE(argName: string, expectedTypes: any[], actualValue: string): TypeError;
+/**
+ * Convert a function to a class-like object.
+ *
+ * This does:
+ * - Sets the name of the function to the given name
+ * - Sets .prototype to Object.create(base?.prototype, { constructor: { value: fn } })
+ * - Calls Object.setPrototypeOf(fn, base ?? Function.prototype)
+ *
+ * @param fn - The function to convert to a class
+ * @param name - The name of the class
+ * @param base - The base class to inherit from
+ */
+declare function $toClass(fn: Function, name: string, base?: Function | undefined | null);

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -81,7 +81,6 @@ using namespace JSC;
     macro(encoding) \
     macro(end) \
     macro(errno) \
-    macro(makeErrorWithCode) \
     macro(errorSteps) \
     macro(evaluateCommonJSModule) \
     macro(evaluated) \
@@ -134,6 +133,7 @@ using namespace JSC;
     macro(localStreams) \
     macro(main) \
     macro(makeDOMException) \
+    macro(makeErrorWithCode) \
     macro(makeGetterTypeError) \
     macro(makeThisTypeError) \
     macro(method) \
@@ -152,8 +152,8 @@ using namespace JSC;
     macro(password) \
     macro(patch) \
     macro(path) \
-    macro(paths) \
     macro(pathname) \
+    macro(paths) \
     macro(pause) \
     macro(pendingAbortRequest) \
     macro(pendingPullIntos) \
@@ -227,6 +227,7 @@ using namespace JSC;
     macro(textEncoderStreamEncoder) \
     macro(TextEncoderStreamEncoder) \
     macro(textEncoderStreamTransform) \
+    macro(toClass) \
     macro(toNamespacedPath) \
     macro(trace) \
     macro(transformAlgorithm) \

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -8,6 +8,51 @@ import * as stream from "node:stream";
 import * as util from "node:util";
 import * as zlib from "node:zlib";
 
+describe("prototype and name and constructor", () => {
+  for (let [name, Class] of [
+    ["Gzip", zlib.Gzip],
+    ["Gunzip", zlib.Gunzip],
+    ["Deflate", zlib.Deflate],
+    ["Inflate", zlib.Inflate],
+    ["DeflateRaw", zlib.DeflateRaw],
+  ]) {
+    describe(`${name}`, () => {
+      it(`${name}.prototype should be instanceof ${name}.__proto__`, () => {
+        expect(Class.prototype).toBeInstanceOf(Class.__proto__);
+      });
+      it(`${name}.prototype.constructor should be ${name}`, () => {
+        expect(Class.prototype.constructor).toBe(Class);
+      });
+      it(`${name}.name should be ${name}`, () => {
+        expect(Class.name).toBe(name);
+      });
+      it(`${name}.prototype.__proto__.constructor.name should be Zlib`, () => {
+        expect(Class.prototype.__proto__.constructor.name).toBe("Zlib");
+      });
+    });
+  }
+
+  for (let [name, Class] of [
+    ["BrotliCompress", zlib.BrotliCompress],
+    ["BrotliDecompress", zlib.BrotliDecompress],
+  ]) {
+    describe(`${name}`, () => {
+      it(`${name}.prototype should be instanceof ${name}.__proto__`, () => {
+        expect(Class.prototype).toBeInstanceOf(Class.__proto__);
+      });
+      it(`${name}.prototype.constructor should be ${name}`, () => {
+        expect(Class.prototype.constructor).toBe(Class);
+      });
+      it(`${name}.name should be ${name}`, () => {
+        expect(Class.name).toBe(name);
+      });
+      it(`${name}.prototype.__proto__.constructor.name should be Brotli`, () => {
+        expect(Class.prototype.__proto__.constructor.name).toBe("Brotli");
+      });
+    });
+  }
+});
+
 describe("zlib", () => {
   for (let library of ["zlib", "libdeflate"]) {
     for (let outputLibrary of ["zlib", "libdeflate"]) {


### PR DESCRIPTION
### What does this PR do?

- We were missing Object.setPrototypeOf calls on all the Zlib classes (cc @nektro), which can cause bugs when things are subclassed.
- This ensures the function names are set for the various zlib exports

### How did you verify your code works?

There is a test for the prototypical inheritance stuff. I manually verified it matches Node.