### PR TITLE
Fix issue with sveltekit-adapter-node

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1350,33 +1350,37 @@ pub const ServerConfig = struct {
             }
             if (global.hasException()) return;
 
-            if (arg.getTruthy(global, "hostname") orelse arg.getTruthy(global, "host")) |host| {
-                const host_str = host.toSlice(
-                    global,
-                    bun.default_allocator,
-                );
-                defer host_str.deinit();
+            if (arg.get(global, "hostname") orelse arg.get(global, "host")) |host| {
+                if (host.toBoolean()) {
+                    const host_str = host.toSlice(
+                        global,
+                        bun.default_allocator,
+                    );
+                    defer host_str.deinit();
 
-                if (host_str.len > 0) {
-                    args.address.tcp.hostname = bun.default_allocator.dupeZ(u8, host_str.slice()) catch unreachable;
-                    has_hostname = true;
+                    if (host_str.len > 0) {
+                        args.address.tcp.hostname = bun.default_allocator.dupeZ(u8, host_str.slice()) catch unreachable;
+                        has_hostname = true;
+                    }
                 }
             }
             if (global.hasException()) return;
 
-            if (arg.getTruthy(global, "unix")) |unix| {
-                const unix_str = unix.toSlice(
-                    global,
-                    bun.default_allocator,
-                );
-                defer unix_str.deinit();
-                if (unix_str.len > 0) {
-                    if (has_hostname) {
-                        JSC.throwInvalidArguments("Cannot specify both hostname and unix", .{}, global, exception);
-                        return;
-                    }
+            if (arg.get(global, "unix")) |unix| {
+                if (unix.toBoolean()) {
+                    const unix_str = unix.toSlice(
+                        global,
+                        bun.default_allocator,
+                    );
+                    defer unix_str.deinit();
+                    if (unix_str.len > 0) {
+                        if (has_hostname) {
+                            JSC.throwInvalidArguments("Cannot specify both hostname and unix", .{}, global, exception);
+                            return;
+                        }
 
-                    args.address = .{ .unix = bun.default_allocator.dupeZ(u8, unix_str.slice()) catch unreachable };
+                        args.address = .{ .unix = bun.default_allocator.dupeZ(u8, unix_str.slice()) catch unreachable };
+                    }
                 }
             }
             if (global.hasException()) return;


### PR DESCRIPTION
### What does this PR do?

Fix issue with sveltekit-adapter-node

Treat `unix: ""` like `if ("")`  in Bun.serve()

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
