### PR TITLE
Fix indent `console.time/table/count` within `console.group` 

### DIFF
--- a/test/js/web/console/__snapshots__/console-log.test.ts.snap
+++ b/test/js/web/console/__snapshots__/console-log.test.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`console.group: console-group-error 1`] = `
 "Warning log
-  Error log"
+  Error log
+  [] Time test
+  [] Time"
 `;
 
 exports[`console.group: console-group-output 1`] = `
@@ -41,5 +43,16 @@ null
   Inside unicode group
   Tab	Newline
 Quote"Backslash
-    Special chars"
+    Special chars
+Table inside group
+  ┌───┬───┬───┐
+  │   │ a │ b │
+  ├───┼───┼───┤
+  │ 0 │ 1 │ 2 │
+  │ 1 │ 3 │ 4 │
+  └───┴───┴───┘
+Count inside group
+  Count: 1
+  Count: 2
+Time inside group"
 `;

--- a/test/js/web/console/console-group.fixture.js
+++ b/test/js/web/console/console-group.fixture.js
@@ -76,3 +76,22 @@ console.group('Tab\tNewline\nQuote"Backslash');
 console.log("Special chars");
 console.groupEnd();
 console.groupEnd();
+
+// Table inside group
+console.group("Table inside group");
+console.table([{ a: 1, b: 2 }, { a: 3, b: 4 }]);
+console.groupEnd();
+
+// Count inside group
+console.group("Count inside group");
+console.count("Count");
+console.count("Count");
+console.groupEnd();
+
+// Time inside group
+console.group("Time inside group");
+console.time("Time");
+console.timeLog("Time", 'test');
+console.timeStamp("Time");
+console.timeEnd("Time");
+console.groupEnd();

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -64,6 +64,6 @@ it("console.group", async () => {
     stdio: ["inherit", "pipe", "pipe"],
   });
   expect(proc.exitCode).toBe(0);
-  expect(proc.stderr.toString("utf8").replaceAll("\r\n", "\n").trim()).toMatchSnapshot("console-group-error");
-  expect(proc.stdout.toString("utf8").replaceAll("\r\n", "\n").trim()).toMatchSnapshot("console-group-output");
+  expect(proc.stderr.toString("utf8").replaceAll("\r\n", "\n").trim().replace(/\[.+s\] /gm, "[] ")).toMatchSnapshot("console-group-error");
+  expect(proc.stdout.toString("utf8").replaceAll("\r\n", "\n").trim().replace(/\[.+s\] /gm, "[] ")).toMatchSnapshot("console-group-output");
 });


### PR DESCRIPTION
### What does this PR do?

Optionally, I could convert `ConsoleObject.Formatter.writeIndent(writer)` to a global function `writeIndent(writer, indent)`. This would remove the need to create a `ConsoleObject.Formatter` in methods like `console.timeEnd/timeLog`.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I edited automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
