### PR TITLE
fix(install): package-lock.json migration and non-existent `cafile` fixes

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8367,7 +8367,9 @@ pub const PackageManager = struct {
     fn httpThreadOnInitError(err: HTTP.InitError, opts: HTTP.HTTPThread.InitOpts) noreturn {
         switch (err) {
             error.LoadCAFile => {
-                if (!bun.sys.existsZ(opts.abs_ca_file_name)) {
+                var normalizer: bun.path.PosixToWinNormalizer = .{};
+                const normalized = normalizer.resolveZ(FileSystem.instance.top_level_dir, opts.abs_ca_file_name);
+                if (!bun.sys.existsZ(normalized)) {
                     Output.err("HTTPThread", "could not find CA file: '{s}'", .{opts.abs_ca_file_name});
                 } else {
                     Output.err("HTTPThread", "invalid CA file: '{s}'", .{opts.abs_ca_file_name});
@@ -12521,6 +12523,7 @@ pub const PackageManager = struct {
         ) usize {
             if (comptime Environment.allow_assert) {
                 bun.assertWithLocation(resolution_tag != .root, @src());
+                bun.assertWithLocation(resolution_tag != .workspace, @src());
                 bun.assertWithLocation(package_id != 0, @src());
             }
             var count: usize = 0;
@@ -13010,23 +13013,28 @@ pub const PackageManager = struct {
                             }
                         }
 
-                        if (resolution.tag != .workspace and !is_trusted and this.lockfile.packages.items(.meta)[package_id].hasInstallScript()) {
-                            // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
-                            // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
-                            const count = this.getInstalledPackageScriptsCount(alias, package_id, resolution.tag, destination_dir, log_level);
-                            if (count > 0) {
-                                if (comptime log_level.isVerbose()) {
-                                    Output.prettyError("Blocked {d} scripts for: {s}@{}\n", .{
-                                        count,
-                                        alias,
-                                        resolution.fmt(this.lockfile.buffers.string_bytes.items, .posix),
-                                    });
+                        switch (resolution.tag) {
+                            .root, .workspace => {
+                                // these will never be blocked
+                            },
+                            else => if (!is_trusted and this.metas[package_id].hasInstallScript()) {
+                                // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
+                                // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
+                                const count = this.getInstalledPackageScriptsCount(alias, package_id, resolution.tag, destination_dir, log_level);
+                                if (count > 0) {
+                                    if (comptime log_level.isVerbose()) {
+                                        Output.prettyError("Blocked {d} scripts for: {s}@{}\n", .{
+                                            count,
+                                            alias,
+                                            resolution.fmt(this.lockfile.buffers.string_bytes.items, .posix),
+                                        });
+                                    }
                                 }
 
                                 const entry = this.summary.packages_with_blocked_scripts.getOrPut(this.manager.allocator, name_hash) catch bun.outOfMemory();
                                 if (!entry.found_existing) entry.value_ptr.* = 0;
                                 entry.value_ptr.* += count;
-                            }
+                            },
                         }
 
                         if (!pkg_has_patch) this.incrementTreeInstallCount(this.current_tree_id, destination_dir, !is_pending_package_install, log_level);

--- a/test/cli/install/migration/migrate-package-with-dependency-on-root/.gitignore
+++ b/test/cli/install/migration/migrate-package-with-dependency-on-root/.gitignore
@@ -1,0 +1,1 @@
+!package-lock.json

--- a/test/cli/install/migration/migrate-package-with-dependency-on-root/package-lock.json
+++ b/test/cli/install/migration/migrate-package-with-dependency-on-root/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "test-pkg",
+  "version": "2.2.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-pkg",
+      "version": "2.2.2",
+      "hasInstallScript": true,
+      "dependencies": {
+        "test-pkg": "."
+      }
+    },
+    "node_modules/test-pkg": {
+      "resolved": "",
+      "link": true
+    }
+  }
+}

--- a/test/cli/install/migration/migrate-package-with-dependency-on-root/package.json
+++ b/test/cli/install/migration/migrate-package-with-dependency-on-root/package.json
@@ -1,6 +1,9 @@
 {
   "name": "test-pkg",
   "version": "2.2.2",
+  "scripts": {
+    "postinstall": "echo success!"
+  },
   "dependencies": {
     "test-pkg": "."
   }

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -68,11 +68,13 @@ test("migrate package with dependency on root package", async () => {
 
   fs.cpSync(join(import.meta.dir, "migrate-package-with-dependency-on-root"), testDir, { recursive: true });
 
-  Bun.spawnSync([bunExe(), "install"], {
+  const { stdout } = Bun.spawnSync([bunExe(), "install"], {
     env: bunEnv,
     cwd: join(testDir),
+    stdout: "pipe",
   });
 
+  expect(stdout.toString()).toContain("success!");
   expect(fs.existsSync(join(testDir, "node_modules", "test-pkg", "package.json"))).toBeTrue();
 });
 

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -642,6 +642,22 @@ describe("certificate authority", () => {
     expect(await exited).toBe(1);
   });
 
+  test("non-existent --cafile (absolute path)", async () => {
+    await write(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", "dependencies": { "no-deps": "1.1.1" } }));
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--cafile", "/does/not/exist"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+    const out = await Bun.readableStreamToText(stdout);
+    expect(out).not.toContain("no-deps");
+    const err = await Bun.readableStreamToText(stderr);
+    expect(err).toContain(`HTTPThread: could not find CA file: '/does/not/exist'`);
+    expect(await exited).toBe(1);
+  });
+
   test("cafile from bunfig does not exist", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
### What does this PR do?
fixes BUN-7ZR
fixes #14741
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added tests for both bugs
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
