### PR TITLE
fix `import(data:...)` with `.` in code

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2347,6 +2347,10 @@ pub const ModuleLoader = struct {
                     break :loader options.Loader.tsx;
                 }
 
+                if (strings.hasPrefixComptime(path.name.dir, "data:")) {
+                    break :loader options.Loader.tsx;
+                }
+
                 // Unknown extensions are to be treated as file loader
                 break :loader options.Loader.file;
             } else {

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -1301,7 +1301,7 @@ pub const Bundler = struct {
                 break :brk logger.Source.initPathString(path.text, "");
             }
 
-            if (strings.startsWith(path.text, "data:")) {
+            if (strings.hasPrefixComptime(path.text, "data:")) {
                 const data_url = DataURL.parseWithoutCheck(path.text) catch |err| {
                     bundler.log.addErrorFmt(null, logger.Loc.Empty, bundler.allocator, "{s} parsing data url \"{s}\"", .{ @errorName(err), path.text }) catch {};
                     return null;

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -14,6 +14,12 @@ test("should import and execute ES module from string (base64)", async () => {
   expect(result).toEqual(2);
 });
 
+test("can import module with '.' in source code", async () => {
+  const code = `export default 1.1;`;
+  const mod = await import("data:text/javascript," + code).then(mode => mode.default);
+  expect(mod).toBe(1.1);
+});
+
 test("should throw when importing malformed string (base64)", async () => {
   expect(() => import("data:text/javascript;base64,asdasdasd")).toThrowError("Base64DecodeError");
 });


### PR DESCRIPTION
### What does this PR do?
Not sure if this is the best fix
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
