### PR TITLE
Use linux syscall interface more in I/O

### DIFF
--- a/src/fd.zig
+++ b/src/fd.zig
@@ -242,7 +242,7 @@ pub const FDImpl = packed struct {
                 const fd = this.encode();
                 bun.assert(fd != bun.invalid_fd);
                 bun.assert(fd.cast() >= 0);
-                break :result switch (bun.C.getErrno(bun.sys.system.close(fd.cast()))) {
+                break :result switch (bun.C.getErrno(bun.sys.syscall.close(fd.cast()))) {
                     .BADF => bun.sys.Error{ .errno = @intFromEnum(posix.E.BADF), .syscall = .close, .fd = fd },
                     else => null,
                 };
@@ -251,7 +251,7 @@ pub const FDImpl = packed struct {
                 const fd = this.encode();
                 bun.assert(fd != bun.invalid_fd);
                 bun.assert(fd.cast() >= 0);
-                break :result switch (bun.C.getErrno(bun.sys.system.@"close$NOCANCEL"(fd.cast()))) {
+                break :result switch (bun.C.getErrno(bun.sys.syscall.@"close$NOCANCEL"(fd.cast()))) {
                     .BADF => bun.sys.Error{ .errno = @intFromEnum(posix.E.BADF), .syscall = .close, .fd = fd },
                     else => null,
                 };

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -11,8 +11,8 @@ const default_allocator = bun.default_allocator;
 const kernel32 = bun.windows;
 const mem = std.mem;
 const mode_t = posix.mode_t;
-const open_sym = system.open;
-const sys = std.posix.system;
+const libc = std.posix.system;
+
 const windows = bun.windows;
 
 const C = bun.C;
@@ -23,16 +23,20 @@ const PathString = bun.PathString;
 const Syscall = @This();
 const SystemError = JSC.SystemError;
 
-const linux = system;
+const linux = syscall;
 
 pub const sys_uv = if (Environment.isWindows) @import("./sys_uv.zig") else Syscall;
 
 const log = bun.Output.scoped(.SYS, false);
 pub const syslog = log;
 
-pub const system = switch (Environment.os) {
+pub const syscall = switch (Environment.os) {
     .linux => std.os.linux,
+
+    // This is actually libc on MacOS
+    // We don't directly use the Darwin syscall interface.
     .mac => bun.AsyncIO.system,
+
     else => @compileError("not implemented"),
 };
 
@@ -297,17 +301,17 @@ pub const Error = struct {
         return copy;
     }
 
-    pub fn fromCode(errno: E, syscall: Syscall.Tag) Error {
+    pub fn fromCode(errno: E, syscall_tag: Syscall.Tag) Error {
         return .{
             .errno = @as(Int, @intCast(@intFromEnum(errno))),
-            .syscall = syscall,
+            .syscall = syscall_tag,
         };
     }
 
-    pub fn fromCodeInt(errno: anytype, syscall: Syscall.Tag) Error {
+    pub fn fromCodeInt(errno: anytype, syscall_tag: Syscall.Tag) Error {
         return .{
             .errno = @as(Int, @intCast(if (Environment.isWindows) @abs(errno) else errno)),
-            .syscall = syscall,
+            .syscall = syscall_tag,
         };
     }
 
@@ -502,7 +506,7 @@ pub fn chdirOSPath(destination: bun.OSPathSliceZ) Maybe(void) {
     assertIsValidWindowsPath(bun.OSPathChar, destination);
 
     if (comptime Environment.isPosix) {
-        const rc = sys.chdir(destination);
+        const rc = syscall.chdir(destination);
         return Maybe(void).errnoSys(rc, .chdir) orelse Maybe(void).success;
     }
 
@@ -626,7 +630,7 @@ pub fn mkdiratA(dir_fd: bun.FileDescriptor, file_path: []const u8) Maybe(void) {
 
 pub fn mkdiratZ(dir_fd: bun.FileDescriptor, file_path: [*:0]const u8, mode: mode_t) Maybe(void) {
     return switch (Environment.os) {
-        .mac => Maybe(void).errnoSysP(system.mkdirat(@intCast(dir_fd.cast()), file_path, mode), .mkdir, file_path) orelse Maybe(void).success,
+        .mac => Maybe(void).errnoSysP(syscall.mkdirat(@intCast(dir_fd.cast()), file_path, mode), .mkdir, file_path) orelse Maybe(void).success,
         .linux => Maybe(void).errnoSysP(linux.mkdirat(@intCast(dir_fd.cast()), file_path, mode), .mkdir, file_path) orelse Maybe(void).success,
         else => @compileError("mkdir is not implemented on this platform"),
     };
@@ -667,7 +671,7 @@ pub fn fstatat(fd: bun.FileDescriptor, path: [:0]const u8) Maybe(bun.Stat) {
         };
     }
     var stat_ = mem.zeroes(bun.Stat);
-    if (Maybe(bun.Stat).errnoSys(sys.fstatat(fd.int(), path, &stat_, 0), .fstatat)) |err| {
+    if (Maybe(bun.Stat).errnoSys(syscall.fstatat(fd.int(), path, &stat_, 0), .fstatat)) |err| {
         log("fstatat({}, {s}) = {s}", .{ fd, path, @tagName(err.getErrno()) });
         return err;
     }
@@ -677,9 +681,9 @@ pub fn fstatat(fd: bun.FileDescriptor, path: [:0]const u8) Maybe(bun.Stat) {
 
 pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
     return switch (Environment.os) {
-        .mac => Maybe(void).errnoSysP(system.mkdir(file_path, flags), .mkdir, file_path) orelse Maybe(void).success,
+        .mac => Maybe(void).errnoSysP(syscall.mkdir(file_path, flags), .mkdir, file_path) orelse Maybe(void).success,
 
-        .linux => Maybe(void).errnoSysP(system.mkdir(file_path, flags), .mkdir, file_path) orelse Maybe(void).success,
+        .linux => Maybe(void).errnoSysP(syscall.mkdir(file_path, flags), .mkdir, file_path) orelse Maybe(void).success,
 
         .windows => {
             var wbuf: bun.WPathBuffer = undefined;
@@ -696,7 +700,7 @@ pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
 
 pub fn mkdirA(file_path: []const u8, flags: bun.Mode) Maybe(void) {
     if (comptime Environment.isMac) {
-        return Maybe(void).errnoSysP(system.mkdir(&(std.posix.toPosixPath(file_path) catch return Maybe(void){
+        return Maybe(void).errnoSysP(syscall.mkdir(&(std.posix.toPosixPath(file_path) catch return Maybe(void){
             .err = .{
                 .errno = @intFromEnum(bun.C.E.NOMEM),
                 .syscall = .open,
@@ -1254,7 +1258,7 @@ pub fn openatWindowsA(
 pub fn openatOSPath(dirfd: bun.FileDescriptor, file_path: bun.OSPathSliceZ, flags: bun.Mode, perm: bun.Mode) Maybe(bun.FileDescriptor) {
     if (comptime Environment.isMac) {
         // https://opensource.apple.com/source/xnu/xnu-7195.81.3/libsyscall/wrappers/open-base.c
-        const rc = system.@"openat$NOCANCEL"(dirfd.cast(), file_path.ptr, @as(c_uint, @intCast(flags)), @as(c_int, @intCast(perm)));
+        const rc = syscall.@"openat$NOCANCEL"(dirfd.cast(), file_path.ptr, @as(c_uint, @intCast(flags)), @as(c_int, @intCast(perm)));
         if (comptime Environment.allow_assert)
             log("openat({}, {s}) = {d}", .{ dirfd, bun.sliceTo(file_path, 0), rc });
 
@@ -1264,7 +1268,7 @@ pub fn openatOSPath(dirfd: bun.FileDescriptor, file_path: bun.OSPathSliceZ, flag
     }
 
     while (true) {
-        const rc = Syscall.system.openat(dirfd.cast(), file_path, bun.O.toPacked(flags), perm);
+        const rc = syscall.openat(dirfd.cast(), file_path, bun.O.toPacked(flags), perm);
         if (comptime Environment.allow_assert)
             log("openat({}, {s}) = {d}", .{ dirfd, bun.sliceTo(file_path, 0), rc });
         return switch (Syscall.getErrno(rc)) {
@@ -1280,6 +1284,10 @@ pub fn openatOSPath(dirfd: bun.FileDescriptor, file_path: bun.OSPathSliceZ, flag
             },
         };
     }
+}
+
+pub fn access(path: bun.OSPathSliceZ, mode: bun.Mode) Maybe(void) {
+    return Maybe(void).errnoSysP(syscall.access(path, mode), .access, path) orelse .{ .result = {} };
 }
 
 pub fn openat(dirfd: bun.FileDescriptor, file_path: [:0]const u8, flags: bun.Mode, perm: bun.Mode) Maybe(bun.FileDescriptor) {
@@ -1364,7 +1372,7 @@ pub fn write(fd: bun.FileDescriptor, bytes: []const u8) Maybe(usize) {
 
     return switch (Environment.os) {
         .mac => {
-            const rc = system.@"write$NOCANCEL"(fd.cast(), bytes.ptr, adjusted_len);
+            const rc = syscall.@"write$NOCANCEL"(fd.cast(), bytes.ptr, adjusted_len);
             log("write({}, {d}) = {d} ({})", .{ fd, adjusted_len, rc, debug_timer });
 
             if (Maybe(usize).errnoSysFd(rc, .write, fd)) |err| {
@@ -1375,7 +1383,7 @@ pub fn write(fd: bun.FileDescriptor, bytes: []const u8) Maybe(usize) {
         },
         .linux => {
             while (true) {
-                const rc = sys.write(fd.cast(), bytes.ptr, adjusted_len);
+                const rc = syscall.write(fd.cast(), bytes.ptr, adjusted_len);
                 log("write({}, {d}) = {d} {}", .{ fd, adjusted_len, rc, debug_timer });
 
                 if (Maybe(usize).errnoSysFd(rc, .write, fd)) |err| {
@@ -1554,39 +1562,35 @@ pub fn preadv(fd: bun.FileDescriptor, buffers: []std.posix.iovec, position: isiz
 const preadv_sym = if (builtin.os.tag == .linux and builtin.link_libc)
     std.os.linux.preadv
 else if (builtin.os.tag.isDarwin())
-    system.@"preadv$NOCANCEL"
+    syscall.@"preadv$NOCANCEL"
 else
-    system.preadv;
+    syscall.preadv;
 
 const readv_sym = if (builtin.os.tag == .linux and builtin.link_libc)
     std.os.linux.readv
 else if (builtin.os.tag.isDarwin())
-    system.@"readv$NOCANCEL"
+    syscall.@"readv$NOCANCEL"
 else
-    system.readv;
+    syscall.readv;
 
 const pwritev_sym = if (builtin.os.tag == .linux and builtin.link_libc)
     std.os.linux.pwritev
 else if (builtin.os.tag.isDarwin())
-    system.@"pwritev$NOCANCEL"
+    syscall.@"pwritev$NOCANCEL"
 else
-    system.pwritev;
+    syscall.pwritev;
 
-const writev_sym = if (builtin.os.tag == .linux and builtin.link_libc)
-    std.os.linux.writev
-else if (builtin.os.tag.isDarwin())
-    system.@"writev$NOCANCEL"
+const writev_sym = if (builtin.os.tag.isDarwin())
+    syscall.@"writev$NOCANCEL"
 else
-    system.writev;
+    syscall.writev;
 
-const pread_sym = if (builtin.os.tag == .linux and builtin.link_libc and !bun.Environment.isMusl)
-    sys.pread64
-else if (builtin.os.tag.isDarwin())
-    system.@"pread$NOCANCEL"
+const pread_sym = if (builtin.os.tag.isDarwin())
+    syscall.@"pread$NOCANCEL"
 else
-    system.pread;
+    syscall.pread;
 
-const fcntl_symbol = system.fcntl;
+const fcntl_symbol = syscall.fcntl;
 
 pub fn pread(fd: bun.FileDescriptor, buf: []u8, offset: i64) Maybe(usize) {
     const adjusted_len = @min(buf.len, max_count);
@@ -1609,9 +1613,9 @@ pub fn pread(fd: bun.FileDescriptor, buf: []u8, offset: i64) Maybe(usize) {
 }
 
 const pwrite_sym = if (builtin.os.tag == .linux and builtin.link_libc and !bun.Environment.isMusl)
-    sys.pwrite64
+    libc.pwrite64
 else
-    sys.pwrite;
+    syscall.pwrite;
 
 pub fn pwrite(fd: bun.FileDescriptor, bytes: []const u8, offset: i64) Maybe(usize) {
     if (comptime Environment.allow_assert) {
@@ -1644,7 +1648,7 @@ pub fn read(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
     const adjusted_len = @min(buf.len, max_count);
     return switch (Environment.os) {
         .mac => {
-            const rc = system.@"read$NOCANCEL"(fd.cast(), buf.ptr, adjusted_len);
+            const rc = syscall.@"read$NOCANCEL"(fd.cast(), buf.ptr, adjusted_len);
 
             if (Maybe(usize).errnoSysFd(rc, .read, fd)) |err| {
                 log("read({}, {d}) = {s} ({any})", .{ fd, adjusted_len, err.err.name(), debug_timer });
@@ -1656,7 +1660,7 @@ pub fn read(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
         },
         .linux => {
             while (true) {
-                const rc = sys.read(fd.cast(), buf.ptr, adjusted_len);
+                const rc = syscall.read(fd.cast(), buf.ptr, adjusted_len);
                 log("read({}, {d}) = {d} ({any})", .{ fd, adjusted_len, rc, debug_timer });
 
                 if (Maybe(usize).errnoSysFd(rc, .read, fd)) |err| {
@@ -1710,7 +1714,7 @@ pub fn recv(fd: bun.FileDescriptor, buf: []u8, flag: u32) Maybe(usize) {
     }
 
     if (comptime Environment.isMac) {
-        const rc = system.@"recvfrom$NOCANCEL"(fd.cast(), buf.ptr, adjusted_len, flag, null, null);
+        const rc = syscall.@"recvfrom$NOCANCEL"(fd.cast(), buf.ptr, adjusted_len, flag, null, null);
 
         if (Maybe(usize).errnoSys(rc, .recv)) |err| {
             log("recv({}, {d}) = {s} {}", .{ fd, adjusted_len, err.err.name(), debug_timer });
@@ -1741,7 +1745,7 @@ pub fn sendNonBlock(fd: bun.FileDescriptor, buf: []const u8) Maybe(usize) {
 
 pub fn send(fd: bun.FileDescriptor, buf: []const u8, flag: u32) Maybe(usize) {
     if (comptime Environment.isMac) {
-        const rc = system.@"sendto$NOCANCEL"(fd.cast(), buf.ptr, buf.len, flag, null, 0);
+        const rc = syscall.@"sendto$NOCANCEL"(fd.cast(), buf.ptr, buf.len, flag, null, 0);
 
         if (Maybe(usize).errnoSys(rc, .send)) |err| {
             syslog("send({}, {d}) = {s}", .{ fd, buf.len, err.err.name() });
@@ -1767,13 +1771,25 @@ pub fn send(fd: bun.FileDescriptor, buf: []const u8, flag: u32) Maybe(usize) {
     }
 }
 
+pub fn lseek(fd: bun.FileDescriptor, offset: i64, whence: usize) Maybe(usize) {
+    while (true) {
+        const rc = syscall.lseek(fd.cast(), offset, whence);
+        if (Maybe(usize).errnoSys(rc, .lseek)) |err| {
+            if (err.getErrno() == .INTR) continue;
+            return err;
+        }
+
+        return Maybe(usize){ .result = rc };
+    }
+}
+
 pub fn readlink(in: [:0]const u8, buf: []u8) Maybe([:0]u8) {
     if (comptime Environment.isWindows) {
         return sys_uv.readlink(in, buf);
     }
 
     while (true) {
-        const rc = sys.readlink(in, buf.ptr, buf.len);
+        const rc = syscall.readlink(in, buf.ptr, buf.len);
 
         if (Maybe([:0]u8).errnoSys(rc, .readlink)) |err| {
             if (err.getErrno() == .INTR) continue;
@@ -1786,7 +1802,7 @@ pub fn readlink(in: [:0]const u8, buf: []u8) Maybe([:0]u8) {
 
 pub fn readlinkat(fd: bun.FileDescriptor, in: [:0]const u8, buf: []u8) Maybe([:0]const u8) {
     while (true) {
-        const rc = sys.readlinkat(fd.cast(), in, buf.ptr, buf.len);
+        const rc = syscall.readlinkat(fd.cast(), in, buf.ptr, buf.len);
 
         if (Maybe([:0]const u8).errnoSys(rc, .readlink)) |err| {
             if (err.getErrno() == .INTR) continue;
@@ -1807,7 +1823,7 @@ pub fn ftruncate(fd: bun.FileDescriptor, size: isize) Maybe(void) {
     }
 
     return while (true) {
-        if (Maybe(void).errnoSys(sys.ftruncate(fd.cast(), size), .ftruncate)) |err| {
+        if (Maybe(void).errnoSys(syscall.ftruncate(fd.cast(), size), .ftruncate)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -1817,7 +1833,7 @@ pub fn ftruncate(fd: bun.FileDescriptor, size: isize) Maybe(void) {
 
 pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
     while (true) {
-        if (Maybe(void).errnoSys(sys.rename(from, to), .rename)) |err| {
+        if (Maybe(void).errnoSys(syscall.rename(from, to), .rename)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -1963,7 +1979,7 @@ pub fn renameat(from_dir: bun.FileDescriptor, from: [:0]const u8, to_dir: bun.Fi
         return rc;
     }
     while (true) {
-        if (Maybe(void).errnoSys(sys.renameat(from_dir.cast(), from, to_dir.cast(), to), .rename)) |err| {
+        if (Maybe(void).errnoSys(syscall.renameat(from_dir.cast(), from, to_dir.cast(), to), .rename)) |err| {
             if (err.getErrno() == .INTR) continue;
             if (comptime Environment.allow_assert)
                 log("renameat({}, {s}, {}, {s}) = {d}", .{ from_dir, from, to_dir, to, @intFromEnum(err.getErrno()) });
@@ -1987,7 +2003,7 @@ pub fn chown(path: [:0]const u8, uid: posix.uid_t, gid: posix.gid_t) Maybe(void)
 
 pub fn symlink(target: [:0]const u8, dest: [:0]const u8) Maybe(void) {
     while (true) {
-        if (Maybe(void).errnoSys(sys.symlink(target, dest), .symlink)) |err| {
+        if (Maybe(void).errnoSys(syscall.symlink(target, dest), .symlink)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -1997,7 +2013,7 @@ pub fn symlink(target: [:0]const u8, dest: [:0]const u8) Maybe(void) {
 
 pub fn symlinkat(target: [:0]const u8, dirfd: bun.FileDescriptor, dest: [:0]const u8) Maybe(void) {
     while (true) {
-        if (Maybe(void).errnoSys(sys.symlinkat(target, dirfd.cast(), dest), .symlinkat)) |err| {
+        if (Maybe(void).errnoSys(syscall.symlinkat(target, dirfd.cast(), dest), .symlinkat)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -2120,7 +2136,7 @@ pub fn fcopyfile(fd_in: bun.FileDescriptor, fd_out: bun.FileDescriptor, flags: u
     if (comptime !Environment.isMac) @compileError("macOS only");
 
     while (true) {
-        if (Maybe(void).errnoSys(system.fcopyfile(fd_in.cast(), fd_out.cast(), null, flags), .fcopyfile)) |err| {
+        if (Maybe(void).errnoSys(syscall.fcopyfile(fd_in.cast(), fd_out.cast(), null, flags), .fcopyfile)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -2143,7 +2159,7 @@ pub fn unlink(from: [:0]const u8) Maybe(void) {
     }
 
     while (true) {
-        if (Maybe(void).errnoSys(sys.unlink(from), .unlink)) |err| {
+        if (Maybe(void).errnoSys(syscall.unlink(from), .unlink)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
@@ -2171,7 +2187,7 @@ pub fn unlinkatWithFlags(dirfd: bun.FileDescriptor, to: anytype, flags: c_uint) 
     }
 
     while (true) {
-        if (Maybe(void).errnoSys(sys.unlinkat(dirfd.cast(), to, flags), .unlink)) |err| {
+        if (Maybe(void).errnoSys(syscall.unlinkat(dirfd.cast(), to, flags), .unlink)) |err| {
             if (err.getErrno() == .INTR) continue;
             if (comptime Environment.allow_assert)
                 log("unlinkat({}, {s}) = {d}", .{ dirfd, bun.sliceTo(to, 0), @intFromEnum(err.getErrno()) });
@@ -2189,7 +2205,7 @@ pub fn unlinkat(dirfd: bun.FileDescriptor, to: anytype) Maybe(void) {
         return unlinkatWithFlags(dirfd, to, 0);
     }
     while (true) {
-        if (Maybe(void).errnoSys(sys.unlinkat(dirfd.cast(), to, 0), .unlink)) |err| {
+        if (Maybe(void).errnoSys(syscall.unlinkat(dirfd.cast(), to, 0), .unlink)) |err| {
             if (err.getErrno() == .INTR) continue;
             if (comptime Environment.allow_assert)
                 log("unlinkat({}, {s}) = {d}", .{ dirfd, bun.sliceTo(to, 0), @intFromEnum(err.getErrno()) });
@@ -2216,7 +2232,7 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *[MAX_PATH_BYTES]u8) Maybe(
             // On macOS, we can use F.GETPATH fcntl command to query the OS for
             // the path to the file descriptor.
             @memset(out_buffer[0..MAX_PATH_BYTES], 0);
-            if (Maybe([]u8).errnoSys(system.fcntl(fd.cast(), posix.F.GETPATH, out_buffer), .fcntl)) |err| {
+            if (Maybe([]u8).errnoSys(syscall.fcntl(fd.cast(), posix.F.GETPATH, out_buffer), .fcntl)) |err| {
                 return err;
             }
             const len = mem.indexOfScalar(u8, out_buffer[0..], @as(u8, 0)) orelse MAX_PATH_BYTES;
@@ -2293,7 +2309,7 @@ pub fn mmapFile(path: [:0]const u8, flags: std.c.MAP, wanted_size: ?usize, offse
 }
 
 pub fn munmap(memory: []align(mem.page_size) const u8) Maybe(void) {
-    if (Maybe(void).errnoSys(system.munmap(memory.ptr, memory.len), .munmap)) |err| {
+    if (Maybe(void).errnoSys(syscall.munmap(memory.ptr, memory.len), .munmap)) |err| {
         return err;
     } else return Maybe(void).success;
 }
@@ -2456,7 +2472,7 @@ pub fn getFileAttributes(path: anytype) ?WindowsFileAttributes {
 
 pub fn existsOSPath(path: bun.OSPathSliceZ, file_only: bool) bool {
     if (comptime Environment.isPosix) {
-        return system.access(path, 0) == 0;
+        return syscall.access(path, 0) == 0;
     }
 
     if (comptime Environment.isWindows) {
@@ -2474,7 +2490,7 @@ pub fn existsOSPath(path: bun.OSPathSliceZ, file_only: bool) bool {
 
 pub fn exists(path: []const u8) bool {
     if (comptime Environment.isPosix) {
-        return system.access(&(std.posix.toPosixPath(path) catch return false), 0) == 0;
+        return syscall.access(&(std.posix.toPosixPath(path) catch return false), 0) == 0;
     }
 
     if (comptime Environment.isWindows) {
@@ -2486,7 +2502,7 @@ pub fn exists(path: []const u8) bool {
 
 pub fn existsZ(path: [:0]const u8) bool {
     if (comptime Environment.isPosix) {
-        return system.access(path, 0) == 0;
+        return syscall.access(path, 0) == 0;
     }
 
     if (comptime Environment.isWindows) {
@@ -2750,7 +2766,7 @@ pub fn pipe() Maybe([2]bun.FileDescriptor) {
     }
 
     var fds: [2]i32 = undefined;
-    const rc = system.pipe(&fds);
+    const rc = syscall.pipe(&fds);
     if (Maybe([2]bun.FileDescriptor).errnoSys(
         rc,
         .pipe,
@@ -2793,15 +2809,15 @@ pub fn dupWithFlags(fd: bun.FileDescriptor, flags: i32) Maybe(bun.FileDescriptor
     }
 
     const ArgType = if (comptime Environment.isLinux) usize else c_int;
-    const out = system.fcntl(fd.cast(), @as(i32, bun.C.F.DUPFD_CLOEXEC), @as(ArgType, 0));
+    const out = syscall.fcntl(fd.cast(), @as(i32, bun.C.F.DUPFD_CLOEXEC), @as(ArgType, 0));
     log("dup({d}) = {d}", .{ fd.cast(), out });
     if (Maybe(bun.FileDescriptor).errnoSysFd(out, .dup, fd)) |err| {
         return err;
     }
 
     if (flags != 0) {
-        const fd_flags: ArgType = @intCast(system.fcntl(@intCast(out), @as(i32, std.posix.F.GETFD), @as(ArgType, 0)));
-        _ = system.fcntl(@intCast(out), @as(i32, std.posix.F.SETFD), @as(ArgType, @intCast(fd_flags | @as(ArgType, @intCast(flags)))));
+        const fd_flags: ArgType = @intCast(syscall.fcntl(@intCast(out), @as(i32, std.posix.F.GETFD), @as(ArgType, 0)));
+        _ = syscall.fcntl(@intCast(out), @as(i32, std.posix.F.SETFD), @as(ArgType, @intCast(fd_flags | @as(ArgType, @intCast(flags)))));
     }
 
     return Maybe(bun.FileDescriptor){
@@ -3394,7 +3410,7 @@ pub const File = struct {
 
 pub inline fn toLibUVOwnedFD(
     maybe_windows_fd: bun.FileDescriptor,
-    comptime syscall: Syscall.Tag,
+    comptime syscall_tag: Syscall.Tag,
     comptime error_case: enum { close_on_fail, leak_fd_on_fail },
 ) Maybe(bun.FileDescriptor) {
     if (!Environment.isWindows) {
@@ -3410,7 +3426,7 @@ pub inline fn toLibUVOwnedFD(
                 return .{
                     .err = .{
                         .errno = @intFromEnum(bun.C.E.MFILE),
-                        .syscall = syscall,
+                        .syscall = syscall_tag,
                     },
                 };
             },


### PR DESCRIPTION
### What does this PR do?

Use linux syscall interface more in I/O

makes some musl libc stuff more consistent

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
