### PR TITLE
fix behavior when destroyed or pending and cork/uncork and ready event so we can match node.js

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1516,25 +1516,25 @@ class ClientRequest extends OutgoingMessage {
   _write(chunk, encoding, callback) {
     if (!this.#bodyChunks) {
       this.#bodyChunks = [chunk];
-      // process.nextTick(callback);
-      callback();
+      process.nextTick(callback);
+      // callback();
       return;
     }
     this.#bodyChunks.push(chunk);
-    // process.nextTick(callback);
-    callback();
+    process.nextTick(callback);
+    // callback();
   }
 
   _writev(chunks, callback) {
     if (!this.#bodyChunks) {
       this.#bodyChunks = chunks;
-      // process.nextTick(callback);
-      callback();
+      process.nextTick(callback);
+      // callback();
       return;
     }
     this.#bodyChunks.push(...chunks);
-    // process.nextTick(callback);
-    callback();
+    process.nextTick(callback);
+    // callback();
   }
 
   _destroy(err, callback) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1799,6 +1799,12 @@ class Http2Stream extends Duplex {
   }
 
   _writev(data, callback) {
+    if (this.pending) {
+      this.once("ready", this._writev.bind(this, data, callback));
+      return;
+    }
+    if (this.destroyed) return;
+
     const session = this[bunHTTP2Session];
     if (session) {
       const native = session[bunHTTP2Native];
@@ -1840,6 +1846,12 @@ class Http2Stream extends Duplex {
     }
   }
   _write(chunk, encoding, callback) {
+    if (this.pending) {
+      this.once("ready", this._write.bind(this, chunk, encoding, callback));
+      return;
+    }
+    if (this.destroyed) return;
+
     const session = this[bunHTTP2Session];
     if (session) {
       const native = session[bunHTTP2Native];


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Should pass http2 on CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
