### PR TITLE
fix(socket) Support named pipes on Windows using forward slashes 

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -459,22 +459,14 @@ fn isValidPipeName(pipe_name: []const u8) bool {
     }
     // check for valid pipe names
     // at minimum we need to have \\.\pipe\ or \\?\pipe\ + 1 char that is not a separator
-    if (pipe_name.len > 9) {
-        if (NodePath.isSepWindowsT(u8, pipe_name[0])) {
-            if (NodePath.isSepWindowsT(u8, pipe_name[1])) {
-                if (pipe_name[2] == '.' or pipe_name[2] == '?') {
-                    if (NodePath.isSepWindowsT(u8, pipe_name[3])) {
-                        if (strings.eql(pipe_name[4..8], "pipe")) {
-                            if (NodePath.isSepWindowsT(u8, pipe_name[8])) {
-                                return !NodePath.isSepWindowsT(u8, pipe_name[9]);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return false;
+    return pipe_name.len > 9 and
+        NodePath.isSepWindowsT(u8, pipe_name[0]) and
+        NodePath.isSepWindowsT(u8, pipe_name[1]) and
+        (pipe_name[2] == '.' or pipe_name[2] == '?') and
+        NodePath.isSepWindowsT(u8, pipe_name[3]) and
+        strings.eql(pipe_name[4..8], "pipe") and
+        NodePath.isSepWindowsT(u8, pipe_name[8]) and
+        !NodePath.isSepWindowsT(u8, pipe_name[9]);
 }
 
 fn normalizePipeName(pipe_name: []const u8, buffer: []u8) ?[]const u8 {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -600,6 +600,9 @@ it.if(isWindows)("should work with named pipes", async () => {
   for (let i = 0; i < 200; i++) {
     batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
     batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
+    batch.push(test(`//?/pipe/test/${randomUUID()}`));
+    batch.push(test(`//./pipe/test/${randomUUID()}`));
+
     if (i % 50 === 0) {
       await Promise.all(batch);
       batch.length = 0;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -563,51 +563,57 @@ it("should not hang after destroy", async () => {
   }
 });
 
-it.if(isWindows)("should work with named pipes", async () => {
-  async function test(pipe_name: string) {
-    const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
-    const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
-    let client: ReturnType<typeof connect> | null = null;
-    let server: ReturnType<typeof createServer> | null = null;
-    try {
-      server = createServer(socket => {
-        socket.on("data", data => {
-          const message = data.toString();
-          socket.end("Goodbye World!");
-          resolveMessageReceived(message);
+it.if(isWindows)(
+  "should work with named pipes",
+  async () => {
+    async function test(pipe_name: string) {
+      const { promise: messageReceived, resolve: resolveMessageReceived } = Promise.withResolvers();
+      const { promise: clientReceived, resolve: resolveClientReceived } = Promise.withResolvers();
+      let client: ReturnType<typeof connect> | null = null;
+      let server: ReturnType<typeof createServer> | null = null;
+      try {
+        server = createServer(socket => {
+          socket.on("data", data => {
+            const message = data.toString();
+            socket.end("Goodbye World!");
+            resolveMessageReceived(message);
+          });
         });
-      });
 
-      server.listen(pipe_name);
-      client = connect(pipe_name).on("data", data => {
-        const message = data.toString();
-        resolveClientReceived(message);
-      });
+        server.listen(pipe_name);
+        client = connect(pipe_name).on("data", data => {
+          const message = data.toString();
+          resolveClientReceived(message);
+        });
 
-      client?.write("Hello World!");
-      const message = await messageReceived;
-      expect(message).toBe("Hello World!");
-      const client_message = await clientReceived;
-      expect(client_message).toBe("Goodbye World!");
-    } finally {
-      client?.destroy();
-      server?.close();
+        client?.write("Hello World!");
+        const message = await messageReceived;
+        expect(message).toBe("Hello World!");
+        const client_message = await clientReceived;
+        expect(client_message).toBe("Goodbye World!");
+      } finally {
+        client?.destroy();
+        server?.close();
+      }
     }
-  }
 
-  const batch = [];
-  const before = heapStats().objectTypeCounts.TLSSocket || 0;
-  for (let i = 0; i < 200; i++) {
-    batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
-    batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
-    batch.push(test(`//?/pipe/test/${randomUUID()}`));
-    batch.push(test(`//./pipe/test/${randomUUID()}`));
-
-    if (i % 50 === 0) {
-      await Promise.all(batch);
-      batch.length = 0;
+    const batch = [];
+    const before = heapStats().objectTypeCounts.TLSSocket || 0;
+    for (let i = 0; i < 100; i++) {
+      batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
+      batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
+      batch.push(test(`//?/pipe/test/${randomUUID()}`));
+      batch.push(test(`//./pipe/test/${randomUUID()}`));
+      batch.push(test(`/\\./pipe/test/${randomUUID()}`));
+      batch.push(test(`/\\./pipe\\test/${randomUUID()}`));
+      batch.push(test(`\\/.\\pipe/test\\${randomUUID()}`));
+      if (i % 50 === 0) {
+        await Promise.all(batch);
+        batch.length = 0;
+      }
     }
-  }
-  await Promise.all(batch);
-  expectMaxObjectTypeCount(expect, "TCPSocket", before);
-});
+    await Promise.all(batch);
+    expectMaxObjectTypeCount(expect, "TCPSocket", before);
+  },
+  20_000,
+);


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/14329
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
