### PR TITLE
fix(bundler) fix pretty path resolution

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -349,7 +349,23 @@ pub const BakeEntryPoint = struct {
         return .{ .path = path, .graph = .client, .css = true };
     }
 };
+fn genericPathWithPrettyInitialized(path: Fs.Path, target: options.Target, top_level_dir: string, allocator: std.mem.Allocator) !Fs.Path {
+    // TODO: outbase
+    var buf: bun.PathBuffer = undefined;
+    const rel = bun.path.relativePlatform(top_level_dir, path.text, .loose, false);
+    var path_clone = path;
 
+    // stack-allocated temporary is not leaked because dupeAlloc on the path will
+    // move .pretty into the heap. that function also fixes some slash issues.
+    if (target == .bake_server_components_ssr) {
+        // the SSR graph needs different pretty names or else HMR mode will
+        // confuse the two modules.
+        path_clone.pretty = std.fmt.bufPrint(&buf, "ssr:{s}", .{rel}) catch buf[0..];
+    } else {
+        path_clone.pretty = rel;
+    }
+    return path_clone.dupeAllocFixPretty(allocator);
+}
 pub const BundleV2 = struct {
     bundler: *Bundler,
     /// When Server Component is enabled, this is used for the client bundles
@@ -2274,21 +2290,7 @@ pub const BundleV2 = struct {
     }
 
     fn pathWithPrettyInitialized(this: *BundleV2, path: Fs.Path, target: options.Target) !Fs.Path {
-        // TODO: outbase
-        var buf: bun.PathBuffer = undefined;
-        const rel = bun.path.relativePlatform(this.bundler.fs.top_level_dir, path.text, .loose, false);
-        var path_clone = path;
-
-        // stack-allocated temporary is not leaked because dupeAlloc on the path will
-        // move .pretty into the heap. that function also fixes some slash issues.
-        if (target == .bake_server_components_ssr) {
-            // the SSR graph needs different pretty names or else HMR mode will
-            // confuse the two modules.
-            path_clone.pretty = std.fmt.bufPrint(&buf, "ssr:{s}", .{rel}) catch buf[0..];
-        } else {
-            path_clone.pretty = rel;
-        }
-        return path_clone.dupeAllocFixPretty(this.graph.allocator);
+        return genericPathWithPrettyInitialized(path, target, this.bundler.fs.top_level_dir, this.graph.allocator);
     }
 
     fn reserveSourceIndexesForBake(this: *BundleV2) !void {
@@ -5012,6 +5014,13 @@ pub const LinkerContext = struct {
     /// Used by Bake to extract []CompileResult before it is joined
     dev_server: ?*bun.bake.DevServer = null,
     framework: ?*const bake.Framework = null,
+
+    fn pathWithPrettyInitialized(this: *LinkerContext, path: Fs.Path) !Fs.Path {
+        if (path.text.ptr != path.pretty.ptr) {
+            return path;
+        }
+        return genericPathWithPrettyInitialized(path, this.options.target, this.resolver.fs.top_level_dir, this.graph.allocator);
+    }
 
     pub const LinkerOptions = struct {
         output_format: options.Format = .esm,
@@ -9583,10 +9592,7 @@ pub const LinkerContext = struct {
                     if (source.path.isFile()) {
                         // Use the pretty path as the file name since it should be platform-
                         // independent (relative paths and the "/" path separator)
-                        if (source.path.pretty.ptr == source.path.text.ptr) {
-                            const rel = bun.path.relativePlatform(c.resolver.fs.top_level_dir, source.path.text, .loose, false);
-                            source.path.pretty = c.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
-                        }
+                        source.path.* = pathWithPrettyInitialized(source.path);
                         source.path.assertPrettyIsValid();
 
                         break :brk source.path.pretty;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9590,7 +9590,7 @@ pub const LinkerContext = struct {
                         // Use the pretty path as the file name since it should be platform-
                         // independent (relative paths and the "/" path separator)
                         if (source.path.text.ptr == source.path.pretty.ptr) {
-                            source.path = c.pathWithPrettyInitialized(source.path);
+                            source.path = c.pathWithPrettyInitialized(source.path) catch bun.outOfMemory();
                         }
                         source.path.assertPrettyIsValid();
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -5016,9 +5016,6 @@ pub const LinkerContext = struct {
     framework: ?*const bake.Framework = null,
 
     fn pathWithPrettyInitialized(this: *LinkerContext, path: Fs.Path) !Fs.Path {
-        if (path.text.ptr != path.pretty.ptr) {
-            return path;
-        }
         return genericPathWithPrettyInitialized(path, this.options.target, this.resolver.fs.top_level_dir, this.graph.allocator);
     }
 
@@ -9592,7 +9589,9 @@ pub const LinkerContext = struct {
                     if (source.path.isFile()) {
                         // Use the pretty path as the file name since it should be platform-
                         // independent (relative paths and the "/" path separator)
-                        source.path.* = pathWithPrettyInitialized(source.path);
+                        if (source.path.text.ptr != source.path.pretty.ptr) {
+                            source.path = pathWithPrettyInitialized(source.path);
+                        }
                         source.path.assertPrettyIsValid();
 
                         break :brk source.path.pretty;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9589,8 +9589,8 @@ pub const LinkerContext = struct {
                     if (source.path.isFile()) {
                         // Use the pretty path as the file name since it should be platform-
                         // independent (relative paths and the "/" path separator)
-                        if (source.path.text.ptr != source.path.pretty.ptr) {
-                            source.path = pathWithPrettyInitialized(source.path);
+                        if (source.path.text.ptr == source.path.pretty.ptr) {
+                            source.path = c.pathWithPrettyInitialized(source.path);
                         }
                         source.path.assertPrettyIsValid();
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -9583,9 +9583,8 @@ pub const LinkerContext = struct {
                     if (source.path.isFile()) {
                         // Use the pretty path as the file name since it should be platform-
                         // independent (relative paths and the "/" path separator)
-                        const path = source.path;
-                        if (path.pretty.ptr == path.text.ptr) {
-                            const rel = bun.path.relativePlatform(c.resolver.fs.top_level_dir, path.text, .loose, false);
+                        if (source.path.pretty.ptr == source.path.text.ptr) {
+                            const rel = bun.path.relativePlatform(c.resolver.fs.top_level_dir, source.path.text, .loose, false);
                             source.path.pretty = c.graph.allocator.dupe(u8, rel) catch bun.outOfMemory();
                         }
                         source.path.assertPrettyIsValid();

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
-import fs from "node:fs";
-import path from "node:path";
+import fs, { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import path, { join } from "node:path";
+import { isWindows } from "harness";
 
 describe("bun build", () => {
   test("warnings dont return exit code 1", () => {
@@ -77,5 +78,58 @@ describe("bun build", () => {
     });
     expect(stdout.toString()).toContain(path.join(baseDir, "我") + "\n");
     expect(stdout.toString()).toContain(path.join(baseDir, "我", "我.ts") + "\n");
+  });
+
+  test.skipIf(!isWindows)("should be able to handle pretty path when using pnpm + build", async () => {
+    // this test code follows the same structure as and
+    // is based on the code for testing issue 4893
+
+    let testDir = tmpdirSync();
+
+    // Clean up from prior runs if necessary
+    rmSync(testDir, { recursive: true, force: true });
+
+    // Create a directory with our test file
+    mkdirSync(testDir, { recursive: true });
+
+    writeFileSync(
+      join(testDir, "index.ts"),
+      "import chalk from \"chalk\"; export function main() { console.log(chalk.red('Hello, World!')); }",
+    );
+    writeFileSync(
+      join(testDir, "package.json"),
+      `
+  {
+  "dependencies": {
+    "chalk": "^5.3.0"
+  }
+}`,
+    );
+    testDir = realpathSync(testDir);
+
+    Bun.spawnSync({
+      cmd: ["pnpm", "i"],
+      env: bunEnv,
+      stderr: "pipe",
+      cwd: testDir,
+    });
+    // bun build --entrypoints ./index.ts --outdir ./dist --target node
+    const { stderr, exitCode } = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "build",
+        "--entrypoints",
+        join(testDir, "index.ts"),
+        "--outdir",
+        join(testDir, "dist"),
+        "--target",
+        "node",
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    expect(stderr.toString()).toBe("");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -80,7 +80,7 @@ describe("bun build", () => {
     expect(stdout.toString()).toContain(path.join(baseDir, "我", "我.ts") + "\n");
   });
 
-  test.skipIf(!isWindows)("should be able to handle pretty path when using pnpm + build", async () => {
+  test.skipIf(!isWindows)("should be able to handle pretty path when using pnpm +  #14685", async () => {
     // this test code follows the same structure as and
     // is based on the code for testing issue 4893
 
@@ -108,7 +108,7 @@ describe("bun build", () => {
     testDir = realpathSync(testDir);
 
     Bun.spawnSync({
-      cmd: ["pnpm", "i"],
+      cmd: [bunExe(), "x", "pnpm@9", "i"],
       env: bunEnv,
       stderr: "pipe",
       cwd: testDir,
@@ -132,4 +132,4 @@ describe("bun build", () => {
     expect(stderr.toString()).toBe("");
     expect(exitCode).toBe(0);
   });
-});
+}, 10_000);

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -134,7 +134,7 @@ describe("bun build", () => {
   });
 }, 10_000);
 
-it.skipIf(!isWindows)("should be able to handle pretty path on windows #13897", async () => {
+test.skipIf(!isWindows)("should be able to handle pretty path on windows #13897", async () => {
   // this test code follows the same structure as and
   // is based on the code for testing issue 4893
 


### PR DESCRIPTION
### What does this PR do?
Fix:  https://github.com/oven-sh/bun/issues/15103
Fix: https://github.com/oven-sh/bun/issues/14835
Fix: https://github.com/oven-sh/bun/issues/14688
Fix: https://github.com/oven-sh/bun/issues/14590
Fix: https://github.com/oven-sh/bun/issues/13897
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
