### PR TITLE
fix(guide): snapshot doc URL and description

### DIFF
--- a/docs/guides/test/snapshot.md
+++ b/docs/guides/test/snapshot.md
@@ -96,4 +96,4 @@ Ran 1 tests across 1 files. [102.00ms]
 
 ---
 
-See [Docs > Test Runner > Snapshots](https://bun.sh/docs/test/mocks) for complete documentation on mocking with the Bun test runner.
+See [Docs > Test Runner > Snapshots](https://bun.sh/docs/test/snapshots) for complete documentation on snapshot testing with the Bun test runner.


### PR DESCRIPTION
### What does this PR do?

This fix a wrong URL on the snapshot guide page on the https://bun.sh/guides/test/snapshot from https://bun.sh/docs/test/mocks to https://bun.sh/docs/test/snapshots

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

N/A: Documentation changes