### PR TITLE
cpp: Bun::toStringRef: return dead when exception has been thrown

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -149,7 +149,7 @@ BunString toStringRef(JSC::JSGlobalObject* globalObject, JSValue value)
 {
     auto str = value.toWTFString(globalObject);
     if (str.isEmpty()) {
-        return { BunStringTag::Empty };
+        return { BunStringTag::Dead };
     }
 
     StringImpl* impl = str.impl();

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -116,11 +116,9 @@ BunString toString(const char* bytes, size_t length)
 BunString fromJS(JSC::JSGlobalObject* globalObject, JSValue value)
 {
     WTF::String str = value.toWTFString(globalObject);
-
     if (UNLIKELY(str.isNull())) {
         return { BunStringTag::Dead };
     }
-
     if (UNLIKELY(str.length() == 0)) {
         return { BunStringTag::Empty };
     }
@@ -148,8 +146,11 @@ BunString toString(JSC::JSGlobalObject* globalObject, JSValue value)
 BunString toStringRef(JSC::JSGlobalObject* globalObject, JSValue value)
 {
     auto str = value.toWTFString(globalObject);
-    if (str.isEmpty()) {
+    if (UNLIKELY(str.isNull())) {
         return { BunStringTag::Dead };
+    }
+    if (UNLIKELY(str.length() == 0)) {
+        return { BunStringTag::Empty };
     }
 
     StringImpl* impl = str.impl();


### PR DESCRIPTION
tag is compared against here https://github.com/oven-sh/bun/blob/bun-v1.1.34/src/bun.js/bindings/BunString.cpp#L64
`::Empty` is `""`
`::Dead` means a JS exception has been thrown and we need to detect that

`Bun::toString` already does this correctly