### PR TITLE
zig: remove JSValue.isEmpty

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -453,7 +453,7 @@ pub const TablePrinter = struct {
                 value = row_value.getOwn(this.globalObject, col.name) orelse JSValue.zero;
             }
 
-            if (value.isEmpty()) {
+            if (value == .zero) {
                 try writer.writeByteNTimes(' ', col.width + (PADDING * 2));
             } else {
                 const len: u32 = this.getWidthForValue(value);
@@ -2259,7 +2259,7 @@ pub const Formatter = struct {
                             this.addForNewLine(2);
                         }
 
-                        if (element.isEmpty()) {
+                        if (element == .zero) {
                             empty_start = 0;
                             break :first;
                         }
@@ -2278,7 +2278,7 @@ pub const Formatter = struct {
 
                     while (i < len) : (i += 1) {
                         const element = value.getDirectIndex(this.globalThis, i);
-                        if (element.isEmpty()) {
+                        if (element == .zero) {
                             if (empty_start == null) {
                                 empty_start = i;
                             }

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -4320,7 +4320,7 @@ pub const FFIObject = struct {
         value: JSValue,
         byteOffset: ?JSValue,
     ) JSValue {
-        if (value.isEmpty()) {
+        if (value == .zero) {
             return JSC.JSValue.jsNull();
         }
 

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -667,7 +667,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
 
                 while (iter.next()) |key_| {
                     const value = iter.value;
-                    if (value.isEmpty()) continue;
+                    if (value == .zero) continue;
 
                     const key = try key_.toOwnedSlice(bun.default_allocator);
 
@@ -1090,12 +1090,12 @@ pub fn transformSync(
             return .zero;
         }
     }
-    if (!js_ctx_value.isEmpty()) {
+    if (js_ctx_value != .zero) {
         js_ctx_value.ensureStillAlive();
     }
 
     defer {
-        if (!js_ctx_value.isEmpty()) {
+        if (js_ctx_value != .zero) {
             js_ctx_value.ensureStillAlive();
         }
     }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2000,7 +2000,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
                 if (class_name.eqlComptime("Response")) {
                     Output.errGeneric("Expected a native Response object, but received a polyfilled Response object. Bun.serve() only supports native Response objects.", .{});
-                } else if (!value.isEmpty() and !globalThis.hasException()) {
+                } else if (value != .zero and !globalThis.hasException()) {
                     var formatter = JSC.ConsoleObject.Formatter{
                         .globalThis = globalThis,
                         .quote_strings = true,
@@ -2500,7 +2500,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.flags.has_finalized = true;
             }
 
-            if (!this.response_jsvalue.isEmpty()) {
+            if (this.response_jsvalue != .zero) {
                 ctxLog("finalizeWithoutDeinit: response_jsvalue != .zero", .{});
                 if (this.flags.response_protected) {
                     this.response_jsvalue.unprotect();
@@ -3698,7 +3698,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         ) void {
             JSC.markBinding(@src());
             if (this.server) |server| {
-                if (!server.config.onError.isEmpty() and !this.flags.has_called_error_handler) {
+                if (server.config.onError != .zero and !this.flags.has_called_error_handler) {
                     this.flags.has_called_error_handler = true;
                     const result = server.config.onError.call(
                         server.globalThis,
@@ -4878,7 +4878,7 @@ pub const ServerWebSocket = struct {
             return .zero;
         }
 
-        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
             globalThis.throw("publish expects compress to be a boolean", .{});
             return .zero;
         }
@@ -4960,7 +4960,7 @@ pub const ServerWebSocket = struct {
         var topic_slice = topic_value.toSlice(globalThis, bun.default_allocator);
         defer topic_slice.deinit();
 
-        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
             globalThis.throw("publishText expects compress to be a boolean", .{});
             return .zero;
         }
@@ -5026,7 +5026,7 @@ pub const ServerWebSocket = struct {
             return .zero;
         }
 
-        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
             globalThis.throw("publishBinary expects compress to be a boolean", .{});
             return .zero;
         }
@@ -5202,7 +5202,7 @@ pub const ServerWebSocket = struct {
         const message_value = args.ptr[0];
         const compress_value = args.ptr[1];
 
-        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
             globalThis.throw("send expects compress to be a boolean", .{});
             return .zero;
         }
@@ -5276,7 +5276,7 @@ pub const ServerWebSocket = struct {
         const message_value = args.ptr[0];
         const compress_value = args.ptr[1];
 
-        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
             globalThis.throw("sendText expects compress to be a boolean", .{});
             return .zero;
         }
@@ -5360,7 +5360,7 @@ pub const ServerWebSocket = struct {
         const message_value = args.ptr[0];
         const compress_value = args.ptr[1];
 
-        if (!compress_value.isBoolean() and !compress_value.isUndefined() and !compress_value.isEmpty()) {
+        if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
             globalThis.throw("sendBinary expects compress to be a boolean", .{});
             return .zero;
         }
@@ -5553,7 +5553,7 @@ pub const ServerWebSocket = struct {
         }
 
         const code = brk: {
-            if (args.ptr[0].isEmpty() or args.ptr[0].isUndefined()) {
+            if (args.ptr[0] == .zero or args.ptr[0].isUndefined()) {
                 // default exception code
                 break :brk 1000;
             }
@@ -5567,7 +5567,7 @@ pub const ServerWebSocket = struct {
         };
 
         var message_value: ZigString.Slice = brk: {
-            if (args.ptr[1].isEmpty() or args.ptr[1].isUndefined()) break :brk ZigString.Slice.empty;
+            if (args.ptr[1] == .zero or args.ptr[1].isUndefined()) break :brk ZigString.Slice.empty;
 
             if (args.ptr[1].toSliceOrNull(globalThis)) |slice| {
                 break :brk slice;

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -479,7 +479,7 @@ pub const ArrayBuffer = extern struct {
     const log = Output.scoped(.ArrayBuffer, false);
 
     pub fn toJS(this: ArrayBuffer, ctx: JSC.C.JSContextRef, exception: JSC.C.ExceptionRef) JSC.JSValue {
-        if (!this.value.isEmpty()) {
+        if (this.value != .zero) {
             return this.value;
         }
 
@@ -519,7 +519,7 @@ pub const ArrayBuffer = extern struct {
         callback: JSC.C.JSTypedArrayBytesDeallocator,
         exception: JSC.C.ExceptionRef,
     ) JSC.JSValue {
-        if (!this.value.isEmpty()) {
+        if (this.value != .zero) {
             return this.value;
         }
 

--- a/src/bun.js/bindings/JSPropertyIterator.zig
+++ b/src/bun.js/bindings/JSPropertyIterator.zig
@@ -58,7 +58,7 @@ pub fn JSPropertyIterator(comptime options: JSPropertyIteratorOptions) type {
             var name = bun.String.dead;
             if (comptime options.include_value) {
                 const current = Bun__JSPropertyIterator__getNameAndValue(this.impl, this.globalObject, this.object, &name, i);
-                if (current.isEmpty()) {
+                if (current == .zero) {
                     return this.next();
                 }
                 current.ensureStillAlive();

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2434,7 +2434,7 @@ pub const JSPromise = extern struct {
     }
 
     pub fn wrapValue(globalObject: *JSGlobalObject, value: JSValue) JSValue {
-        if (value.isEmpty()) {
+        if (value == .zero) {
             return resolvedPromiseValue(globalObject, JSValue.jsUndefined());
         } else if (value.isEmptyOrUndefinedOrNull() or !value.isCell()) {
             return resolvedPromiseValue(globalObject, value);
@@ -4169,9 +4169,7 @@ pub const JSValue = enum(JSValueReprInt) {
     pub fn jsType(
         this: JSValue,
     ) JSType {
-        if (comptime bun.Environment.allow_assert) {
-            bun.assert(!this.isEmpty());
-        }
+        bun.assert(this != .zero);
         return cppFn("jsType", .{this});
     }
 
@@ -4793,13 +4791,6 @@ pub const JSValue = enum(JSValueReprInt) {
             else => false,
         };
     }
-    /// Empty as in "JSValue {}" rather than an empty string
-    pub inline fn isEmpty(this: JSValue) bool {
-        return switch (@intFromEnum(this)) {
-            0 => true,
-            else => false,
-        };
-    }
     pub fn isBoolean(this: JSValue) bool {
         return cppFn("isBoolean", .{this});
     }
@@ -5274,6 +5265,7 @@ pub const JSValue = enum(JSValueReprInt) {
 
     /// Equivalent to `obj.property` in JavaScript.
     /// Reminder: `undefined` is a value!
+    // TODO: change the return of this from `?JSValue` to `bun.JSError!JSValue`
     pub fn get(this: JSValue, global: *JSGlobalObject, property: []const u8) ?JSValue {
         if (comptime bun.Environment.isDebug) {
             if (BuiltinName.has(property)) {
@@ -5282,7 +5274,7 @@ pub const JSValue = enum(JSValueReprInt) {
         }
 
         const value = getIfPropertyExistsImpl(this, global, property.ptr, @as(u32, @intCast(property.len)));
-        return if (value.isEmpty()) null else value;
+        return if (value == .zero) null else value;
     }
 
     extern fn JSC__JSValue__getOwn(value: JSValue, globalObject: *JSGlobalObject, propertyName: [*c]const bun.String) JSValue;

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2764,7 +2764,7 @@ pub const Arguments = struct {
                         mode = JSC.Node.modeFromJS(ctx, mode_, exception) orelse mode;
                         if (exception.* != null) return null;
                     }
-                } else if (!val.isEmpty()) {
+                } else if (val != .zero) {
                     if (!val.isUndefinedOrNull()) {
                         // error is handled below
                         flags = FileSystemFlags.fromJS(ctx, val, exception) orelse flags;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1902,7 +1902,7 @@ fn formatLabel(globalThis: *JSGlobalObject, label: string, function_args: []JSVa
 
             switch (label[idx + 1]) {
                 's' => {
-                    try consumeArg(globalThis, !current_arg.isEmpty() and current_arg.jsType().isString(), &idx, &args_idx, &list, &current_arg, "%s");
+                    try consumeArg(globalThis, current_arg != .zero and current_arg.jsType().isString(), &idx, &args_idx, &list, &current_arg, "%s");
                 },
                 'i' => {
                     try consumeArg(globalThis, current_arg.isAnyInt(), &idx, &args_idx, &list, &current_arg, "%i");
@@ -2144,7 +2144,7 @@ inline fn createEach(
     }
 
     var array = args[0];
-    if (array.isEmpty() or !array.jsType().isArray()) {
+    if (array == .zero or !array.jsType().isArray()) {
         globalThis.throwPretty("{s} expects an array", .{signature});
         return .zero;
     }

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -195,7 +195,7 @@ pub const TextEncoder = struct {
             return .undefined;
         }
 
-        if (array.isEmpty()) {
+        if (array == .zero) {
             array = JSC.JSValue.createUninitializedUint8Array(globalThis, length);
             array.ensureStillAlive();
             @memcpy(array.asArrayBuffer(globalThis).?.ptr[0..length], buf_to_use[0..length]);

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -8450,7 +8450,7 @@ pub const Macro = struct {
             var js_args: []JSC.JSValue = &.{};
             var js_processed_args_len: usize = 0;
             defer {
-                for (js_args[0..js_processed_args_len -| @as(usize, @intFromBool(!javascript_object.isEmpty()))]) |arg| {
+                for (js_args[0..js_processed_args_len -| @as(usize, @intFromBool(javascript_object != .zero))]) |arg| {
                     arg.unprotect();
                 }
 
@@ -8462,7 +8462,7 @@ pub const Macro = struct {
             switch (caller.data) {
                 .e_call => |call| {
                     const call_args: []Expr = call.args.slice();
-                    js_args = try allocator.alloc(JSC.JSValue, call_args.len + @as(usize, @intFromBool(!javascript_object.isEmpty())));
+                    js_args = try allocator.alloc(JSC.JSValue, call_args.len + @as(usize, @intFromBool(javascript_object != .zero)));
                     js_processed_args_len = js_args.len;
 
                     for (0.., call_args, js_args[0..call_args.len]) |i, in, *out| {
@@ -8487,7 +8487,7 @@ pub const Macro = struct {
                 },
             }
 
-            if (!javascript_object.isEmpty()) {
+            if (javascript_object != .zero) {
                 if (js_args.len == 0) {
                     js_args = try allocator.alloc(JSC.JSValue, 1);
                 }

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -617,7 +617,7 @@ pub export fn napi_set_element(env: napi_env, object_: napi_value, index: c_uint
     if (!object.jsType().isIndexable()) {
         return .array_expected;
     }
-    if (value.isEmpty())
+    if (value == .zero)
         return invalidArg();
     JSC.C.JSObjectSetPropertyAtIndex(env.ref(), object.asObjectRef(), index, value.asObjectRef(), TODO_EXCEPTION);
     return .ok;
@@ -1004,7 +1004,7 @@ pub export fn napi_is_promise(_: napi_env, value_: napi_value, is_promise_: ?*bo
         return invalidArg();
     };
 
-    if (value.isEmpty()) {
+    if (value == .zero) {
         return invalidArg();
     }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3284,7 +3284,7 @@ pub const Resolver = struct {
         bun.JSC.markBinding(@src());
         const argument: bun.JSC.JSValue = callframe.argument(0);
 
-        if (argument.isEmpty() or !argument.isString()) {
+        if (argument == .zero or !argument.isString()) {
             globalThis.throwInvalidArgumentType("nodeModulePaths", "path", "string");
             return .zero;
         }

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -3782,7 +3782,7 @@ pub fn handleTemplateValue(
     jsobjref_buf: []u8,
 ) !bool {
     var builder = ShellSrcBuilder.init(globalThis, out_script, jsstrings);
-    if (template_value == .zero) {
+    if (template_value != .zero) {
         if (template_value.asArrayBuffer(globalThis)) |array_buffer| {
             _ = array_buffer;
             const idx = out_jsobjs.items.len;

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -3782,7 +3782,7 @@ pub fn handleTemplateValue(
     jsobjref_buf: []u8,
 ) !bool {
     var builder = ShellSrcBuilder.init(globalThis, out_script, jsstrings);
-    if (!template_value.isEmpty()) {
+    if (template_value == .zero) {
         if (template_value.asArrayBuffer(globalThis)) |array_buffer| {
             _ = array_buffer;
             const idx = out_jsobjs.items.len;


### PR DESCRIPTION
progress towards zig JSValue stability and safety
making these direct comparisons to `.zero` makes it clearer to the reader what we're dealing with
and eases the transition to remove `.zero` later