### PR TITLE
ci: upload-release.sh: add missing error message in send_bench_webhook

### DIFF
--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -165,7 +165,8 @@ function upload_s3_file() {
 function send_bench_webhook() {
   if [ -z "$BENCHMARK_URL" ]; then
     echo "error: \$BENCHMARK_URL is not set"
-    exit 1
+    # exit 1 # TODO: this isn't live yet
+    return
   fi
 
   local tag="$1"

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -164,7 +164,8 @@ function upload_s3_file() {
 
 function send_bench_webhook() {
   if [ -z "$BENCHMARK_URL" ]; then
-    return 1
+    echo "error: \$BENCHMARK_URL is not set"
+    exit 1
   fi
 
   local tag="$1"


### PR DESCRIPTION
noticed because main branch ci is running into it
now if this fails again we'll know exactly why