### PR TITLE
Remove assertion in js printer triggering for unicode comments

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -933,9 +933,6 @@ fn NewPrinter(
                     p.writer.print(@TypeOf(span), span);
                 },
                 else => {
-                    if (Environment.allow_assert and ascii_only) {
-                        for (str) |char| std.debug.assert(char > 0 and char < 0x80);
-                    }
                     p.writer.print(StringType, str);
                 },
             }

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -93,4 +93,13 @@ error: Hello World`,
       },
     },
   });
+  itBundled("bun/unicode comment", {
+    target: "bun",
+    files: {
+      "/a.ts": /* js */ `
+        /* æ */
+      `,
+    },
+    run: { stdout: "" },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Removes the assertion I added to check that output is all ascii because `/* æ */` would trigger it. It is fine to have a utf-8 comment within a latin-1 file because the comment contents is ignored by javascriptcore.