### PR TITLE
Shrink the CSS parser

### DIFF
--- a/src/css/declaration.zig
+++ b/src/css/declaration.zig
@@ -153,7 +153,7 @@ pub const DeclarationBlock = struct {
         context: *css.PropertyHandlerContext,
     ) void {
         const handle = struct {
-            inline fn handle(
+            fn handle(
                 self: *This,
                 ctx: *css.PropertyHandlerContext,
                 hndlr: *DeclarationHandler,
@@ -299,12 +299,12 @@ pub fn parse_declaration(
         property_id: css.PropertyId,
         options: *const css.ParserOptions,
     };
-    var closure = Closure{
+    const closure = Closure{
         .property_id = property_id,
         .options = options,
     };
-    const property = switch (input.parseUntilBefore(delimiters, css.Property, &closure, struct {
-        pub fn parseFn(this: *Closure, input2: *css.Parser) Result(css.Property) {
+    const property = switch (input.parseUntilBefore(delimiters, css.Property, *const Closure, &closure, struct {
+        pub fn parseFn(this: *const Closure, input2: *css.Parser) Result(css.Property) {
             return css.Property.parse(this.property_id, input2, this.options);
         }
     }.parseFn)) {

--- a/src/css/media_query.zig
+++ b/src/css/media_query.zig
@@ -49,7 +49,7 @@ pub const MediaList = struct {
     pub fn parse(input: *css.Parser) Result(MediaList) {
         var media_queries = ArrayList(MediaQuery){};
         while (true) {
-            const mq = switch (input.parseUntilBefore(css.Delimiters{ .comma = true }, MediaQuery, {}, css.voidWrap(MediaQuery, MediaQuery.parse))) {
+            const mq = switch (input.parseUntilBefore(css.Delimiters{ .comma = true }, MediaQuery, void, {}, css.voidWrap(MediaQuery, MediaQuery.parse))) {
                 .result => |v| v,
                 .err => |e| {
                     if (e.kind == .basic and e.kind.basic == .end_of_input) break;

--- a/src/css/printer.zig
+++ b/src/css/printer.zig
@@ -198,7 +198,7 @@ pub fn Printer(comptime Writer: type) type {
             };
         }
 
-        pub inline fn getImportRecords(this: *This) PrintErr!*const bun.BabyList(bun.ImportRecord) {
+        pub fn getImportRecords(this: *This) PrintErr!*const bun.BabyList(bun.ImportRecord) {
             if (this.import_records) |import_records| return import_records;
             try this.addNoImportRecordError();
             unreachable;
@@ -215,13 +215,13 @@ pub fn Printer(comptime Writer: type) type {
             return this.addNoImportRecordError();
         }
 
-        pub inline fn importRecord(this: *Printer(Writer), import_record_idx: u32) PrintErr!*const bun.ImportRecord {
+        pub fn importRecord(this: *Printer(Writer), import_record_idx: u32) PrintErr!*const bun.ImportRecord {
             if (this.import_records) |import_records| return import_records.at(import_record_idx);
             try this.addNoImportRecordError();
             unreachable;
         }
 
-        pub inline fn getImportRecordUrl(this: *This, import_record_idx: u32) PrintErr![]const u8 {
+        pub fn getImportRecordUrl(this: *This, import_record_idx: u32) PrintErr![]const u8 {
             return (try this.importRecord(import_record_idx)).path.text;
         }
 

--- a/src/css/rules/style.zig
+++ b/src/css/rules/style.zig
@@ -241,7 +241,7 @@ pub fn StyleRule(comptime R: type) type {
 
         /// Returns whether this rule is a duplicate of another rule.
         /// This means it has the same selectors and properties.
-        pub inline fn isDuplicate(this: *const This, other: *const This) bool {
+        pub fn isDuplicate(this: *const This, other: *const This) bool {
             return this.declarations.len() == other.declarations.len() and
                 this.selectors.eql(&other.selectors) and
                 brk: {

--- a/src/css/selectors/parser.zig
+++ b/src/css/selectors/parser.zig
@@ -1550,7 +1550,7 @@ pub fn GenericSelectorList(comptime Impl: type) type {
                     .nesting_requirement = nesting_requirement,
                     .parser = parser,
                 };
-                const selector = input.parseUntilBefore(css.Delimiters{ .comma = true }, SelectorT, &closure, Closure.parsefn);
+                const selector = input.parseUntilBefore(css.Delimiters{ .comma = true }, SelectorT, *Closure, &closure, Closure.parsefn);
 
                 const was_ok = selector.isOk();
                 switch (selector) {
@@ -1610,7 +1610,7 @@ pub fn GenericSelectorList(comptime Impl: type) type {
                     .nesting_requirement = nesting_requirement,
                     .parser = parser,
                 };
-                const selector = input.parseUntilBefore(css.Delimiters{ .comma = true }, SelectorT, &closure, Closure.parsefn);
+                const selector = input.parseUntilBefore(css.Delimiters{ .comma = true }, SelectorT, *Closure, &closure, Closure.parsefn);
 
                 const was_ok = selector.isOk();
                 switch (selector) {

--- a/src/css/selectors/selector.zig
+++ b/src/css/selectors/selector.zig
@@ -866,7 +866,7 @@ pub const serialize = struct {
         }
 
         const Helpers = struct {
-            pub inline fn writePrefixed(
+            pub fn writePrefixed(
                 d: *Printer(W),
                 prefix: css.VendorPrefix,
                 comptime val: []const u8,
@@ -881,7 +881,7 @@ pub const serialize = struct {
                 try vp.toCss(W, d);
                 try d.writeStr(val);
             }
-            pub inline fn pseudo(
+            pub fn pseudo(
                 d: *Printer(W),
                 comptime key: []const u8,
                 comptime s: []const u8,
@@ -1583,7 +1583,7 @@ const CompoundSelectorIter = struct {
     ///  .split(|x| x.is_combinator()) // splits the slice into subslices by elements that match over the predicate
     ///  .rev() // reverse
     /// ```
-    pub inline fn next(this: *@This()) ?[]const parser.Component {
+    pub fn next(this: *@This()) ?[]const parser.Component {
         // Since we iterating backwards, we convert all indices into "backwards form" by doing `this.sel.components.items.len - 1 - i`
         while (this.i < this.sel.components.items.len) {
             const next_index: ?usize = next_index: {

--- a/src/css/small_list.zig
+++ b/src/css/small_list.zig
@@ -53,7 +53,7 @@ pub fn SmallList(comptime T: type, comptime N: comptime_int) type {
             var values: @This() = .{};
             while (true) {
                 input.skipWhitespace();
-                switch (input.parseUntilBefore(Delimiters{ .comma = true }, T, {}, parseFn)) {
+                switch (input.parseUntilBefore(Delimiters{ .comma = true }, T, void, {}, parseFn)) {
                     .result => |v| {
                         values.append(input.allocator(), v);
                     },

--- a/src/css/values/angle.zig
+++ b/src/css/values/angle.zig
@@ -170,7 +170,7 @@ pub const Angle = union(Tag) {
         };
     }
 
-    pub fn map(this: *const Angle, comptime opfn: *const fn (f32) f32) Angle {
+    pub fn map(this: *const Angle, opfn: *const fn (f32) f32) Angle {
         return switch (this.*) {
             .deg => |deg| .{ .deg = opfn(deg) },
             .rad => |rad| .{ .rad = opfn(rad) },
@@ -179,7 +179,7 @@ pub const Angle = union(Tag) {
         };
     }
 
-    pub fn tryMap(this: *const Angle, comptime opfn: *const fn (f32) f32) ?Angle {
+    pub fn tryMap(this: *const Angle, opfn: *const fn (f32) f32) ?Angle {
         return map(this, opfn);
     }
 
@@ -189,7 +189,7 @@ pub const Angle = union(Tag) {
                 return a + b;
             }
         };
-        return Angle.op(&this, &rhs, {}, addfn.add);
+        return Angle.op(&this, &rhs, void, {}, addfn.add);
     }
 
     pub fn tryAdd(this: *const Angle, _: std.mem.Allocator, rhs: *const Angle) ?Angle {
@@ -217,27 +217,30 @@ pub const Angle = union(Tag) {
     pub fn tryOp(
         this: *const Angle,
         other: *const Angle,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) f32,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, f32, f32) f32,
     ) ?Angle {
-        return Angle.op(this, other, ctx, op_fn);
+        return Angle.op(this, other, Ctx, ctx, op_fn);
     }
 
     pub fn tryOpTo(
         this: *const Angle,
         other: *const Angle,
         comptime R: type,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) R,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, f32, f32) R,
     ) ?R {
-        return Angle.opTo(this, other, R, ctx, op_fn);
+        return Angle.opTo(this, other, R, Ctx, ctx, op_fn);
     }
 
     pub fn op(
         this: *const Angle,
         other: *const Angle,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) f32,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, a: f32, b: f32) f32,
     ) Angle {
         // PERF: not sure if this is faster
         const self_tag: u8 = @intFromEnum(this.*);
@@ -261,8 +264,9 @@ pub const Angle = union(Tag) {
         this: *const Angle,
         other: *const Angle,
         comptime T: type,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) T,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, a: f32, b: f32) T,
     ) T {
         // PERF: not sure if this is faster
         const self_tag: u8 = @intFromEnum(this.*);

--- a/src/css/values/gradient.zig
+++ b/src/css/values/gradient.zig
@@ -538,7 +538,7 @@ pub const ConicGradient = struct {
 
     pub fn parse(input: *css.Parser) Result(ConicGradient) {
         const angle = input.tryParse(struct {
-            inline fn parse(i: *css.Parser) Result(Angle) {
+            fn parse(i: *css.Parser) Result(Angle) {
                 if (i.expectIdentMatching("from").asErr()) |e| return .{ .err = e };
                 // Spec allows unitless zero angles for gradients.
                 // https://w3c.github.io/csswg-drafts/css-images-4/#valdef-conic-gradient-angle
@@ -547,7 +547,7 @@ pub const ConicGradient = struct {
         }.parse, .{}).unwrapOr(Angle{ .deg = 0.0 });
 
         const position = input.tryParse(struct {
-            inline fn parse(i: *css.Parser) Result(Position) {
+            fn parse(i: *css.Parser) Result(Position) {
                 if (i.expectIdentMatching("at").asErr()) |e| return .{ .err = e };
                 return Position.parse(i);
             }
@@ -1543,6 +1543,7 @@ pub fn parseItems(comptime D: type, input: *css.Parser) Result(ArrayList(Gradien
         if (input.parseUntilBefore(
             css.Delimiters{ .comma = true },
             void,
+            Closure,
             Closure{ .items = &items, .seen_stop = &seen_stop },
             struct {
                 fn parse(closure: Closure, i: *css.Parser) Result(void) {

--- a/src/css/values/length.zig
+++ b/src/css/values/length.zig
@@ -373,7 +373,7 @@ pub const LengthValue = union(enum) {
         unreachable;
     }
 
-    pub fn map(this: *const @This(), comptime map_fn: *const fn (f32) f32) LengthValue {
+    pub fn map(this: *const @This(), map_fn: *const fn (f32) f32) LengthValue {
         inline for (comptime bun.meta.EnumFields(@This())) |field| {
             if (field.value == @intFromEnum(this.*)) {
                 return @unionInit(LengthValue, field.name, map_fn(@field(this, field.name)));
@@ -419,8 +419,9 @@ pub const LengthValue = union(enum) {
     pub fn tryOp(
         this: *const LengthValue,
         other: *const LengthValue,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) f32,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, f32, f32) f32,
     ) ?LengthValue {
         if (@intFromEnum(this.*) == @intFromEnum(other.*)) {
             inline for (bun.meta.EnumFields(LengthValue)) |field| {
@@ -445,8 +446,9 @@ pub const LengthValue = union(enum) {
         this: *const LengthValue,
         other: *const LengthValue,
         comptime R: type,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) R,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, f32, f32) R,
     ) ?R {
         if (@intFromEnum(this.*) == @intFromEnum(other.*)) {
             inline for (bun.meta.EnumFields(LengthValue)) |field| {
@@ -751,7 +753,7 @@ pub const Length = union(enum) {
         return null;
     }
 
-    pub fn tryMap(this: *const Length, comptime map_fn: *const fn (f32) f32) ?Length {
+    pub fn tryMap(this: *const Length, map_fn: *const fn (f32) f32) ?Length {
         return switch (this.*) {
             .value => |v| .{ .value = v.map(map_fn) },
             else => null,
@@ -761,11 +763,12 @@ pub const Length = union(enum) {
     pub fn tryOp(
         this: *const Length,
         other: *const Length,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) f32,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, f32, f32) f32,
     ) ?Length {
         if (this.* == .value and other.* == .value) {
-            if (this.value.tryOp(&other.value, ctx, op_fn)) |val| return .{ .value = val };
+            if (this.value.tryOp(&other.value, Ctx, ctx, op_fn)) |val| return .{ .value = val };
             return null;
         }
         return null;
@@ -775,11 +778,12 @@ pub const Length = union(enum) {
         this: *const Length,
         other: *const Length,
         comptime R: type,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) R,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, f32, f32) R,
     ) ?R {
         if (this.* == .value and other.* == .value) {
-            return this.value.tryOpTo(&other.value, R, ctx, op_fn);
+            return this.value.tryOpTo(&other.value, R, Ctx, ctx, op_fn);
         }
         return null;
     }

--- a/src/css/values/size.zig
+++ b/src/css/values/size.zig
@@ -71,14 +71,14 @@ pub fn Size2D(comptime T: type) type {
             return css.implementDeepClone(@This(), this, allocator);
         }
 
-        pub inline fn valEql(lhs: *const T, rhs: *const T) bool {
+        pub fn valEql(lhs: *const T, rhs: *const T) bool {
             return switch (T) {
                 f32 => lhs.* == rhs.*,
                 else => lhs.eql(rhs),
             };
         }
 
-        pub inline fn eql(lhs: *const @This(), rhs: *const @This()) bool {
+        pub fn eql(lhs: *const @This(), rhs: *const @This()) bool {
             return switch (T) {
                 f32 => lhs.a == rhs.b,
                 else => lhs.a.eql(&rhs.b),

--- a/src/css/values/time.zig
+++ b/src/css/values/time.zig
@@ -149,7 +149,7 @@ pub const Time = union(enum) {
         return css.generic.partialCmpF32(&this.toMs(), &other.toMs());
     }
 
-    pub fn map(this: *const @This(), comptime map_fn: *const fn (f32) f32) Time {
+    pub fn map(this: *const @This(), map_fn: *const fn (f32) f32) Time {
         return switch (this.*) {
             .seconds => Time{ .seconds = map_fn(this.seconds) },
             .milliseconds => Time{ .milliseconds = map_fn(this.milliseconds) },
@@ -166,8 +166,9 @@ pub const Time = union(enum) {
     pub fn op(
         this: *const Time,
         other: *const Time,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) f32,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, a: f32, b: f32) f32,
     ) Time {
         const self_tag: u16 = @intFromEnum(this.*);
         const other_tag: u16 = @intFromEnum(other.*);
@@ -188,8 +189,9 @@ pub const Time = union(enum) {
         this: *const Time,
         other: *const Time,
         comptime R: type,
-        ctx: anytype,
-        comptime op_fn: *const fn (@TypeOf(ctx), a: f32, b: f32) R,
+        comptime Ctx: type,
+        ctx: Ctx,
+        op_fn: *const fn (Ctx, a: f32, b: f32) R,
     ) R {
         const self_tag: u16 = @intFromEnum(this.*);
         const other_tag: u16 = @intFromEnum(other.*);


### PR DESCRIPTION
### What does this PR do?


Before:
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/2e5870ff-e325-4bdc-8e25-360a159ed1d5">

After:
<img width="997" alt="image" src="https://github.com/user-attachments/assets/f38e3125-a41a-423b-b515-f294f9e6d2b2">



### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
