### PR TITLE
node:https: fix prototype chain of Agent

### DIFF
--- a/src/js/internal/cluster/Worker.ts
+++ b/src/js/internal/cluster/Worker.ts
@@ -23,7 +23,7 @@ function Worker(options) {
     this.process.on("message", (message, handle) => this.emit("message", message, handle));
   }
 }
-Worker.prototype = Object.create(EventEmitter.prototype);
+$toClass(Worker, "Worker", EventEmitter);
 
 Worker.prototype.kill = function () {
   this.destroy.$apply(this, arguments);

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -877,7 +877,7 @@ function ReadStream(this: typeof ReadStream, pathOrFd, options) {
   $assert(overridden_fs);
   this[kFs] = overridden_fs;
 }
-ReadStream.prototype = Object.create(NativeReadable.prototype);
+$toClass(ReadStream, "ReadStream", NativeReadable);
 
 ReadStream.prototype._construct = function (callback) {
   if (NativeReadablePrototype._construct) {
@@ -1185,7 +1185,8 @@ var WriteStreamClass = (WriteStream = function WriteStream(path, options = defau
 });
 
 const NativeWritable = Stream.NativeWritable;
-const WriteStreamPrototype = (WriteStream.prototype = Object.create(NativeWritable.prototype));
+$toClass(WriteStream, "WriteStream", NativeWritable);
+const WriteStreamPrototype = WriteStream.prototype;
 
 Object.defineProperties(WriteStreamPrototype, {
   autoClose: {

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -277,7 +277,7 @@ function Agent(options = kEmptyObject) {
   this.defaultPort = options.defaultPort || 80;
   this.protocol = options.protocol || "http:";
 }
-Agent.prototype = Object.create(EventEmitter.prototype);
+$toClass(Agent, "Agent", EventEmitter);
 
 ObjectDefineProperty(Agent, "globalAgent", {
   get: function () {

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -42,7 +42,7 @@ function Agent(options) {
   this.maxCachedSessions = this.options.maxCachedSessions;
   if (this.maxCachedSessions === undefined) this.maxCachedSessions = 100;
 }
-Agent.prototype = Object.create(http.Agent.prototype);
+$toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = http.createConnection;
 
 var https = {

--- a/src/js/node/stream.ts
+++ b/src/js/node/stream.ts
@@ -5441,8 +5441,7 @@ function createNativeStreamReadable(Readable) {
     ptr.onClose = this[_onClose].bind(this);
     ptr.onDrain = this[_onDrain].bind(this);
   }
-  NativeReadable.prototype = {};
-  ObjectSetPrototypeOf(NativeReadable.prototype, Readable.prototype);
+  $toClass(NativeReadable, "NativeReadable", Readable);
 
   NativeReadable.prototype[_onClose] = function () {
     this.push(null);
@@ -5657,8 +5656,7 @@ function NativeWritable(pathOrFdOrSink, options = {}) {
 
   this[_pathOrFdOrSink] = pathOrFdOrSink;
 }
-Object.setPrototypeOf(NativeWritable, Writable);
-NativeWritable.prototype = Object.create(Writable.prototype);
+$toClass(NativeWritable, "NativeWritable", Writable);
 
 // These are confusingly two different fns for construct which initially were the same thing because
 // `_construct` is part of the lifecycle of Writable and is not called lazily,

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2390,3 +2390,7 @@ it("must set headersSent to true after headers are sent when using chunk encoded
     server.close();
   }
 });
+
+it("should work when sending https.request with agent:false", () => {
+  https.request("https://example.com/", { agent: false }).end();
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2391,6 +2391,12 @@ it("must set headersSent to true after headers are sent when using chunk encoded
   }
 });
 
-it("should work when sending https.request with agent:false", () => {
-  https.request("https://example.com/", { agent: false }).end();
+it("should work when sending https.request with agent:false", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const client = https.request("https://example.com/", { agent: false });
+  client.on("error", reject);
+  client.on("close", resolve);
+  client.end();
+  await promise;
 });
+


### PR DESCRIPTION
fixes https://github.com/oven-sh/bun/issues/14184
fixed a few others while i was here

code

```js
import { request } from "node:https";

request("https://example.com/", { agent: false }).end();
```

before

```
❯ bun index.js 
ConnectionRefused: Unable to connect. Is the computer able to access the url?
 path: "https://example.com:80/"

Bun v1.1.33 (macOS arm64)
```

after

```
❯ ~/src/bun2/build/debug/bun-debug index.js 
```
