### PR TITLE
Fix `node:net` not handling path in `listen`

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1204,8 +1204,20 @@ class Server extends EventEmitter {
         path = options.path;
         port = options.port;
 
+        const isLinux = process.platform === "linux";
+
+
         if (!Number.isSafeInteger(port) || port < 0) {
           if (path) {
+            const isAbstractPath = path.startsWith("\0");
+            if (isLinux && isAbstractPath && (options.writableAll || options.readableAll)) {
+              const message = `The argument 'options' can not set readableAll or writableAll to true when path is abstract unix socket. Received ${JSON.stringify(options)}`;
+
+              const error = new TypeError(message);
+              error.code = "ERR_INVALID_ARG_VALUE";
+              throw error;
+            }
+
             hostname = path;
             port = undefined;
           } else {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1201,7 +1201,7 @@ class Server extends EventEmitter {
 
         hostname = options.host;
         exclusive = options.exclusive === true;
-        const path = options.path;
+        path = options.path;
         port = options.port;
 
         if (!Number.isSafeInteger(port) || port < 0) {
@@ -1232,7 +1232,7 @@ class Server extends EventEmitter {
         // ipv6Only <boolean> For TCP servers, setting ipv6Only to true will disable dual-stack support, i.e., binding to host :: won't make 0.0.0.0 be bound. Default: false.
         // signal <AbortSignal> An AbortSignal that may be used to close a listening server.
 
-        if (typeof port.callback === "function") onListen = port?.callback;
+        if (typeof options.callback === "function") onListen = options?.callback;
       } else if (!Number.isSafeInteger(port) || port < 0) {
         port = 0;
       }

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -565,4 +565,26 @@ describe("net.createServer events", () => {
       }).catch(closeAndFail);
     });
   });
+
+  it("#8374", async () => {
+    const server = createServer();
+    const socketPath = join(tmpdir(), "test-unix-socket");
+
+
+    server.listen({ path: socketPath });
+
+
+    const address = server.address() as string;
+    expect(address).toBe(socketPath);
+
+    const client = await Bun.connect({
+      unix: socketPath,
+      socket: {
+        data() {},
+      }
+    });
+
+    client.end();
+    server.close();
+  });
 });

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -3,7 +3,7 @@ import { AddressInfo, createServer, Server, Socket } from "net";
 import { createTest } from "node-harness";
 import { tmpdir } from "os";
 import { join } from "path";
-import { unlinkSync } from "../fs/export-star-from";
+import { once } from "node:events";
 
 const { describe, expect, it, createCallCheckCtx } = createTest(import.meta.path);
 
@@ -571,9 +571,8 @@ describe("net.createServer events", () => {
     const server = createServer();
     const socketPath = join(tmpdir(), "test-unix-socket");
 
-    await new Promise<void>(resolve => {
-      server.listen({ path: socketPath }, () => resolve());
-    });
+    server.listen({ path: socketPath });
+    await once(server, "listening");
 
     try {
       const address = server.address() as string;

--- a/test/js/node/test/parallel/pipe-abstract-socket.test.js
+++ b/test/js/node/test/parallel/pipe-abstract-socket.test.js
@@ -12,47 +12,56 @@ if (!isLinux) {
 } else {
   describe("Abstract Unix socket tests", () => {
     const path = "\0abstract";
-    const expectedErrorMessage = "can not set readableAll or writableAllt to true when path is abstract unix socket";
+    const expectedErrorMessage = "The argument 'options' can not set readableAll or writableAll to true when path is abstract unix socket. Received";
 
     test("throws when setting readableAll to true", () => {
+      const options = {
+        path,
+        readableAll: true,
+      };
+
       expect(() => {
         const server = net.createServer(jest.fn());
-        server.listen({
-          path,
-          readableAll: true,
-        });
+        server.listen(options);
       }).toThrow(
         expect.objectContaining({
-          message: expect.any(String),
+          message: `${expectedErrorMessage} ${JSON.stringify(options)}`,
+          code: "ERR_INVALID_ARG_VALUE",
         }),
       );
     });
 
     test("throws when setting writableAll to true", () => {
+      const options = {
+        path,
+        writableAll: true,
+      } ;
+
       expect(() => {
         const server = net.createServer(jest.fn());
-        server.listen({
-          path,
-          writableAll: true,
-        });
+        server.listen(options);
       }).toThrow(
         expect.objectContaining({
-          message: expect.any(String),
+          message: `${expectedErrorMessage} ${JSON.stringify(options)}`,
+          code: "ERR_INVALID_ARG_VALUE",
         }),
       );
     });
 
     test("throws when setting both readableAll and writableAll to true", () => {
+      const options = {
+        path,
+        readableAll: true,
+        writableAll: true,
+      };
+
       expect(() => {
         const server = net.createServer(jest.fn());
-        server.listen({
-          path,
-          readableAll: true,
-          writableAll: true,
-        });
+        server.listen(options);
       }).toThrow(
         expect.objectContaining({
-          message: expect.any(String),
+          message: `${expectedErrorMessage} ${JSON.stringify(options)}`,
+          code: "ERR_INVALID_ARG_VALUE",
         }),
       );
     });


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/8374

Fixes abstract path issue in linux when `readableAll` or `writableAll` is set to true

bun 1.1.34:
![Screenshot 2024-11-15 at 14 57 55](https://github.com/user-attachments/assets/7e5b1734-6378-4c58-8148-ed9afee8d9bb)

node 22.11.0:
![Screenshot 2024-11-15 at 14 56 53](https://github.com/user-attachments/assets/ce696c36-176c-490f-a505-29f60b20949a)

bun-debug:
![Screenshot 2024-11-15 at 14 58 51](https://github.com/user-attachments/assets/116f2d2f-94ec-44de-b643-79ecd2530357)

