### PR TITLE
musl: fix 'bun upgrade'

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -87,7 +87,9 @@ pub const Version = struct {
 
     pub const arch_label = if (Environment.isAarch64) "aarch64" else "x64";
     pub const triplet = platform_label ++ "-" ++ arch_label;
-    const suffix = if (Environment.baseline) "-baseline" else "";
+    const suffix_abi = if (Environment.isMusl) "-musl" else "";
+    const suffix_cpu = if (Environment.baseline) "-baseline" else "";
+    const suffix = suffix_abi ++ suffix_cpu;
     pub const folder_name = "bun-" ++ triplet ++ suffix;
     pub const baseline_folder_name = "bun-" ++ triplet ++ "-baseline";
     pub const zip_filename = folder_name ++ ".zip";


### PR DESCRIPTION
progress towards https://github.com/oven-sh/bun/issues/918

before

```
error: 'bun upgrade' is unsupported on systems without ld

You are likely on an immutable system such as NixOS, where dynamic
libraries are stored in a global cache.

Please use your system's package manager to properly upgrade bun.
```

after

```
Downloading... error: Canary builds are not available for this platform yet

   Release: https://github.com/oven-sh/bun/releases/tag/canary
  Filename: bun-linux-x64-musl.zip
```

^ will work once there is a first canary release of musl