### PR TITLE
fix auto-install on windows when symlinks aren't available

### DIFF
--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -565,11 +565,8 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
         } else {
             var index_dir = bun.MakePath.makeOpenPath(cache_dir, name, .{}) catch break :create_index;
             defer index_dir.close();
-            index_dir.symLink(
-                final_path,
-                dest_name,
-                .{ .is_directory = true },
-            ) catch break :create_index;
+
+            bun.sys.symlinkat(final_path, bun.toFD(index_dir), dest_name).unwrap() catch break :create_index;
         }
     }
 

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -475,7 +475,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     };
     defer final_dir.close();
     // and get the fd path
-    const final_path = bun.getFdPath(
+    const final_path = bun.getFdPathZ(
         final_dir.fd,
         &final_path_buf,
     ) catch |err| {
@@ -538,18 +538,39 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
 
     // create an index storing each version of a package installed
     if (strings.indexOfChar(basename, '/') == null) create_index: {
-        var index_dir = bun.MakePath.makeOpenPath(cache_dir, name, .{}) catch break :create_index;
-        defer index_dir.close();
-        index_dir.symLink(
-            final_path,
-            switch (this.resolution.tag) {
-                .github => folder_name["@GH@".len..],
-                // trim "name@" from the prefix
-                .npm => folder_name[name.len + 1 ..],
-                else => folder_name,
-            },
-            .{ .is_directory = true },
-        ) catch break :create_index;
+        const dest_name = switch (this.resolution.tag) {
+            .github => folder_name["@GH@".len..],
+            // trim "name@" from the prefix
+            .npm => folder_name[name.len + 1 ..],
+            else => folder_name,
+        };
+
+        if (comptime Environment.isWindows) {
+            bun.MakePath.makePath(u8, cache_dir, name) catch {
+                break :create_index;
+            };
+
+            const dest_buf: bun.PathBuffer = undefined;
+            const dest_path = bun.path.joinAbsStringBufZ(
+                // only set once, should be fine to read not on main thread
+                this.package_manager.caceh_directory_path,
+                &dest_buf,
+                &.{ name, dest_name },
+                .windows,
+            );
+
+            bun.sys.sys_uv.symlinkUV(final_path, dest_path, bun.windows.libuv.UV_FS_SYMLINK_JUNCTION).unwrap() catch {
+                break :create_index;
+            };
+        } else {
+            var index_dir = bun.MakePath.makeOpenPath(cache_dir, name, .{}) catch break :create_index;
+            defer index_dir.close();
+            index_dir.symLink(
+                final_path,
+                dest_name,
+                .{ .is_directory = true },
+            ) catch break :create_index;
+        }
     }
 
     const ret_json_path = try FileSystem.instance.dirname_store.append(@TypeOf(json_path), json_path);

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -550,12 +550,12 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                 break :create_index;
             };
 
-            const dest_buf: bun.PathBuffer = undefined;
+            var dest_buf: bun.PathBuffer = undefined;
             const dest_path = bun.path.joinAbsStringBufZ(
                 // only set once, should be fine to read not on main thread
-                this.package_manager.caceh_directory_path,
+                this.package_manager.cache_directory_path,
                 &dest_buf,
-                &.{ name, dest_name },
+                &[_]string{ name, dest_name },
                 .windows,
             );
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1800,16 +1800,16 @@ pub fn readlink(in: [:0]const u8, buf: []u8) Maybe([:0]u8) {
     }
 }
 
-pub fn readlinkat(fd: bun.FileDescriptor, in: [:0]const u8, buf: []u8) Maybe([:0]const u8) {
+pub fn readlinkat(fd: bun.FileDescriptor, in: [:0]const u8, buf: []u8) Maybe([:0]u8) {
     while (true) {
         const rc = syscall.readlinkat(fd.cast(), in, buf.ptr, buf.len);
 
-        if (Maybe([:0]const u8).errnoSys(rc, .readlink)) |err| {
+        if (Maybe([:0]u8).errnoSys(rc, .readlink)) |err| {
             if (err.getErrno() == .INTR) continue;
             return err;
         }
         buf[@intCast(rc)] = 0;
-        return Maybe([:0]const u8){ .result = buf[0..@intCast(rc) :0] };
+        return Maybe([:0]u8){ .result = buf[0..@intCast(rc) :0] };
     }
 }
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -927,9 +927,9 @@ it("should add aliased dependency (GitHub)", async () => {
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache", "uglify"))).toEqual([
     "mishoo-UglifyJS-e219a9a@@@1",
   ]);
-  expect(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))).toBe(
-    join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"),
-  );
+  expect(
+    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))),
+  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,7 @@ import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
-import { join, relative } from "path";
+import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
   dummyAfterAll,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -23,7 +23,7 @@ import {
   runBunInstall,
   isWindows,
 } from "harness";
-import { join, sep } from "path";
+import { join, sep, resolve } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -3452,9 +3452,9 @@ it("should handle GitHub URL in dependencies (user/repo#commit-id)", async () =>
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache", "uglify"))).toEqual([
     "mishoo-UglifyJS-e219a9a@@@1",
   ]);
-  expect(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))).toBe(
-    join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"),
-  );
+  expect(
+    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))),
+  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -3518,9 +3518,9 @@ it("should handle GitHub URL in dependencies (user/repo#tag)", async () => {
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache", "uglify"))).toEqual([
     "mishoo-UglifyJS-e219a9a@@@1",
   ]);
-  expect(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))).toBe(
-    join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"),
-  );
+  expect(
+    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))),
+  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -3744,9 +3744,9 @@ it("should handle GitHub URL in dependencies (github:user/repo#tag)", async () =
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache", "uglify"))).toEqual([
     "mishoo-UglifyJS-e219a9a@@@1",
   ]);
-  expect(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))).toBe(
-    join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"),
-  );
+  expect(
+    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))),
+  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -3868,9 +3868,9 @@ it("should handle GitHub URL in dependencies (git://github.com/user/repo.git#com
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache", "uglify"))).toEqual([
     "mishoo-UglifyJS-e219a9a@@@1",
   ]);
-  expect(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))).toBe(
-    join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"),
-  );
+  expect(
+    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))),
+  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/registry/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/registry/__snapshots__/bun-install-registry.test.ts.snap
@@ -126,3 +126,11 @@ exports[`outdated NO_COLOR works 1`] = `
 |--------------------------------------|
 "
 `;
+
+exports[`auto-install symlinks (and junctions) are created correctly in the install cache 1`] = `
+"{
+  name: "is-number",
+  version: "2.0.0",
+}
+"
+`;

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -522,7 +522,6 @@ ${Object.keys(opts)
 
 describe("auto-install", () => {
   test("symlinks (and junctions) are created correctly in the install cache", async () => {
-    console.log(packageDir);
     const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "--print", "require('is-number')"],
       cwd: packageDir,
@@ -540,7 +539,7 @@ describe("auto-install", () => {
     expect(err).not.toContain("error:");
     expect(await exited).toBe(0);
 
-    expect(await readlink(join(packageDir, ".bun-cache", "is-number", "2.0.0@@localhost@@@1"))).toBe(
+    expect(resolve(await readlink(join(packageDir, ".bun-cache", "is-number", "2.0.0@@localhost@@@1")))).toBe(
       join(packageDir, ".bun-cache", "is-number@2.0.0@@localhost@@@1"),
     );
   });

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -520,6 +520,32 @@ ${Object.keys(opts)
   );
 });
 
+describe("auto-install", () => {
+  test("symlinks (and junctions) are created correctly in the install cache", async () => {
+    console.log(packageDir);
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "--print", "require('is-number')"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+      },
+    });
+
+    const out = await Bun.readableStreamToText(stdout);
+    expect(out).toMatchSnapshot();
+    const err = await Bun.readableStreamToText(stderr);
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    expect(await readlink(join(packageDir, ".bun-cache", "is-number", "2.0.0@@localhost@@@1"))).toBe(
+      join(packageDir, ".bun-cache", "is-number@2.0.0@@localhost@@@1"),
+    );
+  });
+});
+
 describe("certificate authority", () => {
   const mockRegistryFetch = function (opts?: any): (req: Request) => Promise<Response> {
     return async function (req: Request) {


### PR DESCRIPTION
### What does this PR do?
Uses junctions instead of symlinks in the install cache.

Most likely fixes #9201 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually and added a test.

There are a few tests that needed to be updated because libuv creates junctions with trailing slashes. The original reason is unknown, and recently there was a pr removing the trailing slashes.

https://github.com/libuv/libuv/pull/4582
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
