### PR TITLE
musl: fix third_party/prisma.test.ts

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -895,11 +895,21 @@ if(LINUX)
     )
   endif()
 
+  if(NOT ABI STREQUAL "musl")
+    target_link_options(${bun} PUBLIC
+      -static-libstdc++
+      -static-libgcc
+    )
+  else()
+    target_link_options(${bun} PUBLIC
+      -lstdc++
+      -lgcc
+    )
+  endif()
+
   target_link_options(${bun} PUBLIC
     --ld-path=${LLD_PROGRAM}
     -fno-pic
-    -static-libstdc++
-    -static-libgcc
     -Wl,-no-pie
     -Wl,-icf=safe
     -Wl,--as-needed


### PR DESCRIPTION
progress towards https://github.com/oven-sh/bun/issues/918

dynamically links libstdc++ and libgcc on musl so that all symbols are available for relocation when `require`ing node addons

example of the error before this patch

```
TypeError: Error relocating /var/lib/bun/bun/test/node_modules/@napi-rs/canvas-linux-x64-musl/skia.linux-x64-musl.node: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructEmc: symbol not found
```

node also exhibits this behavior on musl/alpine

```
/ # ldd `which node`
    /lib/ld-musl-aarch64.so.1 (0xffff8a9a0000)
    libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0xffff84000000)
    libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0xffff8a96f000)
    libc.musl-aarch64.so.1 => /lib/ld-musl-aarch64.so.1 (0xffff8a9a0000)
```
