### PR TITLE
Introduce InspectorLifecycleAgent and InspectorTestReporterAgent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 *.db
 *.dmg
 *.dSYM
+*.generated.ts
 *.jsb
 *.lib
 *.log
@@ -53,8 +54,8 @@
 /test-report.md
 /test.js
 /test.ts
-/testdir
 /test.zig
+/testdir
 build
 build.ninja
 bun-binary
@@ -111,8 +112,10 @@ pnpm-lock.yaml
 profile.json
 README.md.template
 release/
+scripts/env.local
 sign.*.json
 sign.json
+src/bake/generated.ts
 src/bun.js/bindings-obj
 src/bun.js/bindings/GeneratedJS2Native.zig
 src/bun.js/debug-bindings-obj
@@ -131,17 +134,13 @@ src/runtime.version
 src/tests.zig
 test.txt
 test/js/bun/glob/fixtures
+test/node.js/upstream
 tsconfig.tsbuildinfo
 txt.js
 x64
 yarn.lock
 zig-cache
 zig-out
-test/node.js/upstream
-.zig-cache
-scripts/env.local
-*.generated.ts
-src/bake/generated.ts
 
 # Dependencies
 /vendor
@@ -149,22 +148,23 @@ src/bake/generated.ts
 # Dependencies (before CMake)
 # These can be removed in the far future
 /src/bun.js/WebKit
-/src/deps/WebKit
 /src/deps/boringssl
 /src/deps/brotli
 /src/deps/c*ares
-/src/deps/lol*html
 /src/deps/libarchive
 /src/deps/libdeflate
 /src/deps/libuv
+/src/deps/lol*html
 /src/deps/ls*hpack
 /src/deps/mimalloc
 /src/deps/picohttpparser
 /src/deps/tinycc
-/src/deps/zstd
-/src/deps/zlib
+/src/deps/WebKit
 /src/deps/zig
+/src/deps/zlib
+/src/deps/zstd
 
 # Generated files
 
 .buildkite/ci.yml
+*.sock

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 2b4747b0ce61675509e5b53a0aab77da23794d24)
+  set(WEBKIT_VERSION 8f9ae4f01a047c666ef548864294e01df731d4ea)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 3bc4abf2d5875baf500b4687ef869987f6d19e00)
+  set(WEBKIT_VERSION 2b4747b0ce61675509e5b53a0aab77da23794d24)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts
+++ b/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts
@@ -1,5 +1,60 @@
 // GENERATED - DO NOT EDIT
 export namespace JSC {
+  export namespace Audit {
+    /**
+     * Creates the `WebInspectorAudit` object that is passed to run. Must call teardown before calling setup more than once.
+     * @request `Audit.setup`
+     */
+    export type SetupRequest = {
+      /**
+       * Specifies in which isolated context to run the test. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page.
+       */
+      contextId?: Runtime.ExecutionContextId | undefined;
+    };
+    /**
+     * Creates the `WebInspectorAudit` object that is passed to run. Must call teardown before calling setup more than once.
+     * @response `Audit.setup`
+     */
+    export type SetupResponse = {};
+    /**
+     * Parses and evaluates the given test string and sends back the result. Returned values are saved to the "audit" object group. Call setup before and teardown after if the `WebInspectorAudit` object should be passed into the test.
+     * @request `Audit.run`
+     */
+    export type RunRequest = {
+      /**
+       * Test string to parse and evaluate.
+       */
+      test: string;
+      /**
+       * Specifies in which isolated context to run the test. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page.
+       */
+      contextId?: Runtime.ExecutionContextId | undefined;
+    };
+    /**
+     * Parses and evaluates the given test string and sends back the result. Returned values are saved to the "audit" object group. Call setup before and teardown after if the `WebInspectorAudit` object should be passed into the test.
+     * @response `Audit.run`
+     */
+    export type RunResponse = {
+      /**
+       * Evaluation result.
+       */
+      result: Runtime.RemoteObject;
+      /**
+       * True if the result was thrown during the evaluation.
+       */
+      wasThrown?: boolean | undefined;
+    };
+    /**
+     * Destroys the `WebInspectorAudit` object that is passed to run. Must call setup before calling teardown.
+     * @request `Audit.teardown`
+     */
+    export type TeardownRequest = {};
+    /**
+     * Destroys the `WebInspectorAudit` object that is passed to run. Must call setup before calling teardown.
+     * @response `Audit.teardown`
+     */
+    export type TeardownResponse = {};
+  }
   export namespace Console {
     /**
      * Channels for different types of log messages.
@@ -29,7 +84,7 @@ export namespace JSC {
     /**
      * The reason the console is being cleared.
      */
-    export type ClearReason = "console-api" | "main-frame-navigation";
+    export type ClearReason = "console-api" | "frontend" | "main-frame-navigation";
     /**
      * Logging channel.
      */
@@ -225,6 +280,18 @@ export namespace JSC {
      */
     export type ClearMessagesResponse = {};
     /**
+     * Control whether calling <code>console.clear()</code> has an effect in Web Inspector. Defaults to true.
+     * @request `Console.setConsoleClearAPIEnabled`
+     */
+    export type SetConsoleClearAPIEnabledRequest = {
+      enable: boolean;
+    };
+    /**
+     * Control whether calling <code>console.clear()</code> has an effect in Web Inspector. Defaults to true.
+     * @response `Console.setConsoleClearAPIEnabled`
+     */
+    export type SetConsoleClearAPIEnabledResponse = {};
+    /**
      * List of the different message sources that are non-default logging channels.
      * @request `Console.getLoggingChannels`
      */
@@ -258,81 +325,6 @@ export namespace JSC {
      * @response `Console.setLoggingChannelLevel`
      */
     export type SetLoggingChannelLevelResponse = {};
-  }
-  export namespace CPUProfiler {
-    /**
-     * CPU usage for an individual thread.
-     */
-    export type ThreadInfo = {
-      /**
-       * Some thread identification information.
-       */
-      name: string;
-      /**
-       * CPU usage for this thread. This should not exceed 100% for an individual thread.
-       */
-      usage: number;
-      /**
-       * Type of thread. There should be a single main thread.
-       */
-      type?: "main" | "webkit" | undefined;
-      /**
-       * A thread may be associated with a target, such as a Worker, in the process.
-       */
-      targetId?: string | undefined;
-    };
-    export type Event = {
-      timestamp: number;
-      /**
-       * Percent of total cpu usage. If there are multiple cores the usage may be greater than 100%.
-       */
-      usage: number;
-      /**
-       * Per-thread CPU usage information. Does not include the main thread.
-       */
-      threads?: ThreadInfo[] | undefined;
-    };
-    /**
-     * Tracking started.
-     * @event `CPUProfiler.trackingStart`
-     */
-    export type TrackingStartEvent = {
-      timestamp: number;
-    };
-    /**
-     * Periodic tracking updates with event data.
-     * @event `CPUProfiler.trackingUpdate`
-     */
-    export type TrackingUpdateEvent = {
-      event: Event;
-    };
-    /**
-     * Tracking stopped.
-     * @event `CPUProfiler.trackingComplete`
-     */
-    export type TrackingCompleteEvent = {
-      timestamp: number;
-    };
-    /**
-     * Start tracking cpu usage.
-     * @request `CPUProfiler.startTracking`
-     */
-    export type StartTrackingRequest = {};
-    /**
-     * Start tracking cpu usage.
-     * @response `CPUProfiler.startTracking`
-     */
-    export type StartTrackingResponse = {};
-    /**
-     * Stop tracking cpu usage. This will produce a `trackingComplete` event.
-     * @request `CPUProfiler.stopTracking`
-     */
-    export type StopTrackingRequest = {};
-    /**
-     * Stop tracking cpu usage. This will produce a `trackingComplete` event.
-     * @response `CPUProfiler.stopTracking`
-     */
-    export type StopTrackingResponse = {};
   }
   export namespace Debugger {
     /**
@@ -1192,23 +1184,27 @@ export namespace JSC {
       savedResultIndex?: number | undefined;
     };
     /**
-     * Sets whether the given URL should be in the list of blackboxed scripts, which are ignored when pausing/stepping/debugging.
+     * Sets whether the given URL should be in the list of blackboxed scripts, which are ignored when pausing.
      * @request `Debugger.setShouldBlackboxURL`
      */
     export type SetShouldBlackboxURLRequest = {
       url: string;
       shouldBlackbox: boolean;
       /**
-       * If true, <code>url</code> is case sensitive.
+       * If <code>true</code>, <code>url</code> is case sensitive.
        */
       caseSensitive?: boolean | undefined;
       /**
-       * If true, treat <code>url</code> as regular expression.
+       * If <code>true</code>, treat <code>url</code> as regular expression.
        */
       isRegex?: boolean | undefined;
+      /**
+       * If provided, limits where in the script the debugger will skip pauses. Expected structure is a repeated <code>[startLine, startColumn, endLine, endColumn]</code>. Ignored if <code>shouldBlackbox</code> is <code>false</code>.
+       */
+      sourceRanges?: number[] | undefined;
     };
     /**
-     * Sets whether the given URL should be in the list of blackboxed scripts, which are ignored when pausing/stepping/debugging.
+     * Sets whether the given URL should be in the list of blackboxed scripts, which are ignored when pausing.
      * @response `Debugger.setShouldBlackboxURL`
      */
     export type SetShouldBlackboxURLResponse = {};
@@ -1224,21 +1220,6 @@ export namespace JSC {
      * @response `Debugger.setBlackboxBreakpointEvaluations`
      */
     export type SetBlackboxBreakpointEvaluationsResponse = {};
-  }
-  export namespace GenericTypes {
-    /**
-     * Search match in a resource.
-     */
-    export type SearchMatch = {
-      /**
-       * Line number in resource content.
-       */
-      lineNumber: number;
-      /**
-       * Line with match content.
-       */
-      lineContent: string;
-    };
   }
   export namespace Heap {
     /**
@@ -1448,1006 +1429,62 @@ export namespace JSC {
      */
     export type InitializedResponse = {};
   }
-  export namespace Network {
+  export namespace LifecycleReporter {
     /**
-     * Unique loader identifier.
+     * undefined
+     * @event `LifecycleReporter.reload`
      */
-    export type LoaderId = string;
+    export type ReloadEvent = {};
     /**
-     * Unique frame identifier.
+     * undefined
+     * @event `LifecycleReporter.error`
      */
-    export type FrameId = string;
-    /**
-     * Unique request identifier.
-     */
-    export type RequestId = string;
-    /**
-     * Elapsed seconds since frontend connected.
-     */
-    export type Timestamp = number;
-    /**
-     * Number of seconds since epoch.
-     */
-    export type Walltime = number;
-    /**
-     * Controls how much referrer information is sent with the request
-     */
-    export type ReferrerPolicy =
-      | "empty-string"
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url";
-    /**
-     * Request / response headers as keys / values of JSON object.
-     */
-    export type Headers = Record<string, unknown>;
-    /**
-     * Timing information for the request.
-     */
-    export type ResourceTiming = {
+    export type ErrorEvent = {
       /**
-       * Request is initiated
+       * Source of the error
        */
-      startTime: Timestamp;
-      /**
-       * Started redirect resolution.
-       */
-      redirectStart: Timestamp;
-      /**
-       * Finished redirect resolution.
-       */
-      redirectEnd: Timestamp;
-      /**
-       * Resource fetching started.
-       */
-      fetchStart: Timestamp;
-      /**
-       * Started DNS address resolve in milliseconds relative to fetchStart.
-       */
-      domainLookupStart: number;
-      /**
-       * Finished DNS address resolve in milliseconds relative to fetchStart.
-       */
-      domainLookupEnd: number;
-      /**
-       * Started connecting to the remote host in milliseconds relative to fetchStart.
-       */
-      connectStart: number;
-      /**
-       * Connected to the remote host in milliseconds relative to fetchStart.
-       */
-      connectEnd: number;
-      /**
-       * Started SSL handshake in milliseconds relative to fetchStart.
-       */
-      secureConnectionStart: number;
-      /**
-       * Started sending request in milliseconds relative to fetchStart.
-       */
-      requestStart: number;
-      /**
-       * Started receiving response headers in milliseconds relative to fetchStart.
-       */
-      responseStart: number;
-      /**
-       * Finished receiving response headers in milliseconds relative to fetchStart.
-       */
-      responseEnd: number;
+      message: Console.ConsoleMessage;
     };
     /**
-     * HTTP request data.
-     */
-    export type Request = {
-      /**
-       * Request URL.
-       */
-      url: string;
-      /**
-       * HTTP request method.
-       */
-      method: string;
-      /**
-       * HTTP request headers.
-       */
-      headers: Headers;
-      /**
-       * HTTP POST request data.
-       */
-      postData?: string | undefined;
-      /**
-       * The level of included referrer information.
-       */
-      referrerPolicy?: ReferrerPolicy | undefined;
-      /**
-       * The base64 cryptographic hash of the resource.
-       */
-      integrity?: string | undefined;
-    };
-    /**
-     * HTTP response data.
-     */
-    export type Response = {
-      /**
-       * Response URL. This URL can be different from CachedResource.url in case of redirect.
-       */
-      url: string;
-      /**
-       * HTTP response status code.
-       */
-      status: number;
-      /**
-       * HTTP response status text.
-       */
-      statusText: string;
-      /**
-       * HTTP response headers.
-       */
-      headers: Headers;
-      /**
-       * Resource mimeType as determined by the browser.
-       */
-      mimeType: string;
-      /**
-       * Specifies where the response came from.
-       */
-      source: "unknown" | "network" | "memory-cache" | "disk-cache" | "service-worker" | "inspector-override";
-      /**
-       * Refined HTTP request headers that were actually transmitted over the network.
-       */
-      requestHeaders?: Headers | undefined;
-      /**
-       * Timing information for the given request.
-       */
-      timing?: ResourceTiming | undefined;
-      /**
-       * The security information for the given request.
-       */
-      security?: Security.Security | undefined;
-    };
-    /**
-     * Network load metrics.
-     */
-    export type Metrics = {
-      /**
-       * Network protocol. ALPN Protocol ID Identification Sequence, as per RFC 7301 (for example, http/2, http/1.1, spdy/3.1)
-       */
-      protocol?: string | undefined;
-      /**
-       * Network priority.
-       */
-      priority?: "low" | "medium" | "high" | undefined;
-      /**
-       * Connection identifier.
-       */
-      connectionIdentifier?: string | undefined;
-      /**
-       * Remote IP address.
-       */
-      remoteAddress?: string | undefined;
-      /**
-       * Refined HTTP request headers that were actually transmitted over the network.
-       */
-      requestHeaders?: Headers | undefined;
-      /**
-       * Total HTTP request header bytes sent over the network.
-       */
-      requestHeaderBytesSent?: number | undefined;
-      /**
-       * Total HTTP request body bytes sent over the network.
-       */
-      requestBodyBytesSent?: number | undefined;
-      /**
-       * Total HTTP response header bytes received over the network.
-       */
-      responseHeaderBytesReceived?: number | undefined;
-      /**
-       * Total HTTP response body bytes received over the network.
-       */
-      responseBodyBytesReceived?: number | undefined;
-      /**
-       * Total decoded response body size in bytes.
-       */
-      responseBodyDecodedSize?: number | undefined;
-      /**
-       * Connection information for the completed request.
-       */
-      securityConnection?: Security.Connection | undefined;
-      /**
-       * Whether or not the connection was proxied through a server. If <code>true</code>, the <code>remoteAddress</code> will be for the proxy server, not the server that provided the resource to the proxy server.
-       */
-      isProxyConnection?: boolean | undefined;
-    };
-    /**
-     * WebSocket request data.
-     */
-    export type WebSocketRequest = {
-      /**
-       * HTTP response headers.
-       */
-      headers: Headers;
-    };
-    /**
-     * WebSocket response data.
-     */
-    export type WebSocketResponse = {
-      /**
-       * HTTP response status code.
-       */
-      status: number;
-      /**
-       * HTTP response status text.
-       */
-      statusText: string;
-      /**
-       * HTTP response headers.
-       */
-      headers: Headers;
-    };
-    /**
-     * WebSocket frame data.
-     */
-    export type WebSocketFrame = {
-      /**
-       * WebSocket frame opcode.
-       */
-      opcode: number;
-      /**
-       * WebSocket frame mask.
-       */
-      mask: boolean;
-      /**
-       * WebSocket frame payload data, binary frames (opcode = 2) are base64-encoded.
-       */
-      payloadData: string;
-      /**
-       * WebSocket frame payload length in bytes.
-       */
-      payloadLength: number;
-    };
-    /**
-     * Information about the cached resource.
-     */
-    export type CachedResource = {
-      /**
-       * Resource URL. This is the url of the original network request.
-       */
-      url: string;
-      /**
-       * Type of this resource.
-       */
-      type: Page.ResourceType;
-      /**
-       * Cached response data.
-       */
-      response?: Response | undefined;
-      /**
-       * Cached response body size.
-       */
-      bodySize: number;
-      /**
-       * URL of source map associated with this resource (if any).
-       */
-      sourceMapURL?: string | undefined;
-    };
-    /**
-     * Information about the request initiator.
-     */
-    export type Initiator = {
-      /**
-       * Type of this initiator.
-       */
-      type: "parser" | "script" | "other";
-      /**
-       * Initiator JavaScript stack trace, set for Script only.
-       */
-      stackTrace?: Console.StackTrace | undefined;
-      /**
-       * Initiator URL, set for Parser type only.
-       */
-      url?: string | undefined;
-      /**
-       * Initiator line number, set for Parser type only.
-       */
-      lineNumber?: number | undefined;
-      /**
-       * Set if the load was triggered by a DOM node, in addition to the other initiator information.
-       */
-      nodeId?: DOM.NodeId | undefined;
-    };
-    /**
-     * Different stages of a network request.
-     */
-    export type NetworkStage = "request" | "response";
-    /**
-     * Different stages of a network request.
-     */
-    export type ResourceErrorType = "General" | "AccessControl" | "Cancellation" | "Timeout";
-    /**
-     * Fired when page is about to send HTTP request.
-     * @event `Network.requestWillBeSent`
-     */
-    export type RequestWillBeSentEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Frame identifier.
-       */
-      frameId: FrameId;
-      /**
-       * Loader identifier.
-       */
-      loaderId: LoaderId;
-      /**
-       * URL of the document this request is loaded for.
-       */
-      documentURL: string;
-      /**
-       * Request data.
-       */
-      request: Request;
-      timestamp: Timestamp;
-      walltime: Walltime;
-      /**
-       * Request initiator.
-       */
-      initiator: Initiator;
-      /**
-       * Redirect response data.
-       */
-      redirectResponse?: Response | undefined;
-      /**
-       * Resource type.
-       */
-      type?: Page.ResourceType | undefined;
-      /**
-       * Identifier for the context of where the load originated. In general this is the target identifier. For Workers this will be the workerId.
-       */
-      targetId?: string | undefined;
-    };
-    /**
-     * Fired when HTTP response is available.
-     * @event `Network.responseReceived`
-     */
-    export type ResponseReceivedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Frame identifier.
-       */
-      frameId: FrameId;
-      /**
-       * Loader identifier.
-       */
-      loaderId: LoaderId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * Resource type.
-       */
-      type: Page.ResourceType;
-      /**
-       * Response data.
-       */
-      response: Response;
-    };
-    /**
-     * Fired when data chunk was received over the network.
-     * @event `Network.dataReceived`
-     */
-    export type DataReceivedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * Data chunk length.
-       */
-      dataLength: number;
-      /**
-       * Actual bytes received (might be less than dataLength for compressed encodings).
-       */
-      encodedDataLength: number;
-    };
-    /**
-     * Fired when HTTP request has finished loading.
-     * @event `Network.loadingFinished`
-     */
-    export type LoadingFinishedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * URL of source map associated with this resource (if any).
-       */
-      sourceMapURL?: string | undefined;
-      /**
-       * Network metrics.
-       */
-      metrics?: Metrics | undefined;
-    };
-    /**
-     * Fired when HTTP request has failed to load.
-     * @event `Network.loadingFailed`
-     */
-    export type LoadingFailedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * User friendly error message.
-       */
-      errorText: string;
-      /**
-       * True if loading was canceled.
-       */
-      canceled?: boolean | undefined;
-    };
-    /**
-     * Fired when HTTP request has been served from memory cache.
-     * @event `Network.requestServedFromMemoryCache`
-     */
-    export type RequestServedFromMemoryCacheEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Frame identifier.
-       */
-      frameId: FrameId;
-      /**
-       * Loader identifier.
-       */
-      loaderId: LoaderId;
-      /**
-       * URL of the document this request is loaded for.
-       */
-      documentURL: string;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * Request initiator.
-       */
-      initiator: Initiator;
-      /**
-       * Cached resource data.
-       */
-      resource: CachedResource;
-    };
-    /**
-     * Fired when HTTP request has been intercepted. The frontend must respond with <code>Network.interceptContinue</code>, <code>Network.interceptWithRequest</code>` or <code>Network.interceptWithResponse</code>` to resolve this request.
-     * @event `Network.requestIntercepted`
-     */
-    export type RequestInterceptedEvent = {
-      /**
-       * Identifier for this intercepted network. Corresponds with an earlier <code>Network.requestWillBeSent</code>.
-       */
-      requestId: RequestId;
-      /**
-       * Original request content that would proceed if this is continued.
-       */
-      request: Request;
-    };
-    /**
-     * Fired when HTTP response has been intercepted. The frontend must response with <code>Network.interceptContinue</code> or <code>Network.interceptWithResponse</code>` to continue this response.
-     * @event `Network.responseIntercepted`
-     */
-    export type ResponseInterceptedEvent = {
-      /**
-       * Identifier for this intercepted network. Corresponds with an earlier <code>Network.requestWillBeSent</code>.
-       */
-      requestId: RequestId;
-      /**
-       * Original response content that would proceed if this is continued.
-       */
-      response: Response;
-    };
-    /**
-     * Fired when WebSocket is about to initiate handshake.
-     * @event `Network.webSocketWillSendHandshakeRequest`
-     */
-    export type WebSocketWillSendHandshakeRequestEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      timestamp: Timestamp;
-      walltime: Walltime;
-      /**
-       * WebSocket request data.
-       */
-      request: WebSocketRequest;
-    };
-    /**
-     * Fired when WebSocket handshake response becomes available.
-     * @event `Network.webSocketHandshakeResponseReceived`
-     */
-    export type WebSocketHandshakeResponseReceivedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      timestamp: Timestamp;
-      /**
-       * WebSocket response data.
-       */
-      response: WebSocketResponse;
-    };
-    /**
-     * Fired upon WebSocket creation.
-     * @event `Network.webSocketCreated`
-     */
-    export type WebSocketCreatedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * WebSocket request URL.
-       */
-      url: string;
-    };
-    /**
-     * Fired when WebSocket is closed.
-     * @event `Network.webSocketClosed`
-     */
-    export type WebSocketClosedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-    };
-    /**
-     * Fired when WebSocket frame is received.
-     * @event `Network.webSocketFrameReceived`
-     */
-    export type WebSocketFrameReceivedEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * WebSocket response data.
-       */
-      response: WebSocketFrame;
-    };
-    /**
-     * Fired when WebSocket frame error occurs.
-     * @event `Network.webSocketFrameError`
-     */
-    export type WebSocketFrameErrorEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * WebSocket frame error message.
-       */
-      errorMessage: string;
-    };
-    /**
-     * Fired when WebSocket frame is sent.
-     * @event `Network.webSocketFrameSent`
-     */
-    export type WebSocketFrameSentEvent = {
-      /**
-       * Request identifier.
-       */
-      requestId: RequestId;
-      /**
-       * Timestamp.
-       */
-      timestamp: Timestamp;
-      /**
-       * WebSocket response data.
-       */
-      response: WebSocketFrame;
-    };
-    /**
-     * Enables network tracking, network events will now be delivered to the client.
-     * @request `Network.enable`
+     * Enables LifecycleReporter domain events.
+     * @request `LifecycleReporter.enable`
      */
     export type EnableRequest = {};
     /**
-     * Enables network tracking, network events will now be delivered to the client.
-     * @response `Network.enable`
+     * Enables LifecycleReporter domain events.
+     * @response `LifecycleReporter.enable`
      */
     export type EnableResponse = {};
     /**
-     * Disables network tracking, prevents network events from being sent to the client.
-     * @request `Network.disable`
+     * Disables LifecycleReporter domain events.
+     * @request `LifecycleReporter.disable`
      */
     export type DisableRequest = {};
     /**
-     * Disables network tracking, prevents network events from being sent to the client.
-     * @response `Network.disable`
+     * Disables LifecycleReporter domain events.
+     * @response `LifecycleReporter.disable`
      */
     export type DisableResponse = {};
     /**
-     * Specifies whether to always send extra HTTP headers with the requests from this page.
-     * @request `Network.setExtraHTTPHeaders`
+     * Prevents the process from exiting.
+     * @request `LifecycleReporter.preventExit`
      */
-    export type SetExtraHTTPHeadersRequest = {
-      /**
-       * Map with extra HTTP headers.
-       */
-      headers: Headers;
-    };
+    export type PreventExitRequest = {};
     /**
-     * Specifies whether to always send extra HTTP headers with the requests from this page.
-     * @response `Network.setExtraHTTPHeaders`
+     * Prevents the process from exiting.
+     * @response `LifecycleReporter.preventExit`
      */
-    export type SetExtraHTTPHeadersResponse = {};
+    export type PreventExitResponse = {};
     /**
-     * Returns content served for the given request.
-     * @request `Network.getResponseBody`
+     * Does not prevent the process from exiting.
+     * @request `LifecycleReporter.stopPreventingExit`
      */
-    export type GetResponseBodyRequest = {
-      /**
-       * Identifier of the network request to get content for.
-       */
-      requestId: RequestId;
-    };
+    export type StopPreventingExitRequest = {};
     /**
-     * Returns content served for the given request.
-     * @response `Network.getResponseBody`
+     * Does not prevent the process from exiting.
+     * @response `LifecycleReporter.stopPreventingExit`
      */
-    export type GetResponseBodyResponse = {
-      /**
-       * Response body.
-       */
-      body: string;
-      /**
-       * True, if content was sent as base64.
-       */
-      base64Encoded: boolean;
-    };
-    /**
-     * Toggles whether the resource cache may be used when loading resources in the inspected page. If <code>true</code>, the resource cache will not be used when loading resources.
-     * @request `Network.setResourceCachingDisabled`
-     */
-    export type SetResourceCachingDisabledRequest = {
-      /**
-       * Whether to prevent usage of the resource cache.
-       */
-      disabled: boolean;
-    };
-    /**
-     * Toggles whether the resource cache may be used when loading resources in the inspected page. If <code>true</code>, the resource cache will not be used when loading resources.
-     * @response `Network.setResourceCachingDisabled`
-     */
-    export type SetResourceCachingDisabledResponse = {};
-    /**
-     * Loads a resource in the context of a frame on the inspected page without cross origin checks.
-     * @request `Network.loadResource`
-     */
-    export type LoadResourceRequest = {
-      /**
-       * Frame to load the resource from.
-       */
-      frameId: FrameId;
-      /**
-       * URL of the resource to load.
-       */
-      url: string;
-    };
-    /**
-     * Loads a resource in the context of a frame on the inspected page without cross origin checks.
-     * @response `Network.loadResource`
-     */
-    export type LoadResourceResponse = {
-      /**
-       * Resource content.
-       */
-      content: string;
-      /**
-       * Resource mimeType.
-       */
-      mimeType: string;
-      /**
-       * HTTP response status code.
-       */
-      status: number;
-    };
-    /**
-     * Fetches a serialized secure certificate for the given requestId to be displayed via InspectorFrontendHost.showCertificate.
-     * @request `Network.getSerializedCertificate`
-     */
-    export type GetSerializedCertificateRequest = {
-      requestId: RequestId;
-    };
-    /**
-     * Fetches a serialized secure certificate for the given requestId to be displayed via InspectorFrontendHost.showCertificate.
-     * @response `Network.getSerializedCertificate`
-     */
-    export type GetSerializedCertificateResponse = {
-      /**
-       * Represents a base64 encoded WebCore::CertificateInfo object.
-       */
-      serializedCertificate: string;
-    };
-    /**
-     * Resolves JavaScript WebSocket object for given request id.
-     * @request `Network.resolveWebSocket`
-     */
-    export type ResolveWebSocketRequest = {
-      /**
-       * Identifier of the WebSocket resource to resolve.
-       */
-      requestId: RequestId;
-      /**
-       * Symbolic group name that can be used to release multiple objects.
-       */
-      objectGroup?: string | undefined;
-    };
-    /**
-     * Resolves JavaScript WebSocket object for given request id.
-     * @response `Network.resolveWebSocket`
-     */
-    export type ResolveWebSocketResponse = {
-      /**
-       * JavaScript object wrapper for given node.
-       */
-      object: Runtime.RemoteObject;
-    };
-    /**
-     * Enable interception of network requests.
-     * @request `Network.setInterceptionEnabled`
-     */
-    export type SetInterceptionEnabledRequest = {
-      enabled: boolean;
-    };
-    /**
-     * Enable interception of network requests.
-     * @response `Network.setInterceptionEnabled`
-     */
-    export type SetInterceptionEnabledResponse = {};
-    /**
-     * Add an interception.
-     * @request `Network.addInterception`
-     */
-    export type AddInterceptionRequest = {
-      /**
-       * URL pattern to intercept, intercept everything if not specified or empty
-       */
-      url: string;
-      /**
-       * Stage to intercept.
-       */
-      stage: NetworkStage;
-      /**
-       * If false, ignores letter casing of `url` parameter.
-       */
-      caseSensitive?: boolean | undefined;
-      /**
-       * If true, treats `url` parameter as a regular expression.
-       */
-      isRegex?: boolean | undefined;
-    };
-    /**
-     * Add an interception.
-     * @response `Network.addInterception`
-     */
-    export type AddInterceptionResponse = {};
-    /**
-     * Remove an interception.
-     * @request `Network.removeInterception`
-     */
-    export type RemoveInterceptionRequest = {
-      url: string;
-      /**
-       * Stage to intercept.
-       */
-      stage: NetworkStage;
-      /**
-       * If false, ignores letter casing of `url` parameter.
-       */
-      caseSensitive?: boolean | undefined;
-      /**
-       * If true, treats `url` parameter as a regular expression.
-       */
-      isRegex?: boolean | undefined;
-    };
-    /**
-     * Remove an interception.
-     * @response `Network.removeInterception`
-     */
-    export type RemoveInterceptionResponse = {};
-    /**
-     * Continue request or response without modifications.
-     * @request `Network.interceptContinue`
-     */
-    export type InterceptContinueRequest = {
-      /**
-       * Identifier for the intercepted Network request or response to continue.
-       */
-      requestId: RequestId;
-      /**
-       * Stage to continue.
-       */
-      stage: NetworkStage;
-    };
-    /**
-     * Continue request or response without modifications.
-     * @response `Network.interceptContinue`
-     */
-    export type InterceptContinueResponse = {};
-    /**
-     * Replace intercepted request with the provided one.
-     * @request `Network.interceptWithRequest`
-     */
-    export type InterceptWithRequestRequest = {
-      /**
-       * Identifier for the intercepted Network request or response to continue.
-       */
-      requestId: RequestId;
-      /**
-       * HTTP request url.
-       */
-      url?: string | undefined;
-      /**
-       * HTTP request method.
-       */
-      method?: string | undefined;
-      /**
-       * HTTP response headers. Pass through original values if unmodified.
-       */
-      headers?: Headers | undefined;
-      /**
-       * HTTP POST request data, base64-encoded.
-       */
-      postData?: string | undefined;
-    };
-    /**
-     * Replace intercepted request with the provided one.
-     * @response `Network.interceptWithRequest`
-     */
-    export type InterceptWithRequestResponse = {};
-    /**
-     * Provide response content for an intercepted response.
-     * @request `Network.interceptWithResponse`
-     */
-    export type InterceptWithResponseRequest = {
-      /**
-       * Identifier for the intercepted Network response to modify.
-       */
-      requestId: RequestId;
-      content: string;
-      /**
-       * True, if content was sent as base64.
-       */
-      base64Encoded: boolean;
-      /**
-       * MIME Type for the data.
-       */
-      mimeType?: string | undefined;
-      /**
-       * HTTP response status code. Pass through original values if unmodified.
-       */
-      status?: number | undefined;
-      /**
-       * HTTP response status text. Pass through original values if unmodified.
-       */
-      statusText?: string | undefined;
-      /**
-       * HTTP response headers. Pass through original values if unmodified.
-       */
-      headers?: Headers | undefined;
-    };
-    /**
-     * Provide response content for an intercepted response.
-     * @response `Network.interceptWithResponse`
-     */
-    export type InterceptWithResponseResponse = {};
-    /**
-     * Provide response for an intercepted request. Request completely bypasses the network in this case and is immediately fulfilled with the provided data.
-     * @request `Network.interceptRequestWithResponse`
-     */
-    export type InterceptRequestWithResponseRequest = {
-      /**
-       * Identifier for the intercepted Network response to modify.
-       */
-      requestId: RequestId;
-      content: string;
-      /**
-       * True, if content was sent as base64.
-       */
-      base64Encoded: boolean;
-      /**
-       * MIME Type for the data.
-       */
-      mimeType: string;
-      /**
-       * HTTP response status code.
-       */
-      status: number;
-      /**
-       * HTTP response status text.
-       */
-      statusText: string;
-      /**
-       * HTTP response headers.
-       */
-      headers: Headers;
-    };
-    /**
-     * Provide response for an intercepted request. Request completely bypasses the network in this case and is immediately fulfilled with the provided data.
-     * @response `Network.interceptRequestWithResponse`
-     */
-    export type InterceptRequestWithResponseResponse = {};
-    /**
-     * Fail request with given error type.
-     * @request `Network.interceptRequestWithError`
-     */
-    export type InterceptRequestWithErrorRequest = {
-      /**
-       * Identifier for the intercepted Network request to fail.
-       */
-      requestId: RequestId;
-      /**
-       * Deliver error reason for the request failure.
-       */
-      errorType: ResourceErrorType;
-    };
-    /**
-     * Fail request with given error type.
-     * @response `Network.interceptRequestWithError`
-     */
-    export type InterceptRequestWithErrorResponse = {};
-    /**
-     * Emulate various network conditions (e.g. bytes per second, latency, etc.).
-     * @request `Network.setEmulatedConditions`
-     */
-    export type SetEmulatedConditionsRequest = {
-      /**
-       * Limits the bytes per second of requests if positive. Removes any limits if zero or not provided.
-       */
-      bytesPerSecondLimit?: number | undefined;
-    };
-    /**
-     * Emulate various network conditions (e.g. bytes per second, latency, etc.).
-     * @response `Network.setEmulatedConditions`
-     */
-    export type SetEmulatedConditionsResponse = {};
+    export type StopPreventingExitResponse = {};
   }
   export namespace Runtime {
     /**
@@ -3453,222 +2490,264 @@ export namespace JSC {
      */
     export type StopTrackingResponse = {};
   }
+  export namespace TestReporter {
+    export type TestStatus = "pass" | "fail" | "timeout" | "skip" | "todo";
+    /**
+     * undefined
+     * @event `TestReporter.found`
+     */
+    export type FoundEvent = {
+      /**
+       * Unique identifier of the test that was found.
+       */
+      id: number;
+      /**
+       * Unique identifier of the script that started the test.
+       */
+      scriptId: Debugger.ScriptId;
+      /**
+       * Line number in the script that started the test.
+       */
+      line: number;
+      /**
+       * Name of the test that started.
+       */
+      name?: string | undefined;
+    };
+    /**
+     * undefined
+     * @event `TestReporter.start`
+     */
+    export type StartEvent = {
+      /**
+       * Unique identifier of the test that started.
+       */
+      id: number;
+    };
+    /**
+     * undefined
+     * @event `TestReporter.end`
+     */
+    export type EndEvent = {
+      /**
+       * Unique identifier of the test that ended.
+       */
+      id: number;
+      /**
+       * Status of the test that ended.
+       */
+      status: TestStatus;
+      /**
+       * Elapsed time in milliseconds since the test started.
+       */
+      elapsed: number;
+    };
+    /**
+     * Enables TestReporter domain events.
+     * @request `TestReporter.enable`
+     */
+    export type EnableRequest = {};
+    /**
+     * Enables TestReporter domain events.
+     * @response `TestReporter.enable`
+     */
+    export type EnableResponse = {};
+    /**
+     * Disables TestReporter domain events.
+     * @request `TestReporter.disable`
+     */
+    export type DisableRequest = {};
+    /**
+     * Disables TestReporter domain events.
+     * @response `TestReporter.disable`
+     */
+    export type DisableResponse = {};
+  }
   export type EventMap = {
+    "Console.heapSnapshot": Console.HeapSnapshotEvent;
     "Console.messageAdded": Console.MessageAddedEvent;
     "Console.messageRepeatCountUpdated": Console.MessageRepeatCountUpdatedEvent;
     "Console.messagesCleared": Console.MessagesClearedEvent;
-    "Console.heapSnapshot": Console.HeapSnapshotEvent;
-    "CPUProfiler.trackingStart": CPUProfiler.TrackingStartEvent;
-    "CPUProfiler.trackingUpdate": CPUProfiler.TrackingUpdateEvent;
-    "CPUProfiler.trackingComplete": CPUProfiler.TrackingCompleteEvent;
-    "Debugger.globalObjectCleared": Debugger.GlobalObjectClearedEvent;
-    "Debugger.scriptParsed": Debugger.ScriptParsedEvent;
-    "Debugger.scriptFailedToParse": Debugger.ScriptFailedToParseEvent;
     "Debugger.breakpointResolved": Debugger.BreakpointResolvedEvent;
-    "Debugger.paused": Debugger.PausedEvent;
-    "Debugger.resumed": Debugger.ResumedEvent;
     "Debugger.didSampleProbe": Debugger.DidSampleProbeEvent;
+    "Debugger.globalObjectCleared": Debugger.GlobalObjectClearedEvent;
+    "Debugger.paused": Debugger.PausedEvent;
     "Debugger.playBreakpointActionSound": Debugger.PlayBreakpointActionSoundEvent;
+    "Debugger.resumed": Debugger.ResumedEvent;
+    "Debugger.scriptFailedToParse": Debugger.ScriptFailedToParseEvent;
+    "Debugger.scriptParsed": Debugger.ScriptParsedEvent;
     "Heap.garbageCollected": Heap.GarbageCollectedEvent;
-    "Heap.trackingStart": Heap.TrackingStartEvent;
     "Heap.trackingComplete": Heap.TrackingCompleteEvent;
+    "Heap.trackingStart": Heap.TrackingStartEvent;
     "Inspector.evaluateForTestInFrontend": Inspector.EvaluateForTestInFrontendEvent;
     "Inspector.inspect": Inspector.InspectEvent;
-    "Network.requestWillBeSent": Network.RequestWillBeSentEvent;
-    "Network.responseReceived": Network.ResponseReceivedEvent;
-    "Network.dataReceived": Network.DataReceivedEvent;
-    "Network.loadingFinished": Network.LoadingFinishedEvent;
-    "Network.loadingFailed": Network.LoadingFailedEvent;
-    "Network.requestServedFromMemoryCache": Network.RequestServedFromMemoryCacheEvent;
-    "Network.requestIntercepted": Network.RequestInterceptedEvent;
-    "Network.responseIntercepted": Network.ResponseInterceptedEvent;
-    "Network.webSocketWillSendHandshakeRequest": Network.WebSocketWillSendHandshakeRequestEvent;
-    "Network.webSocketHandshakeResponseReceived": Network.WebSocketHandshakeResponseReceivedEvent;
-    "Network.webSocketCreated": Network.WebSocketCreatedEvent;
-    "Network.webSocketClosed": Network.WebSocketClosedEvent;
-    "Network.webSocketFrameReceived": Network.WebSocketFrameReceivedEvent;
-    "Network.webSocketFrameError": Network.WebSocketFrameErrorEvent;
-    "Network.webSocketFrameSent": Network.WebSocketFrameSentEvent;
+    "LifecycleReporter.error": LifecycleReporter.ErrorEvent;
+    "LifecycleReporter.reload": LifecycleReporter.ReloadEvent;
     "Runtime.executionContextCreated": Runtime.ExecutionContextCreatedEvent;
+    "ScriptProfiler.trackingComplete": ScriptProfiler.TrackingCompleteEvent;
     "ScriptProfiler.trackingStart": ScriptProfiler.TrackingStartEvent;
     "ScriptProfiler.trackingUpdate": ScriptProfiler.TrackingUpdateEvent;
-    "ScriptProfiler.trackingComplete": ScriptProfiler.TrackingCompleteEvent;
+    "TestReporter.end": TestReporter.EndEvent;
+    "TestReporter.found": TestReporter.FoundEvent;
+    "TestReporter.start": TestReporter.StartEvent;
   };
   export type RequestMap = {
-    "Console.enable": Console.EnableRequest;
-    "Console.disable": Console.DisableRequest;
+    "Audit.run": Audit.RunRequest;
+    "Audit.setup": Audit.SetupRequest;
+    "Audit.teardown": Audit.TeardownRequest;
     "Console.clearMessages": Console.ClearMessagesRequest;
+    "Console.disable": Console.DisableRequest;
+    "Console.enable": Console.EnableRequest;
     "Console.getLoggingChannels": Console.GetLoggingChannelsRequest;
+    "Console.setConsoleClearAPIEnabled": Console.SetConsoleClearAPIEnabledRequest;
     "Console.setLoggingChannelLevel": Console.SetLoggingChannelLevelRequest;
-    "CPUProfiler.startTracking": CPUProfiler.StartTrackingRequest;
-    "CPUProfiler.stopTracking": CPUProfiler.StopTrackingRequest;
-    "Debugger.enable": Debugger.EnableRequest;
-    "Debugger.disable": Debugger.DisableRequest;
-    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthRequest;
-    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveRequest;
-    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlRequest;
-    "Debugger.setBreakpoint": Debugger.SetBreakpointRequest;
-    "Debugger.removeBreakpoint": Debugger.RemoveBreakpointRequest;
     "Debugger.addSymbolicBreakpoint": Debugger.AddSymbolicBreakpointRequest;
-    "Debugger.removeSymbolicBreakpoint": Debugger.RemoveSymbolicBreakpointRequest;
-    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopRequest;
     "Debugger.continueToLocation": Debugger.ContinueToLocationRequest;
-    "Debugger.stepNext": Debugger.StepNextRequest;
-    "Debugger.stepOver": Debugger.StepOverRequest;
-    "Debugger.stepInto": Debugger.StepIntoRequest;
-    "Debugger.stepOut": Debugger.StepOutRequest;
+    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopRequest;
+    "Debugger.disable": Debugger.DisableRequest;
+    "Debugger.enable": Debugger.EnableRequest;
+    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameRequest;
+    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsRequest;
+    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsRequest;
+    "Debugger.getScriptSource": Debugger.GetScriptSourceRequest;
     "Debugger.pause": Debugger.PauseRequest;
+    "Debugger.removeBreakpoint": Debugger.RemoveBreakpointRequest;
+    "Debugger.removeSymbolicBreakpoint": Debugger.RemoveSymbolicBreakpointRequest;
     "Debugger.resume": Debugger.ResumeRequest;
     "Debugger.searchInContent": Debugger.SearchInContentRequest;
-    "Debugger.getScriptSource": Debugger.GetScriptSourceRequest;
-    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsRequest;
-    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsRequest;
+    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthRequest;
+    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsRequest;
+    "Debugger.setBreakpoint": Debugger.SetBreakpointRequest;
+    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlRequest;
+    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveRequest;
+    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsRequest;
+    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsRequest;
     "Debugger.setPauseOnDebuggerStatements": Debugger.SetPauseOnDebuggerStatementsRequest;
     "Debugger.setPauseOnExceptions": Debugger.SetPauseOnExceptionsRequest;
-    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsRequest;
     "Debugger.setPauseOnMicrotasks": Debugger.SetPauseOnMicrotasksRequest;
-    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsRequest;
-    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameRequest;
     "Debugger.setShouldBlackboxURL": Debugger.SetShouldBlackboxURLRequest;
-    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsRequest;
-    "Heap.enable": Heap.EnableRequest;
+    "Debugger.stepInto": Debugger.StepIntoRequest;
+    "Debugger.stepNext": Debugger.StepNextRequest;
+    "Debugger.stepOut": Debugger.StepOutRequest;
+    "Debugger.stepOver": Debugger.StepOverRequest;
     "Heap.disable": Heap.DisableRequest;
+    "Heap.enable": Heap.EnableRequest;
     "Heap.gc": Heap.GcRequest;
+    "Heap.getPreview": Heap.GetPreviewRequest;
+    "Heap.getRemoteObject": Heap.GetRemoteObjectRequest;
     "Heap.snapshot": Heap.SnapshotRequest;
     "Heap.startTracking": Heap.StartTrackingRequest;
     "Heap.stopTracking": Heap.StopTrackingRequest;
-    "Heap.getPreview": Heap.GetPreviewRequest;
-    "Heap.getRemoteObject": Heap.GetRemoteObjectRequest;
-    "Inspector.enable": Inspector.EnableRequest;
     "Inspector.disable": Inspector.DisableRequest;
+    "Inspector.enable": Inspector.EnableRequest;
     "Inspector.initialized": Inspector.InitializedRequest;
-    "Network.enable": Network.EnableRequest;
-    "Network.disable": Network.DisableRequest;
-    "Network.setExtraHTTPHeaders": Network.SetExtraHTTPHeadersRequest;
-    "Network.getResponseBody": Network.GetResponseBodyRequest;
-    "Network.setResourceCachingDisabled": Network.SetResourceCachingDisabledRequest;
-    "Network.loadResource": Network.LoadResourceRequest;
-    "Network.getSerializedCertificate": Network.GetSerializedCertificateRequest;
-    "Network.resolveWebSocket": Network.ResolveWebSocketRequest;
-    "Network.setInterceptionEnabled": Network.SetInterceptionEnabledRequest;
-    "Network.addInterception": Network.AddInterceptionRequest;
-    "Network.removeInterception": Network.RemoveInterceptionRequest;
-    "Network.interceptContinue": Network.InterceptContinueRequest;
-    "Network.interceptWithRequest": Network.InterceptWithRequestRequest;
-    "Network.interceptWithResponse": Network.InterceptWithResponseRequest;
-    "Network.interceptRequestWithResponse": Network.InterceptRequestWithResponseRequest;
-    "Network.interceptRequestWithError": Network.InterceptRequestWithErrorRequest;
-    "Network.setEmulatedConditions": Network.SetEmulatedConditionsRequest;
-    "Runtime.parse": Runtime.ParseRequest;
-    "Runtime.evaluate": Runtime.EvaluateRequest;
+    "LifecycleReporter.disable": LifecycleReporter.DisableRequest;
+    "LifecycleReporter.enable": LifecycleReporter.EnableRequest;
+    "LifecycleReporter.preventExit": LifecycleReporter.PreventExitRequest;
+    "LifecycleReporter.stopPreventingExit": LifecycleReporter.StopPreventingExitRequest;
     "Runtime.awaitPromise": Runtime.AwaitPromiseRequest;
     "Runtime.callFunctionOn": Runtime.CallFunctionOnRequest;
+    "Runtime.disable": Runtime.DisableRequest;
+    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerRequest;
+    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerRequest;
+    "Runtime.enable": Runtime.EnableRequest;
+    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerRequest;
+    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerRequest;
+    "Runtime.evaluate": Runtime.EvaluateRequest;
+    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksRequest;
+    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesRequest;
+    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesRequest;
     "Runtime.getPreview": Runtime.GetPreviewRequest;
     "Runtime.getProperties": Runtime.GetPropertiesRequest;
-    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesRequest;
-    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesRequest;
-    "Runtime.saveResult": Runtime.SaveResultRequest;
-    "Runtime.setSavedResultAlias": Runtime.SetSavedResultAliasRequest;
+    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsRequest;
+    "Runtime.parse": Runtime.ParseRequest;
     "Runtime.releaseObject": Runtime.ReleaseObjectRequest;
     "Runtime.releaseObjectGroup": Runtime.ReleaseObjectGroupRequest;
-    "Runtime.enable": Runtime.EnableRequest;
-    "Runtime.disable": Runtime.DisableRequest;
-    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsRequest;
-    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerRequest;
-    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerRequest;
-    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerRequest;
-    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerRequest;
-    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksRequest;
+    "Runtime.saveResult": Runtime.SaveResultRequest;
+    "Runtime.setSavedResultAlias": Runtime.SetSavedResultAliasRequest;
     "ScriptProfiler.startTracking": ScriptProfiler.StartTrackingRequest;
     "ScriptProfiler.stopTracking": ScriptProfiler.StopTrackingRequest;
+    "TestReporter.disable": TestReporter.DisableRequest;
+    "TestReporter.enable": TestReporter.EnableRequest;
   };
   export type ResponseMap = {
-    "Console.enable": Console.EnableResponse;
-    "Console.disable": Console.DisableResponse;
+    "Audit.run": Audit.RunResponse;
+    "Audit.setup": Audit.SetupResponse;
+    "Audit.teardown": Audit.TeardownResponse;
     "Console.clearMessages": Console.ClearMessagesResponse;
+    "Console.disable": Console.DisableResponse;
+    "Console.enable": Console.EnableResponse;
     "Console.getLoggingChannels": Console.GetLoggingChannelsResponse;
+    "Console.setConsoleClearAPIEnabled": Console.SetConsoleClearAPIEnabledResponse;
     "Console.setLoggingChannelLevel": Console.SetLoggingChannelLevelResponse;
-    "CPUProfiler.startTracking": CPUProfiler.StartTrackingResponse;
-    "CPUProfiler.stopTracking": CPUProfiler.StopTrackingResponse;
-    "Debugger.enable": Debugger.EnableResponse;
-    "Debugger.disable": Debugger.DisableResponse;
-    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthResponse;
-    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveResponse;
-    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlResponse;
-    "Debugger.setBreakpoint": Debugger.SetBreakpointResponse;
-    "Debugger.removeBreakpoint": Debugger.RemoveBreakpointResponse;
     "Debugger.addSymbolicBreakpoint": Debugger.AddSymbolicBreakpointResponse;
-    "Debugger.removeSymbolicBreakpoint": Debugger.RemoveSymbolicBreakpointResponse;
-    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopResponse;
     "Debugger.continueToLocation": Debugger.ContinueToLocationResponse;
-    "Debugger.stepNext": Debugger.StepNextResponse;
-    "Debugger.stepOver": Debugger.StepOverResponse;
-    "Debugger.stepInto": Debugger.StepIntoResponse;
-    "Debugger.stepOut": Debugger.StepOutResponse;
+    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopResponse;
+    "Debugger.disable": Debugger.DisableResponse;
+    "Debugger.enable": Debugger.EnableResponse;
+    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameResponse;
+    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsResponse;
+    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsResponse;
+    "Debugger.getScriptSource": Debugger.GetScriptSourceResponse;
     "Debugger.pause": Debugger.PauseResponse;
+    "Debugger.removeBreakpoint": Debugger.RemoveBreakpointResponse;
+    "Debugger.removeSymbolicBreakpoint": Debugger.RemoveSymbolicBreakpointResponse;
     "Debugger.resume": Debugger.ResumeResponse;
     "Debugger.searchInContent": Debugger.SearchInContentResponse;
-    "Debugger.getScriptSource": Debugger.GetScriptSourceResponse;
-    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsResponse;
-    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsResponse;
+    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthResponse;
+    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsResponse;
+    "Debugger.setBreakpoint": Debugger.SetBreakpointResponse;
+    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlResponse;
+    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveResponse;
+    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsResponse;
+    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsResponse;
     "Debugger.setPauseOnDebuggerStatements": Debugger.SetPauseOnDebuggerStatementsResponse;
     "Debugger.setPauseOnExceptions": Debugger.SetPauseOnExceptionsResponse;
-    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsResponse;
     "Debugger.setPauseOnMicrotasks": Debugger.SetPauseOnMicrotasksResponse;
-    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsResponse;
-    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameResponse;
     "Debugger.setShouldBlackboxURL": Debugger.SetShouldBlackboxURLResponse;
-    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsResponse;
-    "Heap.enable": Heap.EnableResponse;
+    "Debugger.stepInto": Debugger.StepIntoResponse;
+    "Debugger.stepNext": Debugger.StepNextResponse;
+    "Debugger.stepOut": Debugger.StepOutResponse;
+    "Debugger.stepOver": Debugger.StepOverResponse;
     "Heap.disable": Heap.DisableResponse;
+    "Heap.enable": Heap.EnableResponse;
     "Heap.gc": Heap.GcResponse;
+    "Heap.getPreview": Heap.GetPreviewResponse;
+    "Heap.getRemoteObject": Heap.GetRemoteObjectResponse;
     "Heap.snapshot": Heap.SnapshotResponse;
     "Heap.startTracking": Heap.StartTrackingResponse;
     "Heap.stopTracking": Heap.StopTrackingResponse;
-    "Heap.getPreview": Heap.GetPreviewResponse;
-    "Heap.getRemoteObject": Heap.GetRemoteObjectResponse;
-    "Inspector.enable": Inspector.EnableResponse;
     "Inspector.disable": Inspector.DisableResponse;
+    "Inspector.enable": Inspector.EnableResponse;
     "Inspector.initialized": Inspector.InitializedResponse;
-    "Network.enable": Network.EnableResponse;
-    "Network.disable": Network.DisableResponse;
-    "Network.setExtraHTTPHeaders": Network.SetExtraHTTPHeadersResponse;
-    "Network.getResponseBody": Network.GetResponseBodyResponse;
-    "Network.setResourceCachingDisabled": Network.SetResourceCachingDisabledResponse;
-    "Network.loadResource": Network.LoadResourceResponse;
-    "Network.getSerializedCertificate": Network.GetSerializedCertificateResponse;
-    "Network.resolveWebSocket": Network.ResolveWebSocketResponse;
-    "Network.setInterceptionEnabled": Network.SetInterceptionEnabledResponse;
-    "Network.addInterception": Network.AddInterceptionResponse;
-    "Network.removeInterception": Network.RemoveInterceptionResponse;
-    "Network.interceptContinue": Network.InterceptContinueResponse;
-    "Network.interceptWithRequest": Network.InterceptWithRequestResponse;
-    "Network.interceptWithResponse": Network.InterceptWithResponseResponse;
-    "Network.interceptRequestWithResponse": Network.InterceptRequestWithResponseResponse;
-    "Network.interceptRequestWithError": Network.InterceptRequestWithErrorResponse;
-    "Network.setEmulatedConditions": Network.SetEmulatedConditionsResponse;
-    "Runtime.parse": Runtime.ParseResponse;
-    "Runtime.evaluate": Runtime.EvaluateResponse;
+    "LifecycleReporter.disable": LifecycleReporter.DisableResponse;
+    "LifecycleReporter.enable": LifecycleReporter.EnableResponse;
+    "LifecycleReporter.preventExit": LifecycleReporter.PreventExitResponse;
+    "LifecycleReporter.stopPreventingExit": LifecycleReporter.StopPreventingExitResponse;
     "Runtime.awaitPromise": Runtime.AwaitPromiseResponse;
     "Runtime.callFunctionOn": Runtime.CallFunctionOnResponse;
+    "Runtime.disable": Runtime.DisableResponse;
+    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerResponse;
+    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerResponse;
+    "Runtime.enable": Runtime.EnableResponse;
+    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerResponse;
+    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerResponse;
+    "Runtime.evaluate": Runtime.EvaluateResponse;
+    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksResponse;
+    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesResponse;
+    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesResponse;
     "Runtime.getPreview": Runtime.GetPreviewResponse;
     "Runtime.getProperties": Runtime.GetPropertiesResponse;
-    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesResponse;
-    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesResponse;
-    "Runtime.saveResult": Runtime.SaveResultResponse;
-    "Runtime.setSavedResultAlias": Runtime.SetSavedResultAliasResponse;
+    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsResponse;
+    "Runtime.parse": Runtime.ParseResponse;
     "Runtime.releaseObject": Runtime.ReleaseObjectResponse;
     "Runtime.releaseObjectGroup": Runtime.ReleaseObjectGroupResponse;
-    "Runtime.enable": Runtime.EnableResponse;
-    "Runtime.disable": Runtime.DisableResponse;
-    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsResponse;
-    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerResponse;
-    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerResponse;
-    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerResponse;
-    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerResponse;
-    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksResponse;
+    "Runtime.saveResult": Runtime.SaveResultResponse;
+    "Runtime.setSavedResultAlias": Runtime.SetSavedResultAliasResponse;
     "ScriptProfiler.startTracking": ScriptProfiler.StartTrackingResponse;
     "ScriptProfiler.stopTracking": ScriptProfiler.StopTrackingResponse;
+    "TestReporter.disable": TestReporter.DisableResponse;
+    "TestReporter.enable": TestReporter.EnableResponse;
   };
 
   export type Event<T extends keyof EventMap = keyof EventMap> = {

--- a/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts
+++ b/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts
@@ -1441,9 +1441,25 @@ export namespace JSC {
      */
     export type ErrorEvent = {
       /**
-       * Source of the error
+       * string associated with the error
        */
-      message: Console.ConsoleMessage;
+      message: string;
+      /**
+       * If an Error instance, the error.name property
+       */
+      name: string;
+      /**
+       * Array of URLs associated with the error
+       */
+      urls: string[];
+      /**
+       * Line, column pairs associated with the error. Already sourcemapped.
+       */
+      lineColumns: number[];
+      /**
+       * Source code preview associated with the error for up to 5 lines before the error, relative to the first non-internal stack frame.
+       */
+      sourceLines: string[];
     };
     /**
      * Enables LifecycleReporter domain events.
@@ -2502,9 +2518,13 @@ export namespace JSC {
        */
       id: number;
       /**
-       * Unique identifier of the script that started the test.
+       * Unique identifier of the script the test is in. Available when the debugger is attached.
        */
-      scriptId: Debugger.ScriptId;
+      scriptId?: Debugger.ScriptId | undefined;
+      /**
+       * url of the script the test is in. Available when the debugger is not attached.
+       */
+      url?: string | undefined;
       /**
        * Line number in the script that started the test.
        */
@@ -2564,190 +2584,190 @@ export namespace JSC {
     export type DisableResponse = {};
   }
   export type EventMap = {
-    "Console.heapSnapshot": Console.HeapSnapshotEvent;
     "Console.messageAdded": Console.MessageAddedEvent;
     "Console.messageRepeatCountUpdated": Console.MessageRepeatCountUpdatedEvent;
     "Console.messagesCleared": Console.MessagesClearedEvent;
-    "Debugger.breakpointResolved": Debugger.BreakpointResolvedEvent;
-    "Debugger.didSampleProbe": Debugger.DidSampleProbeEvent;
+    "Console.heapSnapshot": Console.HeapSnapshotEvent;
     "Debugger.globalObjectCleared": Debugger.GlobalObjectClearedEvent;
-    "Debugger.paused": Debugger.PausedEvent;
-    "Debugger.playBreakpointActionSound": Debugger.PlayBreakpointActionSoundEvent;
-    "Debugger.resumed": Debugger.ResumedEvent;
-    "Debugger.scriptFailedToParse": Debugger.ScriptFailedToParseEvent;
     "Debugger.scriptParsed": Debugger.ScriptParsedEvent;
+    "Debugger.scriptFailedToParse": Debugger.ScriptFailedToParseEvent;
+    "Debugger.breakpointResolved": Debugger.BreakpointResolvedEvent;
+    "Debugger.paused": Debugger.PausedEvent;
+    "Debugger.resumed": Debugger.ResumedEvent;
+    "Debugger.didSampleProbe": Debugger.DidSampleProbeEvent;
+    "Debugger.playBreakpointActionSound": Debugger.PlayBreakpointActionSoundEvent;
     "Heap.garbageCollected": Heap.GarbageCollectedEvent;
-    "Heap.trackingComplete": Heap.TrackingCompleteEvent;
     "Heap.trackingStart": Heap.TrackingStartEvent;
+    "Heap.trackingComplete": Heap.TrackingCompleteEvent;
     "Inspector.evaluateForTestInFrontend": Inspector.EvaluateForTestInFrontendEvent;
     "Inspector.inspect": Inspector.InspectEvent;
-    "LifecycleReporter.error": LifecycleReporter.ErrorEvent;
     "LifecycleReporter.reload": LifecycleReporter.ReloadEvent;
+    "LifecycleReporter.error": LifecycleReporter.ErrorEvent;
     "Runtime.executionContextCreated": Runtime.ExecutionContextCreatedEvent;
-    "ScriptProfiler.trackingComplete": ScriptProfiler.TrackingCompleteEvent;
     "ScriptProfiler.trackingStart": ScriptProfiler.TrackingStartEvent;
     "ScriptProfiler.trackingUpdate": ScriptProfiler.TrackingUpdateEvent;
-    "TestReporter.end": TestReporter.EndEvent;
+    "ScriptProfiler.trackingComplete": ScriptProfiler.TrackingCompleteEvent;
     "TestReporter.found": TestReporter.FoundEvent;
     "TestReporter.start": TestReporter.StartEvent;
+    "TestReporter.end": TestReporter.EndEvent;
   };
   export type RequestMap = {
-    "Audit.run": Audit.RunRequest;
     "Audit.setup": Audit.SetupRequest;
+    "Audit.run": Audit.RunRequest;
     "Audit.teardown": Audit.TeardownRequest;
-    "Console.clearMessages": Console.ClearMessagesRequest;
-    "Console.disable": Console.DisableRequest;
     "Console.enable": Console.EnableRequest;
-    "Console.getLoggingChannels": Console.GetLoggingChannelsRequest;
+    "Console.disable": Console.DisableRequest;
+    "Console.clearMessages": Console.ClearMessagesRequest;
     "Console.setConsoleClearAPIEnabled": Console.SetConsoleClearAPIEnabledRequest;
+    "Console.getLoggingChannels": Console.GetLoggingChannelsRequest;
     "Console.setLoggingChannelLevel": Console.SetLoggingChannelLevelRequest;
-    "Debugger.addSymbolicBreakpoint": Debugger.AddSymbolicBreakpointRequest;
-    "Debugger.continueToLocation": Debugger.ContinueToLocationRequest;
-    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopRequest;
-    "Debugger.disable": Debugger.DisableRequest;
     "Debugger.enable": Debugger.EnableRequest;
-    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameRequest;
-    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsRequest;
-    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsRequest;
-    "Debugger.getScriptSource": Debugger.GetScriptSourceRequest;
-    "Debugger.pause": Debugger.PauseRequest;
+    "Debugger.disable": Debugger.DisableRequest;
+    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthRequest;
+    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveRequest;
+    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlRequest;
+    "Debugger.setBreakpoint": Debugger.SetBreakpointRequest;
     "Debugger.removeBreakpoint": Debugger.RemoveBreakpointRequest;
+    "Debugger.addSymbolicBreakpoint": Debugger.AddSymbolicBreakpointRequest;
     "Debugger.removeSymbolicBreakpoint": Debugger.RemoveSymbolicBreakpointRequest;
+    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopRequest;
+    "Debugger.continueToLocation": Debugger.ContinueToLocationRequest;
+    "Debugger.stepNext": Debugger.StepNextRequest;
+    "Debugger.stepOver": Debugger.StepOverRequest;
+    "Debugger.stepInto": Debugger.StepIntoRequest;
+    "Debugger.stepOut": Debugger.StepOutRequest;
+    "Debugger.pause": Debugger.PauseRequest;
     "Debugger.resume": Debugger.ResumeRequest;
     "Debugger.searchInContent": Debugger.SearchInContentRequest;
-    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthRequest;
-    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsRequest;
-    "Debugger.setBreakpoint": Debugger.SetBreakpointRequest;
-    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlRequest;
-    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveRequest;
-    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsRequest;
-    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsRequest;
+    "Debugger.getScriptSource": Debugger.GetScriptSourceRequest;
+    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsRequest;
+    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsRequest;
     "Debugger.setPauseOnDebuggerStatements": Debugger.SetPauseOnDebuggerStatementsRequest;
     "Debugger.setPauseOnExceptions": Debugger.SetPauseOnExceptionsRequest;
+    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsRequest;
     "Debugger.setPauseOnMicrotasks": Debugger.SetPauseOnMicrotasksRequest;
+    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsRequest;
+    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameRequest;
     "Debugger.setShouldBlackboxURL": Debugger.SetShouldBlackboxURLRequest;
-    "Debugger.stepInto": Debugger.StepIntoRequest;
-    "Debugger.stepNext": Debugger.StepNextRequest;
-    "Debugger.stepOut": Debugger.StepOutRequest;
-    "Debugger.stepOver": Debugger.StepOverRequest;
-    "Heap.disable": Heap.DisableRequest;
+    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsRequest;
     "Heap.enable": Heap.EnableRequest;
+    "Heap.disable": Heap.DisableRequest;
     "Heap.gc": Heap.GcRequest;
-    "Heap.getPreview": Heap.GetPreviewRequest;
-    "Heap.getRemoteObject": Heap.GetRemoteObjectRequest;
     "Heap.snapshot": Heap.SnapshotRequest;
     "Heap.startTracking": Heap.StartTrackingRequest;
     "Heap.stopTracking": Heap.StopTrackingRequest;
-    "Inspector.disable": Inspector.DisableRequest;
+    "Heap.getPreview": Heap.GetPreviewRequest;
+    "Heap.getRemoteObject": Heap.GetRemoteObjectRequest;
     "Inspector.enable": Inspector.EnableRequest;
+    "Inspector.disable": Inspector.DisableRequest;
     "Inspector.initialized": Inspector.InitializedRequest;
-    "LifecycleReporter.disable": LifecycleReporter.DisableRequest;
     "LifecycleReporter.enable": LifecycleReporter.EnableRequest;
+    "LifecycleReporter.disable": LifecycleReporter.DisableRequest;
     "LifecycleReporter.preventExit": LifecycleReporter.PreventExitRequest;
     "LifecycleReporter.stopPreventingExit": LifecycleReporter.StopPreventingExitRequest;
+    "Runtime.parse": Runtime.ParseRequest;
+    "Runtime.evaluate": Runtime.EvaluateRequest;
     "Runtime.awaitPromise": Runtime.AwaitPromiseRequest;
     "Runtime.callFunctionOn": Runtime.CallFunctionOnRequest;
-    "Runtime.disable": Runtime.DisableRequest;
-    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerRequest;
-    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerRequest;
-    "Runtime.enable": Runtime.EnableRequest;
-    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerRequest;
-    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerRequest;
-    "Runtime.evaluate": Runtime.EvaluateRequest;
-    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksRequest;
-    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesRequest;
-    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesRequest;
     "Runtime.getPreview": Runtime.GetPreviewRequest;
     "Runtime.getProperties": Runtime.GetPropertiesRequest;
-    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsRequest;
-    "Runtime.parse": Runtime.ParseRequest;
-    "Runtime.releaseObject": Runtime.ReleaseObjectRequest;
-    "Runtime.releaseObjectGroup": Runtime.ReleaseObjectGroupRequest;
+    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesRequest;
+    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesRequest;
     "Runtime.saveResult": Runtime.SaveResultRequest;
     "Runtime.setSavedResultAlias": Runtime.SetSavedResultAliasRequest;
+    "Runtime.releaseObject": Runtime.ReleaseObjectRequest;
+    "Runtime.releaseObjectGroup": Runtime.ReleaseObjectGroupRequest;
+    "Runtime.enable": Runtime.EnableRequest;
+    "Runtime.disable": Runtime.DisableRequest;
+    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsRequest;
+    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerRequest;
+    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerRequest;
+    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerRequest;
+    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerRequest;
+    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksRequest;
     "ScriptProfiler.startTracking": ScriptProfiler.StartTrackingRequest;
     "ScriptProfiler.stopTracking": ScriptProfiler.StopTrackingRequest;
-    "TestReporter.disable": TestReporter.DisableRequest;
     "TestReporter.enable": TestReporter.EnableRequest;
+    "TestReporter.disable": TestReporter.DisableRequest;
   };
   export type ResponseMap = {
-    "Audit.run": Audit.RunResponse;
     "Audit.setup": Audit.SetupResponse;
+    "Audit.run": Audit.RunResponse;
     "Audit.teardown": Audit.TeardownResponse;
-    "Console.clearMessages": Console.ClearMessagesResponse;
-    "Console.disable": Console.DisableResponse;
     "Console.enable": Console.EnableResponse;
-    "Console.getLoggingChannels": Console.GetLoggingChannelsResponse;
+    "Console.disable": Console.DisableResponse;
+    "Console.clearMessages": Console.ClearMessagesResponse;
     "Console.setConsoleClearAPIEnabled": Console.SetConsoleClearAPIEnabledResponse;
+    "Console.getLoggingChannels": Console.GetLoggingChannelsResponse;
     "Console.setLoggingChannelLevel": Console.SetLoggingChannelLevelResponse;
-    "Debugger.addSymbolicBreakpoint": Debugger.AddSymbolicBreakpointResponse;
-    "Debugger.continueToLocation": Debugger.ContinueToLocationResponse;
-    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopResponse;
-    "Debugger.disable": Debugger.DisableResponse;
     "Debugger.enable": Debugger.EnableResponse;
-    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameResponse;
-    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsResponse;
-    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsResponse;
-    "Debugger.getScriptSource": Debugger.GetScriptSourceResponse;
-    "Debugger.pause": Debugger.PauseResponse;
+    "Debugger.disable": Debugger.DisableResponse;
+    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthResponse;
+    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveResponse;
+    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlResponse;
+    "Debugger.setBreakpoint": Debugger.SetBreakpointResponse;
     "Debugger.removeBreakpoint": Debugger.RemoveBreakpointResponse;
+    "Debugger.addSymbolicBreakpoint": Debugger.AddSymbolicBreakpointResponse;
     "Debugger.removeSymbolicBreakpoint": Debugger.RemoveSymbolicBreakpointResponse;
+    "Debugger.continueUntilNextRunLoop": Debugger.ContinueUntilNextRunLoopResponse;
+    "Debugger.continueToLocation": Debugger.ContinueToLocationResponse;
+    "Debugger.stepNext": Debugger.StepNextResponse;
+    "Debugger.stepOver": Debugger.StepOverResponse;
+    "Debugger.stepInto": Debugger.StepIntoResponse;
+    "Debugger.stepOut": Debugger.StepOutResponse;
+    "Debugger.pause": Debugger.PauseResponse;
     "Debugger.resume": Debugger.ResumeResponse;
     "Debugger.searchInContent": Debugger.SearchInContentResponse;
-    "Debugger.setAsyncStackTraceDepth": Debugger.SetAsyncStackTraceDepthResponse;
-    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsResponse;
-    "Debugger.setBreakpoint": Debugger.SetBreakpointResponse;
-    "Debugger.setBreakpointByUrl": Debugger.SetBreakpointByUrlResponse;
-    "Debugger.setBreakpointsActive": Debugger.SetBreakpointsActiveResponse;
-    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsResponse;
-    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsResponse;
+    "Debugger.getScriptSource": Debugger.GetScriptSourceResponse;
+    "Debugger.getFunctionDetails": Debugger.GetFunctionDetailsResponse;
+    "Debugger.getBreakpointLocations": Debugger.GetBreakpointLocationsResponse;
     "Debugger.setPauseOnDebuggerStatements": Debugger.SetPauseOnDebuggerStatementsResponse;
     "Debugger.setPauseOnExceptions": Debugger.SetPauseOnExceptionsResponse;
+    "Debugger.setPauseOnAssertions": Debugger.SetPauseOnAssertionsResponse;
     "Debugger.setPauseOnMicrotasks": Debugger.SetPauseOnMicrotasksResponse;
+    "Debugger.setPauseForInternalScripts": Debugger.SetPauseForInternalScriptsResponse;
+    "Debugger.evaluateOnCallFrame": Debugger.EvaluateOnCallFrameResponse;
     "Debugger.setShouldBlackboxURL": Debugger.SetShouldBlackboxURLResponse;
-    "Debugger.stepInto": Debugger.StepIntoResponse;
-    "Debugger.stepNext": Debugger.StepNextResponse;
-    "Debugger.stepOut": Debugger.StepOutResponse;
-    "Debugger.stepOver": Debugger.StepOverResponse;
-    "Heap.disable": Heap.DisableResponse;
+    "Debugger.setBlackboxBreakpointEvaluations": Debugger.SetBlackboxBreakpointEvaluationsResponse;
     "Heap.enable": Heap.EnableResponse;
+    "Heap.disable": Heap.DisableResponse;
     "Heap.gc": Heap.GcResponse;
-    "Heap.getPreview": Heap.GetPreviewResponse;
-    "Heap.getRemoteObject": Heap.GetRemoteObjectResponse;
     "Heap.snapshot": Heap.SnapshotResponse;
     "Heap.startTracking": Heap.StartTrackingResponse;
     "Heap.stopTracking": Heap.StopTrackingResponse;
-    "Inspector.disable": Inspector.DisableResponse;
+    "Heap.getPreview": Heap.GetPreviewResponse;
+    "Heap.getRemoteObject": Heap.GetRemoteObjectResponse;
     "Inspector.enable": Inspector.EnableResponse;
+    "Inspector.disable": Inspector.DisableResponse;
     "Inspector.initialized": Inspector.InitializedResponse;
-    "LifecycleReporter.disable": LifecycleReporter.DisableResponse;
     "LifecycleReporter.enable": LifecycleReporter.EnableResponse;
+    "LifecycleReporter.disable": LifecycleReporter.DisableResponse;
     "LifecycleReporter.preventExit": LifecycleReporter.PreventExitResponse;
     "LifecycleReporter.stopPreventingExit": LifecycleReporter.StopPreventingExitResponse;
+    "Runtime.parse": Runtime.ParseResponse;
+    "Runtime.evaluate": Runtime.EvaluateResponse;
     "Runtime.awaitPromise": Runtime.AwaitPromiseResponse;
     "Runtime.callFunctionOn": Runtime.CallFunctionOnResponse;
-    "Runtime.disable": Runtime.DisableResponse;
-    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerResponse;
-    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerResponse;
-    "Runtime.enable": Runtime.EnableResponse;
-    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerResponse;
-    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerResponse;
-    "Runtime.evaluate": Runtime.EvaluateResponse;
-    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksResponse;
-    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesResponse;
-    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesResponse;
     "Runtime.getPreview": Runtime.GetPreviewResponse;
     "Runtime.getProperties": Runtime.GetPropertiesResponse;
-    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsResponse;
-    "Runtime.parse": Runtime.ParseResponse;
-    "Runtime.releaseObject": Runtime.ReleaseObjectResponse;
-    "Runtime.releaseObjectGroup": Runtime.ReleaseObjectGroupResponse;
+    "Runtime.getDisplayableProperties": Runtime.GetDisplayablePropertiesResponse;
+    "Runtime.getCollectionEntries": Runtime.GetCollectionEntriesResponse;
     "Runtime.saveResult": Runtime.SaveResultResponse;
     "Runtime.setSavedResultAlias": Runtime.SetSavedResultAliasResponse;
+    "Runtime.releaseObject": Runtime.ReleaseObjectResponse;
+    "Runtime.releaseObjectGroup": Runtime.ReleaseObjectGroupResponse;
+    "Runtime.enable": Runtime.EnableResponse;
+    "Runtime.disable": Runtime.DisableResponse;
+    "Runtime.getRuntimeTypesForVariablesAtOffsets": Runtime.GetRuntimeTypesForVariablesAtOffsetsResponse;
+    "Runtime.enableTypeProfiler": Runtime.EnableTypeProfilerResponse;
+    "Runtime.disableTypeProfiler": Runtime.DisableTypeProfilerResponse;
+    "Runtime.enableControlFlowProfiler": Runtime.EnableControlFlowProfilerResponse;
+    "Runtime.disableControlFlowProfiler": Runtime.DisableControlFlowProfilerResponse;
+    "Runtime.getBasicBlocks": Runtime.GetBasicBlocksResponse;
     "ScriptProfiler.startTracking": ScriptProfiler.StartTrackingResponse;
     "ScriptProfiler.stopTracking": ScriptProfiler.StopTrackingResponse;
-    "TestReporter.disable": TestReporter.DisableResponse;
     "TestReporter.enable": TestReporter.EnableResponse;
+    "TestReporter.disable": TestReporter.DisableResponse;
   };
 
   export type Event<T extends keyof EventMap = keyof EventMap> = {

--- a/packages/bun-inspector-protocol/src/protocol/jsc/protocol.json
+++ b/packages/bun-inspector-protocol/src/protocol/jsc/protocol.json
@@ -1638,8 +1638,37 @@
           "parameters": [
             {
               "name": "message",
-              "$ref": "Console.ConsoleMessage",
-              "description": "Source of the error"
+              "type": "string",
+              "description": "string associated with the error"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "If an Error instance, the error.name property"
+            },
+            {
+              "name": "urls",
+              "type": "array",
+              "description": "Array of URLs associated with the error",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "lineColumns",
+              "type": "array",
+              "description": "Line, column pairs associated with the error. Already sourcemapped.",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "name": "sourceLines",
+              "type": "array",
+              "description": "Source code preview associated with the error for up to 5 lines before the error, relative to the first non-internal stack frame.",
+              "items": {
+                "type": "string"
+              }
             }
           ]
         }
@@ -2978,7 +3007,7 @@
     },
     {
       "domain": "TestReporter",
-      "description": "TestReporter domain allows reporting of lifecycle events.",
+      "description": "TestReporter domain allows reporting of test-related events.",
       "debuggableTypes": ["itml", "javascript"],
       "targetTypes": ["itml", "javascript"],
       "types": [
@@ -3010,7 +3039,14 @@
             {
               "name": "scriptId",
               "$ref": "Debugger.ScriptId",
-              "description": "Unique identifier of the script that started the test."
+              "description": "Unique identifier of the script the test is in. Available when the debugger is attached.",
+              "optional": true
+            },
+            {
+              "name": "url",
+              "type": "string",
+              "description": "url of the script the test is in. Available when the debugger is not attached.",
+              "optional": true
             },
             {
               "name": "line",
@@ -3050,7 +3086,7 @@
             },
             {
               "name": "elapsed",
-              "type": "number",
+              "type": "integer",
               "description": "Elapsed time in milliseconds since the test started."
             }
           ]

--- a/packages/bun-inspector-protocol/src/protocol/jsc/protocol.json
+++ b/packages/bun-inspector-protocol/src/protocol/jsc/protocol.json
@@ -1,7 +1,65 @@
 {
   "name": "JSC",
-  "version": { "major": 1, "minor": 3 },
+  "version": {
+    "major": 1,
+    "minor": 4
+  },
   "domains": [
+    {
+      "domain": "Audit",
+      "description": "",
+      "version": 4,
+      "debuggableTypes": ["itml", "javascript", "page", "service-worker", "web-page"],
+      "targetTypes": ["itml", "javascript", "page", "service-worker", "worker"],
+      "commands": [
+        {
+          "name": "setup",
+          "description": "Creates the `WebInspectorAudit` object that is passed to run. Must call teardown before calling setup more than once.",
+          "parameters": [
+            {
+              "name": "contextId",
+              "$ref": "Runtime.ExecutionContextId",
+              "optional": true,
+              "description": "Specifies in which isolated context to run the test. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page."
+            }
+          ]
+        },
+        {
+          "name": "run",
+          "description": "Parses and evaluates the given test string and sends back the result. Returned values are saved to the \"audit\" object group. Call setup before and teardown after if the `WebInspectorAudit` object should be passed into the test.",
+          "parameters": [
+            {
+              "name": "test",
+              "type": "string",
+              "description": "Test string to parse and evaluate."
+            },
+            {
+              "name": "contextId",
+              "$ref": "Runtime.ExecutionContextId",
+              "optional": true,
+              "description": "Specifies in which isolated context to run the test. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page."
+            }
+          ],
+          "returns": [
+            {
+              "name": "result",
+              "$ref": "Runtime.RemoteObject",
+              "description": "Evaluation result."
+            },
+            {
+              "name": "wasThrown",
+              "type": "boolean",
+              "optional": true,
+              "description": "True if the result was thrown during the evaluation."
+            }
+          ]
+        },
+        {
+          "name": "teardown",
+          "description": "Destroys the `WebInspectorAudit` object that is passed to run. Must call setup before calling teardown."
+        }
+      ]
+    },
     {
       "domain": "Console",
       "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
@@ -41,28 +99,44 @@
         {
           "id": "ClearReason",
           "type": "string",
-          "enum": ["console-api", "main-frame-navigation"],
+          "enum": ["console-api", "frontend", "main-frame-navigation"],
           "description": "The reason the console is being cleared."
         },
         {
           "id": "Channel",
           "description": "Logging channel.",
           "type": "object",
-          "properties": [{ "name": "source", "$ref": "ChannelSource" }, { "name": "level", "$ref": "ChannelLevel" }]
+          "properties": [
+            {
+              "name": "source",
+              "$ref": "ChannelSource"
+            },
+            {
+              "name": "level",
+              "$ref": "ChannelLevel"
+            }
+          ]
         },
         {
           "id": "ConsoleMessage",
           "type": "object",
           "description": "Console message.",
           "properties": [
-            { "name": "source", "$ref": "ChannelSource" },
+            {
+              "name": "source",
+              "$ref": "ChannelSource"
+            },
             {
               "name": "level",
               "type": "string",
               "enum": ["log", "info", "warning", "error", "debug"],
               "description": "Message severity."
             },
-            { "name": "text", "type": "string", "description": "Message text." },
+            {
+              "name": "text",
+              "type": "string",
+              "description": "Message text."
+            },
             {
               "name": "type",
               "type": "string",
@@ -85,7 +159,12 @@
               ],
               "description": "Console message type."
             },
-            { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+            {
+              "name": "url",
+              "type": "string",
+              "optional": true,
+              "description": "URL of the message origin."
+            },
             {
               "name": "line",
               "type": "integer",
@@ -107,7 +186,9 @@
             {
               "name": "parameters",
               "type": "array",
-              "items": { "$ref": "Runtime.RemoteObject" },
+              "items": {
+                "$ref": "Runtime.RemoteObject"
+              },
               "optional": true,
               "description": "Message parameters in case of the formatted message."
             },
@@ -136,11 +217,31 @@
           "type": "object",
           "description": "Stack entry for console errors and assertions.",
           "properties": [
-            { "name": "functionName", "type": "string", "description": "JavaScript function name." },
-            { "name": "url", "type": "string", "description": "JavaScript script name or url." },
-            { "name": "scriptId", "$ref": "Debugger.ScriptId", "description": "Script identifier." },
-            { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
-            { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+            {
+              "name": "functionName",
+              "type": "string",
+              "description": "JavaScript function name."
+            },
+            {
+              "name": "url",
+              "type": "string",
+              "description": "JavaScript script name or url."
+            },
+            {
+              "name": "scriptId",
+              "$ref": "Debugger.ScriptId",
+              "description": "Script identifier."
+            },
+            {
+              "name": "lineNumber",
+              "type": "integer",
+              "description": "JavaScript script line number."
+            },
+            {
+              "name": "columnNumber",
+              "type": "integer",
+              "description": "JavaScript script column number."
+            }
           ]
         },
         {
@@ -148,7 +249,13 @@
           "description": "Call frames for async function calls, console assertions, and error messages.",
           "type": "object",
           "properties": [
-            { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" } },
+            {
+              "name": "callFrames",
+              "type": "array",
+              "items": {
+                "$ref": "CallFrame"
+              }
+            },
             {
               "name": "topCallFrameIsBoundary",
               "type": "boolean",
@@ -161,7 +268,12 @@
               "optional": true,
               "description": "Whether one or more frames have been truncated from the bottom of the stack."
             },
-            { "name": "parentStackTrace", "$ref": "StackTrace", "optional": true, "description": "Parent StackTrace." }
+            {
+              "name": "parentStackTrace",
+              "$ref": "StackTrace",
+              "optional": true,
+              "description": "Parent StackTrace."
+            }
           ]
         }
       ],
@@ -174,20 +286,48 @@
           "name": "disable",
           "description": "Disables console domain, prevents further console messages from being reported to the client."
         },
-        { "name": "clearMessages", "description": "Clears console messages collected in the browser." },
+        {
+          "name": "clearMessages",
+          "description": "Clears console messages collected in the browser."
+        },
+        {
+          "name": "setConsoleClearAPIEnabled",
+          "description": "Control whether calling <code>console.clear()</code> has an effect in Web Inspector. Defaults to true.",
+          "parameters": [
+            {
+              "name": "enable",
+              "type": "boolean"
+            }
+          ]
+        },
         {
           "name": "getLoggingChannels",
           "description": "List of the different message sources that are non-default logging channels.",
           "returns": [
-            { "name": "channels", "type": "array", "items": { "$ref": "Channel" }, "description": "Logging channels." }
+            {
+              "name": "channels",
+              "type": "array",
+              "items": {
+                "$ref": "Channel"
+              },
+              "description": "Logging channels."
+            }
           ]
         },
         {
           "name": "setLoggingChannelLevel",
           "description": "Modify the level of a channel.",
           "parameters": [
-            { "name": "source", "$ref": "ChannelSource", "description": "Logging channel to modify." },
-            { "name": "level", "$ref": "ChannelLevel", "description": "New level." }
+            {
+              "name": "source",
+              "$ref": "ChannelSource",
+              "description": "Logging channel to modify."
+            },
+            {
+              "name": "level",
+              "$ref": "ChannelLevel",
+              "description": "New level."
+            }
           ]
         }
       ],
@@ -196,14 +336,22 @@
           "name": "messageAdded",
           "description": "Issued when new console message is added.",
           "parameters": [
-            { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+            {
+              "name": "message",
+              "$ref": "ConsoleMessage",
+              "description": "Console message that has been added."
+            }
           ]
         },
         {
           "name": "messageRepeatCountUpdated",
           "description": "Issued when subsequent message(s) are equal to the previous one(s).",
           "parameters": [
-            { "name": "count", "type": "integer", "description": "New repeat count value." },
+            {
+              "name": "count",
+              "type": "integer",
+              "description": "New repeat count value."
+            },
             {
               "name": "timestamp",
               "type": "number",
@@ -216,14 +364,21 @@
           "name": "messagesCleared",
           "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation.",
           "parameters": [
-            { "name": "reason", "$ref": "ClearReason", "description": "The reason the console is being cleared." }
+            {
+              "name": "reason",
+              "$ref": "ClearReason",
+              "description": "The reason the console is being cleared."
+            }
           ]
         },
         {
           "name": "heapSnapshot",
           "description": "Issued from console.takeHeapSnapshot.",
           "parameters": [
-            { "name": "timestamp", "type": "number" },
+            {
+              "name": "timestamp",
+              "type": "number"
+            },
             {
               "name": "snapshotData",
               "$ref": "Heap.HeapSnapshotData",
@@ -240,93 +395,31 @@
       ]
     },
     {
-      "domain": "CPUProfiler",
-      "description": "CPUProfiler domain exposes cpu usage tracking.",
-      "condition": "defined(ENABLE_RESOURCE_USAGE) && ENABLE_RESOURCE_USAGE",
-      "debuggableTypes": ["page", "web-page"],
-      "targetTypes": ["page"],
-      "types": [
-        {
-          "id": "ThreadInfo",
-          "description": "CPU usage for an individual thread.",
-          "type": "object",
-          "properties": [
-            { "name": "name", "type": "string", "description": "Some thread identification information." },
-            {
-              "name": "usage",
-              "type": "number",
-              "description": "CPU usage for this thread. This should not exceed 100% for an individual thread."
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "enum": ["main", "webkit"],
-              "optional": true,
-              "description": "Type of thread. There should be a single main thread."
-            },
-            {
-              "name": "targetId",
-              "type": "string",
-              "optional": true,
-              "description": "A thread may be associated with a target, such as a Worker, in the process."
-            }
-          ]
-        },
-        {
-          "id": "Event",
-          "type": "object",
-          "properties": [
-            { "name": "timestamp", "type": "number" },
-            {
-              "name": "usage",
-              "type": "number",
-              "description": "Percent of total cpu usage. If there are multiple cores the usage may be greater than 100%."
-            },
-            {
-              "name": "threads",
-              "type": "array",
-              "items": { "$ref": "ThreadInfo" },
-              "optional": true,
-              "description": "Per-thread CPU usage information. Does not include the main thread."
-            }
-          ]
-        }
-      ],
-      "commands": [
-        { "name": "startTracking", "description": "Start tracking cpu usage." },
-        {
-          "name": "stopTracking",
-          "description": "Stop tracking cpu usage. This will produce a `trackingComplete` event."
-        }
-      ],
-      "events": [
-        {
-          "name": "trackingStart",
-          "description": "Tracking started.",
-          "parameters": [{ "name": "timestamp", "type": "number" }]
-        },
-        {
-          "name": "trackingUpdate",
-          "description": "Periodic tracking updates with event data.",
-          "parameters": [{ "name": "event", "$ref": "Event" }]
-        },
-        {
-          "name": "trackingComplete",
-          "description": "Tracking stopped.",
-          "parameters": [{ "name": "timestamp", "type": "number" }]
-        }
-      ]
-    },
-    {
       "domain": "Debugger",
       "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
       "debuggableTypes": ["itml", "javascript", "page", "service-worker", "web-page"],
       "targetTypes": ["itml", "javascript", "page", "service-worker", "worker"],
       "types": [
-        { "id": "BreakpointId", "type": "string", "description": "Breakpoint identifier." },
-        { "id": "BreakpointActionIdentifier", "type": "integer", "description": "Breakpoint action identifier." },
-        { "id": "ScriptId", "type": "string", "description": "Unique script identifier." },
-        { "id": "CallFrameId", "type": "string", "description": "Call frame identifier." },
+        {
+          "id": "BreakpointId",
+          "type": "string",
+          "description": "Breakpoint identifier."
+        },
+        {
+          "id": "BreakpointActionIdentifier",
+          "type": "integer",
+          "description": "Breakpoint action identifier."
+        },
+        {
+          "id": "ScriptId",
+          "type": "string",
+          "description": "Unique script identifier."
+        },
+        {
+          "id": "CallFrameId",
+          "type": "string",
+          "description": "Call frame identifier."
+        },
         {
           "id": "Location",
           "type": "object",
@@ -337,7 +430,11 @@
               "$ref": "ScriptId",
               "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>."
             },
-            { "name": "lineNumber", "type": "integer", "description": "Line number in the script (0-based)." },
+            {
+              "name": "lineNumber",
+              "type": "integer",
+              "description": "Line number in the script (0-based)."
+            },
             {
               "name": "columnNumber",
               "type": "integer",
@@ -392,7 +489,9 @@
               "name": "actions",
               "type": "array",
               "optional": true,
-              "items": { "$ref": "BreakpointAction" },
+              "items": {
+                "$ref": "BreakpointAction"
+              },
               "description": "Actions to perform automatically when the breakpoint is triggered."
             },
             {
@@ -414,7 +513,11 @@
           "type": "object",
           "description": "Information about the function.",
           "properties": [
-            { "name": "location", "$ref": "Location", "description": "Location of the function." },
+            {
+              "name": "location",
+              "$ref": "Location",
+              "description": "Location of the function."
+            },
             {
               "name": "name",
               "type": "string",
@@ -431,7 +534,9 @@
               "name": "scopeChain",
               "type": "array",
               "optional": true,
-              "items": { "$ref": "Scope" },
+              "items": {
+                "$ref": "Scope"
+              },
               "description": "Scope chain for this closure."
             }
           ]
@@ -451,11 +556,17 @@
               "type": "string",
               "description": "Name of the JavaScript function called on this call frame."
             },
-            { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+            {
+              "name": "location",
+              "$ref": "Location",
+              "description": "Location in the source code."
+            },
             {
               "name": "scopeChain",
               "type": "array",
-              "items": { "$ref": "Scope" },
+              "items": {
+                "$ref": "Scope"
+              },
               "description": "Scope chain for this call frame."
             },
             {
@@ -494,7 +605,12 @@
               ],
               "description": "Scope type."
             },
-            { "name": "name", "type": "string", "optional": true, "description": "Name associated with the scope." },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true,
+              "description": "Name associated with the scope."
+            },
             {
               "name": "location",
               "$ref": "Location",
@@ -519,14 +635,26 @@
               "$ref": "BreakpointActionIdentifier",
               "description": "Identifier of the probe breakpoint action that created the sample."
             },
-            { "name": "sampleId", "type": "integer", "description": "Unique identifier for this sample." },
+            {
+              "name": "sampleId",
+              "type": "integer",
+              "description": "Unique identifier for this sample."
+            },
             {
               "name": "batchId",
               "type": "integer",
               "description": "A batch identifier which is the same for all samples taken at the same breakpoint hit."
             },
-            { "name": "timestamp", "type": "number", "description": "Timestamp of when the sample was taken." },
-            { "name": "payload", "$ref": "Runtime.RemoteObject", "description": "Contents of the sample." }
+            {
+              "name": "timestamp",
+              "type": "number",
+              "description": "Timestamp of when the sample was taken."
+            },
+            {
+              "name": "payload",
+              "$ref": "Runtime.RemoteObject",
+              "description": "Contents of the sample."
+            }
           ]
         },
         {
@@ -559,7 +687,11 @@
           "type": "object",
           "description": "The pause reason auxiliary data when paused because of a Content Security Policy directive.",
           "properties": [
-            { "name": "directive", "type": "string", "description": "The CSP directive that blocked script execution." }
+            {
+              "name": "directive",
+              "type": "string",
+              "description": "The CSP directive that blocked script execution."
+            }
           ]
         }
       ],
@@ -568,24 +700,41 @@
           "name": "enable",
           "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
         },
-        { "name": "disable", "description": "Disables debugger for given page." },
+        {
+          "name": "disable",
+          "description": "Disables debugger for given page."
+        },
         {
           "name": "setAsyncStackTraceDepth",
           "description": "Set the async stack trace depth for the page. A value of zero disables recording of async stack traces.",
-          "parameters": [{ "name": "depth", "type": "integer", "description": "Async stack trace depth." }]
+          "parameters": [
+            {
+              "name": "depth",
+              "type": "integer",
+              "description": "Async stack trace depth."
+            }
+          ]
         },
         {
           "name": "setBreakpointsActive",
           "description": "Activates / deactivates all breakpoints on the page.",
           "parameters": [
-            { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+            {
+              "name": "active",
+              "type": "boolean",
+              "description": "New value for breakpoints active state."
+            }
           ]
         },
         {
           "name": "setBreakpointByUrl",
           "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads.",
           "parameters": [
-            { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+            {
+              "name": "lineNumber",
+              "type": "integer",
+              "description": "Line number to set breakpoint at."
+            },
             {
               "name": "url",
               "type": "string",
@@ -620,7 +769,9 @@
             {
               "name": "locations",
               "type": "array",
-              "items": { "$ref": "Location" },
+              "items": {
+                "$ref": "Location"
+              },
               "description": "List of the locations this breakpoint resolved into upon addition."
             }
           ]
@@ -629,7 +780,11 @@
           "name": "setBreakpoint",
           "description": "Sets JavaScript breakpoint at a given location.",
           "parameters": [
-            { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+            {
+              "name": "location",
+              "$ref": "Location",
+              "description": "Location to set breakpoint in."
+            },
             {
               "name": "options",
               "$ref": "BreakpointOptions",
@@ -643,19 +798,32 @@
               "$ref": "BreakpointId",
               "description": "Id of the created breakpoint for further reference."
             },
-            { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+            {
+              "name": "actualLocation",
+              "$ref": "Location",
+              "description": "Location this breakpoint resolved into."
+            }
           ]
         },
         {
           "name": "removeBreakpoint",
           "description": "Removes JavaScript breakpoint.",
-          "parameters": [{ "name": "breakpointId", "$ref": "BreakpointId" }]
+          "parameters": [
+            {
+              "name": "breakpointId",
+              "$ref": "BreakpointId"
+            }
+          ]
         },
         {
           "name": "addSymbolicBreakpoint",
           "description": "Adds a JavaScript breakpoint that pauses execution whenever a function with the given name is about to be called.",
           "parameters": [
-            { "name": "symbol", "type": "string", "description": "The name of the function to pause in when called." },
+            {
+              "name": "symbol",
+              "type": "string",
+              "description": "The name of the function to pause in when called."
+            },
             {
               "name": "caseSensitive",
               "type": "boolean",
@@ -680,7 +848,11 @@
           "name": "removeSymbolicBreakpoint",
           "description": "Removes a previously added symbolic breakpoint.",
           "parameters": [
-            { "name": "symbol", "type": "string", "description": "The name of the function to pause in when called." },
+            {
+              "name": "symbol",
+              "type": "string",
+              "description": "The name of the function to pause in when called."
+            },
             {
               "name": "caseSensitive",
               "type": "boolean",
@@ -702,7 +874,13 @@
         {
           "name": "continueToLocation",
           "description": "Continues execution until specific location is reached. This will trigger either a Debugger.paused or Debugger.resumed event.",
-          "parameters": [{ "name": "location", "$ref": "Location", "description": "Location to continue to." }]
+          "parameters": [
+            {
+              "name": "location",
+              "$ref": "Location",
+              "description": "Location to continue to."
+            }
+          ]
         },
         {
           "name": "stepNext",
@@ -720,7 +898,10 @@
           "name": "stepOut",
           "description": "Steps out of the function call. This will trigger either a Debugger.paused or Debugger.resumed event."
         },
-        { "name": "pause", "description": "Stops on the next JavaScript statement." },
+        {
+          "name": "pause",
+          "description": "Stops on the next JavaScript statement."
+        },
         {
           "name": "resume",
           "description": "Resumes JavaScript execution. This will trigger a Debugger.resumed event."
@@ -729,8 +910,16 @@
           "name": "searchInContent",
           "description": "Searches for given string in script content.",
           "parameters": [
-            { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
-            { "name": "query", "type": "string", "description": "String to search for." },
+            {
+              "name": "scriptId",
+              "$ref": "ScriptId",
+              "description": "Id of the script to search in."
+            },
+            {
+              "name": "query",
+              "type": "string",
+              "description": "String to search for."
+            },
             {
               "name": "caseSensitive",
               "type": "boolean",
@@ -748,7 +937,9 @@
             {
               "name": "result",
               "type": "array",
-              "items": { "$ref": "GenericTypes.SearchMatch" },
+              "items": {
+                "$ref": "GenericTypes.SearchMatch"
+              },
               "description": "List of search matches."
             }
           ]
@@ -757,9 +948,19 @@
           "name": "getScriptSource",
           "description": "Returns source for the script with given id.",
           "parameters": [
-            { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+            {
+              "name": "scriptId",
+              "$ref": "ScriptId",
+              "description": "Id of the script to get source for."
+            }
           ],
-          "returns": [{ "name": "scriptSource", "type": "string", "description": "Script source." }]
+          "returns": [
+            {
+              "name": "scriptSource",
+              "type": "string",
+              "description": "Script source."
+            }
+          ]
         },
         {
           "name": "getFunctionDetails",
@@ -772,7 +973,11 @@
             }
           ],
           "returns": [
-            { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+            {
+              "name": "details",
+              "$ref": "FunctionDetails",
+              "description": "Information about the function."
+            }
           ]
         },
         {
@@ -794,7 +999,9 @@
             {
               "name": "locations",
               "type": "array",
-              "items": { "$ref": "Location" },
+              "items": {
+                "$ref": "Location"
+              },
               "description": "List of resolved breakpoint locations."
             }
           ]
@@ -803,7 +1010,10 @@
           "name": "setPauseOnDebuggerStatements",
           "description": "Control whether the debugger pauses execution before `debugger` statements.",
           "parameters": [
-            { "name": "enabled", "type": "boolean" },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
             {
               "name": "options",
               "$ref": "BreakpointOptions",
@@ -834,7 +1044,10 @@
           "name": "setPauseOnAssertions",
           "description": "Set pause on assertions state. Assertions are console.assert assertions.",
           "parameters": [
-            { "name": "enabled", "type": "boolean" },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
             {
               "name": "options",
               "$ref": "BreakpointOptions",
@@ -847,7 +1060,10 @@
           "name": "setPauseOnMicrotasks",
           "description": "Pause when running the next JavaScript microtask.",
           "parameters": [
-            { "name": "enabled", "type": "boolean" },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
             {
               "name": "options",
               "$ref": "BreakpointOptions",
@@ -859,14 +1075,27 @@
         {
           "name": "setPauseForInternalScripts",
           "description": "Change whether to pause in the debugger for internal scripts. The default value is false.",
-          "parameters": [{ "name": "shouldPause", "type": "boolean" }]
+          "parameters": [
+            {
+              "name": "shouldPause",
+              "type": "boolean"
+            }
+          ]
         },
         {
           "name": "evaluateOnCallFrame",
           "description": "Evaluates expression on a given call frame.",
           "parameters": [
-            { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
-            { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+            {
+              "name": "callFrameId",
+              "$ref": "CallFrameId",
+              "description": "Call frame identifier to evaluate on."
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Expression to evaluate."
+            },
             {
               "name": "objectGroup",
               "type": "string",
@@ -932,28 +1161,48 @@
         },
         {
           "name": "setShouldBlackboxURL",
-          "description": "Sets whether the given URL should be in the list of blackboxed scripts, which are ignored when pausing/stepping/debugging.",
+          "description": "Sets whether the given URL should be in the list of blackboxed scripts, which are ignored when pausing.",
           "parameters": [
-            { "name": "url", "type": "string" },
-            { "name": "shouldBlackbox", "type": "boolean" },
+            {
+              "name": "url",
+              "type": "string"
+            },
+            {
+              "name": "shouldBlackbox",
+              "type": "boolean"
+            },
             {
               "name": "caseSensitive",
               "type": "boolean",
               "optional": true,
-              "description": "If true, <code>url</code> is case sensitive."
+              "description": "If <code>true</code>, <code>url</code> is case sensitive."
             },
             {
               "name": "isRegex",
               "type": "boolean",
               "optional": true,
-              "description": "If true, treat <code>url</code> as regular expression."
+              "description": "If <code>true</code>, treat <code>url</code> as regular expression."
+            },
+            {
+              "name": "sourceRanges",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "optional": true,
+              "description": "If provided, limits where in the script the debugger will skip pauses. Expected structure is a repeated <code>[startLine, startColumn, endLine, endColumn]</code>. Ignored if <code>shouldBlackbox</code> is <code>false</code>."
             }
           ]
         },
         {
           "name": "setBlackboxBreakpointEvaluations",
           "description": "Sets whether evaluation of breakpoint conditions, ignore counts, and actions happen at the location of the breakpoint or are deferred due to blackboxing.",
-          "parameters": [{ "name": "blackboxBreakpointEvaluations", "type": "boolean" }]
+          "parameters": [
+            {
+              "name": "blackboxBreakpointEvaluations",
+              "type": "boolean"
+            }
+          ]
         }
       ],
       "events": [
@@ -965,8 +1214,16 @@
           "name": "scriptParsed",
           "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.",
           "parameters": [
-            { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
-            { "name": "url", "type": "string", "description": "URL of the script parsed (if any)." },
+            {
+              "name": "scriptId",
+              "$ref": "ScriptId",
+              "description": "Identifier of the script parsed."
+            },
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL of the script parsed (if any)."
+            },
             {
               "name": "startLine",
               "type": "integer",
@@ -977,8 +1234,16 @@
               "type": "integer",
               "description": "Column offset of the script within the resource with given URL."
             },
-            { "name": "endLine", "type": "integer", "description": "Last line of the script." },
-            { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+            {
+              "name": "endLine",
+              "type": "integer",
+              "description": "Last line of the script."
+            },
+            {
+              "name": "endColumn",
+              "type": "integer",
+              "description": "Length of the last line of the script."
+            },
             {
               "name": "isContentScript",
               "type": "boolean",
@@ -1009,23 +1274,47 @@
           "name": "scriptFailedToParse",
           "description": "Fired when virtual machine fails to parse the script.",
           "parameters": [
-            { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL of the script that failed to parse."
+            },
             {
               "name": "scriptSource",
               "type": "string",
               "description": "Source text of the script that failed to parse."
             },
-            { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
-            { "name": "errorLine", "type": "integer", "description": "Line with error." },
-            { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+            {
+              "name": "startLine",
+              "type": "integer",
+              "description": "Line offset of the script within the resource."
+            },
+            {
+              "name": "errorLine",
+              "type": "integer",
+              "description": "Line with error."
+            },
+            {
+              "name": "errorMessage",
+              "type": "string",
+              "description": "Parse error message."
+            }
           ]
         },
         {
           "name": "breakpointResolved",
           "description": "Fired when breakpoint is resolved to an actual script and location.",
           "parameters": [
-            { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
-            { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+            {
+              "name": "breakpointId",
+              "$ref": "BreakpointId",
+              "description": "Breakpoint unique identifier."
+            },
+            {
+              "name": "location",
+              "$ref": "Location",
+              "description": "Actual breakpoint location."
+            }
           ]
         },
         {
@@ -1035,7 +1324,9 @@
             {
               "name": "callFrames",
               "type": "array",
-              "items": { "$ref": "CallFrame" },
+              "items": {
+                "$ref": "CallFrame"
+              },
               "description": "Call stack the virtual machine stopped on."
             },
             {
@@ -1075,11 +1366,20 @@
             }
           ]
         },
-        { "name": "resumed", "description": "Fired when the virtual machine resumed execution." },
+        {
+          "name": "resumed",
+          "description": "Fired when the virtual machine resumed execution."
+        },
         {
           "name": "didSampleProbe",
           "description": "Fires when a new probe sample is collected.",
-          "parameters": [{ "name": "sample", "$ref": "ProbeSample", "description": "A collected probe sample." }]
+          "parameters": [
+            {
+              "name": "sample",
+              "$ref": "ProbeSample",
+              "description": "A collected probe sample."
+            }
+          ]
         },
         {
           "name": "playBreakpointActionSound",
@@ -1090,21 +1390,6 @@
               "$ref": "BreakpointActionIdentifier",
               "description": "Breakpoint action identifier."
             }
-          ]
-        }
-      ]
-    },
-    {
-      "domain": "GenericTypes",
-      "description": "Exposes generic types to be used by any domain.",
-      "types": [
-        {
-          "id": "SearchMatch",
-          "type": "object",
-          "description": "Search match in a resource.",
-          "properties": [
-            { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
-            { "name": "lineContent", "type": "string", "description": "Line with match content." }
           ]
         }
       ]
@@ -1126,20 +1411,48 @@
               "enum": ["full", "partial"],
               "description": "The type of garbage collection."
             },
-            { "name": "startTime", "type": "number" },
-            { "name": "endTime", "type": "number" }
+            {
+              "name": "startTime",
+              "type": "number"
+            },
+            {
+              "name": "endTime",
+              "type": "number"
+            }
           ]
         },
-        { "id": "HeapSnapshotData", "description": "JavaScriptCore HeapSnapshot JSON data.", "type": "string" }
+        {
+          "id": "HeapSnapshotData",
+          "description": "JavaScriptCore HeapSnapshot JSON data.",
+          "type": "string"
+        }
       ],
       "commands": [
-        { "name": "enable", "description": "Enables Heap domain events." },
-        { "name": "disable", "description": "Disables Heap domain events." },
-        { "name": "gc", "description": "Trigger a full garbage collection." },
+        {
+          "name": "enable",
+          "description": "Enables Heap domain events."
+        },
+        {
+          "name": "disable",
+          "description": "Disables Heap domain events."
+        },
+        {
+          "name": "gc",
+          "description": "Trigger a full garbage collection."
+        },
         {
           "name": "snapshot",
           "description": "Take a heap snapshot.",
-          "returns": [{ "name": "timestamp", "type": "number" }, { "name": "snapshotData", "$ref": "HeapSnapshotData" }]
+          "returns": [
+            {
+              "name": "timestamp",
+              "type": "number"
+            },
+            {
+              "name": "snapshotData",
+              "$ref": "HeapSnapshotData"
+            }
+          ]
         },
         {
           "name": "startTracking",
@@ -1160,14 +1473,24 @@
             }
           ],
           "returns": [
-            { "name": "string", "type": "string", "optional": true, "description": "String value." },
+            {
+              "name": "string",
+              "type": "string",
+              "optional": true,
+              "description": "String value."
+            },
             {
               "name": "functionDetails",
               "$ref": "Debugger.FunctionDetails",
               "optional": true,
               "description": "Function details."
             },
-            { "name": "preview", "$ref": "Runtime.ObjectPreview", "optional": true, "description": "Object preview." }
+            {
+              "name": "preview",
+              "$ref": "Runtime.ObjectPreview",
+              "optional": true,
+              "description": "Object preview."
+            }
           ]
         },
         {
@@ -1186,29 +1509,54 @@
               "description": "Symbolic group name that can be used to release multiple objects."
             }
           ],
-          "returns": [{ "name": "result", "$ref": "Runtime.RemoteObject", "description": "Resulting object." }]
+          "returns": [
+            {
+              "name": "result",
+              "$ref": "Runtime.RemoteObject",
+              "description": "Resulting object."
+            }
+          ]
         }
       ],
       "events": [
         {
           "name": "garbageCollected",
           "description": "Information about the garbage collection.",
-          "parameters": [{ "name": "collection", "$ref": "GarbageCollection" }]
+          "parameters": [
+            {
+              "name": "collection",
+              "$ref": "GarbageCollection"
+            }
+          ]
         },
         {
           "name": "trackingStart",
           "description": "Tracking started.",
           "parameters": [
-            { "name": "timestamp", "type": "number" },
-            { "name": "snapshotData", "$ref": "HeapSnapshotData", "description": "Snapshot at the start of tracking." }
+            {
+              "name": "timestamp",
+              "type": "number"
+            },
+            {
+              "name": "snapshotData",
+              "$ref": "HeapSnapshotData",
+              "description": "Snapshot at the start of tracking."
+            }
           ]
         },
         {
           "name": "trackingComplete",
           "description": "Tracking stopped.",
           "parameters": [
-            { "name": "timestamp", "type": "number" },
-            { "name": "snapshotData", "$ref": "HeapSnapshotData", "description": "Snapshot at the end of tracking." }
+            {
+              "name": "timestamp",
+              "type": "number"
+            },
+            {
+              "name": "snapshotData",
+              "$ref": "HeapSnapshotData",
+              "description": "Snapshot at the end of tracking."
+            }
           ]
         }
       ]
@@ -1218,809 +1566,81 @@
       "debuggableTypes": ["itml", "javascript", "page", "web-page"],
       "targetTypes": ["itml", "javascript", "page"],
       "commands": [
-        { "name": "enable", "description": "Enables inspector domain notifications." },
-        { "name": "disable", "description": "Disables inspector domain notifications." },
+        {
+          "name": "enable",
+          "description": "Enables inspector domain notifications."
+        },
+        {
+          "name": "disable",
+          "description": "Disables inspector domain notifications."
+        },
         {
           "name": "initialized",
           "description": "Sent by the frontend after all initialization messages have been sent."
         }
       ],
       "events": [
-        { "name": "evaluateForTestInFrontend", "parameters": [{ "name": "script", "type": "string" }] },
+        {
+          "name": "evaluateForTestInFrontend",
+          "parameters": [
+            {
+              "name": "script",
+              "type": "string"
+            }
+          ]
+        },
         {
           "name": "inspect",
-          "parameters": [{ "name": "object", "$ref": "Runtime.RemoteObject" }, { "name": "hints", "type": "object" }]
+          "parameters": [
+            {
+              "name": "object",
+              "$ref": "Runtime.RemoteObject"
+            },
+            {
+              "name": "hints",
+              "type": "object"
+            }
+          ]
         }
       ]
     },
     {
-      "domain": "Network",
-      "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
-      "debuggableTypes": ["itml", "page", "service-worker", "web-page"],
-      "targetTypes": ["itml", "page", "service-worker"],
-      "types": [
-        { "id": "LoaderId", "type": "string", "description": "Unique loader identifier." },
-        { "id": "FrameId", "type": "string", "description": "Unique frame identifier." },
-        { "id": "RequestId", "type": "string", "description": "Unique request identifier." },
-        { "id": "Timestamp", "type": "number", "description": "Elapsed seconds since frontend connected." },
-        { "id": "Walltime", "type": "number", "description": "Number of seconds since epoch." },
-        {
-          "id": "ReferrerPolicy",
-          "type": "string",
-          "description": "Controls how much referrer information is sent with the request",
-          "enum": [
-            "empty-string",
-            "no-referrer",
-            "no-referrer-when-downgrade",
-            "same-origin",
-            "origin",
-            "strict-origin",
-            "origin-when-cross-origin",
-            "strict-origin-when-cross-origin",
-            "unsafe-url"
-          ]
-        },
-        {
-          "id": "Headers",
-          "type": "object",
-          "description": "Request / response headers as keys / values of JSON object."
-        },
-        {
-          "id": "ResourceTiming",
-          "type": "object",
-          "description": "Timing information for the request.",
-          "properties": [
-            { "name": "startTime", "$ref": "Timestamp", "description": "Request is initiated" },
-            { "name": "redirectStart", "$ref": "Timestamp", "description": "Started redirect resolution." },
-            { "name": "redirectEnd", "$ref": "Timestamp", "description": "Finished redirect resolution." },
-            { "name": "fetchStart", "$ref": "Timestamp", "description": "Resource fetching started." },
-            {
-              "name": "domainLookupStart",
-              "type": "number",
-              "description": "Started DNS address resolve in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "domainLookupEnd",
-              "type": "number",
-              "description": "Finished DNS address resolve in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "connectStart",
-              "type": "number",
-              "description": "Started connecting to the remote host in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "connectEnd",
-              "type": "number",
-              "description": "Connected to the remote host in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "secureConnectionStart",
-              "type": "number",
-              "description": "Started SSL handshake in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "requestStart",
-              "type": "number",
-              "description": "Started sending request in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "responseStart",
-              "type": "number",
-              "description": "Started receiving response headers in milliseconds relative to fetchStart."
-            },
-            {
-              "name": "responseEnd",
-              "type": "number",
-              "description": "Finished receiving response headers in milliseconds relative to fetchStart."
-            }
-          ]
-        },
-        {
-          "id": "Request",
-          "type": "object",
-          "description": "HTTP request data.",
-          "properties": [
-            { "name": "url", "type": "string", "description": "Request URL." },
-            { "name": "method", "type": "string", "description": "HTTP request method." },
-            { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
-            { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." },
-            {
-              "name": "referrerPolicy",
-              "$ref": "ReferrerPolicy",
-              "optional": true,
-              "description": "The level of included referrer information."
-            },
-            {
-              "name": "integrity",
-              "type": "string",
-              "optional": true,
-              "description": "The base64 cryptographic hash of the resource."
-            }
-          ]
-        },
-        {
-          "id": "Response",
-          "type": "object",
-          "description": "HTTP response data.",
-          "properties": [
-            {
-              "name": "url",
-              "type": "string",
-              "description": "Response URL. This URL can be different from CachedResource.url in case of redirect."
-            },
-            { "name": "status", "type": "integer", "description": "HTTP response status code." },
-            { "name": "statusText", "type": "string", "description": "HTTP response status text." },
-            { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
-            { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
-            {
-              "name": "source",
-              "type": "string",
-              "enum": ["unknown", "network", "memory-cache", "disk-cache", "service-worker", "inspector-override"],
-              "description": "Specifies where the response came from."
-            },
-            {
-              "name": "requestHeaders",
-              "$ref": "Headers",
-              "optional": true,
-              "description": "Refined HTTP request headers that were actually transmitted over the network."
-            },
-            {
-              "name": "timing",
-              "$ref": "ResourceTiming",
-              "optional": true,
-              "description": "Timing information for the given request."
-            },
-            {
-              "name": "security",
-              "$ref": "Security.Security",
-              "optional": true,
-              "description": "The security information for the given request."
-            }
-          ]
-        },
-        {
-          "id": "Metrics",
-          "type": "object",
-          "description": "Network load metrics.",
-          "properties": [
-            {
-              "name": "protocol",
-              "type": "string",
-              "optional": true,
-              "description": "Network protocol. ALPN Protocol ID Identification Sequence, as per RFC 7301 (for example, http/2, http/1.1, spdy/3.1)"
-            },
-            {
-              "name": "priority",
-              "type": "string",
-              "enum": ["low", "medium", "high"],
-              "optional": true,
-              "description": "Network priority."
-            },
-            {
-              "name": "connectionIdentifier",
-              "type": "string",
-              "optional": true,
-              "description": "Connection identifier."
-            },
-            { "name": "remoteAddress", "type": "string", "optional": true, "description": "Remote IP address." },
-            {
-              "name": "requestHeaders",
-              "$ref": "Headers",
-              "optional": true,
-              "description": "Refined HTTP request headers that were actually transmitted over the network."
-            },
-            {
-              "name": "requestHeaderBytesSent",
-              "type": "number",
-              "optional": true,
-              "description": "Total HTTP request header bytes sent over the network."
-            },
-            {
-              "name": "requestBodyBytesSent",
-              "type": "number",
-              "optional": true,
-              "description": "Total HTTP request body bytes sent over the network."
-            },
-            {
-              "name": "responseHeaderBytesReceived",
-              "type": "number",
-              "optional": true,
-              "description": "Total HTTP response header bytes received over the network."
-            },
-            {
-              "name": "responseBodyBytesReceived",
-              "type": "number",
-              "optional": true,
-              "description": "Total HTTP response body bytes received over the network."
-            },
-            {
-              "name": "responseBodyDecodedSize",
-              "type": "number",
-              "optional": true,
-              "description": "Total decoded response body size in bytes."
-            },
-            {
-              "name": "securityConnection",
-              "$ref": "Security.Connection",
-              "optional": true,
-              "description": "Connection information for the completed request."
-            },
-            {
-              "name": "isProxyConnection",
-              "type": "boolean",
-              "optional": true,
-              "description": "Whether or not the connection was proxied through a server. If <code>true</code>, the <code>remoteAddress</code> will be for the proxy server, not the server that provided the resource to the proxy server."
-            }
-          ]
-        },
-        {
-          "id": "WebSocketRequest",
-          "type": "object",
-          "description": "WebSocket request data.",
-          "properties": [{ "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }]
-        },
-        {
-          "id": "WebSocketResponse",
-          "type": "object",
-          "description": "WebSocket response data.",
-          "properties": [
-            { "name": "status", "type": "integer", "description": "HTTP response status code." },
-            { "name": "statusText", "type": "string", "description": "HTTP response status text." },
-            { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
-          ]
-        },
-        {
-          "id": "WebSocketFrame",
-          "type": "object",
-          "description": "WebSocket frame data.",
-          "properties": [
-            { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
-            { "name": "mask", "type": "boolean", "description": "WebSocket frame mask." },
-            {
-              "name": "payloadData",
-              "type": "string",
-              "description": "WebSocket frame payload data, binary frames (opcode = 2) are base64-encoded."
-            },
-            { "name": "payloadLength", "type": "number", "description": "WebSocket frame payload length in bytes." }
-          ]
-        },
-        {
-          "id": "CachedResource",
-          "type": "object",
-          "description": "Information about the cached resource.",
-          "properties": [
-            {
-              "name": "url",
-              "type": "string",
-              "description": "Resource URL. This is the url of the original network request."
-            },
-            { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
-            { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
-            { "name": "bodySize", "type": "number", "description": "Cached response body size." },
-            {
-              "name": "sourceMapURL",
-              "type": "string",
-              "optional": true,
-              "description": "URL of source map associated with this resource (if any)."
-            }
-          ]
-        },
-        {
-          "id": "Initiator",
-          "type": "object",
-          "description": "Information about the request initiator.",
-          "properties": [
-            {
-              "name": "type",
-              "type": "string",
-              "enum": ["parser", "script", "other"],
-              "description": "Type of this initiator."
-            },
-            {
-              "name": "stackTrace",
-              "$ref": "Console.StackTrace",
-              "optional": true,
-              "description": "Initiator JavaScript stack trace, set for Script only."
-            },
-            {
-              "name": "url",
-              "type": "string",
-              "optional": true,
-              "description": "Initiator URL, set for Parser type only."
-            },
-            {
-              "name": "lineNumber",
-              "type": "number",
-              "optional": true,
-              "description": "Initiator line number, set for Parser type only."
-            },
-            {
-              "name": "nodeId",
-              "$ref": "DOM.NodeId",
-              "optional": true,
-              "description": "Set if the load was triggered by a DOM node, in addition to the other initiator information."
-            }
-          ]
-        },
-        {
-          "id": "NetworkStage",
-          "type": "string",
-          "description": "Different stages of a network request.",
-          "enum": ["request", "response"]
-        },
-        {
-          "id": "ResourceErrorType",
-          "type": "string",
-          "description": "Different stages of a network request.",
-          "enum": ["General", "AccessControl", "Cancellation", "Timeout"]
-        }
-      ],
+      "domain": "LifecycleReporter",
+      "description": "LifecycleReporter domain allows reporting of lifecycle events.",
+      "debuggableTypes": ["itml", "javascript"],
+      "targetTypes": ["itml", "javascript"],
+      "types": [],
       "commands": [
         {
           "name": "enable",
-          "description": "Enables network tracking, network events will now be delivered to the client."
+          "description": "Enables LifecycleReporter domain events."
         },
         {
           "name": "disable",
-          "description": "Disables network tracking, prevents network events from being sent to the client."
+          "description": "Disables LifecycleReporter domain events."
         },
         {
-          "name": "setExtraHTTPHeaders",
-          "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
-          "targetTypes": ["page"],
-          "parameters": [{ "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }]
+          "name": "preventExit",
+          "description": "Prevents the process from exiting."
         },
         {
-          "name": "getResponseBody",
-          "description": "Returns content served for the given request.",
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier of the network request to get content for."
-            }
-          ],
-          "returns": [
-            { "name": "body", "type": "string", "description": "Response body." },
-            { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
-          ]
-        },
-        {
-          "name": "setResourceCachingDisabled",
-          "description": "Toggles whether the resource cache may be used when loading resources in the inspected page. If <code>true</code>, the resource cache will not be used when loading resources.",
-          "parameters": [
-            { "name": "disabled", "type": "boolean", "description": "Whether to prevent usage of the resource cache." }
-          ]
-        },
-        {
-          "name": "loadResource",
-          "description": "Loads a resource in the context of a frame on the inspected page without cross origin checks.",
-          "targetTypes": ["page"],
-          "async": true,
-          "parameters": [
-            { "name": "frameId", "$ref": "FrameId", "description": "Frame to load the resource from." },
-            { "name": "url", "type": "string", "description": "URL of the resource to load." }
-          ],
-          "returns": [
-            { "name": "content", "type": "string", "description": "Resource content." },
-            { "name": "mimeType", "type": "string", "description": "Resource mimeType." },
-            { "name": "status", "type": "integer", "description": "HTTP response status code." }
-          ]
-        },
-        {
-          "name": "getSerializedCertificate",
-          "description": "Fetches a serialized secure certificate for the given requestId to be displayed via InspectorFrontendHost.showCertificate.",
-          "targetTypes": ["page"],
-          "parameters": [{ "name": "requestId", "$ref": "RequestId" }],
-          "returns": [
-            {
-              "name": "serializedCertificate",
-              "type": "string",
-              "description": "Represents a base64 encoded WebCore::CertificateInfo object."
-            }
-          ]
-        },
-        {
-          "name": "resolveWebSocket",
-          "description": "Resolves JavaScript WebSocket object for given request id.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier of the WebSocket resource to resolve."
-            },
-            {
-              "name": "objectGroup",
-              "type": "string",
-              "optional": true,
-              "description": "Symbolic group name that can be used to release multiple objects."
-            }
-          ],
-          "returns": [
-            {
-              "name": "object",
-              "$ref": "Runtime.RemoteObject",
-              "description": "JavaScript object wrapper for given node."
-            }
-          ]
-        },
-        {
-          "name": "setInterceptionEnabled",
-          "description": "Enable interception of network requests.",
-          "targetTypes": ["page"],
-          "parameters": [{ "name": "enabled", "type": "boolean" }]
-        },
-        {
-          "name": "addInterception",
-          "description": "Add an interception.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "url",
-              "type": "string",
-              "description": "URL pattern to intercept, intercept everything if not specified or empty"
-            },
-            { "name": "stage", "$ref": "NetworkStage", "description": "Stage to intercept." },
-            {
-              "name": "caseSensitive",
-              "type": "boolean",
-              "optional": true,
-              "description": "If false, ignores letter casing of `url` parameter."
-            },
-            {
-              "name": "isRegex",
-              "type": "boolean",
-              "optional": true,
-              "description": "If true, treats `url` parameter as a regular expression."
-            }
-          ]
-        },
-        {
-          "name": "removeInterception",
-          "description": "Remove an interception.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "url", "type": "string" },
-            { "name": "stage", "$ref": "NetworkStage", "description": "Stage to intercept." },
-            {
-              "name": "caseSensitive",
-              "type": "boolean",
-              "optional": true,
-              "description": "If false, ignores letter casing of `url` parameter."
-            },
-            {
-              "name": "isRegex",
-              "type": "boolean",
-              "optional": true,
-              "description": "If true, treats `url` parameter as a regular expression."
-            }
-          ]
-        },
-        {
-          "name": "interceptContinue",
-          "description": "Continue request or response without modifications.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for the intercepted Network request or response to continue."
-            },
-            { "name": "stage", "$ref": "NetworkStage", "description": "Stage to continue." }
-          ]
-        },
-        {
-          "name": "interceptWithRequest",
-          "description": "Replace intercepted request with the provided one.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for the intercepted Network request or response to continue."
-            },
-            { "name": "url", "type": "string", "optional": true, "description": "HTTP request url." },
-            { "name": "method", "type": "string", "optional": true, "description": "HTTP request method." },
-            {
-              "name": "headers",
-              "$ref": "Headers",
-              "optional": true,
-              "description": "HTTP response headers. Pass through original values if unmodified."
-            },
-            {
-              "name": "postData",
-              "type": "string",
-              "optional": true,
-              "description": "HTTP POST request data, base64-encoded."
-            }
-          ]
-        },
-        {
-          "name": "interceptWithResponse",
-          "description": "Provide response content for an intercepted response.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for the intercepted Network response to modify."
-            },
-            { "name": "content", "type": "string" },
-            { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." },
-            { "name": "mimeType", "type": "string", "optional": true, "description": "MIME Type for the data." },
-            {
-              "name": "status",
-              "type": "integer",
-              "optional": true,
-              "description": "HTTP response status code. Pass through original values if unmodified."
-            },
-            {
-              "name": "statusText",
-              "type": "string",
-              "optional": true,
-              "description": "HTTP response status text. Pass through original values if unmodified."
-            },
-            {
-              "name": "headers",
-              "$ref": "Headers",
-              "optional": true,
-              "description": "HTTP response headers. Pass through original values if unmodified."
-            }
-          ]
-        },
-        {
-          "name": "interceptRequestWithResponse",
-          "description": "Provide response for an intercepted request. Request completely bypasses the network in this case and is immediately fulfilled with the provided data.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for the intercepted Network response to modify."
-            },
-            { "name": "content", "type": "string" },
-            { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." },
-            { "name": "mimeType", "type": "string", "description": "MIME Type for the data." },
-            { "name": "status", "type": "integer", "description": "HTTP response status code." },
-            { "name": "statusText", "type": "string", "description": "HTTP response status text." },
-            { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
-          ]
-        },
-        {
-          "name": "interceptRequestWithError",
-          "description": "Fail request with given error type.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for the intercepted Network request to fail."
-            },
-            {
-              "name": "errorType",
-              "$ref": "ResourceErrorType",
-              "description": "Deliver error reason for the request failure."
-            }
-          ]
-        },
-        {
-          "name": "setEmulatedConditions",
-          "description": "Emulate various network conditions (e.g. bytes per second, latency, etc.).",
-          "targetTypes": ["page"],
-          "condition": "defined(ENABLE_INSPECTOR_NETWORK_THROTTLING) && ENABLE_INSPECTOR_NETWORK_THROTTLING",
-          "parameters": [
-            {
-              "name": "bytesPerSecondLimit",
-              "type": "integer",
-              "optional": true,
-              "description": "Limits the bytes per second of requests if positive. Removes any limits if zero or not provided."
-            }
-          ]
+          "name": "stopPreventingExit",
+          "description": "Does not prevent the process from exiting."
         }
       ],
       "events": [
         {
-          "name": "requestWillBeSent",
-          "description": "Fired when page is about to send HTTP request.",
+          "name": "reload",
+          "parameters": []
+        },
+        {
+          "name": "error",
           "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
-            { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
             {
-              "name": "documentURL",
-              "type": "string",
-              "description": "URL of the document this request is loaded for."
-            },
-            { "name": "request", "$ref": "Request", "description": "Request data." },
-            { "name": "timestamp", "$ref": "Timestamp" },
-            { "name": "walltime", "$ref": "Walltime" },
-            { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
-            {
-              "name": "redirectResponse",
-              "optional": true,
-              "$ref": "Response",
-              "description": "Redirect response data."
-            },
-            { "name": "type", "$ref": "Page.ResourceType", "optional": true, "description": "Resource type." },
-            {
-              "name": "targetId",
-              "type": "string",
-              "optional": true,
-              "description": "Identifier for the context of where the load originated. In general this is the target identifier. For Workers this will be the workerId."
+              "name": "message",
+              "$ref": "Console.ConsoleMessage",
+              "description": "Source of the error"
             }
-          ]
-        },
-        {
-          "name": "responseReceived",
-          "description": "Fired when HTTP response is available.",
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
-            { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
-            { "name": "response", "$ref": "Response", "description": "Response data." }
-          ]
-        },
-        {
-          "name": "dataReceived",
-          "description": "Fired when data chunk was received over the network.",
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
-            {
-              "name": "encodedDataLength",
-              "type": "integer",
-              "description": "Actual bytes received (might be less than dataLength for compressed encodings)."
-            }
-          ]
-        },
-        {
-          "name": "loadingFinished",
-          "description": "Fired when HTTP request has finished loading.",
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            {
-              "name": "sourceMapURL",
-              "type": "string",
-              "optional": true,
-              "description": "URL of source map associated with this resource (if any)."
-            },
-            { "name": "metrics", "$ref": "Metrics", "optional": true, "description": "Network metrics." }
-          ]
-        },
-        {
-          "name": "loadingFailed",
-          "description": "Fired when HTTP request has failed to load.",
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "errorText", "type": "string", "description": "User friendly error message." },
-            { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
-          ]
-        },
-        {
-          "name": "requestServedFromMemoryCache",
-          "description": "Fired when HTTP request has been served from memory cache.",
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
-            { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
-            {
-              "name": "documentURL",
-              "type": "string",
-              "description": "URL of the document this request is loaded for."
-            },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
-            { "name": "resource", "$ref": "CachedResource", "description": "Cached resource data." }
-          ]
-        },
-        {
-          "name": "requestIntercepted",
-          "description": "Fired when HTTP request has been intercepted. The frontend must respond with <code>Network.interceptContinue</code>, <code>Network.interceptWithRequest</code>` or <code>Network.interceptWithResponse</code>` to resolve this request.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for this intercepted network. Corresponds with an earlier <code>Network.requestWillBeSent</code>."
-            },
-            {
-              "name": "request",
-              "$ref": "Request",
-              "description": "Original request content that would proceed if this is continued."
-            }
-          ]
-        },
-        {
-          "name": "responseIntercepted",
-          "description": "Fired when HTTP response has been intercepted. The frontend must response with <code>Network.interceptContinue</code> or <code>Network.interceptWithResponse</code>` to continue this response.",
-          "targetTypes": ["page"],
-          "parameters": [
-            {
-              "name": "requestId",
-              "$ref": "RequestId",
-              "description": "Identifier for this intercepted network. Corresponds with an earlier <code>Network.requestWillBeSent</code>."
-            },
-            {
-              "name": "response",
-              "$ref": "Response",
-              "description": "Original response content that would proceed if this is continued."
-            }
-          ]
-        },
-        {
-          "name": "webSocketWillSendHandshakeRequest",
-          "description": "Fired when WebSocket is about to initiate handshake.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp" },
-            { "name": "walltime", "$ref": "Walltime" },
-            { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
-          ]
-        },
-        {
-          "name": "webSocketHandshakeResponseReceived",
-          "description": "Fired when WebSocket handshake response becomes available.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp" },
-            { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
-          ]
-        },
-        {
-          "name": "webSocketCreated",
-          "description": "Fired upon WebSocket creation.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "url", "type": "string", "description": "WebSocket request URL." }
-          ]
-        },
-        {
-          "name": "webSocketClosed",
-          "description": "Fired when WebSocket is closed.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
-          ]
-        },
-        {
-          "name": "webSocketFrameReceived",
-          "description": "Fired when WebSocket frame is received.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
-          ]
-        },
-        {
-          "name": "webSocketFrameError",
-          "description": "Fired when WebSocket frame error occurs.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
-          ]
-        },
-        {
-          "name": "webSocketFrameSent",
-          "description": "Fired when WebSocket frame is sent.",
-          "targetTypes": ["page"],
-          "parameters": [
-            { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
-            { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
-            { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
           ]
         }
       ]
@@ -2031,7 +1651,11 @@
       "debuggableTypes": ["itml", "javascript", "page", "service-worker", "web-page"],
       "targetTypes": ["itml", "javascript", "page", "service-worker", "worker"],
       "types": [
-        { "id": "RemoteObjectId", "type": "string", "description": "Unique object identifier." },
+        {
+          "id": "RemoteObjectId",
+          "type": "string",
+          "description": "Unique object identifier."
+        },
         {
           "id": "RemoteObject",
           "type": "object",
@@ -2162,14 +1786,18 @@
             {
               "name": "properties",
               "type": "array",
-              "items": { "$ref": "PropertyPreview" },
+              "items": {
+                "$ref": "PropertyPreview"
+              },
               "optional": true,
               "description": "List of the properties."
             },
             {
               "name": "entries",
               "type": "array",
-              "items": { "$ref": "EntryPreview" },
+              "items": {
+                "$ref": "EntryPreview"
+              },
               "optional": true,
               "description": "List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only."
             },
@@ -2185,7 +1813,11 @@
           "id": "PropertyPreview",
           "type": "object",
           "properties": [
-            { "name": "name", "type": "string", "description": "Property name." },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
             {
               "name": "type",
               "type": "string",
@@ -2260,7 +1892,11 @@
               "optional": true,
               "description": "Entry key. Specified for map-like collection entries."
             },
-            { "name": "value", "$ref": "ObjectPreview", "description": "Entry value." }
+            {
+              "name": "value",
+              "$ref": "ObjectPreview",
+              "description": "Entry value."
+            }
           ]
         },
         {
@@ -2273,7 +1909,11 @@
               "optional": true,
               "description": "Entry key of a map-like collection, otherwise not provided."
             },
-            { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Entry value." }
+            {
+              "name": "value",
+              "$ref": "Runtime.RemoteObject",
+              "description": "Entry value."
+            }
           ]
         },
         {
@@ -2281,7 +1921,11 @@
           "type": "object",
           "description": "Object property descriptor.",
           "properties": [
-            { "name": "name", "type": "string", "description": "Property name or symbol description." },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name or symbol description."
+            },
             {
               "name": "value",
               "$ref": "RemoteObject",
@@ -2355,7 +1999,11 @@
           "type": "object",
           "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
           "properties": [
-            { "name": "name", "type": "string", "description": "Conventional property name." },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Conventional property name."
+            },
             {
               "name": "value",
               "$ref": "RemoteObject",
@@ -2369,11 +2017,25 @@
           "type": "object",
           "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
           "properties": [
-            { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
-            { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+            {
+              "name": "value",
+              "type": "any",
+              "optional": true,
+              "description": "Primitive value."
+            },
+            {
+              "name": "objectId",
+              "$ref": "RemoteObjectId",
+              "optional": true,
+              "description": "Remote object handle."
+            }
           ]
         },
-        { "id": "ExecutionContextId", "type": "integer", "description": "Id of an execution context." },
+        {
+          "id": "ExecutionContextId",
+          "type": "integer",
+          "description": "Id of an execution context."
+        },
         {
           "id": "ExecutionContextType",
           "type": "string",
@@ -2390,9 +2052,20 @@
               "$ref": "ExecutionContextId",
               "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed."
             },
-            { "name": "type", "$ref": "ExecutionContextType" },
-            { "name": "name", "type": "string", "description": "Human readable name describing given context." },
-            { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the owning frame." }
+            {
+              "name": "type",
+              "$ref": "ExecutionContextType"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Human readable name describing given context."
+            },
+            {
+              "name": "frameId",
+              "$ref": "Network.FrameId",
+              "description": "Id of the owning frame."
+            }
           ]
         },
         {
@@ -2406,8 +2079,16 @@
           "type": "object",
           "description": "Range of an error in source code.",
           "properties": [
-            { "name": "startOffset", "type": "integer", "description": "Start offset of range (inclusive)." },
-            { "name": "endOffset", "type": "integer", "description": "End offset of range (exclusive)." }
+            {
+              "name": "startOffset",
+              "type": "integer",
+              "description": "Start offset of range (inclusive)."
+            },
+            {
+              "name": "endOffset",
+              "type": "integer",
+              "description": "End offset of range (exclusive)."
+            }
           ]
         },
         {
@@ -2417,14 +2098,18 @@
             {
               "name": "fields",
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "optional": true,
               "description": "Array of strings, where the strings represent object properties."
             },
             {
               "name": "optionalFields",
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "optional": true,
               "description": "Array of strings, where the strings represent optional object properties."
             },
@@ -2529,7 +2214,9 @@
             {
               "name": "structures",
               "type": "array",
-              "items": { "$ref": "StructureDescription" },
+              "items": {
+                "$ref": "StructureDescription"
+              },
               "optional": true,
               "description": "Array of descriptions for all structures seen for this variable."
             },
@@ -2551,8 +2238,16 @@
               "type": "integer",
               "description": "What kind of type information do we want (normal, function return values, 'this' statement)."
             },
-            { "name": "sourceID", "type": "string", "description": "sourceID uniquely identifying a script" },
-            { "name": "divot", "type": "integer", "description": "character offset for assignment range" }
+            {
+              "name": "sourceID",
+              "type": "string",
+              "description": "sourceID uniquely identifying a script"
+            },
+            {
+              "name": "divot",
+              "type": "integer",
+              "description": "character offset for assignment range"
+            }
           ]
         },
         {
@@ -2560,8 +2255,16 @@
           "type": "object",
           "description": "From Wikipedia: a basic block is a portion of the code within a program with only one entry point and only one exit point. This type gives the location of a basic block and if that basic block has executed.",
           "properties": [
-            { "name": "startOffset", "type": "integer", "description": "Start offset of the basic block." },
-            { "name": "endOffset", "type": "integer", "description": "End offset of the basic block." },
+            {
+              "name": "startOffset",
+              "type": "integer",
+              "description": "Start offset of the basic block."
+            },
+            {
+              "name": "endOffset",
+              "type": "integer",
+              "description": "End offset of the basic block."
+            },
             {
               "name": "hasExecuted",
               "type": "boolean",
@@ -2579,10 +2282,25 @@
         {
           "name": "parse",
           "description": "Parses JavaScript source code for errors.",
-          "parameters": [{ "name": "source", "type": "string", "description": "Source code to parse." }],
+          "parameters": [
+            {
+              "name": "source",
+              "type": "string",
+              "description": "Source code to parse."
+            }
+          ],
           "returns": [
-            { "name": "result", "$ref": "SyntaxErrorType", "description": "Parse result." },
-            { "name": "message", "type": "string", "optional": true, "description": "Parse error message." },
+            {
+              "name": "result",
+              "$ref": "SyntaxErrorType",
+              "description": "Parse result."
+            },
+            {
+              "name": "message",
+              "type": "string",
+              "optional": true,
+              "description": "Parse error message."
+            },
             {
               "name": "range",
               "$ref": "ErrorRange",
@@ -2595,7 +2313,11 @@
           "name": "evaluate",
           "description": "Evaluates expression on global object.",
           "parameters": [
-            { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Expression to evaluate."
+            },
             {
               "name": "objectGroup",
               "type": "string",
@@ -2646,7 +2368,11 @@
             }
           ],
           "returns": [
-            { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+            {
+              "name": "result",
+              "$ref": "RemoteObject",
+              "description": "Evaluation result."
+            },
             {
               "name": "wasThrown",
               "type": "boolean",
@@ -2665,7 +2391,11 @@
           "name": "awaitPromise",
           "description": "Calls the async callback when the promise with the given ID gets settled.",
           "parameters": [
-            { "name": "promiseObjectId", "$ref": "RemoteObjectId", "description": "Identifier of the promise." },
+            {
+              "name": "promiseObjectId",
+              "$ref": "RemoteObjectId",
+              "description": "Identifier of the promise."
+            },
             {
               "name": "returnByValue",
               "type": "boolean",
@@ -2686,7 +2416,11 @@
             }
           ],
           "returns": [
-            { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+            {
+              "name": "result",
+              "$ref": "RemoteObject",
+              "description": "Evaluation result."
+            },
             {
               "name": "wasThrown",
               "type": "boolean",
@@ -2711,11 +2445,18 @@
               "$ref": "RemoteObjectId",
               "description": "Identifier of the object to call function on."
             },
-            { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+            {
+              "name": "functionDeclaration",
+              "type": "string",
+              "description": "Declaration of the function to call."
+            },
             {
               "name": "arguments",
               "type": "array",
-              "items": { "$ref": "CallArgument", "description": "Call argument." },
+              "items": {
+                "$ref": "CallArgument",
+                "description": "Call argument."
+              },
               "optional": true,
               "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object."
             },
@@ -2751,7 +2492,11 @@
             }
           ],
           "returns": [
-            { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+            {
+              "name": "result",
+              "$ref": "RemoteObject",
+              "description": "Call result."
+            },
             {
               "name": "wasThrown",
               "type": "boolean",
@@ -2771,7 +2516,12 @@
               "description": "Identifier of the object to return a preview for."
             }
           ],
-          "returns": [{ "name": "preview", "$ref": "ObjectPreview" }]
+          "returns": [
+            {
+              "name": "preview",
+              "$ref": "ObjectPreview"
+            }
+          ]
         },
         {
           "name": "getProperties",
@@ -2811,14 +2561,18 @@
             {
               "name": "properties",
               "type": "array",
-              "items": { "$ref": "PropertyDescriptor" },
+              "items": {
+                "$ref": "PropertyDescriptor"
+              },
               "description": "Object properties."
             },
             {
               "name": "internalProperties",
               "optional": true,
               "type": "array",
-              "items": { "$ref": "InternalPropertyDescriptor" },
+              "items": {
+                "$ref": "InternalPropertyDescriptor"
+              },
               "description": "Internal object properties. Only included if `fetchStart` is 0."
             }
           ]
@@ -2855,14 +2609,18 @@
             {
               "name": "properties",
               "type": "array",
-              "items": { "$ref": "PropertyDescriptor" },
+              "items": {
+                "$ref": "PropertyDescriptor"
+              },
               "description": "Object properties."
             },
             {
               "name": "internalProperties",
               "optional": true,
               "type": "array",
-              "items": { "$ref": "InternalPropertyDescriptor" },
+              "items": {
+                "$ref": "InternalPropertyDescriptor"
+              },
               "description": "Internal object properties. Only included if `fetchStart` is 0."
             }
           ]
@@ -2899,7 +2657,9 @@
             {
               "name": "entries",
               "type": "array",
-              "items": { "$ref": "CollectionEntry" },
+              "items": {
+                "$ref": "CollectionEntry"
+              },
               "description": "Array of collection entries."
             }
           ]
@@ -2908,7 +2668,11 @@
           "name": "saveResult",
           "description": "Assign a saved result index to this value.",
           "parameters": [
-            { "name": "value", "$ref": "CallArgument", "description": "Id or value of the object to save." },
+            {
+              "name": "value",
+              "$ref": "CallArgument",
+              "description": "Id or value of the object to save."
+            },
             {
               "name": "contextId",
               "optional": true,
@@ -2941,19 +2705,32 @@
           "name": "releaseObject",
           "description": "Releases remote object with given id.",
           "parameters": [
-            { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+            {
+              "name": "objectId",
+              "$ref": "RemoteObjectId",
+              "description": "Identifier of the object to release."
+            }
           ]
         },
         {
           "name": "releaseObjectGroup",
           "description": "Releases all remote objects that belong to a given group.",
-          "parameters": [{ "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }]
+          "parameters": [
+            {
+              "name": "objectGroup",
+              "type": "string",
+              "description": "Symbolic object group name."
+            }
+          ]
         },
         {
           "name": "enable",
           "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
         },
-        { "name": "disable", "description": "Disables reporting of execution contexts creation." },
+        {
+          "name": "disable",
+          "description": "Disables reporting of execution contexts creation."
+        },
         {
           "name": "getRuntimeTypesForVariablesAtOffsets",
           "description": "Returns detailed information on the given function.",
@@ -2961,7 +2738,9 @@
             {
               "name": "locations",
               "type": "array",
-              "items": { "$ref": "TypeLocation" },
+              "items": {
+                "$ref": "TypeLocation"
+              },
               "description": "An array of type locations we're requesting information for. Results are expected in the same order they're sent in."
             }
           ],
@@ -2969,14 +2748,29 @@
             {
               "name": "types",
               "type": "array",
-              "items": { "$ref": "TypeDescription", "description": "Types for requested variable." }
+              "items": {
+                "$ref": "TypeDescription",
+                "description": "Types for requested variable."
+              }
             }
           ]
         },
-        { "name": "enableTypeProfiler", "description": "Enables type profiling on the VM." },
-        { "name": "disableTypeProfiler", "description": "Disables type profiling on the VM." },
-        { "name": "enableControlFlowProfiler", "description": "Enables control flow profiling on the VM." },
-        { "name": "disableControlFlowProfiler", "description": "Disables control flow profiling on the VM." },
+        {
+          "name": "enableTypeProfiler",
+          "description": "Enables type profiling on the VM."
+        },
+        {
+          "name": "disableTypeProfiler",
+          "description": "Disables type profiling on the VM."
+        },
+        {
+          "name": "enableControlFlowProfiler",
+          "description": "Enables control flow profiling on the VM."
+        },
+        {
+          "name": "disableControlFlowProfiler",
+          "description": "Disables control flow profiling on the VM."
+        },
         {
           "name": "getBasicBlocks",
           "description": "Returns a list of basic blocks for the given sourceID with information about their text ranges and whether or not they have executed.",
@@ -2991,7 +2785,10 @@
             {
               "name": "basicBlocks",
               "type": "array",
-              "items": { "$ref": "BasicBlock", "description": "Array of basic blocks." }
+              "items": {
+                "$ref": "BasicBlock",
+                "description": "Array of basic blocks."
+              }
             }
           ]
         }
@@ -3016,49 +2813,94 @@
       "debuggableTypes": ["itml", "javascript", "page", "web-page"],
       "targetTypes": ["itml", "javascript", "page"],
       "types": [
-        { "id": "EventType", "type": "string", "enum": ["API", "Microtask", "Other"] },
+        {
+          "id": "EventType",
+          "type": "string",
+          "enum": ["API", "Microtask", "Other"]
+        },
         {
           "id": "Event",
           "type": "object",
           "properties": [
-            { "name": "startTime", "type": "number" },
-            { "name": "endTime", "type": "number" },
-            { "name": "type", "$ref": "EventType" }
+            {
+              "name": "startTime",
+              "type": "number"
+            },
+            {
+              "name": "endTime",
+              "type": "number"
+            },
+            {
+              "name": "type",
+              "$ref": "EventType"
+            }
           ]
         },
         {
           "id": "ExpressionLocation",
           "type": "object",
           "properties": [
-            { "name": "line", "type": "integer", "description": "1-based." },
-            { "name": "column", "type": "integer", "description": "1-based." }
+            {
+              "name": "line",
+              "type": "integer",
+              "description": "1-based."
+            },
+            {
+              "name": "column",
+              "type": "integer",
+              "description": "1-based."
+            }
           ]
         },
         {
           "id": "StackFrame",
           "type": "object",
           "properties": [
-            { "name": "sourceID", "$ref": "Debugger.ScriptId", "description": "Unique script identifier." },
+            {
+              "name": "sourceID",
+              "$ref": "Debugger.ScriptId",
+              "description": "Unique script identifier."
+            },
             {
               "name": "name",
               "type": "string",
               "description": "A displayable name for the stack frame. i.e function name, (program), etc."
             },
-            { "name": "line", "type": "integer", "description": "-1 if unavailable. 1-based if available." },
-            { "name": "column", "type": "integer", "description": "-1 if unavailable. 1-based if available." },
-            { "name": "url", "type": "string" },
-            { "name": "expressionLocation", "$ref": "ExpressionLocation", "optional": true }
+            {
+              "name": "line",
+              "type": "integer",
+              "description": "-1 if unavailable. 1-based if available."
+            },
+            {
+              "name": "column",
+              "type": "integer",
+              "description": "-1 if unavailable. 1-based if available."
+            },
+            {
+              "name": "url",
+              "type": "string"
+            },
+            {
+              "name": "expressionLocation",
+              "$ref": "ExpressionLocation",
+              "optional": true
+            }
           ]
         },
         {
           "id": "StackTrace",
           "type": "object",
           "properties": [
-            { "name": "timestamp", "type": "number" },
+            {
+              "name": "timestamp",
+              "type": "number"
+            },
             {
               "name": "stackFrames",
               "type": "array",
-              "items": { "$ref": "StackFrame" },
+              "items": {
+                "$ref": "StackFrame"
+              },
               "description": "First array item is the bottom of the call stack and last array item is the top of the call stack."
             }
           ]
@@ -3066,7 +2908,15 @@
         {
           "id": "Samples",
           "type": "object",
-          "properties": [{ "name": "stackTraces", "type": "array", "items": { "$ref": "StackTrace" } }]
+          "properties": [
+            {
+              "name": "stackTraces",
+              "type": "array",
+              "items": {
+                "$ref": "StackTrace"
+              }
+            }
+          ]
         }
       ],
       "commands": [
@@ -3091,19 +2941,118 @@
         {
           "name": "trackingStart",
           "description": "Tracking started.",
-          "parameters": [{ "name": "timestamp", "type": "number" }]
+          "parameters": [
+            {
+              "name": "timestamp",
+              "type": "number"
+            }
+          ]
         },
         {
           "name": "trackingUpdate",
           "description": "Periodic tracking updates with event data.",
-          "parameters": [{ "name": "event", "$ref": "Event" }]
+          "parameters": [
+            {
+              "name": "event",
+              "$ref": "Event"
+            }
+          ]
         },
         {
           "name": "trackingComplete",
           "description": "Tracking stopped. Includes any buffered data during tracking, such as profiling information.",
           "parameters": [
-            { "name": "timestamp", "type": "number" },
-            { "name": "samples", "$ref": "Samples", "optional": true, "description": "Stack traces." }
+            {
+              "name": "timestamp",
+              "type": "number"
+            },
+            {
+              "name": "samples",
+              "$ref": "Samples",
+              "optional": true,
+              "description": "Stack traces."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "domain": "TestReporter",
+      "description": "TestReporter domain allows reporting of lifecycle events.",
+      "debuggableTypes": ["itml", "javascript"],
+      "targetTypes": ["itml", "javascript"],
+      "types": [
+        {
+          "id": "TestStatus",
+          "type": "string",
+          "enum": ["pass", "fail", "timeout", "skip", "todo"]
+        }
+      ],
+      "commands": [
+        {
+          "name": "enable",
+          "description": "Enables TestReporter domain events."
+        },
+        {
+          "name": "disable",
+          "description": "Disables TestReporter domain events."
+        }
+      ],
+      "events": [
+        {
+          "name": "found",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "integer",
+              "description": "Unique identifier of the test that was found."
+            },
+            {
+              "name": "scriptId",
+              "$ref": "Debugger.ScriptId",
+              "description": "Unique identifier of the script that started the test."
+            },
+            {
+              "name": "line",
+              "type": "integer",
+              "description": "Line number in the script that started the test."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of the test that started.",
+              "optional": true
+            }
+          ]
+        },
+        {
+          "name": "start",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "integer",
+              "description": "Unique identifier of the test that started."
+            }
+          ]
+        },
+        {
+          "name": "end",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "integer",
+              "description": "Unique identifier of the test that ended."
+            },
+            {
+              "name": "status",
+              "$ref": "TestStatus",
+              "description": "Status of the test that ended."
+            },
+            {
+              "name": "elapsed",
+              "type": "number",
+              "description": "Elapsed time in milliseconds since the test started."
+            }
           ]
         }
       ]

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4534,6 +4534,11 @@ declare module "bun" {
     unix: string;
   }
 
+  interface FdSocketOptions<Data = undefined> extends SocketOptions<Data> {
+    tls?: TLSOptions;
+    fd: number;
+  }
+
   /**
    * Create a TCP client that connects to a server
    *

--- a/src/bun.js/bindings/BunDebugger.cpp
+++ b/src/bun.js/bindings/BunDebugger.cpp
@@ -106,6 +106,15 @@ public:
         inspector.setInspectable(true);
 
         globalObject->inspectorController().connectFrontend(*this, true, false); // waitingForConnection
+        static bool hasConnected = false;
+
+        if (!hasConnected) {
+            hasConnected = true;
+            globalObject->inspectorController().registerAlternateAgent(
+                WTF::makeUnique<Inspector::InspectorLifecycleAgent>(*globalObject));
+            globalObject->inspectorController().registerAlternateAgent(
+                WTF::makeUnique<Inspector::InspectorTestReporterAgent>(*globalObject));
+        }
 
         Inspector::JSGlobalObjectDebugger* debugger = reinterpret_cast<Inspector::JSGlobalObjectDebugger*>(globalObject->debugger());
         if (debugger) {
@@ -494,11 +503,6 @@ extern "C" void Bun__ensureDebugger(ScriptExecutionContextIdentifier scriptId, b
 
     auto& inspector = globalObject->inspectorDebuggable();
     inspector.setInspectable(true);
-
-    globalObject->inspectorController().registerAlternateAgent(
-        WTF::makeUnique<Inspector::InspectorLifecycleAgent>(*globalObject));
-    globalObject->inspectorController().registerAlternateAgent(
-        WTF::makeUnique<Inspector::InspectorTestReporterAgent>(*globalObject));
 
     Inspector::JSGlobalObjectDebugger* debugger = reinterpret_cast<Inspector::JSGlobalObjectDebugger*>(globalObject->debugger());
     if (debugger) {

--- a/src/bun.js/bindings/ConsoleObject.h
+++ b/src/bun.js/bindings/ConsoleObject.h
@@ -6,6 +6,8 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
+#include <JavaScriptCore/InspectorConsoleAgent.h>
+
 namespace Inspector {
 class InspectorConsoleAgent;
 class InspectorDebuggerAgent;
@@ -31,6 +33,7 @@ public:
     static bool logToSystemConsole();
     static void setLogToSystemConsole(bool);
 
+    Inspector::InspectorConsoleAgent* consoleAgent() { return m_consoleAgent; }
     void setDebuggerAgent(InspectorDebuggerAgent* agent) { m_debuggerAgent = agent; }
     void setPersistentScriptProfilerAgent(InspectorScriptProfilerAgent* agent)
     {

--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -36,7 +36,7 @@ static ImplementationVisibility getImplementationVisibility(JSC::CodeBlock* code
     return ImplementationVisibility::Public;
 }
 
-static bool isImplementationVisibilityPrivate(JSC::StackVisitor& visitor)
+bool isImplementationVisibilityPrivate(JSC::StackVisitor& visitor)
 {
     ImplementationVisibility implementationVisibility = [&]() -> ImplementationVisibility {
         if (visitor->callee().isCell()) {
@@ -63,7 +63,7 @@ static bool isImplementationVisibilityPrivate(JSC::StackVisitor& visitor)
     return implementationVisibility != ImplementationVisibility::Public;
 }
 
-static bool isImplementationVisibilityPrivate(const JSC::StackFrame& frame)
+bool isImplementationVisibilityPrivate(const JSC::StackFrame& frame)
 {
     ImplementationVisibility implementationVisibility = [&]() -> ImplementationVisibility {
 

--- a/src/bun.js/bindings/ErrorStackTrace.h
+++ b/src/bun.js/bindings/ErrorStackTrace.h
@@ -211,4 +211,6 @@ private:
     }
 };
 
+bool isImplementationVisibilityPrivate(JSC::StackVisitor& visitor);
+bool isImplementationVisibilityPrivate(const JSC::StackFrame& frame);
 }

--- a/src/bun.js/bindings/InspectorLifecycleAgent.cpp
+++ b/src/bun.js/bindings/InspectorLifecycleAgent.cpp
@@ -1,0 +1,144 @@
+#include "InspectorLifecycleAgent.h"
+
+#include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <wtf/text/WTFString.h>
+#include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <JavaScriptCore/ScriptArguments.h>
+#include <JavaScriptCore/ConsoleMessage.h>
+#include <JavaScriptCore/InspectorConsoleAgent.h>
+#include <JavaScriptCore/JSGlobalObjectDebuggable.h>
+#include <JavaScriptCore/JSGlobalObjectInspectorController.h>
+#include "ConsoleObject.h"
+namespace Inspector {
+
+// Zig bindings implementation
+extern "C" {
+
+void Bun__LifecycleAgentEnable(Inspector::InspectorLifecycleAgent* agent);
+void Bun__LifecycleAgentDisable(Inspector::InspectorLifecycleAgent* agent);
+
+void Bun__LifecycleAgentReportReload(Inspector::InspectorLifecycleAgent* agent)
+{
+    agent->reportReload();
+}
+
+void Bun__LifecycleAgentReportError(Inspector::InspectorLifecycleAgent* agent, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue errorOrExceptionEncoded)
+{
+    JSC::JSValue errorOrException = JSC::JSValue::decode(errorOrExceptionEncoded);
+    ASSERT(errorOrException);
+
+    agent->reportError(*globalObject, errorOrException);
+}
+
+void Bun__LifecycleAgentPreventExit(Inspector::InspectorLifecycleAgent* agent);
+void Bun__LifecycleAgentStopPreventingExit(Inspector::InspectorLifecycleAgent* agent);
+}
+
+InspectorLifecycleAgent::InspectorLifecycleAgent(JSC::JSGlobalObject& globalObject)
+    : InspectorAgentBase("LifecycleReporter"_s)
+    , m_globalObject(globalObject)
+{
+}
+
+InspectorLifecycleAgent::~InspectorLifecycleAgent()
+{
+    if (m_enabled) {
+        Bun__LifecycleAgentDisable(this);
+    }
+}
+
+void InspectorLifecycleAgent::didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*)
+{
+    this->m_frontendDispatcher = makeUnique<LifecycleReporterFrontendDispatcher>(const_cast<FrontendRouter&>(m_globalObject.inspectorController().frontendRouter()));
+}
+
+void InspectorLifecycleAgent::willDestroyFrontendAndBackend(DisconnectReason)
+{
+    disable();
+}
+
+Protocol::ErrorStringOr<void> InspectorLifecycleAgent::enable()
+{
+    if (m_enabled)
+        return {};
+
+    m_enabled = true;
+    Bun__LifecycleAgentEnable(this);
+    return {};
+}
+
+Protocol::ErrorStringOr<void> InspectorLifecycleAgent::disable()
+{
+    if (!m_enabled)
+        return {};
+
+    m_enabled = false;
+    Bun__LifecycleAgentDisable(this);
+    return {};
+}
+
+void InspectorLifecycleAgent::reportReload()
+{
+    if (!m_enabled || !m_frontendDispatcher)
+        return;
+
+    m_frontendDispatcher->reload();
+}
+
+void InspectorLifecycleAgent::reportError(JSC::JSGlobalObject& globalObject, JSC::JSValue errorOrException)
+{
+    if (!m_enabled || !m_frontendDispatcher)
+        return;
+
+    auto* cell = errorOrException.asCell();
+
+    Ref<ScriptCallStack> callStack = ScriptCallStack::create();
+
+    WTF::String message;
+    JSC::JSValue valueForMessage = errorOrException;
+
+    if (cell) {
+        if (cell->inherits<JSC::Exception>()) {
+            auto* exception = static_cast<JSC::Exception*>(cell);
+            callStack = Inspector::createScriptCallStackFromException(&globalObject, exception);
+            JSC::JSValue value = exception->value();
+            valueForMessage = value;
+        } else if (auto* error = JSC::jsDynamicCast<JSC::ErrorInstance*>(cell)) {
+            if (error->stackTrace()) {
+                auto& stackTrace = *error->stackTrace();
+                callStack = Inspector::createScriptCallStackFromStackTrace(&globalObject, { stackTrace.begin(), stackTrace.end() }, error);
+                message = error->sanitizedToString(&globalObject);
+            }
+        }
+    }
+
+    if (!message) {
+        message = valueForMessage.toWTFStringForConsole(&globalObject);
+    }
+
+    auto consoleMessage = Protocol::Console::ConsoleMessage::create()
+                              .setLevel(Protocol::Console::ConsoleMessage::Level::Error)
+                              .setText(message)
+                              .setSource(Protocol::Console::ChannelSource::Other)
+                              .release();
+
+    consoleMessage->setStackTrace(callStack->buildInspectorObject());
+
+    m_frontendDispatcher->error(WTFMove(consoleMessage));
+}
+
+Protocol::ErrorStringOr<void> InspectorLifecycleAgent::preventExit()
+{
+    m_preventingExit = true;
+    return {};
+}
+
+Protocol::ErrorStringOr<void> InspectorLifecycleAgent::stopPreventingExit()
+{
+    m_preventingExit = false;
+    return {};
+}
+
+} // namespace Inspector

--- a/src/bun.js/bindings/InspectorLifecycleAgent.h
+++ b/src/bun.js/bindings/InspectorLifecycleAgent.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/AlternateDispatchableAgent.h>
+#include <JavaScriptCore/InspectorAgentBase.h>
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+
+namespace Inspector {
+
+class FrontendRouter;
+class BackendDispatcher;
+class LifecycleReporterFrontendDispatcher;
+enum class DisconnectReason;
+
+class InspectorLifecycleAgent final : public InspectorAgentBase, public Inspector::LifecycleReporterBackendDispatcherHandler {
+    WTF_MAKE_NONCOPYABLE(InspectorLifecycleAgent);
+
+public:
+    InspectorLifecycleAgent(JSC::JSGlobalObject&);
+    virtual ~InspectorLifecycleAgent();
+
+    // InspectorAgentBase
+    virtual void didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*) final;
+    virtual void willDestroyFrontendAndBackend(DisconnectReason) final;
+
+    // LifecycleReporterBackendDispatcherHandler
+    virtual Protocol::ErrorStringOr<void> enable() final;
+    virtual Protocol::ErrorStringOr<void> disable() final;
+
+    // Public API
+    void reportReload();
+    void reportError(JSC::JSGlobalObject&, JSC::JSValue);
+    Protocol::ErrorStringOr<void> preventExit();
+    Protocol::ErrorStringOr<void> stopPreventingExit();
+
+private:
+    JSC::JSGlobalObject& m_globalObject;
+    std::unique_ptr<LifecycleReporterFrontendDispatcher> m_frontendDispatcher;
+    bool m_enabled { false };
+    bool m_preventingExit { false };
+};
+
+} // namespace Inspector

--- a/src/bun.js/bindings/InspectorLifecycleAgent.h
+++ b/src/bun.js/bindings/InspectorLifecycleAgent.h
@@ -40,6 +40,7 @@ public:
 private:
     JSC::JSGlobalObject& m_globalObject;
     std::unique_ptr<LifecycleReporterFrontendDispatcher> m_frontendDispatcher;
+    Ref<LifecycleReporterBackendDispatcher> m_backendDispatcher;
     bool m_enabled { false };
     bool m_preventingExit { false };
 };

--- a/src/bun.js/bindings/InspectorLifecycleAgent.h
+++ b/src/bun.js/bindings/InspectorLifecycleAgent.h
@@ -8,7 +8,7 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
-
+#include "headers-handwritten.h"
 namespace Inspector {
 
 class FrontendRouter;
@@ -33,7 +33,7 @@ public:
 
     // Public API
     void reportReload();
-    void reportError(JSC::JSGlobalObject&, JSC::JSValue);
+    void reportError(ZigException&);
     Protocol::ErrorStringOr<void> preventExit();
     Protocol::ErrorStringOr<void> stopPreventingExit();
 

--- a/src/bun.js/bindings/InspectorTestReporterAgent.cpp
+++ b/src/bun.js/bindings/InspectorTestReporterAgent.cpp
@@ -68,6 +68,8 @@ void Bun__TestReporterAgentReportTestEnd(Inspector::InspectorTestReporterAgent* 
 InspectorTestReporterAgent::InspectorTestReporterAgent(JSC::JSGlobalObject& globalObject)
     : InspectorAgentBase("TestReporter"_s)
     , m_globalObject(globalObject)
+    , m_backendDispatcher(TestReporterBackendDispatcher::create(m_globalObject.inspectorController().backendDispatcher(), this))
+    , m_frontendDispatcher(makeUnique<TestReporterFrontendDispatcher>(const_cast<FrontendRouter&>(m_globalObject.inspectorController().frontendRouter())))
 {
 }
 
@@ -111,7 +113,7 @@ Protocol::ErrorStringOr<void> InspectorTestReporterAgent::disable()
 
 void InspectorTestReporterAgent::reportTestFound(JSC::CallFrame* callFrame, int testId, const String& name)
 {
-    if (!m_enabled || !m_frontendDispatcher)
+    if (!m_enabled)
         return;
 
     JSC::LineColumn lineColumn;

--- a/src/bun.js/bindings/InspectorTestReporterAgent.cpp
+++ b/src/bun.js/bindings/InspectorTestReporterAgent.cpp
@@ -1,0 +1,150 @@
+#include "InspectorTestReporterAgent.h"
+
+#include <JavaScriptCore/InspectorFrontendRouter.h>
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <wtf/text/WTFString.h>
+#include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/JSGlobalObjectDebuggable.h>
+#include <JavaScriptCore/JSGlobalObjectInspectorController.h>
+#include "ErrorStackTrace.h"
+#include "ZigGlobalObject.h"
+
+#include "ModuleLoader.h"
+
+namespace Inspector {
+
+// Zig bindings implementation
+extern "C" {
+
+void Bun__TestReporterAgentEnable(Inspector::InspectorTestReporterAgent* agent);
+void Bun__TestReporterAgentDisable(Inspector::InspectorTestReporterAgent* agent);
+
+void Bun__TestReporterAgentReportTestFound(Inspector::InspectorTestReporterAgent* agent, JSC::CallFrame* callFrame, int testId, int line, BunString* name)
+{
+    auto str = name->toWTFString(BunString::ZeroCopy);
+    agent->reportTestFound(callFrame, testId, line, str);
+}
+
+void Bun__TestReporterAgentReportTestStart(Inspector::InspectorTestReporterAgent* agent, int testId)
+{
+    agent->reportTestStart(testId);
+}
+
+enum class BunTestStatus : uint8_t {
+    Pass,
+    Fail,
+    Timeout,
+    Skip,
+    Todo,
+};
+
+void Bun__TestReporterAgentReportTestEnd(Inspector::InspectorTestReporterAgent* agent, int testId, BunTestStatus bunTestStatus, double elapsed)
+{
+    Protocol::TestReporter::TestStatus status;
+    switch (bunTestStatus) {
+    case BunTestStatus::Pass:
+        status = Protocol::TestReporter::TestStatus::Pass;
+        break;
+    case BunTestStatus::Fail:
+        status = Protocol::TestReporter::TestStatus::Fail;
+        break;
+    case BunTestStatus::Timeout:
+        status = Protocol::TestReporter::TestStatus::Timeout;
+        break;
+    case BunTestStatus::Skip:
+        status = Protocol::TestReporter::TestStatus::Skip;
+        break;
+    case BunTestStatus::Todo:
+        status = Protocol::TestReporter::TestStatus::Todo;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+    agent->reportTestEnd(testId, status, elapsed);
+}
+}
+
+InspectorTestReporterAgent::InspectorTestReporterAgent(JSC::JSGlobalObject& globalObject)
+    : InspectorAgentBase("TestReporter"_s)
+    , m_globalObject(globalObject)
+{
+}
+
+InspectorTestReporterAgent::~InspectorTestReporterAgent()
+{
+    if (m_enabled) {
+        Bun__TestReporterAgentDisable(this);
+    }
+}
+
+void InspectorTestReporterAgent::didCreateFrontendAndBackend(FrontendRouter* frontendRouter, BackendDispatcher* backendDispatcher)
+{
+    this->m_frontendDispatcher = makeUnique<TestReporterFrontendDispatcher>(const_cast<FrontendRouter&>(m_globalObject.inspectorController().frontendRouter()));
+}
+
+void InspectorTestReporterAgent::willDestroyFrontendAndBackend(DisconnectReason)
+{
+    disable();
+    m_frontendDispatcher = nullptr;
+}
+
+Protocol::ErrorStringOr<void> InspectorTestReporterAgent::enable()
+{
+    if (m_enabled)
+        return {};
+
+    m_enabled = true;
+    Bun__TestReporterAgentEnable(this);
+    return {};
+}
+
+Protocol::ErrorStringOr<void> InspectorTestReporterAgent::disable()
+{
+    if (!m_enabled)
+        return {};
+
+    m_enabled = false;
+    Bun__TestReporterAgentDisable(this);
+    return {};
+}
+
+void InspectorTestReporterAgent::reportTestFound(JSC::CallFrame* callFrame, int testId, int line, const String& name)
+{
+    if (!m_enabled || !m_frontendDispatcher)
+        return;
+
+    JSC::LineColumn lineColumn;
+    JSC::SourceID sourceID = 0;
+
+    auto stackTrace = Zig::JSCStackTrace::captureCurrentJSStackTrace(defaultGlobalObject(&m_globalObject), callFrame, 1, {});
+    if (stackTrace.size() > 0) {
+        auto& frame = stackTrace.at(0);
+        auto* sourcePositions = frame.getSourcePositions();
+        if (sourcePositions) {
+            lineColumn.line = sourcePositions->line.oneBasedInt();
+            lineColumn.column = sourcePositions->column.oneBasedInt();
+        }
+        sourceID = frame.sourceID();
+    }
+
+    m_frontendDispatcher->found(testId, String::number(sourceID), sourceID != 0 ? lineColumn.line : -1, name);
+}
+
+void InspectorTestReporterAgent::reportTestStart(int testId)
+{
+    if (!m_enabled || !m_frontendDispatcher)
+        return;
+
+    m_frontendDispatcher->start(testId);
+}
+
+void InspectorTestReporterAgent::reportTestEnd(int testId, Protocol::TestReporter::TestStatus status, double elapsed)
+{
+    if (!m_enabled || !m_frontendDispatcher)
+        return;
+
+    m_frontendDispatcher->end(testId, status, elapsed);
+}
+
+} // namespace Inspector

--- a/src/bun.js/bindings/InspectorTestReporterAgent.h
+++ b/src/bun.js/bindings/InspectorTestReporterAgent.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/AlternateDispatchableAgent.h>
+#include <JavaScriptCore/InspectorAgentBase.h>
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+
+namespace Inspector {
+
+class FrontendRouter;
+class BackendDispatcher;
+class TestReporterFrontendDispatcher;
+enum class DisconnectReason;
+
+class InspectorTestReporterAgent final : public InspectorAgentBase, public Inspector::TestReporterBackendDispatcherHandler {
+    WTF_MAKE_NONCOPYABLE(InspectorTestReporterAgent);
+
+public:
+    InspectorTestReporterAgent(JSC::JSGlobalObject&);
+    virtual ~InspectorTestReporterAgent();
+
+    // InspectorAgentBase
+    virtual void didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*) final;
+    virtual void willDestroyFrontendAndBackend(DisconnectReason) final;
+
+    // TestReporterBackendDispatcherHandler
+    virtual Protocol::ErrorStringOr<void> enable() final;
+    virtual Protocol::ErrorStringOr<void> disable() final;
+
+    // Public API for reporting test events
+    void reportTestFound(JSC::CallFrame*, int testId, int line, const String& name);
+    void reportTestStart(int testId);
+    void reportTestEnd(int testId, Protocol::TestReporter::TestStatus status, double elapsed);
+
+private:
+    JSC::JSGlobalObject& m_globalObject;
+    std::unique_ptr<TestReporterFrontendDispatcher> m_frontendDispatcher;
+    bool m_enabled { false };
+};
+
+} // namespace Inspector

--- a/src/bun.js/bindings/InspectorTestReporterAgent.h
+++ b/src/bun.js/bindings/InspectorTestReporterAgent.h
@@ -32,7 +32,7 @@ public:
     virtual Protocol::ErrorStringOr<void> disable() final;
 
     // Public API for reporting test events
-    void reportTestFound(JSC::CallFrame*, int testId, int line, const String& name);
+    void reportTestFound(JSC::CallFrame*, int testId, const String& name);
     void reportTestStart(int testId);
     void reportTestEnd(int testId, Protocol::TestReporter::TestStatus status, double elapsed);
 

--- a/src/bun.js/bindings/InspectorTestReporterAgent.h
+++ b/src/bun.js/bindings/InspectorTestReporterAgent.h
@@ -39,6 +39,7 @@ public:
 private:
     JSC::JSGlobalObject& m_globalObject;
     std::unique_ptr<TestReporterFrontendDispatcher> m_frontendDispatcher;
+    Ref<TestReporterBackendDispatcher> m_backendDispatcher;
     bool m_enabled { false };
 };
 

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -455,8 +455,6 @@ extern "C" void Bun__onFulfillAsyncModule(
     }
 }
 
-extern "C" bool isBunTest;
-
 JSValue fetchCommonJSModule(
     Zig::GlobalObject* globalObject,
     JSCommonJSModule* target,

--- a/src/bun.js/bindings/ModuleLoader.h
+++ b/src/bun.js/bindings/ModuleLoader.h
@@ -47,6 +47,8 @@ struct OnLoadResult {
     bool wasMock;
 };
 
+extern "C" bool isBunTest;
+
 class PendingVirtualModuleResult : public JSC::JSInternalFieldObjectImpl<3> {
 public:
     using Base = JSC::JSInternalFieldObjectImpl<3>;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -57,6 +57,7 @@ pub const Tag = enum(u3) {
     todo,
 };
 const debug = Output.scoped(.jest, false);
+var max_test_id_for_debugger: u32 = 0;
 pub const TestRunner = struct {
     tests: TestRunner.Test.List = .{},
     log: *logger.Log,
@@ -586,7 +587,7 @@ pub const TestScope = struct {
     func_arg: []JSValue,
     func_has_callback: bool = false,
 
-    id: TestRunner.Test.ID = 0,
+    test_id_for_debugger: TestRunner.Test.ID = 0,
     promise: ?*JSInternalPromise = null,
     ran: bool = false,
     task: ?*TestRunnerTask = null,
@@ -724,6 +725,14 @@ pub const TestScope = struct {
             this.timeout_millis,
             task.test_id,
         );
+
+        if (task.test_id_for_debugger > 0) {
+            if (vm.debugger) |*debugger| {
+                if (debugger.test_reporter_agent.isEnabled()) {
+                    debugger.test_reporter_agent.reportTestStart(@intCast(task.test_id_for_debugger));
+                }
+            }
+        }
 
         if (this.func_has_callback) {
             const callback_func = JSC.NewFunctionWithData(
@@ -1177,6 +1186,7 @@ pub const DescribeScope = struct {
                     .describe = this,
                     .globalThis = globalObject,
                     .source_file_path = source.path.text,
+                    .test_id_for_debugger = 0,
                 };
                 runner.ref.ref(globalObject.bunVM());
 
@@ -1185,6 +1195,8 @@ pub const DescribeScope = struct {
             }
         }
 
+        const maybe_report_debugger = max_test_id_for_debugger > 0;
+
         while (i < end) : (i += 1) {
             var runner = allocator.create(TestRunnerTask) catch unreachable;
             runner.* = .{
@@ -1192,6 +1204,7 @@ pub const DescribeScope = struct {
                 .describe = this,
                 .globalThis = globalObject,
                 .source_file_path = source.path.text,
+                .test_id_for_debugger = if (maybe_report_debugger) tests[i].test_id_for_debugger else 0,
             };
             runner.ref.ref(globalObject.bunVM());
 
@@ -1272,6 +1285,7 @@ pub const WrappedDescribeScope = struct {
 
 pub const TestRunnerTask = struct {
     test_id: TestRunner.Test.ID,
+    test_id_for_debugger: TestRunner.Test.ID,
     describe: *DescribeScope,
     globalThis: *JSGlobalObject,
     source_file_path: string = "",
@@ -1356,7 +1370,6 @@ pub const TestRunnerTask = struct {
         jsc_vm.last_reported_error_for_dedupe = .zero;
 
         const test_id = this.test_id;
-
         if (test_id == std.math.maxInt(TestRunner.Test.ID)) {
             describe.onTestComplete(globalThis, test_id, true);
             Jest.runner.?.runNextTest();
@@ -1366,15 +1379,17 @@ pub const TestRunnerTask = struct {
 
         var test_: TestScope = this.describe.tests.items[test_id];
         describe.current_test_id = test_id;
+        const test_id_for_debugger = test_.test_id_for_debugger;
+        this.test_id_for_debugger = test_id_for_debugger;
 
         if (test_.func == .zero or !describe.shouldEvaluateScope() or (test_.tag != .only and Jest.runner.?.only)) {
             const tag = if (!describe.shouldEvaluateScope()) describe.tag else test_.tag;
             switch (tag) {
                 .todo => {
-                    this.processTestResult(globalThis, .{ .todo = {} }, test_, test_id, describe);
+                    this.processTestResult(globalThis, .{ .todo = {} }, test_, test_id, test_id_for_debugger, describe);
                 },
                 .skip => {
-                    this.processTestResult(globalThis, .{ .skip = {} }, test_, test_id, describe);
+                    this.processTestResult(globalThis, .{ .skip = {} }, test_, test_id, test_id_for_debugger, describe);
                 },
                 else => {},
             }
@@ -1556,17 +1571,18 @@ pub const TestRunnerTask = struct {
         }
 
         checkAssertionsCounter(result);
-        processTestResult(this, this.globalThis, result.*, test_, test_id, describe);
+        processTestResult(this, this.globalThis, result.*, test_, test_id, this.test_id_for_debugger, describe);
     }
 
-    fn processTestResult(this: *TestRunnerTask, globalThis: *JSGlobalObject, result: Result, test_: TestScope, test_id: u32, describe: *DescribeScope) void {
+    fn processTestResult(this: *TestRunnerTask, globalThis: *JSGlobalObject, result: Result, test_: TestScope, test_id: u32, test_id_for_debugger: u32, describe: *DescribeScope) void {
+        const elapsed = this.started_at.sinceNow();
         switch (result.forceTODO(test_.tag == .todo)) {
             .pass => |count| Jest.runner.?.reportPass(
                 test_id,
                 this.source_file_path,
                 test_.label,
                 count,
-                this.started_at.sinceNow(),
+                elapsed,
                 describe,
             ),
             .fail => |count| Jest.runner.?.reportFailure(
@@ -1574,7 +1590,7 @@ pub const TestRunnerTask = struct {
                 this.source_file_path,
                 test_.label,
                 count,
-                this.started_at.sinceNow(),
+                elapsed,
                 describe,
             ),
             .fail_because_expected_has_assertions => {
@@ -1585,7 +1601,7 @@ pub const TestRunnerTask = struct {
                     this.source_file_path,
                     test_.label,
                     0,
-                    this.started_at.sinceNow(),
+                    elapsed,
                     describe,
                 );
             },
@@ -1600,7 +1616,7 @@ pub const TestRunnerTask = struct {
                     this.source_file_path,
                     test_.label,
                     counter.actual,
-                    this.started_at.sinceNow(),
+                    elapsed,
                     describe,
                 );
             },
@@ -1613,12 +1629,26 @@ pub const TestRunnerTask = struct {
                     this.source_file_path,
                     test_.label,
                     count,
-                    this.started_at.sinceNow(),
+                    elapsed,
                     describe,
                 );
             },
             .pending => @panic("Unexpected pending test"),
         }
+
+        if (test_id_for_debugger > 0) {
+            if (globalThis.bunVM().debugger) |*debugger| {
+                if (debugger.test_reporter_agent.isEnabled()) {
+                    debugger.test_reporter_agent.reportTestEnd(@intCast(test_id_for_debugger), switch (result) {
+                        .pass => .pass,
+                        .skip => .skip,
+                        .todo => .todo,
+                        else => .fail,
+                    }, @floatFromInt(elapsed));
+                }
+            }
+        }
+
         describe.onTestComplete(globalThis, test_id, result == .skip or (!Jest.runner.?.test_options.run_todo and result == .todo));
 
         Jest.runner.?.runNextTest();
@@ -1803,6 +1833,21 @@ inline fn createScope(
             .func_arg = function_args,
             .func_has_callback = has_callback,
             .timeout_millis = timeout_ms,
+            .test_id_for_debugger = brk: {
+                if (!is_skip) {
+                    const vm = globalThis.bunVM();
+                    if (vm.debugger) |*debugger| {
+                        if (debugger.test_reporter_agent.isEnabled()) {
+                            max_test_id_for_debugger += 1;
+                            var name = bun.String.init(label);
+                            debugger.test_reporter_agent.reportTestFound(callframe, @intCast(max_test_id_for_debugger), &name);
+                            break :brk max_test_id_for_debugger;
+                        }
+                    }
+                }
+
+                break :brk 0;
+            },
         }) catch unreachable;
     } else {
         var scope = allocator.create(DescribeScope) catch unreachable;

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -610,11 +610,13 @@ const Scanner = struct {
             return false;
         }
 
-        if (jest.Jest.runner.?.test_options.coverage.skip_test_files) {
-            const name_without_extension = slice[0 .. slice.len - ext.len];
-            inline for (test_name_suffixes) |suffix| {
-                if (strings.endsWithComptime(name_without_extension, suffix)) {
-                    return false;
+        if (jest.Jest.runner) |runner| {
+            if (runner.test_options.coverage.skip_test_files) {
+                const name_without_extension = slice[0 .. slice.len - ext.len];
+                inline for (test_name_suffixes) |suffix| {
+                    if (strings.endsWithComptime(name_without_extension, suffix)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -850,6 +850,9 @@ pub const TestCommand = struct {
 
         // Start the debugger before we scan for files
         // But, don't block the main thread waiting if they used --inspect-wait.
+        //
+        try vm.ensureDebugger(false);
+
         const test_files, const search_count = scan: {
             if (for (ctx.positionals) |arg| {
                 if (std.fs.path.isAbsolute(arg) or

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -848,6 +848,8 @@ pub const TestCommand = struct {
         var results = try std.ArrayList(PathString).initCapacity(ctx.allocator, ctx.positionals.len);
         defer results.deinit();
 
+        // Start the debugger before we scan for files
+        // But, don't block the main thread waiting if they used --inspect-wait.
         const test_files, const search_count = scan: {
             if (for (ctx.positionals) |arg| {
                 if (std.fs.path.isAbsolute(arg) or

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -273,6 +273,7 @@ class Debugger {
             framer,
             backend,
           };
+          socket.ref();
         },
         data: (socket, bytes) => {
           if (!socket.data) {

--- a/test/cli/inspect/__snapshots__/inspect.test.ts.snap
+++ b/test/cli/inspect/__snapshots__/inspect.test.ts.snap
@@ -1,0 +1,19 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`junit reporter 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="<dir>/a.test.js" tests="2" failures="1" errors="0" skipped="0" timestamp="2024-12-17T15:37:38.935Z">
+    <testcase classname="<dir>/a.test.js" name="fail"       <failure message="Test failed" type="AssertionError">
+        Error: expect(received).toBe(expected)
+
+Expected: 2
+Received: 1
+
+
+      </failure>
+    </testcase>
+    <testcase classname="<dir>/a.test.js" name="success"     </testcase>
+  </testsuite>
+</testsuites>"
+`;

--- a/test/cli/inspect/junit-reporter.ts
+++ b/test/cli/inspect/junit-reporter.ts
@@ -1,0 +1,351 @@
+// This is a test app for:
+// - TestReporter.enable
+// - TestReporter.found
+// - TestReporter.start
+// - TestReporter.end
+// - Console.messageAdded
+// - LifecycleReporter.enable
+// - LifecycleReporter.error
+
+const debug = false;
+import { listen, type Socket } from "bun";
+
+import { SocketFramer } from "./socket-framer.ts";
+import type { JSC } from "../../../packages/bun-inspector-protocol/src/protocol/jsc";
+
+interface Message {
+  id?: number;
+  method?: string;
+  params?: any;
+  result?: any;
+}
+
+class InspectorSession {
+  private messageCallbacks: Map<number, (result: any) => void>;
+  private eventListeners: Map<string, ((params: any) => void)[]>;
+  private nextId: number;
+  framer?: SocketFramer;
+  socket?: Socket<{ onData: (socket: Socket<any>, data: Buffer) => void }>;
+
+  constructor() {
+    this.messageCallbacks = new Map();
+    this.eventListeners = new Map();
+    this.nextId = 1;
+  }
+
+  onMessage(data: string) {
+    if (debug) console.log(data);
+    const message: Message = JSON.parse(data);
+
+    if (message.id && this.messageCallbacks.has(message.id)) {
+      const callback = this.messageCallbacks.get(message.id)!;
+      callback(message.result);
+      this.messageCallbacks.delete(message.id);
+    } else if (message.method && this.eventListeners.has(message.method)) {
+      if (debug) console.log("event", message.method, message.params);
+      const listeners = this.eventListeners.get(message.method)!;
+      for (const listener of listeners) {
+        listener(message.params);
+      }
+    }
+  }
+
+  send(method: string, params: any = {}) {
+    if (!this.framer) throw new Error("Socket not connected");
+    const id = this.nextId++;
+    const message = { id, method, params };
+    this.framer.send(this.socket as any, JSON.stringify(message));
+  }
+
+  addEventListener(method: string, callback: (params: any) => void) {
+    if (!this.eventListeners.has(method)) {
+      this.eventListeners.set(method, []);
+    }
+    this.eventListeners.get(method)!.push(callback);
+  }
+}
+
+interface JUnitTestCase {
+  name: string;
+  classname: string;
+  time: number;
+  failure?: {
+    message: string;
+    type: string;
+    content: string;
+  };
+  systemOut?: string;
+  systemErr?: string;
+}
+
+interface JUnitTestSuite {
+  name: string;
+  tests: number;
+  failures: number;
+  errors: number;
+  skipped: number;
+  time: number;
+  timestamp: string;
+  testCases: JUnitTestCase[];
+}
+
+interface TestInfo {
+  id: number;
+  name: string;
+  file: string;
+  startTime?: number;
+  stdout: string[];
+  stderr: string[];
+}
+
+class JUnitReporter {
+  private session: InspectorSession;
+  private testSuites: Map<string, JUnitTestSuite>;
+  private tests: Map<number, TestInfo>;
+  private currentTest: TestInfo | null = null;
+
+  constructor(session: InspectorSession) {
+    this.session = session;
+    this.testSuites = new Map();
+    this.tests = new Map();
+
+    this.enableDomains();
+    this.setupEventListeners();
+  }
+
+  private async enableDomains() {
+    this.session.send("Inspector.enable");
+    this.session.send("TestReporter.enable");
+    this.session.send("LifecycleReporter.enable");
+    this.session.send("Console.enable");
+    this.session.send("Runtime.enable");
+  }
+
+  private setupEventListeners() {
+    this.session.addEventListener("TestReporter.found", this.handleTestFound.bind(this));
+    this.session.addEventListener("TestReporter.start", this.handleTestStart.bind(this));
+    this.session.addEventListener("TestReporter.end", this.handleTestEnd.bind(this));
+    this.session.addEventListener("Console.messageAdded", this.handleConsoleMessage.bind(this));
+    this.session.addEventListener("LifecycleReporter.error", this.handleException.bind(this));
+  }
+
+  private getOrCreateTestSuite(file: string): JUnitTestSuite {
+    if (!this.testSuites.has(file)) {
+      this.testSuites.set(file, {
+        name: file,
+        tests: 0,
+        failures: 0,
+        errors: 0,
+        skipped: 0,
+        time: 0,
+        timestamp: new Date().toISOString(),
+        testCases: [],
+      });
+    }
+    return this.testSuites.get(file)!;
+  }
+
+  private handleTestFound(params: JSC.TestReporter.FoundEvent) {
+    const file = params.url || "unknown";
+    const suite = this.getOrCreateTestSuite(file);
+    suite.tests++;
+
+    const test: TestInfo = {
+      id: params.id,
+      name: params.name || `Test ${params.id}`,
+      file,
+      stdout: [],
+      stderr: [],
+    };
+    this.tests.set(params.id, test);
+  }
+
+  private handleTestStart(params: JSC.TestReporter.StartEvent) {
+    const test = this.tests.get(params.id);
+    if (test) {
+      test.startTime = Date.now();
+      this.currentTest = test;
+    }
+  }
+
+  private handleTestEnd(params: JSC.TestReporter.EndEvent) {
+    const test = this.tests.get(params.id);
+    if (!test || !test.startTime) return;
+
+    const suite = this.getOrCreateTestSuite(test.file);
+    const testCase: JUnitTestCase = {
+      name: test.name,
+      classname: test.file,
+      time: (Date.now() - test.startTime) / 1000,
+    };
+
+    if (test.stdout.length > 0) {
+      testCase.systemOut = test.stdout.join("\n");
+    }
+    if (test.stderr.length > 0) {
+      testCase.systemErr = test.stderr.join("\n");
+    }
+
+    if (params.status === "fail") {
+      suite.failures++;
+      testCase.failure = {
+        message: "Test failed",
+        type: "AssertionError",
+        content: test.stderr.join("\n") || "No error details available",
+      };
+    } else if (params.status === "skip" || params.status === "todo") {
+      suite.skipped++;
+    }
+
+    suite.testCases.push(testCase);
+    this.currentTest = null;
+  }
+
+  private handleConsoleMessage(params: any) {
+    if (!this.currentTest) return;
+
+    const message = params.message;
+    const text = message.text || "";
+
+    if (message.level === "error" || message.level === "warning") {
+      this.currentTest.stderr.push(text);
+    } else {
+      this.currentTest.stdout.push(text);
+    }
+  }
+
+  private handleException(params: JSC.LifecycleReporter.ErrorEvent) {
+    if (!this.currentTest) return;
+
+    const error = params;
+    let stackTrace = "";
+    for (let i = 0; i < error.urls.length; i++) {
+      let url = error.urls[i];
+      let line = Number(error.lineColumns[i * 2]);
+      let column = Number(error.lineColumns[i * 2 + 1]);
+
+      if (column > 0 && line > 0) {
+        stackTrace += `  at ${url}:${line}:${column}\n`;
+      } else if (line > 0) {
+        stackTrace += `  at ${url}:${line}\n`;
+      } else {
+        stackTrace += `  at ${url}\n`;
+      }
+    }
+
+    this.currentTest.stderr.push(`${error.name || "Error"}: ${error.message || "Unknown error"}`, "");
+    if (stackTrace) {
+      this.currentTest.stderr.push(stackTrace);
+      this.currentTest.stderr.push("");
+    }
+  }
+
+  generateReport(): string {
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+    xml += "<testsuites>\n";
+
+    for (const suite of this.testSuites.values()) {
+      const totalTime = suite.testCases.reduce((sum, test) => sum + test.time, 0);
+      suite.time = totalTime;
+
+      xml += `  <testsuite name="${escapeXml(suite.name)}" `;
+      xml += `tests="${suite.tests}" `;
+      xml += `failures="${suite.failures}" `;
+      xml += `errors="${suite.errors}" `;
+      xml += `skipped="${suite.skipped}" `;
+      xml += `time="${suite.time}" `;
+      xml += `timestamp="${suite.timestamp}">\n`;
+
+      for (const testCase of suite.testCases) {
+        xml += `    <testcase classname="${escapeXml(testCase.classname)}" `;
+        xml += `name="${escapeXml(testCase.name)}" `;
+        xml += `time="${testCase.time}">\n`;
+
+        if (testCase.failure) {
+          xml += `      <failure message="${escapeXml(testCase.failure.message)}" `;
+          xml += `type="${escapeXml(testCase.failure.type)}">\n`;
+          xml += `        ${escapeXml(testCase.failure.content)}\n`;
+          xml += "      </failure>\n";
+        }
+
+        if (testCase.systemOut) {
+          xml += `      <system-out>${escapeXml(testCase.systemOut)}</system-out>\n`;
+        }
+
+        if (testCase.systemErr) {
+          xml += `      <system-err>${escapeXml(testCase.systemErr)}</system-err>\n`;
+        }
+
+        xml += "    </testcase>\n";
+      }
+
+      xml += "  </testsuite>\n";
+    }
+
+    xml += "</testsuites>";
+    return xml;
+  }
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+async function connect(address: string): Promise<Socket<{ onData: (socket: Socket<any>, data: Buffer) => void }>> {
+  const { promise, resolve } = Promise.withResolvers<Socket<{ onData: (socket: Socket<any>, data: Buffer) => void }>>();
+
+  var listener = listen<{ onData: (socket: Socket<any>, data: Buffer) => void }>({
+    unix: address.slice("unix://".length),
+    socket: {
+      open: socket => {
+        listener.stop();
+        socket.ref();
+        resolve(socket);
+      },
+      data(socket, data: Buffer) {
+        socket.data?.onData(socket, data);
+      },
+      error(socket, error) {
+        console.error(error);
+      },
+    },
+  });
+
+  return await promise;
+}
+
+// Main execution
+const address = process.argv[2];
+if (!address) {
+  throw new Error("Please provide the inspector address as an argument");
+}
+
+let reporter: JUnitReporter;
+let session: InspectorSession;
+
+const socket = await connect(address);
+const framer = new SocketFramer((message: string) => {
+  session.onMessage(message);
+});
+
+session = new InspectorSession();
+session.socket = socket;
+session.framer = framer;
+socket.data = {
+  onData: framer.onData.bind(framer),
+};
+
+reporter = new JUnitReporter(session);
+
+// Handle process exit
+process.on("exit", () => {
+  if (reporter) {
+    const report = reporter.generateReport();
+    console.log(report);
+  }
+});

--- a/test/cli/inspect/socket-framer.ts
+++ b/test/cli/inspect/socket-framer.ts
@@ -1,0 +1,79 @@
+interface Socket<T = any> {
+  data: T;
+  write(data: string | Buffer): void;
+}
+
+const enum FramerState {
+  WaitingForLength,
+  WaitingForMessage,
+}
+
+let socketFramerMessageLengthBuffer: Buffer;
+export class SocketFramer {
+  private state: FramerState = FramerState.WaitingForLength;
+  private pendingLength: number = 0;
+  private sizeBuffer: Buffer = Buffer.alloc(0);
+  private sizeBufferIndex: number = 0;
+  private bufferedData: Buffer = Buffer.alloc(0);
+
+  constructor(private onMessage: (message: string) => void) {
+    if (!socketFramerMessageLengthBuffer) {
+      socketFramerMessageLengthBuffer = Buffer.alloc(4);
+    }
+    this.reset();
+  }
+
+  reset(): void {
+    this.state = FramerState.WaitingForLength;
+    this.bufferedData = Buffer.alloc(0);
+    this.sizeBufferIndex = 0;
+    this.sizeBuffer = Buffer.alloc(4);
+  }
+
+  send(socket: Socket, data: string): void {
+    socketFramerMessageLengthBuffer.writeUInt32BE(data.length, 0);
+    socket.write(socketFramerMessageLengthBuffer);
+    socket.write(data);
+  }
+
+  onData(socket: Socket, data: Buffer): void {
+    this.bufferedData = this.bufferedData.length > 0 ? Buffer.concat([this.bufferedData, data]) : data;
+
+    let messagesToDeliver: string[] = [];
+
+    while (this.bufferedData.length > 0) {
+      if (this.state === FramerState.WaitingForLength) {
+        if (this.sizeBufferIndex + this.bufferedData.length < 4) {
+          const remainingBytes = Math.min(4 - this.sizeBufferIndex, this.bufferedData.length);
+          this.bufferedData.copy(this.sizeBuffer, this.sizeBufferIndex, 0, remainingBytes);
+          this.sizeBufferIndex += remainingBytes;
+          this.bufferedData = this.bufferedData.slice(remainingBytes);
+          break;
+        }
+
+        const remainingBytes = 4 - this.sizeBufferIndex;
+        this.bufferedData.copy(this.sizeBuffer, this.sizeBufferIndex, 0, remainingBytes);
+        this.pendingLength = this.sizeBuffer.readUInt32BE(0);
+
+        this.state = FramerState.WaitingForMessage;
+        this.sizeBufferIndex = 0;
+        this.bufferedData = this.bufferedData.slice(remainingBytes);
+      }
+
+      if (this.bufferedData.length < this.pendingLength) {
+        break;
+      }
+
+      const message = this.bufferedData.toString("utf-8", 0, this.pendingLength);
+      this.bufferedData = this.bufferedData.slice(this.pendingLength);
+      this.state = FramerState.WaitingForLength;
+      this.pendingLength = 0;
+      this.sizeBufferIndex = 0;
+      messagesToDeliver.push(message);
+    }
+
+    for (const message of messagesToDeliver) {
+      this.onMessage(message);
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

This adds two new APIs to the WebKit Inspector Protocol when used in Bun.

This lets you implement a test reporter on top of the WebKit inspector protocol. This also unlocks reporting runtime errors in editor diagnostic APIs without the debugger attached.

The API will change a little more before this merges. The diagnostics need to already be stacktraced since the client may not have the debugger connected.

### How did you verify your code works?

This will need some tests before it merges.