### PR TITLE
Support `Headers` & `URLSearchParams` in expect().toEqual()

### DIFF
--- a/src/bun.js/bindings/BunInjectedScriptHost.cpp
+++ b/src/bun.js/bindings/BunInjectedScriptHost.cpp
@@ -144,16 +144,16 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
                 return array;
             }
 
-            if (auto* params = jsDynamicCast<JSURLSearchParams*>(value)) {
-                auto* array = constructEmptyArray(exec, nullptr);
-                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, params));
-                RETURN_IF_EXCEPTION(scope, {});
-                return array;
-            }
-
             if (auto* formData = jsDynamicCast<JSDOMFormData*>(value)) {
                 auto* array = constructEmptyArray(exec, nullptr);
                 constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, formData));
+                RETURN_IF_EXCEPTION(scope, {});
+                return array;
+            }
+        } else if (type == JSAsJSONType) {
+            if (auto* params = jsDynamicCast<JSURLSearchParams*>(value)) {
+                auto* array = constructEmptyArray(exec, nullptr);
+                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, params));
                 RETURN_IF_EXCEPTION(scope, {});
                 return array;
             }

--- a/src/bun.js/bindings/webcore/FetchHeaders.h
+++ b/src/bun.js/bindings/webcore/FetchHeaders.h
@@ -71,12 +71,12 @@ public:
 
     size_t memoryCost() const;
 
-    inline uint32_t size()
+    inline uint32_t size() const
     {
         return m_headers.size();
     }
 
-    inline uint32_t sizeAfterJoiningSetCookieHeader()
+    inline uint32_t sizeAfterJoiningSetCookieHeader() const
     {
         return m_headers.commonHeaders().size() + m_headers.uncommonHeaders().size() + (m_headers.getSetCookieHeaders().size() > 0);
     }

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -558,7 +558,7 @@ pub const Expect = struct {
 
                 const signature = comptime getSignature("toBe", "<green>expected<r>", false);
                 if (left.deepEquals(right, globalThis) or left.strictDeepEquals(right, globalThis)) {
-                    const fmt = signature ++
+                    const fmt =
                         (if (!has_custom_label) "\n\n<d>If this test should pass, replace \"toBe\" with \"toEqual\" or \"toStrictEqual\"<r>" else "") ++
                         "\n\nExpected: <green>{any}<r>\n" ++
                         "Received: serializes to the same string\n";

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -243,7 +243,7 @@ describe("expect()", () => {
     if (isBun) {
       test("URL", () => {
         expect(new URL("https://example.com")).toEqual(new URL("https://example.com"));
-        expect(new URL("http://wat")).toStrictEqual(new URL("http://huh"));
+        expect(new URL("http://wat")).not.toStrictEqual(new URL("http://huh"));
       });
     }
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -233,6 +233,31 @@ describe("expect()", () => {
     expect([, 1]).toEqual([undefined, 1]);
   });
 
+  describe("toEqual() with DOM types", () => {
+    test("URLSearchParams", () => {
+      expect(new URLSearchParams("a=1")).not.toEqual(new URLSearchParams("b=1"));
+      expect(new URLSearchParams("a=1")).toEqual(new URLSearchParams("a=1"));
+      expect(new URLSearchParams("a=1&b=2")).not.toEqual(new URLSearchParams("a=1&"));
+    });
+
+    if (isBun) {
+      test("URL", () => {
+        expect(new URL("https://example.com")).toEqual(new URL("https://example.com"));
+        expect(new URL("http://wat")).toStrictEqual(new URL("http://huh"));
+      });
+    }
+
+    test("Headers", () => {
+      expect(new Headers({ "a": "1" })).toEqual(new Headers({ "a": "1" }));
+      expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "b": "1" }));
+      expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "a": "2" }));
+      expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "a": "1", "b": "2" }));
+    });
+
+    // TODO: FormData
+    // It would need to compare Blob, which is tricky.
+  });
+
   describe("BigInt", () => {
     it("compares correctly (literal)", () => {
       expect(42n).toBe(42n);


### PR DESCRIPTION
### What does this PR do?

- Support `Headers` & `URLSearchParams` in expect().toEqual()
- Fixes a bug where `expect(foo).toBe(bar)` failing printed the signature twice
- Fixes a bug where the debugger inspector print would not show useful info for URLSearchParams objects

### How did you verify your code works?

There is a test for the expect changes