### PR TITLE
Introduce `deathSig` option in Bun.spawn

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4862,6 +4862,35 @@ declare module "bun" {
        * ```
        */
       signal?: AbortSignal;
+
+      /**
+       * When Bun exits, automatically send this signal to subprocesses. This is
+       * helpful in cases where you want to make it harder for a subprocess to
+       * continue running after Bun has exited. Detached processes will ignore this.
+       *
+       * **Linux-only** - internally, this uses [`prctl(PR_SET_PDEATHSIG, ...)`](https://man7.org/linux/man-pages/man2/pr_set_pdeathsig.2const.html)
+       * When used on other platforms, this option is silently ignored.
+       *
+       * @example
+       *
+       * ```ts
+       * import {spawn} from "bun";
+       * const subprocess = spawn({
+       *  cmd: ["sleep", "1000000"],
+       *  deathSig: "SIGTERM",
+       * });
+       * process.exit(0);
+       * ```
+       *
+       * Then, run
+       *
+       * ```sh
+       * ps aux | grep sleep
+       * ```
+       *
+       * You'll see that the `sleep` process is no longer running after the `ps` command is run.
+       */
+      deathSig?: "SIGTERM" | "SIGINT" | "SIGKILL" | number | string;
     }
 
     type OptionsToSubprocess<Opts extends OptionsObject> =

--- a/src/bun.js/api/bun/spawn.zig
+++ b/src/bun.js/api/bun/spawn.zig
@@ -367,6 +367,7 @@ pub const PosixSpawn = struct {
                     },
                     .chdir_buf = if (actions) |a| a.chdir_buf else null,
                     .detached = if (attr) |a| a.detached else false,
+                    .deathsig = if (attr) |a| a.deathsig else 0,
                 },
                 argv,
                 envp,

--- a/src/bun.js/api/bun/spawn.zig
+++ b/src/bun.js/api/bun/spawn.zig
@@ -64,6 +64,7 @@ pub const BunSpawn = struct {
         chdir_buf: ?[*:0]u8 = null,
         actions: std.ArrayListUnmanaged(Action) = .{},
         detached: bool = false,
+        deathsig: i32 = 0,
 
         pub fn init() !Actions {
             return .{};
@@ -126,7 +127,7 @@ pub const BunSpawn = struct {
 
     pub const Attr = struct {
         detached: bool = false,
-
+        deathsig: i32 = 0,
         pub fn init() !Attr {
             return Attr{};
         }
@@ -299,6 +300,7 @@ pub const PosixSpawn = struct {
     const BunSpawnRequest = extern struct {
         chdir_buf: ?[*:0]u8 = null,
         detached: bool = false,
+        deathsig: i32 = 0,
         actions: ActionsList = .{},
 
         const ActionsList = extern struct {

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1879,7 +1879,7 @@ pub const Subprocess = struct {
                         const signal_int = globalThis.validateIntegerRange(death_signal_val, u8, 0, .{ .min = 1, .max = @intFromEnum(bun.SignalCode.max) }) orelse return .zero;
                         death_signal = @enumFromInt(signal_int);
                     } else if (death_signal_val.isString()) {
-                        death_signal = bun.SignalCode.fromJS(globalThis, death_signal_val) orelse {
+                        death_signal = bun.SignalCode.Map.fromJS(globalThis, death_signal_val) orelse {
                             globalThis.throwInvalidArguments("deathSignal must be a valid signal code", .{});
                             return .zero;
                         };

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1876,7 +1876,7 @@ pub const Subprocess = struct {
 
                 if (args.getTruthy(globalThis, "deathSig")) |death_signal_val| {
                     if (death_signal_val.isNumber()) {
-                        const signal_int = globalThis.validateIntegerRange(death_signal_val, u8, 0, .{ .min = 1, .max = @intFromEnum(bun.SignalCode.max) }) orelse return .zero;
+                        const signal_int = globalThis.validateIntegerRange(death_signal_val, u8, 0, .{ .min = 1, .max = bun.SignalCode.max }) orelse return .zero;
                         death_signal = @enumFromInt(signal_int);
                     } else if (death_signal_val.isString()) {
                         death_signal = bun.SignalCode.Map.fromJS(globalThis, death_signal_val) orelse {

--- a/src/bun.js/bindings/bun-spawn.cpp
+++ b/src/bun.js/bindings/bun-spawn.cpp
@@ -12,7 +12,6 @@
 #include <signal.h>
 #include <sys/syscall.h>
 #include <sys/resource.h>
-#include <linux/prctl.h> /* Definition of PR_* constants */
 #include <sys/prctl.h>
 
 extern char** environ;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1206,6 +1206,8 @@ pub const SignalCode = enum(u8) {
     SIGSYS = 31,
     _,
 
+    pub const max = @intFromEnum(SignalCode.SIGSYS);
+
     // The `subprocess.kill()` method sends a signal to the child process. If no
     // argument is given, the process will be sent the 'SIGTERM' signal.
     pub const default = @intFromEnum(SignalCode.SIGTERM);

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -637,6 +637,7 @@ pub const BunxCommand = struct {
             .stderr = .inherit,
             .stdout = .inherit,
             .stdin = .inherit,
+            .deathsig = .SIGTERM,
 
             .windows = if (Environment.isWindows) .{
                 .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(this_bundler.env)),

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -147,6 +147,7 @@ fn execTask(allocator: std.mem.Allocator, task_: string, cwd: string, _: string,
     _ = bun.spawnSync(&.{
         .argv = argv,
         .envp = null,
+        .deathsig = .SIGTERM,
 
         .cwd = cwd,
         .stderr = .inherit,
@@ -1515,6 +1516,7 @@ pub const CreateCommand = struct {
                 .stderr = .inherit,
                 .stdout = .inherit,
                 .stdin = .inherit,
+                .deathsig = .SIGTERM,
 
                 .windows = if (Environment.isWindows) .{
                     .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(null)),

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -332,6 +332,7 @@ pub const RunCommand = struct {
             .stdout = .inherit,
             .stdin = .inherit,
             .ipc = ipc_fd,
+            .deathsig = .SIGTERM,
 
             .windows = if (Environment.isWindows) .{
                 .loop = JSC.EventLoopHandle.init(JSC.MiniEventLoop.initGlobal(env)),
@@ -497,6 +498,7 @@ pub const RunCommand = struct {
             .stdout = .inherit,
             .stdin = .inherit,
             .use_execve_on_macos = silent,
+            .deathsig = .SIGTERM,
 
             .windows = if (Environment.isWindows) .{
                 .loop = JSC.EventLoopHandle.init(JSC.MiniEventLoop.initGlobal(env)),

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -684,6 +684,7 @@ pub const UpgradeCommand = struct {
                         .stderr = .inherit,
                         .stdout = .inherit,
                         .stdin = .inherit,
+                        .deathsig = .SIGTERM,
 
                         .windows = if (Environment.isWindows) .{
                             .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(null)),

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -185,6 +185,8 @@ pub const LifecycleScriptSubprocess = struct {
                 },
             .cwd = cwd,
 
+            .deathsig = .SIGTERM,
+
             .windows = if (Environment.isWindows)
                 .{
                     .loop = JSC.EventLoopHandle.init(&manager.event_loop),

--- a/src/open.zig
+++ b/src/open.zig
@@ -36,6 +36,7 @@ pub fn openURL(url: stringZ) void {
             .stderr = .inherit,
             .stdout = .inherit,
             .stdin = .inherit,
+            .deathsig = .SIGTERM,
 
             .windows = if (Environment.isWindows) .{
                 .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(null)),

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -1291,6 +1291,7 @@ pub fn spawnOpts(
         .cwd = cwd,
         .envp = envp,
         .argv = argv,
+        .deathsig = .SIGTERM,
         .windows = if (bun.Environment.isWindows) .{ .loop = switch (loop.*) {
             .js => |x| .{ .js = x },
             .mini => |*x| .{ .mini = x },


### PR DESCRIPTION
### What does this PR do?

Introduce `deathSig` option in `Bun.spawn`

This is a Linux-only option that lets you automatically make spawned processes get killed when Bun exits (as long as they don't set detached: true, or call setsid()).



This enables this option in `bun run <package.json script>`, `bun install` for lifecycle scripts, and almost everywhere else we spawn processes. 

### How did you verify your code works?

WIP. 