### PR TITLE
Add notice about not running amd64 under MacOS Silicon

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,6 +9,10 @@ Bun ships as a single executable with no dependencies that can be installed a fe
 Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1. Use `uname -r` to check Kernel version.
 {% /callout %}
 
+{% callout %}
+**MacOS Silicon users** — Running amd64 Bun under Rosetta2 is not supported, please build/compile/install for your architecture.
+{% /callout %}
+
 {% codetabs %}
 
 ```bash#macOS/Linux_(curl)


### PR DESCRIPTION
Update installation.md

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Add a notice in the https://bun.sh/docs/installation#installing page to warn MacOS Silicon to only use arm builds (see #15204 )
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation
- [ ] Code changes

