### PR TITLE
[Bun.sql] Support TLS

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -201,7 +201,7 @@ struct loop_ssl_data * us_internal_set_loop_ssl_data(struct us_internal_ssl_sock
 
 struct us_internal_ssl_socket_t *ssl_on_open(struct us_internal_ssl_socket_t *s,
                                              int is_client, char *ip,
-                                             int ip_length) {
+                                             int ip_length, const char* sni) {
 
   struct us_internal_ssl_socket_context_t *context =
       (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
@@ -231,6 +231,10 @@ struct us_internal_ssl_socket_t *ssl_on_open(struct us_internal_ssl_socket_t *s,
   if (is_client) {
     SSL_set_renegotiate_mode(s->ssl, ssl_renegotiate_explicit);
     SSL_set_connect_state(s->ssl);
+
+    if (sni) {
+      SSL_set_tlsext_host_name(s->ssl, sni);
+    }
   } else {
     SSL_set_accept_state(s->ssl);
     // we do not allow renegotiation on the server side (should be the default for BoringSSL, but we set to make openssl compatible)
@@ -1603,6 +1607,10 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(
           socket_ext_size);
 }
 
+static void ssl_on_open_without_sni(struct us_internal_ssl_socket_t *s, int is_client, char *ip, int ip_length) {
+  ssl_on_open(s, is_client, ip, ip_length, NULL);
+}
+
 void us_internal_ssl_socket_context_on_open(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *(*on_open)(
@@ -1611,7 +1619,7 @@ void us_internal_ssl_socket_context_on_open(
   us_socket_context_on_open(
       0, &context->sc,
       (struct us_socket_t * (*)(struct us_socket_t *, int, char *, int))
-          ssl_on_open);
+          ssl_on_open_without_sni);
   context->on_open = on_open;
 }
 
@@ -2005,7 +2013,30 @@ us_internal_ssl_socket_open(struct us_internal_ssl_socket_t *s, int is_client,
     return s;
 
   // start SSL open
-  return ssl_on_open(s, is_client, ip, ip_length);
+  return ssl_on_open(s, is_client, ip, ip_length, NULL);
+}
+
+struct us_socket_t *us_socket_upgrade_to_tls(us_socket_r s, us_socket_context_r new_context, const char *sni) {
+  // Resize to tls + ext size
+  void** prev_ext_ptr = (void**)us_socket_ext(0, s);
+  void* prev_ext = *prev_ext_ptr;
+  struct us_internal_ssl_socket_t *socket =
+      (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
+          0, new_context, s,
+          (sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t)) + sizeof(void*));
+  socket->ssl = NULL;
+  socket->ssl_write_wants_read = 0;
+  socket->ssl_read_wants_write = 0;
+  socket->fatal_error = 0;
+  socket->handshake_state = HANDSHAKE_PENDING;
+
+  void** new_ext_ptr = (void**)us_socket_ext(1, (struct us_socket_t *)socket);
+  *new_ext_ptr = prev_ext;
+
+  ssl_on_open(socket, 1, NULL, 0, sni);
+
+
+  return (struct us_socket_t *)socket;
 }
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -338,6 +338,8 @@ struct us_loop_t *us_socket_context_loop(int ssl, us_socket_context_r context) n
  * Used mainly for "socket upgrades" such as when transitioning from HTTP to WebSocket. */
 struct us_socket_t *us_socket_context_adopt_socket(int ssl, us_socket_context_r context, us_socket_r s, int ext_size);
 
+struct us_socket_t *us_socket_upgrade_to_tls(us_socket_r s, us_socket_context_r new_context, const char *sni);
+
 /* Create a child socket context which acts much like its own socket context with its own callbacks yet still relies on the
  * parent socket context for some shared resources. Child socket contexts should be used together with socket adoptions and nothing else. */
 struct us_socket_context_t *us_create_child_socket_context(int ssl, us_socket_context_r context, int context_ext_size);

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1866,21 +1866,11 @@ fn NewSocket(comptime ssl: bool) type {
                 }
             } else {
                 // call handhsake callback with authorized and authorization error if has one
-                var authorization_error: JSValue = undefined;
-                if (ssl_error.error_no == 0) {
-                    authorization_error = JSValue.jsNull();
-                } else {
-                    const code = if (ssl_error.code == null) "" else ssl_error.code[0..bun.len(ssl_error.code)];
+                const authorization_error: JSValue = if (ssl_error.error_no == 0)
+                    JSValue.jsNull()
+                else
+                    ssl_error.toJS(globalObject);
 
-                    const reason = if (ssl_error.reason == null) "" else ssl_error.reason[0..bun.len(ssl_error.reason)];
-
-                    const fallback = JSC.SystemError{
-                        .code = bun.String.createUTF8(code),
-                        .message = bun.String.createUTF8(reason),
-                    };
-
-                    authorization_error = fallback.toErrorInstance(globalObject);
-                }
                 result = callback.call(globalObject, this_value, &[_]JSValue{
                     this_value,
                     JSValue.jsBoolean(authorized),

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -6803,7 +6803,7 @@ pub const CallFrame = opaque {
         const ptr = self.argumentsPtr();
         return switch (@as(u4, @min(len, max))) {
             0 => .{ .ptr = undefined, .len = 0 },
-            inline 1...9 => |count| Arguments(max).init(comptime @min(count, max), ptr),
+            inline 1...10 => |count| Arguments(max).init(comptime @min(count, max), ptr),
             else => unreachable,
         };
     }

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2640,12 +2640,36 @@ pub const create_bun_socket_error_t = enum(i32) {
     load_ca_file,
     invalid_ca_file,
     invalid_ca,
+
+    pub fn toJS(this: create_bun_socket_error_t, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        return switch (this) {
+            .none => brk: {
+                bun.debugAssert(false);
+                break :brk .null;
+            },
+            .load_ca_file => globalObject.ERR_BORINGSSL("Failed to load CA file", .{}).toJS(),
+            .invalid_ca_file => globalObject.ERR_BORINGSSL("Invalid CA file", .{}).toJS(),
+            .invalid_ca => globalObject.ERR_BORINGSSL("Invalid CA", .{}).toJS(),
+        };
+    }
 };
 
 pub const us_bun_verify_error_t = extern struct {
     error_no: i32 = 0,
     code: [*c]const u8 = null,
     reason: [*c]const u8 = null,
+
+    pub fn toJS(this: *const us_bun_verify_error_t, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        const code = if (this.code == null) "" else this.code[0..bun.len(this.code)];
+        const reason = if (this.reason == null) "" else this.reason[0..bun.len(this.reason)];
+
+        const fallback = JSC.SystemError{
+            .code = bun.String.createUTF8(code),
+            .message = bun.String.createUTF8(reason),
+        };
+
+        return fallback.toErrorInstance(globalObject);
+    }
 };
 pub extern fn us_ssl_socket_verify_error_from_ssl(ssl: *BoringSSL.SSL) us_bun_verify_error_t;
 
@@ -4521,3 +4545,5 @@ pub fn onThreadExit() void {
 }
 
 extern fn uws_app_clear_routes(ssl_flag: c_int, app: *uws_app_t) void;
+
+pub extern fn us_socket_upgrade_to_tls(s: *Socket, new_context: *SocketContext, sni: ?[*:0]const u8) ?*Socket;

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -13,6 +13,14 @@ pub const PostgresShort = u16;
 const Crypto = JSC.API.Bun.Crypto;
 const JSValue = JSC.JSValue;
 
+pub const SSLMode = enum(u8) {
+    disable = 0,
+    prefer = 1,
+    require = 2,
+    verify_ca = 3,
+    verify_full = 4,
+};
+
 pub const Data = union(enum) {
     owned: bun.ByteList,
     temporary: []const u8,
@@ -837,7 +845,16 @@ pub const PostgresRequest = struct {
             switch (try reader.int(u8)) {
                 'D' => try connection.on(.DataRow, Context, reader),
                 'd' => try connection.on(.CopyData, Context, reader),
-                'S' => try connection.on(.ParameterStatus, Context, reader),
+                'S' => {
+                    if (connection.tls_status == .message_sent) {
+                        bun.debugAssert(connection.tls_status.message_sent == 8);
+                        connection.tls_status = .ssl_ok;
+                        connection.setupTLS();
+                        return;
+                    }
+
+                    try connection.on(.ParameterStatus, Context, reader);
+                },
                 'Z' => try connection.on(.ReadyForQuery, Context, reader),
                 'C' => try connection.on(.CommandComplete, Context, reader),
                 '2' => try connection.on(.BindComplete, Context, reader),
@@ -851,7 +868,19 @@ pub const PostgresRequest = struct {
                 's' => try connection.on(.PortalSuspended, Context, reader),
                 '3' => try connection.on(.CloseComplete, Context, reader),
                 'G' => try connection.on(.CopyInResponse, Context, reader),
-                'N' => try connection.on(.NoticeResponse, Context, reader),
+                'N' => {
+                    if (connection.tls_status == .message_sent) {
+                        connection.tls_status = .ssl_not_available;
+                        debug("Server does not support SSL", .{});
+                        if (connection.ssl_mode == .require) {
+                            connection.fail("Server does not support SSL", error.SSLNotAvailable);
+                            return;
+                        }
+                        continue;
+                    }
+
+                    try connection.on(.NoticeResponse, Context, reader);
+                },
                 'I' => try connection.on(.EmptyQueryResponse, Context, reader),
                 'H' => try connection.on(.CopyOutResponse, Context, reader),
                 'c' => try connection.on(.CopyDone, Context, reader),
@@ -903,6 +932,23 @@ pub const PostgresSQLConnection = struct {
     options_buf: []const u8 = "",
 
     authentication_state: AuthenticationState = .{ .pending = {} },
+
+    tls_ctx: ?*uws.SocketContext = null,
+    tls_config: JSC.API.ServerConfig.SSLConfig = .{},
+    tls_status: TLSStatus = .none,
+    ssl_mode: SSLMode = .disable,
+
+    pub const TLSStatus = union(enum) {
+        none,
+        pending,
+
+        /// Number of bytes sent of the 8-byte SSL request message.
+        /// Since we may send a partial message, we need to know how many bytes were sent.
+        message_sent: u8,
+
+        ssl_not_available,
+        ssl_ok,
+    };
 
     pub const AuthenticationState = union(enum) {
         pending: void,
@@ -1005,11 +1051,40 @@ pub const PostgresSQLConnection = struct {
     pub const Status = enum {
         disconnected,
         connecting,
+        // Prevent sending the startup message multiple times.
+        // Particularly relevant for TLS connections.
+        sent_startup_message,
         connected,
         failed,
     };
 
     pub usingnamespace JSC.Codegen.JSPostgresSQLConnection;
+
+    pub fn setupTLS(this: *PostgresSQLConnection) void {
+        debug("setupTLS", .{});
+        const new_socket = uws.us_socket_upgrade_to_tls(this.socket.SocketTCP.socket.connected, this.tls_ctx.?, this.tls_config.server_name) orelse {
+            this.fail("Failed to upgrade to TLS", error.TLSUpgradeFailed);
+            return;
+        };
+        this.socket = .{
+            .SocketTLS = .{
+                .socket = .{
+                    .connected = new_socket,
+                },
+            },
+        };
+
+        this.start();
+    }
+
+    fn start(this: *PostgresSQLConnection) void {
+        this.sendStartupMessage();
+
+        const event_loop = this.globalObject.bunVM().eventLoop();
+        event_loop.enter();
+        defer event_loop.exit();
+        this.flushData();
+    }
 
     pub fn hasPendingActivity(this: *PostgresSQLConnection) bool {
         @fence(.acquire);
@@ -1059,24 +1134,29 @@ pub const PostgresSQLConnection = struct {
         }
     }
 
-    pub fn fail(this: *PostgresSQLConnection, message: []const u8, err: anyerror) void {
+    pub fn failWithJSValue(this: *PostgresSQLConnection, value: JSValue) void {
         defer this.updateHasPendingActivity();
         if (this.status == .failed) return;
-        debug("failed: {s}: {s}", .{ message, @errorName(err) });
 
         this.status = .failed;
         if (!this.socket.isClosed()) this.socket.close();
         const on_close = this.on_close.swap();
         if (on_close == .zero) return;
-        const instance = this.globalObject.createErrorInstance("{s}", .{message});
-        instance.put(this.globalObject, JSC.ZigString.static("code"), String.init(@errorName(err)).toJS(this.globalObject));
+
         _ = on_close.call(
             this.globalObject,
             this.js_value,
             &[_]JSValue{
-                instance,
+                value,
             },
         ) catch |e| this.globalObject.reportActiveExceptionAsUnhandled(e);
+    }
+
+    pub fn fail(this: *PostgresSQLConnection, message: []const u8, err: anyerror) void {
+        debug("failed: {s}: {s}", .{ message, @errorName(err) });
+        const instance = this.globalObject.createErrorInstance("{s}", .{message});
+        instance.put(this.globalObject, JSC.ZigString.static("code"), String.init(@errorName(err)).toJS(this.globalObject));
+        this.failWithJSValue(instance);
     }
 
     pub fn onClose(this: *PostgresSQLConnection) void {
@@ -1085,22 +1165,66 @@ pub const PostgresSQLConnection = struct {
         this.fail("Connection closed", error.ConnectionClosed);
     }
 
+    fn sendStartupMessage(this: *PostgresSQLConnection) void {
+        if (this.status != .connecting) return;
+        debug("sendStartupMessage", .{});
+        this.status = .sent_startup_message;
+        var msg = protocol.StartupMessage{
+            .user = Data{ .temporary = this.user },
+            .database = Data{ .temporary = this.database },
+            .options = Data{ .temporary = this.options },
+        };
+        msg.writeInternal(Writer, this.writer()) catch |err| {
+            this.socket.close();
+            this.fail("Failed to write startup message", err);
+        };
+    }
+
+    fn startTLS(this: *PostgresSQLConnection, socket: uws.AnySocket) void {
+        debug("startTLS", .{});
+        const offset = switch (this.tls_status) {
+            .message_sent => |count| count,
+            else => 0,
+        };
+        const ssl_request = [_]u8{
+            0x00, 0x00, 0x00, 0x08, // Length
+            0x04, 0xD2, 0x16, 0x2F, // SSL request code
+        };
+
+        const written = socket.write(ssl_request[offset..], false);
+        if (written > 0) {
+            this.tls_status = .{
+                .message_sent = offset + @as(u8, @intCast(written)),
+            };
+        } else {
+            this.tls_status = .{
+                .message_sent = offset,
+            };
+        }
+    }
+
     pub fn onOpen(this: *PostgresSQLConnection, socket: uws.AnySocket) void {
         this.socket = socket;
 
         this.poll_ref.ref(this.globalObject.bunVM());
         this.updateHasPendingActivity();
 
-        var msg = protocol.StartupMessage{ .user = Data{ .temporary = this.user }, .database = Data{ .temporary = this.database }, .options = Data{ .temporary = this.options } };
-        msg.writeInternal(Writer, this.writer()) catch |err| {
-            socket.close();
-            this.fail("Failed to write startup message", err);
-        };
+        if (this.tls_status == .message_sent or this.tls_status == .pending) {
+            this.startTLS(socket);
+            return;
+        }
 
-        const event_loop = this.globalObject.bunVM().eventLoop();
-        event_loop.enter();
-        defer event_loop.exit();
-        this.flushData();
+        this.start();
+    }
+
+    pub fn onHandshake(this: *PostgresSQLConnection, success: i32, ssl_error: uws.us_bun_verify_error_t) void {
+        debug("onHandshake: {d} {d}", .{ success, ssl_error.error_no });
+        if (success != 1) {
+            if (this.tls_config.reject_unauthorized == 1) {
+                this.failWithJSValue(ssl_error.toJS(this.globalObject));
+                return;
+            }
+        }
     }
 
     pub fn onTimeout(this: *PostgresSQLConnection) void {
@@ -1109,6 +1233,16 @@ pub const PostgresSQLConnection = struct {
     }
 
     pub fn onDrain(this: *PostgresSQLConnection) void {
+
+        // Don't send any other messages while we're waiting for TLS.
+        if (this.tls_status == .message_sent) {
+            if (this.tls_status.message_sent < 8) {
+                this.startTLS(this.socket);
+            }
+
+            return;
+        }
+
         const event_loop = this.globalObject.bunVM().eventLoop();
         event_loop.enter();
         defer event_loop.exit();
@@ -1226,7 +1360,7 @@ pub const PostgresSQLConnection = struct {
 
     pub fn call(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         var vm = globalObject.bunVM();
-        const arguments = callframe.arguments(9).slice();
+        const arguments = callframe.arguments(10).slice();
         const hostname_str = arguments[0].toBunString(globalObject);
         defer hostname_str.deref();
         const port = arguments[1].coerce(i32, globalObject);
@@ -1237,13 +1371,67 @@ pub const PostgresSQLConnection = struct {
         defer password_str.deref();
         const database_str = arguments[4].toBunString(globalObject);
         defer database_str.deref();
-        const tls_object = arguments[5];
+        const ssl_mode: SSLMode = switch (arguments[5].toInt32()) {
+            0 => .disable,
+            1 => .prefer,
+            2 => .require,
+            3 => .verify_ca,
+            4 => .verify_full,
+            else => .disable,
+        };
+
+        const tls_object = arguments[6];
+
+        var tls_config: JSC.API.ServerConfig.SSLConfig = .{};
+        var tls_ctx: ?*uws.SocketContext = null;
+        if (ssl_mode != .disable) {
+            tls_config = if (tls_object.isBoolean() and tls_object.toBoolean())
+                .{}
+            else if (tls_object.isObject())
+                (JSC.API.ServerConfig.SSLConfig.fromJS(vm, globalObject, tls_object) catch return .zero) orelse .{}
+            else {
+                globalObject.throwInvalidArguments("tls must be a boolean or an object", .{});
+                return .zero;
+            };
+
+            if (globalObject.hasException()) {
+                tls_config.deinit();
+                return .zero;
+            }
+
+            if (tls_config.reject_unauthorized != 0)
+                tls_config.request_cert = 1;
+
+            // We create it right here so we can throw errors early.
+            const context_options = tls_config.asUSockets();
+            var err: uws.create_bun_socket_error_t = .none;
+            tls_ctx = uws.us_create_bun_socket_context(1, vm.uwsLoop(), @sizeOf(*PostgresSQLConnection), context_options, &err) orelse {
+                if (err != .none) {
+                    globalObject.throw("failed to create TLS context", .{});
+                } else {
+                    globalObject.throwValue(err.toJS(globalObject));
+                }
+                return .zero;
+            };
+
+            if (err != .none) {
+                tls_config.deinit();
+                globalObject.throwValue(err.toJS(globalObject));
+                if (tls_ctx) |ctx| {
+                    ctx.deinit(true);
+                }
+                return .zero;
+            }
+
+            uws.NewSocketHandler(true).configure(tls_ctx.?, true, *PostgresSQLConnection, SocketHandler(true));
+        }
+
         var username: []const u8 = "";
         var password: []const u8 = "";
         var database: []const u8 = "";
         var options: []const u8 = "";
 
-        const options_str = arguments[6].toBunString(globalObject);
+        const options_str = arguments[7].toBunString(globalObject);
         defer options_str.deref();
 
         const options_buf: []u8 = brk: {
@@ -1270,10 +1458,15 @@ pub const PostgresSQLConnection = struct {
             break :brk b.allocatedSlice();
         };
 
-        const on_connect = arguments[7];
-        const on_close = arguments[8];
+        const on_connect = arguments[8];
+        const on_close = arguments[9];
+
         var ptr = bun.default_allocator.create(PostgresSQLConnection) catch |err| {
             globalObject.throwError(err, "failed to allocate connection");
+            tls_config.deinit();
+            if (tls_ctx) |ctx| {
+                ctx.deinit(true);
+            }
             return .zero;
         };
 
@@ -1289,6 +1482,10 @@ pub const PostgresSQLConnection = struct {
             .socket = undefined,
             .requests = PostgresRequest.Queue.init(bun.default_allocator),
             .statements = PreparedStatementsMap{},
+            .tls_config = tls_config,
+            .tls_ctx = tls_ctx,
+            .ssl_mode = ssl_mode,
+            .tls_status = if (ssl_mode != .disable) .pending else .none,
         };
 
         ptr.updateHasPendingActivity();
@@ -1300,28 +1497,25 @@ pub const PostgresSQLConnection = struct {
         {
             const hostname = hostname_str.toUTF8(bun.default_allocator);
             defer hostname.deinit();
-            if (tls_object.isEmptyOrUndefinedOrNull()) {
-                const ctx = vm.rareData().postgresql_context.tcp orelse brk: {
-                    var err: uws.create_bun_socket_error_t = .none;
-                    const ctx_ = uws.us_create_bun_socket_context(0, vm.uwsLoop(), @sizeOf(*PostgresSQLConnection), uws.us_bun_socket_context_options_t{}, &err).?;
-                    uws.NewSocketHandler(false).configure(ctx_, true, *PostgresSQLConnection, SocketHandler(false));
-                    vm.rareData().postgresql_context.tcp = ctx_;
-                    break :brk ctx_;
-                };
-                ptr.socket = .{
-                    // TODO: investigate if allowHalfOpen: true is necessary here or if brings some advantage
-                    .SocketTCP = uws.SocketTCP.connectAnon(hostname.slice(), port, ctx, ptr, false) catch |err| {
-                        globalObject.throwError(err, "failed to connect to postgresql");
-                        ptr.deinit();
-                        return .zero;
-                    },
-                };
-            } else {
-                // TODO:
-                globalObject.throwTODO("TLS is not supported yet");
-                ptr.deinit();
-                return .zero;
-            }
+
+            const ctx = vm.rareData().postgresql_context.tcp orelse brk: {
+                var err: uws.create_bun_socket_error_t = .none;
+                const ctx_ = uws.us_create_bun_socket_context(0, vm.uwsLoop(), @sizeOf(*PostgresSQLConnection), uws.us_bun_socket_context_options_t{}, &err).?;
+                uws.NewSocketHandler(false).configure(ctx_, true, *PostgresSQLConnection, SocketHandler(false));
+                vm.rareData().postgresql_context.tcp = ctx_;
+                break :brk ctx_;
+            };
+            ptr.socket = .{
+                .SocketTCP = uws.SocketTCP.connectAnon(hostname.slice(), port, ctx, ptr, false) catch |err| {
+                    globalObject.throwError(err, "failed to connect to postgresql");
+                    tls_config.deinit();
+                    if (tls_ctx) |tls| {
+                        tls.deinit(true);
+                    }
+                    ptr.deinit();
+                    return .zero;
+                },
+            };
         }
 
         return js_value;
@@ -1340,6 +1534,12 @@ pub const PostgresSQLConnection = struct {
             pub fn onOpen(this: *PostgresSQLConnection, socket: SocketType) void {
                 this.onOpen(_socket(socket));
             }
+
+            fn onHandshake_(this: *PostgresSQLConnection, _: anytype, success: i32, ssl_error: uws.us_bun_verify_error_t) void {
+                this.onHandshake(success, ssl_error);
+            }
+
+            pub const onHandshake = if (ssl) onHandshake_ else null;
 
             pub fn onClose(this: *PostgresSQLConnection, socket: SocketType, _: i32, _: ?*anyopaque) void {
                 _ = socket;
@@ -1421,6 +1621,7 @@ pub const PostgresSQLConnection = struct {
         this.on_connect.deinit();
         this.backend_parameters.deinit();
         bun.default_allocator.free(this.options_buf);
+        this.tls_config.deinit();
         bun.default_allocator.destroy(this);
     }
 
@@ -2145,6 +2346,18 @@ pub const PostgresSQLConnection = struct {
 
                     .Unknown => {
                         this.fail("Unknown authentication method", error.UNKNOWN_AUTHENTICATION_METHOD);
+                    },
+
+                    .ClearTextPassword => {
+                        debug("ClearTextPassword", .{});
+                        var response = protocol.PasswordMessage{
+                            .password = .{
+                                .temporary = this.password,
+                            },
+                        };
+
+                        try response.writeInternal(PostgresSQLConnection.Writer, this.writer());
+                        this.flushData();
                     },
 
                     else => {

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+import { getSecret } from "harness";
+import { sql as SQL } from "bun";
+
+const TLS_POSTGRES_DATABASE_URL = getSecret("TLS_POSTGRES_DATABASE_URL");
+
+test("tls (explicit)", async () => {
+  const sql = new SQL({
+    url: TLS_POSTGRES_DATABASE_URL!,
+    tls: true,
+    adapter: "postgresql",
+  });
+
+  const [{ one, two }] = await sql`SELECT 1 as one, '2' as two`;
+  expect(one).toBe(1);
+  expect(two).toBe("2");
+});
+
+test("tls (implicit)", async () => {
+  const [{ one, two }] = await SQL`SELECT 1 as one, '2' as two`;
+  expect(one).toBe(1);
+  expect(two).toBe("2");
+});


### PR DESCRIPTION
### What does this PR do?

The following works:
```ts
import { test, expect } from "bun:test";
import { getSecret } from "harness";
import { sql as SQL } from "bun";

const TLS_POSTGRES_DATABASE_URL = getSecret("TLS_POSTGRES_DATABASE_URL");

test("tls (explicit)", async () => {
  const sql = new SQL({
    url: TLS_POSTGRES_DATABASE_URL!,
    tls: true,
    adapter: "postgresql",
  });

  const [{ one, two }] = await sql`SELECT 1 as one, '2' as two`;
  expect(one).toBe(1);
  expect(two).toBe("2");
});

test("tls (implicit)", async () => {
  const [{ one, two }] = await SQL`SELECT 1 as one, '2' as two`;
  expect(one).toBe(1);
  expect(two).toBe("2");
});
```

It successfully connected to Neon and with TLS.


### How did you verify your code works?

There is a test