### PR TITLE
fix(tls) fix type matching

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -190,6 +190,7 @@ struct us_socket_context_options_t {
 };
 
 struct us_bun_verify_error_t {
+    // this is a long because can store a result of BoringSSL.SSL_get_verify_result
     long error;
     const char* code;
     const char* reason;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -84,7 +84,7 @@
 #endif
 
 #include "stddef.h"
-
+#include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -191,7 +191,7 @@ struct us_socket_context_options_t {
 
 struct us_bun_verify_error_t {
     // this is a long because can store a result of BoringSSL.SSL_get_verify_result
-    long error;
+    int64_t error;
     const char* code;
     const char* reason;
 };

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -190,7 +190,7 @@ struct us_socket_context_options_t {
 };
 
 struct us_bun_verify_error_t {
-    // this is a long because can store a result of BoringSSL.SSL_get_verify_result
+    // this is a int64_t because can store a result of BoringSSL.SSL_get_verify_result that uses a long
     int64_t error;
     const char* code;
     const char* reason;

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -18886,7 +18886,7 @@ pub const CertError = error{
     UNKKNOW_CERTIFICATE_VERIFICATION_ERROR,
 };
 
-pub fn getCertErrorFromNo(error_no: i32) CertError {
+pub fn getCertErrorFromNo(error_no: i64) CertError {
     return switch (error_no) {
         X509_V_OK => error.OK,
         X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT => error.UNABLE_TO_GET_ISSUER_CERT,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -154,7 +154,7 @@ pub const UpgradedDuplex = struct {
         log("onHandshake", .{});
 
         this.ssl_error = .{
-            .error_no = @intCast(ssl_error.error_no),
+            .error_no = ssl_error.error_no,
             .code = if (ssl_error.code == null or ssl_error.error_no == 0) "" else bun.default_allocator.dupeZ(u8, ssl_error.code[0..bun.len(ssl_error.code) :0]) catch bun.outOfMemory(),
             .reason = if (ssl_error.reason == null or ssl_error.error_no == 0) "" else bun.default_allocator.dupeZ(u8, ssl_error.reason[0..bun.len(ssl_error.reason) :0]) catch bun.outOfMemory(),
         };
@@ -2644,7 +2644,7 @@ pub const create_bun_socket_error_t = enum(i32) {
 
 pub const us_bun_verify_error_t = extern struct {
     // this is a c_long because can store a result of BoringSSL.SSL_get_verify_result
-    error_no: c_long = 0,
+    error_no: i64 = 0,
     code: [*c]const u8 = null,
     reason: [*c]const u8 = null,
 };

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2643,7 +2643,8 @@ pub const create_bun_socket_error_t = enum(i32) {
 };
 
 pub const us_bun_verify_error_t = extern struct {
-    error_no: i32 = 0,
+    // this is a c_long because can store a result of BoringSSL.SSL_get_verify_result
+    error_no: c_long = 0,
     code: [*c]const u8 = null,
     reason: [*c]const u8 = null,
 };

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2643,7 +2643,7 @@ pub const create_bun_socket_error_t = enum(i32) {
 };
 
 pub const us_bun_verify_error_t = extern struct {
-    // this is a c_long because can store a result of BoringSSL.SSL_get_verify_result
+    // this is a i64 because can store a result of BoringSSL.SSL_get_verify_result that uses a long
     error_no: i64 = 0,
     code: [*c]const u8 = null,
     reason: [*c]const u8 = null,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -95,7 +95,7 @@ pub const InternalLoopData = extern struct {
 
 pub const UpgradedDuplex = struct {
     pub const CertError = struct {
-        error_no: i32 = 0,
+        error_no: i64 = 0,
         code: [:0]const u8 = "",
         reason: [:0]const u8 = "",
 
@@ -154,7 +154,7 @@ pub const UpgradedDuplex = struct {
         log("onHandshake", .{});
 
         this.ssl_error = .{
-            .error_no = ssl_error.error_no,
+            .error_no = @intCast(ssl_error.error_no),
             .code = if (ssl_error.code == null or ssl_error.error_no == 0) "" else bun.default_allocator.dupeZ(u8, ssl_error.code[0..bun.len(ssl_error.code) :0]) catch bun.outOfMemory(),
             .reason = if (ssl_error.reason == null or ssl_error.error_no == 0) "" else bun.default_allocator.dupeZ(u8, ssl_error.reason[0..bun.len(ssl_error.reason) :0]) catch bun.outOfMemory(),
         };
@@ -1700,7 +1700,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             return this.getError() != 0;
         }
 
-        pub fn getError(this: ThisSocket) i32 {
+        pub fn getError(this: ThisSocket) i64 {
             switch (this.socket) {
                 .connected => |socket| {
                     return us_socket_get_error(

--- a/src/http.zig
+++ b/src/http.zig
@@ -320,7 +320,7 @@ const ProxyTunnel = struct {
             this.state.request_stage = .proxy_headers;
             this.state.request_sent_len = 0;
             const handshake_error = HTTPCertError{
-                .error_no = ssl_error.error_no,
+                .error_no = @intCast(ssl_error.error_no),
                 .code = if (ssl_error.code == null) "" else ssl_error.code[0..bun.len(ssl_error.code) :0],
                 .reason = if (ssl_error.code == null) "" else ssl_error.reason[0..bun.len(ssl_error.reason) :0],
             };
@@ -511,7 +511,7 @@ const ProxyTunnel = struct {
 };
 
 pub const HTTPCertError = struct {
-    error_no: i32 = 0,
+    error_no: i64 = 0,
     code: [:0]const u8 = "",
     reason: [:0]const u8 = "",
 };


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Type should match C and BoringSSL.SSL_get_verify_result
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
