### PR TITLE
Fix setTimeout with node:util.promisify

### DIFF
--- a/src/js/internal/promisify.ts
+++ b/src/js/internal/promisify.ts
@@ -72,6 +72,32 @@ var promisify = function promisify(original) {
 };
 promisify.custom = kCustomPromisifiedSymbol;
 
+// Lazily load node:timers/promises promisified functions onto the global timers.
+{
+  const { setTimeout: timeout, setImmediate: immediate, setInterval: interval } = globalThis;
+
+  if (timeout && $isCallable(timeout)) {
+    defineCustomPromisify(timeout, function setTimeout(arg1) {
+      const fn = defineCustomPromisify(timeout, require("node:timers/promises").setTimeout);
+      return fn.$apply(this, arguments);
+    });
+  }
+
+  if (immediate && $isCallable(immediate)) {
+    defineCustomPromisify(immediate, function setImmediate(arg1) {
+      const fn = defineCustomPromisify(immediate, require("node:timers/promises").setImmediate);
+      return fn.$apply(this, arguments);
+    });
+  }
+
+  if (interval && $isCallable(interval)) {
+    defineCustomPromisify(interval, function setInterval(arg1) {
+      const fn = defineCustomPromisify(interval, require("node:timers/promises").setInterval);
+      return fn.$apply(this, arguments);
+    });
+  }
+}
+
 export default {
   defineCustomPromisify,
   defineCustomPromisifyArgs,

--- a/src/js/node/timers.ts
+++ b/src/js/node/timers.ts
@@ -1,31 +1,6 @@
 const { throwNotImplemented } = require("internal/shared");
 const { defineCustomPromisify } = require("internal/promisify");
 
-// Lazily load node:timers/promises promisified functions onto the global timers.
-{
-  const { setTimeout: timeout, setImmediate: immediate, setInterval: interval } = globalThis;
-
-  if (timeout && $isCallable(timeout)) {
-    defineCustomPromisify(timeout, function setTimeout(arg1) {
-      const fn = defineCustomPromisify(timeout, require("node:timers/promises").setTimeout);
-      return fn.$apply(this, arguments);
-    });
-  }
-
-  if (immediate && $isCallable(immediate)) {
-    defineCustomPromisify(immediate, function setImmediate(arg1) {
-      const fn = defineCustomPromisify(immediate, require("node:timers/promises").setImmediate);
-      return fn.$apply(this, arguments);
-    });
-  }
-
-  if (interval && $isCallable(interval)) {
-    defineCustomPromisify(interval, function setInterval(arg1) {
-      const fn = defineCustomPromisify(interval, require("node:timers/promises").setInterval);
-      return fn.$apply(this, arguments);
-    });
-  }
-}
 var timersPromisesValue;
 
 export default {

--- a/src/js/node/timers.ts
+++ b/src/js/node/timers.ts
@@ -1,5 +1,4 @@
 const { throwNotImplemented } = require("internal/shared");
-const { defineCustomPromisify } = require("internal/promisify");
 
 var timersPromisesValue;
 

--- a/test/regression/issue/015201.test.ts
+++ b/test/regression/issue/015201.test.ts
@@ -1,0 +1,6 @@
+import { promisify } from "util";
+
+test("abc", () => {
+  const setTimeout = promisify(globalThis.setTimeout);
+  setTimeout(1, "ok").then(console.log);
+});


### PR DESCRIPTION
Fixes #15201, alternative for #15203

This regressed in 1.1.27 (specifically commit https://github.com/oven-sh/bun/commit/76c4145f0e95b27610e37130c3457eff7e2e95fb) and didn't get caught because it still worked if "node:timers" was imported in the same file.

This is still slightly different from node, in node `setTimeout[Symbol.for("nodejs.util.promisify.custom")]` will return a function without any imports, but with this PR in bun it requires `require("util")` before the custom promisify is defined on setTimeout.