### PR TITLE
Fix bundler crash with onLoad plugins on copy-file loaders used on entrypoints

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -656,7 +656,6 @@ pub const Loader = enum(u8) {
         if (experimental_css) {
             return switch (this) {
                 .file,
-                .css,
                 .napi,
                 .sqlite,
                 .sqlite_embedded,


### PR DESCRIPTION
### What does this PR do?

This fixes a crash in the bundler when:
  - the entry point is a file with a type which should be copied by the bundler (such as `.wasm` or `.css` with `experimentalCss: false`) 
  - an onLoad plugin matches this file

Two problems occurred in this case:
- the entry point was not appending to `additional_files`
- `onLoadAsync` callback was incorrectly appending string to `free_list`

