### PR TITLE
Call Bun__onExit + std.os.windows.kernel32.ExitProcess to exit on Windows

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -118,6 +118,10 @@ pub fn exit(code: u32) noreturn {
 
     switch (Environment.os) {
         .mac => std.c.exit(@bitCast(code)),
+        .windows => {
+            Bun__onExit();
+            std.os.windows.kernel32.ExitProcess(code);
+        },
         else => bun.C.quick_exit(@bitCast(code)),
     }
 }

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -557,7 +557,7 @@ extern "C" void bun_initialize_process()
 
 #if OS(DARWIN)
     atexit(Bun__onExit);
-#else
+#elif !OS(WINDOWS)
     at_quick_exit(Bun__onExit);
 #endif
 }


### PR DESCRIPTION
### What does this PR do?

This fixes crashes on exit in Windows caused by how process termination works on Windows vs. POSIX.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I ran `bun-debug --debug create astro` then Ctrl-C'd partway through to exit, then tried scrolling and running `ls` to see whether the terminal state was being reset properly. I did this in three terminals: VS Code, Windows Terminal and cmd.exe.
