### PR TITLE
docker:alpine: update to 3.20 and use bun musl build

### DIFF
--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.20 AS build
 
 # https://github.com/oven-sh/bun/releases
-# ARG BUN_VERSION=latest
-ARG BUN_VERSION=canary
+ARG BUN_VERSION=latest
 
 RUN apk --no-cache add ca-certificates curl dirmngr gpg gpg-agent unzip \
     && arch="$(apk --print-arch)" \
@@ -36,6 +35,10 @@ RUN apk --no-cache add ca-certificates curl dirmngr gpg gpg-agent unzip \
       -fsSLO \
       --compressed \
       --retry 5 \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+       || (echo "error: failed to verify: $tag" && exit 1) \
+     && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
+       || (echo "error: failed to verify: $tag" && exit 1) \
     && unzip "bun-linux-$build.zip" \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \

--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -36,9 +36,9 @@ RUN apk --no-cache add ca-certificates curl dirmngr gpg gpg-agent unzip \
       --compressed \
       --retry 5 \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-       || (echo "error: failed to verify: $tag" && exit 1) \
-     && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
-       || (echo "error: failed to verify: $tag" && exit 1) \
+      || (echo "error: failed to verify: $tag" && exit 1) \
+    && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
+      || (echo "error: failed to verify: $tag" && exit 1) \
     && unzip "bun-linux-$build.zip" \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \

--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -1,30 +1,14 @@
-FROM alpine:3.18 AS build
+FROM alpine:3.20 AS build
 
 # https://github.com/oven-sh/bun/releases
-ARG BUN_VERSION=latest
+# ARG BUN_VERSION=latest
+ARG BUN_VERSION=canary
 
-# TODO: Instead of downloading glibc from a third-party source, we should
-#      build it from source. This is a temporary solution.
-#      See: https://github.com/sgerrand/alpine-pkg-glibc
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-# https://github.com/sgerrand/alpine-pkg-glibc/issues/176
-ARG GLIBC_VERSION=2.34-r0
-
-# https://github.com/oven-sh/bun/issues/5545#issuecomment-1722461083
-ARG GLIBC_VERSION_AARCH64=2.26-r1
-
-RUN apk --no-cache add \
-      ca-certificates \
-      curl \
-      dirmngr \
-      gpg \
-      gpg-agent \
-      unzip \
+RUN apk --no-cache add ca-certificates curl dirmngr gpg gpg-agent unzip \
     && arch="$(apk --print-arch)" \
     && case "${arch##*-}" in \
-      x86_64) build="x64-baseline";; \
-      aarch64) build="aarch64";; \
+      x86_64) build="x64-musl-baseline";; \
+      aarch64) build="aarch64-musl";; \
       *) echo "error: unsupported architecture: $arch"; exit 1 ;; \
     esac \
     && version="$BUN_VERSION" \
@@ -52,44 +36,12 @@ RUN apk --no-cache add \
       -fsSLO \
       --compressed \
       --retry 5 \
-    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-      || (echo "error: failed to verify: $tag" && exit 1) \
-    && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
-      || (echo "error: failed to verify: $tag" && exit 1) \
     && unzip "bun-linux-$build.zip" \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
-    && chmod +x /usr/local/bin/bun \
-    && cd /tmp \
-    && case "${arch##*-}" in \
-      x86_64) curl "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc v${GLIBC_VERSION}" && exit 1) \
-      && mv "glibc-${GLIBC_VERSION}.apk" glibc.apk \
-      && curl "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc-bin v${GLIBC_VERSION}" && exit 1) \
-      && mv "glibc-bin-${GLIBC_VERSION}.apk" glibc-bin.apk ;; \
-      aarch64) curl "https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-${GLIBC_VERSION_AARCH64}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc v${GLIBC_VERSION_AARCH64}" && exit 1) \
-      && mv "glibc-${GLIBC_VERSION_AARCH64}.apk" glibc.apk \
-      && curl "https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-bin-${GLIBC_VERSION_AARCH64}.apk" \
-        -fsSLO \
-        --compressed \
-        --retry 5 \
-        || (echo "error: failed to download: glibc-bin v${GLIBC_VERSION_AARCH64}" && exit 1) \
-      && mv "glibc-bin-${GLIBC_VERSION_AARCH64}.apk" glibc-bin.apk ;; \
-      *) echo "error: unsupported architecture '$arch'"; exit 1 ;; \
-    esac
+    && chmod +x /usr/local/bin/bun
 
-FROM alpine:3.18
+FROM alpine:3.20
 
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful
@@ -107,10 +59,8 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN --mount=type=bind,from=build,source=/tmp,target=/tmp \
     addgroup -g 1000 bun \
     && adduser -u 1000 -G bun -s /bin/sh -D bun \
-    && apk --no-cache --force-overwrite --allow-untrusted add \
-      /tmp/glibc.apk \
-      /tmp/glibc-bin.apk \
     && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
+    && apk add libgcc libstdc++ \
     && which bun \
     && which bunx \
     && bun --version


### PR DESCRIPTION
progress towards https://github.com/oven-sh/bun/issues/918

```
❯ docker build .
...
 => => writing image sha256:ff88deba704a811e1df88e9ec18fad13dc5c84498fe391e2e196d0cbfb26ce48
```

```
❯ docker run -it sha256:ff88deba704a811e1df88e9ec18fad13dc5c84498fe391e2e196d0cbfb26ce48 sh
/home/bun/app # ldd /usr/local/bin/bun
        /lib/ld-musl-aarch64.so.1 (0xffff8bdc0000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0xffff8ba00000)
        libc.musl-aarch64.so.1 => /lib/ld-musl-aarch64.so.1 (0xffff8bdc0000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0xffff8bd8f000)
```
