### PR TITLE
us_bun_verify_error_t: ensure c struct matches zig extern

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -190,7 +190,7 @@ struct us_socket_context_options_t {
 };
 
 struct us_bun_verify_error_t {
-    long error;
+    int error;
     const char* code;
     const char* reason;
 };


### PR DESCRIPTION
revival of fix from https://github.com/oven-sh/bun/pull/15224

zig code here
https://github.com/oven-sh/bun/tree/ba767aa5ba7f8bd3a562c4467d417c09be88827a/src/deps/uws.zig#L2658
