### PR TITLE
fix(Bun.file) throw OOM if read is too big

### DIFF
--- a/src/bun.js/webcore/blob/ReadFile.zig
+++ b/src/bun.js/webcore/blob/ReadFile.zig
@@ -709,7 +709,13 @@ pub const ReadFileUV = struct {
             this.onFinish();
             return;
         }
-
+        // Out of memory we can't read more than 4GB at a time (ULONG) on Windows
+        if (this.size > @as(usize, std.math.maxInt(bun.windows.ULONG))) {
+            this.errno = bun.errnoToZigErr(bun.C.E.NOMEM);
+            this.system_error = bun.sys.Error.fromCode(bun.C.E.NOMEM, .read).toSystemError();
+            this.onFinish();
+            return;
+        }
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, this.size + 16) catch |err| {
             this.errno = err;

--- a/src/bun.js/webcore/blob/ReadFile.zig
+++ b/src/bun.js/webcore/blob/ReadFile.zig
@@ -717,7 +717,7 @@ pub const ReadFileUV = struct {
             return;
         }
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
-        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, this.size + 16) catch |err| {
+        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size + 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch |err| {
             this.errno = err;
             this.onFinish();
             return;


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/15242
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
Manually tested, CI dont like 4GB+ files.
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
