### PR TITLE
speculative fix for BUN-8MY

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7101,7 +7101,7 @@ pub const PackageManager = struct {
             maybe_cli: ?CommandLineArguments,
             bun_install_: ?*Api.BunInstall,
             subcommand: Subcommand,
-        ) !void {
+        ) bun.OOM!void {
             var base = Api.NpmRegistry{
                 .url = "",
                 .username = "",
@@ -8805,7 +8805,26 @@ pub const PackageManager = struct {
         allocator: std.mem.Allocator,
         cli: CommandLineArguments,
         env: *DotEnv.Loader,
-    ) !*PackageManager {
+    ) *PackageManager {
+        init_with_runtime_once.call(.{
+            log,
+            bun_install,
+            allocator,
+            cli,
+            env,
+        });
+        return PackageManager.get();
+    }
+
+    var init_with_runtime_once = bun.once(initWithRuntimeOnce);
+
+    pub fn initWithRuntimeOnce(
+        log: *logger.Log,
+        bun_install: ?*Api.BunInstall,
+        allocator: std.mem.Allocator,
+        cli: CommandLineArguments,
+        env: *DotEnv.Loader,
+    ) void {
         if (env.get("BUN_INSTALL_VERBOSE") != null) {
             PackageManager.verbose_install = true;
         }
@@ -8813,12 +8832,16 @@ pub const PackageManager = struct {
         const cpu_count = bun.getThreadCount();
         PackageManager.allocatePackageManager();
         const manager = PackageManager.get();
-        var root_dir = try Fs.FileSystem.instance.fs.readDirectory(
+        var root_dir = Fs.FileSystem.instance.fs.readDirectory(
             Fs.FileSystem.instance.top_level_dir,
             null,
             0,
             true,
-        );
+        ) catch |err| {
+            Output.err(err, "failed to read root directory: '{s}'", .{Fs.FileSystem.instance.top_level_dir});
+            @panic("Failed to initialize package manager");
+        };
+
         // var progress = Progress{};
         // var node = progress.start(name: []const u8, estimated_total_items: usize)
         const top_level_dir_no_trailing_slash = strings.withoutTrailingSlash(Fs.FileSystem.instance.top_level_dir);
@@ -8847,7 +8870,7 @@ pub const PackageManager = struct {
             .original_package_json_path = original_package_json_path[0..original_package_json_path.len :0],
             .subcommand = .install,
         };
-        manager.lockfile = try allocator.create(Lockfile);
+        manager.lockfile = allocator.create(Lockfile) catch bun.outOfMemory();
 
         if (Output.enable_ansi_colors_stderr) {
             manager.progress = Progress{};
@@ -8875,14 +8898,18 @@ pub const PackageManager = struct {
             }
         }
 
-        try manager.options.load(
+        manager.options.load(
             allocator,
             log,
             env,
             cli,
             bun_install,
             .install,
-        );
+        ) catch |err| {
+            switch (err) {
+                error.OutOfMemory => bun.outOfMemory(),
+            }
+        };
 
         manager.timestamp_for_manifest_cache_control = @as(
             u32,
@@ -8924,8 +8951,6 @@ pub const PackageManager = struct {
         } else {
             manager.lockfile.initEmpty(allocator);
         }
-
-        return manager;
     }
 
     fn attemptToCreatePackageJSONAndOpen() !std.fs.File {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -275,7 +275,7 @@ pub const Registry = struct {
             return name[1..];
         }
 
-        pub fn fromAPI(name: string, registry_: Api.NpmRegistry, allocator: std.mem.Allocator, env: *DotEnv.Loader) !Scope {
+        pub fn fromAPI(name: string, registry_: Api.NpmRegistry, allocator: std.mem.Allocator, env: *DotEnv.Loader) OOM!Scope {
             var registry = registry_;
 
             // Support $ENV_VAR for registry URLs

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -573,7 +573,7 @@ pub const Resolver = struct {
 
                 .{},
                 this.env_loader.?,
-            ) catch @panic("Failed to initialize package manager");
+            );
             pm.onWake = this.onWakePackageManager;
             this.package_manager = pm;
             break :brk pm;


### PR DESCRIPTION
### What does this PR do?
Ensures `PackageManager` is only allocated once for the runtime
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
