### PR TITLE
docs: `--bail 10` -> `--bail=10`

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -124,7 +124,7 @@ Use the `--bail` flag to abort the test run early after a pre-determined number 
 $ bun test --bail
 
 # bail after 10 failure
-$ bun test --bail 10
+$ bun test --bail=10
 ```
 
 ## Watch mode

--- a/docs/guides/test/bail.md
+++ b/docs/guides/test/bail.md
@@ -14,7 +14,7 @@ To bail after a certain threshold of failures, optionally specify a number after
 
 ```sh
 # bail after 10 failures
-$ bun test --bail 10
+$ bun test --bail=10
 ```
 
 ---

--- a/docs/guides/test/migrate-from-jest.md
+++ b/docs/guides/test/migrate-from-jest.md
@@ -57,7 +57,7 @@ Replace `bail` in your Jest config with the `--bail` CLI flag.
 ``` -->
 
 ```sh
-$ bun test --bail 3
+$ bun test --bail=3
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

fixes docs for #15293 as `--bail` can optionally take arguments, and thus needs `=` and cant be space like normal

in future would be nice to make cli parsing fancier and support it though