### PR TITLE
fix(install): adding two or more git dependencies

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8119,6 +8119,9 @@ pub const PackageManager = struct {
                             request.e_string = new_dependencies[k].value.?.data.e_string;
 
                             if (request.is_aliased) continue :outer;
+
+                            // if package name is unknown continue
+                            if ((request.version.tag == .git or request.version.tag == .github or request.version.tag == .tarball or request.version.tag == .folder) and request.name.len == 0) continue :outer;
                         }
                     }
                 }

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8121,7 +8121,7 @@ pub const PackageManager = struct {
                             if (request.is_aliased) continue :outer;
 
                             // if package name is unknown continue
-                            if ((request.version.tag == .git or request.version.tag == .github or request.version.tag == .tarball or request.version.tag == .folder) and request.name.len == 0) continue :outer;
+                            if (request.version.tag == .git or request.version.tag == .github) continue :outer;
                         }
                     }
                 }


### PR DESCRIPTION
### What does this PR do?
fixes #14296
fixes #14518 (but the dependencies still won't install because we don't support git semver ranges)
fixes #12668
fixes #12505
fixes #11116

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
