### PR TITLE
fix(ws) ping without parameters

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5404,6 +5404,9 @@ pub const ServerWebSocket = struct {
                         return JSValue.jsNumber(0);
                     },
                 }
+            } else {
+                globalThis.throwPretty("{s} requires a string or BufferSource", .{name});
+                return .zero;
             }
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5404,13 +5404,10 @@ pub const ServerWebSocket = struct {
                         return JSValue.jsNumber(0);
                     },
                 }
-            } else {
-                globalThis.throwPretty("{s} requires a string or BufferSource", .{name});
-                return .zero;
             }
         }
 
-        switch (this.websocket().send(&.{}, opcode, false, true)) {
+        switch (this.websocket().send("", opcode, false, true)) {
             .backpressure => {
                 log("{s}() backpressure ({d} bytes)", .{ name, 0 });
                 return JSValue.jsNumber(-1);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -5368,49 +5368,51 @@ pub const ServerWebSocket = struct {
 
         if (args.len > 0) {
             var value = args.ptr[0];
-            if (value.asArrayBuffer(globalThis)) |data| {
-                const buffer = data.slice();
+            if (!value.isEmptyOrUndefinedOrNull()) {
+                if (value.asArrayBuffer(globalThis)) |data| {
+                    const buffer = data.slice();
 
-                switch (this.websocket().send(buffer, opcode, false, true)) {
-                    .backpressure => {
-                        log("{s}() backpressure ({d} bytes)", .{ name, buffer.len });
-                        return JSValue.jsNumber(-1);
-                    },
-                    .success => {
-                        log("{s}() success ({d} bytes)", .{ name, buffer.len });
-                        return JSValue.jsNumber(buffer.len);
-                    },
-                    .dropped => {
-                        log("{s}() dropped ({d} bytes)", .{ name, buffer.len });
-                        return JSValue.jsNumber(0);
-                    },
-                }
-            } else if (value.isString()) {
-                var string_value = value.toString(globalThis).toSlice(globalThis, bun.default_allocator);
-                defer string_value.deinit();
-                const buffer = string_value.slice();
+                    switch (this.websocket().send(buffer, opcode, false, true)) {
+                        .backpressure => {
+                            log("{s}() backpressure ({d} bytes)", .{ name, buffer.len });
+                            return JSValue.jsNumber(-1);
+                        },
+                        .success => {
+                            log("{s}() success ({d} bytes)", .{ name, buffer.len });
+                            return JSValue.jsNumber(buffer.len);
+                        },
+                        .dropped => {
+                            log("{s}() dropped ({d} bytes)", .{ name, buffer.len });
+                            return JSValue.jsNumber(0);
+                        },
+                    }
+                } else if (value.isString()) {
+                    var string_value = value.toString(globalThis).toSlice(globalThis, bun.default_allocator);
+                    defer string_value.deinit();
+                    const buffer = string_value.slice();
 
-                switch (this.websocket().send(buffer, opcode, false, true)) {
-                    .backpressure => {
-                        log("{s}() backpressure ({d} bytes)", .{ name, buffer.len });
-                        return JSValue.jsNumber(-1);
-                    },
-                    .success => {
-                        log("{s}() success ({d} bytes)", .{ name, buffer.len });
-                        return JSValue.jsNumber(buffer.len);
-                    },
-                    .dropped => {
-                        log("{s}() dropped ({d} bytes)", .{ name, buffer.len });
-                        return JSValue.jsNumber(0);
-                    },
+                    switch (this.websocket().send(buffer, opcode, false, true)) {
+                        .backpressure => {
+                            log("{s}() backpressure ({d} bytes)", .{ name, buffer.len });
+                            return JSValue.jsNumber(-1);
+                        },
+                        .success => {
+                            log("{s}() success ({d} bytes)", .{ name, buffer.len });
+                            return JSValue.jsNumber(buffer.len);
+                        },
+                        .dropped => {
+                            log("{s}() dropped ({d} bytes)", .{ name, buffer.len });
+                            return JSValue.jsNumber(0);
+                        },
+                    }
+                } else {
+                    globalThis.throwPretty("{s} requires a string or BufferSource", .{name});
+                    return .zero;
                 }
-            } else {
-                globalThis.throwPretty("{s} requires a string or BufferSource", .{name});
-                return .zero;
             }
         }
 
-        switch (this.websocket().send("", opcode, false, true)) {
+        switch (this.websocket().send(&.{}, opcode, false, true)) {
             .backpressure => {
                 log("{s}() backpressure ({d} bytes)", .{ name, 0 });
                 return JSValue.jsNumber(-1);

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -9,7 +9,14 @@
 extern "C" const char* ares_inet_ntop(int af, const char *src, char *dst, size_t size);
 
 #define uws_res_r uws_res_t* nonnull_arg 
+static inline std::string_view stringViewFromC(const char* message, size_t length) {
+  if(length) {
+    return std::string_view(message, length);
+  }
 
+  return std::string_view();
+  
+}
 extern "C"
 {
 
@@ -471,10 +478,10 @@ extern "C"
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      return uwsApp->numSubscribers(std::string_view(topic, topic_length));
+      return uwsApp->numSubscribers(stringViewFromC(topic, topic_length));
     }
     uWS::App *uwsApp = (uWS::App *)app;
-    return uwsApp->numSubscribers(std::string_view(topic, topic_length));
+    return uwsApp->numSubscribers(stringViewFromC(topic, topic_length));
   }
   bool uws_publish(int ssl, uws_app_t *app, const char *topic,
                    size_t topic_length, const char *message,
@@ -483,13 +490,13 @@ extern "C"
     if (ssl)
     {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      return uwsApp->publish(std::string_view(topic, topic_length),
-                             std::string_view(message, message_length),
+      return uwsApp->publish(stringViewFromC(topic, topic_length),
+                             stringViewFromC(message, message_length),
                              (uWS::OpCode)(unsigned char)opcode, compress);
     }
     uWS::App *uwsApp = (uWS::App *)app;
-    return uwsApp->publish(std::string_view(topic, topic_length),
-                           std::string_view(message, message_length),
+    return uwsApp->publish(stringViewFromC(topic, topic_length),
+                           stringViewFromC(message, message_length),
                            (uWS::OpCode)(unsigned char)opcode, compress);
   }
   void *uws_get_native_handle(int ssl, uws_app_t *app)
@@ -747,12 +754,12 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return (uws_sendstatus_t)uws->send(std::string_view(message, length),
+      return (uws_sendstatus_t)uws->send(stringViewFromC(message, length),
                                          (uWS::OpCode)(unsigned char)opcode);
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return (uws_sendstatus_t)uws->send(std::string_view(message, length),
+    return (uws_sendstatus_t)uws->send(stringViewFromC(message, length),
                                        (uWS::OpCode)(unsigned char)opcode);
   }
 
@@ -765,7 +772,7 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return (uws_sendstatus_t)uws->send(std::string_view(message, length),
+      return (uws_sendstatus_t)uws->send(stringViewFromC(message, length),
                                          (uWS::OpCode)(unsigned char)opcode,
                                          compress, fin);
     }
@@ -774,7 +781,7 @@ extern "C"
 
       uWS::WebSocket<false, true, void *> *uws =
           (uWS::WebSocket<false, true, void *> *)ws;
-      return (uws_sendstatus_t)uws->send(std::string_view(message, length),
+      return (uws_sendstatus_t)uws->send(stringViewFromC(message, length),
                                          (uWS::OpCode)(unsigned char)opcode,
                                          compress, fin);
     }
@@ -789,11 +796,11 @@ extern "C"
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
       return (uws_sendstatus_t)uws->sendFragment(
-          std::string_view(message, length), compress);
+          stringViewFromC(message, length), compress);
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return (uws_sendstatus_t)uws->sendFragment(std::string_view(message, length),
+    return (uws_sendstatus_t)uws->sendFragment(stringViewFromC(message, length),
                                                compress);
   }
   uws_sendstatus_t uws_ws_send_first_fragment(int ssl, uws_websocket_t *ws,
@@ -805,12 +812,12 @@ extern "C"
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
       return (uws_sendstatus_t)uws->sendFirstFragment(
-          std::string_view(message, length), uWS::OpCode::BINARY, compress);
+          stringViewFromC(message, length), uWS::OpCode::BINARY, compress);
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
     return (uws_sendstatus_t)uws->sendFirstFragment(
-        std::string_view(message, length), uWS::OpCode::BINARY, compress);
+        stringViewFromC(message, length), uWS::OpCode::BINARY, compress);
   }
   uws_sendstatus_t
   uws_ws_send_first_fragment_with_opcode(int ssl, uws_websocket_t *ws,
@@ -822,13 +829,13 @@ extern "C"
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
       return (uws_sendstatus_t)uws->sendFirstFragment(
-          std::string_view(message, length), (uWS::OpCode)(unsigned char)opcode,
+          stringViewFromC(message, length), (uWS::OpCode)(unsigned char)opcode,
           compress);
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
     return (uws_sendstatus_t)uws->sendFirstFragment(
-        std::string_view(message, length), (uWS::OpCode)(unsigned char)opcode,
+        stringViewFromC(message, length), (uWS::OpCode)(unsigned char)opcode,
         compress);
   }
   uws_sendstatus_t uws_ws_send_last_fragment(int ssl, uws_websocket_t *ws,
@@ -840,12 +847,12 @@ extern "C"
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
       return (uws_sendstatus_t)uws->sendLastFragment(
-          std::string_view(message, length), compress);
+          stringViewFromC(message, length), compress);
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
     return (uws_sendstatus_t)uws->sendLastFragment(
-        std::string_view(message, length), compress);
+        stringViewFromC(message, length), compress);
   }
 
   void uws_ws_end(int ssl, uws_websocket_t *ws, int code, const char *message,
@@ -855,13 +862,13 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      uws->end(code, std::string_view(message, length));
+      uws->end(code, stringViewFromC(message, length));
     }
     else
     {
       uWS::WebSocket<false, true, void *> *uws =
           (uWS::WebSocket<false, true, void *> *)ws;
-      uws->end(code, std::string_view(message, length));
+      uws->end(code, stringViewFromC(message, length));
     }
   }
 
@@ -891,11 +898,11 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return uws->subscribe(std::string_view(topic, length));
+      return uws->subscribe(stringViewFromC(topic, length));
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return uws->subscribe(std::string_view(topic, length));
+    return uws->subscribe(stringViewFromC(topic, length));
   }
   bool uws_ws_unsubscribe(int ssl, uws_websocket_t *ws, const char *topic,
                           size_t length)
@@ -904,11 +911,11 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return uws->unsubscribe(std::string_view(topic, length));
+      return uws->unsubscribe(stringViewFromC(topic, length));
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return uws->unsubscribe(std::string_view(topic, length));
+    return uws->unsubscribe(stringViewFromC(topic, length));
   }
 
   bool uws_ws_is_subscribed(int ssl, uws_websocket_t *ws, const char *topic,
@@ -918,11 +925,11 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return uws->isSubscribed(std::string_view(topic, length));
+      return uws->isSubscribed(stringViewFromC(topic, length));
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return uws->isSubscribed(std::string_view(topic, length));
+    return uws->isSubscribed(stringViewFromC(topic, length));
   }
   void uws_ws_iterate_topics(int ssl, uws_websocket_t *ws,
                              void (*callback)(const char *topic, size_t length,
@@ -954,13 +961,13 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return uws->publish(std::string_view(topic, topic_length),
-                          std::string_view(message, message_length));
+      return uws->publish(stringViewFromC(topic, topic_length),
+                          stringViewFromC(message, message_length));
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return uws->publish(std::string_view(topic, topic_length),
-                        std::string_view(message, message_length));
+    return uws->publish(stringViewFromC(topic, topic_length),
+                        stringViewFromC(message, message_length));
   }
 
   bool uws_ws_publish_with_options(int ssl, uws_websocket_t *ws,
@@ -972,14 +979,14 @@ extern "C"
     {
       uWS::WebSocket<true, true, void *> *uws =
           (uWS::WebSocket<true, true, void *> *)ws;
-      return uws->publish(std::string_view(topic, topic_length),
-                          std::string_view(message, message_length),
+      return uws->publish(stringViewFromC(topic, topic_length),
+                          stringViewFromC(message, message_length),
                           (uWS::OpCode)(unsigned char)opcode, compress);
     }
     uWS::WebSocket<false, true, void *> *uws =
         (uWS::WebSocket<false, true, void *> *)ws;
-    return uws->publish(std::string_view(topic, topic_length),
-                        std::string_view(message, message_length),
+    return uws->publish(stringViewFromC(topic, topic_length),
+                        stringViewFromC(message, message_length),
                         (uWS::OpCode)(unsigned char)opcode, compress);
   }
 
@@ -1042,13 +1049,13 @@ extern "C"
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
       uwsRes->clearOnWritableAndAborted();
-      uwsRes->end(std::string_view(data, length), close_connection);
+      uwsRes->end(stringViewFromC(data, length), close_connection);
     }
     else
     {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
       uwsRes->clearOnWritableAndAborted();
-      uwsRes->end(std::string_view(data, length), close_connection);
+      uwsRes->end(stringViewFromC(data, length), close_connection);
     }
   }
 
@@ -1116,12 +1123,12 @@ extern "C"
     if (ssl)
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->writeStatus(std::string_view(status, length));
+      uwsRes->writeStatus(stringViewFromC(status, length));
     }
     else
     {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeStatus(std::string_view(status, length));
+      uwsRes->writeStatus(stringViewFromC(status, length));
     }
   }
 
@@ -1132,14 +1139,14 @@ extern "C"
     if (ssl)
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->writeHeader(std::string_view(key, key_length),
-                          std::string_view(value, value_length));
+      uwsRes->writeHeader(stringViewFromC(key, key_length),
+                          stringViewFromC(value, value_length));
     }
     else
     {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeHeader(std::string_view(key, key_length),
-                          std::string_view(value, value_length));
+      uwsRes->writeHeader(stringViewFromC(key, key_length),
+                          stringViewFromC(value, value_length));
     }
   }
   void uws_res_write_header_int(int ssl, uws_res_r res, const char *key,
@@ -1148,13 +1155,13 @@ extern "C"
     if (ssl)
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->writeHeader(std::string_view(key, key_length), value);
+      uwsRes->writeHeader(stringViewFromC(key, key_length), value);
     }
     else
     {
 
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->writeHeader(std::string_view(key, key_length), value);
+      uwsRes->writeHeader(stringViewFromC(key, key_length), value);
     }
   }
   void uws_res_end_sendfile(int ssl, uws_res_r res, uint64_t offset, bool close_connection) 
@@ -1250,10 +1257,10 @@ extern "C"
     if (ssl)
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      return uwsRes->write(std::string_view(data, length));
+      return uwsRes->write(stringViewFromC(data, length));
     }
     uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-    return uwsRes->write(std::string_view(data, length));
+    return uwsRes->write(stringViewFromC(data, length));
   }
   uint64_t uws_res_get_write_offset(int ssl, uws_res_r res) nonnull_fn_decl;
   uint64_t uws_res_get_write_offset(int ssl, uws_res_r res)
@@ -1443,7 +1450,7 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;
 
     std::string_view value = uwsReq->getHeader(
-        std::string_view(lower_case_header, lower_case_header_length));
+        stringViewFromC(lower_case_header, lower_case_header_length));
     *dest = value.data();
     return value.length();
   }
@@ -1462,7 +1469,7 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
   {
     uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;
 
-    std::string_view value = uwsReq->getQuery(std::string_view(key, key_length));
+    std::string_view value = uwsReq->getQuery(stringViewFromC(key, key_length));
     *dest = value.data();
     return value.length();
   }
@@ -1490,9 +1497,9 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
 
     uwsRes->template upgrade<void *>(
         data ? std::move(data) : NULL,
-        std::string_view(sec_web_socket_key, sec_web_socket_key_length),
-        std::string_view(sec_web_socket_protocol, sec_web_socket_protocol_length),
-        std::string_view(sec_web_socket_extensions,
+        stringViewFromC(sec_web_socket_key, sec_web_socket_key_length),
+        stringViewFromC(sec_web_socket_protocol, sec_web_socket_protocol_length),
+        stringViewFromC(sec_web_socket_extensions,
                          sec_web_socket_extensions_length),
         (struct us_socket_context_t *)ws);
     } else {
@@ -1500,9 +1507,9 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
 
     uwsRes->template upgrade<void *>(
         data ? std::move(data) : NULL,
-        std::string_view(sec_web_socket_key, sec_web_socket_key_length),
-        std::string_view(sec_web_socket_protocol, sec_web_socket_protocol_length),
-        std::string_view(sec_web_socket_extensions,
+        stringViewFromC(sec_web_socket_key, sec_web_socket_key_length),
+        stringViewFromC(sec_web_socket_protocol, sec_web_socket_protocol_length),
+        stringViewFromC(sec_web_socket_extensions,
                          sec_web_socket_extensions_length),
         (struct us_socket_context_t *)ws);
     }
@@ -1560,8 +1567,8 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
       for (size_t i = 0; i < count; i++)
       {
-        uwsRes->writeHeader(std::string_view(&buf[names[i].off], names[i].len),
-                            std::string_view(&buf[values[i].off], values[i].len));
+        uwsRes->writeHeader(stringViewFromC(&buf[names[i].off], names[i].len),
+                            stringViewFromC(&buf[values[i].off], values[i].len));
       }
     }
     else
@@ -1569,8 +1576,8 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
       for (size_t i = 0; i < count; i++)
       {
-        uwsRes->writeHeader(std::string_view(&buf[names[i].off], names[i].len),
-                            std::string_view(&buf[values[i].off], values[i].len));
+        uwsRes->writeHeader(stringViewFromC(&buf[names[i].off], names[i].len),
+                            stringViewFromC(&buf[values[i].off], values[i].len));
       }
     }
   }
@@ -1660,7 +1667,7 @@ __attribute__((callback (corker, ctx)))
     if (ssl)
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      auto pair = uwsRes->tryEnd(std::string_view(bytes, len), total_len, close);
+      auto pair = uwsRes->tryEnd(stringViewFromC(bytes, len), total_len, close);
       if (pair.first) {
         uwsRes->clearOnWritableAndAborted();
       }
@@ -1670,7 +1677,7 @@ __attribute__((callback (corker, ctx)))
     else
     {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      auto pair = uwsRes->tryEnd(std::string_view(bytes, len), total_len, close);
+      auto pair = uwsRes->tryEnd(stringViewFromC(bytes, len), total_len, close);
       if (pair.first) {
           uwsRes->clearOnWritableAndAborted();
       }

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -553,7 +553,7 @@ it("WebSocketServer should handle backpressure", async () => {
   }
 });
 
-it("Server should be able to send empty pings", async () => {
+it.only("Server should be able to send empty pings", async () => {
   // WebSocket frame creation function with masking
   function createWebSocketFrame(message: string) {
     const messageBuffer = Buffer.from(message);
@@ -600,7 +600,7 @@ it("Server should be able to send empty pings", async () => {
         incoming.on("message", value => {
           try {
             expect(value.toString()).toBe(helloMessage);
-            if (pingMessage) {
+            if (arguments.length > 1) {
               incoming.ping(pingMessage);
             } else {
               incoming.ping();
@@ -692,6 +692,17 @@ it("Server should be able to send empty pings", async () => {
   {
     // test without any payload
     const pingMessage = await checkPing("");
+    expect(pingMessage).toBe("");
+  }
+  {
+    // test with null payload
+    //@ts-ignore
+    const pingMessage = await checkPing("", null);
+    expect(pingMessage).toBe("");
+  }
+  {
+    // test with undefined payload
+    const pingMessage = await checkPing("", undefined);
     expect(pingMessage).toBe("");
   }
   {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "node:path";
 import { Server, WebSocket, WebSocketServer } from "ws";
+import { createServer } from "http";
+import { connect, AddressInfo } from "net";
+import { once } from "events";
+import crypto from "crypto";
 
 const strings = [
   {
@@ -546,5 +550,166 @@ it("WebSocketServer should handle backpressure", async () => {
     expect(received).toBe(PAYLOAD_SIZE * ITERATIONS);
   } finally {
     wss.close();
+  }
+});
+
+it("Server should be able to send empty pings", async () => {
+  // WebSocket frame creation function with masking
+  function createWebSocketFrame(message: string) {
+    const messageBuffer = Buffer.from(message);
+    const frame = [];
+
+    // Add FIN bit and opcode for text frame
+    frame.push(0x81);
+
+    // Payload length
+    if (messageBuffer.length < 126) {
+      frame.push(messageBuffer.length | 0x80); // Mask bit set
+    } else if (messageBuffer.length < 65536) {
+      frame.push(126 | 0x80); // Mask bit set
+      frame.push((messageBuffer.length >> 8) & 0xff);
+      frame.push(messageBuffer.length & 0xff);
+    } else {
+      frame.push(127 | 0x80); // Mask bit set
+      for (let i = 7; i >= 0; i--) {
+        frame.push((messageBuffer.length >> (i * 8)) & 0xff);
+      }
+    }
+
+    // Generate masking key
+    const maskingKey = crypto.randomBytes(4);
+    frame.push(...maskingKey);
+
+    // Mask the payload
+    const maskedPayload = Buffer.alloc(messageBuffer.length);
+    for (let i = 0; i < messageBuffer.length; i++) {
+      maskedPayload[i] = messageBuffer[i] ^ maskingKey[i % 4];
+    }
+
+    // Combine frame header and masked payload
+    return Buffer.concat([Buffer.from(frame), maskedPayload]);
+  }
+
+  async function checkPing(helloMessage: string, pingMessage?: string) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const server = new WebSocketServer({ noServer: true });
+    const httpServer = createServer();
+
+    try {
+      server.on("connection", async incoming => {
+        incoming.on("message", value => {
+          try {
+            expect(value.toString()).toBe(helloMessage);
+            if (pingMessage) {
+              incoming.ping(pingMessage);
+            } else {
+              incoming.ping();
+            }
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+
+      httpServer.on("upgrade", async (request, socket, head) => {
+        server.handleUpgrade(request, socket, head, ws => {
+          server.emit("connection", ws, request);
+        });
+      });
+      httpServer.listen(0);
+      await once(httpServer, "listening");
+      const socket = connect({
+        port: (httpServer.address() as AddressInfo).port,
+        host: "127.0.0.1",
+      });
+
+      let upgradeResponse = "";
+
+      let state = 0; //connecting
+      socket.on("data", (data: Buffer) => {
+        switch (state) {
+          case 0: {
+            upgradeResponse += data.toString("utf8");
+
+            if (upgradeResponse.indexOf("\r\n\r\n") !== -1) {
+              if (upgradeResponse.indexOf("HTTP/1.1 101 Switching Protocols") !== -1) {
+                state = 1;
+                socket.write(createWebSocketFrame(helloMessage));
+              } else {
+                reject(new Error("Failed to Upgrade WebSockets"));
+                state = 2;
+                socket.end();
+              }
+            }
+            break;
+          }
+          case 1: {
+            if (data.at(0) === 137) {
+              try {
+                const len = data.at(1) as number;
+                if (len > 0) {
+                  const str = data.slice(2, len + 2).toString("utf8");
+                  resolve(str);
+                } else {
+                  resolve("");
+                }
+              } catch (e) {
+                reject(e);
+              }
+              state = 2;
+              socket.end();
+              break;
+            }
+            reject(new Error("Unexpected data received"));
+          }
+          case 2: {
+            reject(new Error("Connection Closed"));
+          }
+        }
+      });
+
+      // Generate a Sec-WebSocket-Key
+      const key = crypto.randomBytes(16).toString("base64");
+
+      // Create the WebSocket upgrade request
+      socket.write(
+        [
+          `GET / HTTP/1.1`,
+          `Host: 127.0.0.1`,
+          `Upgrade: websocket`,
+          `Connection: Upgrade`,
+          `Sec-WebSocket-Key: ${key}`,
+          `Sec-WebSocket-Version: 13`,
+          `\r\n`,
+        ].join("\r\n"),
+      );
+
+      return await promise;
+    } finally {
+      httpServer.closeAllConnections();
+    }
+  }
+  {
+    // test without any payload
+    const pingMessage = await checkPing("");
+    expect(pingMessage).toBe("");
+  }
+  {
+    // test with some payload
+    const pingMessage = await checkPing("Hello", "bun");
+    expect(pingMessage).toBe("bun");
+  }
+  {
+    // test limits
+    const pingPayload = Buffer.alloc(125, "b").toString();
+    const pingMessage = await checkPing("Hello, World", pingPayload);
+    expect(pingMessage).toBe(pingPayload);
+  }
+
+  {
+    // should not be equal because is bigger than 125 bytes
+    const pingPayload = Buffer.alloc(126, "b").toString();
+    const pingMessage = await checkPing("Hello, World", pingPayload);
+    expect(pingMessage).not.toBe(pingPayload);
   }
 });


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/15247
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
