### PR TITLE
fix(ReadableStream) flush as much we can before ending the stream

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3246,8 +3246,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
             var wrote_anything = false;
             if (req.sink) |wrapper| {
-                wrapper.sink.pending_flush = null;
-                wrapper.sink.done = true;
                 req.flags.aborted = req.flags.aborted or wrapper.sink.aborted;
                 wrote_anything = wrapper.sink.wrote > 0;
 

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2592,8 +2592,8 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
         // so it must zero out state instead of make it
         pub fn finalize(this: *@This()) void {
             log("finalize()", .{});
-
             if (!this.done) {
+                _ = this.flushFromJSNoWait();
                 this.done = true;
                 this.unregisterAutoFlusher();
                 this.res.clearOnWritable();

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -2253,21 +2253,26 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
 
         fn flushFromJSNoWait(this: *@This()) JSC.Maybe(JSValue) {
             log("flushFromJSNoWait", .{});
+
+            return .{ .result = JSValue.jsNumber(this.flushNoWait()) };
+        }
+
+        pub fn flushNoWait(this: *@This()) usize {
             if (this.hasBackpressureAndIsTryEnd() or this.done) {
-                return .{ .result = JSValue.jsNumberFromInt32(0) };
+                return 0;
             }
 
             const slice = this.readableSlice();
             if (slice.len == 0) {
-                return .{ .result = JSValue.jsNumberFromInt32(0) };
+                return 0;
             }
 
             const success = this.send(slice);
             if (success) {
-                return .{ .result = JSValue.jsNumber(slice.len) };
+                return slice.len;
             }
 
-            return .{ .result = JSValue.jsNumberFromInt32(0) };
+            return 0;
         }
 
         pub fn flushFromJS(this: *@This(), globalThis: *JSGlobalObject, wait: bool) JSC.Maybe(JSValue) {
@@ -2593,10 +2598,14 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
         pub fn finalize(this: *@This()) void {
             log("finalize()", .{});
             if (!this.done) {
-                _ = this.flushFromJSNoWait();
-                this.done = true;
                 this.unregisterAutoFlusher();
+                // make sure we detached the handlers before flushing inside the finalize function
                 this.res.clearOnWritable();
+                this.res.clearAborted();
+                this.res.clearOnData();
+                _ = this.flushNoWait();
+                this.done = true;
+                // is actually fine to call this if the socket is closed because of flushNoWait, the free will be defered by usockets
                 this.res.endStream(false);
             }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2145,3 +2145,23 @@ it("#6583", async () => {
   await promise;
   expect(callback).not.toHaveBeenCalled();
 });
+
+it("do the best effort to flush everything", async () => {
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(ctrl) {
+            ctrl.write("b");
+            await Bun.sleep(10);
+            ctrl.write("un");
+          },
+        }),
+      );
+    },
+  });
+  let response = await fetch(server.url);
+  expect(await response.text()).toBe("bun");
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fix: https://github.com/oven-sh/bun/issues/15235
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
