### PR TITLE
Fix lockfile print crash

### DIFF
--- a/src/cli/outdated_command.zig
+++ b/src/cli/outdated_command.zig
@@ -350,9 +350,11 @@ pub const OutdatedCommand = struct {
                 const package_name = pkg_names[package_id].slice(string_buf);
                 var expired = false;
                 const manifest = manager.manifests.byNameAllowExpired(
+                    manager,
                     manager.scopeForPackageName(package_name),
                     package_name,
                     &expired,
+                    .load_from_memory_fallback_to_disk,
                 ) orelse continue;
 
                 const latest = manifest.findByDistTag("latest") orelse continue;
@@ -471,9 +473,11 @@ pub const OutdatedCommand = struct {
 
                     var expired = false;
                     const manifest = manager.manifests.byNameAllowExpired(
+                        manager,
                         manager.scopeForPackageName(package_name),
                         package_name,
                         &expired,
+                        .load_from_memory_fallback_to_disk,
                     ) orelse continue;
 
                     const latest = manifest.findByDistTag("latest") orelse continue;
@@ -580,8 +584,10 @@ pub const OutdatedCommand = struct {
 
                 const package_name = pkg_names[package_id].slice(string_buf);
                 _ = manager.manifests.byName(
+                    manager,
                     manager.scopeForPackageName(package_name),
                     package_name,
+                    .load_from_memory_fallback_to_disk,
                 ) orelse {
                     const task_id = Install.Task.Id.forManifest(package_name);
                     if (manager.hasCreatedNetworkTask(task_id, dep.behavior.optional)) continue;

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -393,7 +393,7 @@ pub const PackageManagerCommand = struct {
             }
             handleLoadLockfileErrors(load_lockfile, pm);
             const lockfile = load_lockfile.ok.lockfile;
-            lockfile.saveToDisk(pm.options.lockfile_path);
+            lockfile.saveToDisk(pm.options.lockfile_path, pm.options.log_level.isVerbose());
             Global.exit(0);
         }
 

--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -423,7 +423,7 @@ pub const TrustCommand = struct {
             try pm.lockfile.trusted_dependencies.?.put(ctx.allocator, @truncate(String.Builder.stringHash(name)), {});
         }
 
-        pm.lockfile.saveToDisk(pm.options.lockfile_path);
+        pm.lockfile.saveToDisk(pm.options.lockfile_path, pm.options.log_level.isVerbose());
 
         var buffer_writer = try bun.js_printer.BufferWriter.init(ctx.allocator);
         try buffer_writer.buffer.list.ensureTotalCapacity(ctx.allocator, package_json_contents.len + 1);

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -116,7 +116,7 @@ pub const Context = struct {
     allocator: std.mem.Allocator,
     log: *logger.Log,
     buffer: []const u8,
-    package_manager: *PackageManager,
+    package_manager: ?*PackageManager,
 };
 
 /// Get the name of the package as it should appear in a remote registry.

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2343,7 +2343,7 @@ it("should handle caret range in dependencies when the registry has prereleased 
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ bar@6.3.0",
+    expect.stringContaining("+ bar@6.3.0"),
     "",
     "1 package installed",
   ]);
@@ -5261,7 +5261,7 @@ it("should prefer optionalDependencies over dependencies of the same name", asyn
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ baz@0.0.3",
+    expect.stringContaining("+ baz@0.0.3"),
     "",
     "1 package installed",
   ]);
@@ -5560,7 +5560,7 @@ it("should de-duplicate dependencies alongside tarball URL", async () => {
     expect.stringContaining("bun install v1."),
     "",
     `+ @barn/moo@${root_url}/moo-0.1.0.tgz`,
-    "+ bar@0.0.2",
+    expect.stringContaining("+ bar@0.0.2"),
     "",
     "3 packages installed",
   ]);
@@ -6349,10 +6349,10 @@ cache = false
   expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     `bun install ${Bun.version_with_sha}`,
     "",
-    "+ conditional-type-checks@1.0.6",
-    "+ prettier@2.8.8",
-    "+ tsd@0.22.0",
-    "+ typescript@5.0.4",
+    expect.stringContaining("+ conditional-type-checks@1.0.6"),
+    expect.stringContaining("+ prettier@2.8.8"),
+    expect.stringContaining("+ tsd@0.22.0"),
+    expect.stringContaining("+ typescript@5.0.4"),
     "",
     "112 packages installed",
   ]);
@@ -8163,7 +8163,7 @@ it("should install correct version of peer dependency from root package", async 
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ baz@0.0.3",
+    expect.stringContaining("+ baz@0.0.3"),
     "",
     "1 package installed",
   ]);

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -254,8 +254,8 @@ for (const { input } of [{ input: { baz: "~0.0.3", moo: "~0.1.0" } }, { input: {
       expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun update v1."),
         "",
-        "+ @barn/moo@0.1.0",
-        "+ baz@0.0.3",
+        expect.stringContaining("+ @barn/moo@0.1.0"),
+        expect.stringContaining("+ baz@0.0.3"),
         "",
         "2 packages installed",
       ]);

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -193,7 +193,7 @@ for (const { input } of [{ input: { baz: "~0.0.3", moo: "~0.1.0" } }, { input: {
       expect.stringContaining("bun install v1."),
       "",
       "+ @barn/moo@0.1.0",
-      "+ baz@0.0.3",
+      expect.stringContaining("+ baz@0.0.3"),
       "",
       "2 packages installed",
     ]);

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -1769,7 +1769,7 @@ describe("optionalDependencies", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "",
       "1 package installed",
     ]);
@@ -2228,7 +2228,7 @@ test("dependency from root satisfies range from dependency", async () => {
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "+ one-range-dep@1.0.0",
     "",
     "2 packages installed",
@@ -2259,7 +2259,7 @@ test("dependency from root satisfies range from dependency", async () => {
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "+ one-range-dep@1.0.0",
     "",
     "2 packages installed",
@@ -2466,7 +2466,7 @@ test("peerDependency in child npm dependency should not maintain old version whe
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "+ peer-deps-fixed@1.0.0",
     "",
     "2 packages installed",
@@ -2511,7 +2511,7 @@ test("peerDependency in child npm dependency should not maintain old version whe
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.1",
+    expect.stringContaining("+ no-deps@1.0.1"),
     "",
     "1 package installed",
   ]);
@@ -2590,7 +2590,7 @@ test("package added after install", async () => {
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "",
     "2 packages installed",
   ]);
@@ -2626,7 +2626,7 @@ test("package added after install", async () => {
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "+ one-range-dep@1.0.0",
     "",
     "3 packages installed",
@@ -2687,7 +2687,7 @@ test("--production excludes devDependencies in workspaces", async () => {
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "",
     "4 packages installed",
   ]);
@@ -2708,7 +2708,7 @@ test("--production excludes devDependencies in workspaces", async () => {
     expect.stringContaining("bun install v1."),
     "",
     "+ a1@1.0.0",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "",
     "7 packages installed",
   ]);
@@ -2719,7 +2719,7 @@ test("--production excludes devDependencies in workspaces", async () => {
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "",
     "4 packages installed",
   ]);
@@ -2760,7 +2760,7 @@ test("--production without a lockfile will install and not save lockfile", async
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ no-deps@1.0.0",
+    expect.stringContaining("+ no-deps@1.0.0"),
     "",
     "1 package installed",
   ]);
@@ -2824,8 +2824,8 @@ describe("binaries", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ uses-what-bin@1.5.0",
-      "+ what-bin@1.0.0",
+      expect.stringContaining("+ uses-what-bin@1.5.0"),
+      expect.stringContaining("+ what-bin@1.0.0"),
       "",
       "3 packages installed",
       "",
@@ -2854,8 +2854,8 @@ describe("binaries", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ uses-what-bin@1.5.0",
-      "+ what-bin@1.0.0",
+      expect.stringContaining("+ uses-what-bin@1.5.0"),
+      expect.stringContaining("+ what-bin@1.0.0"),
       "",
       "3 packages installed",
       "",
@@ -2948,7 +2948,7 @@ describe("binaries", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ bin-change-dir@1.0.0",
+      expect.stringContaining("+ bin-change-dir@1.0.0"),
       "",
       "1 package installed",
     ]);
@@ -2989,7 +2989,7 @@ describe("binaries", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ bin-change-dir@1.0.1",
+      expect.stringContaining("+ bin-change-dir@1.0.1"),
       "",
       "1 package installed",
     ]);
@@ -3261,17 +3261,17 @@ test("it should install with missing bun.lockb, node_modules, and/or cache", asy
     expect.stringContaining("bun install v1."),
     "",
     "+ dep-loop-entry@1.0.0",
-    "+ dep-with-tags@3.0.0",
+    expect.stringContaining("+ dep-with-tags@3.0.0"),
     "+ dev-deps@1.0.0",
     "+ left-pad@1.0.0",
     "+ native@1.0.0",
     "+ no-deps-bins@2.0.0",
-    "+ one-fixed-dep@2.0.0",
+    expect.stringContaining("+ one-fixed-dep@2.0.0"),
     "+ optional-native@1.0.0",
     "+ peer-deps-too@1.0.0",
     "+ two-range-deps@1.0.0",
-    "+ uses-what-bin@1.5.0",
-    "+ what-bin@1.0.0",
+    expect.stringContaining("+ uses-what-bin@1.5.0"),
+    expect.stringContaining("+ what-bin@1.0.0"),
     "",
     "19 packages installed",
     "",
@@ -3305,7 +3305,7 @@ test("it should install with missing bun.lockb, node_modules, and/or cache", asy
     expect.stringContaining("bun install v1."),
     "",
     "+ dep-loop-entry@1.0.0",
-    "+ dep-with-tags@3.0.0",
+    expect.stringContaining("+ dep-with-tags@3.0.0"),
     "+ dev-deps@1.0.0",
     "+ left-pad@1.0.0",
     "+ native@1.0.0",
@@ -3314,8 +3314,8 @@ test("it should install with missing bun.lockb, node_modules, and/or cache", asy
     "+ optional-native@1.0.0",
     "+ peer-deps-too@1.0.0",
     "+ two-range-deps@1.0.0",
-    "+ uses-what-bin@1.5.0",
-    "+ what-bin@1.0.0",
+    expect.stringContaining("+ uses-what-bin@1.5.0"),
+    expect.stringContaining("+ what-bin@1.0.0"),
     "",
     "19 packages installed",
     "",
@@ -3777,7 +3777,7 @@ describe("hoisting", async () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "+ peer-deps-fixed@1.0.0",
       "",
       "2 packages installed",
@@ -4004,7 +4004,7 @@ describe("hoisting", async () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "",
       "1 package installed",
     ]);
@@ -5060,7 +5060,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.0",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.0",
-      "+ file-dep@1.0.0",
+      expect.stringContaining("+ file-dep@1.0.0"),
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
@@ -5091,7 +5091,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.0",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.0",
-      "+ file-dep@1.0.0",
+      expect.stringContaining("+ file-dep@1.0.0"),
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
@@ -5153,7 +5153,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.1",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.1",
-      "+ file-dep@1.0.1",
+      expect.stringContaining("+ file-dep@1.0.1"),
       "+ missing-file-dep@1.0.1",
       "+ self-file-dep@1.0.1",
       "",
@@ -5176,7 +5176,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.1",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.1",
-      "+ file-dep@1.0.1",
+      expect.stringContaining("+ file-dep@1.0.1"),
       "+ missing-file-dep@1.0.1",
       "+ self-file-dep@1.0.1",
       "",
@@ -5211,7 +5211,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.0",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.0",
-      "+ file-dep@1.0.0",
+      expect.stringContaining("+ file-dep@1.0.0"),
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
@@ -5242,7 +5242,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.0",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.0",
-      "+ file-dep@1.0.0",
+      expect.stringContaining("+ file-dep@1.0.0"),
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
@@ -5297,7 +5297,7 @@ describe("transitive file dependencies", () => {
       "+ @scoped/file-dep@1.0.0",
       "+ aliased-file-dep@1.0.1",
       "+ dep-file-dep@1.0.0",
-      "+ file-dep@1.0.0",
+      expect.stringContaining("+ file-dep@1.0.0"),
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
@@ -5924,7 +5924,13 @@ describe("update", () => {
     let { out } = await runBunUpdate(env, packageDir, ["--no-save"]);
     assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
 
-    expect(out).toEqual([expect.stringContaining("bun update v1."), "", "+ a-dep@1.0.1", "", "1 package installed"]);
+    expect(out).toEqual([
+      expect.stringContaining("bun update v1."),
+      "",
+      expect.stringContaining("+ a-dep@1.0.1"),
+      "",
+      "1 package installed",
+    ]);
     expect(await file(packageJson).json()).toEqual({
       name: "foo",
       dependencies: {
@@ -5945,7 +5951,13 @@ describe("update", () => {
     ({ out } = await runBunUpdate(env, packageDir, ["--no-save"]));
     assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
 
-    expect(out).toEqual([expect.stringContaining("bun update v1."), "", "+ a-dep@1.0.10", "", "1 package installed"]);
+    expect(out).toEqual([
+      expect.stringContaining("bun update v1."),
+      "",
+      expect.stringContaining("+ a-dep@1.0.10"),
+      "",
+      "1 package installed",
+    ]);
     expect(await file(packageJson).json()).toEqual({
       name: "foo",
       dependencies: {
@@ -6075,17 +6087,17 @@ describe("update", () => {
       "",
       "+ a-dep@1.0.10",
       "+ dep-loop-entry@1.0.0",
-      "+ dep-with-tags@2.0.1",
+      expect.stringContaining("+ dep-with-tags@2.0.1"),
       "+ dev-deps@1.0.0",
       "+ left-pad@1.0.0",
       "+ native@1.0.0",
       "+ no-deps-bins@2.0.0",
-      "+ one-fixed-dep@1.0.0",
+      expect.stringContaining("+ one-fixed-dep@1.0.0"),
       "+ optional-native@1.0.0",
       "+ peer-deps-too@1.0.0",
       "+ two-range-deps@1.0.0",
-      "+ uses-what-bin@1.5.0",
-      "+ what-bin@1.5.0",
+      expect.stringContaining("+ uses-what-bin@1.5.0"),
+      expect.stringContaining("+ what-bin@1.5.0"),
       "",
       // Due to optional-native dependency, this can be either 20 or 19 packages
       expect.stringMatching(/(?:20|19) packages installed/),
@@ -6223,7 +6235,7 @@ describe("update", () => {
         expect(out).toEqual([
           expect.stringContaining("bun update v1."),
           "",
-          args ? "installed a-dep@1.0.10" : "+ a-dep@1.0.10",
+          args ? "installed a-dep@1.0.10" : expect.stringContaining("+ a-dep@1.0.10"),
           "",
           "1 package installed",
         ]);
@@ -6646,7 +6658,7 @@ test("missing package on reinstall, some with binaries", async () => {
     expect.stringContaining("bun install v1."),
     "",
     "+ dep-loop-entry@1.0.0",
-    "+ dep-with-tags@3.0.0",
+    expect.stringContaining("+ dep-with-tags@3.0.0"),
     "+ dev-deps@1.0.0",
     "+ left-pad@1.0.0",
     "+ native@1.0.0",
@@ -6655,8 +6667,8 @@ test("missing package on reinstall, some with binaries", async () => {
     "+ optional-native@1.0.0",
     "+ peer-deps-too@1.0.0",
     "+ two-range-deps@1.0.0",
-    "+ uses-what-bin@1.5.0",
-    "+ what-bin@1.0.0",
+    expect.stringContaining("+ uses-what-bin@1.5.0"),
+    expect.stringContaining("+ what-bin@1.0.0"),
     "",
     "19 packages installed",
     "",
@@ -7181,7 +7193,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ what-bin@1.0.0",
+        expect.stringContaining("+ what-bin@1.0.0"),
         "",
         "1 package installed",
       ]);
@@ -7244,7 +7256,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ what-bin@1.0.0",
+        expect.stringContaining("+ what-bin@1.0.0"),
         "",
         "1 package installed",
       ]);
@@ -8129,7 +8141,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ uses-what-bin@1.0.0",
+        expect.stringContaining("+ uses-what-bin@1.0.0"),
         "+ what-bin@1.5.0",
         "",
         "3 packages installed",
@@ -8210,8 +8222,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ uses-what-bin@1.5.0",
-        "+ what-bin@1.0.0",
+        expect.stringContaining("+ uses-what-bin@1.5.0"),
+        expect.stringContaining("+ what-bin@1.0.0"),
         "",
         "3 packages installed",
       ]);
@@ -8330,7 +8342,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect.stringContaining("bun install v1."),
         "",
         "+ electron@1.0.0",
-        "+ uses-what-bin@1.0.0",
+        expect.stringContaining("+ uses-what-bin@1.0.0"),
         "",
         "3 packages installed",
         "",
@@ -8380,7 +8392,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect.stringContaining("bun install v1."),
         "",
         "+ electron@1.0.0",
-        "+ uses-what-bin@1.0.0",
+        expect.stringContaining("+ uses-what-bin@1.0.0"),
         "",
         "3 packages installed",
         "",
@@ -8428,7 +8440,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect.stringContaining("bun install v1."),
         "",
         "+ electron@1.0.0",
-        "+ uses-what-bin@1.0.0",
+        expect.stringContaining("+ uses-what-bin@1.0.0"),
         "",
         "3 packages installed",
         "",
@@ -8861,7 +8873,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
           expect.stringContaining("bun install v1."),
           "",
-          "+ uses-what-bin@1.0.0",
+          expect.stringContaining("+ uses-what-bin@1.0.0"),
           "",
           "2 packages installed",
         ]);
@@ -8934,7 +8946,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
           expect.stringContaining("bun install v1."),
           "",
-          "+ uses-what-bin@1.0.0",
+          expect.stringContaining("+ uses-what-bin@1.0.0"),
           "",
           "2 packages installed",
         ]);
@@ -9189,7 +9201,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ uses-what-bin@1.5.0",
+        expect.stringContaining("+ uses-what-bin@1.5.0"),
         "",
         "2 packages installed",
         "",
@@ -9270,8 +9282,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
             expect.stringContaining("bun install v1."),
             "",
-            "+ no-deps@1.0.0",
-            "+ uses-what-bin@1.0.0",
+            expect.stringContaining("+ no-deps@1.0.0"),
+            expect.stringContaining("+ uses-what-bin@1.0.0"),
             "",
             "3 packages installed",
             "",
@@ -9390,7 +9402,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           expected = withRm
             ? [
                 "",
-                "+ uses-what-bin@1.0.0",
+                expect.stringContaining("+ uses-what-bin@1.0.0"),
                 "",
                 "1 package installed",
                 "",
@@ -9594,7 +9606,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         "install stdout 🚀",
         "prepare stdout done ✅",
         "",
-        "+ no-deps@1.0.0",
+        expect.stringContaining("+ no-deps@1.0.0"),
         "",
         "1 package installed",
       ]);
@@ -9682,7 +9694,7 @@ describe("pm trust", async () => {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ uses-what-bin@1.0.0",
+        expect.stringContaining("+ uses-what-bin@1.0.0"),
         "",
         "2 packages installed",
         "",
@@ -9757,7 +9769,7 @@ test("it should be able to find binary in node_modules/.bin from parent director
   expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
-    "+ what-bin@1.0.0",
+    expect.stringContaining("+ what-bin@1.0.0"),
     "",
     "1 package installed",
   ]);
@@ -9896,7 +9908,7 @@ describe("semver", () => {
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        `+ dep-with-tags@${expected}`,
+        expect.stringContaining(`+ dep-with-tags@${expected}`),
         "",
         "1 package installed",
       ]);
@@ -10881,7 +10893,7 @@ describe("yarn tests", () => {
       expect.stringContaining("bun install v1."),
       "",
       "+ first@1.0.0",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "+ second@1.0.0",
       "",
       "2 packages installed",
@@ -11072,7 +11084,7 @@ describe("yarn tests", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "+ peer-deps-fixed@1.0.0",
       "",
       "2 packages installed",
@@ -11329,7 +11341,7 @@ describe("yarn tests", () => {
       "",
       "+ forward-peer-deps@1.0.0",
       "+ forward-peer-deps-too@1.0.0",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "",
       "4 packages installed",
     ]);
@@ -11393,7 +11405,7 @@ describe("yarn tests", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "+ no-deps@1.0.0",
+      expect.stringContaining("+ no-deps@1.0.0"),
       "+ peer-deps@1.0.0",
       "+ peer-deps-too@1.0.0",
       "",


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
