### PR TITLE
rename `CallFrame.arguments_old` to `argumentsDeprecated`

### DIFF
--- a/src/bun.js/BuildMessage.zig
+++ b/src/bun.js/BuildMessage.zig
@@ -86,7 +86,7 @@ pub const BuildMessage = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const args_ = callframe.arguments_old(1);
+        const args_ = callframe.deprecatedArguments(1);
         const args = args_.ptr[0..args_.len];
         if (args.len > 0) {
             if (!args[0].isString()) {

--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -116,7 +116,7 @@ pub const ResolveMessage = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const args_ = callframe.arguments_old(1);
+        const args_ = callframe.deprecatedArguments(1);
         const args = args_.ptr[0..args_.len];
         if (args.len > 0) {
             if (!args[0].isString()) {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -260,7 +260,7 @@ const Braces = @import("../../shell/braces.zig");
 const Shell = @import("../../shell/shell.zig");
 
 pub fn shellEscape(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
     if (arguments.len < 1) {
         globalThis.throw("shell escape expected at least 1 argument", .{});
         return .undefined;
@@ -291,7 +291,7 @@ pub fn shellEscape(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) b
 }
 
 pub fn braces(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments_ = callframe.arguments_old(2);
+    const arguments_ = callframe.deprecatedArguments(2);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer arguments.deinit();
 
@@ -392,7 +392,7 @@ pub fn braces(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JS
 }
 
 pub fn which(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments_ = callframe.arguments_old(2);
+    const arguments_ = callframe.deprecatedArguments(2);
     var path_buf: bun.PathBuffer = undefined;
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer arguments.deinit();
@@ -460,7 +460,7 @@ pub fn which(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
 }
 
 pub fn inspectTable(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    var args_buf = callframe.argumentsUndef(5);
+    var args_buf = callframe.arguments(5);
     var all_arguments = args_buf.mut();
     if (all_arguments[0].isUndefined() or all_arguments[0].isNull())
         return bun.String.empty.toJS(globalThis);
@@ -532,7 +532,7 @@ pub fn inspectTable(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) 
 }
 
 pub fn inspect(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(4).slice();
+    const arguments = callframe.deprecatedArguments(4).slice();
     if (arguments.len == 0)
         return bun.String.empty.toJS(globalThis);
 
@@ -598,7 +598,7 @@ pub fn getInspect(globalObject: *JSC.JSGlobalObject, _: *JSC.JSObject) JSC.JSVal
 }
 
 pub fn registerMacro(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments_ = callframe.arguments_old(2);
+    const arguments_ = callframe.deprecatedArguments(2);
     const arguments = arguments_.slice();
     if (arguments.len != 2 or !arguments[0].isNumber()) {
         return globalObject.throwInvalidArguments("Internal error registering macros: invalid args", .{});
@@ -729,7 +729,7 @@ const Editor = @import("../../open.zig").Editor;
 
 pub fn openInEditor(globalThis: js.JSContextRef, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     var edit = &VirtualMachine.get().rareData().editor_context;
-    const args = callframe.arguments_old(4);
+    const args = callframe.deprecatedArguments(4);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), args.slice());
     defer arguments.deinit();
     var path: string = "";
@@ -846,7 +846,7 @@ pub fn getPublicPathWithAssetPrefix(
 }
 
 pub fn sleepSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
 
     // Expect at least one argument.  We allow more than one but ignore them; this
     //  is useful for supporting things like `[1, 2].map(sleepSync)`
@@ -876,7 +876,7 @@ pub fn generateHeapSnapshot(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame
 }
 
 pub fn runGC(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments_ = callframe.arguments_old(1);
+    const arguments_ = callframe.deprecatedArguments(1);
     const arguments = arguments_.slice();
     return globalObject.bunVM().garbageCollect(arguments.len > 0 and arguments[0].isBoolean() and arguments[0].toBoolean());
 }
@@ -982,12 +982,12 @@ fn doResolveWithArgs(ctx: js.JSContextRef, specifier: bun.String, from: bun.Stri
 }
 
 pub fn resolveSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     return try doResolve(globalObject, arguments.slice());
 }
 
 pub fn resolve(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     const value = doResolve(globalObject, arguments.slice()) catch {
         const err = globalObject.tryTakeException().?;
         return JSC.JSPromise.rejectedPromiseValue(globalObject, err);
@@ -1042,7 +1042,7 @@ fn dump_mimalloc(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSErr
 }
 
 pub fn indexOfLine(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments_ = callframe.arguments_old(2);
+    const arguments_ = callframe.deprecatedArguments(2);
     const arguments = arguments_.slice();
     if (arguments.len == 0) {
         return JSC.JSValue.jsNumberFromInt32(-1);
@@ -2106,7 +2106,7 @@ pub const Crypto = struct {
 
         // Once we have bindings generator, this should be replaced with a generated function
         pub fn JSPasswordObject__hash(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments_ = callframe.arguments_old(2);
+            const arguments_ = callframe.deprecatedArguments(2);
             const arguments = arguments_.ptr[0..arguments_.len];
 
             if (arguments.len < 1) {
@@ -2136,7 +2136,7 @@ pub const Crypto = struct {
 
         // Once we have bindings generator, this should be replaced with a generated function
         pub fn JSPasswordObject__hashSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments_ = callframe.arguments_old(2);
+            const arguments_ = callframe.deprecatedArguments(2);
             const arguments = arguments_.ptr[0..arguments_.len];
 
             if (arguments.len < 1) {
@@ -2253,7 +2253,7 @@ pub const Crypto = struct {
 
         // Once we have bindings generator, this should be replaced with a generated function
         pub fn JSPasswordObject__verify(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments_ = callframe.arguments_old(3);
+            const arguments_ = callframe.deprecatedArguments(3);
             const arguments = arguments_.ptr[0..arguments_.len];
 
             if (arguments.len < 2) {
@@ -2304,7 +2304,7 @@ pub const Crypto = struct {
 
         // Once we have bindings generator, this should be replaced with a generated function
         pub fn JSPasswordObject__verifySync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments_ = callframe.arguments_old(3);
+            const arguments_ = callframe.deprecatedArguments(3);
             const arguments = arguments_.ptr[0..arguments_.len];
 
             if (arguments.len < 2) {
@@ -2493,7 +2493,7 @@ pub const Crypto = struct {
 
         // Bun.CryptoHasher(algorithm, hmacKey?: string | Buffer)
         pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*CryptoHasher {
-            const arguments = callframe.arguments_old(2);
+            const arguments = callframe.deprecatedArguments(2);
             if (arguments.len == 0) {
                 return globalThis.throwInvalidArguments("Expected an algorithm name as an argument", .{});
             }
@@ -2565,7 +2565,7 @@ pub const Crypto = struct {
 
         pub fn update(this: *CryptoHasher, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             const thisValue = callframe.this();
-            const arguments = callframe.arguments_old(2);
+            const arguments = callframe.deprecatedArguments(2);
             const input = arguments.ptr[0];
             if (input.isEmptyOrUndefinedOrNull()) {
                 return globalThis.throwInvalidArguments("expected blob, string or buffer", .{});
@@ -3126,7 +3126,7 @@ pub fn nanoseconds(globalThis: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSErr
 }
 
 pub fn serve(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(2).slice();
+    const arguments = callframe.deprecatedArguments(2).slice();
     var config: JSC.API.ServerConfig = brk: {
         var args = JSC.Node.ArgumentsSlice.init(globalObject.bunVM(), arguments);
         var config: JSC.API.ServerConfig = .{};
@@ -3313,7 +3313,7 @@ comptime {
 }
 
 pub fn allocUnsafe(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
     const size = arguments.ptr[0];
     if (!size.isUInt32AsAnyInt()) {
         return globalThis.throwInvalidArguments("Expected a positive number", .{});
@@ -3327,7 +3327,7 @@ pub fn mmapFile(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.
         return globalThis.throwTODO("mmapFile is not supported on Windows");
     }
 
-    const arguments_ = callframe.arguments_old(2);
+    const arguments_ = callframe.deprecatedArguments(2);
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer args.deinit();
 
@@ -3446,7 +3446,7 @@ const HashObject = struct {
         return struct {
             const Hasher = Hasher_;
             pub fn hash(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-                const arguments = callframe.arguments_old(2).slice();
+                const arguments = callframe.deprecatedArguments(2).slice();
                 var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments);
                 defer args.deinit();
 
@@ -3592,7 +3592,7 @@ const UnsafeObject = struct {
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
         const ret = JSValue.jsNumber(@as(i32, @intFromEnum(globalThis.bunVM().aggressive_garbage_collection)));
-        const value = callframe.arguments_old(1).ptr[0];
+        const value = callframe.deprecatedArguments(1).ptr[0];
 
         if (!value.isEmptyOrUndefinedOrNull()) {
             switch (value.coerce(i32, globalThis)) {
@@ -3609,7 +3609,7 @@ const UnsafeObject = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const args = callframe.arguments_old(2).slice();
+        const args = callframe.deprecatedArguments(2).slice();
         if (args.len < 1 or !args[0].isCell() or !args[0].jsType().isTypedArray()) {
             return globalThis.throwInvalidArguments("Expected an ArrayBuffer", .{});
         }
@@ -3657,7 +3657,7 @@ const TOMLObject = struct {
         const allocator = arena.allocator();
         defer arena.deinit();
         var log = logger.Log.init(default_allocator);
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         if (arguments.len == 0 or arguments[0].isEmptyOrUndefinedOrNull()) {
             return globalThis.throwInvalidArguments("Expected a string to parse", .{});
         }
@@ -4321,7 +4321,7 @@ pub const FFIObject = struct {
 };
 
 fn stringWidth(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(2).slice();
+    const arguments = callframe.deprecatedArguments(2).slice();
     const value = if (arguments.len > 0) arguments[0] else .undefined;
     const options_object = if (arguments.len > 1) arguments[1] else .undefined;
 
@@ -4435,7 +4435,7 @@ pub const JSZlib = struct {
 
     // This has to be `inline` due to the callframe.
     inline fn getOptions(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!struct { JSC.Node.StringOrBuffer, ?JSValue } {
-        const arguments = callframe.arguments_old(2).slice();
+        const arguments = callframe.deprecatedArguments(2).slice();
         const buffer_value = if (arguments.len > 0) arguments[0] else .undefined;
         const options_val: ?JSValue =
             if (arguments.len > 1 and arguments[1].isObject())
@@ -4726,7 +4726,7 @@ pub usingnamespace @import("./bun/subprocess.zig");
 
 const InternalTestingAPIs = struct {
     pub fn BunInternalFunction__syntaxHighlighter(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         if (args.len < 1) {
             globalThis.throwNotEnoughArguments("code", 1, 0);
         }

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -708,7 +708,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
 
 pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*Transpiler {
     var temp = bun.ArenaAllocator.init(getAllocator(globalThis));
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     var args = JSC.Node.ArgumentsSlice.init(
         globalThis.bunVM(),
         arguments.slice(),
@@ -838,7 +838,7 @@ pub fn scan(
     callframe: *JSC.CallFrame,
 ) bun.JSError!JSC.JSValue {
     JSC.markBinding(@src());
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.slice());
     defer args.deinit();
     const code_arg = args.next() orelse {
@@ -919,7 +919,7 @@ pub fn transform(
     callframe: *JSC.CallFrame,
 ) bun.JSError!JSC.JSValue {
     JSC.markBinding(@src());
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.slice());
     defer args.arena.deinit();
     const code_arg = args.next() orelse {
@@ -968,7 +968,7 @@ pub fn transformSync(
     callframe: *JSC.CallFrame,
 ) bun.JSError!JSC.JSValue {
     JSC.markBinding(@src());
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
 
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.slice());
     defer args.arena.deinit();
@@ -1139,7 +1139,7 @@ fn namedImportsToJS(
 }
 
 pub fn scanImports(this: *Transpiler, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(2);
+    const arguments = callframe.deprecatedArguments(2);
     var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments.slice());
     defer args.deinit();
 

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1634,7 +1634,7 @@ pub const InternalDNS = struct {
     }
 
     pub fn prefetchFromJS(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2).slice();
+        const arguments = callframe.deprecatedArguments(2).slice();
 
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("prefetch", 1, arguments.len);
@@ -2251,7 +2251,7 @@ pub const DNSResolver = struct {
     };
 
     pub fn resolve(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(3);
+        const arguments = callframe.deprecatedArguments(3);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolve", 2, arguments.len);
         }
@@ -2335,7 +2335,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn reverse(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("reverse", 2, arguments.len);
         }
@@ -2399,7 +2399,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn lookup(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("lookup", 2, arguments.len);
         }
@@ -2468,7 +2468,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveSrv(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveSrv", 2, arguments.len);
         }
@@ -2498,7 +2498,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveSoa(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveSoa", 2, arguments.len);
         }
@@ -2523,7 +2523,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveCaa(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveCaa", 2, arguments.len);
         }
@@ -2553,7 +2553,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveNs(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveNs", 2, arguments.len);
         }
@@ -2578,7 +2578,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolvePtr(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolvePtr", 2, arguments.len);
         }
@@ -2608,7 +2608,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveCname(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveCname", 2, arguments.len);
         }
@@ -2638,7 +2638,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveMx(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveMx", 2, arguments.len);
         }
@@ -2668,7 +2668,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveNaptr(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveNaptr", 2, arguments.len);
         }
@@ -2698,7 +2698,7 @@ pub const DNSResolver = struct {
     }
 
     pub fn resolveTxt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         if (arguments.len < 1) {
             return globalThis.throwNotEnoughArguments("resolveTxt", 2, arguments.len);
         }
@@ -2904,7 +2904,7 @@ pub const DNSResolver = struct {
     // If address is not a valid IP address, a TypeError will be thrown. The port will be coerced to a number.
     // If it is not a legal port, a TypeError will be thrown.
     pub fn lookupService(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(3);
+        const arguments = callframe.deprecatedArguments(3);
         if (arguments.len < 2) {
             return globalThis.throwNotEnoughArguments("lookupService", 3, arguments.len);
         }

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -294,7 +294,7 @@ fn jsGetUnpackedSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.Call
     JSC.markBinding(@src());
     var settings: FullSettingsPayload = .{};
 
-    const args_list = callframe.arguments_old(1);
+    const args_list = callframe.deprecatedArguments(1);
     if (args_list.len < 1) {
         return settings.toJS(globalObject);
     }
@@ -326,7 +326,7 @@ fn jsGetUnpackedSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.Call
 }
 
 fn jsAssertSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const args_list = callframe.arguments_old(1);
+    const args_list = callframe.deprecatedArguments(1);
     if (args_list.len < 1) {
         globalObject.throw("Expected settings to be a object", .{});
         return .zero;
@@ -429,7 +429,7 @@ fn jsAssertSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame
 
 fn jsGetPackedSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     var settings: FullSettingsPayload = .{};
-    const args_list = callframe.arguments_old(1);
+    const args_list = callframe.deprecatedArguments(1);
 
     if (args_list.len > 0 and !args_list.ptr[0].isEmptyOrUndefinedOrNull()) {
         const options = args_list.ptr[0];
@@ -2334,7 +2334,7 @@ pub const H2FrameParser = struct {
 
     pub fn setEncoding(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected encoding argument", .{});
             return .zero;
@@ -2437,7 +2437,7 @@ pub const H2FrameParser = struct {
 
     pub fn updateSettings(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected settings argument", .{});
             return .zero;
@@ -2468,7 +2468,7 @@ pub const H2FrameParser = struct {
     }
     pub fn goaway(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(3);
+        const args_list = callframe.deprecatedArguments(3);
         if (args_list.len < 1) {
             globalObject.throw("Expected errorCode argument", .{});
             return .zero;
@@ -2519,7 +2519,7 @@ pub const H2FrameParser = struct {
 
     pub fn ping(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected payload argument", .{});
             return .zero;
@@ -2543,7 +2543,7 @@ pub const H2FrameParser = struct {
 
     pub fn getEndAfterHeaders(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected stream argument", .{});
             return .zero;
@@ -2571,7 +2571,7 @@ pub const H2FrameParser = struct {
 
     pub fn isStreamAborted(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected stream argument", .{});
             return .zero;
@@ -2602,7 +2602,7 @@ pub const H2FrameParser = struct {
     }
     pub fn getStreamState(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected stream argument", .{});
             return .zero;
@@ -2639,7 +2639,7 @@ pub const H2FrameParser = struct {
 
     pub fn setStreamPriority(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(2);
+        const args_list = callframe.deprecatedArguments(2);
         if (args_list.len < 2) {
             globalObject.throw("Expected stream and options arguments", .{});
             return .zero;
@@ -2738,7 +2738,7 @@ pub const H2FrameParser = struct {
     }
     pub fn rstStream(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(2);
+        const args_list = callframe.deprecatedArguments(2);
         if (args_list.len < 2) {
             globalObject.throw("Expected stream and code arguments", .{});
             return .zero;
@@ -2895,7 +2895,7 @@ pub const H2FrameParser = struct {
     }
     pub fn noTrailers(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected stream, headers and sensitiveHeaders arguments", .{});
             return .zero;
@@ -2936,7 +2936,7 @@ pub const H2FrameParser = struct {
 
     pub fn sendTrailers(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(3);
+        const args_list = callframe.deprecatedArguments(3);
         if (args_list.len < 3) {
             return globalObject.throw2("Expected stream, headers and sensitiveHeaders arguments", .{});
         }
@@ -3078,7 +3078,7 @@ pub const H2FrameParser = struct {
     }
     pub fn writeStream(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args = callframe.argumentsUndef(5);
+        const args = callframe.arguments(5);
         const stream_arg, const data_arg, const encoding_arg, const close_arg, const callback_arg = args.ptr;
 
         if (!stream_arg.isNumber()) {
@@ -3168,7 +3168,7 @@ pub const H2FrameParser = struct {
 
     pub fn getStreamContext(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected stream_id argument", .{});
             return .zero;
@@ -3190,7 +3190,7 @@ pub const H2FrameParser = struct {
 
     pub fn setStreamContext(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(2);
+        const args_list = callframe.deprecatedArguments(2);
         if (args_list.len < 2) {
             globalObject.throw("Expected stream_id and context arguments", .{});
             return .zero;
@@ -3251,7 +3251,7 @@ pub const H2FrameParser = struct {
     pub fn emitErrorToAllStreams(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
 
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected error argument", .{});
             return .undefined;
@@ -3283,7 +3283,7 @@ pub const H2FrameParser = struct {
     pub fn request(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
 
-        const args_list = callframe.arguments_old(5);
+        const args_list = callframe.deprecatedArguments(5);
         if (args_list.len < 4) {
             globalObject.throw("Expected stream_id, stream_ctx, headers and sensitiveHeaders arguments", .{});
             return .zero;
@@ -3623,7 +3623,7 @@ pub const H2FrameParser = struct {
 
     pub fn read(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected 1 argument", .{});
             return .zero;
@@ -3665,7 +3665,7 @@ pub const H2FrameParser = struct {
 
     pub fn setNativeSocketFromJS(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             globalObject.throw("Expected socket argument", .{});
             return .zero;
@@ -3716,7 +3716,7 @@ pub const H2FrameParser = struct {
     }
 
     pub fn constructor(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*H2FrameParser {
-        const args_list = callframe.arguments_old(1);
+        const args_list = callframe.deprecatedArguments(1);
         if (args_list.len < 1) {
             return globalObject.throw2("Expected 1 argument", .{});
         }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -546,7 +546,7 @@ pub const Listener = struct {
     };
 
     pub fn reload(this: *Listener, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
 
         if (args.len < 1 or (this.listener == .none and this.handlers.active_connections == 0)) {
             globalObject.throw("Expected 1 argument", .{});
@@ -911,7 +911,7 @@ pub const Listener = struct {
     }
 
     pub fn stop(this: *Listener, _: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(1);
+        const arguments = callframe.deprecatedArguments(1);
         log("close", .{});
 
         this.doStop(if (arguments.len > 0 and arguments.ptr[0].isBoolean()) arguments.ptr[0].toBoolean() else false);
@@ -1454,7 +1454,7 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn setKeepAlive(this: *This, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
-            const args = callframe.arguments_old(2);
+            const args = callframe.deprecatedArguments(2);
 
             const enabled: bool = brk: {
                 if (args.len >= 1) {
@@ -1483,7 +1483,7 @@ fn NewSocket(comptime ssl: bool) type {
         pub fn setNoDelay(this: *This, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
 
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
             const enabled: bool = brk: {
                 if (args.len >= 1) {
                     break :brk args.ptr[0].coerce(bool, globalThis);
@@ -2017,7 +2017,7 @@ fn NewSocket(comptime ssl: bool) type {
             callframe: *JSC.CallFrame,
         ) bun.JSError!JSValue {
             JSC.markBinding(@src());
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
             if (this.socket.isDetached()) return JSValue.jsUndefined();
             if (args.len == 0) {
                 globalObject.throw("Expected 1 argument, got 0", .{});
@@ -2076,7 +2076,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsNumber(@as(i32, -1));
             }
 
-            var args = callframe.argumentsUndef(5);
+            var args = callframe.arguments(5);
 
             return switch (this.writeOrEnd(globalObject, args.mut(), false, false)) {
                 .fail => .zero,
@@ -2152,7 +2152,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsBoolean(false);
             }
 
-            const args = callframe.argumentsUndef(2);
+            const args = callframe.arguments(2);
 
             return switch (this.writeOrEndBuffered(globalObject, args.ptr[0], args.ptr[1], false)) {
                 .fail => .zero,
@@ -2170,7 +2170,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsBoolean(false);
             }
 
-            const args = callframe.argumentsUndef(2);
+            const args = callframe.arguments(2);
 
             return switch (this.writeOrEndBuffered(globalObject, args.ptr[0], args.ptr[1], false)) {
                 .fail => .zero,
@@ -2463,7 +2463,7 @@ fn NewSocket(comptime ssl: bool) type {
             callframe: *JSC.CallFrame,
         ) bun.JSError!JSValue {
             JSC.markBinding(@src());
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
             this.buffered_data_for_node_net.deinitWithAllocator(bun.default_allocator);
             if (args.len > 0 and args.ptr[0].toBoolean()) {
                 this.socket.shutdownRead();
@@ -2481,7 +2481,7 @@ fn NewSocket(comptime ssl: bool) type {
         ) bun.JSError!JSValue {
             JSC.markBinding(@src());
 
-            var args = callframe.argumentsUndef(5);
+            var args = callframe.arguments(5);
 
             log("end({d} args)", .{args.len});
 
@@ -2557,7 +2557,7 @@ fn NewSocket(comptime ssl: bool) type {
         }
 
         pub fn reload(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
 
             if (args.len < 1) {
                 globalObject.throw("Expected 1 argument", .{});
@@ -2614,7 +2614,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsUndefined();
             }
 
-            const args = callframe.arguments_old(2);
+            const args = callframe.deprecatedArguments(2);
 
             if (args.len < 2) {
                 globalObject.throw("Expected requestCert and rejectUnauthorized arguments", .{});
@@ -2696,7 +2696,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsUndefined();
             }
 
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
 
             if (args.len < 1) {
                 globalObject.throw("Expected session to be a string, Buffer or TypedArray", .{});
@@ -2795,7 +2795,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsUndefined();
             }
 
-            const args = callframe.arguments_old(3);
+            const args = callframe.deprecatedArguments(3);
             if (args.len < 2) {
                 globalObject.throw("Expected length and label to be provided", .{});
                 return .zero;
@@ -3145,7 +3145,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsBoolean(false);
             }
 
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
 
             if (args.len < 1) {
                 globalObject.throw("Expected size to be a number", .{});
@@ -3180,7 +3180,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return JSValue.jsUndefined();
             }
 
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
             var abbreviated: bool = true;
             if (args.len > 0) {
                 const arg = args.ptr[0];
@@ -3268,7 +3268,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return .zero;
             }
 
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
             if (args.len < 1) {
                 globalObject.throw("Expected 1 argument", .{});
                 return .zero;
@@ -3322,7 +3322,7 @@ fn NewSocket(comptime ssl: bool) type {
             if (this.socket.isDetached() or this.socket.isNamedPipe()) {
                 return JSValue.jsUndefined();
             }
-            const args = callframe.arguments_old(1);
+            const args = callframe.deprecatedArguments(1);
 
             if (args.len < 1) {
                 globalObject.throw("Expected 1 arguments", .{});
@@ -4211,7 +4211,7 @@ pub const WindowsNamedPipeContext = if (Environment.isWindows) struct {
 pub fn jsAddServerName(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     JSC.markBinding(@src());
 
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     if (arguments.len < 3) {
         return global.throwNotEnoughArguments("addServerName", 3, arguments.len);
     }
@@ -4225,7 +4225,7 @@ pub fn jsAddServerName(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) b
 pub fn jsUpgradeDuplexToTLS(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     JSC.markBinding(@src());
 
-    const args = callframe.arguments_old(2);
+    const args = callframe.deprecatedArguments(2);
     if (args.len < 2) {
         globalObject.throw("Expected 2 arguments", .{});
         return .zero;
@@ -4336,7 +4336,7 @@ pub fn jsUpgradeDuplexToTLS(globalObject: *JSC.JSGlobalObject, callframe: *JSC.C
 pub fn jsIsNamedPipeSocket(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     JSC.markBinding(@src());
 
-    const arguments = callframe.arguments_old(3);
+    const arguments = callframe.deprecatedArguments(3);
     if (arguments.len < 1) {
         return global.throwNotEnoughArguments("isNamedPipeSocket", 1, arguments.len);
     }

--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -360,7 +360,7 @@ pub const UDPSocket = struct {
             globalThis.throw("Socket is closed", .{});
             return .zero;
         }
-        const arguments = callframe.arguments_old(1);
+        const arguments = callframe.deprecatedArguments(1);
         if (arguments.len != 1) {
             return globalThis.throwInvalidArguments("Expected 1 argument, got {}", .{arguments.len});
         }
@@ -444,7 +444,7 @@ pub const UDPSocket = struct {
             globalThis.throw("Socket is closed", .{});
             return .zero;
         }
-        const arguments = callframe.arguments_old(3);
+        const arguments = callframe.deprecatedArguments(3);
         const dst: ?Destination = brk: {
             if (this.connect_info != null) {
                 if (arguments.len == 1) {
@@ -562,7 +562,7 @@ pub const UDPSocket = struct {
     }
 
     pub fn reload(this: *This, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
 
         if (args.len < 1) {
             return globalThis.throwInvalidArguments("Expected 1 argument", .{});
@@ -665,7 +665,7 @@ pub const UDPSocket = struct {
     }
 
     pub fn jsConnect(globalThis: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const args = callFrame.arguments_old(2);
+        const args = callFrame.deprecatedArguments(2);
 
         const this = callFrame.this().as(UDPSocket) orelse {
             return globalThis.throwInvalidArguments("Expected UDPSocket as 'this'", .{});

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -623,7 +623,7 @@ pub const FFI = struct {
     };
 
     pub fn Bun__FFI__cc(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         if (arguments.len == 0 or !arguments[0].isObject()) {
             return globalThis.throwInvalidArguments("Expected object", .{});
         }

--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -50,7 +50,7 @@ pub const FileSystemRouter = struct {
     pub usingnamespace JSC.Codegen.JSFileSystemRouter;
 
     pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*FileSystemRouter {
-        const argument_ = callframe.arguments_old(1);
+        const argument_ = callframe.deprecatedArguments(1);
         if (argument_.len == 0) {
             return globalThis.throwInvalidArguments("Expected object", .{});
         }
@@ -246,7 +246,7 @@ pub const FileSystemRouter = struct {
     }
 
     pub fn match(this: *FileSystemRouter, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
-        const argument_ = callframe.arguments_old(2);
+        const argument_ = callframe.deprecatedArguments(2);
         if (argument_.len == 0) {
             return globalThis.throwInvalidArguments("Expected string, Request or Response", .{});
         }

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -309,7 +309,7 @@ fn makeGlobWalker(
 pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*Glob {
     const alloc = getAllocator(globalThis);
 
-    const arguments_ = callframe.arguments_old(1);
+    const arguments_ = callframe.deprecatedArguments(1);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer arguments.deinit();
     const pat_arg: JSValue = arguments.nextEat() orelse {
@@ -368,7 +368,7 @@ fn decrPendingActivityFlag(has_pending_activity: *std.atomic.Value(usize)) void 
 pub fn __scan(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     const alloc = getAllocator(globalThis);
 
-    const arguments_ = callframe.arguments_old(1);
+    const arguments_ = callframe.deprecatedArguments(1);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer arguments.deinit();
 
@@ -392,7 +392,7 @@ pub fn __scan(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFram
 pub fn __scanSync(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     const alloc = getAllocator(globalThis);
 
-    const arguments_ = callframe.arguments_old(1);
+    const arguments_ = callframe.deprecatedArguments(1);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer arguments.deinit();
 
@@ -423,7 +423,7 @@ pub fn match(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame
     var arena = Arena.init(alloc);
     defer arena.deinit();
 
-    const arguments_ = callframe.arguments_old(1);
+    const arguments_ = callframe.deprecatedArguments(1);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     defer arguments.deinit();
     const str_arg = arguments.nextEat() orelse {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1920,7 +1920,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         pub fn onResolve(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             ctxLog("onResolve", .{});
 
-            const arguments = callframe.arguments_old(2);
+            const arguments = callframe.deprecatedArguments(2);
             var ctx = arguments.ptr[1].asPromisePtr(@This());
             defer ctx.deref();
 
@@ -2065,7 +2065,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         pub fn onReject(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             ctxLog("onReject", .{});
 
-            const arguments = callframe.arguments_old(2);
+            const arguments = callframe.deprecatedArguments(2);
             const ctx = arguments.ptr[1].asPromisePtr(@This());
             const err = arguments.ptr[0];
             defer ctx.deref();
@@ -3280,7 +3280,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
         pub fn onResolveStream(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             streamLog("onResolveStream", .{});
-            var args = callframe.arguments_old(2);
+            var args = callframe.deprecatedArguments(2);
             var req: *@This() = args.ptr[args.len - 1].asPromisePtr(@This());
             defer req.deref();
             req.handleResolveStream();
@@ -3288,7 +3288,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
         pub fn onRejectStream(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             streamLog("onRejectStream", .{});
-            const args = callframe.arguments_old(2);
+            const args = callframe.deprecatedArguments(2);
             var req = args.ptr[args.len - 1].asPromisePtr(@This());
             const err = args.ptr[0];
             defer req.deref();
@@ -4742,7 +4742,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(4);
+        const args = callframe.deprecatedArguments(4);
         if (args.len < 1) {
             log("publish()", .{});
             globalThis.throw("publish requires at least 1 argument", .{});
@@ -4827,7 +4827,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(4);
+        const args = callframe.deprecatedArguments(4);
 
         if (args.len < 1) {
             log("publish()", .{});
@@ -4890,7 +4890,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(4);
+        const args = callframe.deprecatedArguments(4);
 
         if (args.len < 1) {
             log("publishBinary()", .{});
@@ -5043,7 +5043,7 @@ pub const ServerWebSocket = struct {
         // make sure the `this` value is up to date.
         this_value: JSC.JSValue,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         this.this_value = this_value;
 
         if (args.len < 1) {
@@ -5081,7 +5081,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
 
         if (args.len < 1) {
             log("send()", .{});
@@ -5155,7 +5155,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
 
         if (args.len < 1) {
             log("sendText()", .{});
@@ -5239,7 +5239,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
 
         if (args.len < 1) {
             log("sendBinary()", .{});
@@ -5335,7 +5335,7 @@ pub const ServerWebSocket = struct {
         comptime name: string,
         comptime opcode: uws.Opcode,
     ) JSValue {
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
 
         if (this.isClosed()) {
             return JSValue.jsNumber(0);
@@ -5441,7 +5441,7 @@ pub const ServerWebSocket = struct {
         // Since close() can lead to the close() callback being called, let's always ensure the `this` value is up to date.
         this_value: JSC.JSValue,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
         log("close()", .{});
         this.this_value = this_value;
 
@@ -5482,7 +5482,7 @@ pub const ServerWebSocket = struct {
         this_value: JSC.JSValue,
     ) bun.JSError!JSValue {
         _ = globalThis;
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
         _ = args;
         log("terminate()", .{});
 
@@ -5553,7 +5553,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         if (args.len < 1) {
             globalThis.throw("subscribe requires at least 1 argument", .{});
             return .zero;
@@ -5590,7 +5590,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         if (args.len < 1) {
             globalThis.throw("unsubscribe requires at least 1 argument", .{});
             return .zero;
@@ -5627,7 +5627,7 @@ pub const ServerWebSocket = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         if (args.len < 1) {
             globalThis.throw("isSubscribed requires at least 1 argument", .{});
             return .zero;
@@ -5730,7 +5730,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         pub const doTimeout = JSC.wrapInstanceMethod(ThisServer, "timeout", false);
 
         pub fn doSubscriberCount(this: *ThisServer, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments = callframe.arguments_old(1);
+            const arguments = callframe.deprecatedArguments(1);
             if (arguments.len < 1) {
                 return globalThis.throwNotEnoughArguments("subscriberCount", 1, 0);
             }
@@ -6048,7 +6048,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         }
 
         pub fn onReload(this: *ThisServer, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments = callframe.arguments_old(1).slice();
+            const arguments = callframe.deprecatedArguments(1).slice();
             if (arguments.len < 1) {
                 return globalThis.throwNotEnoughArguments("reload", 1, 0);
             }
@@ -6074,7 +6074,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             callframe: *JSC.CallFrame,
         ) bun.JSError!JSC.JSValue {
             JSC.markBinding(@src());
-            const arguments = callframe.arguments_old(2).slice();
+            const arguments = callframe.deprecatedArguments(2).slice();
             if (arguments.len == 0) {
                 const fetch_error = WebCore.Fetch.fetch_error_no_args;
                 return JSPromise.rejectedPromiseValue(ctx, ZigString.init(fetch_error).toErrorInstance(ctx));

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -6707,7 +6707,8 @@ pub const CallFrame = opaque {
         };
     }
 
-    pub fn arguments_old(self: *const CallFrame, comptime max: usize) Arguments(max) {
+    /// Copy arguments into a buffer of `JSValue.zero` values
+    pub fn deprecatedArguments(self: *const CallFrame, comptime max: usize) Arguments(max) {
         const len = self.argumentsCount();
         const ptr = self.argumentsPtr();
         return switch (@as(u4, @min(len, max))) {
@@ -6717,7 +6718,8 @@ pub const CallFrame = opaque {
         };
     }
 
-    pub fn argumentsUndef(self: *const CallFrame, comptime max: usize) Arguments(max) {
+    /// Copy arguments into a buffer of `JSValue.undefined` values
+    pub fn arguments(self: *const CallFrame, comptime max: usize) Arguments(max) {
         const len = self.argumentsCount();
         const ptr = self.argumentsPtr();
         return switch (@as(u4, @min(len, max))) {

--- a/src/bun.js/node/node_cluster_binding.zig
+++ b/src/bun.js/node/node_cluster_binding.zig
@@ -15,7 +15,7 @@ pub var child_singleton: InternalMsgHolder = .{};
 pub fn sendHelperChild(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     log("sendHelperChild", .{});
 
-    const arguments = callframe.arguments_old(3).ptr;
+    const arguments = callframe.deprecatedArguments(3).ptr;
     const message = arguments[0];
     const handle = arguments[1];
     const callback = arguments[2];
@@ -51,7 +51,7 @@ pub fn sendHelperChild(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFram
 
     const S = struct {
         fn impl(globalThis_: *JSC.JSGlobalObject, callframe_: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments_ = callframe_.arguments_old(1).slice();
+            const arguments_ = callframe_.deprecatedArguments(1).slice();
             const ex = arguments_[0];
             Process__emitErrorEvent(globalThis_, ex);
             return .undefined;
@@ -73,7 +73,7 @@ pub fn sendHelperChild(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFram
 
 pub fn onInternalMessageChild(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     log("onInternalMessageChild", .{});
-    const arguments = callframe.arguments_old(2).ptr;
+    const arguments = callframe.deprecatedArguments(2).ptr;
     child_singleton.worker = JSC.Strong.create(arguments[0], globalThis);
     child_singleton.cb = JSC.Strong.create(arguments[1], globalThis);
     try child_singleton.flush(globalThis);
@@ -175,7 +175,7 @@ pub const InternalMsgHolder = struct {
 pub fn sendHelperPrimary(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     log("sendHelperPrimary", .{});
 
-    const arguments = callframe.arguments_old(4).ptr;
+    const arguments = callframe.deprecatedArguments(4).ptr;
     const subprocess = arguments[0].as(bun.JSC.Subprocess).?;
     const message = arguments[1];
     const handle = arguments[2];
@@ -209,7 +209,7 @@ pub fn sendHelperPrimary(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFr
 }
 
 pub fn onInternalMessagePrimary(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(3).ptr;
+    const arguments = callframe.deprecatedArguments(3).ptr;
     const subprocess = arguments[0].as(bun.JSC.Subprocess).?;
     const ipc_data = subprocess.ipc() orelse return .undefined;
     ipc_data.internal_msg_queue.worker = JSC.Strong.create(arguments[1], globalThis);
@@ -253,7 +253,7 @@ pub fn handleInternalMessagePrimary(globalThis: *JSC.JSGlobalObject, subprocess:
 extern fn Bun__setChannelRef(*JSC.JSGlobalObject, bool) void;
 
 pub fn setRef(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1).ptr;
+    const arguments = callframe.deprecatedArguments(1).ptr;
 
     if (arguments.len == 0) {
         return globalObject.throwMissingArgumentsValue(&.{"enabled"});

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -13,7 +13,7 @@ const PBKDF2 = EVP.PBKDF2;
 const JSValue = JSC.JSValue;
 const validators = @import("./util/validators.zig");
 fn randomInt(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(2).slice();
+    const arguments = callframe.deprecatedArguments(2).slice();
 
     //min, max
     if (!arguments[0].isNumber()) return globalThis.throwInvalidArgumentTypeValue("min", "safe integer", arguments[0]);
@@ -42,7 +42,7 @@ fn pbkdf2(
     globalThis: *JSC.JSGlobalObject,
     callframe: *JSC.CallFrame,
 ) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(5);
+    const arguments = callframe.deprecatedArguments(5);
 
     const data = try PBKDF2.fromJS(globalThis, arguments.slice(), true);
 
@@ -54,7 +54,7 @@ fn pbkdf2Sync(
     globalThis: *JSC.JSGlobalObject,
     callframe: *JSC.CallFrame,
 ) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(5);
+    const arguments = callframe.deprecatedArguments(5);
 
     var data = try PBKDF2.fromJS(globalThis, arguments.slice(), false);
     defer data.deinit();

--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -35,7 +35,7 @@ fn callSync(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
             globalObject: *JSC.JSGlobalObject,
             callframe: *JSC.CallFrame,
         ) bun.JSError!JSC.JSValue {
-            var arguments = callframe.arguments_old(8);
+            var arguments = callframe.deprecatedArguments(8);
 
             var slice = ArgumentsSlice.init(globalObject.bunVM(), arguments.slice());
             defer slice.deinit();
@@ -80,7 +80,7 @@ fn call(comptime FunctionEnum: NodeFSFunctionEnum) NodeFSFunction {
     const Arguments = comptime function.params[1].type.?;
     const NodeBindingClosure = struct {
         pub fn bind(this: *JSC.Node.NodeJSFS, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            var arguments = callframe.arguments_old(8);
+            var arguments = callframe.deprecatedArguments(8);
 
             var slice = ArgumentsSlice.init(globalObject.bunVM(), arguments.slice());
             slice.will_be_async = true;
@@ -240,7 +240,7 @@ pub fn createBinding(globalObject: *JSC.JSGlobalObject) JSC.JSValue {
 }
 
 pub fn createMemfdForTesting(globalObject: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callFrame.arguments_old(1);
+    const arguments = callFrame.deprecatedArguments(1);
 
     if (arguments.len < 1) {
         return .undefined;

--- a/src/bun.js/node/node_http_binding.zig
+++ b/src/bun.js/node/node_http_binding.zig
@@ -8,7 +8,7 @@ const ZigString = JSC.ZigString;
 const uv = bun.windows.libuv;
 
 pub fn getBunServerAllClosedPromise(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1).slice();
+    const arguments = callframe.deprecatedArguments(1).slice();
     if (arguments.len < 1) {
         return globalThis.throwNotEnoughArguments("getBunServerAllClosePromise", 1, arguments.len);
     }
@@ -36,7 +36,7 @@ pub fn getMaxHTTPHeaderSize(globalThis: *JSC.JSGlobalObject, callframe: *JSC.Cal
 }
 
 pub fn setMaxHTTPHeaderSize(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1).slice();
+    const arguments = callframe.deprecatedArguments(1).slice();
     if (arguments.len < 1) {
         return globalThis.throwNotEnoughArguments("setMaxHTTPHeaderSize", 1, arguments.len);
     }

--- a/src/bun.js/node/node_net_binding.zig
+++ b/src/bun.js/node/node_net_binding.zig
@@ -24,7 +24,7 @@ pub fn getDefaultAutoSelectFamily(global: *JSC.JSGlobalObject) JSC.JSValue {
 pub fn setDefaultAutoSelectFamily(global: *JSC.JSGlobalObject) JSC.JSValue {
     return JSC.JSFunction.create(global, "setDefaultAutoSelectFamily", (struct {
         fn setter(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments = callframe.arguments_old(1);
+            const arguments = callframe.deprecatedArguments(1);
             if (arguments.len < 1) {
                 return globalThis.throw2("missing argument", .{});
             }
@@ -57,7 +57,7 @@ pub fn getDefaultAutoSelectFamilyAttemptTimeout(global: *JSC.JSGlobalObject) JSC
 pub fn setDefaultAutoSelectFamilyAttemptTimeout(global: *JSC.JSGlobalObject) JSC.JSValue {
     return JSC.JSFunction.create(global, "setDefaultAutoSelectFamilyAttemptTimeout", (struct {
         fn setter(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments = callframe.arguments_old(1);
+            const arguments = callframe.deprecatedArguments(1);
             if (arguments.len < 1) {
                 return globalThis.throw2("missing argument", .{});
             }

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -309,7 +309,7 @@ pub const OS = struct {
     pub fn getPriority(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
 
-        var args_ = callframe.arguments_old(1);
+        var args_ = callframe.deprecatedArguments(1);
         const arguments: []const JSC.JSValue = args_.ptr[0..args_.len];
 
         if (arguments.len > 0 and !arguments[0].isNumber()) {
@@ -722,7 +722,7 @@ pub const OS = struct {
     pub fn setPriority(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
 
-        var args_ = callframe.arguments_old(2);
+        var args_ = callframe.deprecatedArguments(2);
         var arguments: []const JSC.JSValue = args_.ptr[0..args_.len];
 
         if (arguments.len == 0) {

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -8,7 +8,7 @@ const ZigString = JSC.ZigString;
 const uv = bun.windows.libuv;
 
 pub fn internalErrorName(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1).slice();
+    const arguments = callframe.deprecatedArguments(1).slice();
     if (arguments.len < 1) {
         return globalThis.throwNotEnoughArguments("internalErrorName", 1, arguments.len);
     }

--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -8,7 +8,7 @@ const ZigString = JSC.ZigString;
 const validators = @import("./util/validators.zig");
 
 pub fn crc32(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(2).ptr;
+    const arguments = callframe.deprecatedArguments(2).ptr;
 
     const data: ZigString.Slice = blk: {
         const data: JSC.JSValue = arguments[0];
@@ -60,7 +60,7 @@ pub fn crc32(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
 pub fn CompressionStream(comptime T: type) type {
     return struct {
         pub fn write(this: *T, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments = callframe.argumentsUndef(7).slice();
+            const arguments = callframe.arguments(7).slice();
 
             if (arguments.len != 7) {
                 globalThis.ERR_MISSING_ARGS("write(flush, in, in_off, in_len, out, out_off, out_len)", .{}).throw();
@@ -152,7 +152,7 @@ pub fn CompressionStream(comptime T: type) type {
         }
 
         pub fn writeSync(this: *T, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-            const arguments = callframe.argumentsUndef(7).slice();
+            const arguments = callframe.arguments(7).slice();
 
             if (arguments.len != 7) {
                 globalThis.ERR_MISSING_ARGS("writeSync(flush, in, in_off, in_len, out, out_off, out_len)", .{}).throw();
@@ -322,7 +322,7 @@ pub const SNativeZlib = struct {
     task: JSC.WorkPoolTask = .{ .callback = undefined },
 
     pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*@This() {
-        const arguments = callframe.argumentsUndef(4).ptr;
+        const arguments = callframe.arguments(4).ptr;
 
         var mode = arguments[0];
         if (!mode.isNumber()) {
@@ -356,7 +356,7 @@ pub const SNativeZlib = struct {
     // }
 
     pub fn init(this: *SNativeZlib, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.argumentsUndef(7).slice();
+        const arguments = callframe.arguments(7).slice();
 
         if (arguments.len != 7) {
             globalThis.ERR_MISSING_ARGS("init(windowBits, level, memLevel, strategy, writeResult, writeCallback, dictionary)", .{}).throw();
@@ -381,7 +381,7 @@ pub const SNativeZlib = struct {
     }
 
     pub fn params(this: *SNativeZlib, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.argumentsUndef(2).slice();
+        const arguments = callframe.arguments(2).slice();
 
         if (arguments.len != 2) {
             globalThis.ERR_MISSING_ARGS("params(level, strategy)", .{}).throw();
@@ -682,7 +682,7 @@ pub const SNativeBrotli = struct {
     },
 
     pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*@This() {
-        const arguments = callframe.argumentsUndef(1).ptr;
+        const arguments = callframe.arguments(1).ptr;
 
         var mode = arguments[0];
         if (!mode.isNumber()) {
@@ -720,7 +720,7 @@ pub const SNativeBrotli = struct {
     }
 
     pub fn init(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.argumentsUndef(3).slice();
+        const arguments = callframe.arguments(3).slice();
         if (arguments.len != 3) {
             globalThis.ERR_MISSING_ARGS("init(params, writeResult, writeCallback)", .{}).throw();
             return .zero;

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -362,7 +362,7 @@ pub const Expect = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(2).slice();
+        const arguments = callframe.deprecatedArguments(2).slice();
         const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
 
         var custom_label = bun.String.empty;
@@ -422,7 +422,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
 
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         var _msg: ZigString = ZigString.Empty;
@@ -469,7 +469,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
 
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         var _msg: ZigString = ZigString.Empty;
@@ -512,7 +512,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callframe.this();
-        const arguments_ = callframe.arguments_old(2);
+        const arguments_ = callframe.deprecatedArguments(2);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -578,7 +578,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callframe.this();
-        const arguments_ = callframe.arguments_old(1);
+        const arguments_ = callframe.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -652,7 +652,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -737,7 +737,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -834,7 +834,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -888,7 +888,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -960,7 +960,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1027,7 +1027,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1094,7 +1094,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1150,7 +1150,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1216,7 +1216,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1288,7 +1288,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalObject);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1354,7 +1354,7 @@ pub const Expect = struct {
     ) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -1644,7 +1644,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -1685,7 +1685,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -1721,7 +1721,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(2);
+        const _arguments = callFrame.deprecatedArguments(2);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -1869,7 +1869,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -1931,7 +1931,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -1993,7 +1993,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -2055,7 +2055,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -2117,7 +2117,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const thisArguments = callFrame.arguments_old(2);
+        const thisArguments = callFrame.deprecatedArguments(2);
         const arguments = thisArguments.ptr[0..thisArguments.len];
 
         if (arguments.len < 1) {
@@ -2251,7 +2251,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         incrementExpectCallCounter();
@@ -2628,7 +2628,7 @@ pub const Expect = struct {
     pub fn toMatchSnapshot(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(2);
+        const _arguments = callFrame.deprecatedArguments(2);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         incrementExpectCallCounter();
@@ -2904,7 +2904,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -2974,7 +2974,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -3282,7 +3282,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(2);
+        const _arguments = callFrame.deprecatedArguments(2);
         const arguments = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -3344,7 +3344,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -3561,7 +3561,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -3617,7 +3617,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(2);
+        const arguments_ = callFrame.deprecatedArguments(2);
         const arguments = arguments_.slice();
 
         if (arguments.len < 2) {
@@ -3727,7 +3727,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -3784,7 +3784,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -3840,7 +3840,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -3896,7 +3896,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -3944,7 +3944,7 @@ pub const Expect = struct {
         defer this.postMatch(globalThis);
 
         const thisValue = callFrame.this();
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len < 1) {
@@ -4038,7 +4038,7 @@ pub const Expect = struct {
         JSC.markBinding(@src());
 
         const thisValue = callframe.this();
-        const arguments_ = callframe.arguments_old(1);
+        const arguments_ = callframe.deprecatedArguments(1);
         const arguments: []const JSValue = arguments_.slice();
         defer this.postMatch(globalThis);
         const value: JSValue = try this.getValue(globalThis, thisValue, "toHaveBeenCalledTimes", "<green>expected<r>");
@@ -4081,7 +4081,7 @@ pub const Expect = struct {
 
         defer this.postMatch(globalThis);
         const thisValue = callFrame.this();
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         incrementExpectCallCounter();
 
@@ -4344,7 +4344,7 @@ pub const Expect = struct {
         JSC.markBinding(@src());
 
         const thisValue = callframe.this();
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         defer this.postMatch(globalThis);
 
         const name = comptime if (known_index != null and known_index.? == 0) "toHaveReturned" else "toHaveReturnedTimes";
@@ -4483,7 +4483,7 @@ pub const Expect = struct {
 
     /// Implements `expect.extend({ ... })`
     pub fn extend(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         if (args.len == 0 or !args[0].isObject()) {
             globalThis.throwPretty("<d>expect.<r>extend<d>(<r>matchers<d>)<r>\n\nExpected an object containing matchers\n", .{});
@@ -4776,7 +4776,7 @@ pub const Expect = struct {
     pub fn assertions(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
         defer globalThis.bunVM().autoGarbageCollect();
 
-        const arguments_ = callFrame.arguments_old(1);
+        const arguments_ = callFrame.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         if (arguments.len < 1) {
@@ -4832,7 +4832,7 @@ pub const Expect = struct {
     }
 
     pub fn doUnreachable(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arg = callframe.arguments_old(1).ptr[0];
+        const arg = callframe.deprecatedArguments(1).ptr[0];
 
         if (arg.isEmptyOrUndefinedOrNull()) {
             const error_value = bun.String.init("reached unreachable code").toErrorInstance(globalThis);
@@ -4991,7 +4991,7 @@ pub const ExpectStringMatching = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         if (args.len == 0 or (!args[0].isString() and !args[0].isRegExp())) {
             const fmt = "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string or regular expression\n";
@@ -5028,7 +5028,7 @@ pub const ExpectCloseTo = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(2).slice();
+        const args = callFrame.deprecatedArguments(2).slice();
 
         if (args.len == 0 or !args[0].isNumber()) {
             globalThis.throwPretty("<d>expect.<r>closeTo<d>(<r>number<d>, precision?)<r>\n\nExpected a number value", .{});
@@ -5075,7 +5075,7 @@ pub const ExpectObjectContaining = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         if (args.len == 0 or !args[0].isObject()) {
             const fmt = "<d>expect.<r>objectContaining<d>(<r>object<d>)<r>\n\nExpected an object\n";
@@ -5112,7 +5112,7 @@ pub const ExpectStringContaining = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         if (args.len == 0 or !args[0].isString()) {
             const fmt = "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string\n";
@@ -5147,7 +5147,7 @@ pub const ExpectAny = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const _arguments = callFrame.arguments_old(1);
+        const _arguments = callFrame.deprecatedArguments(1);
         const arguments: []const JSValue = _arguments.ptr[0.._arguments.len];
 
         if (arguments.len == 0) {
@@ -5203,7 +5203,7 @@ pub const ExpectArrayContaining = struct {
     }
 
     pub fn call(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         if (args.len == 0 or !args[0].jsType().isArray()) {
             const fmt = "<d>expect.<r>arrayContaining<d>(<r>array<d>)<r>\n\nExpected a array\n";
@@ -5327,7 +5327,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
     }
 
     pub fn asymmetricMatch(this: *ExpectCustomAsymmetricMatcher, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         const received_value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
         return JSValue.jsBoolean(matched);
@@ -5414,7 +5414,7 @@ pub const ExpectMatcherContext = struct {
     }
 
     pub fn equals(_: *ExpectMatcherContext, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        var arguments = callframe.arguments_old(3);
+        var arguments = callframe.deprecatedArguments(3);
         if (arguments.len < 2) {
             globalThis.throw("expect.extends matcher: this.util.equals expects at least 2 arguments", .{});
             return .zero;
@@ -5483,25 +5483,25 @@ pub const ExpectMatcherUtils = struct {
     }
 
     pub fn stringify(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
         return printValueCatched(globalThis, value, null);
     }
 
     pub fn printExpected(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
         return printValueCatched(globalThis, value, "<green>");
     }
 
     pub fn printReceived(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
         return printValueCatched(globalThis, value, "<red>");
     }
 
     pub fn matcherHint(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(4).slice();
+        const arguments = callframe.deprecatedArguments(4).slice();
 
         if (arguments.len == 0 or !arguments[0].isString()) {
             globalThis.throw("matcherHint: the first argument (matcher name) must be a string", .{});

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -24,7 +24,7 @@ pub const Lifetime = enum {
 
 /// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert
 fn alert(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1).slice();
+    const arguments = callframe.deprecatedArguments(1).slice();
     var output = bun.Output.writer();
     const has_message = arguments.len != 0;
 
@@ -74,7 +74,7 @@ fn alert(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSErr
 }
 
 fn confirm(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1).slice();
+    const arguments = callframe.deprecatedArguments(1).slice();
     var output = bun.Output.writer();
     const has_message = arguments.len != 0;
 
@@ -212,7 +212,7 @@ pub const Prompt = struct {
         globalObject: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(3).slice();
+        const arguments = callframe.deprecatedArguments(3).slice();
         var state = std.heap.stackFallback(2048, bun.default_allocator);
         const allocator = state.get();
         var output = bun.Output.writer();
@@ -546,7 +546,7 @@ pub const Crypto = struct {
     }
 
     pub fn timingSafeEqual(_: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(2).slice();
+        const arguments = callframe.deprecatedArguments(2).slice();
 
         if (arguments.len < 2) {
             return globalThis.throwInvalidArguments("Expected 2 typed arrays but got nothing", .{});
@@ -593,7 +593,7 @@ pub const Crypto = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
         if (arguments.len == 0) {
             return globalThis.throwInvalidArguments("Expected typed array but got nothing", .{});
         }
@@ -656,7 +656,7 @@ pub const Crypto = struct {
         @export(Bun__randomUUIDv7, .{ .name = "Bun__randomUUIDv7" });
     }
     pub fn Bun__randomUUIDv7_(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.argumentsUndef(2).slice();
+        const arguments = callframe.arguments(2).slice();
 
         var encoding_value: JSC.JSValue = .undefined;
 

--- a/src/bun.js/webcore/ObjectURLRegistry.zig
+++ b/src/bun.js/webcore/ObjectURLRegistry.zig
@@ -94,7 +94,7 @@ comptime {
     @export(Bun__createObjectURL, .{ .name = "Bun__createObjectURL" });
 }
 fn Bun__createObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
     if (arguments.len < 1) {
         return globalObject.throwNotEnoughArguments("createObjectURL", 1, arguments.len);
     }
@@ -112,7 +112,7 @@ comptime {
     @export(Bun__revokeObjectURL, .{ .name = "Bun__revokeObjectURL" });
 }
 fn Bun__revokeObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
     if (arguments.len < 1) {
         return globalObject.throwNotEnoughArguments("revokeObjectURL", 1, arguments.len);
     }
@@ -141,7 +141,7 @@ comptime {
     @export(jsFunctionResolveObjectURL, .{ .name = "jsFunctionResolveObjectURL" });
 }
 fn jsFunctionResolveObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
 
     // Errors are ignored.
     // Not thrown.

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -970,7 +970,7 @@ pub const Blob = struct {
     }
 
     pub fn writeFile(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(3).slice();
+        const arguments = callframe.deprecatedArguments(3).slice();
         var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
 
@@ -1423,7 +1423,7 @@ pub const Blob = struct {
         JSC.markBinding(@src());
         const allocator = bun.default_allocator;
         var blob: Blob = undefined;
-        var arguments = callframe.arguments_old(3);
+        var arguments = callframe.deprecatedArguments(3);
         const args = arguments.slice();
 
         if (args.len < 2) {
@@ -1550,7 +1550,7 @@ pub const Blob = struct {
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
         var vm = globalObject.bunVM();
-        const arguments = callframe.arguments_old(2).slice();
+        const arguments = callframe.deprecatedArguments(2).slice();
         var args = JSC.Node.ArgumentsSlice.init(vm, arguments);
         defer args.deinit();
 
@@ -3247,7 +3247,7 @@ pub const Blob = struct {
             return cached;
         }
         var recommended_chunk_size: SizeType = 0;
-        var arguments_ = callframe.arguments_old(2);
+        var arguments_ = callframe.deprecatedArguments(2);
         var arguments = arguments_.ptr[0..arguments_.len];
         if (arguments.len > 0) {
             if (!arguments[0].isNumber() and !arguments[0].isUndefinedOrNull()) {
@@ -3285,7 +3285,7 @@ pub const Blob = struct {
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
         const this = callframe.this().as(Blob) orelse @panic("this is not a Blob");
-        const args = callframe.arguments_old(1).slice();
+        const args = callframe.deprecatedArguments(1).slice();
 
         return JSC.WebCore.ReadableStream.fromFileBlobWithOffset(
             globalThis,
@@ -3450,7 +3450,7 @@ pub const Blob = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        var arguments_ = callframe.arguments_old(1);
+        var arguments_ = callframe.deprecatedArguments(1);
         var arguments = arguments_.ptr[0..arguments_.len];
 
         if (!arguments.ptr[0].isEmptyOrUndefinedOrNull() and !arguments.ptr[0].isObject()) {
@@ -3580,7 +3580,7 @@ pub const Blob = struct {
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
         const allocator = bun.default_allocator;
-        var arguments_ = callframe.arguments_old(3);
+        var arguments_ = callframe.deprecatedArguments(3);
         var args = arguments_.ptr[0..arguments_.len];
 
         if (this.size == 0) {
@@ -3926,7 +3926,7 @@ pub const Blob = struct {
     pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*Blob {
         const allocator = bun.default_allocator;
         var blob: Blob = undefined;
-        var arguments = callframe.arguments_old(2);
+        var arguments = callframe.deprecatedArguments(2);
         const args = arguments.slice();
 
         switch (args.len) {

--- a/src/bun.js/webcore/body.zig
+++ b/src/bun.js/webcore/body.zig
@@ -1505,14 +1505,14 @@ pub const BodyValueBufferer = struct {
     }
 
     pub fn onResolveStream(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        var args = callframe.arguments_old(2);
+        var args = callframe.deprecatedArguments(2);
         var sink: *@This() = args.ptr[args.len - 1].asPromisePtr(@This());
         sink.handleResolveStream(true);
         return JSValue.jsUndefined();
     }
 
     pub fn onRejectStream(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const args = callframe.arguments_old(2);
+        const args = callframe.deprecatedArguments(2);
         var sink = args.ptr[args.len - 1].asPromisePtr(@This());
         const err = args.ptr[0];
         sink.handleRejectStream(err, true);

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -421,7 +421,7 @@ pub const TextEncoderStreamEncoder = struct {
     }
 
     pub fn encode(this: *TextEncoderStreamEncoder, globalObject: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSValue {
-        const arguments = callFrame.arguments_old(1).slice();
+        const arguments = callFrame.deprecatedArguments(1).slice();
         if (arguments.len == 0) {
             return globalObject.throwNotEnoughArguments("TextEncoderStreamEncoder.encode", 1, arguments.len);
         }
@@ -760,7 +760,7 @@ pub const TextDecoder = struct {
     }
 
     pub fn decode(this: *TextDecoder, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
-        const arguments = callframe.arguments_old(2).slice();
+        const arguments = callframe.deprecatedArguments(2).slice();
 
         const input_slice = input_slice: {
             if (arguments.len == 0 or arguments[0].isUndefined()) {
@@ -892,7 +892,7 @@ pub const TextDecoder = struct {
     }
 
     pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*TextDecoder {
-        var args_ = callframe.arguments_old(2);
+        var args_ = callframe.deprecatedArguments(2);
         var arguments: []const JSC.JSValue = args_.ptr[0..args_.len];
 
         var decoder = TextDecoder{};

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -768,7 +768,7 @@ pub const Request = struct {
     }
 
     pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!*Request {
-        const arguments_ = callframe.arguments_old(2);
+        const arguments_ = callframe.deprecatedArguments(2);
         const arguments = arguments_.ptr[0..arguments_.len];
 
         const request = try constructInto(globalThis, arguments);

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -364,7 +364,7 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        const args_list = callframe.arguments_old(2);
+        const args_list = callframe.deprecatedArguments(2);
         // https://github.com/remix-run/remix/blob/db2c31f64affb2095e4286b91306b96435967969/packages/remix-server-runtime/responses.ts#L4
         var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), args_list.ptr[0..args_list.len]);
 
@@ -432,7 +432,7 @@ pub const Response = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSValue {
-        var args_list = callframe.arguments_old(4);
+        var args_list = callframe.deprecatedArguments(4);
         // https://github.com/remix-run/remix/blob/db2c31f64affb2095e4286b91306b96435967969/packages/remix-server-runtime/responses.ts#L4
         var args = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), args_list.ptr[0..args_list.len]);
 
@@ -1904,7 +1904,7 @@ pub const Fetch = struct {
         globalObject: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const arguments = callframe.arguments_old(1).slice();
+        const arguments = callframe.deprecatedArguments(1).slice();
 
         if (arguments.len < 1) {
             return globalObject.throwNotEnoughArguments("fetch.preconnect", 1, arguments.len);
@@ -1970,7 +1970,7 @@ pub const Fetch = struct {
     ) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
         const globalThis = ctx;
-        const arguments = callframe.arguments_old(2);
+        const arguments = callframe.deprecatedArguments(2);
         bun.Analytics.Features.fetch += 1;
         const vm = JSC.VirtualMachine.get();
 

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -1756,7 +1756,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                 }
             }
 
-            const args_list = callframe.arguments_old(4);
+            const args_list = callframe.deprecatedArguments(4);
             const args = args_list.ptr[0..args_list.len];
 
             if (args.len == 0) {
@@ -1826,7 +1826,7 @@ pub fn NewJSSink(comptime SinkType: type, comptime name_: []const u8) type {
                 }
             }
 
-            const args_list = callframe.arguments_old(4);
+            const args_list = callframe.deprecatedArguments(4);
             const args = args_list.ptr[0..args_list.len];
             if (args.len == 0 or !args[0].isString()) {
                 const err = JSC.toTypeError(
@@ -2839,7 +2839,7 @@ pub fn ReadableStreamSource(
             pub fn pull(this: *ReadableStreamSourceType, globalThis: *JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
                 JSC.markBinding(@src());
                 const this_jsvalue = callFrame.this();
-                const arguments = callFrame.arguments_old(2);
+                const arguments = callFrame.deprecatedArguments(2);
                 const view = arguments.ptr[0];
                 view.ensureStillAlive();
                 this.this_jsvalue = this_jsvalue;

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2298,7 +2298,7 @@ pub const bindings = struct {
     // }
 
     pub fn jsReadTarball(global: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
         if (args.len < 1 or !args[0].isString()) {
             global.throw("expected tarball path string argument", .{});
             return .zero;

--- a/src/css/css_internals.zig
+++ b/src/css/css_internals.zig
@@ -36,7 +36,7 @@ pub fn testingImpl(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame, c
     defer arena.reset();
     const alloc = arena.allocator();
 
-    const arguments_ = callframe.arguments_old(3);
+    const arguments_ = callframe.deprecatedArguments(3);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     const source_arg: JSC.JSValue = arguments.nextEat() orelse {
         globalThis.throw("minifyTestWithOptions: expected 2 arguments, got 0", .{});
@@ -202,7 +202,7 @@ pub fn attrTest(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.
     defer arena.reset();
     const alloc = arena.allocator();
 
-    const arguments_ = callframe.arguments_old(4);
+    const arguments_ = callframe.deprecatedArguments(4);
     var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
     const source_arg: JSC.JSValue = arguments.nextEat() orelse {
         globalThis.throw("attrTest: expected 3 arguments, got 0", .{});

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -1561,7 +1561,7 @@ comptime {
 pub fn Bun__canonicalizeIP_(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     JSC.markBinding(@src());
 
-    const arguments = callframe.arguments_old(1);
+    const arguments = callframe.deprecatedArguments(1);
 
     if (arguments.len == 0) {
         return globalThis.throwInvalidArguments("canonicalizeIP() expects a string but received no arguments.", .{});

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -600,7 +600,7 @@ pub const IniTestingAPIs = struct {
     }
 
     pub fn parse(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments_ = callframe.arguments_old(1);
+        const arguments_ = callframe.deprecatedArguments(1);
         const arguments = arguments_.slice();
 
         const jsstr = arguments[0];

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -14997,7 +14997,7 @@ pub const bun_install_js_bindings = struct {
         var log = logger.Log.init(allocator);
         defer log.deinit();
 
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
         const cwd = try args[0].toSliceOrNull(globalObject);
         defer cwd.deinit();
 

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -653,7 +653,7 @@ pub const OperatingSystem = enum(u16) {
 
     const JSC = bun.JSC;
     pub fn jsFunctionOperatingSystemIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         var operating_system = negatable(.none);
         var iter = args.ptr[0].arrayIterator(globalObject);
         while (iter.next()) |item| {
@@ -695,7 +695,7 @@ pub const Libc = enum(u8) {
 
     const JSC = bun.JSC;
     pub fn jsFunctionLibcIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         var libc = negatable(.none);
         var iter = args.ptr[0].arrayIterator(globalObject);
         while (iter.next()) |item| {
@@ -770,7 +770,7 @@ pub const Architecture = enum(u16) {
 
     const JSC = bun.JSC;
     pub fn jsFunctionArchitectureIsMatch(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const args = callframe.arguments_old(1);
+        const args = callframe.deprecatedArguments(1);
         var architecture = negatable(.none);
         var iter = args.ptr[0].arrayIterator(globalObject);
         while (iter.next()) |item| {
@@ -1284,7 +1284,7 @@ pub const PackageManifest = struct {
         }
 
         pub fn jsParseManifest(global: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
-            const args = callFrame.arguments_old(2).slice();
+            const args = callFrame.deprecatedArguments(2).slice();
             if (args.len < 2 or !args[0].isString() or !args[1].isString()) {
                 global.throw("expected manifest filename and registry string arguments", .{});
                 return .zero;

--- a/src/install/semver.zig
+++ b/src/install/semver.zig
@@ -2657,7 +2657,7 @@ pub const SemverObject = struct {
         var stack_fallback = std.heap.stackFallback(512, arena.allocator());
         const allocator = stack_fallback.get();
 
-        const arguments = callFrame.arguments_old(2).slice();
+        const arguments = callFrame.deprecatedArguments(2).slice();
         if (arguments.len < 2) {
             globalThis.throw("Expected two arguments", .{});
             return .zero;
@@ -2709,7 +2709,7 @@ pub const SemverObject = struct {
         var stack_fallback = std.heap.stackFallback(512, arena.allocator());
         const allocator = stack_fallback.get();
 
-        const arguments = callFrame.arguments_old(2).slice();
+        const arguments = callFrame.deprecatedArguments(2).slice();
         if (arguments.len < 2) {
             globalThis.throw("Expected two arguments", .{});
             return .zero;

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -704,7 +704,7 @@ pub const ParsedShellScript = struct {
     }
 
     pub fn setCwd(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const arguments_ = callframe.arguments_old(2);
+        const arguments_ = callframe.deprecatedArguments(2);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const str_js = arguments.nextEat() orelse {
             globalThis.throw("$`...`.cwd(): expected a string argument", .{});
@@ -767,7 +767,7 @@ pub const ParsedShellScript = struct {
     pub fn createParsedShellScript(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         var shargs = ShellArgs.init();
 
-        const arguments_ = callframe.arguments_old(2);
+        const arguments_ = callframe.deprecatedArguments(2);
         const arguments = arguments_.slice();
         if (arguments.len < 2) {
             return globalThis.throwNotEnoughArguments("Bun.$", 2, arguments.len);
@@ -1181,7 +1181,7 @@ pub const Interpreter = struct {
 
     pub fn createShellInterpreter(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         const allocator = bun.default_allocator;
-        const arguments_ = callframe.arguments_old(3);
+        const arguments_ = callframe.deprecatedArguments(3);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
 
         const resolve = arguments.nextEat() orelse return globalThis.throw2("shell: expected 3 arguments, got 0", .{});

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -4316,7 +4316,7 @@ pub const TestingAPIs = struct {
     pub fn disabledOnThisPlatform(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         if (comptime bun.Environment.isWindows) return JSValue.false;
 
-        const arguments_ = callframe.arguments_old(1);
+        const arguments_ = callframe.deprecatedArguments(1);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string = arguments.nextEat() orelse {
             globalThis.throw("shellInternals.disabledOnPosix: expected 1 arguments, got 0", .{});
@@ -4340,7 +4340,7 @@ pub const TestingAPIs = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const arguments_ = callframe.arguments_old(2);
+        const arguments_ = callframe.deprecatedArguments(2);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string_args = arguments.nextEat() orelse {
             globalThis.throw("shell_parse: expected 2 arguments, got 0", .{});
@@ -4428,7 +4428,7 @@ pub const TestingAPIs = struct {
         globalThis: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const arguments_ = callframe.arguments_old(2);
+        const arguments_ = callframe.deprecatedArguments(2);
         var arguments = JSC.Node.ArgumentsSlice.init(globalThis.bunVM(), arguments_.slice());
         const string_args = arguments.nextEat() orelse {
             globalThis.throw("shell_parse: expected 2 arguments, got 0", .{});

--- a/src/string.zig
+++ b/src/string.zig
@@ -1328,7 +1328,7 @@ pub const String = extern struct {
     }
 
     pub fn jsGetStringWidth(globalObject: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-        const args = callFrame.arguments_old(1).slice();
+        const args = callFrame.deprecatedArguments(1).slice();
 
         if (args.len == 0 or !args.ptr[0].isString()) {
             return JSC.jsNumber(@as(i32, 0));

--- a/src/url.zig
+++ b/src/url.zig
@@ -983,7 +983,7 @@ pub const FormData = struct {
     ) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
 
-        const args_ = callframe.arguments_old(2);
+        const args_ = callframe.deprecatedArguments(2);
 
         const args = args_.ptr[0..2];
 


### PR DESCRIPTION


### What does this PR do?

@nektro when you want to say something is deprecated, don't add "old" or "2" to the name. That doesn't communicate useful information. It encourages adding "3" or "oldold" to the name. Instead, say "deprecated". 

### How did you verify your code works?

