### PR TITLE
Fix setRawMode return value on Windows

### DIFF
--- a/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
@@ -199,7 +199,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, Call
 
     Zig::GlobalObject* global = jsCast<Zig::GlobalObject*>(globalObject);
 
-    return Source__setRawModeStdin(raw);
+    return JSValue::encode(jsNumber(Source__setRawModeStdin(raw)));
 #else
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);


### PR DESCRIPTION
### What does this PR do?

Fixes the return value of setRawMode, which until now on Windows was directly returning a C++ int as an EncodedJSValue without actually encoding it. This fixes some `node:readline` crashes on Windows.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

Spammed a script that calls `readline.createInterface` a lot.
