### PR TITLE
Cherry-pick WebKit/WebKit#37039

### DIFF
--- a/src/bun.js/bindings/webcore/AbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/AbortSignal.cpp
@@ -65,15 +65,11 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     auto signal = adoptRef(*new AbortSignal(&context));
     signal->setHasActiveTimeoutTimer(true);
     auto action = [signal](ScriptExecutionContext& context) mutable {
-        signal->setHasActiveTimeoutTimer(false);
-
-        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context.jsGlobalObject());
-        if (!globalObject)
-            return;
-
+        auto* globalObject = defaultGlobalObject(context.globalObject());
         auto& vm = globalObject->vm();
         Locker locker { vm.apiLock() };
         signal->signalAbort(toJS(globalObject, globalObject, DOMException::create(TimeoutError)));
+        signal->setHasActiveTimeoutTimer(false);
     };
 
     if (milliseconds == 0) {

--- a/src/bun.js/bindings/webcore/AbortSignal.h
+++ b/src/bun.js/bindings/webcore/AbortSignal.h
@@ -106,6 +106,7 @@ public:
     void incrementPendingActivityCount() { ++pendingActivityCount; }
     void decrementPendingActivityCount() { --pendingActivityCount; }
     bool hasPendingActivity() const { return pendingActivityCount > 0; }
+    bool isDependent() const { return m_isDependent; }
 
 private:
     enum class Aborted : bool {
@@ -116,7 +117,6 @@ private:
 
     void setHasActiveTimeoutTimer(bool hasActiveTimeoutTimer) { m_hasActiveTimeoutTimer = hasActiveTimeoutTimer; }
 
-    bool isDependent() const { return m_isDependent; }
     void markAsDependent() { m_isDependent = true; }
     void addSourceSignal(AbortSignal&);
     void addDependentSignal(AbortSignal&);

--- a/src/bun.js/bindings/webcore/JSAbortSignalCustom.cpp
+++ b/src/bun.js/bindings/webcore/JSAbortSignalCustom.cpp
@@ -54,10 +54,12 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
                 *reason = "Has Timeout And Abort Event Listener"_s;
             return true;
         }
-        if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
-            if (UNLIKELY(reason))
-                *reason = "Has Source Signals And Abort Event Listener"_s;
-            return true;
+        if (abortSignal.isDependent()) {
+            if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+                if (UNLIKELY(reason))
+                    *reason = "Has Source Signals And Abort Event Listener"_s;
+                return true;
+            }
         }
 
         // https://github.com/oven-sh/bun/issues/4517


### PR DESCRIPTION
### What does this PR do?

- Cherry-pick WebKit/WebKit#37039
- Potentially fix the bug with AbortSignal.timeout(0).


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
