### PR TITLE
Bun.serve incorrect file for error page template

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -71,9 +71,9 @@ pub const Fallback = struct {
 
     pub inline fn errorJS() string {
         return if (Environment.codegen_embed)
-            @embedFile("bun-error/bun-error.css")
+            @embedFile("bun-error/index.js")
         else
-            bun.runtimeEmbedFile(.codegen, "bun-error/bun-error.css");
+            bun.runtimeEmbedFile(.codegen, "bun-error/index.js");
     }
 
     pub inline fn errorCSS() string {


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/15396

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Ran example provided in https://github.com/oven-sh/bun/issues/15396 which now works correctly:

![](https://dl.vixen.link/1rt5fa/Screenshot%20from%202024-11-24%2019-42-11.png)

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
