### PR TITLE
Fix incorrect public TS class field name minification

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -21824,8 +21824,9 @@ fn NewParser_(
                                 if (arg.is_typescript_ctor_field) {
                                     switch (arg.binding.data) {
                                         .b_identifier => |id| {
-                                            const name = p.symbols.items[id.ref.innerIndex()].original_name;
-                                            const ident = p.newExpr(E.Identifier{ .ref = id.ref }, arg.binding.loc);
+                                            const arg_symbol = p.symbols.items[id.ref.innerIndex()];
+                                            const name = arg_symbol.original_name;
+                                            const arg_ident = p.newExpr(E.Identifier{ .ref = id.ref }, arg.binding.loc);
 
                                             stmts.insert(if (super_index) |k| j + k + 1 else j, Stmt.assign(
                                                 p.newExpr(E.Dot{
@@ -21833,12 +21834,17 @@ fn NewParser_(
                                                     .name = name,
                                                     .name_loc = arg.binding.loc,
                                                 }, arg.binding.loc),
-                                                ident,
+                                                arg_ident,
                                             )) catch unreachable;
                                             // O(N)
                                             class_body.items.len += 1;
                                             bun.copy(G.Property, class_body.items[j + 1 ..], class_body.items[j .. class_body.items.len - 1]);
-                                            class_body.items[j] = G.Property{ .key = ident };
+                                            // Copy the argument name symbol to prevent the class field declaration from being renamed
+                                            // but not the constructor argument.
+                                            const field_symbol_ref = p.declareSymbol(.other, arg.binding.loc, name) catch id.ref;
+                                            field_symbol_ref.getSymbol(p.symbols.items).must_not_be_renamed = true;
+                                            const field_ident = p.newExpr(E.Identifier{ .ref = field_symbol_ref }, arg.binding.loc);
+                                            class_body.items[j] = G.Property{ .key = field_ident };
                                             j += 1;
                                         },
                                         else => {},

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -576,7 +576,7 @@ pub const PrintResult = union(enum) {
 // do not make this a packed struct
 // stage1 compiler bug:
 // > /optional-chain-with-function.js: Evaluation failed: TypeError: (intermediate value) is not a function
-// this test failure was caused by the packed structi mplementation
+// this test failure was caused by the packed struct implementation
 const ExprFlag = enum {
     forbid_call,
     forbid_in,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2253,4 +2253,25 @@ describe("bundler", () => {
       stdout: "windows",
     },
   });
+
+  itBundled("edgecase/TSPublicFieldMinification", {
+    files: {
+      "/entry.ts": /* ts */ `
+        export class Foo {
+          constructor(public name: string) {}
+        }
+
+        const keys = Object.keys(new Foo('test'))
+        if (keys.length !== 1) throw new Error('Keys length is not 1')
+        if (keys[0] !== 'name') throw new Error('keys[0] is not "name"')
+        console.log('success')
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: true,
+    target: "bun",
+    run: {
+      stdout: "success",
+    },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where public TS class field names would be minified. This PR preserves the original names.

Fixes #15401

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Added a [new test](https://github.com/oven-sh/bun/blob/b97aa65c2b16ac7abb1358077c438bc730f10c99/test/bundler/bundler_edgecase.test.ts#L2257-L2276) to `test/bundler/bundler_edgecase.test.ts`.

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)