### PR TITLE
Docs: cli/test.md - Completed GH Actions example

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -75,8 +75,10 @@ jobs:
     name: build-app
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install bun
-        uses: oven-sh/setup-bun
+        uses: oven-sh/setup-bun@v2
       - name: Install dependencies # (assuming your project has dependencies)
         run: bun install # You can use npm/yarn/pnpm instead if you prefer
       - name: Run tests


### PR DESCRIPTION
Two changes: first, [action specifiers require a version (or a ref)](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses), second: the example will fail without a checkout

### What does this PR do?

Makes the GitHub Actions model example in the `bun test` documentation a complete and working job definition.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Manually tested in [my own repo](https://github.com/NReilingh/meta-dotfiles/blob/00cb0cadc126c45e9a6f55666cbb220e8ed9294d/.github/workflows/dagger.yml#L23-L26)

