### PR TITLE
bake: params used when doing static site generation

### DIFF
--- a/src/bake/BakeProduction.cpp
+++ b/src/bake/BakeProduction.cpp
@@ -11,6 +11,7 @@ extern "C" JSC::JSPromise* BakeRenderRoutesForProdStatic(
     BunString outBase,
     JSC::JSValue allServerFiles,
     JSC::JSValue renderStatic,
+    JSC::JSValue getParams,
     JSC::JSValue clientEntryUrl,
     JSC::JSValue pattern,
     JSC::JSValue files,
@@ -27,6 +28,7 @@ extern "C" JSC::JSPromise* BakeRenderRoutesForProdStatic(
     args.append(JSC::jsString(vm, outBase.toWTFString()));
     args.append(allServerFiles);
     args.append(renderStatic);
+    args.append(getParams);
     args.append(clientEntryUrl);
     args.append(pattern);
     args.append(files);

--- a/src/bake/bake.d.ts
+++ b/src/bake/bake.d.ts
@@ -388,7 +388,7 @@ declare module "bun" {
        *         return { exhaustive: false };
        *     }
        */
-      getParams?: (paramsMetadata: ParamsMetadata) => Awaitable<ParamsResult>;
+      getParams?: (paramsMetadata: ParamsMetadata) => Awaitable<GetParamIterator>;
       /**
        * When a dynamic build uses static assets, Bun can map content types in the
        * user's `Accept` header to the different static files.
@@ -544,7 +544,7 @@ declare module "bun:bake/client" {
    * Callback is invoked when server-side code is changed. This can be used to
    * fetch a non-html version of the updated page to perform a faster reload. If
    * not provided, the client will perform a hard reload.
-   * 
+   *
    * Only one callback can be set. This function overwrites the previous one.
    */
   export function onServerSideReload(cb: () => void | Promise<void>): Promise<void>;

--- a/src/bake/production.zig
+++ b/src/bake/production.zig
@@ -332,6 +332,7 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
 
     // Static site generator
     const server_render_funcs = JSValue.createEmptyArray(global, router.types.len);
+    const server_param_funcs = JSValue.createEmptyArray(global, router.types.len);
     const client_entry_urls = JSValue.createEmptyArray(global, router.types.len);
 
     for (router.types, 0..) |router_type, i| {
@@ -362,7 +363,23 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
             });
             bun.Global.crash();
         };
+
+        const server_param_func = brk: {
+            const raw = BakeGetOnModuleNamespace(global, server_entry_point, "getParams") orelse
+                break :brk null;
+            if (!raw.isCallable(vm.jsc)) {
+                break :brk null;
+            }
+            break :brk raw;
+        } orelse {
+            Output.errGeneric("Framework does not support static site generation", .{});
+            Output.note("The file {s} is missing the \"getParams\" export, which defines how to generate static files.", .{
+                bun.fmt.quote(bun.path.relative(cwd, entry_points.files.keys()[router_type.server_file.get()].absPath())),
+            });
+            bun.Global.crash();
+        };
         server_render_funcs.putIndex(global, @intCast(i), server_render_func);
+        server_param_funcs.putIndex(global, @intCast(i), server_param_func);
     }
 
     var navigatable_routes = std.ArrayList(FrameworkRouter.Route.Index).init(allocator);
@@ -397,6 +414,15 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
 
         // Count how many JS+CSS files associated with this route and prepare `pattern`
         pattern.prependPart(route.part);
+        switch (route.part) {
+            .param => {
+                params_buf.append(ctx.allocator, route.part.param) catch unreachable;
+            },
+            .catch_all, .catch_all_optional => {
+                global.throw("catch-all routes are not supported in static site generation", .{});
+            },
+            else => {},
+        }
         var file_count: u32 = 1;
         var css_file_count: u32 = @intCast(main_file.referenced_css_files.len);
         if (route.file_layout.unwrap()) |file| {
@@ -407,6 +433,15 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
         while (next) |parent_index| {
             const parent = router.routePtr(parent_index);
             pattern.prependPart(parent.part);
+            switch (parent.part) {
+                .param => {
+                    params_buf.append(ctx.allocator, parent.part.param) catch unreachable;
+                },
+                .catch_all, .catch_all_optional => {
+                    global.throw("catch-all routes are not supported in static site generation", .{});
+                },
+                else => {},
+            }
             if (parent.file_layout.unwrap()) |file| {
                 css_file_count += @intCast(paths.outputFile(file).referenced_css_files.len);
                 file_count += 1;
@@ -434,6 +469,7 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
             }
             file_count += 1;
         }
+
         while (next) |parent_index| {
             const parent = router.routePtr(parent_index);
             if (parent.file_layout.unwrap()) |file| {
@@ -459,7 +495,16 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
         route_type_and_flags.putIndex(global, @intCast(nav_index), JSValue.jsNumberFromInt32(@bitCast(TypeAndFlags{
             .type = route.type.get(),
         })));
-        route_param_info.putIndex(global, @intCast(nav_index), .null);
+
+        if (params_buf.items.len > 0) {
+            const param_info_array = JSValue.createEmptyArray(global, params_buf.items.len);
+            for (params_buf.items, 0..) |param, i| {
+                param_info_array.putIndex(global, @intCast(params_buf.items.len - i - 1), JSValue.toJSString(global, param));
+            }
+            route_param_info.putIndex(global, @intCast(nav_index), param_info_array);
+        } else {
+            route_param_info.putIndex(global, @intCast(nav_index), .null);
+        }
         route_style_references.putIndex(global, @intCast(nav_index), styles);
     }
 
@@ -468,6 +513,7 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
         bun.String.init(root_dir_path),
         all_server_files,
         server_render_funcs,
+        server_param_funcs,
         client_entry_urls,
 
         route_patterns,
@@ -530,6 +576,7 @@ extern fn BakeRenderRoutesForProdStatic(
     out_base: bun.String,
     all_server_files: JSValue,
     render_static: JSValue,
+    get_params: JSValue,
     client_entry_urls: JSValue,
     patterns: JSValue,
     files: JSValue,

--- a/src/js/builtins/Bake.ts
+++ b/src/js/builtins/Bake.ts
@@ -16,6 +16,7 @@ export function renderRoutesForProdStatic(
   allServerFiles: string[],
   // Indexed by router type index
   renderStatic: FrameworkPrerender[],
+  getParams: FrameworkGetParams[],
   clientEntryUrl: string[],
   // Indexed by route index
   patterns: string[],
@@ -41,6 +42,65 @@ export function renderRoutesForProdStatic(
 
   let loadedModules = new Array(allServerFiles.length);
 
+  async function doGenerateRoute(
+    type: number,
+    i: number,
+    layouts: any[],
+    pageModule: any,
+    params: Record<string, string> | null,
+  ) {
+    // Call the framework's rendering function
+    const callback = renderStatic[type];
+    $assert(callback != null && $isCallable(callback));
+    const results = await callback({
+      modules: [clientEntryUrl[type]],
+      modulepreload: [],
+      styles: styles[i],
+      layouts,
+      pageModule,
+      params,
+    } satisfies Bake.RouteMetadata);
+    if (results == null) {
+      throw new Error(`Route ${JSON.stringify(sourceRouteFiles[i])} cannot be pre-rendered to a static page.`);
+    }
+    if (typeof results !== "object") {
+      throw new Error(
+        `Rendering route ${JSON.stringify(sourceRouteFiles[i])} did not return an object, got ${Bun.inspect(results)}. This is a bug in the framework.`,
+      );
+    }
+    const { files } = results;
+    if (files == null) {
+      throw new Error(`Route ${JSON.stringify(sourceRouteFiles[i])} cannot be pre-rendered to a static page.`);
+    }
+    await Promise.all(
+      Object.entries(files).map(([key, value]) => {
+        if (params != null) {
+          $assert(patterns[i].includes(`:`));
+          // replace the :paramName part of patterns[i] with the value of params[paramName]
+          // use a regex in replace with a callback
+          const newKey = patterns[i].replace(/:(\w+)/g, (_, p1) => params[p1]);
+          return Bun.write(pathJoin(outBase, newKey + key), value);
+        }
+        return Bun.write(pathJoin(outBase, patterns[i] + key), value);
+      }),
+    );
+  }
+
+  function callRouteGenerator(
+    type: number,
+    i: number,
+    layouts: any[],
+    pageModule: any,
+    params: Record<string, string>,
+  ) {
+    for (const param of paramInformation[i]!) {
+      if (!params[param]) {
+        throw new Error(`Missing param ${param} for route ${JSON.stringify(sourceRouteFiles[i])}`);
+      }
+    }
+    return doGenerateRoute(type, i, layouts, pageModule, params);
+  }
+
   return Promise.all(
     files.map(async (fileList, i) => {
       const typeAndFlag = typeAndFlags[i];
@@ -61,37 +121,30 @@ export function renderRoutesForProdStatic(
       }
 
       if (paramInformation[i] != null) {
-        throw new Error("TODO: call the framework to get the param information");
+        const getParam = getParams[type];
+        $assert(getParam != null && $isCallable(getParam));
+        const paramGetter: Bake.GetParamIterator = await getParam({
+          pageModule,
+          layouts,
+        });
+        if (paramGetter[Symbol.asyncIterator] != undefined) {
+          for await (const params of paramGetter) {
+            callRouteGenerator(type, i, layouts, pageModule, params);
+          }
+        } else if (paramGetter[Symbol.iterator] != undefined) {
+          for (const params of paramGetter) {
+            callRouteGenerator(type, i, layouts, pageModule, params);
+          }
+        } else {
+          await Promise.all(
+            paramGetter.pages.map(params => {
+              callRouteGenerator(type, i, layouts, pageModule, params);
+            }),
+          );
+        }
+      } else {
+        await doGenerateRoute(type, i, layouts, pageModule, null);
       }
-
-      // Call the framework's rendering function
-      const callback = renderStatic[type];
-      $assert(callback != null && $isCallable(callback));
-      const results = await callback({
-        modules: [clientEntryUrl[type]],
-        modulepreload: [],
-        styles: styles[i],
-        layouts,
-        pageModule,
-        params: null,
-      } satisfies Bake.RouteMetadata);
-      if (results == null) {
-        throw new Error(`Route ${JSON.stringify(sourceRouteFiles[i])} cannot be pre-rendered to a static page.`);
-      }
-      if (typeof results !== "object") {
-        throw new Error(
-          `Rendering route ${JSON.stringify(sourceRouteFiles[i])} did not return an object, got ${Bun.inspect(results)}. This is a bug in the framework.`,
-        );
-      }
-      const { files } = results;
-      if (files == null) {
-        throw new Error(`Route ${JSON.stringify(sourceRouteFiles[i])} cannot be pre-rendered to a static page.`);
-      }
-      await Promise.all(
-        Object.entries(files).map(([key, value]) => {
-          return Bun.write(pathJoin(outBase, patterns[i] + key), value);
-        }),
-      );
     }),
   );
 }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
allows bun build to generate routes w/ params using getStaticPaths
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
