### PR TITLE
support `bun link .`

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9062,7 +9062,9 @@ pub const PackageManager = struct {
             Output.flush();
         }
 
-        if (manager.options.positionals.len == 1) {
+        const is_dot = (manager.options.positionals.len >= 2 and strings.eqlComptime(manager.options.positionals[1], "."));
+
+        if (manager.options.positionals.len == 1 or is_dot) {
             // bun link
 
             var lockfile: Lockfile = undefined;
@@ -9244,7 +9246,9 @@ pub const PackageManager = struct {
             Output.flush();
         }
 
-        if (manager.options.positionals.len == 1) {
+        const is_dot = (manager.options.positionals.len >= 2 and strings.eqlComptime(manager.options.positionals[1], "."));
+
+        if (manager.options.positionals.len == 1 or is_dot) {
             // bun unlink
 
             var lockfile: Lockfile = undefined;

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -354,6 +354,40 @@ it("should link scoped package", async () => {
   expect(err4).toContain(`error: Package "${link_name}" is not linked`);
   expect((await new Response(stdout4).text()).split(/\r?\n/)).toEqual([expect.stringContaining("bun link v1."), ""]);
   expect(await exited4).toBe(1);
+
+  const {
+    stdout: stdout5,
+    stderr: stderr5,
+    exited: exited5,
+  } = spawn({
+    cmd: [bunExe(), "link", "."],
+    cwd: link_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err5 = await new Response(stderr5).text();
+  expect(err5.split(/\r?\n/)).toEqual([""]);
+  expect(await new Response(stdout5).text()).toContain(`Success! Registered "${link_name}"`);
+  expect(await exited5).toBe(0);
+
+  const {
+    stdout: stdout6,
+    stderr: stderr6,
+    exited: exited6,
+  } = spawn({
+    cmd: [bunExe(), "unlink", "."],
+    cwd: link_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err6 = await new Response(stderr6).text();
+  expect(err6.split(/\r?\n/)).toEqual([""]);
+  expect(await new Response(stdout6).text()).toContain(`success: unlinked package "${link_name}"`);
+  expect(await exited6).toBe(0);
 });
 
 it("should link dependency without crashing", async () => {


### PR DESCRIPTION
### What does this PR do?

fixes #2686

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

made tests + manually tested

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
