### PR TITLE
Add "DOM.Iterable" lib to tsconfig-for-init.json

### DIFF
--- a/src/cli/tsconfig-for-init.json
+++ b/src/cli/tsconfig-for-init.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Enable latest features
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",


### PR DESCRIPTION
Would this make sense for `bun init`? I see it as certainly convenient, and in alignment with the existing "ESNext" plus "DOM" combo.