### PR TITLE
fix: Connect with 1 socket to new env var but still work with js debug terminal

### DIFF
--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -120,6 +120,7 @@ async function injectDebugTerminal(terminal: vscode.Terminal): Promise<void> {
       ...env,
       "BUN_INSPECT": `${adapter.url}?${query}`,
       "BUN_INSPECT_NOTIFY": signal.url,
+      BUN_INSPECT_CONNECT_TO: "",
     },
   });
 
@@ -351,6 +352,7 @@ class TerminalDebugSession extends FileDebugSession {
       env: {
         "BUN_INSPECT": `${this.adapter.url}?wait=1`,
         "BUN_INSPECT_NOTIFY": this.signal.url,
+        BUN_INSPECT_CONNECT_TO: "",
       },
       isTransient: true,
       iconPath: new vscode.ThemeIcon("debug-console"),

--- a/packages/bun-vscode/src/global-state.ts
+++ b/packages/bun-vscode/src/global-state.ts
@@ -3,7 +3,7 @@ import { ExtensionContext } from "vscode";
 export const GLOBAL_STATE_VERSION = 1;
 
 export type GlobalStateTypes = {
-  BUN_INSPECT_NOTIFY:
+  BUN_INSPECT_CONNECT_TO:
     | {
         type: "tcp";
         port: number;


### PR DESCRIPTION
### What does this PR do?

Fixes the connection by using a new environment variable, so the logic stays the same from previous versions of bun with BUN_INSPECT and _NOTIFY

### How did you verify your code works?

Test with bun 1.1.37, as well as a local release build in both the normal terminal and the debug terminal.

It's possible I've missed a case for testing here, and in an effort to not have another botched release, it would be great if someone else could test this as well locally.