### PR TITLE
Fixed crash when running server.subscriberCount() in Bun.serve

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -189,6 +189,10 @@ public:
      * This function should probably be optimized a lot in future releases,
      * it could be O(1) with a hash map of fullnames and their counts. */
     unsigned int numSubscribers(std::string_view topic) {
+        if (topicTree == NULL) {
+            return 0;
+        }
+
         Topic *t = topicTree->lookupTopic(topic);
         if (t) {
             return (unsigned int) t->size();


### PR DESCRIPTION
### What does this PR do?

Fixes #15470 `Crash when running server.subscriberCount() in Bun.serve` by checking if topicTree is `NULL` in `App` before attempting to lookup the topic.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I added a test to verify the crash no longer happens. Additionally, I ran every websocket test with `bun test websocket` after compiling it to a release build.