### PR TITLE
`bun upgrade --help` document `--stable` option

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2546,7 +2546,7 @@ pub const Command = struct {
                     const args = comptime switch (Environment.is_canary) {
                         true => .{ "canary", "Switch from the canary version back to the latest stable release", "stable" },
                         false => .{ "stable", "Install the most recent canary version of Bun", "canary" },
-                    };                    
+                    };
 
                     Output.pretty(intro_text, .{});
                     Output.pretty("\n\n", .{});

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2533,11 +2533,14 @@ pub const Command = struct {
                     ;
                     const outro_text =
                         \\<b>Examples:<r>
-                        \\  <d>Install the latest stable version<r>
+                        \\  <d>Install the latest {s} version<r>
                         \\  <b><green>bun upgrade<r>
                         \\
                         \\  <d>Install the most recent canary version of Bun<r>
-                        \\  <b><green>bun upgrade --canary<r>
+                        \\  <b><green>bun upgrade<r> <cyan>--canary<r>
+                        \\
+                        \\  <d>Switch from the canary version back to the latest stable release<r>
+                        \\  <b><green>bun upgrade<r> <cyan>--stable<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/installation#upgrading<r>
                         \\
@@ -2545,7 +2548,7 @@ pub const Command = struct {
                     Output.pretty(intro_text, .{});
                     Output.pretty("\n\n", .{});
                     Output.flush();
-                    Output.pretty(outro_text, .{});
+                    Output.pretty(outro_text, .{if (Environment.is_canary) "canary" else "stable"});
                     Output.flush();
                 },
                 Command.Tag.ReplCommand => {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2536,19 +2536,22 @@ pub const Command = struct {
                         \\  <d>Install the latest {s} version<r>
                         \\  <b><green>bun upgrade<r>
                         \\
-                        \\  <d>Install the most recent canary version of Bun<r>
-                        \\  <b><green>bun upgrade<r> <cyan>--canary<r>
-                        \\
-                        \\  <d>Switch from the canary version back to the latest stable release<r>
-                        \\  <b><green>bun upgrade<r> <cyan>--stable<r>
+                        \\  <d>{s}<r>
+                        \\  <b><green>bun upgrade<r> <cyan>--{s}<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/installation#upgrading<r>
                         \\
                     ;
+
+                    const args = comptime switch (Environment.is_canary) {
+                        true => .{ "canary", "Switch from the canary version back to the latest stable release", "stable" },
+                        false => .{ "stable", "Install the most recent canary version of Bun", "canary" },
+                    };                    
+
                     Output.pretty(intro_text, .{});
                     Output.pretty("\n\n", .{});
                     Output.flush();
-                    Output.pretty(outro_text, .{if (Environment.is_canary) "canary" else "stable"});
+                    Output.pretty(outro_text, args);
                     Output.flush();
                 },
                 Command.Tag.ReplCommand => {


### PR DESCRIPTION
### What does this PR do?

fixes #15113

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
