### PR TITLE
Add request object to Bun.serve error Handler

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1907,7 +1907,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         /// Defer finalization until after the request handler task is completed?
         defer_deinit_until_callback_completes: ?*bool = null,
 
-        js_requestObject: JSC.JSValue = JSC.JSValue.zero,
+        js_request_object: JSC.JSValue = JSC.JSValue.zero,
 
         // TODO: support builtin compression
         const can_sendfile = !ssl_enabled and !Environment.isWindows;
@@ -3660,7 +3660,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     const result = server.config.onError.call(
                         server.globalThis,
                         server.thisObject,
-                        &.{ value, this.js_requestObject },
+                        &.{ value, this.js_request_object },
                     ) catch |err| server.globalThis.takeException(err);
                     defer result.ensureStillAlive();
                     if (!result.isEmptyOrUndefinedOrNull()) {
@@ -7006,9 +7006,9 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 }
             }
 
-            ctx.js_requestObject = request_object.toJS(this.globalThis);
+            ctx.js_request_object = request_object.toJS(this.globalThis);
             return .{
-                .js_request = ctx.js_requestObject,
+                .js_request = ctx.js_request_object,
                 .request_object = request_object,
                 .ctx = ctx,
             };


### PR DESCRIPTION
### What does this PR do?

Fixes #15475 

This PR adds the js request object to the error handler for Bun.serve

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
- [ ] Write Tests 