### PR TITLE
Introduce experimental flag: `bun build --auto-install <entry points...>`

### DIFF
--- a/src/bake/production.zig
+++ b/src/bake/production.zig
@@ -47,14 +47,7 @@ pub fn buildCommand(ctx: bun.CLI.Command.Context) !void {
     vm.argv = ctx.passthrough;
     vm.arena = &arena;
     vm.allocator = arena.allocator();
-    b.options.install = ctx.install;
-    b.resolver.opts.install = ctx.install;
-    b.resolver.opts.global_cache = ctx.debug.global_cache;
-    b.resolver.opts.prefer_offline_install = (ctx.debug.offline_mode_setting orelse .online) == .offline;
-    b.resolver.opts.prefer_latest_install = (ctx.debug.offline_mode_setting orelse .online) == .latest;
-    b.options.global_cache = b.resolver.opts.global_cache;
-    b.options.prefer_offline_install = b.resolver.opts.prefer_offline_install;
-    b.options.prefer_latest_install = b.resolver.opts.prefer_latest_install;
+    b.configureAutoInstall(ctx.install, &ctx.debug);
     b.resolver.env_loader = b.env;
     b.options.minify_identifiers = ctx.bundler_options.minify_identifiers;
     b.options.minify_whitespace = ctx.bundler_options.minify_whitespace;

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -812,7 +812,7 @@ pub const ModuleLoader = struct {
                 this.vm().packageManager().drainDependencyList();
             }
 
-            pub fn onDependencyError(ctx: *anyopaque, dependency: Dependency, root_dependency_id: Install.DependencyID, err: anyerror) void {
+            pub fn onDependencyError(ctx: *anyopaque, dependency: *const Dependency, root_dependency_id: Install.DependencyID, err: anyerror) void {
                 var this = bun.cast(*Queue, ctx);
                 debug("onDependencyError: {s}", .{this.vm().packageManager().lockfile.str(&dependency.name)});
 

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1016,7 +1016,7 @@ pub const ModuleLoader = struct {
                             continue;
                         }
 
-                        const package = pm.lockfile.packages.get(package_id);
+                        const package = &pm.lockfile.packages.get(package_id);
                         bun.assert(package.resolution.tag != .root);
 
                         var name_and_version_hash: ?u64 = null;

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -77,14 +77,7 @@ pub const Run = struct {
         vm.arena = &run.arena;
         vm.allocator = arena.allocator();
 
-        b.options.install = ctx.install;
-        b.resolver.opts.install = ctx.install;
-        b.resolver.opts.global_cache = ctx.debug.global_cache;
-        b.resolver.opts.prefer_offline_install = (ctx.debug.offline_mode_setting orelse .online) == .offline;
-        b.resolver.opts.prefer_latest_install = (ctx.debug.offline_mode_setting orelse .online) == .latest;
-        b.options.global_cache = b.resolver.opts.global_cache;
-        b.options.prefer_offline_install = b.resolver.opts.prefer_offline_install;
-        b.options.prefer_latest_install = b.resolver.opts.prefer_latest_install;
+        b.configureAutoInstall(ctx.install, &ctx.debug);
         b.resolver.env_loader = b.env;
 
         b.options.minify_identifiers = ctx.bundler_options.minify_identifiers;
@@ -222,14 +215,7 @@ pub const Run = struct {
             }
         }
 
-        b.options.install = ctx.install;
-        b.resolver.opts.install = ctx.install;
-        b.resolver.opts.global_cache = ctx.debug.global_cache;
-        b.resolver.opts.prefer_offline_install = (ctx.debug.offline_mode_setting orelse .online) == .offline;
-        b.resolver.opts.prefer_latest_install = (ctx.debug.offline_mode_setting orelse .online) == .latest;
-        b.options.global_cache = b.resolver.opts.global_cache;
-        b.options.prefer_offline_install = b.resolver.opts.prefer_offline_install;
-        b.options.prefer_latest_install = b.resolver.opts.prefer_latest_install;
+        b.configureAutoInstall(ctx.install, &ctx.debug);
         b.resolver.env_loader = b.env;
 
         b.options.minify_identifiers = ctx.bundler_options.minify_identifiers;

--- a/src/bundler.zig
+++ b/src/bundler.zig
@@ -395,6 +395,17 @@ pub const Bundler = struct {
         this.resolver.allocator = allocator;
     }
 
+    pub fn configureAutoInstall(this: *Bundler, install: ?*Api.BunInstall, debug: *const DebugOptions) void {
+        this.options.install = install;
+        this.resolver.opts.install = install;
+        this.resolver.opts.global_cache = debug.global_cache;
+        this.resolver.opts.prefer_offline_install = (debug.offline_mode_setting orelse .online) == .offline;
+        this.resolver.opts.prefer_latest_install = (debug.offline_mode_setting orelse .online) == .latest;
+        this.options.global_cache = this.resolver.opts.global_cache;
+        this.options.prefer_offline_install = this.resolver.opts.prefer_offline_install;
+        this.options.prefer_latest_install = this.resolver.opts.prefer_latest_install;
+    }
+
     fn _resolveEntryPoint(bundler: *Bundler, entry_point: string) !_resolver.Result {
         return bundler.resolver.resolveWithFramework(bundler.fs.top_level_dir, entry_point, .entry_point) catch |err| {
             // Relative entry points that were not resolved to a node_modules package are

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2723,7 +2723,7 @@ pub const BundleV2 = struct {
                 const auto_install: *AutoInstall = bun.cast(*AutoInstall, user_data_ptr);
                 const root_id = root_dependency_ids[tag_i];
                 const resolution_ids = pm.lockfile.buffers.resolutions.items;
-                if (root_id >= resolution_ids.len or auto_install.pending_import_count == 0) continue;
+                if (root_id >= resolution_ids.len or auto_install.pending_import_count == 0 or auto_install.parse_task_result == null) continue;
                 const package_id = resolution_ids[root_id];
 
                 if (prev_auto_install == null or (prev_auto_install.? != auto_install)) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -285,7 +285,7 @@ pub const Arguments = struct {
         clap.parseParam("--experimental-css               Enabled experimental CSS bundling") catch unreachable,
         clap.parseParam("--experimental-css-chunking      Chunk CSS files together to reduce duplicated CSS loaded in a browser. Only has an affect when multiple entrypoints import CSS") catch unreachable,
         clap.parseParam("--no-install                      Disable auto install in the Bun runtime") catch unreachable,
-        clap.parseParam("--auto-install <STR>                   Configure auto-install behavior. One of \"auto\" (default, auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always).") catch unreachable,
+        clap.parseParam("--auto-install <STR>?             Configure auto-install behavior. One of \"auto\" (auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always), \"disable\" (default, no auto-installs).") catch unreachable,
         clap.parseParam("-i                                Auto-install dependencies during execution. Equivalent to --install=fallback.") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
         clap.parseParam("--conditions <STR>...            Pass custom conditions to resolve") catch unreachable,
@@ -846,6 +846,8 @@ pub const Arguments = struct {
                     Output.errGeneric("Invalid value for --auto-install: \"{s}\". Must be either \"auto\", \"fallback\", \"force\", or \"disable\"\n", .{enum_value});
                     Global.exit(1);
                 }
+            } else {
+                ctx.debug.global_cache = .disable;
             }
 
             if (args.options("--external").len > 0) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -285,7 +285,7 @@ pub const Arguments = struct {
         clap.parseParam("--experimental-css               Enabled experimental CSS bundling") catch unreachable,
         clap.parseParam("--experimental-css-chunking      Chunk CSS files together to reduce duplicated CSS loaded in a browser. Only has an affect when multiple entrypoints import CSS") catch unreachable,
         clap.parseParam("--no-install                      Disable auto install in the Bun runtime") catch unreachable,
-        clap.parseParam("--install <STR>                   Configure auto-install behavior. One of \"auto\" (default, auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always).") catch unreachable,
+        clap.parseParam("--auto-install <STR>                   Configure auto-install behavior. One of \"auto\" (default, auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always).") catch unreachable,
         clap.parseParam("-i                                Auto-install dependencies during execution. Equivalent to --install=fallback.") catch unreachable,
         clap.parseParam("--dump-environment-variables") catch unreachable,
         clap.parseParam("--conditions <STR>...            Pass custom conditions to resolve") catch unreachable,
@@ -788,7 +788,7 @@ pub const Arguments = struct {
 
         ctx.bundler_options.ignore_dce_annotations = args.flag("--ignore-dce-annotations");
 
-        if (cmd == .BuildCommand) {
+        if (comptime cmd == .BuildCommand) {
             ctx.bundler_options.transform_only = args.flag("--no-bundle");
             ctx.bundler_options.bytecode = args.flag("--bytecode");
 
@@ -835,15 +835,15 @@ pub const Arguments = struct {
 
             if (args.flag("-i")) {
                 ctx.debug.global_cache = .fallback;
-            } else if (args.option("--install")) |enum_value| {
-                // -i=auto --install=force, --install=disable
+            } else if (args.option("--auto-install")) |enum_value| {
+                // -i=auto --auto-install=force, --auto-install=disable
                 if (options.GlobalCache.Map.get(enum_value)) |result| {
                     ctx.debug.global_cache = result;
-                    // -i, --install
+                    // -i, --auto-install
                 } else if (enum_value.len == 0) {
                     ctx.debug.global_cache = options.GlobalCache.force;
                 } else {
-                    Output.errGeneric("Invalid value for --install: \"{s}\". Must be either \"auto\", \"fallback\", \"force\", or \"disable\"\n", .{enum_value});
+                    Output.errGeneric("Invalid value for --auto-install: \"{s}\". Must be either \"auto\", \"fallback\", \"force\", or \"disable\"\n", .{enum_value});
                     Global.exit(1);
                 }
             }

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -105,8 +105,6 @@ pub const BuildCommand = struct {
         this_bundler.options.emit_dce_annotations = ctx.bundler_options.emit_dce_annotations;
         this_bundler.options.ignore_dce_annotations = ctx.bundler_options.ignore_dce_annotations;
 
-        this_bundler.configureAutoInstall(ctx.install, &ctx.debug);
-
         this_bundler.options.banner = ctx.bundler_options.banner;
         this_bundler.options.footer = ctx.bundler_options.footer;
         this_bundler.options.drop = ctx.args.drop;
@@ -272,6 +270,8 @@ pub const BuildCommand = struct {
         var reachable_file_count: usize = 0;
         var minify_duration: u64 = 0;
         var input_code_length: u64 = 0;
+
+        this_bundler.configureAutoInstall(ctx.install, &ctx.debug);
 
         const output_files: []options.OutputFile = brk: {
             if (ctx.bundler_options.transform_only) {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -105,6 +105,8 @@ pub const BuildCommand = struct {
         this_bundler.options.emit_dce_annotations = ctx.bundler_options.emit_dce_annotations;
         this_bundler.options.ignore_dce_annotations = ctx.bundler_options.ignore_dce_annotations;
 
+        this_bundler.configureAutoInstall(ctx.install, &ctx.debug);
+
         this_bundler.options.banner = ctx.bundler_options.banner;
         this_bundler.options.footer = ctx.bundler_options.footer;
         this_bundler.options.drop = ctx.args.drop;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -3082,8 +3082,8 @@ pub const PackageManager = struct {
             return bun.cast(*const fn (ctx: *anyopaque, pm: *PackageManager) void, t.handler);
         }
 
-        pub inline fn getonDependencyError(t: @This()) *const fn (ctx: *anyopaque, Dependency, DependencyID, anyerror) void {
-            return bun.cast(*const fn (ctx: *anyopaque, Dependency, DependencyID, anyerror) void, t.handler);
+        pub inline fn getonDependencyError(t: @This()) *const fn (ctx: *anyopaque, *const Dependency, DependencyID, anyerror) void {
+            return bun.cast(*const fn (ctx: *anyopaque, *const Dependency, DependencyID, anyerror) void, t.handler);
         }
     };
 
@@ -3091,7 +3091,7 @@ pub const PackageManager = struct {
         if (this.onWake.context) |ctx| {
             this.onWake.getonDependencyError()(
                 ctx,
-                dependency.*,
+                dependency,
                 dependency_id,
                 err,
             );

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -48,8 +48,8 @@ pub const LifecycleScriptSubprocess = struct {
         return this.manager.event_loop.loop();
     }
 
-    pub fn eventLoop(this: *const LifecycleScriptSubprocess) *JSC.AnyEventLoop {
-        return &this.manager.event_loop;
+    pub fn eventLoop(this: *const LifecycleScriptSubprocess) JSC.EventLoopHandle {
+        return this.manager.event_loop;
     }
 
     pub fn scriptName(this: *const LifecycleScriptSubprocess) []const u8 {
@@ -187,7 +187,7 @@ pub const LifecycleScriptSubprocess = struct {
 
             .windows = if (Environment.isWindows)
                 .{
-                    .loop = JSC.EventLoopHandle.init(&manager.event_loop),
+                    .loop = this.eventLoop(),
                 }
             else {},
 
@@ -233,7 +233,7 @@ pub const LifecycleScriptSubprocess = struct {
             }
         }
 
-        const event_loop = &this.manager.event_loop;
+        const event_loop = this.manager.event_loop;
         var process = spawned.toProcess(
             event_loop,
             false,

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -204,7 +204,7 @@ pub const PatchTask = struct {
             var out_name_and_version_hash: ?u64 = null;
             var out_patchfile_hash: ?u64 = null;
             manager.setPreinstallState(pkg.meta.id, manager.lockfile, .unknown);
-            switch (manager.determinePreinstallState(pkg, manager.lockfile, &out_name_and_version_hash, &out_patchfile_hash)) {
+            switch (manager.determinePreinstallState(&pkg, manager.lockfile, &out_name_and_version_hash, &out_patchfile_hash)) {
                 .done => {
                     // patched pkg in folder path, should now be handled by PackageInstall.install()
                     debug("pkg: {s} done", .{pkg.name.slice(manager.lockfile.buffers.string_bytes.items)});

--- a/src/install/resolution.zig
+++ b/src/install/resolution.zig
@@ -342,7 +342,10 @@ pub const Resolution = extern struct {
         }
 
         pub fn canEnqueueInstallTask(this: Tag) bool {
-            return this == .npm or this == .local_tarball or this == .remote_tarball or this == .git or this == .github;
+            return switch (this) {
+                .npm, .local_tarball, .remote_tarball, .git, .github, .gitlab => true,
+                else => false,
+            };
         }
     };
 };

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -626,11 +626,21 @@ const BufferedReaderVTable = struct {
                 }
             }.loop_fn;
 
+            const event_loop_fn = &struct {
+                pub fn event_loop_fn(this: *anyopaque) JSC.EventLoopHandle {
+                    const result = Type.eventLoop(@alignCast(@ptrCast(this)));
+                    if (@TypeOf(result) == JSC.EventLoopHandle) {
+                        return result;
+                    }
+                    return JSC.EventLoopHandle.init(result);
+                }
+            }.event_loop_fn;
+
             return comptime &BufferedReaderVTable.Fn{
                 .onReadChunk = if (@hasDecl(Type, "onReadChunk")) @ptrCast(&Type.onReadChunk) else null,
                 .onReaderDone = @ptrCast(&Type.onReaderDone),
                 .onReaderError = @ptrCast(&Type.onReaderError),
-                .eventLoop = @ptrCast(&Type.eventLoop),
+                .eventLoop = event_loop_fn,
                 .loop = loop_fn,
             };
         }

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -626,16 +626,11 @@ const BufferedReaderVTable = struct {
                 }
             }.loop_fn;
 
-            const eventLoop_fn = &struct {
-                pub fn eventLoop_fn(this: *anyopaque) JSC.EventLoopHandle {
-                    return JSC.EventLoopHandle.init(Type.eventLoop(@alignCast(@ptrCast(this))));
-                }
-            }.eventLoop_fn;
             return comptime &BufferedReaderVTable.Fn{
                 .onReadChunk = if (@hasDecl(Type, "onReadChunk")) @ptrCast(&Type.onReadChunk) else null,
                 .onReaderDone = @ptrCast(&Type.onReaderDone),
                 .onReaderError = @ptrCast(&Type.onReaderError),
-                .eventLoop = eventLoop_fn,
+                .eventLoop = @ptrCast(&Type.eventLoop),
                 .loop = loop_fn,
             };
         }

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -1238,7 +1238,7 @@ pub fn spawnOpts(
     new_folder: []const u8,
     cwd: [:0]const u8,
     git: [:0]const u8,
-    loop: *JSC.AnyEventLoop,
+    loop: JSC.EventLoopHandle,
 ) bun.spawn.sync.Options {
     const argv: []const []const u8 = brk: {
         const ARGV = &[_][:0]const u8{
@@ -1287,10 +1287,7 @@ pub fn spawnOpts(
         .cwd = cwd,
         .envp = envp,
         .argv = argv,
-        .windows = if (bun.Environment.isWindows) .{ .loop = switch (loop.*) {
-            .js => |x| .{ .js = x },
-            .mini => |*x| .{ .mini = x },
-        } } else {},
+        .windows = if (bun.Environment.isWindows) .{ .loop = loop } else {},
     };
 }
 


### PR DESCRIPTION
### What does this PR do?

This implements [auto install](https://bun.sh/docs/runtime/autoimport) for `bun build`. 

When using bun's bundler, you can now automatically install dependencies -- and only the dependencies the bundled code is using. This means you can skip running `bun install` (or npm/yarn/pnpm install).

This can lead to smaller Docker containers and faster CI times than using something like `turbo prune` or `"devDependencies"` in package.json because dependencies which are not used by any code will not be installed.

To use it:
```sh
bun build --auto-install <entry-points...>
bun build -i <entry-points>
```

If a `bun.lockb` or a package-json.lock is present, it will continue to use the resolved versions from the lockfile (and will still save space because it only installs those which are referenced). If no lockfile is present, it will prefer the versions from package.json.

Tradeoffs:
- This doesn't run any postinstall scripts
- This doesn't support patch (though that could be fixed in the future)
- If dependencies are not imported or required in any code visible to `bun build`, it will not be installed

This uses bun's global cache, which conserves disk space by avoiding a per-project node_modules folder.

### How did you verify your code works?

TODO before merging:
- [ ] Handle manifest download errors
- [ ] Handle package download errors
- [ ] Investigate difficulty of supporting Bun.build()
- [ ] Be a little smarter about resolving package versions
- [ ] Some tests
