### PR TITLE
fix(parser): rewrite process.env to bun.env when compiling

### DIFF
--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -8,7 +8,8 @@
 /// Version 9: String printing changes
 /// Version 10: Constant folding for ''.charCodeAt(n)
 /// Version 11: Fix \uFFFF printing regression
-const expected_version = 11;
+/// Version 12: Fix process.env not behaving correctly when compiling
+const expected_version = 12;
 
 const bun = @import("root").bun;
 const std = @import("std");

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3893,6 +3893,7 @@ pub const ParseTask = struct {
         opts.warn_about_unbundled_modules = false;
         opts.macro_context = &this.data.macro_context;
         opts.package_version = task.package_version;
+        opts.rewrite_process_env = target.isBun();
 
         opts.features.auto_polyfill_require = output_format == .esm and !target.isBun();
         opts.features.allow_runtime = !source.index.isRuntime();

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -275,7 +275,7 @@ fn NewLexer_(
 
         /// Look ahead at the next n codepoints without advancing the iterator.
         /// If fewer than n codepoints are available, then return the remainder of the string.
-        fn peek(it: *LexerType, n: usize) string {
+        pub fn peek(it: *LexerType, n: usize) string {
             const original_i = it.current;
             defer it.current = original_i;
 


### PR DESCRIPTION

fixes: #11191 , #7434 , #8125 , #12695

### What does this PR do?

Fixes issue where process.env becomes inlined after compiling to an executable, not actually being read from the environment

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

# Tested manually with:

// index.js
```
const a = process.env.TEST_ENV_VAR;
const b = Bun.env.TEST_ENV_VAR;

a === b ? console.log('process and bun env are equal') : console.log('process and bun env are not equal');
```

Then ran:
```
export TEST_ENV_VAR=test
bun-debug build --compile --target=bun --outfile test ./index.js
./test
```
^ output: process and bun env are equal
then:
```
export TEST_ENV_VAR=test2
./test
```
^ output: process and bun env are equal

Doing the same thing on the release build of bun, after changing the variable the two are not equal.