### PR TITLE
Preserve authorization headers in bun install when redirects are same hostname

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -443,6 +443,7 @@ const NetworkTask = struct {
             .http_proxy = this.package_manager.httpProxy(url),
         });
         this.http.client.flags.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
+        this.http.client.flags.redirect_headers_behavior = .curl;
 
         if (PackageManager.verbose_install) {
             this.http.client.verbose = .headers;
@@ -532,6 +533,7 @@ const NetworkTask = struct {
             .http_proxy = this.package_manager.httpProxy(url),
         });
         this.http.client.flags.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
+        this.http.client.flags.redirect_headers_behavior = .curl;
         if (PackageManager.verbose_install) {
             this.http.client.verbose = .headers;
         }


### PR DESCRIPTION

### What does this PR do?

Preserve authorization headers in bun install when redirects are same hostname

From [make-fetch-happen](https://github.com/npm/cli/blob/fefd509992a05c2dfddbe7bc46931c42f1da69d7/node_modules/make-fetch-happen/lib/fetch.js#L64-L71):
```js
  // Remove authorization if changing hostnames (but not if just
  // changing ports or protocols).  This matches the behavior of request:
  // https://github.com/request/request/blob/b12a6245/lib/redirect.js#L134-L138
  if (new url.URL(request.url).hostname !== redirectUrl.hostname) {
    request.headers.delete('authorization')
    request.headers.delete('cookie')
  }
```
From that comment:
```js
    if (request.uri.hostname !== request.originalHost.split(':')[0]) {
        // Remove authorization if changing hostnames (but not if just
        // changing ports or protocols).  This matches the behavior of curl:
        // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
        request.removeHeader('authorization')
      }
```

Sadly, the perma link there is not so perma

Fixes #15516 

### How did you verify your code works?

Untested. Needs a test