### PR TITLE
docs: add .env.test to guides/runtime/set-env for consistency with do…

### DIFF
--- a/docs/guides/runtime/set-env.md
+++ b/docs/guides/runtime/set-env.md
@@ -16,7 +16,7 @@ Set these variables in a `.env` file.
 Bun reads the following files automatically (listed in order of increasing precedence).
 
 - `.env`
-- `.env.production` or `.env.development` (depending on value of `NODE_ENV`)
+- `.env.production`, `.env.development`, `.env.test` (depending on value of `NODE_ENV`)
 - `.env.local`
 
 ```txt#.env


### PR DESCRIPTION
### What does this PR do?

Fixed a small inconsistency that tripped me up where [guides/runtime/set-env](https://bun.sh/guides/runtime/set-env) didn't mention the existence of `.env.test`.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes