### PR TITLE
fix(net/tls) fix backpressure pause on socket

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2153,6 +2153,8 @@ us_socket_context_on_socket_connect_error(
   socket->ssl_read_wants_write = 0;
   socket->fatal_error = 0;
   socket->handshake_state = HANDSHAKE_PENDING;
+  // always resume the socket
+  us_socket_resume(1, &socket->s);
   return socket;
 }
 

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1457,7 +1457,8 @@ fn NewSocket(comptime ssl: bool) type {
             JSC.markBinding(@src());
 
             log("resume", .{});
-            if (this.flags.is_paused) {
+            // we should not allow pausing/resuming a wrapped socket because a wrapped socket is 2 sockets and this can cause issues
+            if (this.wrapped == .none and this.flags.is_paused) {
                 this.flags.is_paused = !this.socket.resumeStream();
             }
             return .undefined;
@@ -1466,9 +1467,11 @@ fn NewSocket(comptime ssl: bool) type {
             JSC.markBinding(@src());
 
             log("pause", .{});
-            if (!this.flags.is_paused) {
+            // we should not allow pausing/resuming a wrapped socket because a wrapped socket is 2 sockets and this can cause issues
+            if (this.wrapped == .none and !this.flags.is_paused) {
                 this.flags.is_paused = this.socket.pauseStream();
             }
+
             return .undefined;
         }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -149,7 +149,7 @@ const Socket = (function (InternalSocket) {
 
         self.bytesRead += buffer.length;
         if (!self.push(buffer)) {
-          socket.pause();
+          self.pause();
         }
       },
       drain: Socket.#Drain,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -149,7 +149,7 @@ const Socket = (function (InternalSocket) {
 
         self.bytesRead += buffer.length;
         if (!self.push(buffer)) {
-          self.pause();
+          socket.pause();
         }
       },
       drain: Socket.#Drain,

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -1,0 +1,62 @@
+import net from "net";
+import tls from "tls";
+import { once } from "events";
+import { tls as certs } from "harness";
+import { test, expect } from "bun:test";
+
+test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {
+  // enought to trigger backpressure
+  const payload = Buffer.alloc(16 * 1024 * 4, "b").toString("utf8");
+
+  const server = tls.createServer(certs, socket => {
+    // echo
+    socket.on("data", data => {
+      socket.write(data);
+    });
+  });
+
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const socket = net.connect({
+    port: (server.address() as net.AddressInfo).port,
+    host: "127.0.0.1",
+  });
+  await once(socket, "connect");
+
+  // pause raw socket
+  socket.pause();
+
+  const tlsSocket = tls.connect({
+    ca: certs.cert,
+    servername: "localhost",
+    socket,
+  });
+  await once(tlsSocket, "secureConnect");
+
+  // do http request using tls socket
+  async function doWrite(socket: net.Socket) {
+    let downloadedBody = 0;
+    const { promise, resolve, reject } = Promise.withResolvers();
+    function onData(data: Buffer) {
+      downloadedBody += data.byteLength;
+      if (downloadedBody === payload.length * 2) {
+        resolve();
+      }
+    }
+    socket.pause();
+    socket.write(payload);
+    socket.write(payload, () => {
+      socket.on("data", onData);
+      socket.resume();
+    });
+
+    await promise;
+    socket.off("data", onData);
+  }
+  for (let i = 0; i < 100; i++) {
+    // upgrade the tlsSocket
+    await doWrite(tlsSocket);
+  }
+
+  expect().pass();
+});

--- a/test/js/third_party/postgres/postgres.test.ts
+++ b/test/js/third_party/postgres/postgres.test.ts
@@ -11,7 +11,7 @@ describe.skipIf(!databaseUrl)("postgres", () => {
       const [{ version }] = await sql`SELECT version()`;
       expect(version).toMatch(/PostgreSQL/);
     } finally {
-      sql.end();
+      await sql.end();
     }
   });
 
@@ -34,7 +34,7 @@ describe.skipIf(!databaseUrl)("postgres", () => {
         await Promise.all(batch);
       }
     } finally {
-      sql.end();
+      await sql.end();
     }
   });
 

--- a/test/js/third_party/postgres/postgres.test.ts
+++ b/test/js/third_party/postgres/postgres.test.ts
@@ -15,6 +15,29 @@ describe.skipIf(!databaseUrl)("postgres", () => {
     }
   });
 
+  test("should be able to resume after backpressure pause on upgraded handler #15438", async () => {
+    const sql = postgres(databaseUrl!);
+    try {
+      const batch = [];
+      for (let i = 0; i < 1000; i++) {
+        batch.push(
+          (async sql => {
+            const [{ version }] = await sql`SELECT version()`;
+            expect(version).toMatch(/PostgreSQL/);
+          })(sql),
+        );
+        if (batch.length === 50) {
+          await Promise.all(batch);
+        }
+      }
+      if (batch.length > 0) {
+        await Promise.all(batch);
+      }
+    } finally {
+      sql.end();
+    }
+  });
+
   test("should insert, select and delete", async () => {
     const sql = postgres(databaseUrl!);
     try {


### PR DESCRIPTION
### What does this PR do?
Fix: #15438
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Added tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
