### PR TITLE
Fixes ^C on `bun vite`

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -130,7 +130,18 @@ pub fn raiseIgnoringPanicHandler(sig: bun.SignalCode) noreturn {
     Output.flush();
     Output.Source.Stdio.restore();
 
+    // clear segfault handler
     bun.crash_handler.resetSegfaultHandler();
+
+    // clear signal handler
+    var sa: std.c.Sigaction = .{
+        .handler = .{ .handler = std.posix.SIG.DFL },
+        .mask = std.posix.empty_sigset,
+        .flags = std.posix.SA.RESETHAND,
+    };
+    _ = std.c.sigaction(@intFromEnum(sig), &sa, null);
+
+    // kill self
     _ = std.c.raise(@intFromEnum(sig));
     std.c.abort();
 }

--- a/src/Global.zig
+++ b/src/Global.zig
@@ -134,12 +134,14 @@ pub fn raiseIgnoringPanicHandler(sig: bun.SignalCode) noreturn {
     bun.crash_handler.resetSegfaultHandler();
 
     // clear signal handler
-    var sa: std.c.Sigaction = .{
-        .handler = .{ .handler = std.posix.SIG.DFL },
-        .mask = std.posix.empty_sigset,
-        .flags = std.posix.SA.RESETHAND,
-    };
-    _ = std.c.sigaction(@intFromEnum(sig), &sa, null);
+    if (bun.Environment.os != .windows) {
+        var sa: std.c.Sigaction = .{
+            .handler = .{ .handler = std.posix.SIG.DFL },
+            .mask = std.posix.empty_sigset,
+            .flags = std.posix.SA.RESETHAND,
+        };
+        _ = std.c.sigaction(@intFromEnum(sig), &sa, null);
+    }
 
     // kill self
     _ = std.c.raise(@intFromEnum(sig));

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -380,9 +380,8 @@ pub const RunCommand = struct {
                 if (signal.valid() and signal != .SIGINT and !silent) {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> script <b>\"{s}\"<r> was terminated by signal {}<r>", .{ name, signal.fmt(Output.enable_ansi_colors_stderr) });
                     Output.flush();
-
-                    Global.raiseIgnoringPanicHandler(signal);
                 }
+                Global.raiseIgnoringPanicHandler(signal);
             },
 
             .err => |err| {
@@ -548,7 +547,7 @@ pub const RunCommand = struct {
                     },
 
                     .signaled => |signal| {
-                        if (!silent) {
+                        if (signal.valid() and signal != .SIGINT and !silent) {
                             Output.prettyErrorln("<r><red>error<r>: Failed to run \"<b>{s}<r>\" due to signal <b>{s}<r>", .{
                                 basenameOrBun(executable),
                                 signal.name() orelse "unknown",

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 
 test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bun run", () => {
@@ -32,3 +32,68 @@ test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bu
   expect(result.exitCode).toBe(null);
   expect(result.signalCode).toBe("SIGKILL");
 });
+
+for (const mode of [
+  ["vite"],
+  ["dev"],
+  ["./node_modules/.bin/vite"],
+  ["--bun", "vite"],
+  ["--bun", "dev"],
+  ["--bun", "./node_modules/.bin/vite"],
+]) {
+  it("kills on SIGINT in: 'bun " + mode.join(" ") + "'", async () => {
+    const dir = tempDirWithFiles("ctrlc", {
+      "package.json": JSON.stringify({
+        name: "ctrlc",
+        scripts: {
+          "dev": "vite",
+        },
+        devDependencies: {
+          "vite": "^6.0.1",
+        },
+      }),
+    });
+    expect(
+      Bun.spawnSync({
+        cmd: [bunExe(), "install"],
+        cwd: dir,
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      }).exitCode,
+    ).toBe(0);
+    const proc = Bun.spawn({
+      cmd: [bunExe(), ...mode],
+      cwd: dir,
+      stdin: "inherit",
+      stdout: "pipe",
+      stderr: "inherit",
+      env: { ...bunEnv, PORT: "9876" },
+    });
+
+    // wait for vite to start
+    const reader = proc.stdout.getReader();
+    await reader.read(); // wait for first bit of stdout
+    reader.releaseLock();
+
+    expect(proc.killed).toBe(false);
+
+    // send sigint
+    process.kill(proc.pid, "SIGINT");
+
+    // wait for exit or 200ms
+    await Promise.race([proc.exited, Bun.sleep(200)]);
+
+    // wait to allow a moment to be killed
+    await Bun.sleep(100); // wait for kill
+    expect({
+      killed: proc.killed,
+      exitCode: proc.exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
+      killed: true,
+      exitCode: null,
+      signalCode: "SIGINT",
+    });
+  });
+}

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -36,10 +36,10 @@ test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bu
 for (const mode of [
   ["vite"],
   ["dev"],
-  ["./node_modules/.bin/vite"],
+  ...(isWindows ? [] : [["./node_modules/.bin/vite"]]),
   ["--bun", "vite"],
   ["--bun", "dev"],
-  ["--bun", "./node_modules/.bin/vite"],
+  ...(isWindows ? [] : [["--bun", "./node_modules/.bin/vite"]]),
 ]) {
   it("kills on SIGINT in: 'bun " + mode.join(" ") + "'", async () => {
     const dir = tempDirWithFiles("ctrlc", {

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -90,7 +90,11 @@ for (const mode of [
       killed: proc.killed,
       exitCode: proc.exitCode,
       signalCode: proc.signalCode,
-    }).toEqual({
+    }).toEqual(isWindows ? {
+      killed: true,
+      exitCode: 1,
+      signalCode: null,
+    } : {
       killed: true,
       exitCode: null,
       signalCode: "SIGINT",


### PR DESCRIPTION
### What does this PR do?

Fixes:

```
$> bun init -y
$> bun add vite
$> bun vite
^C

before:
  - error: Failed to run "vite" due to signal SIGINT
  - doesn't exit or respond to ^C anymore
after: (exits with code SIGINT)
```

### How did you verify your code works?

Added tests

### TODO

- [ ] Fix tests on windows (on windows, expect exitCode: 1, signalCode: null)
- [ ] Why does it not work with the restored signal handler? In the debugger, trigger the signal and then put a breakpoint on raise and see what happens inside the signal handler

Closes #14375 