### PR TITLE
add a `--config` test for bun install

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9358,7 +9358,7 @@ pub const PackageManager = struct {
         "Possible values: \"hardlink\" (default), \"symlink\", \"copyfile\"";
 
     const shared_params = [_]ParamType{
-        clap.parseParam("-c, --config <STR>?                   Specify path to config file (bunfig.toml)") catch unreachable,
+        clap.parseParam("-c, --config <STR>                    Specify path to config file (bunfig.toml)") catch unreachable,
         clap.parseParam("-y, --yarn                            Write a yarn.lock file (yarn v1)") catch unreachable,
         clap.parseParam("-p, --production                      Don't install devDependencies") catch unreachable,
         clap.parseParam("--no-save                             Don't update package.json or save a lockfile") catch unreachable,

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9358,7 +9358,7 @@ pub const PackageManager = struct {
         "Possible values: \"hardlink\" (default), \"symlink\", \"copyfile\"";
 
     const shared_params = [_]ParamType{
-        clap.parseParam("-c, --config <STR>                    Specify path to config file (bunfig.toml)") catch unreachable,
+        clap.parseParam("-c, --config <STR>?                   Specify path to config file (bunfig.toml)") catch unreachable,
         clap.parseParam("-y, --yarn                            Write a yarn.lock file (yarn v1)") catch unreachable,
         clap.parseParam("-p, --production                      Don't install devDependencies") catch unreachable,
         clap.parseParam("--no-save                             Don't update package.json or save a lockfile") catch unreachable,

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -3200,7 +3200,7 @@ dev = false
 
   // should not install dev dependencies
   ({ exited } = spawn({
-    cmd: [bunExe(), "i", "--config", "bunfig2.toml"],
+    cmd: [bunExe(), "i", "--config=bunfig2.toml"],
     cwd: packageDir,
     stdout: "pipe",
     stderr: "pipe",

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -3156,6 +3156,61 @@ describe("binaries", () => {
   });
 });
 
+test("--config cli flag works", async () => {
+  await Promise.all([
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+        devDependencies: {
+          "a-dep": "1.0.1",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "bunfig2.toml"),
+      `
+[install]
+cache = "${join(packageDir, ".bun-cache")}"
+registry = "http://localhost:${port}/"
+dev = false
+`,
+    ),
+  ]);
+
+  // should install dev dependencies
+  let { exited } = spawn({
+    cmd: [bunExe(), "i"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).toEqual({
+    name: "a-dep",
+    version: "1.0.1",
+  });
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+  // should not install dev dependencies
+  ({ exited } = spawn({
+    cmd: [bunExe(), "i", "--config", "bunfig2.toml"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  }));
+
+  expect(await exited).toBe(0);
+  expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBeFalse();
+});
+
 test("it should invalid cached package if package.json is missing", async () => {
   await Promise.all([
     write(


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
