### PR TITLE
fix(node:crypto): use `options` from `createHash(alg, options)`

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -1203,7 +1203,7 @@ var require_browser2 = __commonJS({
       this._hasher.update(data, encoding);
       return this;
     };
-    LazyHash.prototype.digest = function update(data, encoding) {
+    LazyHash.prototype.digest = function digest(data, encoding) {
       this._checkFinalized();
       this._finalized = true;
       return this._hasher.digest(data, encoding);
@@ -1334,8 +1334,8 @@ var require_browser2 = __commonJS({
       });
     }
 
-    module.exports = function createHash(algorithm) {
-      return new LazyHash(algorithm);
+    module.exports = function createHash(algorithm, options) {
+      return new LazyHash(algorithm, options);
     };
 
     module.exports.createHash = module.exports;

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import crypto from "node:crypto";
-import { PassThrough } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import util from "node:util";
 
 it("crypto.randomBytes should return a Buffer", () => {
@@ -477,6 +477,27 @@ describe("createHash", () => {
     hash.update("world");
     copy.update("world");
     expect(copy.digest("hex")).toBe(hash.digest("hex"));
+  });
+
+  it("uses the Transform options object", () => {
+    const hasher = crypto.createHash("sha256", { defaultEncoding: "binary" });
+    hasher.on("readable", () => {
+      const data = hasher.read();
+      if (data) {
+        expect(data.toString("hex")).toBe("4d4d75d742863ab9656f3d5f76dff8589c3922e95a24ea6812157ffe4aaa3b6b");
+      }
+    });
+    const stream = Readable.from("ï");
+    stream.pipe(hasher);
+  });
+});
+
+describe("Hash", () => {
+  it("should have correct method names", () => {
+    const hash = crypto.createHash("sha256");
+    expect(hash.update.name).toBe("update");
+    expect(hash.digest.name).toBe("digest");
+    expect(hash.copy.name).toBe("copy");
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Two fixes:
- the `options` object from `createHash(alg, options)` was ignored, causing defaults to be used (encoding was always `utf8` because of this).
- `Hash.prototype.digest.name` was set to `update` instead of `digest`.

fixes #9200
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

Added tests for both fixes. We might need more tests for options, only `defaultEncoding` is tested.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
