### PR TITLE
Reduce memory usage of WebSocket server

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -623,7 +623,7 @@ fn ensureRouteIsBundled(
                     .data = switch (kind) {
                         .js_payload => .{ .js_payload = resp },
                         .server_handler => .{
-                            .server_handler = (dev.server.?.DebugHTTPServer.prepareJsRequestContext(req, resp) orelse return)
+                            .server_handler = (dev.server.?.DebugHTTPServer.prepareJsRequestContext(req, resp, null) orelse return)
                                 .save(dev.vm.global, req, resp),
                         },
                     },
@@ -676,7 +676,7 @@ fn ensureRouteIsBundled(
                     .data = switch (kind) {
                         .js_payload => .{ .js_payload = resp },
                         .server_handler => .{
-                            .server_handler = (dev.server.?.DebugHTTPServer.prepareJsRequestContext(req, resp) orelse return)
+                            .server_handler = (dev.server.?.DebugHTTPServer.prepareJsRequestContext(req, resp, null) orelse return)
                                 .save(dev.vm.global, req, resp),
                         },
                     },


### PR DESCRIPTION
### What does this PR do?

This frees the request context earlier when the HTTP request is upgraded to a WebSocket connection.

This also fixes an issue where delaying freeing the request context would not work if it happened synchronously inside onRequest. Fortunately, there aren't code paths where that could happen.

This memory leak test finishes 63% faster and uses 65% less ram:

```js
const batchSize = 1000;
let onClosePromise = Promise.withResolvers();
let onCloseCount = 0;
using server = Bun.serve({
  port: 0,
  fetch(req, server) {
    return server.upgrade(req);
  },
  websocket: {
    open(socket) {},
    drain(ws) {},
    close(ws) {
      onCloseCount++;
      if (onCloseCount === batchSize) {
        onClosePromise.resolve();
      }
    },
  },
});

async function batch() {
  const clients = new Array(batchSize);
  const promises = new Array(batchSize + 1);
  onCloseCount = 0;
  onClosePromise = Promise.withResolvers();

  console.time(`Batch of ${batchSize}`);

  for (let i = 0; i < batchSize; i++) {
    const client = new WebSocket(server.url);
    const { promise, resolve, reject } = Promise.withResolvers();
    clients[i] = client;
    promises[i] = promise;
    client.onclose = () => {
      resolve();
    };
    client.onopen = () => {
      client.close();
    };
  }
  promises[batchSize] = onClosePromise;
  await Promise.all(promises);
  Bun.gc(true);
  console.timeEnd(`Batch of ${batchSize}`);
  console.log(`RSS:`, (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
}

for (let i = 0; i < 200; i++) {
  Bun.gc(true);
  const heapStats = require("bun:jsc").heapStats();
  for (const key in heapStats.zones) {
    if (heapStats.zones[key] < 2048 * 1024) delete heapStats.zones[key];
  }
  for (const key in heapStats.objectTypeCounts) {
    if (heapStats.objectTypeCounts[key] < 100) delete heapStats.objectTypeCounts[key];
  }
  console.log(heapStats);
  await batch();
}
Bun.gc(true);
const rss = process.memoryUsage.rss();
console.log(`Initial RSS: ${(rss / 1024 / 1024) | 0} MB`);

for (let i = 0; i < 100; i++) {
  Bun.gc(true);
  const heapStats = require("bun:jsc").heapStats();
  for (const key in heapStats.zones) {
    if (heapStats.zones[key] < 2048 * 1024) delete heapStats.zones[key];
  }
  for (const key in heapStats.objectTypeCounts) {
    if (heapStats.objectTypeCounts[key] < 100) delete heapStats.objectTypeCounts[key];
  }
  console.log(heapStats);
  await batch();
}
Bun.gc(true);
const finalRss = process.memoryUsage.rss();
console.log(`Final RSS: ${(finalRss / 1024 / 1024) | 0}MB`);
```

### How did you verify your code works?

This does need a test before we can merge it.