### PR TITLE
Remove a duplicate if statement

### DIFF
--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -5716,9 +5716,6 @@ pub fn isZeroWidthCodepointType(comptime T: type, cp: T) bool {
         // Combining Diacritical Marks
         return true;
     }
-    if (cp >= 0x300 and cp <= 0x36f)
-        // Combining Diacritical Marks
-        return true;
 
     if (cp >= 0x200b and cp <= 0x200f) {
         // Modifying Invisible Characters


### PR DESCRIPTION
### What does this PR do?

Removes a duplicate `if (cond) { return true; }` statement. Chances are the compiler removes it as dead code anyway.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I didn't, but this is a trivial change that shouldn't have any effect other than clarifying the source code.