### PR TITLE
Fix #15556 - Buffer.write__ broken without explicit offset

### DIFF
--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -174,43 +174,43 @@ export function readBigUInt64BE(this: BufferExt, offset) {
   return (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).getBigUint64(offset, false);
 }
 
-export function writeInt8(this: BufferExt, value, offset) {
+export function writeInt8(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt8(offset, value);
   return offset + 1;
 }
-export function writeUInt8(this: BufferExt, value, offset) {
+export function writeUInt8(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint8(offset, value);
   return offset + 1;
 }
-export function writeInt16LE(this: BufferExt, value, offset) {
+export function writeInt16LE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, true);
   return offset + 2;
 }
-export function writeInt16BE(this: BufferExt, value, offset) {
+export function writeInt16BE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, false);
   return offset + 2;
 }
-export function writeUInt16LE(this: BufferExt, value, offset) {
+export function writeUInt16LE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, true);
   return offset + 2;
 }
-export function writeUInt16BE(this: BufferExt, value, offset) {
+export function writeUInt16BE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, false);
   return offset + 2;
 }
-export function writeInt32LE(this: BufferExt, value, offset) {
+export function writeInt32LE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, true);
   return offset + 4;
 }
-export function writeInt32BE(this: BufferExt, value, offset) {
+export function writeInt32BE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, false);
   return offset + 4;
 }
-export function writeUInt32LE(this: BufferExt, value, offset) {
+export function writeUInt32LE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, true);
   return offset + 4;
 }
-export function writeUInt32BE(this: BufferExt, value, offset) {
+export function writeUInt32BE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, false);
   return offset + 4;
 }
@@ -360,42 +360,42 @@ export function writeUIntBE(this: BufferExt, value, offset, byteLength) {
   return offset + byteLength;
 }
 
-export function writeFloatLE(this: BufferExt, value, offset) {
+export function writeFloatLE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, true);
   return offset + 4;
 }
 
-export function writeFloatBE(this: BufferExt, value, offset) {
+export function writeFloatBE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, false);
   return offset + 4;
 }
 
-export function writeDoubleLE(this: BufferExt, value, offset) {
+export function writeDoubleLE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, true);
   return offset + 8;
 }
 
-export function writeDoubleBE(this: BufferExt, value, offset) {
+export function writeDoubleBE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, false);
   return offset + 8;
 }
 
-export function writeBigInt64LE(this: BufferExt, value, offset) {
+export function writeBigInt64LE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(offset, value, true);
   return offset + 8;
 }
 
-export function writeBigInt64BE(this: BufferExt, value, offset) {
+export function writeBigInt64BE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(offset, value, false);
   return offset + 8;
 }
 
-export function writeBigUInt64LE(this: BufferExt, value, offset) {
+export function writeBigUInt64LE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(offset, value, true);
   return offset + 8;
 }
 
-export function writeBigUInt64BE(this: BufferExt, value, offset) {
+export function writeBigUInt64BE(this: BufferExt, value, offset = 0) {
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(offset, value, false);
   return offset + 8;
 }


### PR DESCRIPTION
### What does this PR do?

This PR brings the behavior of Buffers `.write__` functions (e.g. `writeInt32LE`) to better parity with the behavior in Node, by having the `offset` argument default to 0. Currently, calling these functions without supplying an offset argument will write to the buffer at offset 0, but they will return a new offset of `NaN` and suffer a major performance degradation.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

Comparing the performance of `bench/snippets/buffer.js` before and after this change with the slight modification specified in #15556 shows that performance is improved, and becomes essentially equivalent, as might be expected. Additionally, the code snippet also in that issue was used to verify the return value is now as expected.

I have not written additional tests for these changes - I'm more than happy to, but it was not quite clear to me exactly where they would best go, so I thought to reach out and ask first. Maybe in a new `test/js/bun/buffer`?

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
