### PR TITLE
ci: make annotations always link to file content by commit

### DIFF
--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1120,17 +1120,6 @@ export function getFileUrl(filename, line) {
   }
 
   const filePath = (cwd ? relative(cwd, filename) : filename).replace(/\\/g, "/");
-  const pullRequest = getPullRequest();
-
-  if (pullRequest) {
-    const fileMd5 = createHash("sha256").update(filePath).digest("hex");
-    const url = new URL(`pull/${pullRequest}/files#diff-${fileMd5}`, `${baseUrl}/`);
-    if (typeof line !== "undefined") {
-      return new URL(`R${line}`, url);
-    }
-    return url;
-  }
-
   const commit = getCommit(cwd);
   const url = new URL(`blob/${commit}/${filePath}`, `${baseUrl}/`).toString();
   if (typeof line !== "undefined") {


### PR DESCRIPTION
- provides a better ui than the `{pr}/files#diff-{hash}` interface
- points at the canonical source for that particular build
- works for files that weren't affected by the particular pr

i believe this is how it used to work so it's nice to have it back
