### PR TITLE
WIP: feat(got + http2-wrapper) http2-wrapper support

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2561,7 +2561,7 @@ class ServerHttp2Session extends Http2Session {
   }
 
   setLocalWindowSize(windowSize) {
-    return this.#parser?.setLocalWindowSize(windowSize);
+    return this.#parser?.setLocalWindowSize?.(windowSize);
   }
 
   settings(settings: Settings, callback) {
@@ -2940,7 +2940,7 @@ class ClientHttp2Session extends Http2Session {
   }
 
   setLocalWindowSize(windowSize) {
-    return this.#parser?.setLocalWindowSize(windowSize);
+    return this.#parser?.setLocalWindowSize?.(windowSize);
   }
   get socket() {
     if (this.#socket_proxy) return this.#socket_proxy;

--- a/test/js/third_party/got/got.http2-wrapper.test.ts
+++ b/test/js/third_party/got/got.http2-wrapper.test.ts
@@ -1,0 +1,11 @@
+// @ts-nocheck
+// can't use @types/express or @types/body-parser because they
+// depend on @types/node which conflicts with bun-types
+import { expect, test } from "bun:test";
+import got from "got";
+
+test("should respond with 404 when wrong method is used", async () => {
+  await got("https://bun.sh", {
+    http2: true,
+  });
+});

--- a/test/js/third_party/got/package.json
+++ b/test/js/third_party/got/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "got",
+  "version": "1.0.0",
+  "dependencies": {
+    "got": "^14.4.5",
+    "http2-wrapper": "2.2.1"
+  }
+}


### PR DESCRIPTION
### What does this PR do?
this is a WIP http2-wrapper uses origin events + ALTSVC not yet present, but should be added here soon

Improve on: https://github.com/oven-sh/bun/issues/14958
Fix: https://github.com/oven-sh/bun/issues/15477
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
