### PR TITLE
fix: gracefully handle missing `.front` in `UnboundedQueue`

### DIFF
--- a/src/bun.js/unbounded_queue.zig
+++ b/src/bun.js/unbounded_queue.zig
@@ -30,7 +30,8 @@ pub fn UnboundedQueue(comptime T: type, comptime next_field: meta.FieldEnum(T)) 
 
                 pub fn next(self: *Self.Batch.Iterator) ?*T {
                     if (self.batch.count == 0) return null;
-                    const front = self.batch.front orelse unreachable;
+                    bun.debugAssert(self.batch.front != null);
+                    const front = self.batch.front orelse return null;
                     self.batch.front = @field(front, next_name);
                     self.batch.count -= 1;
                     return front;

--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -1583,6 +1583,7 @@ var _Interface = class Interface extends InterfaceConstructor {
       this[kSetRawMode](false);
     }
     this.closed = true;
+    this.input.close();
     this.emit("close");
   }
 

--- a/test/js/node/readline/fixtures/readline-stdin-immediate-close.ts
+++ b/test/js/node/readline/fixtures/readline-stdin-immediate-close.ts
@@ -1,0 +1,8 @@
+import readline from "readline";
+
+const rl1 = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl1.close();


### PR DESCRIPTION
### What does this PR do?
Closes #15474
