### PR TITLE
Fix missing "readable" events

### DIFF
--- a/src/js/node/stream.ts
+++ b/src/js/node/stream.ts
@@ -5371,14 +5371,18 @@ function createNativeStreamReadable(Readable) {
       }
 
       if (isClosed) {
-        nativeReadable.push(null);
+        ProcessNextTick(() => {
+          nativeReadable.push(null);
+        });
       }
 
       return remainder.byteLength > 0 ? remainder : undefined;
     }
 
     if (isClosed) {
-      nativeReadable.push(null);
+      ProcessNextTick(() => {
+        nativeReadable.push(null);
+      });
     }
 
     return view;

--- a/src/js/node/stream.ts
+++ b/src/js/node/stream.ts
@@ -5390,7 +5390,9 @@ function createNativeStreamReadable(Readable) {
     }
 
     if (isClosed) {
-      nativeReadable.push(null);
+      ProcessNextTick(() => {
+        nativeReadable.push(null);
+      });
     }
 
     return view;

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -546,33 +546,24 @@ it("should emit prefinish on current tick", done => {
 });
 
 for (const size of [0x10, 0xffff, 0x10000, 0x1f000, 0x20000, 0x20010, 0x7ffff, 0x80000, 0xa0000, 0xa0010]) {
-  it(`should emit "readable" with null data and "close" exactly once each, 0x${size.toString(16)} bytes`, done => {
+  it(`should emit 'readable' with null data and 'close' exactly once each, 0x${size.toString(16)} bytes`, async () => {
     const path = `${tmpdir()}/${Date.now()}.readable_and_close.txt`;
     writeFileSync(path, new Uint8Array(size));
     const stream = createReadStream(path);
-
-    let closes = 0;
-    let null_reads = 0;
+    const close_resolvers = Promise.withResolvers();
+    const readable_resolvers = Promise.withResolvers();
 
     stream.on("close", () => {
-      ++closes;
-      expect(closes).toBe(1);
-      expect(null_reads).toBeLessThanOrEqual(1);
-      if (null_reads >= 1) {
-        done();
-      }
+      close_resolvers.resolve();
     });
 
     stream.on("readable", () => {
       const data = stream.read();
       if (data === null) {
-        ++null_reads;
-        expect(null_reads).toBe(1);
-        expect(closes).toBeLessThanOrEqual(1);
-        if (closes >= 1) {
-          done();
-        }
+        readable_resolvers.resolve();
       }
     });
+
+    await Promise.all([close_resolvers.promise, readable_resolvers.promise]);
   });
 }

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -544,3 +544,25 @@ it("should emit prefinish on current tick", done => {
     done();
   });
 });
+
+for (const size of [0x10, 0xffff, 0x10000, 0x1f000, 0x20000, 0x20010, 0x7ffff, 0x80000, 0xa0000, 0xa0010]) {
+  it(`should emit "readable" with null data and "close" exactly once each, 0x${size.toString(16)} bytes`, done => {
+    const path = `${tmpdir()}/${Date.now()}.readable_and_close.txt`;
+    writeFileSync(path, new Uint8Array(size));
+    const stream = createReadStream(path);
+    const close_cb = jest.fn();
+    const null_read = jest.fn();
+    stream.on("close", close_cb);
+    stream.on("readable", () => {
+      const data = stream.read();
+      if (data === null) {
+        null_read();
+      }
+    });
+    setTimeout(() => {
+      expect(close_cb).toHaveBeenCalledTimes(1);
+      expect(null_read).toHaveBeenCalledTimes(1);
+      done();
+    }, 20);
+  });
+}


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where depending on the size of a file opened with `fs.createReadStream`, a final `readable` event (during which `.read()` returns `null`) can be mistakenly not emitted. This causes, for example, `prisma init` to exit without doing anything.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

I added some tests to `/test/js/node/stream/node-stream.test.js` and I also ran `bun --bun x prisma init`.
