### PR TITLE
refactor: `KeyObject` helper functions return `JSCryptoKey`

### DIFF
--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -918,7 +918,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__createPublicKey, (JSC::JSGlobalObject * glob
         }
         case CryptoKeyClass::OKP: {
             auto& impl = downcast<WebCore::CryptoKeyOKP>(wrapped);
-            encodeKey(KeyObject__createOKPFromPrivate(globalObject, impl.exportKey(), impl.namedCurve(), wrapped.algorithmIdentifier()));
+            return encodeKey(KeyObject__createOKPFromPrivate(globalObject, impl.exportKey(), impl.namedCurve(), wrapped.algorithmIdentifier()));
         }
         default: {
             JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Invalid key object type, expected private"_s);


### PR DESCRIPTION
### What does this PR do?

Refactors helper functions in `KeyObject.cpp` to return `JSCryptoKey` objects instead of `EncodeJSValue`s, along with some other minor refactors. Prereq refactor to `KeyObject` JS -> native migration. Part of #15585.

Note to reviewers: I recommend reviewing each commit individually.

### How did you verify your code works?
Tests already exist for this logic.