### PR TITLE
fix: testing library docs

### DIFF
--- a/docs/guides/test/testing-library.md
+++ b/docs/guides/test/testing-library.md
@@ -49,7 +49,7 @@ Next, add these preload scripts to your `bunfig.toml` (you can also have everyth
 
 ```toml#bunfig.toml
 [test]
-preload = ["happydom.ts", "testing-library.ts"]
+preload = ["./happydom.ts", "./testing-library.ts"]
 ```
 ---
 


### PR DESCRIPTION
This pull request addresses an issue with preloading files in the bunfig.toml configuration. The original configuration used relative file paths that caused errors when preloading, specifically resulting in the error:

```
error: preload not found "happydom.ts"
```

To fix this, the preload paths have been updated to include ./ for proper resolution.