### PR TITLE
Introduce `env` option in Bun.build() and `bun build` to let you inject `FOO_PUBLIC_*`-style env vars

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -570,20 +570,19 @@ $ FOO=bar BAZ=123 bun build ./index.tsx --outdir ./out --env inline
 
 {% /codetabs %}
 
-For example, given the following environment variables:
+For the input below:
 
-```bash
-$ FOO=bar BAZ=123
+```js#input.js
+console.log(process.env.FOO);
+console.log(process.env.BAZ);
 ```
 
 The generated bundle will contain the following code:
 
-```js
+```js#output.js
 console.log("bar");
 console.log("123");
 ```
-
-By default, this is enabled in Bun v1.1.x and lower. In Bun v1.2.x and higher (and has always been), but this will be disabled by default. Sorry for the confusion.
 
 #### `env: "PUBLIC_*"` (prefix)
 
@@ -631,7 +630,7 @@ console.log(process.env.BAZ);
 
 #### `env: "disable"`
 
-Disables environment variable injection entirely. This will be the default in Bun v1.2.x and higher.
+Disables environment variable injection entirely.
 
 For example, given the following environment variables:
 

--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -546,6 +546,114 @@ export type ImportKind =
 
 By design, the manifest is a simple JSON object that can easily be serialized or written to disk. It is also compatible with esbuild's [`metafile`](https://esbuild.github.io/api/#metafile) format. -->
 
+### `env`
+
+Controls how environment variables are handled during bundling. Internally, this uses `define` to inject environment variables into the bundle, but makes it easier to specify the environment variables to inject.
+
+#### `env: "inline"`
+
+Injects environment variables into the bundled output by converting `process.env.FOO` references to string literals containing the actual environment variable values.
+
+{% codetabs group="a" %}
+
+```ts#JavaScript
+await Bun.build({
+  entrypoints: ['./index.tsx'],
+  outdir: './out',
+  env: "inline",
+})
+```
+
+```bash#CLI
+$ FOO=bar BAZ=123 bun build ./index.tsx --outdir ./out --env inline
+```
+
+{% /codetabs %}
+
+For example, given the following environment variables:
+
+```bash
+$ FOO=bar BAZ=123
+```
+
+The generated bundle will contain the following code:
+
+```js
+console.log("bar");
+console.log("123");
+```
+
+By default, this is enabled in Bun v1.1.x and lower. In Bun v1.2.x and higher (and has always been), but this will be disabled by default. Sorry for the confusion.
+
+#### `env: "PUBLIC_*"` (prefix)
+
+Inlines environment variables matching the given prefix (the part before the `*` character), replacing `process.env.FOO` with the actual environment variable value. This is useful for selectively inlining environment variables for things like public-facing URLs or client-side tokens, without worrying about injecting private credentials into output bundles.
+
+{% codetabs group="a" %}
+
+```ts#JavaScript
+await Bun.build({
+  entrypoints: ['./index.tsx'],
+  outdir: './out',
+
+  // Inline all env vars that start with "ACME_PUBLIC_"
+  env: "ACME_PUBLIC_*",
+})
+```
+
+```bash#CLI
+$ FOO=bar BAZ=123 ACME_PUBLIC_URL=https://acme.com bun build ./index.tsx --outdir ./out --env 'ACME_PUBLIC_*'
+```
+
+{% /codetabs %}
+
+For example, given the following environment variables:
+
+```bash
+$ FOO=bar BAZ=123 ACME_PUBLIC_URL=https://acme.com
+```
+
+And source code:
+
+```ts#index.tsx
+console.log(process.env.FOO);
+console.log(process.env.ACME_PUBLIC_URL);
+console.log(process.env.BAZ);
+```
+
+The generated bundle will contain the following code:
+
+```js
+console.log(process.env.FOO);
+console.log("https://acme.com");
+console.log(process.env.BAZ);
+```
+
+#### `env: "disable"`
+
+Disables environment variable injection entirely. This will be the default in Bun v1.2.x and higher.
+
+For example, given the following environment variables:
+
+```bash
+$ FOO=bar BAZ=123 ACME_PUBLIC_URL=https://acme.com
+```
+
+And source code:
+
+```ts#index.tsx
+console.log(process.env.FOO);
+console.log(process.env.ACME_PUBLIC_URL);
+console.log(process.env.BAZ);
+```
+
+The generated bundle will contain the following code:
+
+```js
+console.log(process.env.FOO);
+console.log(process.env.BAZ);
+```
+
 ### `sourcemap`
 
 Specifies the type of sourcemap to generate.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1553,6 +1553,26 @@ declare module "bun" {
      * https://nodejs.org/api/packages.html#exports
      */
     conditions?: Array<string> | string;
+
+    /**
+     * Controls how environment variables are handled during bundling.
+     *
+     * Can be one of:
+     * - `"inline"`: Injects environment variables into the bundled output by converting `process.env.FOO`
+     *   references to string literals containing the actual environment variable values
+     * - `"disable"`: Disables environment variable injection entirely
+     * - A string ending in `*`: Inlines environment variables that match the given prefix.
+     *   For example, `"MY_PUBLIC_*"` will only include env vars starting with "MY_PUBLIC_"
+     *
+     * @example
+     * ```ts
+     * Bun.build({
+     *   env: "MY_PUBLIC_*",
+     *   entrypoints: ["src/index.ts"],
+     * })
+     * ```
+     */
+    env?: "inline" | "disable" | `${string}*`;
     minify?:
       | boolean
       | {
@@ -3899,7 +3919,7 @@ declare module "bun" {
      * The namespace of the importer.
      */
     namespace: string;
-    /** 
+    /**
      * The directory to perform file-based resolutions in.
      */
     resolveDir: string;

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -80,6 +80,9 @@ pub const JSBundler = struct {
         drop: bun.StringSet = bun.StringSet.init(bun.default_allocator),
         has_any_on_before_parse: bool = false,
 
+        env_behavior: Api.DotEnvBehavior = if (!bun.FeatureFlags.breaking_changes_1_2) .load_all else .disable,
+        env_prefix: OwnedString = OwnedString.initEmpty(bun.default_allocator),
+
         pub const List = bun.StringArrayHashMapUnmanaged(Config);
 
         pub fn fromJS(globalThis: *JSC.JSGlobalObject, config: JSC.JSValue, plugins: *?*Plugin, allocator: std.mem.Allocator) JSError!Config {
@@ -229,6 +232,35 @@ pub const JSBundler = struct {
                         "sourcemap",
                         options.SourceMapOption,
                     );
+                }
+            }
+
+            if (try config.get(globalThis, "env")) |env| {
+                if (env != .undefined) {
+                    if (env == .null or env == .false or (env.isNumber() and env.asNumber() == 0)) {
+                        this.env_behavior = .disable;
+                    } else if (env == .true or (env.isNumber() and env.asNumber() == 1)) {
+                        this.env_behavior = .load_all;
+                    } else if (env.isString()) {
+                        const slice = try env.toSlice2(globalThis, bun.default_allocator);
+                        defer slice.deinit();
+                        if (strings.eqlComptime(slice.slice(), "inline")) {
+                            this.env_behavior = .load_all;
+                        } else if (strings.eqlComptime(slice.slice(), "disable")) {
+                            this.env_behavior = .disable;
+                        } else if (strings.indexOfChar(slice.slice(), '*')) |asterisk| {
+                            if (asterisk > 0) {
+                                this.env_behavior = .prefix;
+                                try this.env_prefix.appendSliceExact(slice.slice()[0..asterisk]);
+                            } else {
+                                this.env_behavior = .load_all;
+                            }
+                        } else {
+                            return globalThis.throwInvalidArguments("env must be 'inline', 'disable', or a string with a '*' character", .{});
+                        }
+                    } else {
+                        return globalThis.throwInvalidArguments("env must be 'inline', 'disable', or a string with a '*' character", .{});
+                    }
                 }
             }
 
@@ -530,6 +562,7 @@ pub const JSBundler = struct {
             self.conditions.deinit();
             self.drop.deinit();
             self.banner.deinit();
+            self.env_prefix.deinit();
             self.footer.deinit();
         }
     };

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -1568,7 +1568,11 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
 
         {
             char cwd[PATH_MAX] = { 0 };
-            getcwd(cwd, PATH_MAX);
+
+            if (getcwd(cwd, PATH_MAX) == nullptr) {
+                cwd[0] = '.';
+                cwd[1] = '\0';
+            }
 
             header->putDirect(vm, JSC::Identifier::fromString(vm, "cwd"_s), JSC::jsString(vm, String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const LChar*>(cwd), strlen(cwd) })), 0);
         }
@@ -1584,7 +1588,9 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
         {
             // uname
             struct utsname buf;
-            uname(&buf);
+            if (uname(&buf) != 0) {
+                memset(&buf, 0, sizeof(buf));
+            }
 
             header->putDirect(vm, JSC::Identifier::fromString(vm, "osName"_s), JSC::jsString(vm, String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const LChar*>(buf.sysname), strlen(buf.sysname) })), 0);
             header->putDirect(vm, JSC::Identifier::fromString(vm, "osRelease"_s), JSC::jsString(vm, String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const LChar*>(buf.release), strlen(buf.release) })), 0);
@@ -1596,7 +1602,9 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
         {
             // TODO: use HOSTNAME_MAX
             char host[1024] = { 0 };
-            gethostname(host, 1024);
+            if (gethostname(host, 1024) != 0) {
+                host[0] = '0';
+            }
 
             header->putDirect(vm, JSC::Identifier::fromString(vm, "host"_s), JSC::jsString(vm, String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const LChar*>(host), strlen(host) })), 0);
         }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1656,6 +1656,8 @@ pub const BundleV2 = struct {
                 },
                 completion.env,
             );
+            bundler.options.env.behavior = config.env_behavior;
+            bundler.options.env.prefix = config.env_prefix.slice();
 
             bundler.options.entry_points = config.entry_points.keys();
             bundler.options.jsx = config.jsx;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1481,7 +1481,7 @@ pub const Command = struct {
             bake_debug_dump_server: bool = false,
             bake_debug_disable_minify: bool = false,
 
-            env_behavior: Api.DotEnvBehavior = if (!FeatureFlags.breaking_changes_1_2) .load_all else .disable,
+            env_behavior: Api.DotEnvBehavior = .disable,
             env_prefix: []const u8 = "",
         };
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -288,7 +288,7 @@ pub const Arguments = struct {
         clap.parseParam("--conditions <STR>...            Pass custom conditions to resolve") catch unreachable,
         clap.parseParam("--app                            (EXPERIMENTAL) Build a web app for production using Bun Bake.") catch unreachable,
         clap.parseParam("--server-components              (EXPERIMENTAL) Enable server components") catch unreachable,
-        clap.parseParam("--env <inline|prefix*>            Inline environment variables into the bundle as process.env.${name}. Defaults to 'inline'. To inline environment variables matching a prefix, use my prefix like 'FOO_PUBLIC_*'") catch unreachable,
+        clap.parseParam("--env <inline|prefix*|disable>    Inline environment variables into the bundle as process.env.${name}. Defaults to 'inline'. To inline environment variables matching a prefix, use my prefix like 'FOO_PUBLIC_*'. To disable, use 'disable'. In Bun v1.2+, the default is 'disable'.") catch unreachable,
     } ++ if (FeatureFlags.bake_debugging_features) [_]ParamType{
         clap.parseParam("--debug-dump-server-files        When --app is set, dump all server files to disk even when building statically") catch unreachable,
         clap.parseParam("--debug-no-minify                When --app is set, do not minify anything") catch unreachable,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -288,6 +288,7 @@ pub const Arguments = struct {
         clap.parseParam("--conditions <STR>...            Pass custom conditions to resolve") catch unreachable,
         clap.parseParam("--app                            (EXPERIMENTAL) Build a web app for production using Bun Bake.") catch unreachable,
         clap.parseParam("--server-components              (EXPERIMENTAL) Enable server components") catch unreachable,
+        clap.parseParam("--env <inline|prefix*>            Inline environment variables into the bundle as process.env.${name}. Defaults to 'inline'. To inline environment variables matching a prefix, use my prefix like 'FOO_PUBLIC_*'") catch unreachable,
     } ++ if (FeatureFlags.bake_debugging_features) [_]ParamType{
         clap.parseParam("--debug-dump-server-files        When --app is set, dump all server files to disk even when building statically") catch unreachable,
         clap.parseParam("--debug-no-minify                When --app is set, do not minify anything") catch unreachable,
@@ -847,6 +848,24 @@ pub const Arguments = struct {
                     opts.packages = .external;
                 } else {
                     Output.prettyErrorln("<r><red>error<r>: Invalid packages setting: \"{s}\"", .{packages});
+                    Global.crash();
+                }
+            }
+
+            if (args.option("--env")) |env| {
+                if (strings.indexOfChar(env, '*')) |asterisk| {
+                    if (asterisk == 0) {
+                        ctx.bundler_options.env_behavior = .load_all;
+                    } else {
+                        ctx.bundler_options.env_behavior = .prefix;
+                        ctx.bundler_options.env_prefix = env[0..asterisk];
+                    }
+                } else if (strings.eqlComptime(env, "inline") or strings.eqlComptime(env, "1")) {
+                    ctx.bundler_options.env_behavior = .load_all;
+                } else if (strings.eqlComptime(env, "disable") or strings.eqlComptime(env, "0")) {
+                    ctx.bundler_options.env_behavior = .load_all_without_inlining;
+                } else {
+                    Output.prettyErrorln("<r><red>error<r>: Expected 'env' to be 'inline', 'disable', or a prefix with a '*' character", .{});
                     Global.crash();
                 }
             }
@@ -1461,6 +1480,9 @@ pub const Command = struct {
             bake: bool = false,
             bake_debug_dump_server: bool = false,
             bake_debug_disable_minify: bool = false,
+
+            env_behavior: Api.DotEnvBehavior = if (!FeatureFlags.breaking_changes_1_2) .load_all else .disable,
+            env_prefix: []const u8 = "",
         };
 
         pub fn create(allocator: std.mem.Allocator, log: *logger.Log, comptime command: Command.Tag) anyerror!Context {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -211,6 +211,9 @@ pub const BuildCommand = struct {
         this_bundler.options.code_splitting = ctx.bundler_options.code_splitting;
         this_bundler.options.transform_only = ctx.bundler_options.transform_only;
 
+        this_bundler.options.env.behavior = ctx.bundler_options.env_behavior;
+        this_bundler.options.env.prefix = ctx.bundler_options.env_prefix;
+
         try this_bundler.configureDefines();
         this_bundler.configureLinker();
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -186,18 +186,7 @@ describe("bundler", () => {
       NODE_ENV: "development",
     },
   });
-  itBundled("edgecase/ProcessEnvArbitrary", {
-    files: {
-      "/entry.js": /* js */ `
-        capture(process.env.ARBITRARY);
-      `,
-    },
-    target: "browser",
-    capture: ["process.env.ARBITRARY"],
-    env: {
-      ARBITRARY: "secret environment stuff!",
-    },
-  });
+
   itBundled("edgecase/StarExternal", {
     files: {
       "/entry.js": /* js */ `
@@ -2275,3 +2264,20 @@ describe("bundler", () => {
     },
   });
 });
+
+for (const backend of ["api", "cli"] as const) {
+  describe(`bundler_edgecase/${backend}`, () => {
+    itBundled("edgecase/ProcessEnvArbitrary", {
+      files: {
+        "/entry.js": /* js */ `
+        capture(process.env.ARBITRARY);
+      `,
+      },
+      target: "browser",
+      capture: ["process.env.ARBITRARY"],
+      env: {
+        ARBITRARY: "secret environment stuff!",
+      },
+    });
+  });
+}

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2274,6 +2274,7 @@ for (const backend of ["api", "cli"] as const) {
       `,
       },
       target: "browser",
+      backend,
       capture: ["process.env.ARBITRARY"],
       env: {
         ARBITRARY: "secret environment stuff!",

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,0 +1,120 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+for (let backend of ["api", "cli"] as const) {
+  describe(`bundler/${backend}`, () => {
+    // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
+    if (backend === "cli")
+      itBundled("env/inline", {
+        env: {
+          FOO: "bar",
+          BAZ: "123",
+        },
+        backend: backend,
+        dotenv: "inline",
+        files: {
+          "/a.js": `
+        console.log(process.env.FOO);
+        console.log(process.env.BAZ);
+      `,
+        },
+        run: {
+          env: {
+            FOO: "barz",
+            BAZ: "123z",
+          },
+          stdout: "bar\n123\n",
+        },
+      });
+
+    itBundled("env/inline system", {
+      env: {
+        PATH: process.env.PATH,
+      },
+      backend: backend,
+      dotenv: "inline",
+      files: {
+        "/a.js": `
+        console.log(process.env.PATH);
+      `,
+      },
+      run: {
+        env: {
+          PATH: "/bar",
+        },
+        stdout: process.env.PATH + "\n",
+      },
+    });
+
+    // Test disable mode - no env vars are inlined
+    itBundled("env/disable", {
+      env: {
+        FOO: "bar",
+        BAZ: "123",
+      },
+      backend: backend,
+      dotenv: "disable",
+      files: {
+        "/a.js": `
+        console.log(process.env.FOO);
+        console.log(process.env.BAZ);
+      `,
+      },
+      run: {
+        stdout: "undefined\nundefined\n",
+      },
+    });
+
+    // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
+    // Test pattern matching - only vars with prefix are inlined
+    if (backend === "cli")
+      itBundled("env/pattern-matching", {
+        env: {
+          PUBLIC_FOO: "public_value",
+          PUBLIC_BAR: "another_public",
+          PRIVATE_SECRET: "secret_value",
+        },
+        dotenv: "PUBLIC_*",
+        backend: backend,
+        files: {
+          "/a.js": `
+        console.log(process.env.PUBLIC_FOO);
+        console.log(process.env.PUBLIC_BAR);
+        console.log(process.env.PRIVATE_SECRET);
+      `,
+        },
+        run: {
+          env: {
+            PUBLIC_FOO: "BAD_FOO",
+            PUBLIC_BAR: "BAD_BAR",
+          },
+          stdout: "public_value\nanother_public\nundefined\n",
+        },
+      });
+
+    if (backend === "cli")
+      // Test nested environment variable references
+      itBundled("nested-refs", {
+        env: {
+          BASE_URL: "https://api.example.com",
+          SHOULD_PRINT_BASE_URL: "process.env.BASE_URL",
+          SHOULD_PRINT_$BASE_URL: "$BASE_URL",
+        },
+        dotenv: "inline",
+        backend: backend,
+        files: {
+          "/a.js": `
+      // Test nested references
+      console.log(process.env.SHOULD_PRINT_BASE_URL);
+      console.log(process.env.SHOULD_PRINT_$BASE_URL);
+    `,
+        },
+        run: {
+          env: {
+            "BASE_URL": "https://api.example.com",
+          },
+          stdout: "process.env.BASE_URL\n$BASE_URL",
+        },
+      });
+  });
+}


### PR DESCRIPTION
### What does this PR do?

This makes it simplier to inject environment variables get inlined into the bundle.

For example, to inject all NEXT_PUBLIC_* environment variables set `env: "NEXT_PUBLIC_*"` or `--env=NEXT_PUBLIC_*`

The main caveat with this implementation is that it relies on the system-provided environment variables instead of process.env - meaning that modifications to process.env are ignored. In the future, we probably should add a way to pass an object to inline instead, but we can wait for someone to ask for that before building it.

### How did you verify your code works?

There are tests.