### PR TITLE
test: mock 'node:test' module in node test harness

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -576,6 +576,7 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "build.zig")
 
 set(BUN_USOCKETS_SOURCE ${CWD}/packages/bun-usockets)
 
+# hand written cpp source files. Full list of "source" code (including codegen) is in BUN_CPP_SOURCES
 file(GLOB BUN_CXX_SOURCES ${CONFIGURE_DEPENDS}
   ${CWD}/src/io/*.cpp
   ${CWD}/src/bun.js/modules/*.cpp
@@ -632,6 +633,7 @@ register_command(
 list(APPEND BUN_CPP_SOURCES
   ${BUN_C_SOURCES}
   ${BUN_CXX_SOURCES}
+  ${BUN_ERROR_CODE_OUTPUTS}
   ${VENDOR_PATH}/picohttpparser/picohttpparser.c
   ${NODEJS_HEADERS_PATH}/include/node/node_version.h
   ${BUN_ZIG_GENERATED_CLASSES_OUTPUTS}
@@ -890,7 +892,7 @@ if(LINUX)
         -Wl,--wrap=statx
       )
     endif()
-    
+
     if(ARCH STREQUAL "x64")
       target_link_options(${bun} PUBLIC
         -Wl,--wrap=fcntl

--- a/test/js/node/bunfig.toml
+++ b/test/js/node/bunfig.toml
@@ -1,0 +1,1 @@
+preload = ["./harness.ts"]

--- a/test/js/node/harness.ts
+++ b/test/js/node/harness.ts
@@ -1,11 +1,14 @@
-import { AnyFunction } from "bun";
-import { hideFromStackTrace } from "harness";
+/**
+ * @note this file patches `node:test` via the require cache.
+ */
+import {AnyFunction} from "bun";
+import {hideFromStackTrace} from "harness";
 import assertNode from "node:assert";
 
 type DoneCb = (err?: Error) => any;
 function noop() {}
 export function createTest(path: string) {
-  const { expect, test, it, describe, beforeAll, afterAll, beforeEach, afterEach, mock } = Bun.jest(path);
+  const {expect, test, it, describe, beforeAll, afterAll, beforeEach, afterEach, mock} = Bun.jest(path);
 
   hideFromStackTrace(expect);
 
@@ -201,11 +204,11 @@ export function createTest(path: string) {
     let completed = 0;
     const globalTimer = globalTimeout
       ? (timers.push(
-          setTimeout(() => {
-            console.log("Global Timeout");
-            done(new Error("Timed out!"));
-          }, globalTimeout),
-        ),
+        setTimeout(() => {
+          console.log("Global Timeout");
+          done(new Error("Timed out!"));
+        }, globalTimeout),
+      ),
         timers[timers.length - 1])
       : undefined;
     function createDoneCb(timeout?: number) {
@@ -213,11 +216,11 @@ export function createTest(path: string) {
       const timer =
         timeout !== undefined
           ? (timers.push(
-              setTimeout(() => {
-                console.log("Timeout");
-                done(new Error("Timed out!"));
-              }, timeout),
-            ),
+            setTimeout(() => {
+              console.log("Timeout");
+              done(new Error("Timed out!"));
+            }, timeout),
+          ),
             timers[timers.length - 1])
           : timeout;
       return (result?: Error) => {
@@ -261,4 +264,114 @@ export function createTest(path: string) {
 
 declare namespace Bun {
   function jest(path: string): typeof import("bun:test");
+}
+
+if (Bun.main.includes("node/test/parallel")) {
+  function createMockNodeTestModule() {
+
+    interface TestError extends Error {
+      testStack: string[];
+    }
+    type Context = {
+      filename: string;
+      testStack: string[];
+      failures: Error[];
+      successes: number;
+      addFailure(err: unknown): TestError;
+      recordSuccess(): void;
+    }
+    const contexts: Record</* requiring file */ string, Context> = {}
+
+    // @ts-ignore
+    let activeSuite: Context = undefined;
+
+    function createContext(key: string): Context {
+      return {
+        filename: key, // duplicate for ease-of-use
+        // entered each time describe, it, etc is called
+        testStack: [],
+        failures: [],
+        successes: 0,
+        addFailure(err: unknown) {
+          const error: TestError = (err instanceof Error ? err : new Error(err as any)) as any;
+          error.testStack = this.testStack;
+          const testMessage = `Test failed: ${this.testStack.join(" > ")}`;
+          error.message = testMessage + "\n" + error.message;
+          this.failures.push(error);
+          console.error(error);
+          return error;
+        },
+        recordSuccess() {
+          const fullname = this.testStack.join(" > ");
+          console.log("✅ Test passed:", fullname);
+          this.successes++;
+        }
+      }
+    }
+
+    function getContext() {
+      const key: string = Bun.main;// module.parent?.filename ?? require.main?.filename ?? __filename;
+      return activeSuite = (contexts[key] ??= createContext(key));
+    }
+
+    async function test(label: string | Function, fn?: Function | undefined) {
+      if (typeof fn !== "function" && typeof label === "function") {
+        fn = label;
+        label = fn.name;
+      }
+      const ctx = getContext();
+      try {
+        ctx.testStack.push(label as string);
+        await fn();
+        ctx.recordSuccess();
+      } catch (err) {
+        const error = ctx.addFailure(err);
+        throw error;
+      } finally {
+        ctx.testStack.pop();
+      }
+    }
+
+    function describe(labelOrFn: string | Function, maybeFn?: Function) {
+      const [label, fn] = (typeof labelOrFn == "function" ? [labelOrFn.name, labelOrFn] : [labelOrFn, maybeFn]);
+      if (typeof fn !== "function") throw new TypeError("Second argument to describe() must be a function.");
+
+      getContext().testStack.push(label);
+      try {
+        fn();
+      } catch (e) {
+        getContext().addFailure(e);
+        throw e
+      } finally {
+        getContext().testStack.pop();
+      }
+
+      const failures = getContext().failures.length;
+      const successes = getContext().successes;
+      console.error(`describe("${label}") finished with ${successes} passed and ${failures} failed tests.`);
+      if (failures > 0) {
+        throw new Error(`${failures} tests failed.`);
+      }
+
+    }
+
+    return {
+      test,
+      describe,
+    }
+
+  }
+
+  require.cache["node:test"] ??= {
+    exports: createMockNodeTestModule(),
+    loaded: true,
+    isPreloading: false,
+    id: "node:test",
+    parent: require.main,
+    filename: "node:test",
+    children: [],
+    path: "node:test",
+    paths: [],
+    require,
+  };
 }


### PR DESCRIPTION
### What does this PR do?
Hacks the require cache, injecting a mock `node:test` implementation. Only
affects `node/parallel` test cases that import `node/test/harness.ts`.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
