### PR TITLE
build: trigger cpp build when generated ErrorCode files change

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -576,6 +576,7 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "build.zig")
 
 set(BUN_USOCKETS_SOURCE ${CWD}/packages/bun-usockets)
 
+# hand written cpp source files. Full list of "source" code (including codegen) is in BUN_CPP_SOURCES
 file(GLOB BUN_CXX_SOURCES ${CONFIGURE_DEPENDS}
   ${CWD}/src/io/*.cpp
   ${CWD}/src/bun.js/modules/*.cpp
@@ -632,6 +633,7 @@ register_command(
 list(APPEND BUN_CPP_SOURCES
   ${BUN_C_SOURCES}
   ${BUN_CXX_SOURCES}
+  ${BUN_ERROR_CODE_OUTPUTS}
   ${VENDOR_PATH}/picohttpparser/picohttpparser.c
   ${NODEJS_HEADERS_PATH}/include/node/node_version.h
   ${BUN_ZIG_GENERATED_CLASSES_OUTPUTS}
@@ -890,7 +892,7 @@ if(LINUX)
         -Wl,--wrap=statx
       )
     endif()
-    
+
     if(ARCH STREQUAL "x64")
       target_link_options(${bun} PUBLIC
         -Wl,--wrap=fcntl


### PR DESCRIPTION
### What does this PR do?

Fixes `cmake` so that cpp code in `build/codegen` re-compiles when
`ErrorCode.{h,cpp,ts}` files change.

### How did you verify your code works?
I ran build.

Upstack from #15696

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"12-10-test_mock_node_test_module_in_node_test_harness","parentHead":"5ef7251f1df958a8aed6445ed00540dc264da5e0","parentPull":15696,"trunk":"main"}
```
-->
