### PR TITLE
`bun.lock` workspace sorting and comma bugfix

### DIFF
--- a/test/cli/install/registry/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/registry/__snapshots__/bun-install-registry.test.ts.snap
@@ -134,3 +134,72 @@ exports[`auto-install symlinks (and junctions) are created correctly in the inst
 }
 "
 `;
+
+exports[`text lockfile workspace sorting 1`] = `
+"{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+    "packages/b": {
+      "name": "b",
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+    "packages/c": {
+      "name": "c",
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "b": ["b@workspace:packages/b", { "dependencies": { "no-deps": "1.0.0" } }],
+    "c": ["c@workspace:packages/c", { "dependencies": { "no-deps": "1.0.0" } }],
+    "no-deps": ["no-deps@1.0.0", "http://localhost:53427/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
+  }
+}
+"
+`;
+
+exports[`text lockfile workspace sorting 2`] = `
+"{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+    "packages/a": {
+      "name": "a",
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+    "packages/b": {
+      "name": "b",
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+    "packages/c": {
+      "name": "c",
+      "dependencies": {
+        "no-deps": "1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "a": ["a@workspace:packages/a", { "dependencies": { "no-deps": "1.0.0" } }],
+    "b": ["b@workspace:packages/b", { "dependencies": { "no-deps": "1.0.0" } }],
+    "c": ["c@workspace:packages/c", { "dependencies": { "no-deps": "1.0.0" } }],
+    "no-deps": ["no-deps@1.0.0", "http://localhost:53427/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
+  }
+}
+"
+`;

--- a/test/cli/install/registry/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/registry/__snapshots__/bun-install-registry.test.ts.snap
@@ -160,7 +160,7 @@ exports[`text lockfile workspace sorting 1`] = `
   "packages": {
     "b": ["b@workspace:packages/b", { "dependencies": { "no-deps": "1.0.0" } }],
     "c": ["c@workspace:packages/c", { "dependencies": { "no-deps": "1.0.0" } }],
-    "no-deps": ["no-deps@1.0.0", "http://localhost:53427/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
+    "no-deps": ["no-deps@1.0.0", "http://localhost:1234/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
   }
 }
 "
@@ -198,7 +198,7 @@ exports[`text lockfile workspace sorting 2`] = `
     "a": ["a@workspace:packages/a", { "dependencies": { "no-deps": "1.0.0" } }],
     "b": ["b@workspace:packages/b", { "dependencies": { "no-deps": "1.0.0" } }],
     "c": ["c@workspace:packages/c", { "dependencies": { "no-deps": "1.0.0" } }],
-    "no-deps": ["no-deps@1.0.0", "http://localhost:53427/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
+    "no-deps": ["no-deps@1.0.0", "http://localhost:1234/no-deps/-/no-deps-1.0.0.tgz", {}, "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw=="],
   }
 }
 "

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -1746,7 +1746,9 @@ describe("text lockfile", () => {
     console.log({ out, err });
     expect(await exited).toBe(0);
 
-    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toMatchSnapshot();
+    expect(
+      (await Bun.file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234"),
+    ).toMatchSnapshot();
 
     // now add workspace 'a'
     await write(
@@ -1772,7 +1774,8 @@ describe("text lockfile", () => {
     console.log({ out, err });
     expect(await exited).toBe(0);
 
-    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toMatchSnapshot();
+    const lockfile = await Bun.file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.replaceAll(/localhost:\d+/g, "localhost:1234")).toMatchSnapshot();
   });
 });
 

--- a/test/cli/install/registry/bun-install-registry.test.ts
+++ b/test/cli/install/registry/bun-install-registry.test.ts
@@ -891,7 +891,7 @@ describe("whoami", async () => {
     expect(err).not.toContain("error:");
     expect(await exited).toBe(0);
   });
-    test("two .npmrc", async () => {
+  test("two .npmrc", async () => {
     const token = await generateRegistryUser("whoami-two-npmrc", "whoami-two-npmrc");
     const packageNpmrc = `registry=http://localhost:${port}/`;
     const homeNpmrc = `//localhost:${port}/:_authToken=${token}`;
@@ -1697,6 +1697,82 @@ describe("package.json indentation", async () => {
     });
     expect(await exited).toBe(0);
     expect(await file(packageJson).text()).toBe(`{\n  "dependencies": {\n    "no-deps": "^2.0.0"\n  }\n}\n`);
+  });
+});
+
+describe("text lockfile", () => {
+  test("workspace sorting", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "b", "package.json"),
+        JSON.stringify({
+          name: "b",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "c", "package.json"),
+        JSON.stringify({
+          name: "c",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+    ]);
+
+    let { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    let out = await Bun.readableStreamToText(stdout);
+    let err = await Bun.readableStreamToText(stderr);
+    console.log({ out, err });
+    expect(await exited).toBe(0);
+
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toMatchSnapshot();
+
+    // now add workspace 'a'
+    await write(
+      join(packageDir, "packages", "a", "package.json"),
+      JSON.stringify({
+        name: "a",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+
+    ({ stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    }));
+
+    out = await Bun.readableStreamToText(stdout);
+    err = await Bun.readableStreamToText(stderr);
+    console.log({ out, err });
+    expect(await exited).toBe(0);
+
+    expect(await Bun.file(join(packageDir, "bun.lock")).text()).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
### What does this PR do?
- sorts workspace paths in `"workspaces"`
- fixes extra comma bug
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test for sorting workspaces
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
