### PR TITLE
Fix symbols test. Bump Webkit.

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -908,6 +908,7 @@ if(LINUX)
       -Wl,--wrap=powf
     )
   endif()
+  endif()
 
   if(NOT ABI STREQUAL "musl")
     target_link_options(${bun} PUBLIC

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -891,15 +891,22 @@ if(LINUX)
     target_link_options(${bun} PUBLIC
       -Wl,--wrap=exp
       -Wl,--wrap=expf
+      -Wl,--wrap=fcntl64
       -Wl,--wrap=log
       -Wl,--wrap=log2
       -Wl,--wrap=log2f
       -Wl,--wrap=logf
       -Wl,--wrap=pow
       -Wl,--wrap=powf
-      -Wl,--wrap=fcntl64
     )
-  endif()
+  else()
+    target_link_options(${bun} PUBLIC
+      -Wl,--wrap=exp
+      -Wl,--wrap=expf
+      -Wl,--wrap=log2f
+      -Wl,--wrap=logf
+      -Wl,--wrap=powf
+    )
   endif()
 
   if(NOT ABI STREQUAL "musl")

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION e17d16e0060b3d80ae40e78353d19575c9a8f3af)
+  set(WEBKIT_VERSION 58549ddc4d9e7164823fe9d4e86c46c003e46a19)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
@@ -95,7 +95,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerifyWithAlgorithm(const CryptoK
     if (!expectedSignature)
         return Exception { OperationError };
     // Using a constant time comparison to prevent timing attacks.
-    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->data(), signature.data(), expectedSignature->size());
+    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->span(), signature.span());
 }
 
 ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
@@ -108,7 +108,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, 
     if (!expectedSignature)
         return Exception { OperationError };
     // Using a constant time comparison to prevent timing attacks.
-    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->data(), signature.data(), expectedSignature->size());
+    return signature.size() == expectedSignature->size() && !constantTimeMemcmp(expectedSignature->span(), signature.span());
 }
 
 } // namespace WebCore

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -81,16 +81,20 @@ extern "C" int kill(int pid, int sig)
 #endif
 
 #if defined(__x86_64__)
+__asm__(".symver exp,exp@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");
+__asm__(".symver log2f,log2f@GLIBC_2.2.5");
+__asm__(".symver logf,logf@GLIBC_2.2.5");
+__asm__(".symver powf,powf@GLIBC_2.2.5");
 #elif defined(__aarch64__)
 __asm__(".symver expf,expf@GLIBC_2.17");
-__asm__(".symver powf,powf@GLIBC_2.17");
-__asm__(".symver pow,pow@GLIBC_2.17");
-__asm__(".symver log,log@GLIBC_2.17");
 __asm__(".symver exp,exp@GLIBC_2.17");
-__asm__(".symver logf,logf@GLIBC_2.17");
-__asm__(".symver log2f,log2f@GLIBC_2.17");
+__asm__(".symver log,log@GLIBC_2.17");
 __asm__(".symver log2,log2@GLIBC_2.17");
+__asm__(".symver log2f,log2f@GLIBC_2.17");
+__asm__(".symver logf,logf@GLIBC_2.17");
+__asm__(".symver pow,pow@GLIBC_2.17");
+__asm__(".symver powf,powf@GLIBC_2.17");
 #endif
 
 #if defined(__x86_64__) || defined(__aarch64__)
@@ -101,16 +105,16 @@ __asm__(".symver log2,log2@GLIBC_2.17");
 
 extern "C" {
 
+double BUN_WRAP_GLIBC_SYMBOL(exp)(double);
 float BUN_WRAP_GLIBC_SYMBOL(expf)(float);
+float BUN_WRAP_GLIBC_SYMBOL(log2f)(float);
+float BUN_WRAP_GLIBC_SYMBOL(logf)(float);
+float BUN_WRAP_GLIBC_SYMBOL(powf)(float, float);
 
 #if defined(__aarch64__)
 
-float BUN_WRAP_GLIBC_SYMBOL(powf)(float, float);
 double BUN_WRAP_GLIBC_SYMBOL(pow)(double, double);
 double BUN_WRAP_GLIBC_SYMBOL(log)(double);
-double BUN_WRAP_GLIBC_SYMBOL(exp)(double);
-float BUN_WRAP_GLIBC_SYMBOL(logf)(float);
-float BUN_WRAP_GLIBC_SYMBOL(log2f)(float);
 double BUN_WRAP_GLIBC_SYMBOL(log2)(double);
 int BUN_WRAP_GLIBC_SYMBOL(fcntl64)(int, int, ...);
 
@@ -119,15 +123,15 @@ int BUN_WRAP_GLIBC_SYMBOL(fcntl64)(int, int, ...);
 #if defined(__x86_64__) || defined(__aarch64__)
 
 float __wrap_expf(float x) { return expf(x); }
+float __wrap_powf(float x, float y) { return powf(x, y); }
+float __wrap_logf(float x) { return logf(x); }
+float __wrap_log2f(float x) { return log2f(x); }
+double __wrap_exp(double x) { return exp(x); }
 
 #if defined(__aarch64__)
 
-float __wrap_powf(float x, float y) { return powf(x, y); }
 double __wrap_pow(double x, double y) { return pow(x, y); }
 double __wrap_log(double x) { return log(x); }
-double __wrap_exp(double x) { return exp(x); }
-float __wrap_logf(float x) { return logf(x); }
-float __wrap_log2f(float x) { return log2f(x); }
 double __wrap_log2(double x) { return log2(x); }
 
 #endif


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
