### PR TITLE
document `npm:<package-name>` in install docs

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -149,7 +149,8 @@ Bun supports installing dependencies from Git, GitHub, and local or remotely-hos
     "lodash": "git+ssh://github.com/lodash/lodash.git#4.17.21",
     "moment": "git@github.com:moment/moment.git",
     "zod": "github:colinhacks/zod",
-    "react": "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+    "react": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+    "bun-types": "npm:@types/bun"
   }
 }
 ```


### PR DESCRIPTION
fixes https://github.com/oven-sh/bun/discussions/14938


technically its not "non-npm dependencies", however it is documenting the other ways then normal, so i think it fits and shows capability

(the actual example i chose i have no idea how much it could break though as @types/bun requires bun-types)