### PR TITLE
Don't call _kill when its not observable

### DIFF
--- a/src/bun.js/bindings/BunProcess.h
+++ b/src/bun.js/bindings/BunProcess.h
@@ -45,6 +45,7 @@ public:
     ~Process();
 
     bool m_isExitCodeObservable = false;
+    bool m_isKillFunctionObservable = false;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
 


### PR DESCRIPTION
### What does this PR do?

Don't call _kill when its not observable. This skips a getter and call into JS until the PropertyCallback is called.

### How did you verify your code works?

Existing tests
