### PR TITLE
Make git dependencies faster + further optimize bun install

### DIFF
--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -82,7 +82,7 @@ pub const OS = struct {
         if (std.fs.openFileAbsolute("/proc/stat", .{})) |file| {
             defer file.close();
 
-            const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf).unwrap();
+            const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf, true).unwrap();
             defer file_buf.clearRetainingCapacity();
             const contents = file_buf.items[0..read];
 
@@ -124,7 +124,7 @@ pub const OS = struct {
         if (std.fs.openFileAbsolute("/proc/cpuinfo", .{})) |file| {
             defer file.close();
 
-            const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf).unwrap();
+            const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf, true).unwrap();
             defer file_buf.clearRetainingCapacity();
             const contents = file_buf.items[0..read];
 
@@ -175,7 +175,7 @@ pub const OS = struct {
             if (std.fs.openFileAbsolute(path, .{})) |file| {
                 defer file.close();
 
-                const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf).unwrap();
+                const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf, true).unwrap();
                 defer file_buf.clearRetainingCapacity();
                 const contents = file_buf.items[0..read];
 

--- a/src/install/resolvers/folder_resolver.zig
+++ b/src/install/resolvers/folder_resolver.zig
@@ -200,7 +200,7 @@ pub const FolderResolution = union(Tag) {
                     body.data.reset();
                     var man = body.data.list.toManaged(manager.allocator);
                     defer body.data.list = man.moveToUnmanaged();
-                    _ = try file.readToEndWithArrayList(&man).unwrap();
+                    _ = try file.readToEndWithArrayList(&man, true).unwrap();
                 }
 
                 break :brk logger.Source.initPathString(abs, body.data.list.items);

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -806,7 +806,7 @@ const PosixBufferedReader = struct {
     pub fn finalBuffer(this: *PosixBufferedReader) *std.ArrayList(u8) {
         if (this.flags.memfd and this.handle == .fd) {
             defer this.handle.close(null, {});
-            _ = bun.sys.File.readToEndWithArrayList(.{ .handle = this.handle.fd }, this.buffer()).unwrap() catch |err| {
+            _ = bun.sys.File.readToEndWithArrayList(.{ .handle = this.handle.fd }, this.buffer(), false).unwrap() catch |err| {
                 bun.Output.debugWarn("error reading from memfd\n{}", .{err});
                 return this.buffer();
             };


### PR DESCRIPTION
### What does this PR do?

- Avoid opening directories unnecessarily when linking bins
- Avoid opening directories unnecessarily when verifying git packages
- Add an optimization for reading small files that avoids the fstat() call

### How did you verify your code works?

Our existing tests should cover this, but I did check the syscall count for some git dependencies.