### PR TITLE
CI: Use a consistent version of node for most targets 

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -792,6 +792,10 @@ install_nodejs_from_tar() {
 		execute_sudo ln -sf "$nodejs_bin_dir/$binary" "/usr/bin/$binary"
 		execute_sudo chmod +x "/usr/bin/$binary"
 	done
+
+	# Skip downloading v8 headers
+	execute_sudo cp -r /usr/local/include/node /usr/include
+	append_to_profile "export npm_config_nodedir=/usr"
 }
 
 install_nodejs_headers() {
@@ -801,6 +805,9 @@ install_nodejs_headers() {
 
 	nodejs_headers_include="$nodejs_headers_dir/node-v$(nodejs_version_exact)/include"
 	execute_sudo cp -R "$nodejs_headers_include/" "/usr"
+
+	# Skip downloading v8 headers
+	append_to_profile "export npm_config_nodedir=/usr"
 }
 
 bun_version_exact() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -789,10 +789,8 @@ install_nodejs_from_tar() {
 	# Create symlinks if they don't exist
 	nodejs_bin_dir="/usr/local/bin"
 	for binary in node npm npx corepack; do
-		if [ -f "$nodejs_bin_dir/$binary" ]; then
-			execute_sudo ln -sf "$nodejs_bin_dir/$binary" "/usr/bin/$binary"
-			execute_sudo chmod +x "/usr/bin/$binary"
-		fi
+		execute_sudo ln -sf "$nodejs_bin_dir/$binary" "/usr/bin/$binary"
+		execute_sudo chmod +x "/usr/bin/$binary"
 	done
 }
 

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -433,6 +433,9 @@ const aws = {
           ...device,
           Ebs: {
             VolumeSize: getDiskSize(options),
+            VolumeType: "gp3",
+            Iops: 3000,
+            Throughput: 125,
           },
         };
       }

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -434,8 +434,8 @@ const aws = {
           Ebs: {
             VolumeSize: getDiskSize(options),
             VolumeType: "gp3",
-            Iops: 3000,
-            Throughput: 125,
+            Iops: 6000,
+            Throughput: 250,
           },
         };
       }

--- a/test/js/bun/css/doesnt_crash.test.ts
+++ b/test/js/bun/css/doesnt_crash.test.ts
@@ -15,47 +15,48 @@ describe("doesnt_crash", async () => {
   files = readdirSync(files_dir).map(file => path.join(files_dir, file));
   console.log("Tempdir", temp_dir);
 
-  files.map(absolute => {
+  files.forEach(absolute => {
     absolute = absolute.replaceAll("\\", "/");
     const file = path.basename(absolute);
-    const outfile1 = path.join(temp_dir, "file-1" + file).replaceAll("\\", "/");
-    const outfile2 = path.join(temp_dir, "file-2" + file).replaceAll("\\", "/");
-    const outfile3 = path.join(temp_dir, "file-3" + file).replaceAll("\\", "/");
-    const outfile4 = path.join(temp_dir, "file-4" + file).replaceAll("\\", "/");
 
-    test(file, async () => {
-      {
-        const { stdout, stderr, exitCode } =
-          await Bun.$`${bunExe()} build --experimental-css ${absolute} --outfile=${outfile1}`.quiet().env(bunEnv);
-        expect(exitCode).toBe(0);
-        expect(stdout.toString()).not.toContain("error");
-        expect(stderr.toString()).toBeEmpty();
-      }
+    for (let minify of [false, true]) {
+      test(`${file} - ${minify ? "minify" : "not minify"}`, async () => {
+        const timeLog = `Transpiled ${file} - ${minify ? "minify" : "not minify"}`;
+        console.time(timeLog);
+        const { logs, outputs } = await Bun.build({
+          entrypoints: [absolute],
+          experimentalCss: true,
+          minify: minify,
+        });
+        console.timeEnd(timeLog);
 
-      const { stdout, stderr, exitCode } =
-        await Bun.$`${bunExe()} build --experimental-css ${outfile1} --outfile=${outfile2}`.quiet().env(bunEnv);
-      expect(exitCode).toBe(0);
-      expect(stdout.toString()).not.toContain("error");
-      expect(stderr.toString()).toBeEmpty();
-    });
+        if (logs?.length) {
+          throw new Error(logs.join("\n"));
+        }
 
-    test(`(minify) ${file}`, async () => {
-      {
-        const { stdout, stderr, exitCode } =
-          await Bun.$`${bunExe()} build --experimental-css ${absolute} --minify --outfile=${outfile3}`
-            .quiet()
-            .env(bunEnv);
-        expect(exitCode).toBe(0);
-        expect(stdout.toString()).not.toContain("error");
-        expect(stderr.toString()).toBeEmpty();
-      }
-      const { stdout, stderr, exitCode } =
-        await Bun.$`${bunExe()} build --experimental-css ${outfile3} --minify --outfile=${outfile4}`
-          .quiet()
-          .env(bunEnv);
-      expect(exitCode).toBe(0);
-      expect(stdout.toString()).not.toContain("error");
-      expect(stderr.toString()).toBeEmpty();
-    });
+        expect(outputs.length).toBe(1);
+        const outfile1 = path.join(temp_dir, "file-1" + file).replaceAll("\\", "/");
+
+        await Bun.write(outfile1, outputs[0]);
+
+        {
+          const timeLog = `Re-transpiled ${file} - ${minify ? "minify" : "not minify"}`;
+          console.time(timeLog);
+          const { logs, outputs } = await Bun.build({
+            entrypoints: [outfile1],
+            experimentalCss: true,
+            minify: minify,
+          });
+
+          if (logs?.length) {
+            throw new Error(logs.join("\n"));
+          }
+
+          expect(outputs.length).toBe(1);
+          expect(await outputs[0].text()).not.toBeEmpty();
+          console.timeEnd(timeLog);
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
