### PR TITLE
docs: `dns.prefetch` doesn't require port anymore

### DIFF
--- a/docs/api/fetch.md
+++ b/docs/api/fetch.md
@@ -234,7 +234,7 @@ To prefetch a DNS entry, you can use the `dns.prefetch` API. This API is useful 
 ```ts
 import { dns } from "bun";
 
-dns.prefetch("bun.sh", 443);
+dns.prefetch("bun.sh");
 ```
 
 #### DNS caching


### PR DESCRIPTION
### What does this PR do?
Change to `docs/api/fetch.md`: Removes `port` number parameter from `dns.prefetch` API call.

* [`docs/api/fetch.md`](diffhunk://#diff-a4cb8792140dde023104a7a6075ad23faf3b60cc0a10d94d53a8eb286df90caeL237-R237): Removed the port number parameter from the `dns.prefetch` API call example.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

<img width="652" alt="image" src="https://github.com/user-attachments/assets/b5ac2d4c-57ae-41e1-85e6-46541949511d" />

<img width="330" alt="image" src="https://github.com/user-attachments/assets/879e1be6-2451-40db-a757-e58dadb447fd" />
