### PR TITLE
Fixes #15784

### DIFF
--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -550,6 +550,7 @@ pub const PatchTask = struct {
             resolution,
             &folder_path_buf,
             patch_hash,
+            pkg_manager.lockfile,
         );
 
         const patchfilepath = pkg_manager.allocator.dupe(u8, pkg_manager.lockfile.patched_dependencies.get(name_and_version_hash).?.path.slice(pkg_manager.lockfile.buffers.string_bytes.items)) catch bun.outOfMemory();


### PR DESCRIPTION
### What does this PR do?

Fixes #15784

I believe the bug was the `Lockfile` pointer was to the one on the `PackageManager` (`manager.lockfile`) instead of the newly allocated one, so when it tries to read a string from string_bytes it points to an entirely different memory address.

https://github.com/oven-sh/bun/pull/15809/files#diff-2d4db027e059280840de7dfe46dda1752467e66c1c3014369ed701b026cd06fcR3995-R3999

### How did you verify your code works?

WIP. 