### PR TITLE
Fix macro imports

### DIFF
--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,6 +1,10 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
 import { expect, test } from "bun:test";
 import { addStrings, addStringsUTF16, escape, identity } from "./macro.ts" assert { type: "macro" };
+import defaultMacro, {
+  identity as identity1,
+  identity as identity2,
+} from "./macro.ts" assert { type: "macro" };
 
 test("bun builtins can be used in macros", async () => {
   expect(escapeHTML("abc!")).toBe("abc!");
@@ -87,6 +91,17 @@ test("escaping", () => {
 
 test("utf16 string", () => {
   expect(identity("😊 Smiling Face with Smiling Eyes Emoji")).toBe("😊 Smiling Face with Smiling Eyes Emoji");
+});
+
+test("default export", () => {
+  expect(defaultMacro()).toBe("defaultdefaultdefault");
+});
+
+test("aliases", () => {
+  expect(identity1({ a: 1 })).toEqual({ a: 1 });
+  expect(identity1([1, 2, 3])).toEqual([1, 2, 3]);
+  expect(identity2({ a: 1 })).toEqual({ a: 1 });
+  expect(identity2([1, 2, 3])).toEqual([1, 2, 3]);
 });
 
 // test("template string ascii", () => {

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -6,6 +6,8 @@ import defaultMacro, {
   identity as identity2,
 } from "./macro.ts" assert { type: "macro" };
 
+import * as macros from "./macro.ts" assert { type: "macro" };
+
 test("bun builtins can be used in macros", async () => {
   expect(escapeHTML("abc!")).toBe("abc!");
 });
@@ -93,15 +95,21 @@ test("utf16 string", () => {
   expect(identity("😊 Smiling Face with Smiling Eyes Emoji")).toBe("😊 Smiling Face with Smiling Eyes Emoji");
 });
 
-test("default export", () => {
+test("default import", () => {
   expect(defaultMacro()).toBe("defaultdefaultdefault");
 });
 
-test("aliases", () => {
+test("import aliases", () => {
   expect(identity1({ a: 1 })).toEqual({ a: 1 });
   expect(identity1([1, 2, 3])).toEqual([1, 2, 3]);
   expect(identity2({ a: 1 })).toEqual({ a: 1 });
   expect(identity2([1, 2, 3])).toEqual([1, 2, 3]);
+});
+
+test("namespace import", () => {
+  expect(macros.identity({ a: 1 })).toEqual({ a: 1 });
+  expect(macros.identity([1, 2, 3])).toEqual([1, 2, 3]);
+  expect(macros.escape()).toBe("\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C");
 });
 
 // test("template string ascii", () => {

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -2,6 +2,7 @@ import { escapeHTML } from "bun" assert { type: "macro" };
 import { expect, test } from "bun:test";
 import { addStrings, addStringsUTF16, escape, identity } from "./macro.ts" assert { type: "macro" };
 import defaultMacro, {
+  default as defaultMacroAlias,
   identity as identity1,
   identity as identity2,
 } from "./macro.ts" assert { type: "macro" };
@@ -95,15 +96,16 @@ test("utf16 string", () => {
   expect(identity("😊 Smiling Face with Smiling Eyes Emoji")).toBe("😊 Smiling Face with Smiling Eyes Emoji");
 });
 
-test("default import", () => {
-  expect(defaultMacro()).toBe("defaultdefaultdefault");
-});
-
 test("import aliases", () => {
   expect(identity1({ a: 1 })).toEqual({ a: 1 });
   expect(identity1([1, 2, 3])).toEqual([1, 2, 3]);
   expect(identity2({ a: 1 })).toEqual({ a: 1 });
   expect(identity2([1, 2, 3])).toEqual([1, 2, 3]);
+});
+
+test("default import", () => {
+  expect(defaultMacro()).toBe("defaultdefaultdefault");
+  expect(defaultMacroAlias()).toBe("defaultdefaultdefault");
 });
 
 test("namespace import", () => {

--- a/test/bundler/transpiler/macro.ts
+++ b/test/bundler/transpiler/macro.ts
@@ -13,3 +13,7 @@ export function addStrings(arg: string) {
 export function addStringsUTF16(arg: string) {
   return arg + "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C" + "😊";
 }
+
+export default function() {
+  return "defaultdefaultdefault";
+}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Currently, macros cannot be imported using a namespace import, default imports, or with named import aliases.

```js
// All of the following imports will fail:
import defaultMacro from "macros.js" with {type: "macro"};
import * as macros from "macros.js" with {type: "macro"};
import {macro as myMacro} from "macros.js" with {type: "macro"};
```

Fixes https://github.com/oven-sh/bun/issues/15348

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

## TODO:

- [ ] increment expected_version in RuntimeTranspilerCache?
- [x] test situations with export aliases or re-exports