### PR TITLE
don't make inline sourcemap in normal vscode terminal

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1036,7 +1036,7 @@ pub const VirtualMachine = struct {
         printer: *js_printer.BufferPrinter,
 
         pub fn get(this: *SourceMapHandlerGetter) js_printer.SourceMapHandler {
-            if (this.vm.debugger == null) {
+            if (this.vm.debugger == null or this.vm.debugger.?.mode == .connect) {
                 return SavedSourceMap.SourceMapHandler.init(&this.vm.source_mappings);
             }
 
@@ -2122,7 +2122,7 @@ pub const VirtualMachine = struct {
             },
         }
 
-        if (this.debugger != null) {
+        if (this.isInspectorEnabled() and this.debugger.?.mode != .connect) {
             this.bundler.options.minify_identifiers = false;
             this.bundler.options.minify_syntax = false;
             this.bundler.options.minify_whitespace = false;


### PR DESCRIPTION
the in-vscode error reporting it effectively creates a debugger, however we don't need everything (in this context sourcemap is unneeded)

I have manually tested and both debugger and inline errors still appear to work