### PR TITLE
Make `"use strict"` become CommonJS if we don't know whether it's ESM or CJS

### DIFF
--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -8,7 +8,8 @@
 /// Version 9: String printing changes
 /// Version 10: Constant folding for ''.charCodeAt(n)
 /// Version 11: Fix \uFFFF printing regression
-const expected_version = 11;
+/// Version 12: "use strict"; makes it CommonJS if we otherwise don't know which one to pick.
+const expected_version = 12;
 
 const bun = @import("root").bun;
 const std = @import("std");

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3952,9 +3952,10 @@ pub const Parser = struct {
 
                     if (uses_any_import_statements) {
                         exports_kind = .esm;
-
-                        // Otherwise, if they use CommonJS features its CommonJS
-                    } else if (p.symbols.items[p.require_ref.innerIndex()].use_count_estimate > 0 or uses_dirname or uses_filename) {
+                    }
+                    // Otherwise, if they use CommonJS features its CommonJS.
+                    // If you add a 'use strict'; at the top, you probably meant CommonJS because "use strict"; does nothing in ESM.
+                    else if (p.symbols.items[p.require_ref.innerIndex()].use_count_estimate > 0 or uses_dirname or uses_filename or (!p.options.bundle and p.module_scope.strict_mode == .explicit_strict_mode)) {
                         exports_kind = .cjs;
                     } else {
                         // If unknown, we default to ESM

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
+test("use strict causes CommonJS", () => {
+  const { stdout, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), require.resolve("./use-strict-fixture.js")],
+    env: bunEnv,
+  });
+  expect(stdout.toString()).toBe("function\n");
+  expect(exitCode).toBe(0);
+});
+
 test("non-ascii regexp literals", () => {
   var str = "🔴11 54 / 10,000";
   expect(str.replace(/[🔵🔴,]+/g, "")).toBe("11 54 / 10000");

--- a/test/bundler/transpiler/use-strict-fixture.js
+++ b/test/bundler/transpiler/use-strict-fixture.js
@@ -1,0 +1,5 @@
+"use strict";
+
+// Test that 'use strict' makes it CommonJS when we otherwise don't know which one to pick.
+// Without that, this direct eval becomes indirect, throwing a ReferenceError.
+console.log(eval("typeof module.require"));


### PR DESCRIPTION
### What does this PR do?

If you do `"use strict";` at the top of the file, this does nothing in ES modules.

Therefore, when there's ambiguity (no import statements, no require, __dirname, no __filename, no module access), we can use that as another hint that you want CommonJS and not ESM. 

This means that the following code would no longer error:
```js
"use strict";

console.log(eval("typeof module.require"));
```

### How did you verify your code works?

Test
