### PR TITLE
Handle eintr in kqueue/epoll better related to timers

### DIFF
--- a/src/bake/BakeGlobalObject.cpp
+++ b/src/bake/BakeGlobalObject.cpp
@@ -151,6 +151,7 @@ const JSC::GlobalObjectMethodTable GlobalObject::s_globalObjectMethodTable = {
     INHERIT_HOOK_METHOD(deriveShadowRealmGlobalObject),
     INHERIT_HOOK_METHOD(codeForEval),
     INHERIT_HOOK_METHOD(canCompileStrings),
+    INHERIT_HOOK_METHOD(trustedScriptStructure),
 };
 
 GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure,

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -129,6 +129,14 @@ pub const All = struct {
         return VirtualMachine.get().timer.last_id;
     }
 
+    pub export fn Bun__updateTimeoutAfterEINTR(this: *VirtualMachine, timeout: *timespec) i32 {
+        if (!this.timer.getTimeout(timeout)) {
+            return 0;
+        }
+
+        return 1;
+    }
+
     pub fn getTimeout(this: *const All, spec: *timespec) bool {
         if (this.active_timer_count == 0) {
             return false;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1408,7 +1408,7 @@ pub const EventLoop = struct {
             var event_loop_sleep_timer = if (comptime Environment.isDebug) std.time.Timer.start() catch unreachable else {};
             // for the printer, this is defined:
             var timespec: bun.timespec = if (Environment.isDebug) .{ .sec = 0, .nsec = 0 } else undefined;
-            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec)) &timespec else null);
+            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec)) &timespec else null, ctx);
 
             if (comptime Environment.isDebug) {
                 log("tick {}, timeout: {}", .{ bun.fmt.fmtDuration(event_loop_sleep_timer.read()), bun.fmt.fmtDuration(timespec.ns()) });
@@ -1492,8 +1492,7 @@ pub const EventLoop = struct {
         if (loop.isActive()) {
             this.processGCTimer();
             var timespec: bun.timespec = undefined;
-
-            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec)) &timespec else null);
+            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec)) &timespec else null, ctx);
         } else {
             loop.tickWithoutIdle();
         }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1651,7 +1651,7 @@ pub const VirtualMachine = struct {
                             }
                         }
 
-                        this.uwsLoop().tickWithTimeout(&deadline);
+                        this.uwsLoop().tickWithTimeout(&deadline, this);
 
                         if (comptime Environment.enable_logs)
                             log("waited: {}", .{bun.fmt.fmtDuration(@intCast(@as(i64, @truncate(std.time.nanoTimestamp() - bun.CLI.start_time))))});

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2543,19 +2543,19 @@ pub const PosixLoop = extern struct {
     pub const wake = wakeup;
 
     pub fn tick(this: *PosixLoop) void {
-        us_loop_run_bun_tick(this, null);
+        us_loop_run_bun_tick(this, null, null);
     }
 
     pub fn tickWithoutIdle(this: *PosixLoop) void {
         const timespec = bun.timespec{ .sec = 0, .nsec = 0 };
-        us_loop_run_bun_tick(this, &timespec);
+        us_loop_run_bun_tick(this, &timespec, null);
     }
 
-    pub fn tickWithTimeout(this: *PosixLoop, timespec: ?*const bun.timespec) void {
-        us_loop_run_bun_tick(this, timespec);
+    pub fn tickWithTimeout(this: *PosixLoop, timespec: ?*bun.timespec, timeout_update_ctx: ?*anyopaque) void {
+        us_loop_run_bun_tick(this, timespec, timeout_update_ctx);
     }
 
-    extern fn us_loop_run_bun_tick(loop: ?*Loop, timouetMs: ?*const bun.timespec) void;
+    extern fn us_loop_run_bun_tick(loop: ?*Loop, timouetMs: ?*const bun.timespec, timeout_update_ctx: ?*anyopaque) void;
 
     pub fn nextTick(this: *PosixLoop, comptime UserType: type, user_data: UserType, comptime deferCallback: fn (ctx: UserType) void) void {
         const Handler = struct {
@@ -2597,10 +2597,6 @@ pub const PosixLoop = extern struct {
         return Handler{
             .loop = this,
         };
-    }
-
-    pub fn run(this: *PosixLoop) void {
-        us_loop_run(this);
     }
 };
 
@@ -4286,7 +4282,7 @@ pub const WindowsLoop = extern struct {
 
     pub const wake = wakeup;
 
-    pub fn tickWithTimeout(this: *WindowsLoop, _: ?*const bun.timespec) void {
+    pub fn tickWithTimeout(this: *WindowsLoop, _: ?*const bun.timespec, _: ?*anyopaque) void {
         us_loop_run(this);
     }
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
