### PR TITLE
chore: add usage messages to check-node.sh

### DIFF
--- a/scripts/check-node.sh
+++ b/scripts/check-node.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
 
+# How to use this script:
+# 1. Pick a module from node's standard library (e.g. 'assert', 'fs')
+# 2. Copy over relevant tests from node's parallel test suite into test/js/node/test/parallel
+# 3. Run this script, e.g. `./scripts/check-node.sh fs`
+# 4. Tests that passed get staged for commit
+
 i=0
 j=0
+
+if [[ -z $1 ]]
+then
+  echo "Usage: $0 <module-name>"
+  exit 1
+fi
+
+case $1 in
+  -h|--help)
+    echo "Usage: $0 <module-name>"
+    echo "Run all parallel tests for a single module in node's standard library"
+    exit 0
+    ;;
+esac
 
 export BUN_DEBUG_QUIET_LOGS=1
 export NO_COLOR=1


### PR DESCRIPTION
Makes `check-node.sh` easier to use for newcomers. 
1. `-h,--help` shows a usage message
2. forgetting to pass a module name exits the script with an error code