### PR TITLE
fix(install): sort tree dependencies by behavior and name

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -762,10 +762,14 @@ pub const Tree = struct {
                 const deps_buf = sorter.lockfile.buffers.dependencies.items;
                 const string_buf = sorter.lockfile.buffers.string_bytes.items;
 
-                const l_dep_name = deps_buf[l].name.slice(string_buf);
-                const r_dep_name = deps_buf[r].name.slice(string_buf);
+                const l_dep = deps_buf[l];
+                const r_dep = deps_buf[r];
 
-                return strings.order(l_dep_name, r_dep_name) == .lt;
+                return switch (l_dep.behavior.cmp(r_dep.behavior)) {
+                    .lt => true,
+                    .gt => false,
+                    .eq => strings.order(l_dep.name.slice(string_buf), r_dep.name.slice(string_buf)) == .lt,
+                };
             }
         };
 


### PR DESCRIPTION
### What does this PR do?
fixes #15818
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
TODO: tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
