### PR TITLE
fix `pnpm.test.ts`

### DIFF
--- a/test/js/third_party/pnpm/pnpm.test.ts
+++ b/test/js/third_party/pnpm/pnpm.test.ts
@@ -9,7 +9,7 @@ it("successfully traverses pnpm-generated install directory", async () => {
   //
 
   let { exited } = Bun.spawn({
-    cmd: [bunExe(), "create", "vite", "my-vite-app", "--template", "solid-ts"],
+    cmd: [bunExe(), "create", "vite@5", "my-vite-app", "--template", "solid-ts"],
     cwd: package_dir,
     stdio: ["ignore", "inherit", "inherit"],
     env: bunEnv,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
tested manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
