### PR TITLE
fix #15902

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -15558,7 +15558,8 @@ pub const AstBuilder = struct {
 
             _ = try js_parser.ImportScanner.scan(AstBuilder, p, p.stmts.items, false, true, &hmr_transform_ctx);
 
-            const new_parts = try hmr_transform_ctx.finalize(p, parts.slice());
+            try hmr_transform_ctx.finalize(p, parts.slice());
+            const new_parts = parts.slice();
             // preserve original capacity
             parts.len = @intCast(new_parts.len);
             bun.assert(new_parts.ptr == parts.ptr);

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -4218,8 +4218,19 @@ pub const Parser = struct {
 
         if (before.items.len > 0 or after.items.len > 0) {
             try parts.ensureUnusedCapacity(before.items.len + after.items.len);
-            try parts.insertSlice(0, before.items);
-            parts.appendSliceAssumeCapacity(after.items);
+            const parts_len = parts.items.len;
+            parts.items.len += before.items.len + after.items.len;
+
+            if (before.items.len > 0) {
+                if (parts_len > 0) {
+                    // first copy parts to the middle if before exists
+                    bun.copy(js_ast.Part, parts.items[before.items.len..][0..parts_len], parts.items[0..parts_len]);
+                }
+                bun.copy(js_ast.Part, parts.items[0..before.items.len], before.items);
+            }
+            if (after.items.len > 0) {
+                bun.copy(js_ast.Part, parts.items[parts_len + before.items.len ..][0..after.items.len], after.items);
+            }
         }
 
         // Pop the module scope to apply the "ContainsDirectEval" rules


### PR DESCRIPTION
### What does this PR do?
We need to ensure `parts` has a length of at least one.

fixes #15902
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
