### PR TITLE
fix(process): `process.kill` allows zero or negative pids

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2948,9 +2948,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill,
     auto pid_value = callFrame->argument(0);
     int pid = pid_value.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    if (pid < 0) {
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "pid"_s, "a positive integer"_s, pid_value);
-    }
     JSC::JSValue signalValue = callFrame->argument(1);
     int signal = SIGTERM;
     if (signalValue.isNumber()) {


### PR DESCRIPTION
### What does this PR do?
Fixes #15791.