### PR TITLE
Make originalLine and originalColumn getter calls not observable

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -457,7 +457,7 @@ WTF::String Bun::formatStackTrace(
                 sb.append(remappedFrame.source_url.toWTFString());
 
                 if (remappedFrame.remapped) {
-                    errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(originalLine.oneBasedInt()), 0);
+                    errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(originalLine.oneBasedInt()), PropertyAttribute::DontEnum | 0);
                     hasSet = true;
                     line = remappedFrame.position.line();
                 }
@@ -599,8 +599,8 @@ WTF::String Bun::formatStackTrace(
 
                 if (remappedFrame.remapped) {
                     if (errorInstance) {
-                        errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(originalLine.oneBasedInt()), 0);
-                        errorInstance->putDirect(vm, builtinNames(vm).originalColumnPublicName(), jsNumber(originalColumn.oneBasedInt()), 0);
+                        errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(originalLine.oneBasedInt()), PropertyAttribute::DontEnum | 0);
+                        errorInstance->putDirect(vm, builtinNames(vm).originalColumnPublicName(), jsNumber(originalColumn.oneBasedInt()), PropertyAttribute::DontEnum | 0);
                     }
                 }
             }

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -105,8 +105,8 @@ test("Error inside minified file (no color) ", () => {
     expect(
       normalizeError(
         Bun.inspect(e)
-          .replaceAll(import.meta.dir, "[dir]")
           .replaceAll("\\", "/")
+          .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]")
           .trim(),
       ),
     ).toMatchInlineSnapshot(`

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -5,8 +5,8 @@ test("error.cause", () => {
   const err2 = new Error("error 2", { cause: err });
   expect(
     Bun.inspect(err2)
-      .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]")
-      .replaceAll("\\", "/"),
+      .replaceAll("\\", "/")
+      .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { expect, test, describe, jest } from "bun:test";
 2 | 
@@ -32,8 +32,8 @@ test("Error", () => {
   const err = new Error("my message");
   expect(
     Bun.inspect(err)
-      .replaceAll(import.meta.dir, "[dir]")
-      .replaceAll("\\", "/"),
+      .replaceAll("\\", "/")
+      .replaceAll(import.meta.dir, "[dir]"),
   ).toMatchInlineSnapshot(`
 "27 | "
 28 | \`);
@@ -55,8 +55,8 @@ test("BuildMessage", async () => {
   } catch (e) {
     expect(
       Bun.inspect(e)
-        .replaceAll(import.meta.dir, "[dir]")
-        .replaceAll("\\", "/"),
+        .replaceAll("\\", "/")
+        .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
     ).toMatchInlineSnapshot(`
 "2 | const duplicateConstDecl = 456;
           ^
@@ -135,8 +135,8 @@ test("Error inside minified file (color) ", () => {
       normalizeError(
         stripANSIColors(
           Bun.inspect(e, { colors: true })
-            .replaceAll(import.meta.dir, "[dir]")
             .replaceAll("\\", "/")
+            .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]")
             .trim(),
         ).trim(),
       ),

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -33,7 +33,7 @@ test("Error", () => {
   expect(
     Bun.inspect(err)
       .replaceAll("\\", "/")
-      .replaceAll(import.meta.dir, "[dir]"),
+      .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "27 | "
 28 | \`);

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,13 +1,31 @@
-import { expect, test } from "bun:test";
+import { expect, test, describe, jest } from "bun:test";
 
 test("error.cause", () => {
   const err = new Error("error 1");
   const err2 = new Error("error 2", { cause: err });
   expect(
     Bun.inspect(err2)
-      .replaceAll(import.meta.dir, "[dir]")
+      .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]")
       .replaceAll("\\", "/"),
-  ).toMatchSnapshot();
+  ).toMatchInlineSnapshot(`
+"1 | import { expect, test, describe, jest } from "bun:test";
+2 | 
+3 | test("error.cause", () => {
+4 |   const err = new Error("error 1");
+5 |   const err2 = new Error("error 2", { cause: err });
+                   ^
+error: error 2
+      at [dir]/inspect-error.test.js:5:16
+
+1 | import { expect, test, describe, jest } from "bun:test";
+2 | 
+3 | test("error.cause", () => {
+4 |   const err = new Error("error 1");
+                  ^
+error: error 1
+      at [dir]/inspect-error.test.js:4:15
+"
+`);
 });
 
 test("Error", () => {
@@ -16,7 +34,18 @@ test("Error", () => {
     Bun.inspect(err)
       .replaceAll(import.meta.dir, "[dir]")
       .replaceAll("\\", "/"),
-  ).toMatchSnapshot();
+  ).toMatchInlineSnapshot(`
+"27 | "
+28 | \`);
+29 | });
+30 | 
+31 | test("Error", () => {
+32 |   const err = new Error("my message");
+                   ^
+error: my message
+      at [dir]/inspect-error.test.js:32:15
+"
+`);
 });
 
 test("BuildMessage", async () => {
@@ -28,7 +57,17 @@ test("BuildMessage", async () => {
       Bun.inspect(e)
         .replaceAll(import.meta.dir, "[dir]")
         .replaceAll("\\", "/"),
-    ).toMatchSnapshot();
+    ).toMatchInlineSnapshot(`
+"2 | const duplicateConstDecl = 456;
+          ^
+error: "duplicateConstDecl" has already been declared
+    at [dir]/inspect-error-fixture-bad.js:2:7
+
+1 | const duplicateConstDecl = 123;
+          ^
+note: "duplicateConstDecl" was originally declared here
+   at [dir]/inspect-error-fixture-bad.js:1:7"
+`);
   }
 });
 
@@ -70,7 +109,19 @@ test("Error inside minified file (no color) ", () => {
           .replaceAll("\\", "/")
           .trim(),
       ),
-    ).toMatchSnapshot();
+    ).toMatchInlineSnapshot(`
+"21 | exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED=Z;
+22 | exports.cache=function(a){return function(){var b=U.current;if(!b)return a.apply(null,arguments);var c=b.getCacheForType(V);b=c.get(a);void 0===b&&(b=W(),c.set(a,b));c=0;for(var f=arguments.length;c<f;c++){var d=arguments[c];if("function"===typeof d||"object"===typeof d&&null!==d){var e=b.o;null===e&&(b.o=e=new WeakMap);b=e.get(d);void 0===b&&(b=W(),e.set(d,b))}else e=b.p,null===e&&(b.p=e=new Map),b=e.get(d),void 0===b&&(b=W(),e.set(d,b))}if(1===b.s)return b.v;if(2===b.s)throw b.v;try{var g=a.apply(null,
+23 | arguments);c=b;c.s=1;return c.v=g}catch(h){throw g=b,g.s=2,g.v=h,h;}}};
+24 | exports.cloneElement=function(a,b,c){if(null===a||void 0===a)throw Error("React.cloneElement(...): The argument must be a React element, but you passed "+a+".");var f=C({},a.props),d=a.key,e=a.ref,g=a._owner;if(null!=b){void 0!==b.ref&&(e=b.ref,g=K.current);void 0!==b.key&&(d=""+b.key);if(a.type&&a.type.defaultProps)var h=a.type.defaultProps;for(k in b)J.call(b,k)&&!L.hasOwnProperty(k)&&(f[k]=void 0===b[k]&&void 0!==h?h[k]:b[k])}var k=arguments.length-2;if(1===k)f.children=c;else if(1<k){h=Array(k);
+25 | for(var m=0;m<k;m++)h[m]=arguments[m+2];f.children=h}return{$$typeof:l,type:a.type,key:d,ref:e,props:f,_owner:g}};exports.createContext=function(a){a={$$typeof:u,_currentValue:a,_currentValue2:a,_threadCount:0,Provider:null,Consumer:null,_defaultValue:null,_globalName:null};a.Provider={$$typeof:t,_context:a};return a.Consumer=a};exports.createElement=M;exports.createFactory=function(a){var b=M.bind(null,a);b.type=a;return b};exports.createRef=function(){return{current:null}};
+26 | exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};expo
+
+error: error inside long minified file!
+      at [dir]/inspect-error-fixture.min.js:26:2846
+      at [dir]/inspect-error-fixture.min.js:26:2890
+      at [dir]/inspect-error.test.js:102:5"
+`);
   }
 });
 
@@ -89,6 +140,62 @@ test("Error inside minified file (color) ", () => {
             .trim(),
         ).trim(),
       ),
-    ).toMatchSnapshot();
+    ).toMatchInlineSnapshot(`
+"21 | exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED=Z;
+22 | exports.cache=function(a){return function(){var b=U.current;if(!b)return a.apply(null,arguments);var c=b.getCacheForType(V);b=c.get(a);void 0===b&&(b=W(),c.set(a,b));c=0;for(var f=arguments.length;c<f;c++){var d=arguments[c];if("function"===typeof d||"object"===typeof d&&null!==d){var e=b.o;null===e&&(b.o=e=new WeakMap);b=e.get(d);void 0===b&&(b=W(),e.set(d,b))}else e=b.p,null===e&&(b.p=e=new Map),b=e.get(d),void 0===b&&(b=W(),e.set(d,b))}if(1===b.s)return b.v;if(2===b.s)throw b.v;try{var g=a.apply(null,
+23 | arguments);c=b;c.s=1;return c.v=g}catch(h){throw g=b,g.s=2,g.v=h,h;}}};
+24 | exports.cloneElement=function(a,b,c){if(null===a||void 0===a)throw Error("React.cloneElement(...): The argument must be a React element, but you passed "+a+".");var f=C({},a.props),d=a.key,e=a.ref,g=a._owner;if(null!=b){void 0!==b.ref&&(e=b.ref,g=K.current);void 0!==b.key&&(d=""+b.key);if(a.type&&a.type.defaultProps)var h=a.type.defaultProps;for(k in b)J.call(b,k)&&!L.hasOwnProperty(k)&&(f[k]=void 0===b[k]&&void 0!==h?h[k]:b[k])}var k=arguments.length-2;if(1===k)f.children=c;else if(1<k){h=Array(k);
+25 | for(var m=0;m<k;m++)h[m]=arguments[m+2];f.children=h}return{$$typeof:l,type:a.type,key:d,ref:e,props:f,_owner:g}};exports.createContext=function(a){a={$$typeof:u,_currentValue:a,_currentValue2:a,_threadCount:0,Provider:null,Consumer:null,_defaultValue:null,_globalName:null};a.Provider={$$typeof:t,_context:a};return a.Consumer=a};exports.createElement=M;exports.createFactory=function(a){var b=M.bind(null,a);b.type=a;return b};exports.createRef=function(){return{current:null}};
+26 | exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};expo | ... truncated 
+
+error: error inside long minified file!
+      at [dir]/inspect-error-fixture.min.js:26:2846
+      at [dir]/inspect-error-fixture.min.js:26:2890
+      at [dir]/inspect-error.test.js:130:5"
+`);
   }
+});
+
+test("Inserted originalLine and originalColumn do not appear in node:util.inspect", () => {
+  const err = new Error("my message");
+  expect(
+    require("util")
+      .inspect(err)
+      .replaceAll("\\", "/")
+      .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
+  ).toMatchInlineSnapshot(`
+"Error: my message
+    at <anonymous> ([file]:160:19)"
+`);
+});
+
+describe("observable properties", () => {
+  for (let property of ["sourceURL", "line", "column"]) {
+    test(`${property} is observable`, () => {
+      const mock = jest.fn();
+      const err = new Error("my message");
+      Object.defineProperty(err, property, {
+        get: mock,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(mock).not.toHaveBeenCalled();
+      Bun.inspect(err);
+      expect(mock).not.toHaveBeenCalled();
+    });
+  }
+});
+
+test("error.stack throwing an error doesn't lead to a crash", () => {
+  const err = new Error("my message");
+  Object.defineProperty(err, "stack", {
+    get: () => {
+      throw new Error("my message");
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  expect(() => {
+    throw err;
+  }).toThrow();
 });

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -656,14 +656,9 @@ test("no assertion failures 2", () => {
 
   // Prevent non-enumerable error properties from being printed.
   {
-    // TODO(bun): Make originalLine and originalColumn non-enumerable
     let err = new Error();
     err.message = "foobar";
-    let out = util
-      .inspect(err)
-      .replace(/\{\s*originalLine: .+\s*originalColumn: .+\s*\}/, "")
-      .trim()
-      .split("\n");
+    let out = util.inspect(err).trim().split("\n");
     assert.strictEqual(out[0], "Error: foobar");
     assert(out.at(-1).startsWith("    at "), 'Expected "' + out.at(-1) + '" to start with "    at "');
     // Reset the error, the stack is otherwise not recreated.
@@ -671,21 +666,13 @@ test("no assertion failures 2", () => {
     err.message = "foobar";
     err.name = "Unique";
     Object.defineProperty(err, "stack", { value: err.stack, enumerable: true });
-    out = util
-      .inspect(err)
-      .replace(/\{\s*originalLine: .+\s*originalColumn: .+\s*\}/, "")
-      .trim()
-      .split("\n");
+    out = util.inspect(err).trim().split("\n");
     assert.strictEqual(out[0], "Unique: foobar");
     assert(out.at(-1).startsWith("    at "), 'Expected "' + out.at(-1) + '" to start with "    at "');
     err.name = "Baz";
-    out = util
-      .inspect(err)
-      .replace(/\n\s*originalLine: .+\s*originalColumn: .+/, "")
-      .trim()
-      .split("\n");
+    out = util.inspect(err).trim().split("\n");
     assert.strictEqual(out[0], "Unique: foobar");
-    assert.strictEqual(out.at(-2), "  name: 'Baz',");
+    assert.strictEqual(out.at(-2), "  name: 'Baz'");
     assert.strictEqual(out.at(-1), "}");
   }
 


### PR DESCRIPTION
### What does this PR do?

- We should do our best to avoid calling into JS inside error handlers when possible
- node:util.inspect is displaying originalLine and originalColumn which messes with some node tests

### How did you verify your code works?

Updated tests