### PR TITLE
experiment: don't do aligned allocation when unnecessary

### DIFF
--- a/src/allocators/mimalloc.zig
+++ b/src/allocators/mimalloc.zig
@@ -216,7 +216,7 @@ pub fn canUseAlignedAlloc(_: usize, alignment: usize) bool {
         return false; // no need for aligned allocation
     }
 
-    return false;
+    return true;
 }
 const MI_MAX_ALIGN_SIZE = 16;
 inline fn mi_malloc_satisfies_alignment(alignment: usize, size: usize) bool {


### PR DESCRIPTION
### What does this PR do?

experiment: don't do aligned allocation when unnecessary

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
