### PR TITLE
Fix showing source code that looks like `export default "file-path"`

### DIFF
--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -3620,7 +3620,8 @@ pub const VirtualMachine = struct {
                 if (frame.source_url.hasPrefixComptime("bun:") or
                     frame.source_url.hasPrefixComptime("node:") or
                     frame.source_url.isEmpty() or
-                    frame.source_url.eqlComptime("native"))
+                    frame.source_url.eqlComptime("native") or
+                    frame.source_url.eqlComptime("unknown"))
                 {
                     top_frame_is_builtin = true;
                     continue;

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1505,6 +1505,19 @@ pub const ModuleLoader = struct {
     ) !ResolvedSource {
         const disable_transpilying = comptime flags.disableTranspiling();
 
+        if (comptime disable_transpilying) {
+            if (!(loader.isJavaScriptLike() or loader == .toml or loader == .text or loader == .json)) {
+                // Don't print "export default <file path>"
+                return ResolvedSource{
+                    .allocator = null,
+                    .source_code = bun.String.empty,
+                    .specifier = input_specifier,
+                    .source_url = input_specifier.createIfDifferent(path.text),
+                    .hash = 0,
+                };
+            }
+        }
+
         switch (loader) {
             .js, .jsx, .ts, .tsx, .json, .toml, .text => {
                 jsc_vm.transpiled_count += 1;


### PR DESCRIPTION
### What does this PR do?

Fix showing source code that looks like `export default "file-path"`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
