### PR TITLE
Use JSObject instead of JSFunction in Bun.plugin

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -1,5 +1,6 @@
 #include "BunPlugin.h"
 
+#include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/JSCast.h"
 #include "headers-handwritten.h"
 #include "helpers.h"
@@ -57,9 +58,11 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
     RETURN_IF_EXCEPTION(scope, {});
     JSC::RegExpObject* filter = nullptr;
     if (JSValue filterValue = filterObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "filter"_s))) {
+        RETURN_IF_EXCEPTION(scope, {});
         if (filterValue.isCell() && filterValue.asCell()->inherits<JSC::RegExpObject>())
             filter = jsCast<JSC::RegExpObject*>(filterValue);
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (!filter) {
         throwException(globalObject, scope, createError(globalObject, "onLoad() expects first argument to be an object with a filter RegExp"_s));
@@ -76,8 +79,8 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
                 return {};
             }
         }
-        RETURN_IF_EXCEPTION(scope, {});
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     auto func = callframe->uncheckedArgument(1);
     RETURN_IF_EXCEPTION(scope, {});
@@ -87,7 +90,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
         return {};
     }
 
-    plugin.append(vm, filter->regExp(), jsCast<JSFunction*>(func), namespaceString);
+    plugin.append(vm, filter->regExp(), func.getObject(), namespaceString);
     callback(ctx, globalObject);
 
     return JSValue::encode(jsUndefined());
@@ -163,9 +166,11 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
     RETURN_IF_EXCEPTION(scope, {});
     JSC::RegExpObject* filter = nullptr;
     if (JSValue filterValue = filterObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "filter"_s))) {
+        RETURN_IF_EXCEPTION(scope, {});
         if (filterValue.isCell() && filterValue.asCell()->inherits<JSC::RegExpObject>())
             filter = jsCast<JSC::RegExpObject*>(filterValue);
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (!filter) {
         throwException(globalObject, scope, createError(globalObject, "onResolve() expects first argument to be an object with a filter RegExp"_s));
@@ -194,7 +199,8 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
         return {};
     }
 
-    plugin.append(vm, filter->regExp(), jsCast<JSFunction*>(func), namespaceString);
+    RETURN_IF_EXCEPTION(scope, {});
+    plugin.append(vm, filter->regExp(), jsCast<JSObject*>(func), namespaceString);
     callback(ctx, globalObject);
 
     return JSValue::encode(jsUndefined());
@@ -321,7 +327,7 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     JSC::MarkedArgumentBuffer args;
     args.append(builderObject);
 
-    JSFunction* function = jsCast<JSFunction*>(setupFunctionValue);
+    JSObject* function = jsCast<JSObject*>(setupFunctionValue);
     JSC::CallData callData = JSC::getCallData(function);
     JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), args);
 
@@ -334,13 +340,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsUndefined()));
 }
 
-void BunPlugin::Group::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSFunction* func)
+void BunPlugin::Group::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func)
 {
     filters.append(JSC::Strong<JSC::RegExp> { vm, filter });
-    callbacks.append(JSC::Strong<JSC::JSFunction> { vm, func });
+    callbacks.append(JSC::Strong<JSC::JSObject> { vm, func });
 }
 
-void BunPlugin::Base::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSFunction* func, String& namespaceString)
+void BunPlugin::Base::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func, String& namespaceString)
 {
     if (namespaceString.isEmpty() || namespaceString == "file"_s) {
         this->fileNamespace.append(vm, filter, func);
@@ -354,7 +360,7 @@ void BunPlugin::Base::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSFunction* 
     }
 }
 
-JSFunction* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String& path)
+JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String& path)
 {
     size_t count = filters.size();
     for (size_t i = 0; i < count; i++) {
@@ -691,7 +697,7 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
 
     auto pathString = path->toWTFString(BunString::ZeroCopy);
 
-    JSC::JSFunction* function = group.find(globalObject, pathString);
+    auto* function = group.find(globalObject, pathString);
     if (!function) {
         return JSValue::encode(JSC::jsUndefined());
     }
@@ -777,7 +783,7 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
         if (!filters[i].get()->match(globalObject, pathString, 0)) {
             continue;
         }
-        JSC::JSFunction* function = callbacks[i].get();
+        auto* function = callbacks[i].get();
         if (UNLIKELY(!function)) {
             continue;
         }

--- a/src/bun.js/bindings/BunPlugin.h
+++ b/src/bun.js/bindings/BunPlugin.h
@@ -25,11 +25,11 @@ public:
         // We want JIT!
         // TODO: evaluate if using JSInternalFieldImpl(2) is faster
         Vector<JSC::Strong<JSC::RegExp>> filters = {};
-        Vector<JSC::Strong<JSC::JSFunction>> callbacks = {};
+        Vector<JSC::Strong<JSC::JSObject>> callbacks = {};
         BunPluginTarget target { BunPluginTargetBun };
 
-        void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSFunction* func);
-        JSFunction* find(JSC::JSGlobalObject* globalObj, String& path);
+        void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func);
+        JSObject* find(JSC::JSGlobalObject* globalObj, String& path);
         void clear()
         {
             filters.clear();
@@ -58,7 +58,7 @@ public:
             return nullptr;
         }
 
-        void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSFunction* func, String& namespaceString);
+        void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func, String& namespaceString);
     };
 
     class OnLoad final : public Base {


### PR DESCRIPTION
### What does this PR do?

Use JSObject instead of JSFunction in Bun.plugin

Hopefully will fix this:

```
Bun v1.1.42 ([50eec00](https://github.com/oven-sh/bun/tree/50eec0025b482ad7b340c82f64749903b2fad4b8)) on macos aarch64 [AutoCommand]

Segmentation fault at address 0x00000000

1 unknown/js code
Bun::getIfPropertyExistsPrototypePollutionMitigationUnsafe
Bun::getIfPropertyExistsPrototypePollutionMitigationUnsafe
JSC__JSValue__fastGet
src.bundler.PluginRunner.onResolveJSC
src.bun.js.javascript.VirtualMachine.resolveMaybeNeedsTrailingSlash__anon_124181
Zig__GlobalObject__resolve
Zig::GlobalObject::moduleLoaderResolve
JSC::JSModuleLoader::resolve
JSC::moduleLoaderResolve

Features: Bun.stdin, jsc, spawn, transpiler_cache
```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
