### PR TITLE
Fix macros which call Bun.file operations causing build commands to hang

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1758,7 +1758,7 @@ pub fn NewPackageInstall(comptime kind: PkgInstallKind) type {
             var queue: Queue = undefined;
             pub fn getQueue() *Queue {
                 queue = Queue{
-                    .thread_pool = &PackageManager.get().thread_pool,
+                    .thread_pool = PackageManager.get().thread_pool,
                 };
                 return &queue;
             }
@@ -2687,7 +2687,7 @@ pub const PackageManager = struct {
         }
     } = .{},
 
-    thread_pool: ThreadPool,
+    thread_pool: *ThreadPool,
     task_batch: ThreadPool.Batch = .{},
     task_queue: TaskDependencyQueue = .{},
 
@@ -8982,9 +8982,7 @@ pub const PackageManager = struct {
             .root_dir = entries_option.entries,
             .env = env,
             .cpu_count = cpu_count,
-            .thread_pool = ThreadPool.init(.{
-                .max_threads = cpu_count,
-            }),
+            .thread_pool = JSC.WorkPool.get(),
             .resolve_tasks = .{},
             .lockfile = undefined,
             .root_package_json_file = root_package_json_file,
@@ -9152,9 +9150,7 @@ pub const PackageManager = struct {
             .root_dir = root_dir.entries,
             .env = env,
             .cpu_count = cpu_count,
-            .thread_pool = ThreadPool.init(.{
-                .max_threads = cpu_count,
-            }),
+            .thread_pool = JSC.WorkPool.get(),
             .lockfile = undefined,
             .root_package_json_file = undefined,
             .event_loop = .{

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -490,7 +490,7 @@ noinline fn notifySlow(self: *ThreadPool, is_waking: bool) void {
 
             // We signaled to spawn a new thread
             if (can_wake and sync.spawned < self.max_threads) {
-                const spawn_config = std.Thread.SpawnConfig{ .stack_size = default_thread_stack_size };
+                const spawn_config = std.Thread.SpawnConfig{ .stack_size = self.stack_size };
                 const thread = std.Thread.spawn(spawn_config, Thread.run, .{self}) catch return self.unregister(null);
                 // if (self.name.len > 0) thread.setName(self.name) catch {};
                 return thread.detach();

--- a/test/bundler/bundler_macro.test.ts
+++ b/test/bundler/bundler_macro.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect } from "bun:test";
+import { join } from "node:path";
+import { itBundled } from "./expectBundled";
+const fixturePath = join(import.meta.dir, "fixtures/hello.txt");
+const macros = /* js */ String.raw`
+  export function identity(arg: any) {
+    return arg;
+  }
+
+  export function file(): Promise<string> {
+    return Bun.file(${JSON.stringify(fixturePath)}).text();
+  }
+`;
+
+describe("bundler", () => {
+  itBundled("identity macro", {
+    files: {
+      "/entry.ts": /* js */ `
+        import {identity} from "./macros.ts" with {type: "macro"};
+        console.log(identity(100));
+      `,
+      "/macros.ts": macros,
+    },
+    run: {
+      stdout: "100",
+    },
+  });
+
+  itBundled("file macro", {
+    files: {
+      "/entry.ts": /* js */ `
+        import {file} from "./macros.ts" with {type: "macro"};
+        console.log(file());
+      `,
+      "/macros.ts": macros,
+    },
+    run: {
+      stdout: "hello world\n123456\n",
+    },
+  });
+});

--- a/test/bundler/fixtures/hello.txt
+++ b/test/bundler/fixtures/hello.txt
@@ -1,0 +1,2 @@
+hello world
+123456


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

Users reported in https://github.com/oven-sh/bun/issues/7611 and https://github.com/oven-sh/bun/issues/14104 that calling `Bun.file().text()` in a macro would cause builds to hang. This bug was introduced in v1.0.16, likely when some changes related to how Bun handles multithreading occurred.

I went through a minimal reproduction with a debugger and determined that work would get stuck in ThreadPool threads because the ThreadPool was initialized twice. The double instantiation of ThreadPool, which is assumed to be a global singleton, caused issues in macros because file I/O would get scheduled on a thread, the work would be pushed to the thread local queue/buffer, and then the thread would wait for the promise to resolve, causing a dead lock. There is code which allows for “work stealing” but threads initialized from different thread pools do not steal work each other.

The least invasive fix I found was to consistently call `WorkPool.get()` in the bundle_v2’s initialization code.

Fixes #7611 and fixes #14104.
Happy holidays!

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
