### PR TITLE
fix: avoid world-writable permissions for lockfiles

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -2423,8 +2423,12 @@ pub fn saveToDisk(this: *Lockfile, save_format: LoadResult.LockfileFormat, verbo
     }
 
     if (comptime Environment.isPosix) {
-        // chmod 777 on posix
-        switch (bun.sys.fchmod(file.handle, 0o777)) {
+        // chmod 755 for binary, 644 for plaintext
+        var filemode: bun.Mode = 0o755;
+        if (save_format == .text) {
+            filemode = 0o644;
+        }
+        switch (bun.sys.fchmod(file.handle, filemode)) {
             .err => |err| {
                 file.close();
                 _ = bun.sys.unlink(tmpname);

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1,0 +1,45 @@
+import { spawn } from "bun";
+import { expect, it } from "bun:test";
+import { access, copyFile, open, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { join } from "path";
+
+it("should write plaintext lockfiles", async () => {
+  const package_dir = tmpdirSync();
+
+  // copy bar-0.0.2.tgz to package_dir
+  await copyFile(join(__dirname, "bar-0.0.2.tgz"), join(package_dir, "bar-0.0.2.tgz"));
+
+  // Create a simple package.json
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-package",
+      version: "1.0.0",
+      dependencies: {
+        "dummy-package": "file:./bar-0.0.2.tgz",
+      },
+    }),
+  );
+
+  // Run 'bun install' to generate the lockfile
+  const installResult = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: package_dir,
+    env,
+  });
+  await installResult.exited;
+
+  // Ensure the lockfile was created
+  await access(join(package_dir, "bun.lock"));
+
+  // Assert that the lockfile has the correct permissions
+  const file = await open(join(package_dir, "bun.lock"), "r");
+  const stat = await file.stat();
+  // 0o644 == 33188
+  expect(stat.mode).toBe(33188);
+
+  expect(await file.readFile({ encoding: "utf8" })).toEqual(
+    `{\n  \"lockfileVersion\": 0,\n  \"workspaces\": {\n    \"\": {\n      \"dependencies\": {\n        \"dummy-package\": \"file:./bar-0.0.2.tgz\",\n      },\n    },\n  },\n  \"packages\": {\n    \"dummy-package\": [\"bar@./bar-0.0.2.tgz\", {}],\n  }\n}\n`,
+  );
+});

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { expect, it } from "bun:test";
 import { access, copyFile, open, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isWindows, tmpdirSync } from "harness";
 import { join } from "path";
 
 it("should not print anything to stderr when running bun.lockb", async () => {
@@ -36,8 +36,14 @@ it("should not print anything to stderr when running bun.lockb", async () => {
   // Assert that the lockfile has the correct permissions
   const file = await open(join(package_dir, "bun.lockb"), "r");
   const stat = await file.stat();
-  // 0o755 == 33261
-  expect(stat.mode).toBe(33261);
+
+  // in unix, 0o755 == 33261
+  let mode = 33261;
+  // ..but windows is different
+  if(isWindows) {
+    mode = 33206;
+  }
+  expect(stat.mode).toBe(mode);
 
   // create a .env
   await writeFile(join(package_dir, ".env"), "FOO=bar");

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { expect, it } from "bun:test";
-import { access, constants, copyFile, open, writeFile } from "fs/promises";
+import { access, copyFile, open, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { join } from "path";
 
@@ -31,7 +31,7 @@ it("should not print anything to stderr when running bun.lockb", async () => {
   await installResult.exited;
 
   // Ensure the lockfile was created
-  await access(join(package_dir, "bun.lockb"), constants.F_OK);
+  await access(join(package_dir, "bun.lockb"));
 
   // Assert that the lockfile has the correct permissions
   const file = await open(join(package_dir, "bun.lockb"), "r");

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { expect, it } from "bun:test";
-import { access, copyFile, writeFile } from "fs/promises";
+import { access, constants, copyFile, open, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { join } from "path";
 
@@ -31,7 +31,13 @@ it("should not print anything to stderr when running bun.lockb", async () => {
   await installResult.exited;
 
   // Ensure the lockfile was created
-  await access(join(package_dir, "bun.lockb"));
+  await access(join(package_dir, "bun.lockb"), constants.F_OK);
+
+  // Assert that the lockfile has the correct permissions
+  const file = await open(join(package_dir, "bun.lockb"), "r");
+  const stat = await file.stat();
+  // 0o755 == 33261
+  expect(stat.mode).toBe(33261);
 
   // create a .env
   await writeFile(join(package_dir, ".env"), "FOO=bar");


### PR DESCRIPTION
### What does this PR do?

Use the file mode `0x644` for the plaintext lockfile. Also, switch the permission for the binary lockfile to not default to group/world writable (`0x777` -> `0x755`). Windows has a different behavior, so we test for that.

Finally, add tests for writing plaintext lockfiles and ensure its file stat properties.

### How did you verify your code works?

Built and tested locally.

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

Closes: https://github.com/oven-sh/bun/issues/15953
