### PR TITLE
fix(node/path): crash when joining long paths

### DIFF
--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -1237,7 +1237,7 @@ pub inline fn joinWindowsJS_T(comptime T: type, globalObject: *JSC.JSGlobalObjec
 pub fn joinJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, allocator: std.mem.Allocator, isWindows: bool, paths: []const []const T) JSC.JSValue {
     // Adding 8 bytes when Windows for the possible UNC root.
     var bufLen: usize = if (isWindows) 8 else 0;
-    for (paths) |path| bufLen += if (bufLen > 0 and path.len > 0) path.len + 1 else path.len;
+    for (paths) |path| bufLen += if (path.len > 0) path.len + 1 else path.len;
     bufLen = @max(bufLen, PATH_SIZE(T));
     const buf = allocator.alloc(T, bufLen) catch bun.outOfMemory();
     defer allocator.free(buf);

--- a/test/js/node/path/15704.test.js
+++ b/test/js/node/path/15704.test.js
@@ -1,0 +1,10 @@
+import path from "path";
+import assert from "assert";
+
+test("too-long path names do not crash when joined", () => {
+  const length = 4096;
+  const tooLengthyFolderName = Array.from({ length }).fill("b").join("");
+  assert.equal(path.join(tooLengthyFolderName), "b".repeat(length));
+  assert.equal(path.win32.join(tooLengthyFolderName), "b".repeat(length));
+  assert.equal(path.posix.join(tooLengthyFolderName), "b".repeat(length));
+});


### PR DESCRIPTION
### What does this PR do?
Fixes #15704.

Fixes a crash in `path.join` where not enough buffer space was being allocated for sentinel `0`s, causing an array out-of-bounds error.

### How did you verify your code works?

I wrote automated tests.
