### PR TITLE
refactor: remove unused script execution context file

### DIFF
--- a/src/bun.js/script_execution_context.zig
+++ b/src/bun.js/script_execution_context.zig
@@ -1,7 +1,0 @@
-const JSC = bun.JSC;
-
-pub const ScriptExecutionContext = extern struct {
-    main_file_path: JSC.ZigString,
-    is_macro: bool = false,
-    js_global_object: bool = false,
-};


### PR DESCRIPTION
### What does this PR do?
Deletes `script_execution_context.zig` which is unused and has compile errors (that are not emitted b/c it's not used)