### PR TITLE
Update nextjs.md docs with starter example

### DIFF
--- a/docs/guides/ecosystem/nextjs.md
+++ b/docs/guides/ecosystem/nextjs.md
@@ -15,6 +15,14 @@ $ bun create next-app
 Creating a new Next.js app in /path/to/my-app.
 ```
 
+You can specify a starter template using the `--example` flag.
+
+```sh
+$ bun create next-app --example with-supabase
+✔ What is your project named? … my-app
+...
+```
+
 ---
 
 To start the dev server with Bun, run `bun --bun run dev` from the project root.


### PR DESCRIPTION
Adds an explicit mention of how to create a new nextjs project with a starter template.

I've been asked multiple times in my team on how to do this and figured it warranted a mention in the official docs, in case it wasn't obvious to newcomers.

- [x] Documentation 

