### PR TITLE
fix(us): memory leak when getting root certificate

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -35,6 +35,9 @@ us_ssl_ctx_get_X509_without_callback_from(struct us_cert_string_t content) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_PEM_LIB);
     goto end;
   }
+
+  // NOTE: PEM_read_bio_X509 allocates, so input BIO must be freed.
+  BIO_free(in);
   return x;
 end:
   X509_free(x);


### PR DESCRIPTION
### What does this PR do?
Fixes a memory leak when an x509 root certificate is successfully read for an https server.


### How did you verify your code works?

There are already tests for this. I just ran this command to find+fix it:
```sh
leaks -atExit -- ./build/debug/bun-debug test ./test/js/bun/http/serve-body-leak.test.ts | tee leaks.log
```

There's a bunch of other reported leaks that I'll address in other PRs.