### PR TITLE
transpiler: fix crash with malformed enums

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -11917,6 +11917,8 @@ fn NewParser_(
                     needs_symbol = true;
                 } else {
                     try p.lexer.expect(.t_identifier);
+                    // error early, name is still `undefined`
+                    return error.SyntaxError;
                 }
                 try p.lexer.next();
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -315,6 +315,13 @@ describe("Bun.Transpiler", () => {
       exp("f<{}>()\nfunction f<T>() {}", "let f = function() {\n};\nf()");
     });
 
+    it("malformed enums", () => {
+      const err = ts.expectParseError;
+
+      err("enum Foo { [2]: 'hi' }", 'Expected identifier but found "["');
+      err("enum [] { a }", 'Expected identifier but found "["');
+    });
+
     // TODO: fix all the cases that report generic "Parse error"
     it("types", () => {
       const exp = ts.expectPrinted_;


### PR DESCRIPTION
### What does this PR do?
fixes #16083
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
