### PR TITLE
Revert "Deflake fetch tests"

### DIFF
--- a/test/js/bun/http/async-iterator-throws.fixture.js
+++ b/test/js/bun/http/async-iterator-throws.fixture.js
@@ -1,6 +1,5 @@
 const server = Bun.serve({
   port: 0,
-  idleTimeout: 0,
 
   async fetch(req) {
     return new Response(

--- a/test/js/bun/http/big-form-data.fixture.js
+++ b/test/js/bun/http/big-form-data.fixture.js
@@ -3,7 +3,6 @@ const content = Buffer.alloc(3 * 15360000, "Bun").toString();
 
 const server = Bun.serve({
   port: 0,
-  idleTimeout: 0,
   fetch: async req => {
     const data = await req.formData();
     return new Response(data.get("name") === content ? "OK" : "NO");

--- a/test/js/bun/http/body-leak-test-fixture.ts
+++ b/test/js/bun/http/body-leak-test-fixture.ts
@@ -1,6 +1,5 @@
 const server = Bun.serve({
   port: 0,
-  idleTimeout: 0,
   async fetch(req: Request) {
     const url = req.url;
     if (url.endsWith("/report")) {

--- a/test/js/bun/http/readable-stream-throws.fixture.js
+++ b/test/js/bun/http/readable-stream-throws.fixture.js
@@ -1,6 +1,6 @@
 const server = Bun.serve({
   port: 0,
-  idleTimeout: 0,
+
   error(err) {
     return new Response("Failed", { status: 555 });
   },

--- a/test/js/bun/http/rejected-promise-fixture.js
+++ b/test/js/bun/http/rejected-promise-fixture.js
@@ -1,6 +1,5 @@
 const server = Bun.serve({
   hostname: "localhost",
-  idleTimeout: 0,
   async fetch() {
     throw new Error("Error");
   },

--- a/test/js/bun/websocket/websocket-server-fixture.js
+++ b/test/js/bun/websocket/websocket-server-fixture.js
@@ -9,7 +9,6 @@
 let pending = [];
 using server = Bun.serve({
   port: 0,
-  idleTimeout: 0,
   websocket: {
     open(ws) {
       globalThis.sockets ??= [];

--- a/test/js/web/fetch/fetch-leak-test-fixture-3.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-3.js
@@ -1,15 +1,8 @@
-// Reduce memory pressure by not cloning the buffer each Response.
-const payload = new Blob([Buffer.alloc(64 * 64 * 1024, "X")]);
-
+const payload = Buffer.alloc(64 * 64 * 1024, "X");
 const server = Bun.serve({
   port: 0,
-  idleTimeout: 0,
   async fetch(req) {
     return new Response(payload);
   },
 });
-if (process.send) {
-  process.send(server.url.href);
-} else {
-  console.log(server.url.href);
-}
+console.log(server.url.href);

--- a/test/js/web/fetch/fetch-leak-test-fixture-4.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-4.js
@@ -23,16 +23,8 @@ try {
       Bun.gc(true);
       await Bun.sleep(10);
       const stats = getHeapStats();
-      let { Response, Promise } = stats;
-      Response ||= 0;
-      Promise ||= 0;
-      console.log({
-        rss: ((process.memoryUsage.rss() / 1024 / 1024) | 0) + " MB",
-        Response,
-        Promise,
-      });
-      expect(Response).toBeLessThanOrEqual(threshold);
-      expect(Promise).toBeLessThanOrEqual(threshold);
+      expect(stats.Response || 0).toBeLessThanOrEqual(threshold);
+      expect(stats.Promise || 0).toBeLessThanOrEqual(threshold);
     }
   }
   process.exit(0);


### PR DESCRIPTION
This change makes the flaky tests actually fail. Also it only changes the test files and not source code. Can be un-reverted once the issue is found and resolved.

Reverts oven-sh/bun#16000