### PR TITLE
Report memory cost of sourcemaps to GC

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 30046aef5ec6590c74c6a696e4f01683f962a6a2)
+  set(WEBKIT_VERSION b3d72e752901e40629990469fe5035787230fbc5)
 endif()
 
 if(WEBKIT_LOCAL)

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -56,6 +56,15 @@ extern "C" void Bun__WTFStringImpl__ref(WTF::StringImpl* impl)
     impl->ref();
 }
 
+size_t BunString::memoryCost() const
+{
+    if (tag == BunStringTag::WTFStringImpl) {
+        return impl.wtf->sizeInBytes();
+    }
+
+    return 0;
+}
+
 extern "C" bool BunString__fromJS(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, BunString* bunString)
 {
     JSC::JSValue value = JSC::JSValue::decode(encodedValue);

--- a/src/bun.js/bindings/CommonJSModuleRecord.h
+++ b/src/bun.js/bindings/CommonJSModuleRecord.h
@@ -56,6 +56,9 @@ public:
     bool ignoreESModuleAnnotation { false };
     JSC::SourceCode sourceCode = JSC::SourceCode();
 
+    // Stored separately from SourceCode since we try to free SourceCode sooner.
+    size_t source_map_memory_cost = 0;
+
     static size_t estimatedSize(JSC::JSCell* cell, JSC::VM& vm);
 
     void setSourceCode(JSC::SourceCode&& sourceCode);

--- a/src/bun.js/bindings/ZigSourceProvider.h
+++ b/src/bun.js/bindings/ZigSourceProvider.h
@@ -44,6 +44,7 @@ public:
     ~SourceProvider();
     unsigned hash() const override;
     StringView source() const override;
+    size_t memoryCost() const override { return m_resolvedSource.source_map_memory_cost + m_resolvedSource.source_code.memoryCost(); }
 
     RefPtr<JSC::CachedBytecode> cachedBytecode() const final
     {

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -222,6 +222,7 @@ pub const ResolvedSource = extern struct {
     already_bundled: bool = false,
     bytecode_cache: ?[*]u8 = null,
     bytecode_cache_size: usize = 0,
+    source_map_memory_cost: usize = 0,
 
     pub const Tag = @import("ResolvedSourceTag").ResolvedSourceTag;
 };

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -72,6 +72,8 @@ typedef struct BunString {
     // This one usually will clone the raw bytes.
     WTF::String toWTFString() const;
 
+    size_t memoryCost() const;
+
 } BunString;
 
 typedef struct ZigErrorType {
@@ -107,6 +109,7 @@ typedef struct ResolvedSource {
     bool already_bundled;
     uint8_t* bytecode_cache;
     size_t bytecode_cache_size;
+    size_t source_map_memory_cost;
 } ResolvedSource;
 static const uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
