### PR TITLE
Update `defines` to `define` in `cc` function documentation

### DIFF
--- a/docs/api/cc.md
+++ b/docs/api/cc.md
@@ -179,16 +179,16 @@ type Flags = string | string[];
 
 These are flags like `-I` for include directories and `-D` for preprocessor definitions.
 
-#### `defines: Record<string, string>`
+#### `define: Record<string, string>`
 
-The `defines` is an optional object that should be passed to the TinyCC compiler.
+The `define` is an optional object that should be passed to the TinyCC compiler.
 
 ```ts
 type Defines = Record<string, string>;
 
 cc({
   source: "hello.c",
-  defines: {
+  define: {
     "NDEBUG": "1",
   },
 });


### PR DESCRIPTION
### What does this PR do?

This option is named `defined` [in the code](https://github.com/oven-sh/bun/blob/be959e111ab6842026a54328e5c06747a8e47f6f/packages/bun-types/ffi.d.ts#L676-L698), but it is written as `defines` [in the documentation](https://bun.sh/docs/api/cc#defines-record-string-string).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

