### PR TITLE
fix(server) HEAD requests

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3272,7 +3272,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         }
 
         // Each HTTP request or TCP socket connection is effectively a "task".
-        // Each HTTP request or TCP socket connection is effectively a "task".
         //
         // However, unlike the regular task queue, we don't drain the microtask
         // queue at the end.

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -90,6 +90,7 @@ const linux = std.os.linux;
 const Async = bun.Async;
 const httplog = Output.scoped(.Server, false);
 const ctxLog = Output.scoped(.RequestContext, false);
+const AWS = @import("../../s3.zig").AWSCredentials;
 const BlobFileContentResult = struct {
     data: [:0]const u8,
 
@@ -2029,6 +2030,14 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             ctx.flags.response_protected = true;
             JSC.C.JSValueProtect(ctx.server.?.globalThis, value.asObjectRef());
 
+            if (ctx.method == .HEAD) {
+                if (ctx.resp) |resp| {
+                    var pair = HeaderResponsePair{ .this = ctx, .response = response };
+                    resp.runCorkedWithType(*HeaderResponsePair, doRenderHeadResponse, &pair);
+                }
+                return;
+            }
+
             ctx.render(response);
         }
 
@@ -2354,7 +2363,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
 
             if (this.method == .HEAD) {
-                this.end("", this.shouldCloseConnection());
+                this.endWithoutBody(this.shouldCloseConnection());
                 return false;
             }
 
@@ -3162,7 +3171,107 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             // resp == null or aborted or server.stop(true)
             return this.resp == null or this.flags.aborted or this.server == null or this.server.?.flags.terminated;
         }
+        const HeaderResponseSizePair = struct { this: *RequestContext, size: usize };
+        pub fn doRenderHeadResponseAfterS3SizeResolved(pair: *HeaderResponseSizePair) void {
+            var this = pair.this;
 
+            if (this.resp) |resp| {
+                resp.writeHeaderInt("content-length", pair.size);
+            }
+            this.renderMetadata();
+            this.endWithoutBody(this.shouldCloseConnection());
+            this.deref();
+        }
+        pub fn onS3SizeResolved(result: AWS.S3StatResult, this: *RequestContext) void {
+            defer {
+                this.deref();
+            }
+            if (this.resp) |resp| {
+                var pair = HeaderResponseSizePair{ .this = this, .size = switch (result) {
+                    .failure, .not_found => 0,
+                    .success => |stat| stat.size,
+                } };
+                resp.runCorkedWithType(*HeaderResponseSizePair, doRenderHeadResponseAfterS3SizeResolved, &pair);
+            }
+        }
+        const HeaderResponsePair = struct { this: *RequestContext, response: *JSC.WebCore.Response };
+
+        fn doRenderHeadResponse(pair: *HeaderResponsePair) void {
+            var this = pair.this;
+            var response = pair.response;
+            this.flags.needs_content_length = false;
+            if (this.resp == null) {
+                return;
+            }
+            const resp = this.resp.?;
+            this.response_ptr = response;
+            const server = this.server orelse {
+                // server detached?
+                resp.writeHeaderInt("content-length", 0);
+                this.renderMetadata();
+                this.endWithoutBody(this.shouldCloseConnection());
+                return;
+            };
+            const globalThis = server.globalThis;
+            if (response.getFetchHeaders()) |headers| {
+                // first respect the headers
+                if (headers.get("transfer-encoding", globalThis)) |transfer_encoding| {
+                    resp.writeHeader("transfer-encoding", transfer_encoding);
+                } else if (headers.get("content-length", globalThis)) |content_length| {
+                    const len = std.fmt.parseInt(usize, content_length, 10) catch 0;
+                    resp.writeHeaderInt("content-length", len);
+                } else {
+                    resp.writeHeaderInt("content-length", 0);
+                }
+            } else {
+                // then respect the body
+                response.body.value.toBlobIfPossible();
+                switch (response.body.value) {
+                    .InternalBlob, .WTFStringImpl => {
+                        var blob = response.body.value.useAsAnyBlobAllowNonUTF8String();
+                        defer blob.detach();
+                        const size = blob.size();
+                        if (size == Blob.max_size) {
+                            resp.writeHeaderInt("content-length", 0);
+                        } else {
+                            resp.writeHeaderInt("content-length", size);
+                        }
+                    },
+
+                    .Blob => |*blob| {
+                        if (blob.isS3()) {
+                            // we need to read the size asynchronously
+                            // in this case should always be a redirect so should not hit this path, but in case we change it in the future lets handle it
+                            this.ref();
+
+                            const credentials = blob.store.?.data.s3.getCredentials();
+                            const path = blob.store.?.data.s3.path();
+                            const env = globalThis.bunVM().transpiler.env;
+
+                            credentials.s3Stat(path, @ptrCast(&onS3SizeResolved), this, if (env.getHttpProxy(true, null)) |proxy| proxy.href else null);
+
+                            return;
+                        }
+                        blob.resolveSize();
+                        if (blob.size == Blob.max_size) {
+                            resp.writeHeaderInt("content-length", 0);
+                        } else {
+                            resp.writeHeaderInt("content-length", blob.size);
+                        }
+                    },
+                    .Locked => {
+                        resp.writeHeader("transfer-encoding", "chunked");
+                    },
+                    .Used, .Null, .Empty, .Error => {
+                        resp.writeHeaderInt("content-length", 0);
+                    },
+                }
+            }
+            this.renderMetadata();
+            this.endWithoutBody(this.shouldCloseConnection());
+        }
+
+        // Each HTTP request or TCP socket connection is effectively a "task".
         // Each HTTP request or TCP socket connection is effectively a "task".
         //
         // However, unlike the regular task queue, we don't drain the microtask
@@ -3208,23 +3317,30 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 ctx.response_jsvalue = response_value;
                 ctx.response_jsvalue.ensureStillAlive();
                 ctx.flags.response_protected = false;
+                if (ctx.method == .HEAD) {
+                    if (ctx.resp) |resp| {
+                        var pair = HeaderResponsePair{ .this = ctx, .response = response };
+                        resp.runCorkedWithType(*HeaderResponsePair, doRenderHeadResponse, &pair);
+                    }
+                    return;
+                } else {
+                    response.body.value.toBlobIfPossible();
 
-                response.body.value.toBlobIfPossible();
-
-                switch (response.body.value) {
-                    .Blob => |*blob| {
-                        if (blob.needsToReadFile()) {
+                    switch (response.body.value) {
+                        .Blob => |*blob| {
+                            if (blob.needsToReadFile()) {
+                                response_value.protect();
+                                ctx.flags.response_protected = true;
+                            }
+                        },
+                        .Locked => {
                             response_value.protect();
                             ctx.flags.response_protected = true;
-                        }
-                    },
-                    .Locked => {
-                        response_value.protect();
-                        ctx.flags.response_protected = true;
-                    },
-                    else => {},
+                        },
+                        else => {},
+                    }
+                    ctx.render(response);
                 }
-                ctx.render(response);
                 return;
             }
 
@@ -3260,7 +3376,13 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                         ctx.response_jsvalue.ensureStillAlive();
                         ctx.flags.response_protected = false;
                         ctx.response_ptr = response;
-
+                        if (ctx.method == .HEAD) {
+                            if (ctx.resp) |resp| {
+                                var pair = HeaderResponsePair{ .this = ctx, .response = response };
+                                resp.runCorkedWithType(*HeaderResponsePair, doRenderHeadResponse, &pair);
+                            }
+                            return;
+                        }
                         response.body.value.toBlobIfPossible();
                         switch (response.body.value) {
                             .Blob => |*blob| {
@@ -3467,17 +3589,17 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                                 // If we've received the complete body by the time this function is called
                                 // we can avoid streaming it and just send it all at once.
                                 if (byte_stream.has_received_last_chunk) {
-                                    this.blob.from(byte_stream.buffer);
+                                    this.blob.from(byte_stream.drain().listManaged(bun.default_allocator));
                                     this.readable_stream_ref.deinit();
                                     this.doRenderBlob();
                                     return;
                                 }
-
+                                this.ref();
                                 byte_stream.pipe = JSC.WebCore.Pipe.New(@This(), onPipe).init(this);
                                 this.readable_stream_ref = JSC.WebCore.ReadableStream.Strong.init(stream, globalThis);
 
                                 this.byte_stream = byte_stream;
-                                this.response_buf_owned = byte_stream.buffer.moveToUnmanaged();
+                                this.response_buf_owned = byte_stream.drain().list();
 
                                 // we don't set size here because even if we have a hint
                                 // uWebSockets won't let us partially write streaming content
@@ -3517,10 +3639,11 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
         pub fn onPipe(this: *RequestContext, stream: JSC.WebCore.StreamResult, allocator: std.mem.Allocator) void {
             const stream_needs_deinit = stream == .owned or stream == .owned_and_done;
-
+            const is_done = stream.isDone();
             defer {
+                if (is_done) this.deref();
                 if (stream_needs_deinit) {
-                    if (stream.isDone()) {
+                    if (is_done) {
                         stream.owned_and_done.listManaged(allocator).deinit();
                     } else {
                         stream.owned.listManaged(allocator).deinit();
@@ -3539,12 +3662,12 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             // uSockets will append and manage the buffer
             // so any write will buffer if the write fails
             if (resp.write(chunk)) {
-                if (stream.isDone()) {
+                if (is_done) {
                     this.endStream(this.shouldCloseConnection());
                 }
             } else {
                 // when it's the last one, we just want to know if it's done
-                if (stream.isDone()) {
+                if (is_done) {
                     this.flags.has_marked_pending = true;
                     resp.onWritable(*RequestContext, onWritableResponseBuffer, this);
                 }
@@ -4877,10 +5000,17 @@ pub const ServerWebSocket = struct {
         }
 
         {
-            var string_slice = message_value.toSlice(globalThis, bun.default_allocator);
-            defer string_slice.deinit();
+            var js_string = message_value.toString(globalThis);
+            if (globalThis.hasException()) {
+                return .zero;
+            }
+            const view = js_string.view(globalThis);
+            const slice = view.toSlice(bun.default_allocator);
+            defer slice.deinit();
 
-            const buffer = string_slice.slice();
+            defer js_string.ensureStillAlive();
+
+            const buffer = slice.slice();
 
             const result = if (!publish_to_self and !this.isClosed())
                 this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
@@ -5239,17 +5369,10 @@ pub const ServerWebSocket = struct {
             return globalThis.throw("sendText expects a string", .{});
         }
 
-        var js_string = message_value.toString(globalThis);
-        if (globalThis.hasException()) {
-            return .zero;
-        }
-        const view = js_string.view(globalThis);
-        const slice = view.toSlice(bun.default_allocator);
-        defer slice.deinit();
+        var string_slice = message_value.toSlice(globalThis, bun.default_allocator);
+        defer string_slice.deinit();
 
-        defer js_string.ensureStillAlive();
-
-        const buffer = slice.slice();
+        const buffer = string_slice.slice();
         switch (this.websocket().send(buffer, .text, compress, true)) {
             .backpressure => {
                 log("sendText() backpressure ({d} bytes string)", .{buffer.len});


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/15355

This PR fixed HEAD requests respecting the headers provided or the body informed to get the `Content-Length`, and also don't send the body even if is provided because this would be a malformed http request, now we will never send the body respecting the spec https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.2

```js
 // now if is a HEAD request this will never send the content only the content-length
 // if the body is a readable stream will send transfer-encoding: chunked
 const server = Bun.serve({
      port: 0,
      fetch(req) {
        // or new Response(file(filename))) or any variation
        return new Response("Hello World");
      },
 });
 ```

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
