### PR TITLE
feat: run_command start "pnpx " & "pnpm dlx " -> "bun x "

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -220,6 +220,13 @@ pub const RunCommand = struct {
                             continue;
                         }
 
+                        if (strings.hasPrefixComptime(script[start..], "pnpm dlx ")) {
+                             try copy_script.appendSlice(BUN_BIN_NAME ++ " x ");
+                             entry_i += "pnpm dlx ".len;
+                             delimiter = 0;
+                             continue;
+                         }
+
                         if (strings.hasPrefixComptime(script[start..], "pnpx ")) {
                             try copy_script.appendSlice(BUN_BIN_NAME ++ " x ");
                             entry_i += "pnpx ".len;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -219,6 +219,13 @@ pub const RunCommand = struct {
                             delimiter = 0;
                             continue;
                         }
+
+                        if (strings.hasPrefixComptime(script[start..], "pnpx ")) {
+                            try copy_script.appendSlice(BUN_BIN_NAME ++ " x ");
+                            entry_i += "pnpx ".len;
+                            delimiter = 0;
+                            continue;
+                        }
                     }
 
                     delimiter = 0;


### PR DESCRIPTION
### What does this PR do?

For run commands of `package.json` `"scripts"` bun replaces starting "npx " to "bun x "

I made it replace also the "pnpx" (5 lines of code)

![image](https://github.com/user-attachments/assets/291fa196-7c91-418d-b2f6-8aff4b9c43fb)

### How did you verify your code works?

I haven't tested this small change, hope you can make it yourself

However I haven't tested it not because It's just 5 lines, but because it gives me Zig errors at the middle of compiling. I think your contributing guide has issues, did exact what it said. (Tried on Mac M1)