### PR TITLE
fix(server) HEAD Requests followup

### DIFF
--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -895,6 +895,28 @@ describe("HEAD requests #15355", () => {
     }
   });
 
+  test("should fallback to the body if content-length is missing in the headers", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("Hello World", {
+          headers: {
+            "Content-Type": "text/plain",
+            "X-Bun-Test": "1",
+          },
+        });
+      },
+    });
+
+    const response = await fetch(server.url, {
+      method: "HEAD",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe("11");
+    expect(response.headers.get("x-bun-test")).toBe("1");
+    expect(await response.text()).toBe("");
+  });
+
   test("HEAD requests should not have body", async () => {
     const dir = tempDirWithFiles("fsr", {
       "hello": "Hello World",


### PR DESCRIPTION
### What does this PR do?
followup on https://github.com/oven-sh/bun/pull/16099

Use fastGet + fix fallback in size when header object is provided but Content-Length or Transfer-Encoding is missing.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
