### PR TITLE
lockfile: escape names in `bun.lock`

### DIFF
--- a/src/install/bun.lock.zig
+++ b/src/install/bun.lock.zig
@@ -556,7 +556,9 @@ pub const Stringifier = struct {
 
                     try writer.writeByte('"');
                     // relative_path is empty string for root resolutions
-                    try writer.writeAll(relative_path);
+                    try writer.print("{}", .{
+                        bun.fmt.formatJSONStringUTF8(relative_path, .{ .quote = false }),
+                    });
 
                     if (depth != 0) {
                         try writer.writeByte('/');
@@ -565,8 +567,8 @@ pub const Stringifier = struct {
                     const dep = deps_buf[dep_id];
                     const dep_name = dep.name.slice(buf);
 
-                    try writer.print("{s}\": ", .{
-                        dep_name,
+                    try writer.print("{}\": ", .{
+                        bun.fmt.formatJSONStringUTF8(dep_name, .{ .quote = false }),
                     });
 
                     const pkg_name = pkg_names[pkg_id];
@@ -760,9 +762,9 @@ pub const Stringifier = struct {
                     try writer.writeAll(", ");
                 }
 
-                try writer.print("\"{s}\": \"{s}\"", .{
-                    dep.name.slice(buf),
-                    dep.version.literal.slice(buf),
+                try writer.print("{}: {}", .{
+                    bun.fmt.formatJSONStringUTF8(dep.name.slice(buf), .{}),
+                    bun.fmt.formatJSONStringUTF8(dep.version.literal.slice(buf), .{}),
                 });
             }
 
@@ -779,10 +781,10 @@ pub const Stringifier = struct {
 
             for (optional_peers_buf.items, 0..) |optional_peer, i| {
                 try writer.print(
-                    \\{s}"{s}"{s}
+                    \\{s}{}{s}
                 , .{
                     if (i != 0) " " else "",
-                    optional_peer.slice(buf),
+                    bun.fmt.formatJSONStringUTF8(optional_peer.slice(buf), .{}),
                     if (i != optional_peers_buf.items.len - 1) "," else "",
                 });
             }
@@ -879,8 +881,8 @@ pub const Stringifier = struct {
             });
             try writer.writeByte('\n');
             try incIndent(writer, indent);
-            try writer.print("\"name\": \"{s}\"", .{
-                pkg_names[pkg_id].slice(buf),
+            try writer.print("\"name\": {}", .{
+                bun.fmt.formatJSONStringUTF8(pkg_names[pkg_id].slice(buf), .{}),
             });
 
             if (workspace_versions.get(pkg_name_hashes[pkg_id])) |version| {
@@ -929,7 +931,10 @@ pub const Stringifier = struct {
                 const name = dep.name.slice(buf);
                 const version = dep.version.literal.slice(buf);
 
-                try writer.print("\"{s}\": \"{s}\"", .{ name, version });
+                try writer.print("{}: {}", .{
+                    bun.fmt.formatJSONStringUTF8(name, .{}),
+                    bun.fmt.formatJSONStringUTF8(version, .{}),
+                });
             }
 
             if (!first) {
@@ -955,7 +960,9 @@ pub const Stringifier = struct {
                 try writer.print(
                     \\"{s}",
                     \\
-                , .{optional_peer.slice(buf)});
+                , .{
+                    bun.fmt.formatJSONStringUTF8(optional_peer.slice(buf), .{}),
+                });
             }
             try decIndent(writer, indent);
             try writer.writeByte(']');

--- a/test/cli/install/__snapshots__/bun-lock.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-lock.test.ts.snap
@@ -1,0 +1,25 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should escape names 1`] = `
+"{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {},
+    "packages/\\"": {
+      "name": "\\"",
+    },
+    "packages/pkg1": {
+      "name": "pkg1",
+      "dependencies": {
+        "\\"": "*",
+      },
+    },
+  },
+  "packages": {
+    "\\"": ["\\"@workspace:packages/\\"", {}],
+
+    "pkg1": ["pkg1@workspace:packages/pkg1", { "dependencies": { "\\"": "*" } }],
+  }
+}
+"
+`;

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun";
+import { spawn, write, file } from "bun";
 import { expect, it } from "bun:test";
 import { access, copyFile, open, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, isWindows, tmpdirSync } from "harness";
@@ -48,4 +48,40 @@ it("should write plaintext lockfiles", async () => {
   expect(await file.readFile({ encoding: "utf8" })).toEqual(
     `{\n  \"lockfileVersion\": 0,\n  \"workspaces\": {\n    \"\": {\n      \"dependencies\": {\n        \"dummy-package\": \"file:./bar-0.0.2.tgz\",\n      },\n    },\n  },\n  \"packages\": {\n    \"dummy-package\": [\"bar@./bar-0.0.2.tgz\", {}],\n  }\n}\n`,
   );
+});
+
+// won't work on windows, " is not a valid character in a filename
+it.skipIf(isWindows)("should escape names", async () => {
+  const packageDir = tmpdirSync();
+  await Promise.all([
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "quote-in-dependency-name",
+        workspaces: ["packages/*"],
+      }),
+    ),
+    write(join(packageDir, "packages", '"', "package.json"), JSON.stringify({ name: '"' })),
+    write(
+      join(packageDir, "packages", "pkg1", "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        dependencies: {
+          '"': "*",
+        },
+      }),
+    ),
+  ]);
+
+  const { exited } = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "ignore",
+    env,
+  });
+
+  expect(await exited).toBe(0);
+
+  expect(await file(join(packageDir, "bun.lock")).text()).toMatchSnapshot();
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
