### PR TITLE
Add a 'ci' command alias equivalent to 'install --frozen-lockfile'

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -573,6 +573,8 @@ pub const Command = struct {
 
                 break :brk .InstallCommand;
             },
+            RootCommandMatcher.case("ci") => .InstallCommand,
+
             RootCommandMatcher.case("c"), RootCommandMatcher.case("create") => .CreateCommand,
 
             RootCommandMatcher.case("test") => .TestCommand,


### PR DESCRIPTION
### What does this PR do?

This adds a new command `ci` similar to [npm ci](https://docs.npmjs.com/cli/v11/commands/npm-ci) which is an alias for `install --frozen-lockfile`. The associated changes try to limit new code to handle this alias, I have added specific comments below.

fixes #5283

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

- I wrote one automated test
- I tested locally

.

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

