### PR TITLE
Include array length and promise status in V8 heap snapshots (oven-sh/WebKit#75)

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION c30d63fe69913f17dce5fcbe17d06e670e0eaeff)
+  set(WEBKIT_VERSION e1a802a2287edfe7f4046a9dd8307c8b59f5d816)
 endif()
 
 if(WEBKIT_LOCAL)


### PR DESCRIPTION
### What does this PR do?

When viewing a V8 heap snapshot generated by Bun, arrays now have `Array (length)[]` in the description. Promises have `Promise (pending)`, `Promise (rejected)`, `Promise (fulfilled)`, or `Promise (fulfilled: value)` if the value is a JSCell and we weren't already inside a promise.

These changes were done in our WebKit fork, I'm just bumping the commit so they are included in Bun.

### How did you verify your code works?

Tested the WebKit changes locally. Should ensure that the heap snapshot tests still pass in CI.