### PR TITLE
skip root scripts if root is filtered out with `--filter`

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -15049,7 +15049,7 @@ pub const PackageManager = struct {
                 }
 
                 var abs_path = Path.pathToPosixBuf(u8, FileSystem.instance.top_level_dir, &path_buf);
-                break :abs_root_path abs_path[Path.windowsVolumeNameLen(abs_path)[0]..];
+                break :abs_root_path strings.withoutTrailingSlash(abs_path[Path.windowsVolumeNameLen(abs_path)[0]..]);
             };
 
             for (workspace_filters.items) |filter| {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -885,7 +885,7 @@ pub const Tree = struct {
                                 .name => |pattern| .{ pattern, pkg_names[res_id].slice(builder.buf()) },
 
                                 .path => |pattern| path: {
-                                    const res = pkg_resolutions[res_id];
+                                    const res = &pkg_resolutions[res_id];
                                     if (res.tag != .workspace) {
                                         break :dont_skip;
                                     }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
