### PR TITLE
fix(build/html): handle relative paths in script src

### DIFF
--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -33,8 +33,10 @@ fn createImportRecord(this: *HTMLScanner, input_path: []const u8, kind: ImportKi
     // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
     const path_to_use = if (input_path.len > 1 and input_path[0] == '/')
         bun.path.joinAbsString(bun.fs.FileSystem.instance.top_level_dir, &[_][]const u8{input_path[1..]}, .auto)
-    else if (std.mem.lastIndexOfScalar(u8, input_path, '.')) |index_of_dot| blk: {
+
         // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
+    else if (input_path.len > 2 and input_path[0] != '.' and input_path[1] != '/') blk: {
+        const index_of_dot = std.mem.lastIndexOfScalar(u8, input_path, '.') orelse break :blk input_path;
         const ext = input_path[index_of_dot..];
         if (ext.len > 4) break :blk input_path;
         // /foo/bar/index.html -> /foo/bar

--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -33,8 +33,15 @@ fn createImportRecord(this: *HTMLScanner, input_path: []const u8, kind: ImportKi
     // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
     const path_to_use = if (input_path.len > 1 and input_path[0] == '/')
         bun.path.joinAbsString(bun.fs.FileSystem.instance.top_level_dir, &[_][]const u8{input_path[1..]}, .auto)
-    else
-        input_path;
+    else if (std.mem.lastIndexOfScalar(u8, input_path, '.')) |index_of_dot| blk: {
+        // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
+        const ext = input_path[index_of_dot..];
+        if (ext.len > 4) break :blk input_path;
+        // /foo/bar/index.html -> /foo/bar
+        const dirname: []const u8 = std.fs.path.dirname(this.source.path.text) orelse break :blk input_path;
+        const resolved = bun.path.joinAbsString(dirname, &[_][]const u8{input_path}, .auto);
+        break :blk if (bun.sys.exists(resolved)) resolved else input_path;
+    } else input_path;
 
     const record = ImportRecord{
         .path = fs.Path.init(try this.allocator.dupeZ(u8, path_to_use)),

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1252,9 +1252,11 @@ pub fn joinAbs(cwd: []const u8, comptime _platform: Platform, part: []const u8) 
     return joinAbsString(cwd, &.{part}, _platform);
 }
 
-// Convert parts of potentially invalid file paths into a single valid filpeath
-// without querying the filesystem
-// This is the equivalent of path.resolve
+/// Convert parts of potentially invalid file paths into a single valid filpeath
+/// without querying the filesystem
+/// This is the equivalent of path.resolve
+///
+/// Returned path is stored in a temporary buffer. It must be copied if it needs to be stored.
 pub fn joinAbsString(_cwd: []const u8, parts: anytype, comptime _platform: Platform) []const u8 {
     return joinAbsStringBuf(
         _cwd,
@@ -1264,6 +1266,11 @@ pub fn joinAbsString(_cwd: []const u8, parts: anytype, comptime _platform: Platf
     );
 }
 
+/// Convert parts of potentially invalid file paths into a single valid filpeath
+/// without querying the filesystem
+/// This is the equivalent of path.resolve
+///
+/// Returned path is stored in a temporary buffer. It must be copied if it needs to be stored.
 pub fn joinAbsStringZ(_cwd: []const u8, parts: anytype, comptime _platform: Platform) [:0]const u8 {
     return joinAbsStringBufZ(
         _cwd,

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -33,6 +33,38 @@ describe("bundler", () => {
     },
   });
 
+  // Test relative paths without "./" in script src
+  itBundled("html/implicit-relative-paths", {
+    outdir: "out/",
+    files: {
+      "/src/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="styles.css">
+    <script src="script.js"></script>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>`,
+      "/src/styles.css": "body { background-color: red; }",
+      "/src/script.js": "console.log('Hello World')",
+    },
+    experimentalHtml: true,
+    experimentalCss: true,
+    root: "/src",
+    entryPoints: ["/src/index.html"],
+
+    onAfterBundle(api) {
+      // Check that output HTML references hashed filenames
+      api.expectFile("out/index.html").not.toContain("styles.css");
+      api.expectFile("out/index.html").not.toContain("script.js");
+      api.expectFile("out/index.html").toMatch(/href=".*\.css"/);
+      api.expectFile("out/index.html").toMatch(/src=".*\.js"/);
+    },
+  });
+
   // Test multiple script and style bundling
   itBundled("html/multiple-assets", {
     outdir: "out/",


### PR DESCRIPTION
### What does this PR do?

This is now handled correctly.

```html
<!-- src/index.html -->
<head>
<script src="App.tsx" />
</head>
```

```tsx
// src/App.tsx

function App(props) {
  return <div />
}
// etc
```
### How did you verify your code works?
I tested it manually in a dummy repo and I added an automated test case.