### PR TITLE
Remove rejectOnNextTick

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1626,6 +1626,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             if (callback == .zero) {
                 if (handlers.promise.trySwap()) |promise| {
+                    handlers.promise.deinit();
                     if (this.this_value != .zero) {
                         this.this_value = .zero;
                     }
@@ -1633,7 +1634,7 @@ fn NewSocket(comptime ssl: bool) type {
 
                     // reject the promise on connect() error
                     const err_value = err.toErrorInstance(globalObject);
-                    promise.asPromise().?.rejectOnNextTick(globalObject, err_value);
+                    promise.asPromise().?.reject(globalObject, err_value);
                 }
 
                 return;
@@ -1657,7 +1658,7 @@ fn NewSocket(comptime ssl: bool) type {
                 // The error is effectively handled, but we should still reject the promise.
                 var promise = val.asPromise().?;
                 const err_ = err.toErrorInstance(globalObject);
-                promise.rejectOnNextTickAsHandled(globalObject, err_);
+                promise.rejectAsHandled(globalObject, err_);
             }
         }
         pub fn onConnectError(this: *This, _: Socket, errno: c_int) void {

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2344,10 +2344,6 @@ pub const JSPromise = extern struct {
                 this.reject(globalThis, val);
             }
 
-            pub fn rejectOnNextTick(this: *WeakType, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
-                this.swap().rejectOnNextTick(globalThis, val);
-            }
-
             pub fn resolve(this: *WeakType, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
                 this.swap().resolve(globalThis, val);
             }
@@ -2425,9 +2421,7 @@ pub const JSPromise = extern struct {
             this.reject(globalThis, val);
         }
 
-        pub fn rejectOnNextTick(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
-            this.swap().rejectOnNextTick(globalThis, val);
-        }
+        pub const rejectOnNextTick = @compileError("Either use an event loop task, or you're draining microtasks when you shouldn't be.");
 
         pub fn resolve(this: *Strong, globalThis: *JSC.JSGlobalObject, val: JSC.JSValue) void {
             this.swap().resolve(globalThis, val);
@@ -2544,18 +2538,6 @@ pub const JSPromise = extern struct {
         return cppFn("resolveOnNextTick", .{ promise, globalThis, value });
     }
 
-    pub fn rejectOnNextTick(promise: *JSC.JSPromise, globalThis: *JSGlobalObject, value: JSC.JSValue) void {
-        return rejectOnNextTickWithHandled(promise, globalThis, value, false);
-    }
-
-    pub fn rejectOnNextTickAsHandled(promise: *JSC.JSPromise, globalThis: *JSGlobalObject, value: JSC.JSValue) void {
-        return rejectOnNextTickWithHandled(promise, globalThis, value, true);
-    }
-
-    pub fn rejectOnNextTickWithHandled(promise: *JSC.JSPromise, globalThis: *JSGlobalObject, value: JSC.JSValue, handled: bool) void {
-        return cppFn("rejectOnNextTickWithHandled", .{ promise, globalThis, value, handled });
-    }
-
     /// Create a new promise with an already fulfilled value
     /// This is the faster function for doing that.
     pub fn resolvedPromiseValue(globalThis: *JSGlobalObject, value: JSValue) JSValue {
@@ -2621,7 +2603,6 @@ pub const JSPromise = extern struct {
         "reject",
         "rejectAsHandled",
         "rejectAsHandledException",
-        "rejectOnNextTickWithHandled",
         "rejectedPromise",
         "rejectedPromiseValue",
         "resolve",

--- a/src/bun.js/bindings/headers.zig
+++ b/src/bun.js/bindings/headers.zig
@@ -155,11 +155,9 @@ pub extern fn JSC__JSPromise__rejectAsHandled(arg0: ?*bindings.JSPromise, arg1: 
 pub extern fn JSC__JSPromise__rejectAsHandledException(arg0: ?*bindings.JSPromise, arg1: *bindings.JSGlobalObject, arg2: [*c]bindings.Exception) void;
 pub extern fn JSC__JSPromise__rejectedPromise(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue) ?*bindings.JSPromise;
 pub extern fn JSC__JSPromise__rejectedPromiseValue(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue) JSC__JSValue;
-pub extern fn JSC__JSPromise__rejectOnNextTickWithHandled(arg0: ?*bindings.JSPromise, arg1: *bindings.JSGlobalObject, JSValue2: JSC__JSValue, arg3: bool) void;
 pub extern fn JSC__JSPromise__resolve(arg0: ?*bindings.JSPromise, arg1: *bindings.JSGlobalObject, JSValue2: JSC__JSValue) void;
 pub extern fn JSC__JSPromise__resolvedPromise(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue) ?*bindings.JSPromise;
 pub extern fn JSC__JSPromise__resolvedPromiseValue(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue) JSC__JSValue;
-pub extern fn JSC__JSPromise__resolveOnNextTick(arg0: ?*bindings.JSPromise, arg1: *bindings.JSGlobalObject, JSValue2: JSC__JSValue) void;
 pub extern fn JSC__JSPromise__result(arg0: ?*bindings.JSPromise, arg1: *bindings.VM) JSC__JSValue;
 pub extern fn JSC__JSPromise__setHandled(arg0: ?*bindings.JSPromise, arg1: *bindings.VM) void;
 pub extern fn JSC__JSPromise__status(arg0: [*c]const JSC__JSPromise, arg1: *bindings.VM) u32;

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2816,6 +2816,11 @@ pub const VirtualMachine = struct {
     pub const main_file_name: string = "bun:main";
 
     pub fn drainMicrotasks(this: *VirtualMachine) void {
+        if (comptime Environment.isDebug) {
+            if (this.eventLoop().debug.is_inside_tick_queue) {
+                @panic("Calling drainMicrotasks from inside the event loop tick queue is a bug in your code. Please fix your bug.");
+            }
+        }
         this.eventLoop().drainMicrotasks();
     }
 

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -341,7 +341,7 @@ pub const S3BlobStatTask = struct {
                 this.promise.resolve(globalThis, .true);
             },
             .failure => |err| {
-                this.promise.rejectOnNextTick(globalThis, err.toJS(globalThis, this.store.data.s3.path()));
+                this.promise.reject(globalThis, err.toJS(globalThis, this.store.data.s3.path()));
             },
         }
     }
@@ -355,7 +355,7 @@ pub const S3BlobStatTask = struct {
                 this.promise.resolve(globalThis, JSValue.jsNumber(stat.size));
             },
             inline .not_found, .failure => |err| {
-                this.promise.rejectOnNextTick(globalThis, err.toJS(globalThis, this.store.data.s3.path()));
+                this.promise.reject(globalThis, err.toJS(globalThis, this.store.data.s3.path()));
             },
         }
     }

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1173,8 +1173,6 @@ pub const Fetch = struct {
                 }
 
                 if (!assignment_result.isEmptyOrUndefinedOrNull()) {
-                    this.javascript_vm.drainMicrotasks();
-
                     assignment_result.ensureStillAlive();
                     // it returns a Promise when it goes through ReadableStreamDefaultReader
                     if (assignment_result.asAnyPromise()) |promise| {

--- a/src/s3.zig
+++ b/src/s3.zig
@@ -1723,7 +1723,7 @@ pub const AWSCredentials = struct {
                                 sink.abort();
                                 return;
                             }
-                            sink.endPromise.rejectOnNextTick(globalObject, err.toJS(globalObject, self.path));
+                            sink.endPromise.reject(globalObject, err.toJS(globalObject, self.path));
                         },
                     }
                 }
@@ -1762,7 +1762,7 @@ pub const AWSCredentials = struct {
 
         const err = args.ptr[0];
         if (this.sink.endPromise.hasValue()) {
-            this.sink.endPromise.rejectOnNextTick(globalThis, err);
+            this.sink.endPromise.reject(globalThis, err);
         }
 
         if (this.readable_stream_ref.get()) |stream| {
@@ -1888,7 +1888,7 @@ pub const AWSCredentials = struct {
 
         if (assignment_result.toError()) |err| {
             if (response_stream.sink.endPromise.hasValue()) {
-                response_stream.sink.endPromise.rejectOnNextTick(globalThis, err);
+                response_stream.sink.endPromise.reject(globalThis, err);
             }
 
             task.fail(.{
@@ -1900,8 +1900,6 @@ pub const AWSCredentials = struct {
         }
 
         if (!assignment_result.isEmptyOrUndefinedOrNull()) {
-            task.vm.drainMicrotasks();
-
             assignment_result.ensureStillAlive();
             // it returns a Promise when it goes through ReadableStreamDefaultReader
             if (assignment_result.asAnyPromise()) |promise| {
@@ -1935,7 +1933,7 @@ pub const AWSCredentials = struct {
                     },
                     .rejected => {
                         if (response_stream.sink.endPromise.hasValue()) {
-                            response_stream.sink.endPromise.rejectOnNextTick(globalThis, promise.result(globalThis.vm()));
+                            response_stream.sink.endPromise.reject(globalThis, promise.result(globalThis.vm()));
                         }
 
                         task.fail(.{
@@ -1947,7 +1945,7 @@ pub const AWSCredentials = struct {
                 }
             } else {
                 if (response_stream.sink.endPromise.hasValue()) {
-                    response_stream.sink.endPromise.rejectOnNextTick(globalThis, assignment_result);
+                    response_stream.sink.endPromise.reject(globalThis, assignment_result);
                 }
 
                 task.fail(.{
@@ -1978,7 +1976,7 @@ pub const AWSCredentials = struct {
                                     return;
                                 }
 
-                                sink.endPromise.rejectOnNextTick(globalObject, err.toJS(globalObject, sink.path()));
+                                sink.endPromise.reject(globalObject, err.toJS(globalObject, sink.path()));
                             },
                         }
                     }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
