### PR TITLE
Use better emoji for "TypeScript Type Bug Report" template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
@@ -1,4 +1,4 @@
-name: 🇹 TypeScript Type Bug Report
+name: 🔤 TypeScript Type Bug Report
 description: Report an issue with TypeScript types
 labels: [bug, types]
 body:


### PR DESCRIPTION
Unicode does not recommend previous character (🇹) to represent emoji. Therefore, it will appear as a single black and white Unicode character on most platforms.