### PR TITLE
Download correct musl binaries in `bun build --compile`

### DIFF
--- a/src/compile_target.zig
+++ b/src/compile_target.zig
@@ -28,6 +28,14 @@ const Libc = enum {
     /// musl libc
     musl,
 
+    /// npm package name, `@oven-sh/bun-{os}-{arch}`
+    pub fn npmName(this: Libc) []const u8 {
+        return switch (this) {
+            .default => "",
+            .musl => "-musl",
+        };
+    }
+
     pub fn format(self: @This(), comptime _: []const u8, _: anytype, writer: anytype) !void {
         if (self == .musl) {
             try writer.writeAll("-musl");
@@ -64,21 +72,25 @@ pub fn toNPMRegistryURL(this: *const CompileTarget, buf: []u8) ![]const u8 {
 pub fn toNPMRegistryURLWithURL(this: *const CompileTarget, buf: []u8, registry_url: []const u8) ![]const u8 {
     return switch (this.os) {
         inline else => |os| switch (this.arch) {
-            inline else => |arch| switch (this.baseline) {
-                // https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-0.1.6.tgz
-                inline else => |is_baseline| try std.fmt.bufPrint(buf, comptime "{s}/@oven/bun-" ++
-                    os.npmName() ++ "-" ++ arch.npmName() ++
-                    (if (is_baseline) "-baseline" else "") ++
-                    "/-/bun-" ++
-                    os.npmName() ++ "-" ++ arch.npmName() ++
-                    (if (is_baseline) "-baseline" else "") ++
-                    "-" ++
-                    "{d}.{d}.{d}.tgz", .{
-                    registry_url,
-                    this.version.major,
-                    this.version.minor,
-                    this.version.patch,
-                }),
+            inline else => |arch| switch (this.libc) {
+              inline else => |libc| switch (this.baseline) {
+                  // https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-0.1.6.tgz
+                  inline else => |is_baseline| try std.fmt.bufPrint(buf, comptime "{s}/@oven/bun-" ++
+                      os.npmName() ++ "-" ++ arch.npmName() ++
+                      libc.npmName() ++
+                      (if (is_baseline) "-baseline" else "") ++
+                      "/-/bun-" ++
+                      os.npmName() ++ "-" ++ arch.npmName() ++
+                      libc.npmName() ++
+                      (if (is_baseline) "-baseline" else "") ++
+                      "-" ++
+                      "{d}.{d}.{d}.tgz", .{
+                      registry_url,
+                      this.version.major,
+                      this.version.minor,
+                      this.version.patch,
+                  }),
+                },
             },
         },
     };


### PR DESCRIPTION
### What does this PR do?

This makes sure, when compiling for a musl target, that the correct `-musl` npm package is referenced when downloading the Bun binary in `bun build --compile`

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Manual testing of `bun build --compile` and subsequent running of said binary in an Alpine Linux Docker container. I'd write automated tests except I'm not certain how to set that up for this case. Any pointers would be appreciated!

cc @Jarred-Sumner this fixes the `--compile` issue we discussed
