### PR TITLE
Use separate function to make V8 heap snapshots instead of parameter

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4176,9 +4176,11 @@ declare module "bun" {
   /**
    * Show precise statistics about memory usage of your application
    *
-   * Generate a heap snapshot in JavaScriptCore's format that can be viewed with `bun --inspect` or Safari's Web Inspector
+   * Generate a heap snapshot in JavaScriptCore's format that can be viewed with `bun --inspect` or Safari's Web Inspector.
+   *
+   * This returns an object that should be JSON stringified then written to a file.
    */
-  function generateHeapSnapshot(format?: "jsc"): HeapSnapshot;
+  function generateHeapSnapshot(): HeapSnapshot;
 
   /**
    * Show precise statistics about memory usage of your application
@@ -4187,11 +4189,11 @@ declare module "bun" {
    *
    * This is a JSON string that can be saved to a file.
    * ```ts
-   * const snapshot = Bun.generateHeapSnapshot("v8");
+   * const snapshot = Bun.generateV8HeapSnapshot();
    * await Bun.write("heap.heapsnapshot", snapshot);
    * ```
    */
-  function generateHeapSnapshot(format: "v8"): string;
+  function generateV8HeapSnapshot(): string;
 
   /**
    * The next time JavaScriptCore is idle, clear unused memory and attempt to reduce the heap size.

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -540,28 +540,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
     auto& heapProfiler = *vm.heapProfiler();
     heapProfiler.clearSnapshots();
 
-    JSValue arg0 = callFrame->argument(0);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    bool useV8 = false;
-    if (!arg0.isUndefined()) {
-        if (arg0.isString()) {
-            auto str = arg0.toWTFString(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            if (str == "v8"_s) {
-                useV8 = true;
-            } else if (str == "jsc"_s) {
-                // do nothing
-            } else {
-                throwTypeError(globalObject, throwScope, "Expected 'v8' or 'jsc' or undefined"_s);
-                return {};
-            }
-        }
-    }
-
-    if (useV8) {
-        JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
-        return JSC::JSValue::encode(jsString(vm, builder.json()));
-    }
 
     JSC::HeapSnapshotBuilder builder(heapProfiler);
     builder.buildSnapshot();
@@ -570,6 +549,16 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
     // so we'll just keep it for now.
     JSC::JSValue jsonValue = JSONParseWithException(globalObject, json);
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(jsonValue));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionGenerateV8HeapSnapshot, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    vm.ensureHeapProfiler();
+    auto& heapProfiler = *vm.heapProfiler();
+    heapProfiler.clearSnapshots();
+    JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
+    return JSC::JSValue::encode(jsString(vm, builder.json()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -648,6 +637,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     fileURLToPath                                  functionFileURLToPath                                                DontDelete|Function 1
     gc                                             Generated::BunObject::jsGc                                          DontDelete|Function 1
     generateHeapSnapshot                           functionGenerateHeapSnapshot                                        DontDelete|Function 1
+    generateV8HeapSnapshot                         functionGenerateV8HeapSnapshot                                      DontDelete|Function 1
     gunzipSync                                     BunObject_callback_gunzipSync                                       DontDelete|Function 1
     gzipSync                                       BunObject_callback_gzipSync                                         DontDelete|Function 1
     hash                                           BunObject_getter_wrap_hash                                          DontDelete|PropertyCallback

--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -36,7 +36,7 @@ function getHeapSnapshot() {
     class HeapSnapshotReadable extends Readable {
       constructor() {
         super();
-        this.push(Bun.generateHeapSnapshot("v8"));
+        this.push(Bun.generateV8HeapSnapshot());
         this.push(null);
       }
     }
@@ -142,7 +142,7 @@ function writeHeapSnapshot(path, options) {
   if (!fs) {
     fs = require("node:fs");
   }
-  fs.writeFileSync(path, Bun.generateHeapSnapshot("v8"), "utf-8");
+  fs.writeFileSync(path, Bun.generateV8HeapSnapshot(), "utf-8");
 
   return path;
 }

--- a/test/js/bun/util/v8-heap-snapshot.test.ts
+++ b/test/js/bun/util/v8-heap-snapshot.test.ts
@@ -5,7 +5,7 @@ import * as v8 from "v8";
 import * as v8HeapSnapshot from "v8-heapsnapshot";
 
 test("v8 heap snapshot", async () => {
-  const snapshot = Bun.generateHeapSnapshot("v8");
+  const snapshot = Bun.generateV8HeapSnapshot();
   // Sanity check: run the validations from this library
   const parsed = await v8HeapSnapshot.parseSnapshot(JSON.parse(snapshot));
 


### PR DESCRIPTION
### What does this PR do?

Changes `Bun.generateHeapSnapshot("v8")` to `Bun.generateV8HeapSnapshot()`. `Bun.generateHeapSnapshot()` once again takes no parameter and always returns a snapshot in JSC format.

The motivation for this is that `Bun.generateHeapSnapshot()` currently returns an object, and we can't change that (it is a breaking change), but returning a string is easier for us and for users (since most use cases will just immediately pass the object to `JSON.stringify`). Previously, `Bun.generateHeapSnapshot` would return JSC snapshots as objects, but V8 snapshots as strings. It's unclear to have a function that returns different types according to its parameter. Now it always returns an object, like before, but we can make `Bun.generateV8HeapSnapshot()` return a string since it's a different function.

In short:

```diff
-   function generateHeapSnapshot(format?: "jsc"): HeapSnapshot;
-   function generateHeapSnapshot(format: "v8"): string;
+   function generateHeapSnapshot(): HeapSnapshot;
+   function generateV8HeapSnapshot(): string;
```

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Ran the V8 heap snapshot tests.
