### PR TITLE
Cleanup alpine Dockerfile: Remove temporary /tmp mount

### DIFF
--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -58,8 +58,7 @@ ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 COPY --from=build /usr/local/bin/bun /usr/local/bin/
 COPY docker-entrypoint.sh /usr/local/bin/
 
-# Temporarily use the `build`-stage /tmp folder to access the glibc APKs:
-RUN --mount=type=bind,from=build,source=/tmp,target=/tmp \
+RUN \
     addgroup -g 1000 bun \
     && adduser -u 1000 -G bun -s /bin/sh -D bun \
     && ln -s /usr/local/bin/bun /usr/local/bin/bunx \


### PR DESCRIPTION
### What does this PR do?

Downloaded glibc in /tmp was removed when switching to musl build: #15241

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Verified mentally