### PR TITLE
Don't chmod UNIX sockets to 700

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -843,13 +843,6 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_listen_socket_unix(const char
         return LIBUS_SOCKET_ERROR;
     }
 
-#ifndef _WIN32
-    // 700 permission by default
-    fchmod(listenFd, S_IRWXU);
-#else
-    _chmod(path, S_IREAD | S_IWRITE | S_IEXEC);
-#endif
-
 #ifdef _WIN32
     _unlink(path);
 #else


### PR DESCRIPTION
### What does this PR do?

Fixes #15686. Node.js doesn't chmod UNIX domain sockets after their creation, but we (by way of µSockets) chmod them to 700. This PR fixes that by removing the call to chmod.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

I ran the provided repro in #15686 before and after this PR's changes. On Ubuntu (in a container on a macOS host), the permissions on the UNIX domain socket were 700 before the removal of the chmod call, as reported, and after, they were 755, which matches the expected Node.js behavior. (It's interesting to note that on macOS proper, the permissions were already `srwxr-xr-x` even with the call to chmod in place.)