### PR TITLE
feat: expose `globalThis.gc` when `--expose-gc` flag is passed

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -832,7 +832,7 @@ pub fn gc(vm: *JSC.VirtualMachine, sync: bool) usize {
     return vm.garbageCollect(sync);
 }
 export fn Bun__gc(vm: *JSC.VirtualMachine, sync: bool) callconv(.C) usize {
-    return @call(.always_inline, gc, .{vm, sync});
+    return @call(.always_inline, gc, .{ vm, sync });
 }
 
 pub fn shrink(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -831,6 +831,9 @@ pub fn sleepSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) b
 pub fn gc(vm: *JSC.VirtualMachine, sync: bool) usize {
     return vm.garbageCollect(sync);
 }
+export fn Bun__gc(vm: *JSC.VirtualMachine, sync: bool) callconv(.C) usize {
+    return @call(.always_inline, gc, .{vm, sync});
+}
 
 pub fn shrink(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     globalObject.vm().shrinkFootprint();

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3710,7 +3710,7 @@ extern "C" size_t Bun__gc(void* vm, bool sync);
 JSC_DEFINE_HOST_FUNCTION(functionJsGc,
     (JSC::JSGlobalObject * global, JSC::CallFrame* callFrame))
 {
-    Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(global);
+    Zig::GlobalObject* globalObject = defaultGlobalObject(global);
     Bun__gc(globalObject->bunVM(), true);
     return JSValue::encode(jsUndefined());
 }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3699,7 +3699,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "_stderr"_s), CustomGetterSetter::create(vm, getConsoleStderr, nullptr), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue | 0);
 }
 
-
 // ===================== start conditional builtin globals =====================
 // These functions register globals based on runtime conditions (e.g. CLI flags,
 // environment variables, etc.). See `Run.addConditionalGlobals()` in bun_js.zig
@@ -3714,11 +3713,11 @@ JSC_DEFINE_HOST_FUNCTION(functionJsGc,
     return Generated::BunObject::jsGc(globalObject, callFrame);
 }
 
-extern "C" void JSC__JSGlobalObject__addGc(JSC__JSGlobalObject* globalObject) {
+extern "C" void JSC__JSGlobalObject__addGc(JSC__JSGlobalObject* globalObject)
+{
     JSC::VM& vm = globalObject->vm();
     globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "gc"_s), 0, functionJsGc, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
 }
-
 
 // ====================== end conditional builtin globals ======================
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3705,12 +3705,14 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 // for where these are called.
 
 /// `globalThis.gc()` is an alias for `Bun.gc(true)`
+/// Note that `vm` is a `VirtualMachine*`
+extern "C" size_t Bun__gc(void* vm, bool sync);
 JSC_DEFINE_HOST_FUNCTION(functionJsGc,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+    (JSC::JSGlobalObject * global, JSC::CallFrame* callFrame))
 {
-    // set `force` to true. Note that `Bun.gc` reads from the 0th argument, which is normally reserved for `this`.
-    callFrame->setArgument(0, JSC::jsBoolean(true));
-    return Generated::BunObject::jsGc(globalObject, callFrame);
+    Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(global);
+    Bun__gc(globalObject->bunVM(), true);
+    return JSValue::encode(jsUndefined());
 }
 
 extern "C" void JSC__JSGlobalObject__addGc(JSC__JSGlobalObject* globalObject)

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3708,8 +3708,8 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 JSC_DEFINE_HOST_FUNCTION(functionJsGc,
     (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    // set `force` to true
-    callFrame->setArgument(1, JSC::jsBoolean(true));
+    // set `force` to true. Note that `Bun.gc` reads from the 0th argument, which is normally reserved for `this`.
+    callFrame->setArgument(0, JSC::jsBoolean(true));
     return Generated::BunObject::jsGc(globalObject, callFrame);
 }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -60,6 +60,7 @@
 #include "AsyncContextFrame.h"
 #include "BunClientData.h"
 #include "BunObject.h"
+#include "GeneratedBunObject.h"
 #include "BunPlugin.h"
 #include "BunProcess.h"
 #include "BunWorkerGlobalScope.h"
@@ -1759,6 +1760,14 @@ JSC_DEFINE_HOST_FUNCTION(functionATOB,
     }
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsString(vm, result.releaseReturnValue())));
+}
+
+/// `globalThis.gc()` is an alias for `Bun.gc(true)`
+JSC_DEFINE_HOST_FUNCTION(functionJsGc,
+    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    callFrame->setArgument(1, JSC::jsBoolean(true));
+    return Generated::BunObject::jsGc(globalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionReportError,

--- a/src/bun.js/bindings/ZigGlobalObject.lut.txt
+++ b/src/bun.js/bindings/ZigGlobalObject.lut.txt
@@ -12,7 +12,6 @@
   confirm                         WebCore__confirm                                     Function 1
   dispatchEvent                   jsFunctionDispatchEvent                              Function 1
   fetch                           constructBunFetchObject                              PropertyCallback
-  gc                              functionJsGc                                         Function 0
   postMessage                     jsFunctionPostMessage                                Function 1
   prompt                          WebCore__prompt                                      Function 1
   queueMicrotask                  functionQueueMicrotask                               Function 2

--- a/src/bun.js/bindings/ZigGlobalObject.lut.txt
+++ b/src/bun.js/bindings/ZigGlobalObject.lut.txt
@@ -12,6 +12,7 @@
   confirm                         WebCore__confirm                                     Function 1
   dispatchEvent                   jsFunctionDispatchEvent                              Function 1
   fetch                           constructBunFetchObject                              PropertyCallback
+  gc                              functionJsGc                                         Function 0
   postMessage                     jsFunctionPostMessage                                Function 1
   prompt                          WebCore__prompt                                      Function 1
   queueMicrotask                  functionQueueMicrotask                               Function 2

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -277,6 +277,7 @@ CPP_DECL JSC__JSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC__JSGlobalObj
 CPP_DECL JSC__JSValue JSC__JSGlobalObject__getCachedObject(JSC__JSGlobalObject* arg0, const ZigString* arg1);
 CPP_DECL void JSC__JSGlobalObject__handleRejectedPromises(JSC__JSGlobalObject* arg0);
 CPP_DECL JSC__JSValue JSC__JSGlobalObject__putCachedObject(JSC__JSGlobalObject* arg0, const ZigString* arg1, JSC__JSValue JSValue2);
+CPP_DECL void JSC__JSGlobalObject__addGc(JSC__JSGlobalObject* globalObject);
 CPP_DECL void JSC__JSGlobalObject__queueMicrotaskJob(JSC__JSGlobalObject* arg0, JSC__JSValue JSValue1, JSC__JSValue JSValue2, JSC__JSValue JSValue3);
 CPP_DECL void JSC__JSGlobalObject__reload(JSC__JSGlobalObject* arg0);
 CPP_DECL bool JSC__JSGlobalObject__startRemoteInspector(JSC__JSGlobalObject* arg0, unsigned char* arg1, uint16_t arg2);

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -283,16 +283,12 @@ pub const Run = struct {
         run.any_unhandled = true;
     }
 
-    extern fn Bun__ExposeNodeModuleGlobals(*JSC.JSGlobalObject) void;
-
     pub fn start(this: *Run) void {
         var vm = this.vm;
         vm.hot_reload = this.ctx.debug.hot_reload;
         vm.onUnhandledRejection = &onUnhandledRejectionBeforeClose;
 
-        if (this.ctx.runtime_options.eval.script.len > 0) {
-            Bun__ExposeNodeModuleGlobals(vm.global);
-        }
+        this.addConditionalGlobals();
 
         switch (this.ctx.debug.hot_reload) {
             .hot => JSC.HotReloader.enableHotModuleReloading(vm),
@@ -447,6 +443,23 @@ pub const Run = struct {
 
         if (!JSC.is_bindgen) JSC.napi.fixDeadCodeElimination();
         vm.globalExit();
+    }
+
+    extern fn Bun__ExposeNodeModuleGlobals(*JSC.JSGlobalObject) void;
+    /// add `gc()` to `globalThis`.
+    extern fn JSC__JSGlobalObject__addGc(*JSC.JSGlobalObject) void;
+
+    // fn addConditionalGlobals(vm: *VirtualMachine, ctx: *const Command.Context) void {
+    fn addConditionalGlobals(this: *Run) void {
+        const vm = this.vm;
+        const runtime_options: *const Command.RuntimeOptions = &this.ctx.runtime_options;
+
+        if (runtime_options.eval.script.len > 0) {
+            Bun__ExposeNodeModuleGlobals(vm.global);
+        }
+        if (runtime_options.expose_gc) {
+            JSC__JSGlobalObject__addGc(vm.global);
+        }
     }
 };
 

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -449,7 +449,6 @@ pub const Run = struct {
     /// add `gc()` to `globalThis`.
     extern fn JSC__JSGlobalObject__addGc(*JSC.JSGlobalObject) void;
 
-    // fn addConditionalGlobals(vm: *VirtualMachine, ctx: *const Command.Context) void {
     fn addConditionalGlobals(this: *Run) void {
         const vm = this.vm;
         const runtime_options: *const Command.RuntimeOptions = &this.ctx.runtime_options;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -237,6 +237,7 @@ pub const Arguments = struct {
         clap.parseParam("--fetch-preconnect <STR>...       Preconnect to a URL while code is loading") catch unreachable,
         clap.parseParam("--max-http-header-size <INT>      Set the maximum size of HTTP headers in bytes. Default is 16KiB") catch unreachable,
         clap.parseParam("--expose-internals                Expose internals used for testing Bun itself. Usage of these APIs are completely unsupported.") catch unreachable,
+        clap.parseParam("--expose-gc                       Expose gc() on the global object. Has no effect on Bun.gc().") catch unreachable,
         clap.parseParam("--no-deprecation                  Suppress all reporting of the custom deprecation.") catch unreachable,
         clap.parseParam("--throw-deprecation               Determine whether or not deprecation warnings result in errors.") catch unreachable,
         clap.parseParam("--title <STR>                     Set the process title") catch unreachable,
@@ -762,6 +763,7 @@ pub const Arguments = struct {
             ctx.runtime_options.if_present = args.flag("--if-present");
             ctx.runtime_options.smol = args.flag("--smol");
             ctx.runtime_options.preconnect = args.options("--fetch-preconnect");
+            ctx.runtime_options.expose_gc = args.flag("--expose-gc");
 
             if (args.option("--inspect")) |inspect_flag| {
                 ctx.runtime_options.debugger = if (inspect_flag.len == 0)
@@ -1496,6 +1498,9 @@ pub const Command = struct {
             eval_and_print: bool = false,
         } = .{},
         preconnect: []const []const u8 = &[_][]const u8{},
+        /// `--expose-gc` makes `globalThis.gc()` available. Added for Node
+        /// compatibility.
+        expose_gc: bool = false,
     };
 
     var global_cli_ctx: Context = undefined;

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -198,24 +198,79 @@ it("errors thrown by native code should be TypeError", async () => {
 });
 
 describe("globalThis.gc", () => {
-  it("is a function", () => {
-    expect(globalThis).toHaveProperty("gc");
-    expect(globalThis.gc).toBeInstanceOf(Function);
+  /**
+   * @param {string} expr
+   * @param {string[]} args
+   * @returns {string}
+   */
+  const runAndPrint = (expr, ...args) => {
+    const result = Bun.spawnSync([bunExe(), ...args, "--print", expr], {
+      env: bunEnv,
+    });
+    if (!result.success) throw new Error(result.stderr.toString("utf8"));
+    return result.stdout.toString("utf8").trim();
+  };
+
+  describe("when --expose-gc is not passed", () => {
+    it("globalThis.gc === undefined", () => {
+      expect(runAndPrint("typeof globalThis.gc")).toEqual("undefined");
+    });
+    it(".gc does not take up a property slot", () => {
+      expect(runAndPrint("'gc' in globalThis")).toEqual("false");
+    });
   });
 
-  it("is the same as calling gc directly", () => {
-    expect(globalThis.gc).toBe(gc);
+  describe("when --expose-gc is passed", () => {
+    it("is a function", () => {
+      expect(runAndPrint("typeof globalThis.gc", "--expose-gc")).toEqual("function");
+    });
+
+    it("gc is the same as globalThis.gc", () => {
+      expect(runAndPrint("gc === globalThis.gc", "--expose-gc")).toEqual("true");
+    });
+
+    it("cleans up memory", () => {
+      const src = /* js */ `
+      let arr = []
+      for (let i = 0; i < 100; i++) {
+        arr.push(new Array(100_000));
+      }
+      arr.length = 0;
+
+      const before = process.memoryUsage().heapUsed;
+      globalThis.gc();
+      const after = process.memoryUsage().heapUsed;
+      return before - after;
+      `;
+      const expr = /* js */ `(function() { ${src} })()`;
+
+      const delta = Number.parseInt(runAndPrint(expr, "--expose-gc"));
+      expect(delta).not.toBeNaN();
+      expect(delta).toBeGreaterThanOrEqual(0);
+    });
   });
 
-  it("cleans up memory", () => {
-    const start = process.memoryUsage().heapUsed;
-    // allocate a bunch of crap
-    for (let i = 0; i < 100; i++) {
-      new Array(100_000);
-    }
-    const before = process.memoryUsage().heapUsed;
-    globalThis.gc();
-    const after = process.memoryUsage().heapUsed;
-    expect(after).toBeLessThanOrEqual(before);
-  });
+  // it("is not present in the global scope if --expose-gc is not passed", () => {
+  //   expect(runAndPrint("'gc' in globalThis")).toEqual("false");
+  // });
+  // it("is a function", () => {
+  //   expect(globalThis).toHaveProperty("gc");
+  //   expect(globalThis.gc).toBeInstanceOf(Function);
+  // });
+
+  // it("is the same as calling gc directly", () => {
+  //   expect(globalThis.gc).toBe(gc);
+  // });
+
+  // it("cleans up memory", () => {
+  //   const start = process.memoryUsage().heapUsed;
+  //   // allocate a bunch of crap
+  //   for (let i = 0; i < 100; i++) {
+  //     new Array(100_000);
+  //   }
+  //   const before = process.memoryUsage().heapUsed;
+  //   globalThis.gc();
+  //   const after = process.memoryUsage().heapUsed;
+  //   expect(after).toBeLessThanOrEqual(before);
+  // });
 });

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -196,3 +196,26 @@ it("errors thrown by native code should be TypeError", async () => {
   expect(() => Bun.dns.prefetch()).toThrowError(TypeError);
   expect(async () => await fetch("http://localhost", { body: "123" })).toThrowError(TypeError);
 });
+
+describe("globalThis.gc", () => {
+  it("is a function", () => {
+    expect(globalThis).toHaveProperty("gc");
+    expect(globalThis.gc).toBeInstanceOf(Function);
+  });
+
+  it("is the same as calling gc directly", () => {
+    expect(globalThis.gc).toBe(gc);
+  });
+
+  it("cleans up memory", () => {
+    const start = process.memoryUsage().heapUsed;
+    // allocate a bunch of crap
+    for (let i = 0; i < 100; i++) {
+      new Array(100_000);
+    }
+    const before = process.memoryUsage().heapUsed;
+    globalThis.gc();
+    const after = process.memoryUsage().heapUsed;
+    expect(after).toBeLessThanOrEqual(before);
+  });
+});

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -249,28 +249,4 @@ describe("globalThis.gc", () => {
       expect(delta).toBeGreaterThanOrEqual(0);
     });
   });
-
-  // it("is not present in the global scope if --expose-gc is not passed", () => {
-  //   expect(runAndPrint("'gc' in globalThis")).toEqual("false");
-  // });
-  // it("is a function", () => {
-  //   expect(globalThis).toHaveProperty("gc");
-  //   expect(globalThis.gc).toBeInstanceOf(Function);
-  // });
-
-  // it("is the same as calling gc directly", () => {
-  //   expect(globalThis.gc).toBe(gc);
-  // });
-
-  // it("cleans up memory", () => {
-  //   const start = process.memoryUsage().heapUsed;
-  //   // allocate a bunch of crap
-  //   for (let i = 0; i < 100; i++) {
-  //     new Array(100_000);
-  //   }
-  //   const before = process.memoryUsage().heapUsed;
-  //   globalThis.gc();
-  //   const after = process.memoryUsage().heapUsed;
-  //   expect(after).toBeLessThanOrEqual(before);
-  // });
 });


### PR DESCRIPTION
### What does this PR do?
Closes #9620.

Adds support for Node's `--expose-gc` flag. `process.gc` is effectively an alias for `Bun.gc(true)`.

This change is to make Bun more compatable with Node, as well as making it easier to port parallel test cases that use `process.gc()` (e.g. [this test](https://github.com/oven-sh/bun/blob/07287a07f0ea44786b5b27191bdef72cfd0d72e6/test/js/node/test/parallel/test-vm-create-and-run-in-context.js), which fails after making improvements to assert).

### How did you verify your code works?
I've added tests.
