### PR TITLE
Remove envFile from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -32,7 +31,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "--only", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "1",
@@ -55,7 +53,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -72,7 +69,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "0",
         "BUN_DEBUG_jest": "1",
@@ -89,7 +85,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "--watch", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -106,7 +101,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "--hot", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -123,7 +117,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -146,7 +139,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${file}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -170,7 +162,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "FORCE_COLOR": "0",
         "BUN_DEBUG_QUIET_LOGS": "1",
@@ -187,7 +178,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "0",
@@ -207,7 +197,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "0",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
@@ -223,7 +212,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "--watch", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         // "BUN_DEBUG_DEBUGGER": "1",
         // "BUN_DEBUG_INTERNAL_DEBUGGER": "1",
@@ -242,7 +230,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "--hot", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
@@ -258,7 +245,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "FORCE_COLOR": "0",
         "BUN_DEBUG_QUIET_LOGS": "1",
@@ -281,7 +267,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["run", "${fileBasename}"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "FORCE_COLOR": "0",
         "BUN_DEBUG_QUIET_LOGS": "1",
@@ -305,7 +290,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -322,7 +306,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -339,7 +322,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -356,7 +338,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "--watch", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -373,7 +354,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "--hot", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -390,7 +370,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -413,7 +392,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_DEBUG_jest": "1",
@@ -437,7 +415,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["exec", "${input:testName}"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
@@ -454,7 +431,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
@@ -470,7 +446,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "0",
@@ -486,7 +461,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["test"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
@@ -508,7 +482,6 @@
       "program": "${workspaceFolder}/build/debug/bun-debug",
       "args": ["install"],
       "cwd": "${fileDirname}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
@@ -524,7 +497,6 @@
       "program": "node",
       "args": ["test/runner.node.mjs"],
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
         "BUN_GARBAGE_COLLECTOR_LEVEL": "2",


### PR DESCRIPTION
### What does this PR do?

Removes `"envFile": "${workspaceFolder}/.env"` from entries in our `.vscode/launch.json`. This setting causes a hard-to-understand error if you try to start debugging and don't have a `.env` file:

<img width="261" alt="image" src="https://github.com/user-attachments/assets/4f51915c-c239-4a59-9386-e0d0a25fe0f4" />

### How did you verify your code works?

No code changes.