### PR TITLE
fix: node parallel test check in test runner

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -246,7 +246,7 @@ async function runTests() {
   if (!failedResults.length) {
     for (const testPath of tests) {
       const title = relative(cwd, join(testsPath, testPath)).replace(/\\/g, "/");
-      if (title.startsWith("test/js/node/test/parallel/")) {
+      if (isNodeParallelTest(testPath)) {
         await runTest(title, async () => {
           const { ok, error, stdout } = await spawnBun(execPath, {
             cwd: cwd,
@@ -851,11 +851,19 @@ function isJavaScriptTest(path) {
 }
 
 /**
+ * @param {string} testPath
+ * @returns {boolean}
+ */
+function isNodeParallelTest(testPath) {
+  return testPath.replaceAll(sep, "/").includes("js/node/test/parallel/")
+}
+
+/**
  * @param {string} path
  * @returns {boolean}
  */
 function isTest(path) {
-  if (path.replaceAll(sep, "/").startsWith("js/node/test/parallel/") && targetDoesRunNodeTests()) return true;
+  if (isNodeParallelTest(path) && targetDoesRunNodeTests()) return true;
   if (path.replaceAll(sep, "/").startsWith("js/node/cluster/test-") && path.endsWith(".ts")) return true;
   return isTestStrict(path);
 }
@@ -1035,7 +1043,7 @@ function getRelevantTests(cwd) {
   const filteredTests = [];
 
   if (options["node-tests"]) {
-    tests = tests.filter(testPath => testPath.includes("js/node/test/parallel/"));
+    tests = tests.filter(isNodeParallelTest);
   }
 
   const isMatch = (testPath, filter) => {


### PR DESCRIPTION
### What does this PR do?

Standardizes checks for `node/parallel` test cases. Ensures all checks work on Windows.