### PR TITLE
fix(launch): `bun run ...` launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -160,7 +160,7 @@
       "request": "launch",
       "name": "bun run [file]",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "${fileBasename}"],
+      "args": ["run", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         "FORCE_COLOR": "0",
@@ -176,7 +176,7 @@
       "request": "launch",
       "name": "bun run [file] (fast)",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "${fileBasename}"],
+      "args": ["run", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
@@ -195,7 +195,7 @@
       "request": "launch",
       "name": "bun run [file] (verbose)",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "${fileBasename}"],
+      "args": ["run", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "0",
@@ -210,7 +210,7 @@
       "request": "launch",
       "name": "bun run [file] --watch",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "--watch", "${fileBasename}"],
+      "args": ["run", "--watch", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         // "BUN_DEBUG_DEBUGGER": "1",
@@ -228,7 +228,7 @@
       "request": "launch",
       "name": "bun run [file] --hot",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "--hot", "${fileBasename}"],
+      "args": ["run", "--hot", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         "BUN_DEBUG_QUIET_LOGS": "1",
@@ -243,7 +243,7 @@
       "request": "launch",
       "name": "bun run [file] --inspect",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "${fileBasename}"],
+      "args": ["run", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         "FORCE_COLOR": "0",
@@ -265,7 +265,7 @@
       "request": "launch",
       "name": "bun run [file] --inspect-brk",
       "program": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["run", "${fileBasename}"],
+      "args": ["run", "${file}"],
       "cwd": "${fileDirname}",
       "env": {
         "FORCE_COLOR": "0",


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
