### PR TITLE
Fix build failure on Linux

### DIFF
--- a/src/bun.js/webcore/S3Stat.zig
+++ b/src/bun.js/webcore/S3Stat.zig
@@ -1,5 +1,5 @@
 const bun = @import("../../bun.zig");
-const JSC = @import("../../JSC.zig");
+const JSC = @import("../../jsc.zig");
 
 pub const S3Stat = struct {
     const log = bun.Output.scoped(.S3Stat, false);


### PR DESCRIPTION
Fixes 81fce29fd9a21a4a4b541154067d19390c316ee2

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
should be "jsc.zig", not "JSC.zig". This is case-sensitivity issue on Linux which causes the build error below:
```
Build Summary: 2/5 steps succeeded; 1 failed (disable with --summary none)
obj transitive failure
├─ zig build-obj bun-debug Debug x86_64-linux-gnu.2.27 1 errors
└─ install generated to bun-zig.o transitive failure
   └─ zig build-obj bun-debug Debug x86_64-linux-gnu.2.27 (+2 more reused dependencies)
src/bun.js/webcore/S3Stat.zig:2:21: error: unable to load 'src/JSC.zig': FileNotFound
const JSC = @import("../../JSC.zig");
```
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
