### PR TITLE
Update build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ $ brew install llvm@18
 
 ```bash#Ubuntu/Debian
 $ # LLVM has an automatic installation script that is compatible with all versions of Ubuntu
-$ wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 16 all
+$ wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 18 all
 ```
 
 ```bash#Arch
@@ -71,23 +71,21 @@ $ sudo pacman -S llvm clang lld
 ```
 
 ```bash#Fedora
-$ sudo dnf install 'dnf-command(copr)'
-$ sudo dnf copr enable -y @fedora-llvm-team/llvm17
-$ sudo dnf install llvm16 clang16 lld16-devel
+$ sudo dnf install llvm18 clang18 lld18-devel
 ```
 
 ```bash#openSUSE Tumbleweed
-$ sudo zypper install clang16 lld16 llvm16
+$ sudo zypper install clang18 lld18 llvm18
 ```
 
 {% /codetabs %}
 
-If none of the above solutions apply, you will have to install it [manually](https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.6).
+If none of the above solutions apply, you will have to install it [manually](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.8).
 
 Make sure Clang/LLVM 18 is in your path:
 
 ```bash
-$ which clang-16
+$ which clang-18
 ```
 
 If not, run this to manually add it:
@@ -96,13 +94,13 @@ If not, run this to manually add it:
 
 ```bash#macOS (Homebrew)
 # use fish_add_path if you're using fish
-# use path+="$(brew --prefix llvm@16)/bin" if you are using zsh
-$ export PATH="$(brew --prefix llvm@16)/bin:$PATH"
+# use path+="$(brew --prefix llvm@18)/bin" if you are using zsh
+$ export PATH="$(brew --prefix llvm@18)/bin:$PATH"
 ```
 
 ```bash#Arch
 # use fish_add_path if you're using fish
-$ export PATH="$PATH:/usr/lib/llvm16/bin"
+$ export PATH="$PATH:/usr/lib/llvm18/bin"
 ```
 
 {% /codetabs %}
@@ -240,7 +238,7 @@ The issue may manifest when initially running `bun setup` as Clang being unable 
 ```
 The C++ compiler
 
-  "/usr/bin/clang++-16"
+  "/usr/bin/clang++-18"
 
 is not able to compile a simple test program.
 ```


### PR DESCRIPTION
Fixes 71af1950fbb664dad73cc2ee6df9abd966704bb3

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fixes 71af1950fbb664dad73cc2ee6df9abd966704bb3
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
