### PR TITLE
fix(js): better error messages when makeSafe fails

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -505,6 +505,18 @@
       // Don't pause when the GC runs while the debugger is open.
       "postRunCommands": ["command source '${workspaceFolder}/misctools/lldb/lldb_commands'"],
     },
+    {
+      "type": "bun",
+      "request": "launch",
+      "name": "JS: bun test [file]",
+      "runtime": "${workspaceFolder}/build/debug/bun-debug",
+      "runtimeArgs": ["test"],
+      "program": "${file}",
+      "env": {
+        "BUN_DEBUG_QUIET_LOGS": "1",
+        "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
+      },
+    },
     // Windows: bun test [file]
     {
       "type": "cppvsdbg",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -152,3 +152,4 @@ export const bindgen = $zig("bindgen_test.zig", "getBindgenTestFunctions") as {
 
 export const noOpForTesting = $cpp("NoOpForTesting.cpp", "createNoOpForTesting");
 export const Dequeue = require("internal/fifo");
+export const primordials = require("internal/primordials");

--- a/src/js/internal/primordials.js
+++ b/src/js/internal/primordials.js
@@ -50,7 +50,6 @@ const makeSafe = (unsafe, safe) => {
     let next; // We can reuse the same `next` method.
 
     ArrayPrototypeForEach(Reflect.ownKeys(unsafe.prototype), function makeIterableMethodsSafe(key) {
-      // if (Reflect.hasOwnProperty(safe.prototype, key)) return;
       if (Reflect.getOwnPropertyDescriptor(safe.prototype, key)) return;
 
       const desc = Reflect.getOwnPropertyDescriptor(unsafe.prototype, key);
@@ -58,7 +57,9 @@ const makeSafe = (unsafe, safe) => {
         try {
           var called = desc.value.$call(dummy) || {};
         } catch (e) {
-          const err = new Error(`${unsafe.name}.prototype.${key} thew an error while creating a safe version. This is likely due to prototype pollution.`);
+          const err = new Error(
+            `${unsafe.name}.prototype.${key} thew an error while creating a safe version. This is likely due to prototype pollution.`,
+          );
           Object.assign(err, { unsafe: unsafe.name, safe: safe.name, key, cause: e });
           throw err;
         }

--- a/test/internal/primordials.test.ts
+++ b/test/internal/primordials.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll, afterEach, jest } from "bun:test";
+import { primordials } from "bun:internal-for-testing";
+
+describe("makeSafe(unsafe, safe)", () => {
+  const { makeSafe } = primordials;
+
+  describe("when making a SafeMap", () => {
+    let SafeMap: typeof Map;
+
+    beforeAll(() => {
+      SafeMap = makeSafe(
+        Map,
+        class SafeMap extends Map {
+          constructor(x) {
+            super(x);
+          }
+        },
+      );
+    });
+
+    it("has a prototype with the same properties as the original", () => {
+      expect(SafeMap.prototype).toEqual(expect.objectContaining(Map.prototype));
+    });
+
+    it("has a frozen prototype", () => {
+      const desc = Object.getOwnPropertyDescriptor(SafeMap, "prototype");
+      expect(desc).toBeDefined();
+      expect(desc!.writable).toBeFalse();
+    });
+  }); // </when making a SafeMap>
+
+  describe("given a custom unsafe iterable class", () => {
+    class Unsafe implements Iterable<number> {
+      *[Symbol.iterator]() {
+        yield 1;
+        yield 2;
+        yield 3;
+      }
+      public foo() {
+        throw new Error("foo");
+      }
+    }
+
+    it("when a method throws, a prototype pollution message is thrown", () => {
+      expect(() => makeSafe(Unsafe, class Safe extends Unsafe {})).toThrow(
+        "Unsafe.prototype.foo thew an error while creating a safe version. This is likely due to prototype pollution.",
+      );
+    });
+  }); // </given a custom unsafe iterable class>
+
+  describe("given a custom unsafe non-iterable class", () => {
+    let foo = jest.fn(function foo() {
+      throw new Error("foo");
+    });
+
+    class Unsafe implements Iterable<number> {
+      *[Symbol.iterator]() {
+        yield 1;
+        yield 2;
+        yield 3;
+      }
+      public foo = foo;
+    }
+
+    afterEach(() => {
+      foo.mockClear();
+    });
+
+    it("makeSafe() does not throw", () => {
+      expect(() => makeSafe(Unsafe, class Safe extends Unsafe {})).not.toThrow(
+        "Unsafe.prototype.foo thew an error while creating a safe version. This is likely due to prototype pollution.",
+      );
+    });
+
+    it("Unsafe.foo() is never called()", () => {
+      makeSafe(Unsafe, class Safe extends Unsafe {});
+      expect(foo).not.toHaveBeenCalled();
+    });
+  });
+}); // </makeSafe(unsafe, safe)>


### PR DESCRIPTION
### What does this PR do?
Partial redress of https://github.com/opal/opal/issues/2706. Related to #16259.

`makeSafe` can fail when creating safe iterables if users modify the prototype of `Set` or `Map` before primordials are loaded. This PR adds a better error message for such cases, but does nothing to address the underlying problem. We still need to decide on the best course of action there.

### How did you verify your code works?

I've added tests.
