### PR TITLE
feat(cli/init): new repos use text-based lockfile

### DIFF
--- a/src/cli/init/bunfig.default.toml
+++ b/src/cli/init/bunfig.default.toml
@@ -1,0 +1,6 @@
+# Bun-specific configuration. This file is optional.
+# Docs: https://bun.sh/docs/runtime/bunfig
+
+[install]
+# Use a text-based lockfile instead of a binary one. This will become the default in v1.2
+saveTextLockfile = true

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -65,6 +65,7 @@ pub const InitCommand = struct {
         const @".gitignore" = @embedFile("init/gitignore.default");
         const @"tsconfig.json" = @embedFile("init/tsconfig.default.json");
         const @"README.md" = @embedFile("init/README.default.md");
+        const @"bunfig.toml" = @embedFile("init/bunfig.default.toml");
 
         /// Create a new asset file, overriding anything that already exists. Known
         /// assets will have their contents pre-populated; otherwise the file will be empty.
@@ -321,6 +322,7 @@ pub const InitCommand = struct {
             write_gitignore: bool = true,
             write_package_json: bool = true,
             write_tsconfig: bool = true,
+            write_bunfig: bool = true,
             write_readme: bool = true,
         };
 
@@ -341,6 +343,8 @@ pub const InitCommand = struct {
 
             break :brk true;
         };
+
+        steps.write_bunfig = !existsZ("bunfig.toml");
 
         {
             try fields.object.putString(alloc, "name", fields.name);
@@ -436,6 +440,12 @@ pub const InitCommand = struct {
 
         if (steps.write_gitignore) {
             Assets.create(".gitignore", .{}) catch {
+                // suppressed
+            };
+        }
+
+        if (steps.write_bunfig) {
+            Assets.create("bunfig.toml", .{}) catch {
                 // suppressed
             };
         }

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -37,6 +37,7 @@ test("bun init works", () => {
   expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
   expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
   expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+  expect(fs.existsSync(path.join(temp, "bunfig.toml"))).toBe(true);
 }, 30_000);
 
 test("bun init with piped cli", () => {
@@ -73,4 +74,5 @@ test("bun init with piped cli", () => {
   expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
   expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
   expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+  expect(fs.existsSync(path.join(temp, "bunfig.toml"))).toBe(true);
 }, 30_000);


### PR DESCRIPTION
### What does this PR do?
Repos initialized with `bun init` now get a `bunfig.toml` file that sets `install.saveTextLockfile` to `true`. 

We should probably remove this before the v1.2 release.

### How did you verify your code works?
 I wrote automated tests 