### PR TITLE
fix(test) re-enable autobahn test

### DIFF
--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -10,7 +10,7 @@ function isDockerEnabled(): boolean {
   }
 
   try {
-    const info = child_process.execSync(`${dockerCLI} info`, { stdio: "ignore" });
+    const info = child_process.execSync(`${dockerCLI} info`, { stdio: ["ignore", "pipe", "inherit"] });
     return info.toString().indexOf("Server Version:") !== -1;
   } catch {
     return false;

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -1,11 +1,15 @@
 import { which } from "bun";
 import { afterAll, describe, expect, it } from "bun:test";
 import child_process from "child_process";
-import { tempDirWithFiles } from "harness";
-
+import { tempDirWithFiles, isLinux } from "harness";
 const dockerCLI = which("docker") as string;
 function isDockerEnabled(): boolean {
   if (!dockerCLI) {
+    return false;
+  }
+
+  // TODO: investigate why its not starting on Linux arm64
+  if (isLinux && process.arch === "arm64") {
     return false;
   }
 

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -19,7 +19,7 @@ function isDockerEnabled(): boolean {
 
 if (isDockerEnabled()) {
   describe("autobahn", async () => {
-    const url = "ws://localhost:9001";
+    const url = "ws://localhost:9002";
     const agent = encodeURIComponent("bun/1.0.0");
     let docker: child_process.ChildProcessWithoutNullStreams | null = null;
     const { promise, resolve } = Promise.withResolvers();
@@ -29,7 +29,7 @@ if (isDockerEnabled()) {
     // ],
     const CWD = tempDirWithFiles("autobahn", {
       "fuzzingserver.json": `{
-        "url": "ws://127.0.0.1:9001",
+        "url": "ws://127.0.0.1:9002",
         "outdir": "./",
         "cases": ["*"],
         "exclude-agent-cases": {}
@@ -48,7 +48,7 @@ if (isDockerEnabled()) {
         "-v",
         `${CWD}:/reports`,
         "-p",
-        "9001:9001",
+        "9002:9002",
         "--name",
         "fuzzingserver",
         "crossbario/autobahn-testsuite",


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Test changes

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
