### PR TITLE
feat(cli/bunx): support `--no-install` flag

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1613,6 +1613,7 @@ pub const renamer = @import("./renamer.zig");
 // TODO: Rename to SourceMap as this is a struct.
 pub const sourcemap = @import("./sourcemap/sourcemap.zig");
 
+/// Attempt to coerce some value into a byte slice.
 pub fn asByteSlice(buffer: anytype) []const u8 {
     return switch (@TypeOf(buffer)) {
         []const u8, []u8, [:0]const u8, [:0]u8 => buffer.ptr[0..buffer.len],

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -421,8 +421,8 @@ describe("bunx --no-install", () => {
   it("if the package is not installed, it should fail and print an error message", async () => {
     const [err, out, exited] = await run("--no-install", "http-server", "--version");
 
-    expect(err.trim()).toMatch(
-      /Could not find an existing 'http-server' binary to run. Try running `(bunx|bun x|bun-debug x)` without --no-install.$/,
+    expect(err.trim()).toContain(
+      "Could not find an existing 'http-server' binary to run.",
     );
     expect(out).toHaveLength(0);
     expect(exited).toBe(1);

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { describe, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
 import { rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, tmpdirSync, readdirSorted } from "harness";
 import { readdirSync } from "node:fs";
@@ -83,7 +83,7 @@ it("should choose the tagged versions instead of the PATH versions when a tag is
       cwd: x_dir,
       stdout: "pipe",
       stdin: "ignore",
-      stderr: "inherit",
+      stderr: "ignore",
       env: {
         ...env,
         // BUN_DEBUG_QUIET_LOGS: undefined,
@@ -280,7 +280,7 @@ it("should work for github repository with committish", async () => {
 
   // cached
   const cached = spawn({
-    cmd: [bunExe(), "x", "github:piuccio/cowsay#HEAD", "hello bun!"],
+    cmd: [bunExe(), "x", "--no-install", "github:piuccio/cowsay#HEAD", "hello bun!"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: "inherit",
@@ -395,4 +395,78 @@ it('should set "npm_config_user_agent" to bun', async () => {
   expect(err).not.toContain("error:");
   expect(out.trim()).toContain(`bun/${Bun.version}`);
   expect(exited).toBe(0);
+});
+
+/**
+ * IMPORTANT
+ * Please only use packages with small unpacked sizes for tests. It helps keep them fast.
+ */
+describe("bunx --no-install", () => {
+  const run = (...args: string[]): Promise<[stderr: string, stdout: string, exitCode: number]> => {
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", ...args],
+      cwd: x_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    return Promise.all([
+      new Response(subprocess.stderr).text(),
+      new Response(subprocess.stdout).text(),
+      subprocess.exited,
+    ] as const);
+  };
+
+  it("if the package is not installed, it should fail and print an error message", async () => {
+    const [err, out, exited] = await run("--no-install", "http-server", "--version");
+
+    expect(err.trim()).toMatch(
+      /Could not find an existing 'http-server' binary to run. Try running `(bunx|bun x|bun-debug x)` without --no-install.$/,
+    );
+    expect(out).toHaveLength(0);
+    expect(exited).toBe(1);
+  });
+
+  /*
+    yes, multiple package tests are neccessary.
+      1. there's specialized logic for `bunx tsc` and `bunx typescript`
+      2. http-server checks for non-alphanumeric edge cases. Plus it's small
+      3. eslint is alphanumeric and extremely common
+   */
+  it.each(["typescript", "http-server", "eslint"])("`bunx --no-install %s` should find cached packages", async pkg => {
+    // not cached
+    {
+      const [err, out, code] = await run(pkg, "--version");
+      expect(err).not.toContain("error:");
+      expect(out).not.toBeEmpty();
+      expect(code).toBe(0);
+    }
+
+    // cached
+    {
+      const [err, out, code] = await run("--no-install", pkg, "--version");
+      expect(err).not.toContain("error:");
+      expect(out).not.toBeEmpty();
+      expect(code).toBe(0);
+    }
+  });
+
+  it("when an exact version match is found, should find cached packages", async () => {
+    // not cached
+    {
+      const [err, out, code] = await run("http-server@14.0.0", "--version");
+      expect(err).not.toContain("error:");
+      expect(out).not.toBeEmpty();
+      expect(code).toBe(0);
+    }
+
+    // cached
+    {
+      const [err, out, code] = await run("--no-install", "http-server@14.0.0", "--version");
+      expect(err).not.toContain("error:");
+      expect(out).not.toBeEmpty();
+      expect(code).toBe(0);
+    }
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Closes #16065.

Note that the current implementation has similar limitations to `npx`. Althought matching behavior is "correct" in a strict sense, there are tweaks we could do here for a better developer experience. I'll list them out in an issue, and maybe implement some of them in an downstack pr.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
I wrote automated tests