### PR TITLE
Improve HTMLRewriterTypes.Element.attributes type

### DIFF
--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -50,7 +50,7 @@ declare namespace HTMLRewriterTypes {
 
   interface Element {
     tagName: string;
-    readonly attributes: IterableIterator<string[]>;
+    readonly attributes: IterableIterator<[string, string]>;
     readonly removed: boolean;
     /** Whether the element is explicitly self-closing, e.g. `<foo />` */
     readonly selfClosing: boolean;


### PR DESCRIPTION
Given this code:

```ts
const rewriter = new HTMLRewriter();
rewriter.on("meta", {
  element(el) {
    const props = Object.fromEntries(el.attributes);
  },
});
```

and the bundled types from TS of Object.fromEntries
```ts
interface ObjectConstructor {
    /**
     * Returns an object created by key-value entries for properties and methods
     * @param entries An iterable object that contains key-value entries for properties and methods.
     */
    fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T; };

    /**
     * Returns an object created by key-value entries for properties and methods
     * @param entries An iterable object that contains key-value entries for properties and methods.
     */
    fromEntries(entries: Iterable<readonly any[]>): any;
}
```

The current types give `any`, the new proposed type gives `{ [k: string]: string; }`. 