### PR TITLE
Probably reduce memory usage of JSON IPC

### DIFF
--- a/src/baby_list.zig
+++ b/src/baby_list.zig
@@ -338,9 +338,13 @@ pub fn BabyList(comptime Type: type) type {
             if (comptime Type != u8)
                 @compileError("Unsupported for type " ++ @typeName(Type));
             const initial = this.len;
-            const old = this.listManaged(allocator);
-            const new = try strings.allocateLatin1IntoUTF8WithList(old, old.items.len, []const u8, str);
-            this.update(new);
+            var list_ = this.listManaged(allocator);
+
+            {
+                defer this.update(list_);
+                try strings.allocateLatin1IntoUTF8WithList(&list_, list_.items.len, []const u8, str);
+            }
+
             return this.len - initial;
         }
 

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -484,10 +484,12 @@ pub const ZigString = extern struct {
             return try allocator.dupeZ(u8, this.slice());
 
         var list = std.ArrayList(u8).init(allocator);
-        list = if (this.is16Bit())
-            try strings.toUTF8ListWithType(list, []const u16, this.utf16SliceAligned())
+        errdefer list.deinit();
+
+        if (this.is16Bit())
+            try strings.toUTF8ListWithType(&list, []const u16, this.utf16SliceAligned())
         else
-            try strings.allocateLatin1IntoUTF8WithList(list, 0, []const u8, this.slice());
+            try strings.allocateLatin1IntoUTF8WithList(&list, 0, []const u8, this.slice());
 
         if (list.capacity > list.items.len) {
             list.items.ptr[list.items.len] = 0;
@@ -501,10 +503,12 @@ pub const ZigString = extern struct {
             return allocator.dupeZ(u8, this.slice());
 
         var list = std.ArrayList(u8).init(allocator);
-        list = if (this.is16Bit())
-            try strings.toUTF8ListWithType(list, []const u16, this.utf16SliceAligned())
+        errdefer list.deinit();
+
+        if (this.is16Bit())
+            try strings.toUTF8ListWithType(&list, []const u16, this.utf16SliceAligned())
         else
-            try strings.allocateLatin1IntoUTF8WithList(list, 0, []const u8, this.slice());
+            try strings.allocateLatin1IntoUTF8WithList(&list, 0, []const u8, this.slice());
 
         try list.append(0);
         return list.items[0 .. list.items.len - 1 :0];

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -1053,6 +1053,10 @@ pub const StreamBuffer = struct {
         return this.size() > 0;
     }
 
+    pub fn writeString(this: *StreamBuffer, str: bun.String) !void {
+        try str.writeUTF8Into(&this.list);
+    }
+
     pub fn write(this: *StreamBuffer, buffer: []const u8) !void {
         _ = try this.list.appendSlice(buffer);
     }

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -358,11 +358,12 @@ pub const Archiver = struct {
                     if (comptime ContextType != void and @hasDecl(std.meta.Child(ContextType), "onFirstDirectoryName")) {
                         if (appender.needs_first_dirname) {
                             if (comptime Environment.isWindows) {
-                                const list = std.ArrayList(u8).init(default_allocator);
-                                var result = try strings.toUTF8ListWithType(list, []const u16, pathname[0..pathname.len]);
+                                var list = std.ArrayList(u8).init(default_allocator);
+                                defer list.deinit();
+                                try strings.toUTF8ListWithType(&list, []const u16, pathname[0..pathname.len]);
                                 // onFirstDirectoryName copies the contents of pathname to another buffer, safe to free
-                                defer result.deinit();
-                                appender.onFirstDirectoryName(strings.withoutTrailingSlash(result.items));
+
+                                appender.onFirstDirectoryName(strings.withoutTrailingSlash(list.items));
                             } else {
                                 appender.onFirstDirectoryName(strings.withoutTrailingSlash(bun.asByteSlice(pathname)));
                             }

--- a/src/string.zig
+++ b/src/string.zig
@@ -961,6 +961,23 @@ pub const String = extern struct {
         }
     }
 
+    pub fn writeUTF8Into(this: String, out: *std.ArrayList(u8)) !void {
+        if (this.isEmpty())
+            return;
+
+        if (this.isUTF8()) {
+            try out.appendSlice(this.utf8());
+            return;
+        }
+
+        if (this.is8Bit()) {
+            try bun.strings.allocateLatin1IntoUTF8WithList(out, out.items.len, []const u8, this.latin1());
+            return;
+        }
+
+        try bun.strings.toUTF8AppendToList(out, this.utf16());
+    }
+
     pub fn toUTF8(this: String, allocator: std.mem.Allocator) ZigString.Slice {
         if (this.tag == .WTFStringImpl) {
             return this.value.WTFStringImpl.toUTF8(allocator);

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -2249,7 +2249,9 @@ pub fn allocateLatin1IntoUTF8(allocator: std.mem.Allocator, comptime Type: type,
     var list = try std.ArrayList(u8).initCapacity(allocator, latin1_.len);
     errdefer list.deinit();
     try allocateLatin1IntoUTF8WithList(&list, 0, Type, latin1_);
-    if (list.items.len + 64 < list.capacity) {
+
+    // Large reallocations are expensive and may cause more heap fragmentation.
+    if (list.items.len > 64 and list.items.len + 64 > list.capacity) {
         return list.items;
     }
 

--- a/test/js/bun/spawn/bun-ipc-child.js
+++ b/test/js/bun/spawn/bun-ipc-child.js
@@ -1,1 +1,1 @@
-process.send("hello");
+process.send(process.argv.at(-1));

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -3,38 +3,49 @@ import { describe, expect, it } from "bun:test";
 import { bunExe, gcTick } from "harness";
 import path from "path";
 
-describe.each(["advanced", "json"])("ipc mode %s", mode => {
-  it("the subprocess should be defined and the child should send", done => {
-    gcTick();
-    const returned_subprocess = spawn([bunExe(), path.join(__dirname, "bun-ipc-child.js")], {
-      ipc: (message, subProcess) => {
-        expect(subProcess).toBe(returned_subprocess);
-        expect(message).toBe("hello");
-        subProcess.kill();
-        done();
+const messages = [
+  "ASCII",
+  // latin1
+  String.fromCharCode(...("Copyright " + String.fromCharCode(0x00a9) + " 2025").split("").map(a => a.charCodeAt(0))),
+  // UTF-16
+  "🌟 Hello from the emoji! ✨",
+];
+
+for (const message of messages) {
+  describe(JSON.stringify(message), () => {
+    describe.each(["advanced", "json"])("ipc mode %s", mode => {
+      it("the subprocess should be defined and the child should send", done => {
         gcTick();
-      },
-      stdio: ["inherit", "inherit", "inherit"],
-      serialization: mode,
+        const returned_subprocess = spawn([bunExe(), path.join(__dirname, "bun-ipc-child.js"), message], {
+          ipc: (reply, subProcess) => {
+            expect(subProcess).toBe(returned_subprocess);
+            expect(reply).toBe(message);
+            subProcess.kill();
+            done();
+            gcTick();
+          },
+          stdio: ["inherit", "inherit", "inherit"],
+          serialization: mode,
+        });
+      });
+
+      it("the subprocess should receive the parent message and respond back", done => {
+        gcTick();
+
+        const childProc = spawn([bunExe(), path.join(__dirname, "bun-ipc-child-respond.js")], {
+          ipc: (reply, subProcess) => {
+            expect(reply).toBe(`pong:${message}`);
+            subProcess.kill();
+            done();
+            gcTick();
+          },
+          stdio: ["inherit", "inherit", "inherit"],
+          serialization: mode,
+        });
+
+        childProc.send(message);
+        gcTick();
+      });
     });
   });
-
-  it("the subprocess should receive the parent message and respond back", done => {
-    gcTick();
-
-    const parentMessage = "I am your father";
-    const childProc = spawn([bunExe(), path.join(__dirname, "bun-ipc-child-respond.js")], {
-      ipc: (message, subProcess) => {
-        expect(message).toBe(`pong:${parentMessage}`);
-        subProcess.kill();
-        done();
-        gcTick();
-      },
-      stdio: ["inherit", "inherit", "inherit"],
-      serialization: mode,
-    });
-
-    childProc.send(parentMessage);
-    gcTick();
-  });
-});
+}


### PR DESCRIPTION
### What does this PR do?

Previously, we often cloned JSON strings an extra time over IPC. 

Before merging, need to verify this does in fact reduce memory usage because currently this is just an educated guess

### How did you verify your code works?

Added a test that roundtrip encodes & decodes latin1, ascii and utf-16 for IPC