### PR TITLE
Unify syntax highlighting and ouput for `--help`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2614,7 +2614,7 @@ pub const Command = struct {
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/test<r>
                         \\
                     ;
-                    // Output.pretty("\n", .{});
+
                     Output.pretty(intro_text, .{});
                     Output.flush();
                     Output.pretty("\n\n<b>Flags:<r>", .{});

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2503,6 +2503,11 @@ pub const Command = struct {
         pub fn printHelp(comptime cmd: Tag, show_all_flags: bool) void {
             switch (cmd) {
 
+                // the output of --help uses the following syntax highlighting
+                // template: <b>Usage<r>: <b><green>bun <command><r> <cyan>[flags]<r> <blue>[arguments]<r>
+                // use [foo] for multiple arguments or flags for foo.
+                // use <bar> to emphasize 'bar'
+
                 // these commands do not use Context
                 // .DiscordCommand => return try DiscordCommand.exec(allocator),
                 // .HelpCommand => return try HelpCommand.exec(allocator),
@@ -2527,7 +2532,7 @@ pub const Command = struct {
 
                 .InitCommand => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun init<r> <cyan>[...flags]<r> <blue>[\<entrypoint\> ...]<r>
+                        \\<b>Usage<r>: <b><green>bun init<r> <cyan>[flags]<r> <blue>[\<entrypoints\>]<r>
                         \\  Initialize a Bun project in the current directory.
                         \\  Creates a package.json, tsconfig.json, and bunfig.toml if they don't exist.
                         \\
@@ -2537,7 +2542,7 @@ pub const Command = struct {
                         \\
                         \\<b>Examples:<r>
                         \\  <b><green>bun init<r>
-                        \\  <b><green>bun init <cyan>--yes<r>
+                        \\  <b><green>bun init<r> <cyan>--yes<r>
                     ;
 
                     Output.pretty(intro_text ++ "\n", .{});
@@ -2546,16 +2551,16 @@ pub const Command = struct {
 
                 Command.Tag.BunxCommand => {
                     Output.prettyErrorln(
-                        \\<b>Usage: bunx <r><cyan>[...flags]<r> \<package\><d>[@version] [...flags and arguments]<r>
+                        \\<b>Usage<r>: <b><green>bunx<r> <cyan>[flags]<r> <blue>\<package\><r><d>\<@version\><r> [flags and arguments for the package]<r>
                         \\Execute an npm package executable (CLI), automatically installing into a global shared cache if not installed in node_modules.
                         \\
                         \\Flags:
                         \\  <cyan>--bun<r>      Force the command to run with Bun instead of Node.js
                         \\
                         \\Examples<d>:<r>
-                        \\  <b>bunx prisma migrate<r>
-                        \\  <b>bunx prettier foo.js<r>
-                        \\  <b>bunx<r> <cyan>--bun<r> <b>vite dev foo.js<r>
+                        \\  <b><green>bunx<r> <blue>prisma<r> migrate<r>
+                        \\  <b><green>bunx<r> <blue>prettier<r> foo.js<r>
+                        \\  <b><green>bunx<r> <cyan>--bun<r> <blue>vite<r> dev foo.js<r>
                         \\
                     , .{});
                 },
@@ -2563,20 +2568,20 @@ pub const Command = struct {
                     const intro_text =
                         \\<b>Usage<r>:
                         \\  Transpile and bundle one or more files.
-                        \\  <b><green>bun build<r> <cyan>[...flags]<r> [...entrypoints]
+                        \\  <b><green>bun build<r> <cyan>[flags]<r> <blue>\<entrypoint\><r>
                     ;
 
                     const outro_text =
                         \\<b>Examples:<r>
                         \\  <d>Frontend web apps:<r>
-                        \\  <b><green>bun build<r> <blue>./src/index.ts<r> <cyan>--outfile=bundle.js<r>
-                        \\  <b><green>bun build<r> <blue>./index.jsx ./lib/worker.ts<r> <cyan>--minify --splitting --outdir=out<r>
+                        \\  <b><green>bun build<r> <cyan>--outfile=bundle.js<r> <blue>./src/index.ts<r>
+                        \\  <b><green>bun build<r> <cyan>--minify --splitting --outdir=out<r> <blue>./index.jsx ./lib/worker.ts<r>
                         \\
                         \\  <d>Bundle code to be run in Bun (reduces server startup time)<r>
-                        \\  <b><green>bun build<r> <blue>./server.ts<r> <cyan>--target=bun --outfile=server.js<r>
+                        \\  <b><green>bun build<r> <cyan>--target=bun --outfile=server.js<r> <blue>./server.ts<r>
                         \\
                         \\  <d>Creating a standalone executable (see https://bun.sh/docs/bundler/executables)<r>
-                        \\  <b><green>bun build<r> <blue>./cli.ts<r> <cyan>--compile --outfile=my-app<r>
+                        \\  <b><green>bun build<r> <cyan>--compile --outfile=my-app<r> <blue>./cli.ts<r>
                         \\
                         \\A full list of flags is available at <magenta>https://bun.sh/docs/bundler<r>
                         \\
@@ -2592,19 +2597,19 @@ pub const Command = struct {
                 },
                 Command.Tag.TestCommand => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun test<r> <cyan>[...flags]<r> <blue>[\<pattern\>...]<r>
+                        \\<b>Usage<r>: <b><green>bun test<r> <cyan>[flags]<r> <blue>[\<patterns\>]<r>
                         \\  Run all matching test files and print the results to stdout
                     ;
                     const outro_text =
                         \\<b>Examples:<r>
-                        \\  <d>Run all test files <r>
+                        \\  <d>Run all test files<r>
                         \\  <b><green>bun test<r>
                         \\
                         \\  <d>Run all test files with "foo" or "bar" in the file name<r>
-                        \\  <b><green>bun test foo bar<r>
+                        \\  <b><green>bun test<r> <blue>foo bar<r>
                         \\
                         \\  <d>Run all test files, only including tests whose names includes "baz"<r>
-                        \\  <b><green>bun test<r> <cyan>--test-name-pattern<r> baz<r>
+                        \\  <b><green>bun test<r> <cyan>--test-name-pattern<r> <blue>baz<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/test<r>
                         \\
@@ -2622,8 +2627,8 @@ pub const Command = struct {
                 Command.Tag.CreateCommand => {
                     const intro_text =
                         \\<b>Usage<r>:
-                        \\  <b><green>bun create<r> <blue>\<template\><r> <cyan>[...flags]<r> <blue>[dest]<r>
-                        \\  <b><green>bun create<r> <blue>\<username/repo\><r> <cyan>[...flags]<r> <blue>[dest]<r>
+                        \\  <b><green>bun create<r> <magenta>\<template\><r> <cyan>[...flags]<r> <blue>dest<r>
+                        \\  <b><green>bun create<r> <magenta>\<username/repo\><r> <cyan>[...flags]<r> <blue>dest<r>
                         \\
                         \\<b>Environment variables:<r>
                         \\  <cyan>GITHUB_TOKEN<r>             <d>Supply a token to download code from GitHub with a higher rate limit<r>
@@ -2649,7 +2654,7 @@ pub const Command = struct {
                 },
                 Command.Tag.UpgradeCommand => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun upgrade<r> <cyan>[...flags]<r>
+                        \\<b>Usage<r>: <b><green>bun upgrade<r> <cyan>[flags]<r>
                         \\  Upgrade Bun
                     ;
                     const outro_text =
@@ -2677,7 +2682,7 @@ pub const Command = struct {
                 },
                 Command.Tag.ReplCommand => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun repl<r> <cyan>[...flags]<r>
+                        \\<b>Usage<r>: <b><green>bun repl<r> <cyan>[flags]<r>
                         \\  Open a Bun REPL
                         \\
                     ;

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -102,33 +102,49 @@ pub const PackageManagerCommand = struct {
     }
 
     pub fn printHelp() void {
-        Output.prettyln(
-            \\<b><blue>bun pm<r>: Package manager utilities
+
+        // the output of --help uses the following syntax highlighting
+        // template: <b>Usage<r>: <b><green>bun <command><r> <cyan>[flags]<r> <blue>[arguments]<r>
+        // use [foo] for multiple arguments or flags for foo.
+        // use <bar> to emphasize 'bar'
+
+        const intro_text =
+            \\<b>Usage<r>: <b><green>bun pm<r> <cyan>[flags]<r> <blue>[\<command\>]<r>
+            \\  Run package manager utilities
+        ;
+        const outro_text =
+            \\<b>Examples:<r>
             \\
-            \\  bun pm <b>pack<r>               create a tarball of the current workspace
-            \\  <d>├<r>  <cyan>--dry-run<r>              do everything except for writing the tarball to disk
-            \\  <d>├<r>  <cyan>--destination<r>          the directory the tarball will be saved in
-            \\  <d>├<r>  <cyan>--ignore-scripts<r>       don't run pre/postpack and prepare scripts
-            \\  <d>└<r>  <cyan>--gzip-level<r>           specify a custom compression level for gzip (0-9, default is 9)
-            \\  bun pm <b>bin<r>                print the path to bin folder
-            \\  <d>└<r>  <cyan>-g<r>                     print the <b>global<r> path to bin folder
-            \\  bun pm <b>ls<r>                 list the dependency tree according to the current lockfile
-            \\  <d>└<r>  <cyan>--all<r>                  list the entire dependency tree according to the current lockfile
-            \\  bun pm <b>whoami<r>             print the current npm username
-            \\  bun pm <b>hash<r>               generate & print the hash of the current lockfile
-            \\  bun pm <b>hash-string<r>        print the string used to hash the lockfile
-            \\  bun pm <b>hash-print<r>         print the hash stored in the current lockfile
-            \\  bun pm <b>cache<r>              print the path to the cache folder
-            \\  bun pm <b>cache rm<r>           clear the cache
-            \\  bun pm <b>migrate<r>            migrate another package manager's lockfile without installing anything
-            \\  bun pm <b>untrusted<r>          print current untrusted dependencies with scripts
-            \\  bun pm <b>trust<r> <d>names ...<r>    run scripts for untrusted dependencies and add to `trustedDependencies`
+            \\  <b><green>bun pm<r> <blue>pack<r>               create a tarball of the current workspace
+            \\  <d>├<r> <cyan>--dry-run<r>               do everything except for writing the tarball to disk
+            \\  <d>├<r> <cyan>--destination<r>           the directory the tarball will be saved in
+            \\  <d>├<r> <cyan>--ignore-scripts<r>        don't run pre/postpack and prepare scripts
+            \\  <d>└<r> <cyan>--gzip-level<r>            specify a custom compression level for gzip (0-9, default is 9)
+            \\  <b><green>bun pm<r> <blue>bin<r>                print the path to bin folder
+            \\  <d>└<r> <cyan>-g<r>                      print the <b>global<r> path to bin folder
+            \\  <b><green>bun pm<r> <blue>ls<r>                 list the dependency tree according to the current lockfile
+            \\  <d>└<r> <cyan>--all<r>                   list the entire dependency tree according to the current lockfile
+            \\  <b><green>bun pm<r> <blue>whoami<r>             print the current npm username
+            \\  <b><green>bun pm<r> <blue>hash<r>               generate & print the hash of the current lockfile
+            \\  <b><green>bun pm<r> <blue>hash-string<r>        print the string used to hash the lockfile
+            \\  <b><green>bun pm<r> <blue>hash-print<r>         print the hash stored in the current lockfile
+            \\  <b><green>bun pm<r> <blue>cache<r>              print the path to the cache folder
+            \\  <b><green>bun pm<r> <blue>cache rm<r>           clear the cache
+            \\  <b><green>bun pm<r> <blue>migrate<r>            migrate another package manager's lockfile without installing anything
+            \\  <b><green>bun pm<r> <blue>untrusted<r>          print current untrusted dependencies with scripts
+            \\  <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>    run scripts for untrusted dependencies and add to `trustedDependencies`
             \\  <d>└<r>  <cyan>--all<r>                  trust all untrusted dependencies
-            \\  bun pm <b>default-trusted<r>    print the default trusted dependencies list
+            \\  <b><green>bun pm<r> <blue>default-trusted<r>    print the default trusted dependencies list
             \\
             \\Learn more about these at <magenta>https://bun.sh/docs/cli/pm<r>
             \\
-        , .{});
+        ;
+
+        Output.pretty(intro_text, .{});
+        Output.flush();
+        Output.pretty("\n\n", .{});
+        Output.pretty(outro_text, .{});
+        Output.flush();
     }
 
     pub fn exec(ctx: Command.Context) !void {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9748,12 +9748,18 @@ pub const PackageManager = struct {
         };
 
         pub fn printHelp(subcommand: Subcommand) void {
+
+            // the output of --help uses the following syntax highlighting
+            // template: <b>Usage<r>: <b><green>bun <command><r> <cyan>[flags]<r> <blue>[arguments]<r>
+            // use [foo] for multiple arguments or flags for foo.
+            // use <bar> to emphasize 'bar'
+
             switch (subcommand) {
                 // fall back to HelpCommand.printWithReason
                 Subcommand.install => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun install<r> <cyan>[flags]<r> [...\<pkg\>]
-                        \\<b>Alias: <b>bun i<r>
+                        \\<b>Usage<r>: <b><green>bun install<r> <cyan>[flags]<r> <blue>\<name\><r><d>@\<version\><r>
+                        \\<b>Alias: <b><green>bun i<r>
                         \\  Install the dependencies listed in package.json
                     ;
                     const outro_text =
@@ -9762,7 +9768,7 @@ pub const PackageManager = struct {
                         \\  <b><green>bun install<r>
                         \\
                         \\  <d>Skip devDependencies<r>
-                        \\  <b><green>bun install --production<r>
+                        \\  <b><green>bun install<r> <cyan>--production<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/install<r>
                     ;
@@ -9776,7 +9782,7 @@ pub const PackageManager = struct {
                 },
                 Subcommand.update => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun update<r> <cyan>[flags]<r>
+                        \\<b>Usage<r>: <b><green>bun update<r> <cyan>[flags]<r> <blue>\<name\><r><d>@\<version\><r>
                         \\  Update all dependencies to most recent versions within the version range in package.json
                         \\
                     ;
@@ -9786,10 +9792,10 @@ pub const PackageManager = struct {
                         \\  <b><green>bun update<r>
                         \\
                         \\  <d>Update all dependencies to latest:<r>
-                        \\  <b><green>bun update --latest<r>
+                        \\  <b><green>bun update<r> <cyan>--latest<r>
                         \\
                         \\  <d>Update specific packages:<r>
-                        \\  <b><green>bun update zod jquery@3<r>
+                        \\  <b><green>bun update<r> <blue>zod jquery@3<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/update<r>
                     ;
@@ -9803,7 +9809,7 @@ pub const PackageManager = struct {
                 },
                 Subcommand.patch => {
                     const intro_text =
-                        \\<b>Usage: bun patch <r><cyan>\<name\>@\<version\><r>
+                        \\<b>Usage<r>: <b><green>bun patch<r> <cyan>[flags or options]<r> <blue>\<package\><r><d>@\<version\><r>
                         \\
                         \\Prepare a package for patching.
                         \\
@@ -9815,11 +9821,12 @@ pub const PackageManager = struct {
                     Output.flush();
                     clap.simpleHelp(PackageManager.patch_params);
                     // Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+                    Output.pretty("\n", .{});
                     Output.flush();
                 },
                 Subcommand.@"patch-commit" => {
                     const intro_text =
-                        \\<b>Usage: bun patch-commit <r><cyan>\<directory\><r>
+                        \\<b>Usage<r>: <b><green>bun patch-commit<r> <cyan>[flags or options]<r> <blue>\<directory\><r>
                         \\
                         \\Generate a patc out of a directory and save it.
                         \\
@@ -9840,6 +9847,7 @@ pub const PackageManager = struct {
                     Output.flush();
                     clap.simpleHelp(PackageManager.patch_params);
                     // Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+                    Output.pretty("\n", .{});
                     Output.flush();
                 },
                 Subcommand.pm => {
@@ -9847,20 +9855,20 @@ pub const PackageManager = struct {
                 },
                 Subcommand.add => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun add<r> <cyan>[flags]<r> \<pkg\> [...\<pkg\>]
-                        \\<b>Alias: <b>bun a<r>
+                        \\<b>Usage<r>: <b><green>bun add<r> <cyan>[flags]<r> <blue>\<package\><r><d>\<@version\><r>
+                        \\<b>Alias: <b><green>bun a<r>
                     ;
                     const outro_text =
                         \\<b>Examples:<r>
                         \\  <d>Add a dependency from the npm registry<r>
-                        \\  <b><green>bun add zod<r>
-                        \\  <b><green>bun add zod@next<r>
-                        \\  <b><green>bun add zod@3.0.0<r>
+                        \\  <b><green>bun add<r> <blue>zod<r>
+                        \\  <b><green>bun add<r> <blue>zod@next<r>
+                        \\  <b><green>bun add<r> <blue>zod@3.0.0<r>
                         \\
                         \\  <d>Add a dev, optional, or peer dependency <r>
-                        \\  <b><green>bun add -d typescript<r>
-                        \\  <b><green>bun add --optional lodash<r>
-                        \\  <b><green>bun add --peer esbuild<r>
+                        \\  <b><green>bun add<r> <cyan>-d<r> <blue>typescript<r>
+                        \\  <b><green>bun add<r> <cyan>--optional<r> <blue>lodash<r>
+                        \\  <b><green>bun add<r> <cyan>--peer<r> <blue>esbuild<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/add<r>
                     ;
@@ -9874,7 +9882,7 @@ pub const PackageManager = struct {
                 },
                 Subcommand.remove => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun remove<r> <cyan>[flags]<r> \<pkg\> [...\<pkg\>]
+                        \\<b>Usage<r>: <b><green>bun remove<r> <cyan>[flags]<r> <blue>[\<packages\>]<r>
                         \\<b>Alias: <b>bun r<r>
                         \\  Remove a package from package.json and uninstall from node_modules
                         \\
@@ -9882,7 +9890,7 @@ pub const PackageManager = struct {
                     const outro_text =
                         \\<b>Examples:<r>
                         \\  <d>Remove a dependency<r>
-                        \\  <b><green>bun remove ts-node<r>
+                        \\  <b><green>bun remove<r> <blue>ts-node<r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/remove<r>
                     ;
@@ -9896,7 +9904,7 @@ pub const PackageManager = struct {
                 },
                 Subcommand.link => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun link<r> <cyan>[flags]<r> [\<package\>]
+                        \\<b>Usage<r>: <b><green>bun link<r> <cyan>[flags]<r> <blue>[\<packages\>]<r>
                         \\
                     ;
                     const outro_text =
@@ -9906,7 +9914,7 @@ pub const PackageManager = struct {
                         \\  <b><green>bun link<r>
                         \\
                         \\  <d>Add a previously-registered linkable package as a dependency of the current project.<r>
-                        \\  <b><green>bun link \<package\><r>
+                        \\  <b><green>bun link<r> <blue>\<package\><r>
                         \\
                         \\Full documentation is available at <magenta>https://bun.sh/docs/cli/link<r>
                     ;
@@ -9941,7 +9949,7 @@ pub const PackageManager = struct {
                 },
                 .outdated => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun outdated<r> <cyan>[flags]<r>
+                        \\<b>Usage<r>: <b><green>bun outdated<r> <cyan>[flags]<r> <blue>[filter]<r>
                     ;
 
                     const outro_text =
@@ -9950,14 +9958,14 @@ pub const PackageManager = struct {
                         \\  <b><green>bun outdated<r>
                         \\
                         \\  <d>Use --filter to include more than one workspace.<r>
-                        \\  <b><green>bun outdated --filter="*"<r>
-                        \\  <b><green>bun outdated --filter="./app/*"<r>
-                        \\  <b><green>bun outdated --filter="!frontend"<r>
+                        \\  <b><green>bun outdated<r> <cyan>--filter="*"<r>
+                        \\  <b><green>bun outdated<r> <cyan>--filter="./app/*"<r>
+                        \\  <b><green>bun outdated<r> <cyan>--filter="!frontend"<r>
                         \\
                         \\  <d>Filter dependencies with name patterns.<r>
-                        \\  <b><green>bun outdated jquery<r>
-                        \\  <b><green>bun outdated "is-*"<r>
-                        \\  <b><green>bun outdated "!is-even"<r>
+                        \\  <b><green>bun outdated<r> <blue>jquery<r>
+                        \\  <b><green>bun outdated<r> <blue>"is-*"<r>
+                        \\  <b><green>bun outdated<r> <blue>"!is-even"<r>
                         \\
                     ;
 
@@ -9988,19 +9996,19 @@ pub const PackageManager = struct {
                 },
                 .publish => {
                     const intro_text =
-                        \\<b>Usage<r>: <b><green>bun publish<r> <cyan>[flags]<r>
+                        \\<b>Usage<r>: <b><green>bun publish<r> <cyan>[flags]<r> <blue>[dist]<r>
                     ;
 
                     const outro_text =
                         \\<b>Examples:<r>
                         \\  <d>Display files that would be published, without publishing to the registry.<r>
-                        \\  <b><green>bun publish --dry-run<r>
+                        \\  <b><green>bun publish<r> <cyan>--dry-run<r>
                         \\
                         \\  <d>Publish the current package with public access.<r>
-                        \\  <b><green>bun publish --access public<r>
+                        \\  <b><green>bun publish<r> <cyan>--access public<r>
                         \\
                         \\  <d>Publish a pre-existing package tarball with tag 'next'.<r>
-                        \\  <b><green>bun publish ./path/to/tarball.tgz --tag next<r>
+                        \\  <b><green>bun publish<r> <cyan>--tag next<r> <blue>./path/to/tarball.tgz<r>
                         \\
                     ;
 


### PR DESCRIPTION
### What does this PR do?

Now all `--help` message follow these rules

- the output of --help uses the following syntax highlighting
- template: `<b>Usage<r>: <b><green>bun <command><r> <cyan>[flags]<r> <blue>[arguments]<r>`
- use [foo] for multiple arguments or flags for foo.
- use <bar> to emphasize 'bar'

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
