### PR TITLE
docs(bun-lambda): Use sparse checkout to make it possible to run the command in AWS CloudShell environment

### DIFF
--- a/packages/bun-lambda/README.md
+++ b/packages/bun-lambda/README.md
@@ -7,7 +7,8 @@ A custom runtime layer that runs Bun on AWS Lambda.
 First, you will need to deploy the layer to your AWS account. Clone this repository and run the `publish-layer` script to get started. Note: the `publish-layer` script also builds the layer.
 
 ```sh
-git clone git@github.com:oven-sh/bun.git
+git clone --filter=blob:none --sparse https://github.com/oven-sh/bun.git
+git -C bun sparse-checkout set packages/bun-lambda
 cd bun/packages/bun-lambda
 bun install
 bun run publish-layer


### PR DESCRIPTION
### What does this PR do?

AWS CloudShell comes with only 1 GB of storage space, which is not enough to clone the Bun repo. Doing so would give an error: "No space left on device."

This PR changes the instructions to use Sparse Checkout instead.

Bonus tip: As CloudShell is not available in some regions, if you want to push to a different AWS region, run this command before publishing the layer:

```sh
# Example: Switch to ap-southeast-7
aws configure set region ap-southeast-7
```

### How did you verify your code works?

I tested it in my CloudShell.