### PR TITLE
Update nextjs.md for proper build command

### DIFF
--- a/docs/guides/ecosystem/nextjs.md
+++ b/docs/guides/ecosystem/nextjs.md
@@ -27,6 +27,15 @@ $ bun create next-app --example with-supabase
 
 ---
 
+To build a project with Bun, run `bun run build` from the project root.
+
+```sh
+$ cd my-app
+$ bun run build
+```
+
+---
+
 To start the dev server with Bun, run `bun --bun run dev` from the project root.
 
 ```sh


### PR DESCRIPTION
This pull request includes a change to the `docs/guides/ecosystem/nextjs.md` file to add instructions for building a project with Bun.

### Documentation update:

* [`docs/guides/ecosystem/nextjs.md`](diffhunk://#diff-aab0c778a60b8cef1d760a2004128d006915488d93f8b9f072a04ca8a0279e60R30-R38): Added a new section with instructions on how to build a project using Bun by running `bun run build` from the project root.

Given that to start the dev server you needed the `--bun` flag inside the `bun --bun run dev` command to utilize only Bun and not Node for runtime, I naturally thought the build process would follow a similar command pattern, such as `bun --bun run build`. However, that command introduced the following linting error:

```
Linting and checking the validity of types  .. ⨯ ESLint: Cannot read config file: /Users/geowhale/Desktop/dev-archive/miniqtrade/miniqt-fe/node_modules/eslint-config-next/core-web-vitals.js Error: parent.require is not a function. (In 'parent.require(filePath)', 'parent.require' is undefined) Referenced from
```

Therefore, I believe it is necessary to specifically point out that to build a project with Bun it should simply be `bun run build`. Running `bun run build` works great and passes through the linting checks during the build process.