### PR TITLE
feat(sql) transactions, savepoints, connection pooling and reserve

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1997,6 +1997,19 @@ declare module "bun" {
   };
   /**
    * Configuration options for SQL client connection and behavior
+   *  @example
+   * const config: SQLOptions = {
+   *   host: 'localhost',
+   *   port: 5432,
+   *   user: 'dbuser',
+   *   password: 'secretpass',
+   *   database: 'myapp',
+   *   idleTimeout: 30000,
+   *   max: 20,
+   *   onconnect: (client) => {
+   *     console.log('Connected to database');
+   *   }
+   * };
    */
   type SQLOptions = {
     /** Connection URL (can be string or URL object) */
@@ -2235,7 +2248,8 @@ declare module "bun" {
      * Also know as Two-Phase Commit, in a distributed transaction, Phase 1 involves the coordinator preparing nodes by ensuring data is written and ready to commit, while Phase 2 finalizes with nodes committing or rolling back based on the coordinator's decision, ensuring durability and releasing locks.
      * In PostgreSQL and MySQL distributed transactions persist beyond the original session, allowing privileged users or coordinators to commit/rollback them, ensuring support for distributed transactions, recovery, and administrative tasks.
      * beginDistributed will automatic rollback if any exception are not caught, and you can commit and rollback later if everything goes well.
-     * PostgreSQL natively supports distributed transactions using PREPARE TRANSACTION, while MySQL uses XA Transactions, and MSSQL also supports distributed/XA transactions. However, in MSSQL, distributed transactions are tied to the original session, the DTC coordinator, and the specific connection. These transactions are automatically committed or rolled back following the same rules as regular transactions, with no option for manual intervention from other sessions, in MSSQL distributed transactions are used to coordinate transactions using Linked Servers.
+     * PostgreSQL natively supports distributed transactions using PREPARE TRANSACTION, while MySQL uses XA Transactions, and MSSQL also supports distributed/XA transactions. However, in MSSQL, distributed transactions are tied to the original session, the DTC coordinator, and the specific connection.
+     * These transactions are automatically committed or rolled back following the same rules as regular transactions, with no option for manual intervention from other sessions, in MSSQL distributed transactions are used to coordinate transactions using Linked Servers.
      * @example
      * await sql.beginDistributed("numbers", async sql => {
      *   await sql`create table if not exists numbers (a int)`;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1995,6 +1995,62 @@ declare module "bun" {
      */
     stat(path: string, options?: S3Options): Promise<S3Stats>;
   };
+  type SQLOptions = {
+    host: string;
+    port: number;
+    user: string;
+    password: string;
+    database: string;
+    url: URL | string;
+    adapter: string;
+    idleTimeout: number;
+    connectionTimeout: number;
+    maxLifetime: number;
+    max_lifetime: number;
+    connection_timeout: number;
+    idle_timeout: number;
+    tls: boolean;
+    onconnect: (client: SQLClient) => void;
+    onclose: (client: SQLClient) => void;
+    max: number;
+  };
+  interface SQLQuery extends Promise<any> {
+    active: boolean;
+    cancelled: boolean;
+    cancel(): SQLQuery;
+    execute(): SQLQuery;
+    raw(): SQLQuery;
+    values(): SQLQuery;
+  }
+
+  type SQLContextCallback = (sql: (strings: string, ...values: any[]) => SQLQuery | Array<SQLQuery>) => Promise<any>;
+
+  type SQLClient = {
+    new (options?: SQLOptions | string): SQLClient;
+    (strings: string, ...values: any[]): SQLQuery;
+    commitDistributed(name: string): Promise<undefined>;
+    rollbackDistributed(name: string): Promise<undefined>;
+    connect(): Promise<SQLClient>;
+    close(options?: { timeout?: number }): Promise<undefined>;
+    end(options?: { timeout?: number }): Promise<undefined>;
+    flush(): void;
+    reserve(): Promise<ReservedSQLClient>;
+    begin(fn: SQLContextCallback): Promise<any>;
+    begin(options: string, fn: SQLContextCallback): Promise<any>;
+    transaction(fn: SQLContextCallback): Promise<any>;
+    transaction(options: string, fn: SQLContextCallback): Promise<any>;
+    beginDistributed(name: string, fn: SQLContextCallback): Promise<any>;
+    distributed(name: string, fn: SQLContextCallback): Promise<any>;
+    options: SQLOptions;
+  };
+  interface ReservedSQLClient extends SQLClient {
+    release(): void;
+  }
+  interface TransactionSQLClient extends SQLClient {
+    savepoint(name: string, fn: SQLContextCallback): Promise<undefined>;
+  }
+
+  const sql: SQLClient;
 
   /**
    *   This lets you use macros as regular imports

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2035,9 +2035,9 @@ declare module "bun" {
     /** Whether to use TLS/SSL for the connection */
     tls: boolean;
     /** Callback function executed when a connection is established */
-    onconnect: (client: SQLClient) => void;
+    onconnect: (client: SQL) => void;
     /** Callback function executed when a connection is closed */
-    onclose: (client: SQLClient) => void;
+    onclose: (client: SQL) => void;
     /** Maximum number of connections in the pool */
     max: number;
   };
@@ -2070,23 +2070,23 @@ declare module "bun" {
   /**
    * Main SQL client interface providing connection and transaction management
    */
-  interface SQLClient {
+  interface SQL {
     /** Creates a new SQL client instance
      * @example
      * const sql = new SQL("postgres://localhost:5432/mydb");
      * const sql = new SQL(new URL("postgres://localhost:5432/mydb"));
      */
-    new (connectionString: string | URL): SQLClient;
+    new (connectionString: string | URL): SQL;
     /** Creates a new SQL client instance with options
      * @example
      * const sql = new SQL("postgres://localhost:5432/mydb", { idleTimeout: 1000 });
      */
-    new (connectionString: string | URL, options: SQLOptions): SQLClient;
+    new (connectionString: string | URL, options: SQLOptions): SQL;
     /** Creates a new SQL client instance with options
      * @example
      * const sql = new SQL({ url: "postgres://localhost:5432/mydb", idleTimeout: 1000 });
      */
-    new (options?: SQLOptions): SQLClient;
+    new (options?: SQLOptions): SQL;
     /** Executes a SQL query using template literals
      * @example
      * const [user] = await sql`select * from users where id = ${1}`;
@@ -2106,7 +2106,7 @@ declare module "bun" {
      * @example
      * await sql.connect();
      */
-    connect(): Promise<SQLClient>;
+    connect(): Promise<SQL>;
     /** Closes the database connection with optional timeout in seconds
      * @example
      * await sql.close({ timeout: 1 });
@@ -2141,7 +2141,7 @@ declare module "bun" {
      * await reserved`select * from users`
      * }
      */
-    reserve(): Promise<ReservedSQLClient>;
+    reserve(): Promise<ReservedSQL>;
     /** Begins a new transaction
      * Will reserve a connection for the transaction and supply a scoped sql instance for all transaction uses in the callback function. sql.begin will resolve with the returned value from the callback function.
      * BEGIN is automatically sent with the optional options, and if anything fails ROLLBACK will be called so the connection can be released and execution can continue.
@@ -2270,23 +2270,23 @@ declare module "bun" {
 
   /**
    * Represents a reserved connection from the connection pool
-   * Extends SQLClient with additional release functionality
+   * Extends SQL with additional release functionality
    */
-  interface ReservedSQLClient extends SQLClient {
+  interface ReservedSQL extends SQL {
     /** Releases the client back to the connection pool */
     release(): void;
   }
 
   /**
    * Represents a client within a transaction context
-   * Extends SQLClient with savepoint functionality
+   * Extends SQL with savepoint functionality
    */
-  interface TransactionSQLClient extends SQLClient {
+  interface TransactionSQL extends SQL {
     /** Creates a savepoint within the current transaction */
     savepoint(name: string, fn: SQLContextCallback): Promise<undefined>;
   }
 
-  const sql: SQLClient;
+  var sql: SQL;
 
   /**
    *   This lets you use macros as regular imports

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1995,58 +1995,270 @@ declare module "bun" {
      */
     stat(path: string, options?: S3Options): Promise<S3Stats>;
   };
+  /**
+   * Configuration options for SQL client connection and behavior
+   */
   type SQLOptions = {
+    /** Database server hostname */
     host: string;
+    /** Database server port number */
     port: number;
+    /** Database user for authentication */
     user: string;
+    /** Database password for authentication */
     password: string;
+    /** Name of the database to connect to */
     database: string;
+    /** Connection URL (can be string or URL object) */
     url: URL | string;
+    /** Database adapter/driver to use */
     adapter: string;
+    /** Maximum time in milliseconds to wait for connection to become available */
     idleTimeout: number;
+    /** Maximum time in milliseconds to wait when establishing a connection */
     connectionTimeout: number;
+    /** Maximum lifetime in milliseconds of a connection */
     maxLifetime: number;
+    /** Alternative snake_case naming for maxLifetime */
     max_lifetime: number;
+    /** Alternative snake_case naming for connectionTimeout */
     connection_timeout: number;
+    /** Alternative snake_case naming for idleTimeout */
     idle_timeout: number;
+    /** Whether to use TLS/SSL for the connection */
     tls: boolean;
+    /** Callback function executed when a connection is established */
     onconnect: (client: SQLClient) => void;
+    /** Callback function executed when a connection is closed */
     onclose: (client: SQLClient) => void;
+    /** Maximum number of connections in the pool */
     max: number;
   };
+
+  /**
+   * Represents a SQL query that can be executed, with additional control methods
+   * Extends Promise to allow for async/await usage
+   */
   interface SQLQuery extends Promise<any> {
+    /** Indicates if the query is currently executing */
     active: boolean;
+    /** Indicates if the query has been cancelled */
     cancelled: boolean;
+    /** Cancels the executing query */
     cancel(): SQLQuery;
+    /** Executes the query */
     execute(): SQLQuery;
+    /** Returns the raw query result */
     raw(): SQLQuery;
+    /** Returns only the values from the query result */
     values(): SQLQuery;
   }
 
+  /**
+   * Callback function type for transaction contexts
+   * @param sql Function to execute SQL queries within the transaction
+   */
   type SQLContextCallback = (sql: (strings: string, ...values: any[]) => SQLQuery | Array<SQLQuery>) => Promise<any>;
 
+  /**
+   * Main SQL client interface providing connection and transaction management
+   */
   type SQLClient = {
+    /** Creates a new SQL client instance */
     new (options?: SQLOptions | string): SQLClient;
+    /** Executes a SQL query using template literals */
     (strings: string, ...values: any[]): SQLQuery;
+    /** Commits a distributed transaction also know as prepared transaction in postgres or XA transaction in MySQL
+     * @example
+     * await sql.commitDistributed("my_distributed_transaction");
+     */
     commitDistributed(name: string): Promise<undefined>;
+    /** Rolls back a distributed transaction also know as prepared transaction in postgres or XA transaction in MySQL
+     * @example
+     * await sql.rollbackDistributed("my_distributed_transaction");
+     */
     rollbackDistributed(name: string): Promise<undefined>;
+    /** Waits for the database connection to be established
+     * @example
+     * await sql.connect();
+     */
     connect(): Promise<SQLClient>;
+    /** Closes the database connection with optional timeout in seconds
+     * @example
+     * await sql.close({ timeout: 1 });
+     */
     close(options?: { timeout?: number }): Promise<undefined>;
+    /** Closes the database connection with optional timeout in seconds
+     * @alias close
+     * @example
+     * await sql.end({ timeout: 1 });
+     */
     end(options?: { timeout?: number }): Promise<undefined>;
+    /** Flushes any pending operations */
     flush(): void;
+    /**  The reserve method pulls out a connection from the pool, and returns a client that wraps the single connection.
+     *   This can be used for running queries on an isolated connection.
+     *   Calling reserve in a reserved Sql will return a new reserved connection, not the same connection (behavior matches postgres package).
+     * @example
+     * compatible with `postgres` example
+     * const reserved = await sql.reserve();
+     * await reserved`select * from users`;
+     * await reserved.release();
+     * // with in a production scenario would be something more like
+     * const reserved = await sql.reserve();
+     * try {
+     *   // ... queries
+     * } finally {
+     *   await reserved.release();
+     * }
+     * //To make it simpler bun supportsSymbol.dispose and Symbol.asyncDispose
+     * {
+     * // always release after context (safer)
+     * using reserved = await sql.reserve()
+     * await reserved`select * from users`
+     * }
+     */
     reserve(): Promise<ReservedSQLClient>;
+    /** Begins a new transaction
+     * Will reserve a connection for the transaction and supply a scoped sql instance for all transaction uses in the callback function. sql.begin will resolve with the returned value from the callback function.
+     * BEGIN is automatically sent with the optional options, and if anything fails ROLLBACK will be called so the connection can be released and execution can continue.
+     * @example
+     * const [user, account] = await sql.begin(async sql => {
+     *   const [user] = await sql`
+     *     insert into users (
+     *       name
+     *     ) values (
+     *       'Murray'
+     *     )
+     *     returning *
+     *   `
+     *   const [account] = await sql`
+     *     insert into accounts (
+     *       user_id
+     *     ) values (
+     *       ${ user.user_id }
+     *     )
+     *     returning *
+     *   `
+     *   return [user, account]
+     * })
+     */
     begin(fn: SQLContextCallback): Promise<any>;
+    /** Begins a new transaction with options
+     * Will reserve a connection for the transaction and supply a scoped sql instance for all transaction uses in the callback function. sql.begin will resolve with the returned value from the callback function.
+     * BEGIN is automatically sent with the optional options, and if anything fails ROLLBACK will be called so the connection can be released and execution can continue.
+     * @example
+     * const [user, account] = await sql.begin("read write", async sql => {
+     *   const [user] = await sql`
+     *     insert into users (
+     *       name
+     *     ) values (
+     *       'Murray'
+     *     )
+     *     returning *
+     *   `
+     *   const [account] = await sql`
+     *     insert into accounts (
+     *       user_id
+     *     ) values (
+     *       ${ user.user_id }
+     *     )
+     *     returning *
+     *   `
+     *   return [user, account]
+     * })
+     */
     begin(options: string, fn: SQLContextCallback): Promise<any>;
+    /** Alternative method to begin a transaction
+     * Will reserve a connection for the transaction and supply a scoped sql instance for all transaction uses in the callback function. sql.transaction will resolve with the returned value from the callback function.
+     * BEGIN is automatically sent with the optional options, and if anything fails ROLLBACK will be called so the connection can be released and execution can continue.
+     * @alias begin
+     * @example
+     * const [user, account] = await sql.transaction(async sql => {
+     *   const [user] = await sql`
+     *     insert into users (
+     *       name
+     *     ) values (
+     *       'Murray'
+     *     )
+     *     returning *
+     *   `
+     *   const [account] = await sql`
+     *     insert into accounts (
+     *       user_id
+     *     ) values (
+     *       ${ user.user_id }
+     *     )
+     *     returning *
+     *   `
+     *   return [user, account]
+     * })
+     */
     transaction(fn: SQLContextCallback): Promise<any>;
+    /** Alternative method to begin a transaction with options
+     * Will reserve a connection for the transaction and supply a scoped sql instance for all transaction uses in the callback function. sql.transaction will resolve with the returned value from the callback function.
+     * BEGIN is automatically sent with the optional options, and if anything fails ROLLBACK will be called so the connection can be released and execution can continue.
+     * @alias begin
+     * @example
+     * const [user, account] = await sql.transaction("read write", async sql => {
+     *   const [user] = await sql`
+     *     insert into users (
+     *       name
+     *     ) values (
+     *       'Murray'
+     *     )
+     *     returning *
+     *   `
+     *   const [account] = await sql`
+     *     insert into accounts (
+     *       user_id
+     *     ) values (
+     *       ${ user.user_id }
+     *     )
+     *     returning *
+     *   `
+     *   return [user, account]
+     * })
+     */
     transaction(options: string, fn: SQLContextCallback): Promise<any>;
+    /** Begins a distributed transaction
+     * Also know as Two-Phase Commit, in a distributed transaction, Phase 1 involves the coordinator preparing nodes by ensuring data is written and ready to commit, while Phase 2 finalizes with nodes committing or rolling back based on the coordinator's decision, ensuring durability and releasing locks.
+     * In PostgreSQL and MySQL distributed transactions persist beyond the original session, allowing privileged users or coordinators to commit/rollback them, ensuring support for distributed transactions, recovery, and administrative tasks.
+     * beginDistributed will automatic rollback if any exception are not caught, and you can commit and rollback later if everything goes well.
+     * PostgreSQL natively supports distributed transactions using PREPARE TRANSACTION, while MySQL uses XA Transactions, and MSSQL also supports distributed/XA transactions. However, in MSSQL, distributed transactions are tied to the original session, the DTC coordinator, and the specific connection. These transactions are automatically committed or rolled back following the same rules as regular transactions, with no option for manual intervention from other sessions, in MSSQL distributed transactions are used to coordinate transactions using Linked Servers.
+     * @example
+     * await sql.beginDistributed("numbers", async sql => {
+     *   await sql`create table if not exists numbers (a int)`;
+     *   await sql`insert into numbers values(1)`;
+     * });
+     * // later you can call
+     * await sql.commitDistributed("numbers");
+     * // or await sql.rollbackDistributed("numbers");
+     */
     beginDistributed(name: string, fn: SQLContextCallback): Promise<any>;
+    /** Alternative method to begin a distributed transaction
+     * @alias beginDistributed
+     */
     distributed(name: string, fn: SQLContextCallback): Promise<any>;
+    /** Current client options */
     options: SQLOptions;
   };
+
+  /**
+   * Represents a reserved client from the connection pool
+   * Extends SQLClient with additional release functionality
+   */
   interface ReservedSQLClient extends SQLClient {
+    /** Releases the client back to the connection pool */
     release(): void;
   }
+
+  /**
+   * Represents a client within a transaction context
+   * Extends SQLClient with savepoint functionality
+   */
   interface TransactionSQLClient extends SQLClient {
+    /** Creates a savepoint within the current transaction */
     savepoint(name: string, fn: SQLContextCallback): Promise<undefined>;
   }
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2074,7 +2074,10 @@ declare module "bun" {
      * const sql = new SQL({ url: "postgres://localhost:5432/mydb", idleTimeout: 1000 });
      */
     new (options?: SQLOptions): SQLClient;
-    /** Executes a SQL query using template literals */
+    /** Executes a SQL query using template literals
+     * @example
+     * const [user] = await sql`select * from users where id = ${1}`;
+     */
     (strings: string, ...values: any[]): SQLQuery;
     /** Commits a distributed transaction also know as prepared transaction in postgres or XA transaction in MySQL
      * @example

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -292,13 +292,23 @@ static JSValue constructPluginObject(VM& vm, JSObject* bunObject)
     return pluginFunction;
 }
 
-static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
+static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
     RETURN_IF_EXCEPTION(scope, {});
     return sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword);
+}
+
+static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = defaultGlobalObject(bunObject->globalObject());
+    JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto clientData = WebCore::clientData(vm);
+    return sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName());
 }
 
 extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);
@@ -745,7 +755,8 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     revision                                       constructBunRevision                                                ReadOnly|DontDelete|PropertyCallback
     semver                                         BunObject_getter_wrap_semver                                        ReadOnly|DontDelete|PropertyCallback
     s3                                             BunObject_callback_s3                                               DontDelete|Function 1
-    sql                                            constructBunSQLObject                                               DontDelete|PropertyCallback
+    sql                                            defaultBunSQLObject                                               DontDelete|PropertyCallback
+    SQL                                            constructBunSQLObject                                               DontDelete|PropertyCallback
     serve                                          BunObject_callback_serve                                            DontDelete|Function 1
     sha                                            BunObject_callback_sha                                              DontDelete|Function 1
     shrink                                         BunObject_callback_shrink                                           DontDelete|Function 1

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -167,6 +167,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_POSTGRES_IDLE_TIMEOUT", Error, "PostgresError"],
   ["ERR_POSTGRES_CONNECTION_TIMEOUT", Error, "PostgresError"],
   ["ERR_POSTGRES_LIFETIME_TIMEOUT", Error, "PostgresError"],
+  ["ERR_POSTGRES_INVALID_TRANSACTION_STATE", Error, "PostgresError"],
 
   // S3
   ["ERR_S3_MISSING_CREDENTIALS", Error],

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -168,6 +168,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_POSTGRES_CONNECTION_TIMEOUT", Error, "PostgresError"],
   ["ERR_POSTGRES_LIFETIME_TIMEOUT", Error, "PostgresError"],
   ["ERR_POSTGRES_INVALID_TRANSACTION_STATE", Error, "PostgresError"],
+  ["ERR_POSTGRES_QUERY_CANCELLED", Error, "PostgresError"],
 
   // S3
   ["ERR_S3_MISSING_CREDENTIALS", Error],

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -169,6 +169,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_POSTGRES_LIFETIME_TIMEOUT", Error, "PostgresError"],
   ["ERR_POSTGRES_INVALID_TRANSACTION_STATE", Error, "PostgresError"],
   ["ERR_POSTGRES_QUERY_CANCELLED", Error, "PostgresError"],
+  ["ERR_POSTGRES_UNSAFE_TRANSACTION", Error, "PostgresError"],
 
   // S3
   ["ERR_S3_MISSING_CREDENTIALS", Error],

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -898,7 +898,6 @@ pub const EventLoop = struct {
     pub fn runCallback(this: *EventLoop, callback: JSC.JSValue, globalObject: *JSC.JSGlobalObject, thisValue: JSC.JSValue, arguments: []const JSC.JSValue) void {
         this.enter();
         defer this.exit();
-
         _ = callback.call(globalObject, thisValue, arguments) catch |err|
             globalObject.reportActiveExceptionAsUnhandled(err);
     }

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2514,14 +2514,7 @@ pub const ModuleLoader = struct {
 
                 // These are defined in src/js/*
                 .@"bun:ffi" => return jsSyntheticModule(.@"bun:ffi", specifier),
-                .@"bun:sql" => {
-                    if (!Environment.isDebug) {
-                        if (!is_allowed_to_use_internal_testing_apis and !bun.FeatureFlags.postgresql)
-                            return null;
-                    }
 
-                    return jsSyntheticModule(.@"bun:sql", specifier);
-                },
                 .@"bun:sqlite" => return jsSyntheticModule(.@"bun:sqlite", specifier),
                 .@"detect-libc" => return jsSyntheticModule(if (!Environment.isLinux) .@"detect-libc" else if (!Environment.isMusl) .@"detect-libc/linux" else .@"detect-libc/musl", specifier),
                 .@"node:assert" => return jsSyntheticModule(.@"node:assert", specifier),
@@ -2729,7 +2722,6 @@ pub const HardcodedModule = enum {
     @"bun:jsc",
     @"bun:main",
     @"bun:test", // usually replaced by the transpiler but `await import("bun:" + "test")` has to work
-    @"bun:sql",
     @"bun:sqlite",
     @"detect-libc",
     @"node:assert",
@@ -2816,7 +2808,6 @@ pub const HardcodedModule = enum {
             .{ "bun:test", HardcodedModule.@"bun:test" },
             .{ "bun:sqlite", HardcodedModule.@"bun:sqlite" },
             .{ "bun:internal-for-testing", HardcodedModule.@"bun:internal-for-testing" },
-            .{ "bun:sql", HardcodedModule.@"bun:sql" },
             .{ "detect-libc", HardcodedModule.@"detect-libc" },
             .{ "node-fetch", HardcodedModule.@"node-fetch" },
             .{ "isomorphic-fetch", HardcodedModule.@"isomorphic-fetch" },
@@ -3056,7 +3047,6 @@ pub const HardcodedModule = enum {
             .{ "bun:ffi", .{ .path = "bun:ffi" } },
             .{ "bun:jsc", .{ .path = "bun:jsc" } },
             .{ "bun:sqlite", .{ .path = "bun:sqlite" } },
-            .{ "bun:sql", .{ .path = "bun:sql" } },
             .{ "bun:wrap", .{ .path = "bun:wrap" } },
             .{ "bun:internal-for-testing", .{ .path = "bun:internal-for-testing" } },
             .{ "ffi", .{ .path = "bun:ffi" } },

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -259,6 +259,7 @@ using namespace JSC;
     macro(written) \
     macro(napiDlopenHandle) \
     macro(napiWrappedContents) \
+    macro(SQL) \
     BUN_ADDITIONAL_BUILTIN_NAMES(macro)
 // --- END of BUN_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME ---
 

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -508,6 +508,7 @@ class ConnectionPool {
    * @param {boolean} reserved - Whether the connection is reserved, if is reserved the connection will not be released until release is called, if not release will only decrement the queriesUsing counter
    */
   connect(onConnected: (err: Error | null, result: any) => void, reserved: boolean = false) {
+    // TODO: this always reserve a connection, we should only reserve if reserved is true
     if (this.closed) {
       return onConnected(connectionClosedError(), null);
     }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1091,7 +1091,10 @@ function assertValidTransactionName(name: string) {
     throw Error(`Distributed transaction name cannot contain single quotes.`);
   }
 }
-function SQL(o) {
+function SQL(o, e = {}) {
+  if (typeof o === "string" || o instanceof URL) {
+    o = { ...e, url: o };
+  }
   var connectionInfo = loadOptions(o);
   var pool = new ConnectionPool(connectionInfo);
 

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -712,7 +712,7 @@ function loadOptions(o) {
   password ||= o.password || o.pass || env.PGPASSWORD || "";
   tls ||= o.tls || o.ssl;
   adapter ||= o.adapter || "postgres";
-  max ||= o.max || 10;
+  max = o.max;
 
   idleTimeout ??= o.idleTimeout;
   idleTimeout ??= o.idle_timeout;
@@ -770,8 +770,8 @@ function loadOptions(o) {
 
   if (max != null) {
     max = Number(max);
-    if (max > 2 ** 31 || max < 0 || max !== max) {
-      throw $ERR_INVALID_ARG_VALUE("options.max", max, "must be a non-negative integer less than 2^31");
+    if (max > 2 ** 31 || max < 1 || max !== max) {
+      throw $ERR_INVALID_ARG_VALUE("options.max", max, "must be a non-negative integer between 1 and 2^31");
     }
   }
 

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -870,7 +870,7 @@ function SQL(o) {
       values = v.value;
     }
     if (!allowUnsafeTransaction) {
-      if (sqlString.length === 5 && sqlString.toUpperCase() === "BEGIN" && connectionInfo.max !== 1) {
+      if (sqlString.length === 5 && connectionInfo.max !== 1 && sqlString.toUpperCase() === "BEGIN") {
         throw $ERR_POSTGRES_UNSAFE_TRANSACTION("Only use sql.begin, sql.reserved or max: 1");
       }
     }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1039,8 +1039,10 @@ function SQL(o) {
       pool.release(pooledConnection);
       return Promise.resolve(undefined);
     };
+    // this dont need to be async dispose only disposable but we keep compatibility with other types of sql functions
     reserved_sql[Symbol.asyncDispose] = () => reserved_sql.release();
-    reserved_sql.then = reserved_sql.connect;
+    reserved_sql[Symbol.dispose] = () => reserved_sql.release();
+
     reserved_sql.options = sql.options;
     resolve(reserved_sql);
   }
@@ -1097,7 +1099,6 @@ function SQL(o) {
       state.closed = true;
     };
     transaction_sql[Symbol.asyncDispose] = () => transaction_sql.close();
-    transaction_sql.then = transaction_sql.connect;
     transaction_sql.options = sql.options;
 
     transaction_sql.savepoint = async (fn: TransactionCallback, name?: string) => {
@@ -1262,11 +1263,6 @@ function SQL(o) {
 
   sql.flush = () => pool.flush();
   sql.options = connectionInfo;
-
-  sql.then = () => {
-    // should this wait queries to finish or just return if is connected?
-    return sql.connect();
-  };
 
   return sql;
 }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -577,6 +577,12 @@ class ConnectionPool {
     while ((pending = this.waitingQueue.shift())) {
       pending(connectionClosedError(), null);
     }
+    while (this.reservedQueue.length > 0) {
+      const pendingReserved = this.reservedQueue.shift();
+      if (pendingReserved) {
+        pendingReserved(connectionClosedError(), null);
+      }
+    }
     const promises: Array<Promise<any>> = [];
     if (this.poolStarted) {
       this.poolStarted = false;

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -544,7 +544,8 @@ class ConnectionPool {
         throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
       }
       this.closed = true;
-      await Bun.sleep(timeout * 1000);
+      // TODO: check queryCount to this logic
+      // await Bun.sleep(timeout * 1000);
     } else {
       this.closed = true;
     }
@@ -1261,7 +1262,8 @@ function SQL(o) {
         }
         state.closed = true;
         // no new queries will be allowed
-        await Bun.sleep(timeout * 1000);
+        // TODO: check queryCount to this logic
+        // await Bun.sleep(timeout * 1000);
       } else {
         // close will release the connection back to the pool but will actually close the connection if its open
         state.closed = true;
@@ -1507,7 +1509,8 @@ function SQL(o) {
         if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
           throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
         }
-        await Bun.sleep(timeout * 1000);
+        // TODO: check queryCount to this logic
+        // await Bun.sleep(timeout * 1000);
       }
       if (!state.closed) {
         if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -411,8 +411,11 @@ class ConnectionPool {
     }
     while (this.waitingQueue.length > 0) {
       let endReached = true;
-
-      const nonReservedConnections = Array.from(this.readyConnections).filter(c => !c.preReserved);
+      // no need to filter for reserved connections because there are not in the readyConnections
+      // preReserved only shows that we wanna avoiding adding more queries to it
+      const nonReservedConnections = Array.from(this.readyConnections).filter(
+        c => !(c.flags & PooledConnectionFlags.preReserved),
+      );
       if (nonReservedConnections.length === 0) {
         return;
       }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -294,7 +294,6 @@ class PooledConnection {
     this.pool.release(this);
   }
   constructor(connectionInfo, pool: ConnectionPool) {
-    //TODO: maxLifetime, idleTimeout, connectionTimeout
     this.connection = createConnection(connectionInfo, this.#onConnected.bind(this), this.#onClose.bind(this));
     this.state = "pending";
     this.pool = pool;
@@ -326,7 +325,6 @@ class PooledConnection {
     }
     // we need to reconnect
     // lets use a retry strategy
-    // TODO: implement retry strategy, maxLifetime, idleTimeout, connectionTimeout
 
     // we can only retry if one day we are able to connect
     if (this.canBeConnected) {

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -219,6 +219,9 @@ pub const PostgresSQLQuery = struct {
     pub usingnamespace JSC.Codegen.JSPostgresSQLQuery;
 
     pub fn getTarget(this: *PostgresSQLQuery, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        if (this.thisValue == .zero) {
+            return .zero;
+        }
         const target = PostgresSQLQuery.targetGetCached(this.thisValue) orelse return .zero;
         PostgresSQLQuery.targetSetCached(this.thisValue, globalObject, .zero);
         return target;

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2460,7 +2460,7 @@ pub const PostgresSQLConnection = struct {
                     DataCell.Putter.put,
                 );
 
-                const pending_value = PostgresSQLQuery.pendingValueGetCached(request.thisValue) orelse .zero;
+                const pending_value = if (request.thisValue == .zero) .zero else PostgresSQLQuery.pendingValueGetCached(request.thisValue) orelse .zero;
                 pending_value.ensureStillAlive();
                 const result = putter.toJS(this.globalObject, pending_value, statement.structure(this.js_value, this.globalObject), statement.fields_flags);
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -506,6 +506,21 @@ if (!isCI && hasPsql) {
   //   }
   // });
 
+  test("Prepared transaction", async () => {
+    await sql`create table test (a int)`;
+
+    try {
+      await sql.beginDistributed("tx1", async sql => {
+        await sql`insert into test values(1)`;
+      });
+
+      await sql.commitDistributed("tx1");
+      expect((await sql`select count(1) from test`)[0].count).toBe("1");
+    } finally {
+      await sql`drop table test`;
+    }
+  });
+
   test("Transaction requests are executed implicitly", async () => {
     const sql = postgres({ ...options, debug: true, idle_timeout: 1, fetch_types: false });
     expect(

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1,4 +1,5 @@
-import { postgres, sql } from "bun:sql";
+import { sql } from "bun";
+const postgres = (...args) => new sql(...args);
 import { expect, test, mock } from "bun:test";
 import { $ } from "bun";
 import { bunExe, isCI, withoutAggressiveGC } from "harness";

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -490,7 +490,7 @@ if (!isCI && hasPsql) {
     expect(result[0]?.x).toBe(1);
   });
 
-  // test.only("Prepared transaction", async () => {
+  // test("Prepared transaction", async () => {
   //   await sql`create table test (a int)`;
 
   //   await sql.begin(async sql => {
@@ -506,29 +506,31 @@ if (!isCI && hasPsql) {
   //   }
   // });
 
-  // t('Transaction requests are executed implicitly', async() => {
-  //   const sql = postgres({ debug: true, idle_timeout: 1, fetch_types: false })
-  //   return [
-  //     'testing',
-  //     (await sql.begin(sql => [
-  //       sql`select set_config('bun_sql.test', 'testing', true)`,
-  //       sql`select current_setting('bun_sql.test') as x`
-  //     ]))[1][0].x
-  //   ]
-  // })
+  test("Transaction requests are executed implicitly", async () => {
+    const sql = postgres({ ...options, debug: true, idle_timeout: 1, fetch_types: false });
+    expect(
+      (
+        await sql.begin(sql => [
+          sql`select set_config('bun_sql.test', 'testing', true)`,
+          sql`select current_setting('bun_sql.test') as x`,
+        ])
+      )[1][0].x,
+    ).toBe("testing");
+  });
 
-  // t('Uncaught transaction request errors bubbles to transaction', async() => [
-  //   '42703',
-  //   (await sql.begin(sql => [
-  //     sql`select wat`,
-  //     sql`select current_setting('bun_sql.test') as x, ${ 1 } as a`
-  //   ]).catch(e => e.code))
-  // ])
+  test("Uncaught transaction request errosó rs bubbles to transaction", async () => {
+    const sql = postgres({ ...options, debug: true, idle_timeout: 1, fetch_types: false });
+    expect(
+      await sql
+        .begin(sql => [sql`select wat`, sql`select current_setting('bun_sql.test') as x, ${1} as a`])
+        .catch(e => e.errno),
+    ).toBe(42703);
+  });
 
-  // t('Fragments in transactions', async() => [
-  //   true,
-  //   (await sql.begin(sql => sql`select true as x where ${ sql`1=1` }`))[0].x
-  // ])
+  // test.only("Fragments in transactions", async () => {
+  //   const sql = postgres({ ...options, debug: true, idle_timeout: 1, fetch_types: false });
+  //   expect((await sql.begin(sql => sql`select true as x where ${sql`1=1`}`))[0].x).toBe(true);
+  // });
 
   // t('Transaction rejects with rethrown error', async() => [
   //   'WAT',


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

Add support for transactions:

#### BEGIN / COMMIT `await sql.begin([options = ''], fn) -> fn()`

```js
import { SQL } from "bun:sql";

const sql = new SQL({
  host: "localhost",
  port: 5432,
  user: "ciro",
  password: "bunbunbun",
  database: "bun",
});

const [user, account] = await sql.begin(async sql => {
  const [user] = await sql`
    insert into users (
      name
    ) values (
      'Murray'
    )
    returning *
  `

  const [account] = await sql`
    insert into accounts (
      user_id
    ) values (
      ${ user.user_id }
    )
    returning *
  `

  return [user, account]
})
```
#### SAVEPOINT `await sql.savepoint([name], fn) -> fn()`

```js
sql.begin('read write', async sql => {
  const [user] = await sql`
    insert into users (
      name
    ) values (
      'Murray'
    )
  `

  const [account] = (await sql.savepoint(sql =>
    sql`
      insert into accounts (
        user_id
      ) values (
        ${ user.user_id }
      )
    `
  ).catch(err => {
    // Account could not be created. ROLLBACK SAVEPOINT is called because we caught the rejection.
  })) || []

  return [user, account]
})
.then(([user, account]) => {
  // great success - COMMIT succeeded
})
.catch(() => {
  // not so good - ROLLBACK was called
})
```

`ERR_POSTGRES_UNSAFE_TRANSACTION` error is throw if BEGIN command is used without `.begin()`, `max: 1` or `.reserve()`.

Like `postgres` package if returned an array of Promises on .begin or .savepoint it will `Promise.all` all promises before COMMIT.

```js
 await sql.begin(async sql => [
  sql`insert into test values(1)`,
  sql`insert into test values(2)`,
  sql`insert into test values(3)`
]);
 ```
`sql.transaction` is a alias for `sql.begin`

#### RESERVE `await sql.reserve()`
The reserve method pulls out a connection from the pool, and returns a client that wraps the single connection. This can be used for running queries on an isolated connection.

```js
// compatible with `postgres` example
const reserved = await sql.reserve();
await reserved`select * from users`;
await reserved.release();
// with in a production scenario would be something more like
const reserved = await sql.reserve();
try {
  // ... queries
} finally {
  await reserved.release();
}
```
To make it simpler bun supports`Symbol.dispose` and `Symbol.asyncDispose`
```js
{
// always release after context (safer)
using reserved = await sql.reserve()
await reserved`select * from users`
}
```
Calling `.reserve` in a reserved Sql will return a new reserved connection, not the same connection (behavior matches `postgres` package).


#### DISTRIBUTED TRANSACTIONS `await sql.beginDistributed(name, fn) -> fn()`

Also know as Two-Phase Commit, in a distributed transaction, Phase 1 involves the coordinator preparing nodes by ensuring data is written and ready to commit, while Phase 2 finalizes with nodes committing or rolling back based on the coordinator's decision, ensuring durability and releasing locks.

In PostgreSQL and MySQL distributed transactions persist beyond the original session, allowing privileged users or coordinators to commit/rollback them, ensuring support for distributed transactions, recovery, and administrative tasks.

`beginDistributed` will automatic rollback if any exception are not caught, and you can commit and rollback later if everything goes well.

PostgreSQL natively supports distributed transactions using PREPARE TRANSACTION, while MySQL uses XA Transactions, and MSSQL also supports distributed/XA transactions. However, in MSSQL, distributed transactions are tied to the original session, the DTC coordinator, and the specific connection. These transactions are automatically committed or rolled back following the same rules as regular transactions, with no option for manual intervention from other sessions, in MSSQL distributed transactions are used to coordinate transactions using Linked Servers.

```js
await sql.beginDistributed("numbers", async sql => {
  await sql`create table if not exists numbers (a int)`;
  await sql`insert into numbers values(1)`;
});
// later you can call
await sql.commitDistributed("numbers");
// or await sql.rollbackDistributed("numbers");
```

`sql.distributed` is a alias for `sql.beginDistributed`

### Connection Pool
No connection will be made until a query is made.
```
const sql = Bun.sql() // no connection are created

await sql`...` // pool is started until max is reached (if possible), first available connection is used
await sql`...` // previous connection is reused

// two connections are used now at the same time
await Promise.all([
  sql`...`,
  sql`...`
]);

await sql.close(); // close all connection from the pool no new queries can be made.
```
If a connection is closed or not able to connect it will only retry it if no other connection is currently available to be used, this enables Bun to run even if not all connections are able to established minimizing downtimes. Bun will open as many connections until max number of connections is reached. By default max is 10. This can be changed by setting max in the Bun.sql() call. Example - Bun.sql({ max: 20 }).

Differences from `postgres` package:

1 - Error code `UNSAFE_TRANSACTION` is `ERR_POSTGRES_UNSAFE_TRANSACTION`

2 - `postgres` package will accept 0 in `max` value, we will throw a error, the default value will be the same 10, `postgres` will use 0 with means hanging when trying to do a query.

3 - `postgres` is conservative and will lazy open each connection only if enough concurrency is achieved, until `max` is reached, `Bun.sql` try to keep the pool full (until `max` is reached) when possible after the first query is called or when retries are needed to maximize throughput.

4 - Features present in `postgres` and not in `Bun.sql`:
- `sql.readable()`
-  `sql.writable()`
- `sql.cursor`
- `sql.file`
- `sql.simple`
- `sql.listen`
- `sql.notify`
- `sql.subscribe`
- `sql.unsafe`
- `sql.prepare` in transactions see `sql.beginDistributed`
- `options.types`
- `options.transform`



<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
