### PR TITLE
allow `bundledDependencies: true` in `bun pm pack`

### DIFF
--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -835,22 +835,47 @@ pub const PackCommand = struct {
         const bundled_deps = json.get(field) orelse return null;
 
         invalid_field: {
-            var iter = bundled_deps.asArray() orelse switch (bundled_deps.data) {
-                .e_array => return .{},
+            switch (bundled_deps.data) {
+                .e_array => {
+                    var iter = bundled_deps.asArray() orelse return .{};
+
+                    while (iter.next()) |bundled_dep_item| {
+                        const bundled_dep = try bundled_dep_item.asStringCloned(allocator) orelse break :invalid_field;
+                        try deps.append(allocator, .{
+                            .name = bundled_dep,
+                            .from_root_package_json = true,
+                        });
+                    }
+                },
+                .e_boolean => {
+                    const b = bundled_deps.asBool() orelse return .{};
+                    if (!b == true) return .{};
+
+                    if (json.get("dependencies")) |dependencies_expr| {
+                        switch (dependencies_expr.data) {
+                            .e_object => |dependencies| {
+                                for (dependencies.properties.slice()) |*dependency| {
+                                    if (dependency.key == null) continue;
+                                    if (dependency.value == null) continue;
+
+                                    const bundled_dep = try dependency.key.?.asStringCloned(allocator) orelse break :invalid_field;
+                                    try deps.append(allocator, .{
+                                        .name = bundled_dep,
+                                        .from_root_package_json = true,
+                                    });
+                                }
+                            },
+                            else => {},
+                        }
+                    }
+                },
                 else => break :invalid_field,
-            };
-            while (iter.next()) |bundled_dep_item| {
-                const bundled_dep = try bundled_dep_item.asStringCloned(allocator) orelse break :invalid_field;
-                try deps.append(allocator, .{
-                    .name = bundled_dep,
-                    .from_root_package_json = true,
-                });
             }
 
             return deps;
         }
 
-        Output.errGeneric("expected `{s}` to be an array of strings", .{field});
+        Output.errGeneric("expected `{s}` to be an boolean or array of strings", .{field});
         Global.crash();
     }
 

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -875,7 +875,7 @@ pub const PackCommand = struct {
             return deps;
         }
 
-        Output.errGeneric("expected `{s}` to be an boolean or array of strings", .{field});
+        Output.errGeneric("expected `{s}` to be a boolean or an array of strings", .{field});
         Global.crash();
     }
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -602,6 +602,47 @@ describe("bundledDependnecies", () => {
     });
   }
 
+  test(`basic (bundledDependencies: true)`, async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-bundled",
+          version: "4.4.4",
+          dependencies: {
+            "dep1": "1.1.1",
+          },
+          devDependencies: {
+            "dep2": "1.1.1",
+          },
+          bundledDependencies: true,
+        }),
+      ),
+      write(
+        join(packageDir, "node_modules", "dep1", "package.json"),
+        JSON.stringify({
+          name: "dep1",
+          version: "1.1.1",
+        }),
+      ),
+      write(
+        join(packageDir, "node_modules", "dep2", "package.json"),
+        JSON.stringify({
+          name: "dep2",
+          version: "1.1.1",
+        }),
+      ),
+    ]);
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-bundled-4.4.4.tgz"));
+    expect(tarball.entries).toMatchObject([
+      { "pathname": "package/package.json" },
+      { "pathname": "package/node_modules/dep1/package.json" },
+    ]);
+  });
+
   test("resolve dep of bundled dep", async () => {
     // Test that a bundled dep can have it's dependencies resolved without
     // needing to add them to `bundledDependencies`. Also test that only

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -643,7 +643,7 @@ describe("bundledDependnecies", () => {
     ]);
   });
 
-  test(`basic should throw`, async () => {
+  test(`invalid bundledDependencies value should throw`, async () => {
     await Promise.all([
       write(
         join(packageDir, "package.json"),
@@ -666,7 +666,7 @@ describe("bundledDependnecies", () => {
 
     const err = await Bun.readableStreamToText(stderr);
     expect(err).toContain("error:");
-    expect(err).toContain("to be an array of strings or boolean");
+    expect(err).toContain("to be a boolean or an array of strings");
     expect(err).not.toContain("warning:");
     expect(err).not.toContain("failed");
     expect(err).not.toContain("panic:");


### PR DESCRIPTION
### What does this PR do?

fixes #16375

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

added test
