### PR TITLE
Implement Bun.hash.xxHash32|64()

### DIFF
--- a/docs/api/hashing.md
+++ b/docs/api/hashing.md
@@ -169,6 +169,8 @@ Bun.hash.crc32("data", 1234);
 Bun.hash.adler32("data", 1234);
 Bun.hash.cityHash32("data", 1234);
 Bun.hash.cityHash64("data", 1234);
+Bun.hash.xxHash32("data", 1234);
+Bun.hash.xxHash64("data", 1234);
 Bun.hash.murmur32v3("data", 1234);
 Bun.hash.murmur32v2("data", 1234);
 Bun.hash.murmur64v2("data", 1234);

--- a/docs/api/hashing.md
+++ b/docs/api/hashing.md
@@ -171,6 +171,7 @@ Bun.hash.cityHash32("data", 1234);
 Bun.hash.cityHash64("data", 1234);
 Bun.hash.xxHash32("data", 1234);
 Bun.hash.xxHash64("data", 1234);
+Bun.hash.xxHash3("data", 1234);
 Bun.hash.murmur32v3("data", 1234);
 Bun.hash.murmur32v2("data", 1234);
 Bun.hash.murmur64v2("data", 1234);

--- a/examples/hashing.js
+++ b/examples/hashing.js
@@ -13,6 +13,7 @@ console.log(Bun.hash.cityHash32(input)); // number
 console.log(Bun.hash.cityHash64(input)); // bigint
 console.log(Bun.hash.xxHash32(input)); // number
 console.log(Bun.hash.xxHash64(input)); // bigint
+console.log(Bun.hash.xxHash3(input)); // bigint
 console.log(Bun.hash.murmur32v3(input)); // number
 console.log(Bun.hash.murmur32v2(input)); // number
 console.log(Bun.hash.murmur64v2(input)); // bigint

--- a/examples/hashing.js
+++ b/examples/hashing.js
@@ -11,6 +11,8 @@ console.log(Bun.hash.adler32(input)); // number
 console.log(Bun.hash.crc32(input)); // number
 console.log(Bun.hash.cityHash32(input)); // number
 console.log(Bun.hash.cityHash64(input)); // bigint
+console.log(Bun.hash.xxHash32(input)); // number
+console.log(Bun.hash.xxHash64(input)); // bigint
 console.log(Bun.hash.murmur32v3(input)); // number
 console.log(Bun.hash.murmur32v2(input)); // number
 console.log(Bun.hash.murmur64v2(input)); // bigint

--- a/packages/bun-polyfills/lib/zighash/index.mjs
+++ b/packages/bun-polyfills/lib/zighash/index.mjs
@@ -88,6 +88,11 @@ export function xxhash64(input = '', seed = 0n) {
     const { ptr, size } = typeof input === 'string' ? allocString(input, false) : allocBuffer(input);
     return BigInt.asUintN(64, exports.xxhash64(ptr, size, seed));
 }
+/** @type {JSSeededHash64Function} */
+export function xxhash3(input = '', seed = 0n) {
+    const { ptr, size } = typeof input === 'string' ? allocString(input, false) : allocBuffer(input);
+    return BigInt.asUintN(64, exports.xxhash3(ptr, size, seed));
+}
 /** @type {JSSeededHash32Function} */
 export function murmur32v3(input = '', seed = 0) {
     const { ptr, size } = typeof input === 'string' ? allocString(input, false) : allocBuffer(input);

--- a/packages/bun-polyfills/lib/zighash/index.mjs
+++ b/packages/bun-polyfills/lib/zighash/index.mjs
@@ -79,6 +79,16 @@ export function cityhash64(input = '', seed = 0n) {
     return BigInt.asUintN(64, exports.cityhash64(ptr, size, seed));
 }
 /** @type {JSSeededHash32Function} */
+export function xxhash32(input = '', seed = 0) {
+  const { ptr, size } = typeof input === 'string' ? allocString(input, false) : allocBuffer(input);
+  return exports.xxhash32(ptr, size, seed)
+}
+/** @type {JSSeededHash64Function} */
+export function xxhash64(input = '', seed = 0n) {
+    const { ptr, size } = typeof input === 'string' ? allocString(input, false) : allocBuffer(input);
+    return BigInt.asUintN(64, exports.xxhash64(ptr, size, seed));
+}
+/** @type {JSSeededHash32Function} */
 export function murmur32v3(input = '', seed = 0) {
     const { ptr, size } = typeof input === 'string' ? allocString(input, false) : allocBuffer(input);
     return exports.murmur32v3(ptr, size, seed); //! Bun doesn't unsigned-cast this one, likely unintended but for now we'll do the same

--- a/packages/bun-polyfills/lib/zighash/src/main.zig
+++ b/packages/bun-polyfills/lib/zighash/src/main.zig
@@ -41,6 +41,16 @@ export fn cityhash64(input_ptr: [*]const u8, input_size: u32, seed: u64) u64 {
     defer std.heap.wasm_allocator.free(input);
     return std.hash.CityHash64.hashWithSeed(input, seed);
 }
+export fn xxhash32(input_ptr: [*]const u8, input_size: u32, seed: u32) u32 {
+    const input: []const u8 = input_ptr[0..input_size];
+    defer std.heap.wasm_allocator.free(input);
+    return std.hash.XxHash32.hash(seed, input);
+}
+export fn xxhash64(input_ptr: [*]const u8, input_size: u32, seed: u64) u64 {
+    const input: []const u8 = input_ptr[0..input_size];
+    defer std.heap.wasm_allocator.free(input);
+    return std.hash.XxHash64.hash(seed, input);
+}
 export fn murmur32v3(input_ptr: [*]const u8, input_size: u32, seed: u32) u32 {
     const input: []const u8 = input_ptr[0..input_size];
     defer std.heap.wasm_allocator.free(input);

--- a/packages/bun-polyfills/lib/zighash/src/main.zig
+++ b/packages/bun-polyfills/lib/zighash/src/main.zig
@@ -51,6 +51,11 @@ export fn xxhash64(input_ptr: [*]const u8, input_size: u32, seed: u64) u64 {
     defer std.heap.wasm_allocator.free(input);
     return std.hash.XxHash64.hash(seed, input);
 }
+export fn xxhash3(input_ptr: [*]const u8, input_size: u32, seed: u64) u64 {
+    const input: []const u8 = input_ptr[0..input_size];
+    defer std.heap.wasm_allocator.free(input);
+    return std.hash.XxHash3.hash(seed, input);
+}
 export fn murmur32v3(input_ptr: [*]const u8, input_size: u32, seed: u32) u32 {
     const input: []const u8 = input_ptr[0..input_size];
     defer std.heap.wasm_allocator.free(input);

--- a/packages/bun-polyfills/lib/zighash/types.d.ts
+++ b/packages/bun-polyfills/lib/zighash/types.d.ts
@@ -17,6 +17,8 @@ type ZighashInstance = WebAssembly.WebAssemblyInstantiatedSource & {
             crc32: WasmHash32Function,
             cityhash32: WasmHash32Function,
             cityhash64: WasmSeededHash64Function,
+            xxhash32: WasmSeededHash32Function,
+            xxhash64: WasmSeededHash64Function,
             murmur32v3: WasmSeededHash32Function,
             murmur32v2: WasmSeededHash32Function,
             murmur64v2: WasmSeededHash64Function,

--- a/packages/bun-polyfills/lib/zighash/types.d.ts
+++ b/packages/bun-polyfills/lib/zighash/types.d.ts
@@ -19,6 +19,7 @@ type ZighashInstance = WebAssembly.WebAssemblyInstantiatedSource & {
             cityhash64: WasmSeededHash64Function,
             xxhash32: WasmSeededHash32Function,
             xxhash64: WasmSeededHash64Function,
+            xxhash3: WasmSeededHash64Function,
             murmur32v3: WasmSeededHash32Function,
             murmur32v2: WasmSeededHash32Function,
             murmur64v2: WasmSeededHash64Function,

--- a/packages/bun-polyfills/src/modules/bun/hashes.ts
+++ b/packages/bun-polyfills/src/modules/bun/hashes.ts
@@ -2,7 +2,7 @@ import type { CryptoHashInterface, DigestEncoding, Hash } from 'bun';
 import nodecrypto from 'node:crypto';
 import os from 'node:os';
 import md4, { Md4 } from 'js-md4';
-import { wyhash, adler32, crc32, cityhash32, cityhash64, xxhash32, xxhash64, murmur32v3, murmur64v2, murmur32v2 } from '../../../lib/zighash/index.mjs';
+import { wyhash, adler32, crc32, cityhash32, cityhash64, xxhash32, xxhash64, xxhash3, murmur32v3, murmur64v2, murmur32v2 } from '../../../lib/zighash/index.mjs';
 
 export const bunHash = ((data, seed = 0): bigint => wyhash(data, BigInt(seed))) as typeof Bun.hash;
 export const bunHashProto: Hash = {
@@ -13,6 +13,7 @@ export const bunHashProto: Hash = {
     cityHash64(data, seed = 0n) { return cityhash64(data, seed); },
     xxHash32(data, seed = 0) { return xxhash32(data, seed); },
     xxHash64(data, seed = 0n) { return xxhash64(data, seed); },
+    xxHash3(data, seed = 0n) { return xxhash3(data, seed); },
     murmur32v3(data, seed = 0) { return murmur32v3(data, seed); },
     murmur32v2(data, seed = 0) { return murmur32v2(data, seed); },
     murmur64v2(data, seed = 0n) { return murmur64v2(data, seed); },

--- a/packages/bun-polyfills/src/modules/bun/hashes.ts
+++ b/packages/bun-polyfills/src/modules/bun/hashes.ts
@@ -2,7 +2,7 @@ import type { CryptoHashInterface, DigestEncoding, Hash } from 'bun';
 import nodecrypto from 'node:crypto';
 import os from 'node:os';
 import md4, { Md4 } from 'js-md4';
-import { wyhash, adler32, crc32, cityhash32, cityhash64, murmur32v3, murmur64v2, murmur32v2 } from '../../../lib/zighash/index.mjs';
+import { wyhash, adler32, crc32, cityhash32, cityhash64, xxhash32, xxhash64, murmur32v3, murmur64v2, murmur32v2 } from '../../../lib/zighash/index.mjs';
 
 export const bunHash = ((data, seed = 0): bigint => wyhash(data, BigInt(seed))) as typeof Bun.hash;
 export const bunHashProto: Hash = {
@@ -11,6 +11,8 @@ export const bunHashProto: Hash = {
     crc32(data) { return crc32(data); },
     cityHash32(data) { return cityhash32(data); },
     cityHash64(data, seed = 0n) { return cityhash64(data, seed); },
+    xxHash32(data, seed = 0) { return xxhash32(data, seed); },
+    xxHash64(data, seed = 0n) { return xxhash64(data, seed); },
     murmur32v3(data, seed = 0) { return murmur32v3(data, seed); },
     murmur32v2(data, seed = 0) { return murmur32v2(data, seed); },
     murmur64v2(data, seed = 0n) { return murmur64v2(data, seed); },

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2027,6 +2027,8 @@ declare module "bun" {
     crc32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer) => number;
     cityHash32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer) => number;
     cityHash64: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
+    xxHash32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
+    xxHash64: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
     murmur32v3: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur32v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur64v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2029,6 +2029,7 @@ declare module "bun" {
     cityHash64: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
     xxHash32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     xxHash64: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
+    xxHash3: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
     murmur32v3: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur32v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur64v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -3294,11 +3294,17 @@ const HashObject = struct {
         }
     });
     pub const xxHash64 = hashWrap(struct {
-        pub const Algorithm = std.hash.XxHash64;
         pub fn hash(seed: u32, bytes: []const u8) u64 {
             // sidestep .hash taking in anytype breaking ArgTuple
             // downstream by forcing a type signature on the input
             return std.hash.XxHash64.hash(seed, bytes);
+        }
+    });
+    pub const xxHash3 = hashWrap(struct {
+        pub fn hash(seed: u32, bytes: []const u8) u64 {
+            // sidestep .hash taking in anytype breaking ArgTuple
+            // downstream by forcing a type signature on the input
+            return std.hash.XxHash3.hash(seed, bytes);
         }
     });
     pub const murmur32v2 = hashWrap(std.hash.murmur.Murmur2_32);
@@ -3315,6 +3321,7 @@ const HashObject = struct {
             "cityHash64",
             "xxHash32",
             "xxHash64",
+            "xxHash3",
             "murmur32v2",
             "murmur32v3",
             "murmur64v2",

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -3286,6 +3286,21 @@ const HashObject = struct {
     pub const crc32 = hashWrap(std.hash.Crc32);
     pub const cityHash32 = hashWrap(std.hash.CityHash32);
     pub const cityHash64 = hashWrap(std.hash.CityHash64);
+    pub const xxHash32 = hashWrap(struct {
+        pub fn hash(seed: u32, bytes: []const u8) u32 {
+            // sidestep .hash taking in anytype breaking ArgTuple
+            // downstream by forcing a type signature on the input
+            return std.hash.XxHash32.hash(seed, bytes);
+        }
+    });
+    pub const xxHash64 = hashWrap(struct {
+        pub const Algorithm = std.hash.XxHash64;
+        pub fn hash(seed: u32, bytes: []const u8) u64 {
+            // sidestep .hash taking in anytype breaking ArgTuple
+            // downstream by forcing a type signature on the input
+            return std.hash.XxHash64.hash(seed, bytes);
+        }
+    });
     pub const murmur32v2 = hashWrap(std.hash.murmur.Murmur2_32);
     pub const murmur32v3 = hashWrap(std.hash.murmur.Murmur3_32);
     pub const murmur64v2 = hashWrap(std.hash.murmur.Murmur2_64);
@@ -3298,6 +3313,8 @@ const HashObject = struct {
             "crc32",
             "cityHash32",
             "cityHash64",
+            "xxHash32",
+            "xxHash64",
             "murmur32v2",
             "murmur32v3",
             "murmur64v2",

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -33,6 +33,18 @@ it(`Bun.hash.cityHash64()`, () => {
   expect(Bun.hash.cityHash64(new TextEncoder().encode("hello world"))).toBe(0xc7920bbdbecee42fn);
   gcTick();
 });
+it(`Bun.hash.xxHash32()`, () => {
+  expect(Bun.hash.xxHash32("hello world")).toBe(0xcebb6622);
+  gcTick();
+  expect(Bun.hash.xxHash32(new TextEncoder().encode("hello world"))).toBe(0xcebb6622);
+  gcTick();
+});
+it(`Bun.hash.xxHash64()`, () => {
+  expect(Bun.hash.xxHash64("hello world")).toBe(0x45ab6734b21e6968n);
+  gcTick();
+  expect(Bun.hash.xxHash64(new TextEncoder().encode("hello world"))).toBe(0x45ab6734b21e6968n);
+  gcTick();
+});
 it(`Bun.hash.murmur32v3()`, () => {
   expect(Bun.hash.murmur32v3("hello world")).toBe(0x5e928f0f);
   gcTick();

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -45,6 +45,12 @@ it(`Bun.hash.xxHash64()`, () => {
   expect(Bun.hash.xxHash64(new TextEncoder().encode("hello world"))).toBe(0x45ab6734b21e6968n);
   gcTick();
 });
+it(`Bun.hash.xxHash3()`, () => {
+  expect(Bun.hash.xxHash3("hello world")).toBe(0xd447b1ea40e6988bn);
+  gcTick();
+  expect(Bun.hash.xxHash3(new TextEncoder().encode("hello world"))).toBe(0xd447b1ea40e6988bn);
+  gcTick();
+});
 it(`Bun.hash.murmur32v3()`, () => {
   expect(Bun.hash.murmur32v3("hello world")).toBe(0x5e928f0f);
   gcTick();


### PR DESCRIPTION
### What does this PR do?

This adds the xxHash32 & 64 algorithms to `Bun.hash` and the bun polyfill using zigs `std.hash`

- [x] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

Wrote automated tests

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

```ts
import { describe, it, expect } from "bun:test";

describe("xxHash functions", () => {
  it("Bun.hash.xxHash32()", () => {
    expect(Bun.hash.xxHash32("hello world")).toBe(0xcebb6622);
    expect(Bun.hash.xxHash32(new TextEncoder().encode("hello world"))).toBe(
      0xcebb6622,
    );
  });
  it("Bun.hash.xxHash64()", () => {
    expect(Bun.hash.xxHash64("hello world")).toBe(0x45ab6734b21e6968n);
    expect(Bun.hash.xxHash64(new TextEncoder().encode("hello world"))).toBe(
      0x45ab6734b21e6968n,
    );
  });
  it("Bun.hash.xxHash3()", () => {
    expect(Bun.hash.xxHash3("hello world")).toBe(0xd447b1ea40e6988bn);
    expect(Bun.hash.xxHash3(new TextEncoder().encode("hello world"))).toBe(
      0xd447b1ea40e6988bn,
    );
  });
});
```