### PR TITLE
Disable IPInt again

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -243,6 +243,9 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         JSC::Options::useConcurrentJIT() = true;
         // JSC::Options::useSigillCrashAnalyzer() = true;
         JSC::Options::useWasm() = true;
+        // remove when we have landed https://github.com/WebKit/WebKit/pull/39029 or WebKit no
+        // longer disables IPInt by default
+        JSC::Options::useWasmIPInt() = false;
         JSC::Options::useSourceProviderCache() = true;
         // JSC::Options::useUnlinkedCodeBlockJettisoning() = false;
         JSC::Options::exposeInternalModuleLoader() = true;


### PR DESCRIPTION
### What does this PR do?

Disables IPInt, WebKit's in-place WASM interpreter, by default. This matches upstream behavior where it is disabled as of WebKit/WebKit#39029 due to bugs.

This code change will be unnecessary once either we update to a WebKit commit that disables it by default, or we update to a WebKit which has fixed and re-enabled IPInt.

### How did you verify your code works?

We will see if it compiles
