### PR TITLE
fix: debug builds loading runtime.out.js from wrong path

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -153,7 +153,7 @@ pub const Runtime = struct {
         return if (Environment.codegen_embed)
             @embedFile("runtime.out.js")
         else
-            bun.runtimeEmbedFile(.src, "runtime.out.js");
+            bun.runtimeEmbedFile(.codegen, "runtime.out.js");
     }
 
     pub fn versionHash() u32 {


### PR DESCRIPTION
### What does this PR do?
#16354 changed where `runtime.out.js` gets saved from `src` to `build/codegen`. This isn't a problem in release builds, since those use `@embedFile`. However, when using a debug build, some tests crash because this file is now elsewhere.

### How did you verify your code works?
I ran tests locally via `bun-debug test`. This problem is not detectable in CI (we use release builds)
