### PR TITLE
Fix under-reporting string memory usage to GC

### DIFF
--- a/bench/snippets/read-file.mjs
+++ b/bench/snippets/read-file.mjs
@@ -43,6 +43,3 @@ bench(`${longUTF16.length} utf8`, () => {
 });
 
 await run();
-Bun.gc(true);
-console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
-console.log(require("bun:jsc").heapStats());

--- a/bench/snippets/read-file.mjs
+++ b/bench/snippets/read-file.mjs
@@ -43,3 +43,6 @@ bench(`${longUTF16.length} utf8`, () => {
 });
 
 await run();
+Bun.gc(true);
+console.log("RSS", (process.memoryUsage.rss() / 1024 / 1024) | 0, "MB");
+console.log(require("bun:jsc").heapStats());

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -761,11 +761,9 @@ fn onRequestWithBundle(
             // routerTypeMain
             router_type.server_file_string.get() orelse str: {
                 const name = dev.server_graph.bundled_files.keys()[fromOpaqueFileId(.server, router_type.server_file).get()];
-                const str = bun.String.createUTF8(dev.relativePath(name));
-                defer str.deref();
-                const js = str.toJS(dev.vm.global);
-                router_type.server_file_string = JSC.Strong.create(js, dev.vm.global);
-                break :str js;
+                const str = bun.String.createUTF8ForJS(dev.vm.global, dev.relativePath(name));
+                router_type.server_file_string = JSC.Strong.create(str, dev.vm.global);
+                break :str str;
             },
             // routeModules
             route_bundle.cached_module_list.get() orelse arr: {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -4599,9 +4599,7 @@ const InternalTestingAPIs = struct {
             return globalThis.throwError(err, "Error formatting code");
         };
 
-        var str = bun.String.createUTF8(buffer.list.items);
-        defer str.deref();
-        return str.toJS(globalThis);
+        return bun.String.createUTF8ForJS(globalThis, buffer.list.items);
     }
 };
 

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -1871,9 +1871,7 @@ pub const Element = struct {
     ) JSValue {
         if (this.element == null)
             return JSValue.jsUndefined();
-        var str = bun.String.createUTF8(std.mem.span(this.element.?.namespaceURI()));
-        defer str.deref();
-        return str.toJS(globalObject);
+        return bun.String.createUTF8ForJS(globalObject, std.mem.span(this.element.?.namespaceURI()));
     }
 
     pub fn getAttributes(

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6366,9 +6366,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             this: *ThisServer,
             globalThis: *JSC.JSGlobalObject,
         ) JSC.JSValue {
-            var str = bun.String.createUTF8(this.config.id);
-            defer str.deref();
-            return str.toJS(globalThis);
+            return bun.String.createUTF8ForJS(globalThis, this.config.id);
         }
 
         pub fn getPendingRequests(

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -59,9 +59,7 @@ pub fn toJS(globalObject: *JSC.JSGlobalObject, comptime ValueType: type, value: 
         bool => return JSC.JSValue.jsBoolean(if (comptime Type != ValueType) value.* else value),
         *JSC.JSGlobalObject => return value.toJSValue(),
         []const u8, [:0]const u8, [*:0]const u8, []u8, [:0]u8, [*:0]u8 => {
-            const str = bun.String.createUTF8(value);
-            defer str.deref();
-            return str.toJS(globalObject);
+            return bun.String.createUTF8ForJS(globalObject, value);
         },
         []const bun.String => {
             defer {

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -124,11 +124,11 @@ extern "C" JSC::EncodedJSValue BunString__transferToJS(BunString* bunString, JSC
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (bunString->tag == BunStringTag::Empty || bunString->tag == BunStringTag::Dead) {
+    if (UNLIKELY(bunString->tag == BunStringTag::Empty || bunString->tag == BunStringTag::Dead)) {
         return JSValue::encode(JSC::jsEmptyString(vm));
     }
 
-    if (bunString->tag == BunStringTag::WTFStringImpl) {
+    if (LIKELY(bunString->tag == BunStringTag::WTFStringImpl)) {
         auto str = bunString->toWTFString();
         bunString->impl.wtf->deref();
         *bunString = { .tag = BunStringTag::Dead };

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -1,4 +1,5 @@
 
+
 #include "helpers.h"
 #include "root.h"
 #include "headers-handwritten.h"
@@ -34,6 +35,7 @@
 #include "JSDOMOperation.h"
 
 #include "GCDefferalContext.h"
+#include "wtf/StdLibExtras.h"
 #include "wtf/text/StringImpl.h"
 #include "wtf/text/StringToIntegerConversion.h"
 
@@ -92,6 +94,52 @@ extern "C" BunString BunString__tryCreateAtom(const char* bytes, size_t length)
     return { BunStringTag::Dead, {} };
 }
 
+extern "C" JSC::EncodedJSValue BunString__createUTF8ForJS(JSC::JSGlobalObject* globalObject, const char* ptr, size_t length)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (simdutf::validate_utf8(ptr, length)) {
+        std::span<LChar> destination;
+
+        auto impl = WTF::StringImpl::tryCreateUninitialized(length, destination);
+        if (UNLIKELY(!impl)) {
+            throwOutOfMemoryError(globalObject, scope);
+            return JSC::EncodedJSValue();
+        }
+        std::span<const LChar> source = { reinterpret_cast<const LChar*>(ptr), length };
+        WTF::memcpySpan(destination, source);
+        return JSValue::encode(jsString(vm, String(WTFMove(impl))));
+    }
+
+    auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const LChar*>(ptr), length });
+    if (UNLIKELY(str.isNull())) {
+        throwOutOfMemoryError(globalObject, scope);
+        return JSC::EncodedJSValue();
+    }
+    return JSValue::encode(jsString(vm, str));
+}
+
+extern "C" JSC::EncodedJSValue BunString__transferToJS(BunString* bunString, JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (bunString->tag == BunStringTag::Empty || bunString->tag == BunStringTag::Dead) {
+        return JSValue::encode(JSC::jsEmptyString(vm));
+    }
+
+    if (bunString->tag == BunStringTag::WTFStringImpl) {
+        auto str = bunString->toWTFString();
+        bunString->impl.wtf->deref();
+        *bunString = { .tag = BunStringTag::Dead };
+        return JSValue::encode(jsString(vm, WTFMove(str)));
+    }
+
+    WTF::String str = bunString->toWTFString();
+    *bunString = { .tag = BunStringTag::Dead };
+    return JSValue::encode(jsString(vm, WTFMove(str)));
+}
+
 // int64_t max to say "not a number"
 extern "C" int64_t BunString__toInt32(BunString* bunString)
 {
@@ -115,7 +163,11 @@ JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, BunString bunString)
         return JSValue(JSC::jsEmptyString(globalObject->vm()));
     }
     if (bunString.tag == BunStringTag::WTFStringImpl) {
-        ASSERT(bunString.impl.wtf->refCount() > 0 && !bunString.impl.wtf->isEmpty());
+#if ASSERT_ENABLED
+        unsigned refCount = bunString.impl.wtf->refCount();
+        ASSERT(refCount > 0 && !bunString.impl.wtf->isEmpty());
+#endif
+
         return JSValue(jsString(globalObject->vm(), String(bunString.impl.wtf)));
     }
 

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -98,7 +98,7 @@ extern "C" JSC::EncodedJSValue BunString__createUTF8ForJS(JSC::JSGlobalObject* g
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (simdutf::validate_utf8(ptr, length)) {
+    if (simdutf::validate_ascii(ptr, length)) {
         std::span<LChar> destination;
 
         auto impl = WTF::StringImpl::tryCreateUninitialized(length, destination);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -574,6 +574,10 @@ pub const ZigString = extern struct {
             }
         }
 
+        pub fn isWTFAllocated(this: *const Slice) bool {
+            return bun.String.isWTFAllocator(this.allocator.get() orelse return false);
+        }
+
         pub fn init(allocator: std.mem.Allocator, input: []const u8) Slice {
             return .{
                 .ptr = input.ptr,

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -5422,9 +5422,7 @@ pub const ExpectMatcherUtils = struct {
 
         try buffered_writer.flush();
 
-        const str = bun.String.createUTF8(mutable_string.toOwnedSlice());
-        defer str.deref();
-        return str.toJS(globalThis);
+        return bun.String.createUTF8ForJS(globalThis, mutable_string.toOwnedSlice());
     }
 
     inline fn printValueCatched(globalThis: *JSGlobalObject, value: JSValue, comptime color_or_null: ?[]const u8) JSValue {

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -634,13 +634,12 @@ pub const Crypto = struct {
         globalThis: *JSC.JSGlobalObject,
         _: *JSC.CallFrame,
     ) bun.JSError!JSC.JSValue {
-        const str, var bytes = bun.String.createUninitialized(.latin1, 36);
-        defer str.deref();
+        var str, var bytes = bun.String.createUninitialized(.latin1, 36);
 
         const uuid = globalThis.bunVM().rareData().nextUUID();
 
         uuid.print(bytes[0..36]);
-        return str.toJS(globalThis);
+        return str.transferToJS(globalThis);
     }
 
     comptime {

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -501,8 +501,7 @@ pub fn getBucket(
     globalThis: *JSC.JSGlobalObject,
 ) callconv(JSC.conv) JSValue {
     if (getBucketName(this)) |name| {
-        var str = bun.String.createUTF8(name);
-        return str.transferToJS(globalThis);
+        return bun.String.createUTF8ForJS(globalThis, name);
     }
     return .undefined;
 }

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2504,20 +2504,17 @@ pub const E = struct {
             if (s.isUTF8()) {
                 if (try strings.toUTF16Alloc(allocator, s.slice8(), false, false)) |utf16| {
                     var out, const chars = bun.String.createUninitialized(.utf16, utf16.len);
-                    defer out.deref();
                     @memcpy(chars, utf16);
-                    return out.toJS(globalObject);
+                    return out.transferToJS(globalObject);
                 } else {
                     var out, const chars = bun.String.createUninitialized(.latin1, s.slice8().len);
-                    defer out.deref();
                     @memcpy(chars, s.slice8());
-                    return out.toJS(globalObject);
+                    return out.transferToJS(globalObject);
                 }
             } else {
                 var out, const chars = bun.String.createUninitialized(.utf16, s.slice16().len);
-                defer out.deref();
                 @memcpy(chars, s.slice16());
-                return out.toJS(globalObject);
+                return out.transferToJS(globalObject);
             }
         }
 

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -375,7 +375,8 @@ pub export fn napi_create_string_utf8(env: napi_env, str: ?[*]const u8, length: 
     const globalObject = env.toJS();
     const string = bun.String.createUTF8ForJS(globalObject, slice);
     if (globalObject.hasException()) {
-        return env.genericFailure();
+        env.setLastError(.pending_exception);
+        return @intFromEnum(NapiStatus.pending_exception);
     }
     result.set(env, string);
     return env.ok();

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -375,8 +375,7 @@ pub export fn napi_create_string_utf8(env: napi_env, str: ?[*]const u8, length: 
     const globalObject = env.toJS();
     const string = bun.String.createUTF8ForJS(globalObject, slice);
     if (globalObject.hasException()) {
-        env.setLastError(.pending_exception);
-        return @intFromEnum(NapiStatus.pending_exception);
+        return env.setLastError(.pending_exception);
     }
     result.set(env, string);
     return env.ok();

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -372,13 +372,12 @@ pub export fn napi_create_string_utf8(env: napi_env, str: ?[*]const u8, length: 
 
     log("napi_create_string_utf8: {s}", .{slice});
 
-    var string = bun.String.createUTF8(slice);
-    if (string.tag == .Dead) {
+    const globalObject = env.toJS();
+    const string = bun.String.createUTF8ForJS(globalObject, slice);
+    if (globalObject.hasException()) {
         return env.genericFailure();
     }
-
-    defer string.deref();
-    result.set(env, string.toJS(env.toJS()));
+    result.set(env, string);
     return env.ok();
 }
 pub export fn napi_create_string_utf16(env: napi_env, str: ?[*]const char16_t, length: usize, result_: ?*napi_value) napi_status {
@@ -407,11 +406,9 @@ pub export fn napi_create_string_utf16(env: napi_env, str: ?[*]const char16_t, l
     }
 
     var string, const chars = bun.String.createUninitialized(.utf16, slice.len);
-    defer string.deref();
-
     @memcpy(chars, slice);
 
-    result.set(env, string.toJS(env.toJS()));
+    result.set(env, string.transferToJS(env.toJS()));
     return env.ok();
 }
 pub extern fn napi_create_symbol(env: napi_env, description: napi_value, result: *napi_value) napi_status;

--- a/src/string.zig
+++ b/src/string.zig
@@ -342,11 +342,10 @@ pub const String = extern struct {
         if (this.tag == .WTFStringImpl) this.value.WTFStringImpl.ensureHash();
     }
 
+    extern fn BunString__transferToJS(this: *String, globalThis: *JSC.JSGlobalObject) JSC.JSValue;
     pub fn transferToJS(this: *String, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
-        const js_value = this.toJS(globalThis);
-        this.deref();
-        this.* = dead;
-        return js_value;
+        JSC.markBinding(@src());
+        return BunString__transferToJS(this, globalThis);
     }
 
     pub fn toOwnedSlice(this: String, allocator: std.mem.Allocator) ![]u8 {
@@ -1069,6 +1068,12 @@ pub const String = extern struct {
     extern fn Bun__parseDate(*JSC.JSGlobalObject, *String) f64;
     extern fn BunString__fromJSRef(globalObject: *JSC.JSGlobalObject, value: bun.JSC.JSValue, out: *String) bool;
     extern fn BunString__toWTFString(this: *String) void;
+    extern fn BunString__createUTF8ForJS(globalObject: *JSC.JSGlobalObject, ptr: [*]const u8, len: usize) JSC.JSValue;
+
+    pub fn createUTF8ForJS(globalObject: *JSC.JSGlobalObject, utf8_slice: []const u8) JSC.JSValue {
+        JSC.markBinding(@src());
+        return BunString__createUTF8ForJS(globalObject, utf8_slice.ptr, utf8_slice.len);
+    }
 
     pub fn parseDate(this: *String, globalObject: *JSC.JSGlobalObject) f64 {
         JSC.markBinding(@src());
@@ -1466,6 +1471,14 @@ pub const SliceWithUnderlyingString = struct {
     }
 
     pub fn toJS(this: *SliceWithUnderlyingString, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        return this.toJSWithOptions(globalObject, false);
+    }
+
+    pub fn transferToJS(this: *SliceWithUnderlyingString, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
+        return this.toJSWithOptions(globalObject, true);
+    }
+
+    fn toJSWithOptions(this: *SliceWithUnderlyingString, globalObject: *JSC.JSGlobalObject, transfer: bool) JSC.JSValue {
         if ((this.underlying.tag == .Dead or this.underlying.tag == .Empty) and this.utf8.length() > 0) {
             if (comptime bun.Environment.allow_assert) {
                 if (this.utf8.allocator.get()) |allocator| {
@@ -1487,12 +1500,23 @@ pub const SliceWithUnderlyingString = struct {
                 }
             }
 
-            const out = bun.String.createUTF8(this.utf8.slice());
-            defer out.deref();
-            return out.toJS(globalObject);
+            defer {
+                if (transfer) {
+                    this.utf8.deinit();
+                    this.utf8 = .{};
+                }
+            }
+
+            return String.createUTF8ForJS(globalObject, this.utf8.slice());
         }
 
-        return this.underlying.toJS(globalObject);
+        if (transfer) {
+            this.utf8.deinit();
+            this.utf8 = .{};
+            return this.underlying.transferToJS(globalObject);
+        } else {
+            return this.underlying.toJS(globalObject);
+        }
     }
 };
 


### PR DESCRIPTION
### What does this PR do?

Fix under-reporting string memory usage to GC

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
