### PR TITLE
prefer `bunfig.toml` over `.npmrc` for install

### DIFF
--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -535,5 +535,5 @@ const Fs = bun.fs;
 const Loader = @import("./options.zig").Loader;
 const resolver = @import("./resolver/resolver.zig");
 const resolve_path = @import("./resolver/resolve_path.zig");
-const Output = @import("./global.zig").Output;
+const Output = @import("./Global.zig").Output;
 const Environment = bun.Environment;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8912,7 +8912,7 @@ pub const PackageManager = struct {
         }
 
         try BunArguments.loadConfig(ctx.allocator, cli.config, ctx, .InstallCommand);
-        
+
         const cpu_count = bun.getThreadCount();
 
         const options = Options{

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8865,7 +8865,6 @@ pub const PackageManager = struct {
         };
 
         try bun.sys.chdir(fs.top_level_dir, fs.top_level_dir).unwrap();
-        try BunArguments.loadConfig(ctx.allocator, cli.config, ctx, .InstallCommand);
         bun.copy(u8, &cwd_buf, fs.top_level_dir);
         cwd_buf[fs.top_level_dir.len] = 0;
         fs.top_level_dir = cwd_buf[0..fs.top_level_dir.len :0];
@@ -8911,6 +8910,9 @@ pub const PackageManager = struct {
                 break :brk install_;
             }, env, true, &[_][:0]const u8{".npmrc"});
         }
+
+        try BunArguments.loadConfig(ctx.allocator, cli.config, ctx, .InstallCommand);
+        
         const cpu_count = bun.getThreadCount();
 
         const options = Options{


### PR DESCRIPTION
### What does this PR do?

fixes #16274

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

made a test