### PR TITLE
`bun upgrade --canary` changelog use the git sha of the new build instead of main 

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -456,7 +456,7 @@ pub const UpgradeCommand = struct {
 
         const use_profile = strings.containsAny(bun.argv, "--profile");
 
-        const version: Version = if (!use_canary) v: {
+        var version: Version = if (!use_canary) v: {
             var refresher = Progress{};
             var progress = refresher.start("Fetching version tags", 0);
 
@@ -699,7 +699,7 @@ pub const UpgradeCommand = struct {
             {
                 var verify_argv = [_]string{
                     exe,
-                    "--version",
+                    if (use_canary) "--revision" else "--version",
                 };
 
                 const result = std.process.Child.run(.{
@@ -745,7 +745,12 @@ pub const UpgradeCommand = struct {
 
                 // It should run successfully
                 // but we don't care about the version number if we're doing a canary build
-                if (!use_canary) {
+                if (use_canary) {
+                    var version_string = result.stdout;
+                    if (strings.indexOfChar(version_string, '+')) |i| {
+                        version.tag = version_string[i+1..version_string.len];
+                    }
+                } else {
                     var version_string = result.stdout;
                     if (strings.indexOfChar(version_string, ' ')) |i| {
                         version_string = version_string[0..i];
@@ -925,10 +930,10 @@ pub const UpgradeCommand = struct {
                     \\
                     \\Changelog:
                     \\
-                    \\    https://github.com/oven-sh/bun/compare/{s}...main
+                    \\    https://github.com/oven-sh/bun/compare/{s}...{s}
                     \\
                 ,
-                    .{Environment.git_sha},
+                    .{ Environment.git_sha_short, version.tag },
                 );
             } else {
                 const bun_v = "bun-v" ++ Global.package_json_version;

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -748,7 +748,7 @@ pub const UpgradeCommand = struct {
                 if (use_canary) {
                     var version_string = result.stdout;
                     if (strings.indexOfChar(version_string, '+')) |i| {
-                        version.tag = version_string[i+1..version_string.len];
+                        version.tag = version_string[i + 1 .. version_string.len];
                     }
                 } else {
                     var version_string = result.stdout;


### PR DESCRIPTION
### What does this PR do?

fixes #4115

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
