### PR TITLE
fixes #16431 HEAD requests returning 200 OK regardless of returned re…

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3117,7 +3117,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 this.endWithoutBody(this.shouldCloseConnection());
                 return;
             };
-
             const globalThis = server.globalThis;
             var has_content_length_or_transfer_encoding = false;
             if (response.getFetchHeaders()) |headers| {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3106,11 +3106,12 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             this.response_ptr = response;
             const server = this.server orelse {
                 // server detached?
-                resp.writeHeaderInt("content-length", 0);
                 this.renderMetadata();
+                resp.writeHeaderInt("content-length", 0);
                 this.endWithoutBody(this.shouldCloseConnection());
                 return;
             };
+            this.renderMetadata();
             const globalThis = server.globalThis;
             var has_content_length_or_transfer_encoding = false;
             if (response.getFetchHeaders()) |headers| {
@@ -3173,7 +3174,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                 }
             }
 
-            this.renderMetadata();
             this.endWithoutBody(this.shouldCloseConnection());
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3106,19 +3106,17 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
             const resp = this.resp.?;
             this.response_ptr = response;
+
+            this.doWriteStatus(response.statusCode());
+            this.flags.head_request_status_written = true;
+
             const server = this.server orelse {
                 // server detached?
-                this.doWriteStatus(response.statusCode());
-                this.flags.head_request_status_written = true;
-
                 resp.writeHeaderInt("content-length", 0);
                 this.renderMetadata();
                 this.endWithoutBody(this.shouldCloseConnection());
                 return;
             };
-
-            this.doWriteStatus(response.statusCode());
-            this.flags.head_request_status_written = true;
 
             const globalThis = server.globalThis;
             var has_content_length_or_transfer_encoding = false;

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -795,8 +795,6 @@ describe("HEAD requests #16431", () => {
             return new Response(null, { status: 307 });
           case "/308":
             return new Response(null, { status: 308 });
-          case "/200-with-body":
-            return new Response(null, { status: 200 });
           default:
             return new Response(null, { status: 200 });
         }
@@ -871,14 +869,6 @@ describe("HEAD requests #16431", () => {
     {
       const response = await fetch(server.url + "/308", { method: "HEAD" });
       expect(response.status).toBe(308);
-      expect(await response.text()).toBe("");
-      expect(response.headers.get("content-length")).toBe("0");
-    }
-
-    // Test 200-with-body response
-    {
-      const response = await fetch(server.url + "/200-with-body", { method: "HEAD" });
-      expect(response.status).toBe(200);
       expect(await response.text()).toBe("");
       expect(response.headers.get("content-length")).toBe("0");
     }

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -778,13 +778,27 @@ describe("HEAD requests #16431", () => {
 
         switch (url.pathname) {
           case "/404":
-            return new Response("Not Found", { status: 404 });
+            return new Response(null, { status: 404 });
           case "/500":
-            return new Response("Server Error", { status: 500 });
+            return new Response(null, { status: 500 });
           case "/403":
-            return new Response("Forbidden", { status: 403 });
+            return new Response(null, { status: 403 });
+          case "/401":
+            return new Response(null, { status: 401 });
+          case "/400":
+            return new Response(null, { status: 400 });
+          case "/301":
+            return new Response(null, { status: 301 });
+          case "/302":
+            return new Response(null, { status: 302 });
+          case "/307":
+            return new Response(null, { status: 307 });
+          case "/308":
+            return new Response(null, { status: 308 });
+          case "/200-with-body":
+            return new Response(null, { status: 200 });
           default:
-            return new Response("OK", { status: 200 });
+            return new Response(null, { status: 200 });
         }
       },
     });
@@ -794,7 +808,7 @@ describe("HEAD requests #16431", () => {
       const response = await fetch(server.url + "/404", { method: "HEAD" });
       expect(response.status).toBe(404);
       expect(await response.text()).toBe("");
-      expect(response.headers.get("content-length")).toBe("9");
+      expect(response.headers.get("content-length")).toBe("0");
     }
 
     // Test 500 response
@@ -802,7 +816,7 @@ describe("HEAD requests #16431", () => {
       const response = await fetch(server.url + "/500", { method: "HEAD" });
       expect(response.status).toBe(500);
       expect(await response.text()).toBe("");
-      expect(response.headers.get("content-length")).toBe("12");
+      expect(response.headers.get("content-length")).toBe("0");
     }
 
     // Test 403 response
@@ -810,7 +824,63 @@ describe("HEAD requests #16431", () => {
       const response = await fetch(server.url + "/403", { method: "HEAD" });
       expect(response.status).toBe(403);
       expect(await response.text()).toBe("");
-      expect(response.headers.get("content-length")).toBe("9");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 401 response
+    {
+      const response = await fetch(server.url + "/401", { method: "HEAD" });
+      expect(response.status).toBe(401);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 400 response
+    {
+      const response = await fetch(server.url + "/400", { method: "HEAD" });
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 301 response
+    {
+      const response = await fetch(server.url + "/301", { method: "HEAD" });
+      expect(response.status).toBe(301);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 302 response
+    {
+      const response = await fetch(server.url + "/302", { method: "HEAD" });
+      expect(response.status).toBe(302);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 307 response
+    {
+      const response = await fetch(server.url + "/307", { method: "HEAD" });
+      expect(response.status).toBe(307);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 308 response
+    {
+      const response = await fetch(server.url + "/308", { method: "HEAD" });
+      expect(response.status).toBe(308);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
+    }
+
+    // Test 200-with-body response
+    {
+      const response = await fetch(server.url + "/200-with-body", { method: "HEAD" });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("");
+      expect(response.headers.get("content-length")).toBe("0");
     }
 
     // Test 200 response
@@ -818,7 +888,7 @@ describe("HEAD requests #16431", () => {
       const response = await fetch(server.url + "/200", { method: "HEAD" });
       expect(response.status).toBe(200);
       expect(await response.text()).toBe("");
-      expect(response.headers.get("content-length")).toBe("2");
+      expect(response.headers.get("content-length")).toBe("0");
     }
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes Issue #16431 where HEAD requests would always return 200 OK Status Codes even when a Response was returned with a different status code such as 404.

Writing out Status codes and headers to the response in the server.zig file looks to be handled by the `renderMetaData` function in many cases, but for HEAD requests this function gets called after a header has already been written using a function called `writeHeaderInt`.

`writeHeaderInt` will (ultimately) send a status of 200 OK if no status has been sent yet.  This ensures that headers are NOT sent before status codes which would likely break a lot of things.

This PR adds a new flag named `head_request_status_written` so we can write the status before the call to `writeHeaderInt` and the subsequent call to write the status in `renderMetaData` -> `doWriteStatus` can be skipped.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Added Automated Tests

