### PR TITLE
fix: add `bun.lock` to `.gitattributes`, `.gitignore`, and docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,8 @@
 *.mjs text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mts text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
-*.lockb binary diff=lockb
+bun.lock linguist-language=json
+bun.lockb binary diff=lockb
 
 .vscode/launch.json linguist-generated
 src/api/schema.d.ts linguist-generated

--- a/bench/install/.gitignore
+++ b/bench/install/.gitignore
@@ -7,4 +7,5 @@ node_modules
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+bun.lock
 bun.lockb

--- a/misctools/.gitignore
+++ b/misctools/.gitignore
@@ -7,4 +7,5 @@ httpbench
 fetch
 tgz2hop
 hop
+bun.lock
 bun.lockb

--- a/test/cli/install/migration/complex-workspace/.gitignore
+++ b/test/cli/install/migration/complex-workspace/.gitignore
@@ -1,2 +1,3 @@
 !package-lock.json
+bun.lock
 bun.lockb

--- a/test/cli/install/migration/contoso-test/.gitignore
+++ b/test/cli/install/migration/contoso-test/.gitignore
@@ -1,2 +1,3 @@
 !package-lock.json
+bun.lock
 bun.lockb


### PR DESCRIPTION
Fixes #16462. Supersedes #16324.

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
