### PR TITLE
Alternate fix for `bun --bun folder`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2271,7 +2271,6 @@ pub const Command = struct {
                     break :brk null;
                 };
 
-                const force_using_bun = ctx.debug.run_in_bun;
                 var did_check = false;
                 if (default_loader) |loader| {
                     if (loader.canBeRunByBun()) {
@@ -2280,12 +2279,6 @@ pub const Command = struct {
                             return;
                         }
                         did_check = true;
-                    }
-                }
-
-                if (force_using_bun and !did_check) {
-                    if (maybeOpenWithBunJS(ctx)) {
-                        return;
                     }
                 }
 

--- a/src/cli/exec_command.zig
+++ b/src/cli/exec_command.zig
@@ -39,7 +39,7 @@ pub const ExecCommand = struct {
         };
         const script_path = bun.path.join(parts, .auto);
 
-        const code = bun.shell.Interpreter.initAndRunFromSource(ctx, mini, script_path, script) catch |err| {
+        const code = bun.shell.Interpreter.initAndRunFromSource(ctx, mini, script_path, script, null) catch |err| {
             Output.err(err, "failed to run script <b>{s}<r>", .{script_path});
             Global.exit(1);
         };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1301,12 +1301,12 @@ pub const RunCommand = struct {
             return true;
         }
 
-        if (!did_try_open_with_bun_js and (log_errors or force_using_bun)) {
+        if (!did_try_open_with_bun_js and log_errors) {
             if (script_name_to_search.len > 0) {
                 possibly_open_with_bun_js: {
                     const ext = std.fs.path.extension(script_name_to_search);
                     var has_loader = false;
-                    if (!force_using_bun) {
+                    {
                         if (options.defaultLoaders.get(ext)) |load| {
                             has_loader = true;
                             if (!load.canBeRunByBun())
@@ -1345,7 +1345,7 @@ pub const RunCommand = struct {
 
                     const file = file_ catch break :possibly_open_with_bun_js;
 
-                    if (!force_using_bun) {
+                    {
                         // Due to preload, we don't know if they intend to run
                         // this as a script or as a regular file
                         // once we know it's a file, check if they have any preloads

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -1473,7 +1473,7 @@ pub const Interpreter = struct {
         return code;
     }
 
-    pub fn initAndRunFromSource(ctx: bun.CLI.Command.Context, mini: *JSC.MiniEventLoop, path_for_errors: []const u8, src: []const u8) !ExitCode {
+    pub fn initAndRunFromSource(ctx: bun.CLI.Command.Context, mini: *JSC.MiniEventLoop, path_for_errors: []const u8, src: []const u8, cwd: ?[]const u8) !ExitCode {
         bun.Analytics.Features.standalone_shell += 1;
         var shargs = ShellArgs.init();
         defer shargs.deinit();
@@ -1505,7 +1505,7 @@ pub const Interpreter = struct {
             shargs,
             jsobjs,
             null,
-            null,
+            cwd,
         )) {
             .err => |*e| {
                 e.throwMini();

--- a/test/regression/issue/10132.test.ts
+++ b/test/regression/issue/10132.test.ts
@@ -50,14 +50,14 @@ echo My name is bun-hello2
   }
 });
 
-test("issue #10132, bun run sets cwd", async () => {
+test("issue #10132, bun run sets cwd for script, matching npm", async () => {
   $.cwd(dir);
   const currentPwd = (await $`${bunExe()} run get-pwd`.text()).trim();
   expect(currentPwd).toBe(dir);
 
   const currentPwd2 = join(currentPwd, "subdir", "one");
   $.cwd(currentPwd2);
-  expect((await $`${bunExe()} run get-pwd`.text()).trim()).toBe(currentPwd2);
+  expect((await $`${bunExe()} run get-pwd`.text()).trim()).toBe(dir);
 
   $.cwd(process.cwd());
 });


### PR DESCRIPTION
### What does this PR do?

Alternative for #15117. Sets CWD & fixes `bun --bun run build`, does not fix `bun test.todo` and does not support `bun index` (for index.ts)

Test failures:

- [ ] next-build.test.ts

