### PR TITLE
fix(napi): `napi_get_value_uint32` now handles int32s correctly

### DIFF
--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -300,6 +300,7 @@ int BundlerPlugin::NativePluginList::call(JSC::VM& vm, BundlerPlugin* plugin, in
 
         if (filters[i].match(vm, path)) {
             Bun::NapiExternal* external = callbacks[i].external;
+            ASSERT(onBeforeParseArgs != nullptr);
             if (external) {
                 onBeforeParseArgs->external = external->value();
             } else {

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -563,6 +563,7 @@ public:
         ASSERT(jsCast<NAPIFunction*>(callframe->jsCallee()));
         auto* function = static_cast<NAPIFunction*>(callframe->jsCallee());
         auto* env = toNapi(globalObject);
+        ASSERT(function->m_method);
         auto* callback = reinterpret_cast<napi_callback>(function->m_method);
         JSC::VM& vm = globalObject->vm();
 
@@ -2098,7 +2099,7 @@ extern "C" napi_status napi_get_value_int32(napi_env env, napi_value value, int3
     JSC::JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isNumber(), napi_number_expected);
 
-    *result = jsValue.isInt32() ? jsValue.asInt32() : JSC::toInt32(jsValue.asDouble());
+    *result = jsValue.isInt32() ? jsValue.asInt32() : JSC::toInt32(jsValue.asNumber());
     NAPI_RETURN_SUCCESS(env);
 }
 
@@ -2109,8 +2110,8 @@ extern "C" napi_status napi_get_value_uint32(napi_env env, napi_value value, uin
     NAPI_CHECK_ARG(env, value);
     JSC::JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isNumber(), napi_number_expected);
+    *result = jsValue.isUInt32() ? jsValue.asUInt32() : JSC::toUInt32(jsValue.asNumber());
 
-    *result = jsValue.isUInt32() ? jsValue.asUInt32() : JSC::toUInt32(jsValue.asDouble());
     NAPI_RETURN_SUCCESS(env);
 }
 

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1,11 +1,6 @@
+const assert = require("node:assert");
 const nativeTests = require("./build/Release/napitests.node");
 const secondAddon = require("./build/Release/second_addon.node");
-
-function assert(ok) {
-  if (!ok) {
-    throw new Error("assertion failed");
-  }
-}
 
 async function gcUntil(fn) {
   const MAX = 100;
@@ -157,7 +152,7 @@ nativeTests.test_number_integer_conversions_from_js = () => {
     const actualOutput = nativeTests.double_to_i32(input);
     console.log(`${input} as i32 => ${actualOutput}`);
     if (actualOutput !== expectedOutput) {
-      console.error("wrong");
+      console.error(`${input}: ${actualOutput} != ${expectedOutput}`);
     }
   }
 
@@ -188,7 +183,7 @@ nativeTests.test_number_integer_conversions_from_js = () => {
     const actualOutput = nativeTests.double_to_u32(input);
     console.log(`${input} as u32 => ${actualOutput}`);
     if (actualOutput !== expectedOutput) {
-      console.error("wrong");
+      console.error(`${input}: ${actualOutput} != ${expectedOutput}`);
     }
   }
 
@@ -223,7 +218,7 @@ nativeTests.test_number_integer_conversions_from_js = () => {
       `${typeof input == "number" ? input.toFixed(2) : input} as i64 => ${typeof actualOutput == "number" ? actualOutput.toFixed(2) : actualOutput}`,
     );
     if (actualOutput !== expectedOutput) {
-      console.error("wrong");
+      console.error(`${input}: ${actualOutput} != ${expectedOutput}`);
     }
   }
 };

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -391,11 +391,14 @@ function checkSameOutput(test: string, args: any[] | string) {
   let bunResult = runOn(bunExe(), test, args);
   // remove all debug logs
   bunResult = bunResult.replaceAll(/^\[\w+\].+$/gm, "").trim();
-  expect(bunResult).toBe(nodeResult);
+  expect(bunResult).toEqual(nodeResult);
   return nodeResult;
 }
 
 function runOn(executable: string, test: string, args: any[] | string) {
+  // when the inspector runs (can be due to VSCode extension), there is
+  // a bug that in debug modes the console logs extra stuff
+  const { BUN_INSPECT_CONNECT_TO: _, ...rest } = bunEnv;
   const exec = spawnSync({
     cmd: [
       executable,
@@ -404,7 +407,7 @@ function runOn(executable: string, test: string, args: any[] | string) {
       test,
       typeof args == "string" ? args : JSON.stringify(args),
     ],
-    env: bunEnv,
+    env: rest,
   });
   const errs = exec.stderr.toString();
   if (errs !== "") {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
