### PR TITLE
Normalize algorithm names for hmac

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -72,6 +72,53 @@ Certificate.verifySpkac = verifySpkac;
 Certificate.exportPublicKey = exportPublicKey;
 Certificate.exportChallenge = exportChallenge;
 
+let bunAlgorithmMap: Map<string, string>;
+function normalizeAlgorithmName(alg: string) {
+  if (!bunAlgorithmMap) {
+    // This list should be kept roughly in sync with the ComptimeStringMap used
+    // in Bun.CryptoHasher
+    bunAlgorithmMap = new Map([
+      ["blake2b256", "blake2b256"],
+      ["blake2b512", "blake2b512"],
+
+      // this JS code expects rmd160
+      // so we for now normalize to that instead.
+      ["ripemd160", "rmd160"],
+      ["rmd160", "rmd160"],
+      ["md4", "md4"],
+      ["md5", "md5"],
+      ["sha1", "sha1"],
+      ["sha128", "sha1"],
+      ["sha224", "sha224"],
+      ["sha256", "sha256"],
+      ["sha384", "sha384"],
+      ["sha512", "sha512"],
+      ["sha-1", "sha1"],
+      ["sha-224", "sha224"],
+      ["sha-256", "sha256"],
+      ["sha-384", "sha384"],
+      ["sha-512", "sha512"],
+      ["sha-512/224", "sha512-224"],
+      ["sha-512_224", "sha512-224"],
+      ["sha-512224", "sha512-224"],
+      ["sha512-224", "sha512-224"],
+      ["sha-512/256", "sha512-256"],
+      ["sha-512_256", "sha512-256"],
+      ["sha-512256", "sha512-256"],
+      ["sha512-256", "sha512-256"],
+      ["sha384", "sha384"],
+      ["sha3-224", "sha3-224"],
+      ["sha3-256", "sha3-256"],
+      ["sha3-384", "sha3-384"],
+      ["sha3-512", "sha3-512"],
+      ["shake128", "shake128"],
+      ["shake256", "shake256"],
+    ]);
+  }
+
+  return bunAlgorithmMap.get((alg = alg?.toLowerCase?.())) || alg;
+}
+
 function getCipherInfo(nameOrNid, options) {
   if (typeof nameOrNid !== "string" && typeof nameOrNid !== "number") {
     throw $ERR_INVALID_ARG_TYPE("nameOrNid", ["string", "number"], nameOrNid);
@@ -1471,6 +1518,7 @@ var require_browser3 = __commonJS({
     var sha = require_sha2();
     var ZEROS = Buffer2.alloc(128);
     function Hmac(alg, key) {
+      alg = normalizeAlgorithmName(alg);
       key = exportIfKeyObject(key);
 
       Base.$call(this, "digest"), typeof key == "string" && (key = Buffer2.from(key));

--- a/test/js/node/crypto/crypto-hmac-algorithm.test.ts
+++ b/test/js/node/crypto/crypto-hmac-algorithm.test.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "bun:test";
+
+import crypto from "node:crypto";
+
+test("createHmac works with various algorithm names", () => {
+  const key = "secret-key";
+  const input = "hello world";
+
+  const algorithms = [
+    "sha1",
+    "sha-256",
+    "sHA-256",
+    "sHa-256",
+    "mD5",
+    "sha256",
+    "sha512",
+    "md5",
+    ...Bun.CryptoHasher.algorithms,
+  ];
+
+  const toRemove = [
+    "blake2b256",
+    "blake2b512",
+    "md4",
+    "sha512-224",
+    "sha512-256",
+    "sha3-224",
+    "sha3-256",
+    "sha3-384",
+    "sha3-512",
+    "shake128",
+    "shake256",
+  ];
+  for (const algo of toRemove) {
+    algorithms.splice(algorithms.indexOf(algo), 1);
+  }
+
+  for (const algo of algorithms) {
+    // Both ways of creating HMAC should work
+    const hmac1 = crypto.createHmac(algo, key);
+    const hmac2 = new crypto.Hmac(algo, key);
+
+    hmac1.update(input);
+    hmac2.update(input);
+
+    expect(hmac1.digest("hex")).toBe(hmac2.digest("hex"));
+  }
+});
+
+test("createHmac throws on invalid algorithm", () => {
+  expect(() => {
+    crypto.createHmac("invalid-algo", "key");
+  }).toThrow();
+});
+
+test("Hmac throws on invalid algorithm", () => {
+  expect(() => {
+    new crypto.Hmac("invalid-algo", "key");
+  }).toThrow();
+});
+
+test("Hmac can be updated multiple times", () => {
+  const hmac = crypto.createHmac("sha256", "key");
+  hmac.update("hello");
+  hmac.update(" ");
+  hmac.update("world");
+
+  const singleUpdateHmac = crypto.createHmac("sha256", "key");
+  singleUpdateHmac.update("hello world");
+
+  expect(hmac.digest("hex")).toBe(singleUpdateHmac.digest("hex"));
+});
+
+test("Hmac digest can be called with different encodings", () => {
+  const hmac = crypto.createHmac("sha256", "key");
+  hmac.update("test");
+
+  const hex = hmac.digest("hex");
+  const base64 = hmac.digest("base64");
+
+  expect(hex).toBeString();
+  expect(base64).toBeString();
+  expect(hex).not.toBe(base64);
+});


### PR DESCRIPTION
### What does this PR do?

We support sha-256, but it errors if you pass `"sha-256"` instead of `"sha256"`

So we need to normalize algorithm names for hmac in the browserify code (which we need to delete and will delete soon)

### How did you verify your code works?

Tests