### PR TITLE
read `--ignore-scripts` from `.npmrc` and `bunfig.toml`

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -2986,6 +2986,8 @@ pub const Api = struct {
             list: []const []const u8,
         } = null,
 
+        ignore_scripts: ?bool = null,
+
         pub fn decode(reader: anytype) anyerror!BunInstall {
             var this = std.mem.zeroes(BunInstall);
 

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -482,6 +482,12 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (install_obj.get("ignoreScripts")) |ignore_scripts_expr| {
+                        if (ignore_scripts_expr.asBool()) |ignore_scripts| {
+                            install.ignore_scripts = ignore_scripts;
+                        }
+                    }
+
                     if (install_obj.get("lockfile")) |lockfile_expr| {
                         if (lockfile_expr.get("print")) |lockfile| {
                             try this.expectString(lockfile);

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -1033,6 +1033,12 @@ pub fn loadNpmrc(
         }
     }
 
+    if (out.get("ignore-scripts")) |ignore_scripts| {
+        if (ignore_scripts.isBoolean()) {
+            install.ignore_scripts = ignore_scripts.data.e_boolean.value;
+        }
+    }
+
     var registry_map = install.scoped orelse bun.Schema.Api.NpmRegistryMap{};
 
     // Process scopes

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7440,6 +7440,12 @@ pub const PackageManager = struct {
                     this.cache_directory = cache_dir;
                 }
 
+                if (config.ignore_scripts) |ignore_scripts| {
+                    if (ignore_scripts) {
+                        this.do.run_scripts = false;
+                    }
+                }
+
                 this.explicit_global_directory = config.global_dir orelse this.explicit_global_directory;
             }
 

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2908,3 +2908,47 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
   });
 }
+
+test("ignore-scripts is read from npmrc", async () => {
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.2.3",
+        dependencies: {
+          "uses-what-bin": "1.0.0",
+        },
+        scripts: {
+          postinstall: `${bunExe()} -e 'await Bun.write("postinstall.txt", "postinstall!!")'`,
+        },
+        trustedDependencies: ["uses-what-bin"],
+      }),
+    ),
+    write(join(packageDir, ".npmrc"), "ignore-scripts=true"),
+  ]);
+
+  async function checkScripts(): Promise<boolean[]> {
+    return Promise.all([
+      exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt")),
+      exists(join(packageDir, "postinstall.txt")),
+    ]);
+  }
+
+  await runBunInstall(env, packageDir);
+  expect(await checkScripts()).toEqual([false, false]);
+
+  await write(join(packageDir, ".npmrc"), "ignore-scripts=false");
+
+  await runBunInstall(env, packageDir, { savesLockfile: false });
+  expect(await checkScripts()).toEqual([false, true]);
+
+  await Promise.all([
+    rm(join(packageDir, "postinstall.txt")),
+    rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
+  ]);
+  expect(await checkScripts()).toEqual([false, false]);
+
+  await runBunInstall(env, packageDir, { savesLockfile: false });
+  expect(await checkScripts()).toEqual([true, true]);
+});


### PR DESCRIPTION
### What does this PR do?
Reads `ignore-scripts` from `.npmrc` and `ignoreScripts` from `bunfig.toml`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
