### PR TITLE
wip: leaked JSGlobalObject in worker threads

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -970,6 +970,14 @@ extern "C" JSC__JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
 
     return globalObject;
 }
+extern "C" void Zig__GlobalObject__destroy(JSC__JSGlobalObject* global)
+{
+    ASSERT(global != nullptr);
+    auto& vm = global->vm();
+    JSC::JSLockHolder locker(vm);
+    JSC::gcUnprotect(global);
+    global->vm().derefSuppressingSaferCPPChecking();
+}
 
 JSC_DEFINE_HOST_FUNCTION(functionFulfillModuleSync,
     (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -1219,6 +1227,7 @@ GlobalObject::~GlobalObject()
         ctx->removeFromContextsMap();
         ctx->deref();
     }
+    globalEventScope.deref();
 }
 
 void GlobalObject::destroy(JSCell* cell)

--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -66,6 +66,10 @@ pub const ZigGlobalObject = extern struct {
         return global;
     }
 
+    pub fn destroy(global: *JSGlobalObject) void {
+        shim.cppFn("destroy", .{global});
+    }
+
     pub fn getModuleRegistryMap(global: *JSGlobalObject) *anyopaque {
         return shim.cppFn("getModuleRegistryMap", .{global});
     }

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -554,6 +554,7 @@ extern "C" JSC__JSValue SYSV_ABI Reader__intptr__slowpath(JSC__JSGlobalObject* a
 #pragma mark - Zig::GlobalObject
 
 CPP_DECL JSC__JSGlobalObject* Zig__GlobalObject__create(void* arg0, int32_t arg1, bool arg2, bool arg3, void* arg4);
+CPP_DECL void Zig__GlobalObject__destroy(JSC__JSGlobalObject* global);
 CPP_DECL void* Zig__GlobalObject__getModuleRegistryMap(JSC__JSGlobalObject* arg0);
 CPP_DECL bool Zig__GlobalObject__resetModuleRegistryMap(JSC__JSGlobalObject* arg0, void* arg1);
 

--- a/src/bun.js/bindings/headers.zig
+++ b/src/bun.js/bindings/headers.zig
@@ -328,6 +328,7 @@ pub extern fn Reader__i64__put(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JS
 pub extern fn Reader__u64__put(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue) void;
 pub extern fn Reader__intptr__put(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue) void;
 pub extern fn Zig__GlobalObject__create(arg0: ?*anyopaque, arg1: i32, arg2: bool, arg3: bool, arg4: ?*anyopaque) *bindings.JSGlobalObject;
+pub extern fn Zig__GlobalObject__destroy(global: *bindings.JSGlobalObject) void;
 pub extern fn Zig__GlobalObject__getModuleRegistryMap(arg0: *bindings.JSGlobalObject) ?*anyopaque;
 pub extern fn Zig__GlobalObject__resetModuleRegistryMap(arg0: *bindings.JSGlobalObject, arg1: ?*anyopaque) bool;
 pub extern fn ArrayBufferSink__assignToStream(arg0: *bindings.JSGlobalObject, JSValue1: JSC__JSValue, arg2: ?*anyopaque, arg3: [*c]*anyopaque) JSC__JSValue;

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2914,6 +2914,7 @@ pub const VirtualMachine = struct {
     // TODO:
     pub fn deinit(this: *VirtualMachine) void {
         this.auto_killer.deinit();
+        ZigGlobalObject.destroy(this.global);
 
         if (source_code_printer) |print| {
             print.getMutableBuffer().deinit();

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2716,8 +2716,6 @@ pub const FetchFlags = enum {
     }
 };
 
-const SavedSourceMap = JSC.SavedSourceMap;
-
 pub const HardcodedModule = enum {
     bun,
     @"abort-controller",


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
