### PR TITLE
Support `import with { type: "json" }` and others

### DIFF
--- a/docs/bundler/loaders.md
+++ b/docs/bundler/loaders.md
@@ -2,7 +2,7 @@ The Bun bundler implements a set of default loaders out of the box. As a rule of
 
 `.js` `.cjs` `.mjs` `.mts` `.cts` `.ts` `.tsx` `.jsx` `.toml` `.json` `.txt` `.wasm` `.node` `.html`
 
-Bun uses the file extension to determine which built-in _loader_ should be used to parse the file. Every loader has a name, such as `js`, `tsx`, or `json`. These names are used when building [plugins](https://bun.sh/docs/bundler/plugins) that extend Bun with custom loaders.
+Bun uses the file extension to determine which built-in _loader_ should be used to parse the file. Every loader has a name, such as `js`, `tsx`, or `json`. These names are used when building [plugins](https://bun.sh/docs/bundler/plugins) that extend Bun with custom loaders. A loader can be manually selected by using `import "./my_file" with { loader: "toml" }`.
 
 ## Built-in loaders
 

--- a/docs/bundler/loaders.md
+++ b/docs/bundler/loaders.md
@@ -2,7 +2,13 @@ The Bun bundler implements a set of default loaders out of the box. As a rule of
 
 `.js` `.cjs` `.mjs` `.mts` `.cts` `.ts` `.tsx` `.jsx` `.toml` `.json` `.txt` `.wasm` `.node` `.html`
 
-Bun uses the file extension to determine which built-in _loader_ should be used to parse the file. Every loader has a name, such as `js`, `tsx`, or `json`. These names are used when building [plugins](https://bun.sh/docs/bundler/plugins) that extend Bun with custom loaders. A loader can be manually selected by using `import "./my_file" with { loader: "toml" }`.
+Bun uses the file extension to determine which built-in _loader_ should be used to parse the file. Every loader has a name, such as `js`, `tsx`, or `json`. These names are used when building [plugins](https://bun.sh/docs/bundler/plugins) that extend Bun with custom loaders.
+
+You can explicitly specify which loader to use using the 'loader' import attribute.
+
+```ts
+import my_toml from "./my_file" with { loader: "toml" };
+```
 
 ## Built-in loaders
 

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -5096,6 +5096,7 @@ const DirectoryWatchStore = struct {
             // loaders do not depend on importing other files.
             .file,
             .json,
+            .jsonc,
             .toml,
             .wasm,
             .napi,

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -490,6 +490,8 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
                 &transpiler.log,
                 source,
                 allocator,
+                .json,
+                false,
             ) catch null) orelse break :macros;
             transpiler.macro_map = PackageJSON.parseMacrosJSON(allocator, json, &transpiler.log, &source);
         }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -4403,6 +4403,10 @@ JSC::JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
 
             if (params.type() == ScriptFetchParameters::Type::HostDefined) {
                 typeAttributeString = params.hostDefinedImportType();
+            } else if (params.type() == ScriptFetchParameters::Type::JSON) {
+                typeAttributeString = "json"_s;
+            } else if (params.type() == ScriptFetchParameters::Type::WebAssembly) {
+                typeAttributeString = "webassembly"_s;
             }
         }
     }

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -2427,93 +2427,15 @@ pub const VirtualMachine = struct {
 
         const specifier_clone = _specifier.toUTF8(bun.default_allocator);
         defer specifier_clone.deinit();
-        const normalized_file_path_from_specifier, const specifier = ModuleLoader.normalizeSpecifier(jsc_vm, specifier_clone.slice());
         const referrer_clone = referrer.toUTF8(bun.default_allocator);
         defer referrer_clone.deinit();
-        var path = Fs.Path.init(normalized_file_path_from_specifier);
 
-        // For blobs.
-        var blob_source: ?JSC.WebCore.Blob = null;
         var virtual_source_to_use: ?logger.Source = null;
-        defer {
-            if (blob_source) |*blob| {
-                blob.deinit();
-            }
-        }
-
-        const loader, const virtual_source = brk: {
-            if (jsc_vm.module_loader.eval_source) |eval_source| {
-                if (strings.endsWithComptime(specifier, bun.pathLiteral("/[eval]"))) {
-                    break :brk .{ .tsx, eval_source };
-                }
-                if (strings.endsWithComptime(specifier, bun.pathLiteral("/[stdin]"))) {
-                    break :brk .{ .tsx, eval_source };
-                }
-            }
-
-            var ext_for_loader = path.name.ext;
-
-            // Support errors within blob: URLs
-            // Be careful to handle Bun.file(), in addition to regular Blob/File objects
-            // Bun.file() should be treated the same as a file path.
-            if (JSC.WebCore.ObjectURLRegistry.isBlobURL(specifier)) {
-                if (JSC.WebCore.ObjectURLRegistry.singleton().resolveAndDupe(specifier["blob:".len..])) |blob| {
-                    blob_source = blob;
-
-                    if (blob.getFileName()) |filename| {
-                        const current_path = Fs.Path.init(filename);
-                        if (blob.needsToReadFile()) {
-                            path = current_path;
-                        }
-
-                        ext_for_loader = current_path.name.ext;
-                    } else if (blob.getMimeTypeOrContentType()) |mime_type| {
-                        if (strings.hasPrefixComptime(mime_type.value, "application/javascript-jsx")) {
-                            ext_for_loader = ".jsx";
-                        } else if (strings.hasPrefixComptime(mime_type.value, "application/typescript-jsx")) {
-                            ext_for_loader = ".tsx";
-                        } else if (strings.hasPrefixComptime(mime_type.value, "application/javascript")) {
-                            ext_for_loader = ".js";
-                        } else if (strings.hasPrefixComptime(mime_type.value, "application/typescript")) {
-                            ext_for_loader = ".ts";
-                        } else if (strings.hasPrefixComptime(mime_type.value, "application/json")) {
-                            ext_for_loader = ".json";
-                        } else if (strings.hasPrefixComptime(mime_type.value, "application/json5")) {
-                            ext_for_loader = ".jsonc";
-                        } else if (strings.hasPrefixComptime(mime_type.value, "application/jsonc")) {
-                            ext_for_loader = ".jsonc";
-                        } else if (mime_type.category == .text) {
-                            ext_for_loader = ".txt";
-                        } else {
-                            // Be maximally permissive.
-                            ext_for_loader = ".tsx";
-                        }
-                    } else {
-                        // Be maximally permissive.
-                        ext_for_loader = ".tsx";
-                    }
-
-                    if (!blob.needsToReadFile()) {
-                        virtual_source_to_use = logger.Source{
-                            .path = path,
-                            .contents = blob.sharedView(),
-                        };
-                    }
-                } else {
-                    return error.ModuleNotFound;
-                }
-            }
-
-            break :brk .{
-                jsc_vm.transpiler.options.loaders.get(ext_for_loader) orelse brk2: {
-                    if (strings.eqlLong(specifier, jsc_vm.main, true)) {
-                        break :brk2 options.Loader.js;
-                    }
-                    break :brk2 options.Loader.file;
-                },
-                if (virtual_source_to_use) |*src| src else null,
-            };
+        var blob_to_deinit: ?JSC.WebCore.Blob = null;
+        const lr = options.getLoaderAndVirtualSource(specifier_clone.slice(), jsc_vm, &virtual_source_to_use, &blob_to_deinit, null) catch {
+            return error.ModuleNotFound;
         };
+        defer if (blob_to_deinit) |*blob| blob.deinit();
 
         // .print_source, which is used by exceptions avoids duplicating the entire source code
         // but that means we have to be careful of the lifetime of the source code
@@ -2523,13 +2445,13 @@ pub const VirtualMachine = struct {
 
         return try ModuleLoader.transpileSourceCode(
             jsc_vm,
-            specifier,
+            lr.specifier,
             referrer_clone.slice(),
             _specifier,
-            path,
-            loader,
+            lr.path,
+            lr.loader orelse if (lr.is_main) .js else .file,
             log,
-            virtual_source,
+            lr.virtual_source,
             null,
             VirtualMachine.source_code_printer.?,
             globalObject,

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1473,9 +1473,7 @@ pub const ModuleLoader = struct {
         var jsc_vm = global.bunVM();
         const filename = str.toUTF8(jsc_vm.allocator);
         defer filename.deinit();
-        // This is called from handleOnLoadResultNotPromise. Is this correct behaviour? Or should handleOnLoadResultNotPromise
-        // be called with a loader in order to not need this fn?
-        const loader = jsc_vm.transpiler.options.loaderForExtension(Fs.PathName.init(filename.slice()).ext).toAPI();
+        const loader = jsc_vm.transpiler.options.loader(Fs.PathName.init(filename.slice()).ext).toAPI();
         if (loader == .file) {
             return Api.Loader.js;
         }

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -243,6 +243,7 @@ pub const RuntimeTranspilerStore = struct {
         input_specifier: bun.String,
         path: Fs.Path,
         referrer: bun.String,
+        loader: bun.options.Loader,
     ) *anyopaque {
         var job: *TranspilerJob = this.store.get();
         const owned_path = Fs.Path.init(bun.default_allocator.dupe(u8, path.text) catch unreachable);
@@ -254,7 +255,7 @@ pub const RuntimeTranspilerStore = struct {
             .non_threadsafe_referrer = referrer,
             .vm = vm,
             .log = logger.Log.init(bun.default_allocator),
-            .loader = vm.transpiler.options.loader(owned_path.name.ext),
+            .loader = loader,
             .promise = JSC.Strong.create(JSValue.fromCell(promise), globalObject),
             .poll_ref = .{},
             .fetcher = TranspilerJob.Fetcher{
@@ -1472,7 +1473,9 @@ pub const ModuleLoader = struct {
         var jsc_vm = global.bunVM();
         const filename = str.toUTF8(jsc_vm.allocator);
         defer filename.deinit();
-        const loader = jsc_vm.transpiler.options.loader(Fs.PathName.init(filename.slice()).ext).toAPI();
+        // This is called from handleOnLoadResultNotPromise. Is this correct behaviour? Or should handleOnLoadResultNotPromise
+        // be called with a loader in order to not need this fn?
+        const loader = jsc_vm.transpiler.options.loaderForExtension(Fs.PathName.init(filename.slice()).ext).toAPI();
         if (loader == .file) {
             return Api.Loader.js;
         }
@@ -2373,6 +2376,7 @@ pub const ModuleLoader = struct {
                         specifier_ptr.dupeRef(),
                         path,
                         referrer.dupeRef(),
+                        concurrent_loader,
                     );
                 }
             }

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -2325,29 +2325,9 @@ pub const ModuleLoader = struct {
             }
         }
 
-        if (type_attribute) |attribute| {
-            if (attribute.eqlComptime("sqlite")) {
-                loader = .sqlite;
-            } else if (attribute.eqlComptime("text")) {
-                loader = .text;
-            } else if (attribute.eqlComptime("json")) {
-                loader = .json;
-            } else if (attribute.eqlComptime("toml")) {
-                loader = .toml;
-            } else if (attribute.eqlComptime("file")) {
-                loader = .file;
-            } else if (attribute.eqlComptime("js")) {
-                loader = .js;
-            } else if (attribute.eqlComptime("jsx")) {
-                loader = .jsx;
-            } else if (attribute.eqlComptime("ts")) {
-                loader = .ts;
-            } else if (attribute.eqlComptime("tsx")) {
-                loader = .tsx;
-            } else if (attribute.eqlComptime("html")) {
-                loader = .html;
-            }
-        }
+        if (type_attribute) |attribute| if (attribute.asUTF8()) |attr_utf8| if (bun.options.Loader.fromString(attr_utf8)) |attr_loader| {
+            loader = attr_loader;
+        };
 
         // If we were going to choose file loader, see if it's a bun.lock
         if (loader == null) {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -4750,6 +4750,18 @@ pub const Blob = struct {
         return null;
     }
 
+    pub fn getLoader(blob: *const Blob, jsc_vm: *VirtualMachine) ?bun.options.Loader {
+        if (blob.getFileName()) |filename| {
+            const current_path = bun.fs.Path.init(filename);
+            return current_path.loader(&jsc_vm.transpiler.options.loaders) orelse .tsx;
+        } else if (blob.getMimeTypeOrContentType()) |mime_type| {
+            return .fromMimeType(mime_type);
+        } else {
+            // Be maximally permissive.
+            return .tsx;
+        }
+    }
+
     // TODO: Move this to a separate `File` object or BunFile
     pub fn getLastModified(
         this: *Blob,

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -924,8 +924,8 @@ pub const BundleV2 = struct {
         if (!entry.found_existing) {
             path.* = this.pathWithPrettyInitialized(path.*, target) catch bun.outOfMemory();
             const loader: Loader = (brk: {
-                var record: *ImportRecord = &this.graph.ast.items(.import_records)[import_record.importer_source_index].slice()[import_record.import_record_index];
-                if (record.loader()) |out_loader| {
+                const record: *ImportRecord = &this.graph.ast.items(.import_records)[import_record.importer_source_index].slice()[import_record.import_record_index];
+                if (record.loader) |out_loader| {
                     break :brk out_loader;
                 }
                 break :brk path.loader(&transpiler.options.loaders) orelse options.Loader.file;
@@ -3049,12 +3049,12 @@ pub const BundleV2 = struct {
             }
 
             // By default, we treat .sqlite files as external.
-            if (import_record.tag == .with_type_sqlite) {
+            if (import_record.loader != null and import_record.loader.? == .sqlite) {
                 import_record.is_external_without_side_effects = true;
                 continue;
             }
 
-            if (import_record.tag == .with_type_sqlite_embedded) {
+            if (import_record.loader != null and import_record.loader.? == .sqlite_embedded) {
                 import_record.is_external_without_side_effects = true;
             }
 
@@ -3289,7 +3289,7 @@ pub const BundleV2 = struct {
 
             // Figure out the loader.
             {
-                if (import_record.tag.loader()) |l| {
+                if (import_record.loader) |l| {
                     resolve_task.loader = l;
                 }
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -8878,7 +8878,7 @@ pub const LinkerContext = struct {
                     const loader = loaders[record.source_index.get()];
 
                     switch (loader) {
-                        .jsx, .js, .ts, .tsx, .napi, .sqlite, .json, .html, .sqlite_embedded => {
+                        .jsx, .js, .ts, .tsx, .napi, .sqlite, .json, .jsonc, .html, .sqlite_embedded => {
                             log.addErrorFmt(
                                 source,
                                 record.range.loc,

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -4212,8 +4212,13 @@ pub const ParseTask = struct {
             .toml => {
                 const trace = tracer(@src(), "ParseTOML");
                 defer trace.end();
-                const root = try TOML.parse(&source, log, allocator, false);
-                return JSAst.init((try js_parser.newLazyExportAST(allocator, transpiler.options.define, opts, log, root, &source, "")).?);
+                var temp_log = bun.logger.Log.init(allocator);
+                defer {
+                    temp_log.cloneToWithRecycled(log, true) catch bun.outOfMemory();
+                    temp_log.msgs.clearAndFree();
+                }
+                const root = try TOML.parse(&source, &temp_log, allocator, false);
+                return JSAst.init((try js_parser.newLazyExportAST(allocator, transpiler.options.define, opts, &temp_log, root, &source, "")).?);
             },
             .text => {
                 const root = Expr.init(E.String, E.String{

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -320,15 +320,15 @@ pub const Json = struct {
             break :handler null;
         };
     }
-    pub fn parseJSON(cache: *@This(), log: *logger.Log, source: logger.Source, allocator: std.mem.Allocator) anyerror!?js_ast.Expr {
+    pub fn parseJSON(cache: *@This(), log: *logger.Log, source: logger.Source, allocator: std.mem.Allocator, mode: enum { json, jsonc }, comptime force_utf8: bool) anyerror!?js_ast.Expr {
         // tsconfig.* and jsconfig.* files are JSON files, but they are not valid JSON files.
         // They are JSON files with comments and trailing commas.
         // Sometimes tooling expects this to work.
-        if (source.path.isJSONCFile()) {
-            return try parse(cache, log, source, allocator, json_parser.parseTSConfig, true);
+        if (mode == .jsonc) {
+            return try parse(cache, log, source, allocator, json_parser.parseTSConfig, force_utf8);
         }
 
-        return try parse(cache, log, source, allocator, json_parser.parse, false);
+        return try parse(cache, log, source, allocator, json_parser.parse, force_utf8);
     }
 
     pub fn parsePackageJSON(cache: *@This(), log: *logger.Log, source: logger.Source, allocator: std.mem.Allocator, comptime force_utf8: bool) anyerror!?js_ast.Expr {

--- a/src/import_record.zig
+++ b/src/import_record.zig
@@ -104,6 +104,7 @@ pub const ImportRecord = struct {
     path: fs.Path,
     kind: ImportKind,
     tag: Tag = .none,
+    loader: ?bun.options.Loader = null,
 
     source_index: bun.JSAst.Index = .invalid,
 
@@ -167,10 +168,6 @@ pub const ImportRecord = struct {
 
     pub const List = bun.BabyList(ImportRecord);
 
-    pub fn loader(this: *const ImportRecord) ?bun.options.Loader {
-        return this.tag.loader();
-    }
-
     pub const Tag = enum {
         /// A normal import to a user's source file
         none,
@@ -189,40 +186,7 @@ pub const ImportRecord = struct {
         /// crossover to the SSR graph. See bake.Framework.ServerComponents.separate_ssr_graph
         bake_resolve_to_ssr_graph,
 
-        with_type_sqlite,
-        with_type_sqlite_embedded,
-        with_type_text,
-        with_type_json,
-        with_type_toml,
-        with_type_file,
-
-        pub fn loader(this: Tag) ?bun.options.Loader {
-            return switch (this) {
-                .with_type_sqlite => .sqlite,
-                .with_type_sqlite_embedded => .sqlite_embedded,
-                .with_type_text => .text,
-                .with_type_json => .json,
-                .with_type_toml => .toml,
-                .with_type_file => .file,
-                else => null,
-            };
-        }
-
-        pub fn onlySupportsDefaultImports(this: Tag) bool {
-            return switch (this) {
-                .with_type_file, .with_type_text => true,
-                else => false,
-            };
-        }
-
-        pub fn isSQLite(this: Tag) bool {
-            return switch (this) {
-                .with_type_sqlite,
-                .with_type_sqlite_embedded,
-                => true,
-                else => false,
-            };
-        }
+        tailwind,
 
         pub inline fn isRuntime(this: Tag) bool {
             return this == .runtime;

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -4435,36 +4435,26 @@ fn NewPrinter(
 
                     p.printImportRecordPath(record);
 
-                    switch (record.tag) {
-                        .with_type_sqlite, .with_type_sqlite_embedded => {
-                            // we do not preserve "embed": "true" since it is not necessary
-                            p.printWhitespacer(ws(" with { type: \"sqlite\" }"));
-                        },
-                        .with_type_text => {
-                            if (comptime is_bun_platform) {
-                                p.printWhitespacer(ws(" with { type: \"text\" }"));
-                            }
-                        },
-                        .with_type_json => {
-                            // backwards compatibility: previously, we always stripped type json
-                            if (comptime is_bun_platform) {
-                                p.printWhitespacer(ws(" with { type: \"json\" }"));
-                            }
-                        },
-                        .with_type_toml => {
-                            // backwards compatibility: previously, we always stripped type
-                            if (comptime is_bun_platform) {
-                                p.printWhitespacer(ws(" with { type: \"toml\" }"));
-                            }
-                        },
-                        .with_type_file => {
-                            // backwards compatibility: previously, we always stripped type
-                            if (comptime is_bun_platform) {
-                                p.printWhitespacer(ws(" with { type: \"file\" }"));
-                            }
-                        },
-                        else => {},
-                    }
+                    // backwards compatibility: previously, we always stripped type
+                    if (comptime is_bun_platform) if (record.loader) |loader| switch (loader) {
+                        .jsx => p.printWhitespacer(ws(" with { type: \"jsx\" }")),
+                        .js => p.printWhitespacer(ws(" with { type: \"js\" }")),
+                        .ts => p.printWhitespacer(ws(" with { type: \"ts\" }")),
+                        .tsx => p.printWhitespacer(ws(" with { type: \"tsx\" }")),
+                        .css => p.printWhitespacer(ws(" with { type: \"css\" }")),
+                        .file => p.printWhitespacer(ws(" with { type: \"file\" }")),
+                        .json => p.printWhitespacer(ws(" with { type: \"json\" }")),
+                        .toml => p.printWhitespacer(ws(" with { type: \"toml\" }")),
+                        .wasm => p.printWhitespacer(ws(" with { type: \"wasm\" }")),
+                        .napi => p.printWhitespacer(ws(" with { type: \"napi\" }")),
+                        .base64 => p.printWhitespacer(ws(" with { type: \"base64\" }")),
+                        .dataurl => p.printWhitespacer(ws(" with { type: \"dataurl\" }")),
+                        .text => p.printWhitespacer(ws(" with { type: \"text\" }")),
+                        .bunsh => p.printWhitespacer(ws(" with { type: \"sh\" }")),
+                        // sqlite_embedded only relevant when bundling
+                        .sqlite, .sqlite_embedded => p.printWhitespacer(ws(" with { type: \"sqlite\" }")),
+                        .html => p.printWhitespacer(ws(" with { type: \"html\" }")),
+                    };
                     p.printSemicolonAfterStatement();
                 },
                 .s_block => |s| {

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -4444,6 +4444,7 @@ fn NewPrinter(
                         .css => p.printWhitespacer(ws(" with { type: \"css\" }")),
                         .file => p.printWhitespacer(ws(" with { type: \"file\" }")),
                         .json => p.printWhitespacer(ws(" with { type: \"json\" }")),
+                        .jsonc => p.printWhitespacer(ws(" with { type: \"jsonc\" }")),
                         .toml => p.printWhitespacer(ws(" with { type: \"toml\" }")),
                         .wasm => p.printWhitespacer(ws(" with { type: \"wasm\" }")),
                         .napi => p.printWhitespacer(ws(" with { type: \"napi\" }")),

--- a/src/options.zig
+++ b/src/options.zig
@@ -1676,7 +1676,9 @@ pub const BundleOptions = struct {
         this.defines_loaded = true;
     }
 
-    pub fn loader(this: *const BundleOptions, ext: string) Loader {
+    pub const loader = loaderForExtension;
+    /// loader from {type: ""} import attribute must be preferred over the file extension
+    pub fn loaderForExtension(this: *const BundleOptions, ext: string) Loader {
         return this.loaders.get(ext) orelse .file;
     }
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -770,6 +770,7 @@ pub const Loader = enum(u8) {
         .{ "jsonc", .json },
         .{ "toml", .toml },
         .{ "wasm", .wasm },
+        .{ "napi", .napi },
         .{ "node", .napi },
         .{ "dataurl", .dataurl },
         .{ "base64", .base64 },

--- a/src/options.zig
+++ b/src/options.zig
@@ -1686,9 +1686,7 @@ pub const BundleOptions = struct {
         this.defines_loaded = true;
     }
 
-    pub const loader = loaderForExtension;
-    /// loader from {type: ""} import attribute must be preferred over the file extension
-    pub fn loaderForExtension(this: *const BundleOptions, ext: string) Loader {
+    pub fn loader(this: *const BundleOptions, ext: string) Loader {
         return this.loaders.get(ext) orelse .file;
     }
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -1022,6 +1022,9 @@ pub fn getLoaderAndVirtualSource(
         }
     }
 
+    if (strings.eqlComptime(query, "?raw")) {
+        loader = .text;
+    }
     if (type_attribute_str) |attr_str| if (bun.options.Loader.fromString(attr_str)) |attr_loader| {
         loader = attr_loader;
     };

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -666,7 +666,7 @@ pub const Transpiler = struct {
         };
 
         switch (loader) {
-            .jsx, .tsx, .js, .ts, .json, .toml, .text => {
+            .jsx, .tsx, .js, .ts, .json, .jsonc, .toml, .text => {
                 var result = transpiler.parse(
                     ParseOptions{
                         .allocator = transpiler.allocator,
@@ -1184,14 +1184,13 @@ pub const Transpiler = struct {
                 };
             },
             // TODO: use lazy export AST
-            inline .toml, .json => |kind| {
-                var expr = if (kind == .json)
+            inline .toml, .json, .jsonc => |kind| {
+                var expr = if (kind == .jsonc)
                     // We allow importing tsconfig.*.json or jsconfig.*.json with comments
                     // These files implicitly become JSONC files, which aligns with the behavior of text editors.
-                    if (source.path.isJSONCFile())
-                        JSON.parseTSConfig(&source, transpiler.log, allocator, false) catch return null
-                    else
-                        JSON.parse(&source, transpiler.log, allocator, false) catch return null
+                    JSON.parseTSConfig(&source, transpiler.log, allocator, false) catch return null
+                else if (kind == .json)
+                    JSON.parse(&source, transpiler.log, allocator, false) catch return null
                 else if (kind == .toml)
                     TOML.parse(&source, transpiler.log, allocator, false) catch return null
                 else

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -1,19 +1,8 @@
 import { bunExe, tempDirWithFiles } from "harness";
 import * as path from "path";
 
-// .napi is skipped (hard to make an example)
-// .sh is skipped (only works from `bun somefile.sh`)
-// .html, .css is skipped
 const loaders = ["js", "jsx", "ts", "tsx", "json", "jsonc", "toml", "text", "sqlite", "file"];
-
 const other_loaders_do_not_crash = ["webassembly", "does_not_exist"];
-
-// ctrl+shift+f for tailwind
-// next bug: ModuleLoader.cpp:1665
-// - only some files use the jsonc loader, based on if `path.isJSONCFile()`:
-// - this probably improves performance
-// - if we want this, we should make a seperate jsonc loader instead of overloading json
-//   and checking the fliepath to determine if it is jsonc
 
 async function testBunRun(dir: string, loader: string | null, filename: string): Promise<unknown> {
   const cmd = [

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -1,0 +1,177 @@
+import { bunExe, tempDirWithFiles } from "harness";
+import * as path from "path";
+
+// .napi is skipped (hard to make an example)
+// .sh is skipped (only works from `bun somefile.sh`)
+const loaders = ["js", "jsx", "ts", "tsx", "json", "toml", "html", "css"];
+
+// bug 1 found:
+// - module_loader.zig:2386
+//   - it determines the loader based on the type attribute, checks if it's js like, then proceeds to drop it and not pass it to transpile()
+//   - transpile() then figures out the loader itself based on file extension:
+//     - module_loader.zig:266
+
+async function testBunRun(dir: string, loader: string): Promise<unknown> {
+  const cmd = [
+    bunExe(),
+    "-e",
+    `import * as contents from './_the_file' with {type: '${loader}'}; console.log(JSON.stringify(contents));`,
+  ];
+  const result = Bun.spawnSync({
+    cmd: cmd,
+    cwd: dir,
+  });
+  if (result.exitCode !== 0) {
+    if (result.stderr.toString().includes("panic")) {
+      console.error("cmd stderr");
+      console.log(result.stderr.toString());
+      console.error("cmd stdout");
+      console.log(result.stdout.toString());
+      console.error("cmd args");
+      console.log(JSON.stringify(cmd));
+      console.error("cmd cwd");
+      console.log(dir);
+      throw new Error("panic");
+    }
+    return "error";
+    // return result.stderr.toString().match(/error: .+/)?.[0];
+  } else {
+    return JSON.parse(result.stdout.toString());
+  }
+}
+async function testBunRunAwaitImport(dir: string, loader: string): Promise<unknown> {
+  const cmd = [
+    bunExe(),
+    "-e",
+    `console.log(JSON.stringify(await import('./_the_file', {with: {type: '${loader}'}})));`,
+  ];
+  const result = Bun.spawnSync({
+    cmd: cmd,
+    cwd: dir,
+  });
+  console.timeEnd("testBunRunAwaitImport: " + dir + " " + loader);
+  if (result.exitCode !== 0) {
+    if (result.stderr.toString().includes("panic")) {
+      console.error("cmd stderr");
+      console.log(result.stderr.toString());
+      console.error("cmd stdout");
+      console.log(result.stdout.toString());
+      console.error("cmd args");
+      console.log(JSON.stringify(cmd));
+      console.error("cmd cwd");
+      console.log(dir);
+      throw new Error("panic");
+    }
+    return "error";
+    // return result.stderr.toString().match(/error: .+/)?.[0];
+  } else {
+    return JSON.parse(result.stdout.toString());
+  }
+}
+async function testBunBuild(dir: string, loader: string): Promise<unknown> {
+  await Bun.write(
+    path.join(dir, "main_" + loader + ".js"),
+    `import * as contents from '${dir}/_the_file' with {type: '${loader}'}; console.log(JSON.stringify(contents));`,
+  );
+  const result = await Bun.build({
+    entrypoints: [path.join(dir, "main_" + loader + ".js")],
+    throw: false,
+    target: "bun",
+    outdir: path.join(dir, "out"),
+  });
+  if (result.success) {
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "out/main_" + loader + ".js"],
+      cwd: dir,
+    });
+    if (result.exitCode !== 0) {
+      if (result.stderr.toString().includes("panic")) {
+        console.error("cmd stderr");
+        console.log(result.stderr.toString());
+        console.error("cmd stdout");
+        console.log(result.stdout.toString());
+        console.error("cmd args");
+        console.log(JSON.stringify(cmd));
+        console.error("cmd cwd");
+        console.log(dir);
+        throw new Error("panic");
+      }
+      // return result.stderr.toString().match(/error: .+/)?.[0];
+      return "error";
+    } else {
+      return JSON.parse(result.stdout.toString());
+    }
+  } else {
+    return "error";
+    // return result.logs;
+  }
+}
+async function compileAndTest(code: string): Record<string, string> {
+  const v1 = await compileAndTest_inner(code, testBunRun);
+  const v2 = await compileAndTest_inner(code, testBunRunAwaitImport);
+  expect(v1).toStrictEqual(v2);
+  const v3 = await compileAndTest_inner(code, testBunBuild);
+  expect(v1).toStrictEqual(v3);
+  return v1;
+}
+async function compileAndTest_inner(
+  code: string,
+  cb: (dir: string, loader: string) => Promise<unknown>,
+): Record<string, string> {
+  const dir = tempDirWithFiles("import-attributes", {
+    "_the_file": code,
+  });
+
+  let res: Record<string, unknown> = {};
+  for (const loader of loaders) {
+    res[loader] = await cb(dir, loader);
+  }
+  expect(await cb(dir, "text")).toEqual({ default: code });
+  const sqlite_res = await cb(dir, "sqlite");
+  delete (sqlite_res as any).__esModule;
+  expect(sqlite_res).toStrictEqual({
+    db: { filename: path.join(dir, "_the_file") },
+    default: { filename: path.join(dir, "_the_file") },
+  });
+  if (cb === testBunBuild) {
+    expect(await cb(dir, "file")).toEqual({
+      default: expect.any(String),
+    });
+  } else {
+    const file_res = await cb(dir, "file");
+    delete (file_res as any).__esModule;
+    expect(file_res).toEqual({
+      default: path.join(dir, "_the_file"),
+    });
+  }
+  const res_flipped: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(res)) {
+    (res_flipped[JSON.stringify(v)] ??= []).push(k);
+  }
+  return Object.fromEntries(Object.entries(res_flipped).map(([k, v]) => [v.join(","), k]));
+}
+
+test("javascript", async () => {
+  expect(await compileAndTest(`export const a = "demo";`)).toMatchInlineSnapshot();
+});
+
+test("typescript", async () => {
+  expect(await compileAndTest(`export const a = (<T>() => {}).toString();`)).toMatchInlineSnapshot();
+});
+
+test("json", async () => {
+  expect(await compileAndTest(`{"key": "value"}`)).toMatchInlineSnapshot();
+});
+test("jsonc", async () => {
+  expect(
+    await compileAndTest(`{
+      "key": "value", // my json
+    }`),
+  ).toMatchInlineSnapshot();
+});
+test("toml", async () => {
+  expect(
+    await compileAndTest(`[section]
+    key = "value"`),
+  ).toMatchInlineSnapshot();
+});

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -3,13 +3,13 @@ import * as path from "path";
 
 // .napi is skipped (hard to make an example)
 // .sh is skipped (only works from `bun somefile.sh`)
+// .html, .css is skipped
 const loaders = ["js", "jsx", "ts", "tsx", "json", "toml", "html", "css"];
 
-// bug 1 found:
-// - module_loader.zig:2386
-//   - it determines the loader based on the type attribute, checks if it's js like, then proceeds to drop it and not pass it to transpile()
-//   - transpile() then figures out the loader itself based on file extension:
-//     - module_loader.zig:266
+// ctrl+shift+f for tailwind
+// next bug: ZigGlobalObject.cpp:4226
+// - in the case of `with {type: "json"}`, `params.type()` is `ScriptFetchParameters::Type::JSON` so
+//   the type attribute string is not set.
 
 async function testBunRun(dir: string, loader: string): Promise<unknown> {
   const cmd = [

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -6,25 +6,7 @@ import * as path from "path";
 // .html, .css is skipped
 const loaders = ["js", "jsx", "ts", "tsx", "json", "toml"];
 
-const skipped_loaders = [
-  "mjs",
-  "cjs",
-  "cts",
-  "mts",
-  "css",
-  "jsonc",
-  "wasm",
-  "webassembly",
-  "napi",
-  "node",
-  "dataurl",
-  "base64",
-  "txt",
-  "sh",
-  "sqlite_embedded",
-  "html",
-  "does_not_exist",
-];
+const other_loaders_do_not_crash = ["webassembly", "does_not_exist"];
 
 // ctrl+shift+f for tailwind
 // next bug: ZigGlobalObject.cpp:4226
@@ -128,15 +110,15 @@ async function testBunBuild(dir: string, loader: string): Promise<unknown> {
   }
 }
 async function compileAndTest(code: string): Promise<Record<string, unknown>> {
-  console.time("v1");
+  console.time("import {} from '';");
   const v1 = await compileAndTest_inner(code, "", testBunRun);
-  console.timeEnd("v1");
-  console.time("v2");
+  console.timeEnd("import {} from '';");
+  console.time("await import()");
   const v2 = await compileAndTest_inner(code, "", testBunRunAwaitImport);
-  console.timeEnd("v2");
-  console.time("v3");
+  console.timeEnd("await import()");
+  console.time("Bun.build()");
   const v3 = await compileAndTest_inner(code, "", testBunBuild);
-  console.timeEnd("v3");
+  console.timeEnd("Bun.build()");
   if (!Bun.deepEquals(v1, v2) || !Bun.deepEquals(v2, v3)) {
     console.log("====  regular import  ====\n" + JSON.stringify(v1, null, 2) + "\n");
     console.log("====  await import  ====\n" + JSON.stringify(v2, null, 2) + "\n");
@@ -257,7 +239,7 @@ test("toml", async () => {
 });
 
 describe("other loaders do not crash", () => {
-  for (const skipped_loader of skipped_loaders) {
+  for (const skipped_loader of other_loaders_do_not_crash) {
     test(skipped_loader, async () => {
       await compileAndTest(`export const a = "demo";`);
     });

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -150,7 +150,9 @@ async function compileAndTest_inner(
       expect(sqlite_res).toStrictEqual({
         default: { filename: expect.any(String) },
       });
-      expect((sqlite_res as any).default.filename).toStartWith(path.join(tests.sqlite!.dir!, "out"));
+      expect((sqlite_res as any).default.filename.toUpperCase()).toStartWith(
+        path.join(tests.sqlite!.dir!, "out").toUpperCase(),
+      );
     } else {
       expect(sqlite_res).toStrictEqual({
         db: { filename: path.join(tests.sqlite!.dir!, tests.sqlite!.filename) },

--- a/test/js/bun/resolve/toml/crash/not.toml
+++ b/test/js/bun/resolve/toml/crash/not.toml
@@ -1,0 +1,1 @@
+export const a = "demo";

--- a/test/js/bun/resolve/toml/crash/toml-crash.test.ts
+++ b/test/js/bun/resolve/toml/crash/toml-crash.test.ts
@@ -1,0 +1,8 @@
+test("toml import error has correct lineText", async () => {
+  const result = await Bun.build({
+    entrypoints: [import.meta.dirname + "/not.toml"],
+    throw: false,
+    target: "bun",
+  });
+  expect(result.logs[0].position!.lineText).toBe('export const a = "demo";');
+});


### PR DESCRIPTION
### What does this PR do?

Fixes:

```ts
import config from "./.prettierrc" with { type: "json" };
console.log(config);
// before: /path/to/.prettierrc
// after: (contents)
```

```ts
await import("./some.file", {with: {type: "js"}});
// before: (crash)
// after: (imports some.file as js)
```

Breaking change: must now use `with {type: "jsonc"}` or change the file path to `.jsonc` when using `bun build` (`bun.lock`/`tsconfig.json`/... are unaffected) 

```ts
// a.ts
import config from "./my_jsonc_file.json"
console.log(config);
// before: `bun build a.ts` : works (different than `bun a.ts`)
// after: `bun build a.ts`: errors (same as `bun a.ts`)
```

fixes #12175