### PR TITLE
js: fix printing of empty Symbol's

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2262,7 +2262,7 @@ pub const Formatter = struct {
                     this.addForNewLine(description.len + "()".len);
                     writer.print(comptime Output.prettyFmt("<r><blue>Symbol({any})<r>", enable_ansi_colors), .{description});
                 } else {
-                    writer.print(comptime Output.prettyFmt("<r><blue>Symbol<r>", enable_ansi_colors), .{});
+                    writer.print(comptime Output.prettyFmt("<r><blue>Symbol()<r>", enable_ansi_colors), .{});
                 }
             },
             .Error => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -602,3 +602,8 @@ it("console.log on a arguments shows list", () => {
 it("console.log on null prototype", () => {
   expect(Bun.inspect(Object.create(null))).toBe("[Object: null prototype] {}");
 });
+
+it("Symbol", () => {
+  expect(Bun.inspect(Symbol())).toBe("Symbol()");
+  expect(Bun.inspect(Symbol(""))).toBe("Symbol()");
+});


### PR DESCRIPTION
pulled out from https://github.com/oven-sh/bun/pull/15722

before:

```
❯ node -p 'Symbol()' ; bun -p 'Symbol()'
Symbol()
Symbol
```

after

```
❯ node -p 'Symbol()' ; ./build/debug/bun-debug -p 'Symbol()' 
Symbol()
Symbol()
```
