### PR TITLE
Clean up node:fs `utimes`, `futimes` , and `lutimes`

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -228,6 +228,7 @@ set(BUN_ZIG_GENERATED_CLASSES_OUTPUTS
   ${CODEGEN_PATH}/ZigGeneratedClasses+DOMIsoSubspaces.h
   ${CODEGEN_PATH}/ZigGeneratedClasses+lazyStructureImpl.h
   ${CODEGEN_PATH}/ZigGeneratedClasses.zig
+  ${CODEGEN_PATH}/ZigGeneratedClasses.lut.txt
 )
 
 register_command(
@@ -406,6 +407,7 @@ set(BUN_OBJECT_LUT_SOURCES
   ${CWD}/src/bun.js/bindings/ProcessBindingConstants.cpp
   ${CWD}/src/bun.js/bindings/ProcessBindingNatives.cpp
   ${CWD}/src/bun.js/modules/NodeModuleModule.cpp
+  ${CODEGEN_PATH}/ZigGeneratedClasses.lut.txt
 )
 
 set(BUN_OBJECT_LUT_OUTPUTS
@@ -416,6 +418,7 @@ set(BUN_OBJECT_LUT_OUTPUTS
   ${CODEGEN_PATH}/ProcessBindingConstants.lut.h
   ${CODEGEN_PATH}/ProcessBindingNatives.lut.h
   ${CODEGEN_PATH}/NodeModuleModule.lut.h
+  ${CODEGEN_PATH}/ZigGeneratedClasses.lut.h
 )
 
 macro(WEBKIT_ADD_SOURCE_DEPENDENCIES _source _deps)
@@ -447,6 +450,8 @@ foreach(i RANGE 0 ${BUN_OBJECT_LUT_SOURCES_MAX_INDEX})
       bun-codegen-lut-${filename}
     COMMENT
       "Generating ${filename}.lut.h"
+    DEPENDS
+      ${BUN_OBJECT_LUT_SOURCE}
     COMMAND
       ${BUN_EXECUTABLE}
         run
@@ -477,6 +482,8 @@ WEBKIT_ADD_SOURCE_DEPENDENCIES(
   ${CWD}/src/bun.js/bindings/ZigGlobalObject.cpp
   ${CODEGEN_PATH}/ZigGlobalObject.lut.h
 )
+
+
 
 WEBKIT_ADD_SOURCE_DEPENDENCIES(
   ${CWD}/src/bun.js/bindings/InternalModuleRegistry.cpp

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -80,7 +80,7 @@ pub const All = struct {
             else
                 timespec{ .nsec = 0, .sec = 0 };
 
-            this.uv_timer.start(wait.ms(), 0, &onUVTimer);
+            this.uv_timer.start(wait.msUnsigned(), 0, &onUVTimer);
 
             if (this.active_timer_count > 0) {
                 this.uv_timer.ref();

--- a/src/bun.js/node/node.classes.ts
+++ b/src/bun.js/node/node.classes.ts
@@ -244,63 +244,26 @@ export default [
           pure: true,
         },
       },
-      dev: {
-        getter: "dev",
-      },
-      ino: {
-        getter: "ino",
-      },
-      mode: {
-        getter: "mode",
-      },
-      nlink: {
-        getter: "nlink",
-      },
-      uid: {
-        getter: "uid",
-      },
-      gid: {
-        getter: "gid",
-      },
-      rdev: {
-        getter: "rdev",
-      },
-      size: {
-        getter: "size",
-      },
-      blksize: {
-        getter: "blksize",
-      },
-      blocks: {
-        getter: "blocks",
-      },
-      atime: {
-        getter: "atime",
-        cache: true,
-      },
-      mtime: {
-        getter: "mtime",
-        cache: true,
-      },
-      ctime: {
-        getter: "ctime",
-        cache: true,
-      },
-      birthtime: {
-        getter: "birthtime",
-      },
-      atimeMs: {
-        getter: "atimeMs",
-      },
-      mtimeMs: {
-        getter: "mtimeMs",
-      },
-      ctimeMs: {
-        getter: "ctimeMs",
-      },
-      birthtimeMs: {
-        getter: "birthtimeMs",
-      },
+    },
+    own: {
+      dev: "dev",
+      ino: "ino",
+      mode: "mode",
+      nlink: "nlink",
+      uid: "uid",
+      gid: "gid",
+      rdev: "rdev",
+      size: "size",
+      blksize: "blksize",
+      blocks: "blocks",
+      atimeMs: "atimeMs",
+      mtimeMs: "mtimeMs",
+      ctimeMs: "ctimeMs",
+      birthtimeMs: "birthtimeMs",
+      atime: "atime",
+      mtime: "mtime",
+      ctime: "ctime",
+      birthtime: "birthtime",
     },
   }),
   define({
@@ -386,76 +349,30 @@ export default [
           pure: true,
         },
       },
-      dev: {
-        getter: "dev",
-      },
-      ino: {
-        getter: "ino",
-      },
-      mode: {
-        getter: "mode",
-      },
-      nlink: {
-        getter: "nlink",
-      },
-      uid: {
-        getter: "uid",
-      },
-      gid: {
-        getter: "gid",
-      },
-      rdev: {
-        getter: "rdev",
-      },
-      size: {
-        getter: "size",
-      },
-      blksize: {
-        getter: "blksize",
-      },
-      blocks: {
-        getter: "blocks",
-      },
-      atime: {
-        getter: "atime",
-        cache: true,
-      },
-      mtime: {
-        getter: "mtime",
-        cache: true,
-      },
-      ctime: {
-        getter: "ctime",
-        cache: true,
-      },
-      birthtime: {
-        getter: "birthtime",
-        cache: true,
-      },
-      atimeMs: {
-        getter: "atimeMs",
-      },
-      mtimeMs: {
-        getter: "mtimeMs",
-      },
-      ctimeMs: {
-        getter: "ctimeMs",
-      },
-      birthtimeMs: {
-        getter: "birthtimeMs",
-      },
-      atimeNs: {
-        getter: "atimeNs",
-      },
-      mtimeNs: {
-        getter: "mtimeNs",
-      },
-      ctimeNs: {
-        getter: "ctimeNs",
-      },
-      birthtimeNs: {
-        getter: "birthtimeNs",
-      },
+    },
+    own: {
+      atime: "atime",
+      atimeMs: "atimeMs",
+      atimeNs: "atimeNs",
+      birthtime: "birthtime",
+      birthtimeMs: "birthtimeMs",
+      birthtimeNs: "birthtimeNs",
+      blksize: "blksize",
+      blocks: "blocks",
+      ctime: "ctime",
+      ctimeMs: "ctimeMs",
+      ctimeNs: "ctimeNs",
+      dev: "dev",
+      gid: "gid",
+      ino: "ino",
+      mode: "mode",
+      mtime: "mtime",
+      mtimeMs: "mtimeMs",
+      mtimeNs: "mtimeNs",
+      nlink: "nlink",
+      rdev: "rdev",
+      size: "size",
+      uid: "uid",
     },
   }),
   define({
@@ -685,4 +602,3 @@ export default [
     },
   }),
 ];
-

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3572,7 +3572,7 @@ pub const NodeFS = struct {
                     }
 
                     if (ret.errnoSysP(C.clonefile(src, dest, 0), .copyfile, src) == null) {
-                        _ = C.chmod(dest, stat_.mode);
+                        _ = Syscall.chmod(dest, stat_.mode);
                         return ret.success;
                     }
                 } else {
@@ -3595,8 +3595,8 @@ pub const NodeFS = struct {
                         .err => |err| return Maybe(Return.CopyFile){ .err = err.withPath(args.dest.slice()) },
                     };
                     defer {
-                        _ = std.c.ftruncate(dest_fd.int(), @as(std.c.off_t, @intCast(@as(u63, @truncate(wrote)))));
-                        _ = C.fchmod(dest_fd.int(), stat_.mode);
+                        _ = Syscall.ftruncate(dest_fd, @as(std.c.off_t, @intCast(@as(u63, @truncate(wrote)))));
+                        _ = Syscall.fchmod(dest_fd, stat_.mode);
                         _ = Syscall.close(dest_fd);
                     }
 
@@ -3659,7 +3659,7 @@ pub const NodeFS = struct {
                     _ = bun.sys.unlink(dest);
                     return err;
                 }
-                _ = C.fchmod(dest_fd.cast(), stat_.mode);
+                _ = Syscall.fchmod(dest_fd, stat_.mode);
                 _ = Syscall.close(dest_fd);
                 return ret.success;
             }
@@ -3668,7 +3668,7 @@ pub const NodeFS = struct {
             if (posix.S.ISREG(stat_.mode) and bun.can_use_ioctl_ficlone()) {
                 const rc = bun.C.linux.ioctl_ficlone(dest_fd, src_fd);
                 if (rc == 0) {
-                    _ = C.fchmod(dest_fd.cast(), stat_.mode);
+                    _ = Syscall.fchmod(dest_fd, stat_.mode);
                     _ = Syscall.close(dest_fd);
                     return ret.success;
                 }
@@ -6249,7 +6249,7 @@ pub const NodeFS = struct {
                     }
 
                     if (ret.errnoSysP(C.clonefile(src, dest, 0), .clonefile, src) == null) {
-                        _ = C.chmod(dest, stat_.mode);
+                        _ = Syscall.chmod(dest, stat_.mode);
                         return ret.success;
                     }
                 } else {
@@ -6301,7 +6301,7 @@ pub const NodeFS = struct {
                     };
                     defer {
                         _ = Syscall.ftruncate(dest_fd, @intCast(@as(u63, @truncate(wrote))));
-                        _ = C.fchmod(dest_fd.int(), stat_.mode);
+                        _ = Syscall.fchmod(dest_fd, stat_.mode);
                         _ = Syscall.close(dest_fd);
                     }
 
@@ -6400,7 +6400,7 @@ pub const NodeFS = struct {
             if (posix.S.ISREG(stat_.mode) and bun.can_use_ioctl_ficlone()) {
                 const rc = bun.C.linux.ioctl_ficlone(dest_fd, src_fd);
                 if (rc == 0) {
-                    _ = C.fchmod(dest_fd.cast(), stat_.mode);
+                    _ = Syscall.fchmod(dest_fd, stat_.mode);
                     _ = Syscall.close(dest_fd);
                     return ret.success;
                 }
@@ -6409,8 +6409,8 @@ pub const NodeFS = struct {
             }
 
             defer {
-                _ = linux.ftruncate(dest_fd.cast(), @as(i64, @intCast(@as(u63, @truncate(wrote)))));
-                _ = linux.fchmod(dest_fd.cast(), stat_.mode);
+                _ = Syscall.ftruncate(dest_fd, @as(i64, @intCast(@as(u63, @truncate(wrote)))));
+                _ = Syscall.fchmod(dest_fd, stat_.mode);
                 _ = Syscall.close(dest_fd);
             }
 

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3817,7 +3817,7 @@ pub const NodeFS = struct {
 
     pub fn fstat(_: *NodeFS, args: Arguments.Fstat, _: Flavor) Maybe(Return.Fstat) {
         return switch (Syscall.fstat(args.fd)) {
-            .result => |result| .{ .result = Stats.init(result, false) },
+            .result => |result| .{ .result = Stats.init(result, args.big_int) },
             .err => |err| .{ .err = err },
         };
     }

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -341,17 +341,18 @@ pub const StatWatcher = struct {
         watcher: *StatWatcher,
         task: JSC.WorkPoolTask = .{ .callback = &workPoolCallback },
 
+        pub usingnamespace bun.New(@This());
+
         pub fn createAndSchedule(
             watcher: *StatWatcher,
         ) void {
-            var task = bun.default_allocator.create(InitialStatTask) catch bun.outOfMemory();
-            task.* = .{ .watcher = watcher };
+            const task = InitialStatTask.new(.{ .watcher = watcher });
             JSC.WorkPool.schedule(&task.task);
         }
 
         fn workPoolCallback(task: *JSC.WorkPoolTask) void {
             const initial_stat_task: *InitialStatTask = @fieldParentPtr("task", task);
-            defer bun.default_allocator.destroy(initial_stat_task);
+            defer initial_stat_task.destroy();
             const this = initial_stat_task.watcher;
 
             if (this.closed) {
@@ -454,7 +455,8 @@ pub const StatWatcher = struct {
     pub fn init(args: Arguments) !*StatWatcher {
         log("init", .{});
 
-        var buf: bun.PathBuffer = undefined;
+        const buf = bun.PathBufferPool.get();
+        defer bun.PathBufferPool.put(buf);
         var slice = args.path.slice();
         if (bun.strings.startsWith(slice, "file://")) {
             slice = slice[6..];
@@ -463,7 +465,7 @@ pub const StatWatcher = struct {
         var parts = [_]string{slice};
         const file_path = Path.joinAbsStringBuf(
             Fs.FileSystem.instance.top_level_dir,
-            &buf,
+            buf,
             &parts,
             .auto,
         );
@@ -487,7 +489,7 @@ pub const StatWatcher = struct {
             // Instant.now will not fail on our target platforms.
             .last_check = std.time.Instant.now() catch unreachable,
             // InitStatTask is responsible for setting this
-            .last_stat = undefined,
+            .last_stat = std.mem.zeroes(bun.Stat),
             .last_jsvalue = JSC.Strong.init(),
         };
         errdefer this.deinit();

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -2517,3 +2517,6 @@ pub const StatFS = union(enum) {
         @compileError("Only use Stats.toJSNewlyCreated() or Stats.toJS() directly on a StatsBig or StatsSmall");
     }
 };
+
+pub const uid_t = if (Environment.isPosix) std.posix.uid_t else bun.windows.libuv.uv_uid_t;
+pub const gid_t = if (Environment.isPosix) std.posix.gid_t else bun.windows.libuv.uv_gid_t;

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1300,7 +1300,7 @@ fn timeLikeFromMilliseconds(milliseconds: f64) TimeLike {
     var nsec: f64 = @mod(milliseconds, std.time.ms_per_s) * std.time.ns_per_ms;
 
     if (nsec < 0) {
-        nsec += 1e6;
+        nsec += std.time.ns_per_s;
         sec -= 1;
     }
 
@@ -1664,6 +1664,13 @@ pub fn StatType(comptime big: bool) type {
         const StatTimespec = if (Environment.isWindows) bun.windows.libuv.uv_timespec_t else std.posix.timespec;
 
         inline fn toNanoseconds(ts: StatTimespec) Timestamp {
+            if (ts.tv_sec < 0) {
+                return @intCast(@max(bun.timespec.nsSigned(&bun.timespec{
+                    .sec = @intCast(ts.tv_sec),
+                    .nsec = @intCast(ts.tv_nsec),
+                }), 0));
+            }
+
             return bun.timespec.ns(&bun.timespec{
                 .sec = @intCast(ts.tv_sec),
                 .nsec = @intCast(ts.tv_nsec),

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1664,9 +1664,10 @@ pub fn StatType(comptime big: bool) type {
         const StatTimespec = if (Environment.isWindows) bun.windows.libuv.uv_timespec_t else std.posix.timespec;
 
         inline fn toNanoseconds(ts: StatTimespec) Timestamp {
-            const tv_sec: i64 = @intCast(ts.tv_sec);
-            const tv_nsec: i64 = @intCast(ts.tv_nsec);
-            return @as(Timestamp, @intCast(tv_sec * 1_000_000_000)) + @as(Timestamp, @intCast(tv_nsec));
+            return bun.timespec.ns(&bun.timespec{
+                .sec = @intCast(ts.tv_sec),
+                .nsec = @intCast(ts.tv_nsec),
+            });
         }
 
         fn toTimeMS(ts: StatTimespec) Float {
@@ -1683,8 +1684,10 @@ pub fn StatType(comptime big: bool) type {
                 return @as(i64, sec * std.time.ms_per_s) +
                     @as(i64, @divTrunc(nsec, std.time.ns_per_ms));
             } else {
-                return (@as(f64, @floatFromInt(tv_sec)) * std.time.ms_per_s) +
-                    (@as(f64, @floatFromInt(tv_nsec)) / std.time.ns_per_ms);
+                return @floatFromInt(bun.timespec.ms(&bun.timespec{
+                    .sec = @intCast(tv_sec),
+                    .nsec = @intCast(tv_nsec),
+                }));
             }
         }
 

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1428,7 +1428,7 @@ pub const TestRunnerTask = struct {
         const elapsed = now.duration(&this.started_at).ms();
         this.ref.unref(this.globalThis.bunVM());
         this.globalThis.throwTerminationException();
-        this.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .{ .timeout = elapsed });
+        this.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .{ .timeout = @intCast(@max(elapsed, 0)) });
     }
 
     const ResultType = union(enum) {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3767,6 +3767,10 @@ pub const timespec = extern struct {
         return ms_from_sec +% ms_from_nsec;
     }
 
+    pub fn msUnsigned(this: *const timespec) u64 {
+        return this.ns() / std.time.ns_per_ms;
+    }
+
     pub fn greater(a: *const timespec, b: *const timespec) bool {
         return a.order(b) == .gt;
     }

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3757,8 +3757,16 @@ pub const timespec = extern struct {
             return max;
     }
 
-    pub fn ms(this: *const timespec) u64 {
-        return this.ns() / std.time.ns_per_ms;
+    pub fn nsSigned(this: *const timespec) i64 {
+        const ns_per_sec = this.sec *% std.time.ns_per_s;
+        const ns_from_nsec = @divFloor(this.nsec, 1_000_000);
+        return ns_per_sec +% ns_from_nsec;
+    }
+
+    pub fn ms(this: *const timespec) i64 {
+        const ms_from_sec = this.sec *% 1000;
+        const ms_from_nsec = @divFloor(this.nsec, 1_000_000);
+        return ms_from_sec +% ms_from_nsec;
     }
 
     pub fn greater(a: *const timespec, b: *const timespec) bool {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3745,16 +3745,14 @@ pub const timespec = extern struct {
 
         assert(this.sec >= 0);
         assert(this.nsec >= 0);
-
-        const max = std.math.maxInt(u64);
         const s_ns = std.math.mul(
             u64,
             @as(u64, @intCast(this.sec)),
             std.time.ns_per_s,
-        ) catch return max;
+        ) catch return std.math.maxInt(u64);
 
         return std.math.add(u64, s_ns, @as(u64, @intCast(this.nsec))) catch
-            return max;
+            return std.math.maxInt(i64);
     }
 
     pub fn nsSigned(this: *const timespec) i64 {

--- a/src/c-headers-for-zig.h
+++ b/src/c-headers-for-zig.h
@@ -24,6 +24,8 @@
 
 #if DARWIN
 #include <sys/mount.h>
+#include <sys/stat.h>
 #elif LINUX
 #include <sys/statfs.h>
+#include <sys/stat.h>
 #endif

--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -47,7 +47,7 @@ export type Field =
       length?: number;
     };
 
-export interface ClassDefinition {
+export class ClassDefinition {
   name: string;
   construct?: boolean;
   call?: boolean;
@@ -55,6 +55,7 @@ export interface ClassDefinition {
   overridesToJS?: boolean;
   klass: Record<string, Field>;
   proto: Record<string, Field>;
+  own: Record<string, string>;
   values?: string[];
   JSType?: string;
   noConstructor?: boolean;
@@ -94,6 +95,23 @@ export interface ClassDefinition {
   structuredClone?: boolean | { transferable: boolean; tag: number };
 
   callbacks?: Record<string, string>;
+
+  constructor(options: Partial<ClassDefinition>) {
+    this.name = options.name ?? "";
+    this.klass = options.klass ?? {};
+    this.proto = options.proto ?? {};
+    this.own = options.own ?? {};
+
+    Object.assign(this, options);
+  }
+
+  hasOwnProperties() {
+    for (const key in this.own) {
+      return true;
+    }
+
+    return false;
+  }
 }
 
 export interface CustomField {
@@ -107,6 +125,7 @@ export function define(
   {
     klass = {},
     proto = {},
+    own = {},
     values = [],
     overridesToJS = false,
     estimatedSize = false,
@@ -114,9 +133,9 @@ export function define(
     construct = false,
     structuredClone = false,
     ...rest
-  } = {} as ClassDefinition,
-): ClassDefinition {
-  return {
+  } = {} as Partial<ClassDefinition>,
+): Partial<ClassDefinition> {
+  return new ClassDefinition({
     ...rest,
     call,
     overridesToJS,
@@ -124,6 +143,7 @@ export function define(
     estimatedSize,
     structuredClone,
     values,
+    own: own || {},
     klass: Object.fromEntries(
       Object.entries(klass)
         .sort(([a], [b]) => a.localeCompare(b))
@@ -140,5 +160,5 @@ export function define(
           return [k, v];
         }),
     ),
-  };
+  });
 }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -308,6 +308,17 @@ function propRow(
 
   throw "Unsupported property";
 }
+function ownRow(
+  symbolName: (a: string, b: string) => string,
+  typeName: string,
+  name: string,
+  prop: Field,
+  isWrapped = true,
+  defaultPropertyAttributes,
+  supportsObjectCreate = false,
+) {
+  throw "Unsupported property";
+}
 
 export function generateHashTable(nameToUse, symbolName, typeName, obj, props = {}, wrapped) {
   const rows = [];
@@ -345,6 +356,45 @@ export function generateHashTable(nameToUse, symbolName, typeName, obj, props = 
   }
   return `
   static const HashTableValue ${nameToUse}TableValues[${rows.length}] = {${"\n" + rows.join("  ,\n") + "\n"}};
+`;
+}
+
+export function generateHashTableComment(nameToUse, symbolName, obj, props = {}, wrapped) {
+  const rows = [];
+  let defaultPropertyAttributes = undefined;
+
+  if ("enumerable" in obj) {
+    defaultPropertyAttributes ||= {};
+    defaultPropertyAttributes.enumerable = obj.enumerable;
+  }
+
+  if ("configurable" in obj) {
+    defaultPropertyAttributes ||= {};
+    defaultPropertyAttributes.configurable = obj.configurable;
+  }
+
+  for (const name in props) {
+    if (name.startsWith("@@")) continue;
+    externs += `
+extern JSC_CALLCONV JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${protoSymbolName(
+      obj.name,
+      name,
+    )}(void* ptr, JSC::JSGlobalObject*);
+namespace WebCore {
+static JSC::JSValue construct${symbolName(name)}PropertyCallback(JSC::VM &vm, JSC::JSObject* initialThisObject);
+}
+    `;
+    rows.push(`${name}  WebCore::construct${symbolName(name)}PropertyCallback    PropertyCallback`);
+  }
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  return `
+@begin ${nameToUse}Table
+${rows.join("\n")}
+@end
 `;
 }
 
@@ -1261,6 +1311,7 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
   class ${name}${final ? " final" : ""} : public JSC::JSDestructibleObject {
     public:
         using Base = JSC::JSDestructibleObject;
+        static constexpr unsigned StructureFlags = Base::StructureFlags${obj.hasOwnProperties() ? ` | HasStaticPropertyTable` : ""};
         static ${name}* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, void* ctx);
 
         DECLARE_EXPORT_INFO;
@@ -1378,6 +1429,7 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
     hasPendingActivity = false,
     getInternalProperties = false,
     callbacks = {},
+    own,
   } = obj;
   const name = className(typeName);
 
@@ -1479,6 +1531,22 @@ ${renderCallbacksCppImpl(typeName, callbacks)}
     `;
   }
 
+  if (obj.hasOwnProperties()) {
+    output += Object.entries(own)
+      .map(
+        ([name, getterName]) => `
+static JSC::JSValue construct${symbolName(obj.name, name)}PropertyCallback(JSC::VM &vm, JSC::JSObject* initialThisObject) {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    Bun::JS${obj.name}* thisObject = jsCast<Bun::JS${obj.name}*>(initialThisObject);
+    JSC::EncodedJSValue result = ${protoSymbolName(obj.name, getterName)}(thisObject->wrapped(), thisObject->globalObject());
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::decode(result);
+}
+    `,
+      )
+      .join("\n");
+  }
+
   if (finalize) {
     output += `
 ${name}::~${name}()
@@ -1535,7 +1603,7 @@ void ${name}::destroy(JSCell* cell)
     static_cast<${name}*>(cell)->${name}::~${name}();
 }
 
-const ClassInfo ${name}::s_info = { "${typeName}"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(${name}) };
+const ClassInfo ${name}::s_info = { "${typeName}"_s, &Base::s_info, ${obj.hasOwnProperties() ? `&${typeName}Table` : "nullptr"}, nullptr, CREATE_METHOD_TABLE(${name}) };
 
 void ${name}::finishCreation(VM& vm)
 {
@@ -1667,10 +1735,22 @@ function generateHeader(typeName, obj) {
   return "\n" + fields.join("\n").trim();
 }
 
-function generateImpl(typeName, obj) {
+let lutTextFile = `
+/* Source for ZigGeneratedClasses.lut.h
+`;
+function generateOwnProperties(typeName, symbolName, obj, props = {}, wrapped) {
+  lutTextFile += `
+${generateHashTableComment(typeName, symbolName, obj, props, wrapped)}
+`;
+}
+
+function generateImpl(typeName, obj: ClassDefinition) {
   if (obj.zigOnly) return "";
 
   const proto = obj.proto;
+  if (obj?.hasOwnProperties?.()) {
+    generateOwnProperties(typeName, name => symbolName(typeName, name), obj, obj.own);
+  }
   return [
     (obj.final ?? true) ? generatePrototypeHeader(typeName, true) : null,
     !obj.noConstructor ? generateConstructorHeader(typeName).trim() + "\n" : null,
@@ -1687,6 +1767,7 @@ function generateZig(
   {
     klass = {},
     proto = {},
+    own = {},
     construct,
     finalize,
     noConstructor = false,
@@ -1720,6 +1801,11 @@ function generateZig(
 
     exports.set("onStructuredCloneDeserialize", symbolName(typeName, "onStructuredCloneDeserialize"));
   }
+
+  proto = {
+    ...Object.fromEntries(Object.entries(own || {}).map(([name, getterName]) => [name, { getter: getterName }])),
+    ...proto,
+  };
 
   const externs = Object.entries({
     ...proto,
@@ -2168,6 +2254,8 @@ namespace WebCore {
 using namespace JSC;
 using namespace Zig;
 
+#include "ZigGeneratedClasses.lut.h"
+
 `;
 
 const GENERATED_CLASSES_IMPL_FOOTER = `
@@ -2278,12 +2366,15 @@ classes.sort((a, b) => (a.name < b.name ? -1 : 1));
 
 // sort all the prototype keys and klass keys
 for (const obj of classes) {
-  let { klass = {}, proto = {} } = obj;
+  let { klass = {}, proto = {}, own = {} } = obj;
 
   klass = Object.fromEntries(Object.entries(klass).sort(([a], [b]) => a.localeCompare(b)));
   proto = Object.fromEntries(Object.entries(proto).sort(([a], [b]) => a.localeCompare(b)));
+  own = Object.fromEntries(Object.entries(own).sort(([a], [b]) => a.localeCompare(b)));
+
   obj.klass = klass;
   obj.proto = proto;
+  obj.own = own;
 }
 
 const GENERATED_CLASSES_FOOTER = `
@@ -2395,6 +2486,13 @@ if (!process.env.ONLY_ZIG) {
     GENERATED_CLASSES_IMPL_FOOTER,
     jsInheritsCppImpl(),
   ]);
+
+  if (lutTextFile.length) {
+    lutTextFile += `
+/*
+`;
+    await writeIfNotChanged(`${outBase}/ZigGeneratedClasses.lut.txt`, [lutTextFile]);
+  }
 
   await writeIfNotChanged(
     `${outBase}/ZigGeneratedClasses+lazyStructureHeader.h`,

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -76,16 +76,16 @@ pub extern "c" fn fclonefileat(c_int, c_int, [*:0]const u8, uint32_t: c_int) c_i
 pub extern "c" fn clonefile(src: [*:0]const u8, dest: [*:0]const u8, flags: c_int) c_int;
 
 pub const lstat = blk: {
-    const T = *const fn ([*c]const u8, [*c]std.c.Stat) callconv(.C) c_int;
+    const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.C) c_int;
     break :blk @extern(T, .{ .name = "lstat64" });
 };
 
 pub const fstat = blk: {
-    const T = *const fn ([*c]const u8, [*c]std.c.Stat) callconv(.C) c_int;
+    const T = *const fn (i32, ?*bun.Stat) callconv(.C) c_int;
     break :blk @extern(T, .{ .name = "fstat64" });
 };
 pub const stat = blk: {
-    const T = *const fn ([*c]const u8, [*c]std.c.Stat) callconv(.C) c_int;
+    const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.C) c_int;
     break :blk @extern(T, .{ .name = "stat64" });
 };
 

--- a/test/js/node/test/parallel/test-fs-stat-bigint.js
+++ b/test/js/node/test/parallel/test-fs-stat-bigint.js
@@ -18,10 +18,35 @@ function getFilename() {
   return filename;
 }
 
+const allStatKeys = [
+  "dev",
+  "ino",
+  "mode",
+  "nlink",
+  "uid",
+  "gid",
+  "rdev",
+  "size",
+  "blksize",
+  "blocks",
+  "atime",
+  "mtime",
+  "ctime",
+  "birthtime",
+  "atimeMs",
+  "mtimeMs",
+  "ctimeMs",
+  "birthtimeMs",
+  "atimeNs",
+  "mtimeNs",
+  "ctimeNs",
+  "birthtimeNs",
+];
+const statKeys = allStatKeys.filter((key) => !key.endsWith("Ns"));
 function verifyStats(bigintStats, numStats, allowableDelta) {
   // allowableDelta: It's possible that the file stats are updated between the
   // two stat() calls so allow for a small difference.
-  for (const key of Object.keys(numStats)) {
+  for (const key of statKeys) {
     const val = numStats[key];
     if (isDate(val)) {
       const time = val.getTime();

--- a/test/js/node/test/parallel/test-fs-stat-bigint.js
+++ b/test/js/node/test/parallel/test-fs-stat-bigint.js
@@ -18,35 +18,11 @@ function getFilename() {
   return filename;
 }
 
-const allStatKeys = [
-  "dev",
-  "ino",
-  "mode",
-  "nlink",
-  "uid",
-  "gid",
-  "rdev",
-  "size",
-  "blksize",
-  "blocks",
-  "atime",
-  "mtime",
-  "ctime",
-  "birthtime",
-  "atimeMs",
-  "mtimeMs",
-  "ctimeMs",
-  "birthtimeMs",
-  "atimeNs",
-  "mtimeNs",
-  "ctimeNs",
-  "birthtimeNs",
-];
-const statKeys = allStatKeys.filter((key) => !key.endsWith("Ns"));
+
 function verifyStats(bigintStats, numStats, allowableDelta) {
   // allowableDelta: It's possible that the file stats are updated between the
   // two stat() calls so allow for a small difference.
-  for (const key of statKeys) {
+  for (const key of Object.keys(numStats)) {
     const val = numStats[key];
     if (isDate(val)) {
       const time = val.getTime();

--- a/test/js/node/test/parallel/test-fs-stat-date.mjs
+++ b/test/js/node/test/parallel/test-fs-stat-date.mjs
@@ -1,0 +1,96 @@
+import * as common from '../common/index.mjs';
+
+// Test timestamps returned by fsPromises.stat and fs.statSync
+
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import assert from 'node:assert';
+import tmpdir from '../common/tmpdir.js';
+
+// On some platforms (for example, ppc64) boundaries are tighter
+// than usual. If we catch these errors, skip corresponding test.
+const ignoredErrors = new Set(['EINVAL', 'EOVERFLOW']);
+
+tmpdir.refresh();
+const filepath = tmpdir.resolve('timestamp');
+
+await (await fsPromises.open(filepath, 'w')).close();
+
+// Perform a trivial check to determine if filesystem supports setting
+// and retrieving atime and mtime. If it doesn't, skip the test.
+await fsPromises.utimes(filepath, 2, 2);
+const { atimeMs, mtimeMs } = await fsPromises.stat(filepath);
+if (atimeMs !== 2000 || mtimeMs !== 2000) {
+  common.skip(`Unsupported filesystem (atime=${atimeMs}, mtime=${mtimeMs})`);
+}
+
+// Date might round down timestamp
+function closeEnough(actual, expected, margin) {
+  // On ppc64, value is rounded to seconds
+  if (process.arch === 'ppc64') {
+    margin += 1000;
+  }
+
+  // Filesystems without support for timestamps before 1970-01-01, such as NFSv3,
+  // should return 0 for negative numbers. Do not treat it as error.
+  if (actual === 0 && expected < 0) {
+    console.log(`ignored 0 while expecting ${expected}`);
+    return;
+  }
+
+  assert.ok(Math.abs(Number(actual - expected)) < margin,
+            `expected ${expected} ± ${margin}, got ${actual}`);
+}
+
+async function runTest(atime, mtime, margin = 0) {
+  margin += Number.EPSILON;
+  try {
+    const atimeDate = new Date(atime);
+    const mtimeDate = new Date(mtime);
+    await fsPromises.utimes(filepath, atimeDate, mtimeDate);
+  } catch (e) {
+    if (ignoredErrors.has(e.code)) return;
+    throw e;
+  }
+
+  const stats = await fsPromises.stat(filepath);
+  closeEnough(stats.atimeMs, atime, margin);
+  closeEnough(stats.mtimeMs, mtime, margin);
+  closeEnough(stats.atime.getTime(), new Date(atime).getTime(), margin);
+  closeEnough(stats.mtime.getTime(), new Date(mtime).getTime(), margin);
+
+  const statsBigint = await fsPromises.stat(filepath, { bigint: true });
+  closeEnough(statsBigint.atimeMs, BigInt(atime), margin);
+  closeEnough(statsBigint.mtimeMs, BigInt(mtime), margin);
+  closeEnough(statsBigint.atime.getTime(), new Date(atime).getTime(), margin);
+  closeEnough(statsBigint.mtime.getTime(), new Date(mtime).getTime(), margin);
+
+  const statsSync = fs.statSync(filepath);
+  closeEnough(statsSync.atimeMs, atime, margin);
+  closeEnough(statsSync.mtimeMs, mtime, margin);
+  closeEnough(statsSync.atime.getTime(), new Date(atime).getTime(), margin);
+  closeEnough(statsSync.mtime.getTime(), new Date(mtime).getTime(), margin);
+
+  const statsSyncBigint = fs.statSync(filepath, { bigint: true });
+  closeEnough(statsSyncBigint.atimeMs, BigInt(atime), margin);
+  closeEnough(statsSyncBigint.mtimeMs, BigInt(mtime), margin);
+  closeEnough(statsSyncBigint.atime.getTime(), new Date(atime).getTime(), margin);
+  closeEnough(statsSyncBigint.mtime.getTime(), new Date(mtime).getTime(), margin);
+}
+
+// Too high/low numbers produce too different results on different platforms
+{
+  // TODO(LiviaMedeiros): investigate outdated stat time on FreeBSD.
+  // On Windows, filetime is stored and handled differently. Supporting dates
+  // after Y2038 is preferred over supporting dates before 1970-01-01.
+  if (!common.isFreeBSD && !common.isWindows) {
+    await runTest(-40691, -355, 1); // Potential precision loss on 32bit
+    await runTest(-355, -40691, 1);  // Potential precision loss on 32bit
+    await runTest(-1, -1);
+  }
+  await runTest(0, 0);
+  await runTest(1, 1);
+  await runTest(355, 40691, 1); // Precision loss on 32bit
+  await runTest(40691, 355, 1); // Precision loss on 32bit
+  await runTest(1713037251360, 1713037251360, 1); // Precision loss
+}

--- a/test/js/node/test/parallel/test-fs-stat.js
+++ b/test/js/node/test/parallel/test-fs-stat.js
@@ -1,0 +1,223 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+fs.stat('.', common.mustSucceed(function(stats) {
+  assert.ok(stats.mtime instanceof Date);
+  assert.ok(Object.hasOwn(stats, 'blksize'));
+  assert.ok(Object.hasOwn(stats, 'blocks'));
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
+}));
+
+fs.lstat('.', common.mustSucceed(function(stats) {
+  assert.ok(stats.mtime instanceof Date);
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
+}));
+
+// fstat
+fs.open('.', 'r', undefined, common.mustSucceed(function(fd) {
+  assert.ok(fd);
+
+  fs.fstat(-0, common.mustSucceed());
+
+  fs.fstat(fd, common.mustSucceed(function(stats) {
+    assert.ok(stats.mtime instanceof Date);
+    fs.close(fd, assert.ifError);
+    // Confirm that we are not running in the context of the internal binding
+    // layer.
+    // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+    assert.strictEqual(this, undefined);
+  }));
+
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
+}));
+
+// fstatSync
+fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
+  const stats = fs.fstatSync(fd);
+  assert.ok(stats.mtime instanceof Date);
+  fs.close(fd, common.mustSucceed());
+}));
+
+fs.stat(__filename, common.mustSucceed((s) => {
+  assert.strictEqual(s.isDirectory(), false);
+  assert.strictEqual(s.isFile(), true);
+  assert.strictEqual(s.isSocket(), false);
+  assert.strictEqual(s.isBlockDevice(), false);
+  assert.strictEqual(s.isCharacterDevice(), false);
+  assert.strictEqual(s.isFIFO(), false);
+  assert.strictEqual(s.isSymbolicLink(), false);
+
+  [
+    'dev', 'mode', 'nlink', 'uid',
+    'gid', 'rdev', 'blksize', 'ino', 'size', 'blocks',
+    'atime', 'mtime', 'ctime', 'birthtime',
+    'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs',
+  ].forEach(function(k) {
+    assert.ok(k in s, `${k} should be in Stats`);
+    assert.notStrictEqual(s[k], undefined, `${k} should not be undefined`);
+    assert.notStrictEqual(s[k], null, `${k} should not be null`);
+  });
+  [
+    'dev', 'mode', 'nlink', 'uid', 'gid', 'rdev', 'blksize', 'ino', 'size',
+    'blocks', 'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs',
+  ].forEach((k) => {
+    assert.strictEqual(typeof s[k], 'number', `${k} should be a number`);
+  });
+  ['atime', 'mtime', 'ctime', 'birthtime'].forEach((k) => {
+    assert.ok(s[k] instanceof Date, `${k} should be a Date`);
+  });
+}));
+
+['', false, null, undefined, {}, []].forEach((input) => {
+  ['fstat', 'fstatSync'].forEach((fnName) => {
+    assert.throws(
+      () => fs[fnName](input),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError'
+      }
+    );
+  });
+});
+
+[false, 1, {}, [], null, undefined].forEach((input) => {
+  assert.throws(
+    () => fs.lstat(input, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+  assert.throws(
+    () => fs.lstatSync(input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+  assert.throws(
+    () => fs.stat(input, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+  assert.throws(
+    () => fs.statSync(input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+});
+
+// Should not throw an error
+fs.stat(__filename, undefined, common.mustCall());
+
+fs.open(__filename, 'r', undefined, common.mustCall((err, fd) => {
+  // Should not throw an error
+  fs.fstat(fd, undefined, common.mustCall());
+}));
+
+// Should not throw an error
+fs.lstat(__filename, undefined, common.mustCall());
+
+{
+  fs.Stats(
+    0,                                        // dev
+    0,                                        // mode
+    0,                                        // nlink
+    0,                                        // uid
+    0,                                        // gid
+    0,                                        // rdev
+    0,                                        // blksize
+    0,                                        // ino
+    0,                                        // size
+    0,                                        // blocks
+    Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
+    Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
+    Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
+    Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
+  );
+  // common.expectWarning({
+  //   DeprecationWarning: [
+  //     ['fs.Stats constructor is deprecated.',
+  //      'DEP0180'],
+  //   ]
+  // });
+}
+
+{
+  // These two tests have an equivalent in ./test-fs-stat-bigint.js
+
+  // Stats Date properties can be set before reading them
+  fs.stat(__filename, common.mustSucceed((s) => {
+    s.atime = 2;
+    s.mtime = 3;
+    s.ctime = 4;
+    s.birthtime = 5;
+
+    assert.strictEqual(s.atime, 2);
+    assert.strictEqual(s.mtime, 3);
+    assert.strictEqual(s.ctime, 4);
+    assert.strictEqual(s.birthtime, 5);
+  }));
+
+  // Stats Date properties can be set after reading them
+  fs.stat(__filename, common.mustSucceed((s) => {
+    // eslint-disable-next-line no-unused-expressions
+    s.atime, s.mtime, s.ctime, s.birthtime;
+
+    s.atime = 2;
+    s.mtime = 3;
+    s.ctime = 4;
+    s.birthtime = 5;
+
+    assert.strictEqual(s.atime, 2);
+    assert.strictEqual(s.mtime, 3);
+    assert.strictEqual(s.ctime, 4);
+    assert.strictEqual(s.birthtime, 5);
+  }));
+}
+
+{
+  assert.throws(
+    () => fs.fstat(Symbol('test'), () => {}),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+    },
+  );
+}


### PR DESCRIPTION

### What does this PR do?

- Handle EINTR
- Use syscall interface on linux
- Use `UTIME_NOW` which sets it to the current system time instead of getting the current time manually


### How did you verify your code works?

- Worked around an issue preventing fs-stat-bigint from fully being run
- Added test-fs-stat-date.mjs