### PR TITLE
fix(node/url): respect `process.noDeprecation` in `url.parse()`

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -105,25 +105,11 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     "file:": true,
   };
 
-let urlParseWarned = false;
 function urlParse(
   url: string | URL | Url, // really has unknown type but intellisense is nice
   parseQueryString?: boolean,
   slashesDenoteHost?: boolean,
 ) {
-  const noDeprecation = process.noDeprecation;
-  const showDep = noDeprecation == null ? true : !noDeprecation;
-  if (!urlParseWarned && showDep && !lazyUtil().isInsideNodeModules()) {
-    urlParseWarned = true;
-    process.emitWarning(
-      "`url.parse()` behavior is not standardized and prone to " +
-        "errors that have security implications. Use the WHATWG URL API " +
-        "instead. CVEs are not issued for `url.parse()` vulnerabilities.",
-      "DeprecationWarning",
-      "DEP0169",
-    );
-  }
-
   if ($isObject(url) && url instanceof Url) return url;
 
   var u = new Url();

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -111,7 +111,8 @@ function urlParse(
   parseQueryString?: boolean,
   slashesDenoteHost?: boolean,
 ) {
-  const showDep = process.noDeprecation == null ? true : !process.noDeprecation;
+  const noDeprecation = process.noDeprecation;
+  const showDep = noDeprecation == null ? true : !noDeprecation;
   if (!urlParseWarned && showDep && !lazyUtil().isInsideNodeModules()) {
     urlParseWarned = true;
     process.emitWarning(

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -111,7 +111,8 @@ function urlParse(
   parseQueryString?: boolean,
   slashesDenoteHost?: boolean,
 ) {
-  if (!urlParseWarned && !lazyUtil().isInsideNodeModules()) {
+  const showDep = process.noDeprecation == null ? true : !process.noDeprecation;
+  if (!urlParseWarned && showDep && !lazyUtil().isInsideNodeModules()) {
     urlParseWarned = true;
     process.emitWarning(
       "`url.parse()` behavior is not standardized and prone to " +

--- a/test/js/node/test/parallel/test-url-parse-invalid-input.js
+++ b/test/js/node/test/parallel/test-url-parse-invalid-input.js
@@ -96,8 +96,8 @@ if (common.hasIntl) {
   // Warning should only happen once per process.
   common.expectWarning({
     DeprecationWarning: {
-      // eslint-disable-next-line @stylistic/js/max-len
-      DEP0169: '`url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.',
+      // NOTE: this warning is noisy and annoying. We've disabled it intentionally.
+      // DEP0169: '`url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.',
       DEP0170: `The URL ${badURLs[0]} is invalid. Future versions of Node.js will throw an error.`,
     },
   });

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -81,18 +81,3 @@ it("URL constructor throws ERR_MISSING_ARGS", () => {
   // @ts-expect-error
   expect(err?.code).toEqual("ERR_MISSING_ARGS");
 });
-
-describe("url.parse()", () => {
-  it("respects process.noDeprecation", () => {
-    const dir = tempDirWithFiles("url-parse", {
-      "index.js": `
-        process.noDeprecation = true;
-        const { parse } = require("url");
-        parse("http://example.com");
-      `,
-    });
-
-    const { stderr } = bunRun(path.join(dir, "index.js"));
-    expect(stderr).toBeEmpty();
-  });
-});

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -1,3 +1,5 @@
+import { bunRunAsScript, bunRun, tempDirWithFiles } from "harness";
+import path from "path";
 import { parse } from "url";
 
 describe("Url.prototype.parse", () => {
@@ -78,4 +80,19 @@ it("URL constructor throws ERR_MISSING_ARGS", () => {
 
   // @ts-expect-error
   expect(err?.code).toEqual("ERR_MISSING_ARGS");
+});
+
+describe("url.parse()", () => {
+  it("respects process.noDeprecation", () => {
+    const dir = tempDirWithFiles("url-parse", {
+      "index.js": `
+        process.noDeprecation = true;
+        const { parse } = require("url");
+        parse("http://example.com");
+      `,
+    });
+
+    const { stderr } = bunRun(path.join(dir, "index.js"));
+    expect(stderr).toBeEmpty();
+  });
 });

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -1,5 +1,3 @@
-import { bunRunAsScript, bunRun, tempDirWithFiles } from "harness";
-import path from "path";
 import { parse } from "url";
 
 describe("Url.prototype.parse", () => {


### PR DESCRIPTION
### What does this PR do?
Closes #16639




### How did you verify your code works?
Existing `node:url` tests cover most of this behavior. I've added tests for the rest.