### PR TITLE
Allow workers to continue execution if `onerror` is handled

### DIFF
--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -372,4 +372,15 @@ describe("worker_threads", () => {
     await p;
     expect(message).toEqual("hello");
   });
+
+  test("worker catching error doesn't terminate", done => {
+    const worker = new wt.Worker(
+      "self.onerror = e => { setTimeout(() => { postMessage('hello'); }, 1); }; throw new Error('test')",
+      { eval: true },
+    );
+    worker.on("message", e => {
+      expect(e).toEqual("hello");
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Accidentally closed from force-pushing superseding #16606.