### PR TITLE
Allow indented inline snapshots

### DIFF
--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -41,6 +41,8 @@ pub const Snapshots = struct {
         has_matchers: bool,
         is_added: bool,
         kind: []const u8, // static lifetime
+        start_indent: ?[]const u8, // owned by Snapshots.allocator
+        end_indent: ?[]const u8, // owned by Snapshots.allocator
 
         fn lessThanFn(_: void, a: InlineSnapshotToWrite, b: InlineSnapshotToWrite) bool {
             if (a.line < b.line) return true;
@@ -395,12 +397,49 @@ pub const Snapshots = struct {
                 try result_text.appendSlice(file_text[uncommitted_segment_end..final_start_usize]);
                 uncommitted_segment_end = final_end_usize;
 
-                // TODO: count the indentation level of the caller & indent the written snapshot with that level + "  "
+                // preserve existing indentation level, otherwise indent the same as the start position plus two spaces
+                var needs_more_spaces = false;
+                const start_indent = ils.start_indent orelse D: {
+                    const source_until_final_start = source.contents[0..final_start_usize];
+                    const line_start = if (std.mem.lastIndexOfScalar(u8, source_until_final_start, '\n')) |newline_loc| newline_loc + 1 else 0;
+                    const indent_count = for (source_until_final_start[line_start..], 0..) |char, j| {
+                        if (char != ' ' and char != '\t') break j;
+                    } else source_until_final_start[line_start..].len;
+                    needs_more_spaces = true;
+                    break :D source_until_final_start[line_start..][0..indent_count];
+                };
+
+                var re_indented_string = std.ArrayList(u8).init(arena);
+                defer re_indented_string.deinit();
+                const re_indented = if (ils.value.len > 0 and ils.value[0] == '\n') blk: {
+                    // append starting newline
+                    try re_indented_string.appendSlice("\n");
+                    var re_indented_source = ils.value[1..];
+                    while (re_indented_source.len > 0) {
+                        const next_newline = if (std.mem.indexOfScalar(u8, re_indented_source, '\n')) |a| a + 1 else re_indented_source.len;
+                        const segment = re_indented_source[0..next_newline];
+                        if (segment.len == 0) {
+                            // last line; loop already exited
+                            unreachable;
+                        } else if (bun.strings.eqlComptime(segment, "\n")) {
+                            // zero length line. no indent.
+                        } else {
+                            // regular line. indent.
+                            try re_indented_string.appendSlice(start_indent);
+                            if (needs_more_spaces) try re_indented_string.appendSlice("  ");
+                        }
+                        try re_indented_string.appendSlice(segment);
+                        re_indented_source = re_indented_source[next_newline..];
+                    }
+                    // indent before backtick
+                    try re_indented_string.appendSlice(ils.end_indent orelse start_indent);
+                    break :blk re_indented_string.items;
+                } else ils.value;
 
                 if (needs_pre_comma) try result_text.appendSlice(", ");
                 const result_text_writer = result_text.writer();
                 try result_text.appendSlice("`");
-                try bun.js_printer.writePreQuotedString(ils.value, @TypeOf(result_text_writer), result_text_writer, '`', false, false, .utf8);
+                try bun.js_printer.writePreQuotedString(re_indented, @TypeOf(result_text_writer), result_text_writer, '`', false, false, .utf8);
                 try result_text.appendSlice("`");
 
                 if (ils.is_added) Jest.runner.?.snapshots.added += 1;

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -298,7 +298,7 @@ pub const Snapshots = struct {
                     };
                     const fn_name = ils.kind;
                     if (!bun.strings.startsWith(file_text[next_start..], fn_name)) {
-                        try log.addErrorFmt(&source, .{ .start = @intCast(next_start) }, arena, "Failed to update inline snapshot: Could not find 'toMatchInlineSnapshot' here", .{});
+                        try log.addErrorFmt(&source, .{ .start = @intCast(next_start) }, arena, "Failed to update inline snapshot: Could not find '{s}' here", .{fn_name});
                         continue;
                     }
                     next_start += fn_name.len;
@@ -394,6 +394,8 @@ pub const Snapshots = struct {
 
                 try result_text.appendSlice(file_text[uncommitted_segment_end..final_start_usize]);
                 uncommitted_segment_end = final_end_usize;
+
+                // TODO: count the indentation level of the caller & indent the written snapshot with that level + "  "
 
                 if (needs_pre_comma) try result_text.appendSlice(", ");
                 const result_text_writer = result_text.writer();

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -346,7 +346,11 @@ pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: 
             },
 
             '\t' => {
-                try writer.writeAll("\\t");
+                if (quote_char == '`') {
+                    try writer.writeAll("\t");
+                } else {
+                    try writer.writeAll("\\t");
+                }
                 i += 1;
             },
 

--- a/test/js/bun/test/snapshot-tests/snapshots/__snapshots__/snapshot.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/snapshots/__snapshots__/snapshot.test.ts.snap
@@ -607,3 +607,19 @@ exports[`snapshot numbering 4`] = `"snap"`;
 exports[`snapshot numbering 6`] = `"hello"`;
 
 exports[`snapshot numbering: hinted 1`] = `"hello"`;
+
+exports[`indented inline snapshots 4`] = `
+"\x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoMatchInlineSnapshot\x1B[2m(\x1B[0m\x1B[32mexpected\x1B[0m\x1B[2m)\x1B[0m
+
+Expected: \x1B[2m
+\x1B[0m\x1B[32m                \x1B[0m\x1B[2m{
+  \x1B[0m\x1B[32m            \x1B[0m\x1B[2m"a": 2,
+\x1B[0m\x1B[32m                \x1B[0m\x1B[2m}
+\x1B[0m
+Received: \x1B[2m
+\x1B[0m\x1B[2m{
+  \x1B[0m\x1B[2m"a": 2,
+\x1B[0m\x1B[2m}
+\x1B[0m
+"
+`;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -742,6 +742,24 @@ describe("inline snapshots", () => {
     );
   });
 });
+test("indented inline snapshots", () => {
+  expect("a\nb").toMatchInlineSnapshot(`
+    "a
+    b"
+`);
+  expect({ a: 2 }).toMatchInlineSnapshot(`
+    {
+      "a": 2,
+    }
+            `);
+  expect(() => {
+    expect({ a: 2 }).toMatchInlineSnapshot(`
+                {
+              "a": 2,
+                }
+`);
+  }).toThrowErrorMatchingSnapshot();
+});
 
 test("error snapshots", () => {
   expect(() => {
@@ -756,6 +774,14 @@ test("error snapshots", () => {
   expect(() => {
     throw undefined; // this one doesn't work in jest because it doesn't think the function threw
   }).toThrowErrorMatchingInlineSnapshot(`undefined`);
+  expect(() => {
+    expect(() => {}).toThrowErrorMatchingInlineSnapshot(`undefined`);
+  }).toThrowErrorMatchingInlineSnapshot(`
+"\x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoThrowErrorMatchingInlineSnapshot\x1B[2m(\x1B[0m\x1B[2m)\x1B[0m
+
+\x1B[1mMatcher error\x1B[0m: Received function did not throw
+"
+`);
 });
 test("error inline snapshots", () => {
   expect(() => {

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -410,6 +410,13 @@ class InlineSnapshotTester {
       cb((a, b, c) => c),
     );
   }
+  testUpdateOnly(cb: (v: (b: string, c: string) => string) => string): void {
+    this.testInternal(
+      true,
+      cb((b, c) => b),
+      cb((b, c) => c),
+    );
+  }
   testInternal(use_update: boolean, before_value: string, after_value: string): void {
     const thefile = this.tmpfile(before_value);
 
@@ -513,6 +520,7 @@ describe("inline snapshots", () => {
   });
   test("inline snapshot update cases", () => {
     tester.test(
+      // prettier-ignore
       v => /*js*/ `
         test("cases", () => {
           expect("1").toMatchInlineSnapshot(${v("", bad, '`"1"`')});
@@ -534,19 +542,72 @@ describe("inline snapshots", () => {
                   ${v("", bad, '`"12"`')})\r
                     ;
           expect("13").toMatchInlineSnapshot(${v("", bad, '`"13"`')}); expect("14").toMatchInlineSnapshot(${v("", bad, '`"14"`')}); expect("15").toMatchInlineSnapshot(${v("", bad, '`"15"`')});
-          expect({a: new Date()}).toMatchInlineSnapshot({a: expect.any(Date)}${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()}).toMatchInlineSnapshot({a: expect.any(Date)}${v(",", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()}).toMatchInlineSnapshot({a: expect.any(Date)\n}${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()}).\ntoMatchInlineSnapshot({a: expect.any(Date)\n}${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()})\n.\ntoMatchInlineSnapshot({a: expect.any(Date)\n}${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()})\n.\ntoMatchInlineSnapshot({a: \nexpect.any(Date)\n}${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()})\n.\ntoMatchInlineSnapshot({a: \nexpect.any(\nDate)\n}${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()}).toMatchInlineSnapshot( {a: expect.any(Date)} ${v("", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect({a: new Date()}).toMatchInlineSnapshot( {a: expect.any(Date)} ${v(",", ', "bad"', ', `\n{\n  "a": Any<Date>,\n}\n`')});
-          expect("😊").toMatchInlineSnapshot(${v("", bad, '`"😊"`')});
-          expect("\\r").toMatchInlineSnapshot(${v("", bad, '`\n"\n"\n`')});
-          expect("\\r\\n").toMatchInlineSnapshot(${v("", bad, '`\n"\n"\n`')});
-          expect("\\n").toMatchInlineSnapshot(${v("", bad, '`\n"\n"\n`')});
+          expect({a: new Date()}).toMatchInlineSnapshot({a: expect.any(Date)}${v("", `, "bad"`, `, \`
+            {
+              "a": Any<Date>,
+            }
+          \``)});
+          expect({a: new Date()}).toMatchInlineSnapshot({a: expect.any(Date)}${v(",", `, "bad"`, `, \`
+            {
+              "a": Any<Date>,
+            }
+          \``)});
+          expect({a: new Date()}).toMatchInlineSnapshot({a: expect.any(Date)
+}${v("", `, "bad"`, `, \`
+  {
+    "a": Any<Date>,
+  }
+\``)});
+          expect({a: new Date()}).\ntoMatchInlineSnapshot({a: expect.any(Date)
+}${v("", `, "bad"`, `, \`
+  {
+    "a": Any<Date>,
+  }
+\``)});
+          expect({a: new Date()})\n.\ntoMatchInlineSnapshot({a: expect.any(Date)
+}${v("", `, "bad"`, `, \`
+  {
+    "a": Any<Date>,
+  }
+\``)});
+          expect({a: new Date()})\n.\ntoMatchInlineSnapshot({a: 
+expect.any(Date)
+}${v("", `, "bad"`, `, \`
+  {
+    "a": Any<Date>,
+  }
+\``)});
+          expect({a: new Date()})\n.\ntoMatchInlineSnapshot({a: 
+expect.any(
+Date)
+}${v("", `, "bad"`, `, \`
+  {
+    "a": Any<Date>,
+  }
+\``)});
+          expect({a: new Date()}).toMatchInlineSnapshot( {a: expect.any(Date)} ${v("", `, "bad"`, `, \`
+            {
+              "a": Any<Date>,
+            }
+          \``)});
+          expect({a: new Date()}).toMatchInlineSnapshot( {a: expect.any(Date)} ${v(",", `, "bad"`, `, \`
+            {
+              "a": Any<Date>,
+            }
+          \``)});
+          expect("😊").toMatchInlineSnapshot(${v("", bad, `\`"😊"\``)});
+          expect("\\r").toMatchInlineSnapshot(${v("", bad, `\`
+            "
+            "
+          \``)});
+          expect("\\r\\n").toMatchInlineSnapshot(${v("", bad, `\`
+            "
+            "
+          \``)});
+          expect("\\n").toMatchInlineSnapshot(${v("", bad, `\`
+            "
+            "
+          \``)});
         });
       `,
     );
@@ -741,9 +802,42 @@ describe("inline snapshots", () => {
       `,
     );
   });
-  // it("keeps indentation", () => {
-  //   tester.test(v => ``);
-  // });
+  it("indentation", () => {
+    tester.test(
+      // prettier-ignore
+      v => /*js*/ `
+        test("cases", () => {
+          expect("abc\\n\\ndef").toMatchInlineSnapshot(${v("", `"hello"`, `\`
+            "abc
+
+            def"
+          \``)});
+          expect("from indented to dedented").toMatchInlineSnapshot(${v("", `\`
+            "abc
+
+            def"
+          \``, `\`"from indented to dedented"\``)});
+        });
+      `,
+    );
+  });
+  it("preserve existing indentation", () => {
+    tester.testUpdateOnly(
+      // prettier-ignore
+      v => /*js*/ `
+        test("cases", () => {
+          expect("keeps the same\\n\\nindentation").toMatchInlineSnapshot(${v(`\`
+                  "weird existing
+                  indentation" 
+    \``, `\`
+                  "keeps the same
+
+                  indentation"
+    \``)});
+        });
+      `,
+    );
+  });
 });
 test("indented inline snapshots", () => {
   expect("a\nb").toMatchInlineSnapshot(`

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -741,6 +741,9 @@ describe("inline snapshots", () => {
       `,
     );
   });
+  // it("keeps indentation", () => {
+  //   tester.test(v => ``);
+  // });
 });
 test("indented inline snapshots", () => {
   expect("a\nb").toMatchInlineSnapshot(`


### PR DESCRIPTION
### What does this PR do?

Fixes #16403

Indentation in inline snapshots is ignored, and when new inline snapshots are created, they are automatically indented. Existing snapshots preserve indentation when updated.