### PR TITLE
fix(node/fs): `fs.close` and `fs.Dir.closeSync`

### DIFF
--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -1065,6 +1065,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_STREAM_UNABLE_TO_PIPE, "Cannot pipe to a closed or destroyed stream"_s));
     case ErrorCode::ERR_ILLEGAL_CONSTRUCTOR:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor"_s));
+    case ErrorCode::ERR_DIR_CLOSED:
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_DIR_CLOSED, "Directory handle was closed"_s));
 
     default: {
         break;

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -92,6 +92,9 @@ const errors: ErrorCodeMapping = [
   // Console
   ["ERR_CONSOLE_WRITABLE_STREAM", TypeError, "TypeError"],
 
+  // FS
+  ["ERR_DIR_CLOSED", Error],
+
   // DNS
   ["ERR_DNS_SET_SERVERS_FAILED", Error],
 

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1017,7 +1017,7 @@ class Dir {
    * `-1` when closed. stdio handles (0, 1, 2) don't actually get closed by
    * {@link close} or {@link closeSync}.
    */
-  #handle: number | undefined;
+  #handle: number;
   #path;
   #options;
   #entries: any[] | null = null;
@@ -1066,7 +1066,7 @@ class Dir {
     if (cb) {
       process.nextTick(cb);
     }
-    if (handle > 2) fs.closeSync(this.#handle);
+    if (handle > 2) fs.closeSync(handle);
     this.#handle = -1;
   }
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1040,7 +1040,7 @@ export function mergeWindowEnvs(envs: Record<string, string | undefined>[]) {
   return flat;
 }
 
-export function tmpdirSync(pattern: string = "bun.test.") {
+export function tmpdirSync(pattern: string = "bun.test."): string {
   return fs.mkdtempSync(join(fs.realpathSync.native(os.tmpdir()), pattern));
 }
 

--- a/test/js/node/fs/dir.test.ts
+++ b/test/js/node/fs/dir.test.ts
@@ -1,0 +1,34 @@
+import { describe, beforeAll, afterAll, it, expect } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("given a directory that exists", () => {
+  let dirname: string;
+
+  beforeAll(() => {
+    const name = "dir-sync.test." + String(Math.random() * 100).substring(0, 6);
+    dirname = path.join(os.tmpdir(), name);
+    fs.mkdirSync(dirname);
+  });
+
+  afterAll(() => {
+    fs.rmdirSync(dirname, { recursive: true });
+  });
+
+  it("can be opened/closed synchronously", () => {
+    const dir = fs.opendirSync(dirname);
+    expect(dir).toBeDefined();
+    expect(dir).toBeInstanceOf(fs.Dir);
+    expect(dir.closeSync()).toBeUndefined();
+    expect(() => dir.readSync()).toThrow("Directory handle was closed");
+  });
+
+  it("can be opened/closed asynchronously", async () => {
+    const dir = await fs.promises.opendir(dirname);
+    expect(dir).toBeDefined();
+    expect(dir).toBeInstanceOf(fs.Dir);
+    expect(await dir.close()).toBeUndefined();
+    expect(() => dir.read()).toThrow("Directory handle was closed");
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Closes  #16622

- fix misnamed `closedirSync` call to `closeSync` (if only we had type checking...
- fill in method stub for `fs.Dir.prototype.closeSync`
- throw `ERR_DIR_CLOSED` when `dir.read[Sync]()` is called after `dir.close[Sync]()`'

### How did you verify your code works?

I added tests
