### PR TITLE
update `bun.lock` types

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6972,7 +6972,7 @@ declare module "bun" {
    * Types for `bun.lock`
    */
   type BunLockFile = {
-    lockfileVersion: 0;
+    lockfileVersion: 0 | 1;
     workspaces: {
       [workspace: string]: BunLockFileWorkspacePackage;
     };
@@ -6984,10 +6984,11 @@ declare module "bun" {
      * ```
      * INFO = { prod/dev/optional/peer dependencies, os, cpu, libc (TODO), bin, binDir }
      *
+     * // first index is resolution for each type of package
      * npm         -> [ "name@version", registry (TODO: remove if default), INFO, integrity]
      * symlink     -> [ "name@link:path", INFO ]
      * folder      -> [ "name@file:path", INFO ]
-     * workspace   -> [ "name@workspace:path", INFO ]
+     * workspace   -> [ "name@workspace:path" ] // workspace is only path
      * tarball     -> [ "name@tarball", INFO ]
      * root        -> [ "name@root:", { bin, binDir } ]
      * git         -> [ "name@git+repo", INFO, .bun-tag string (TODO: remove this) ]
@@ -7005,6 +7006,8 @@ declare module "bun" {
     optionalDependencies?: Record<string, string>;
     peerDependencies?: Record<string, string>;
     optionalPeers?: string[];
+    bin?: string | Record<string, string>;
+    binDir?: string;
   };
 
   type BunLockFileWorkspacePackage = BunLockFileBasePackageInfo & {
@@ -7015,8 +7018,6 @@ declare module "bun" {
   type BunLockFilePackageInfo = BunLockFileBasePackageInfo & {
     os?: string | string[];
     cpu?: string | string[];
-    bin?: Record<string, string>;
-    binDir?: string;
     bundled?: true;
   };
 
@@ -7024,10 +7025,12 @@ declare module "bun" {
   type BunLockFilePackageArray =
     /** npm */
     | [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string]
-    /** symlink, folder, tarball, workspace */
+    /** symlink, folder, tarball */
     | [pkg: string, info: BunLockFilePackageInfo]
+    /** workspace */
+    | [pkg: string]
     /** git, github */
     | [pkg: string, info: BunLockFilePackageInfo, bunTag: string]
     /** root */
-    | [pkg: string, info: Pick<BunLockFilePackageInfo, "bin" | "binDir">];
+    | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">];
 }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
