### PR TITLE
js: Buffer: alias toString as toLocaleString

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -2301,6 +2301,8 @@ void JSBufferPrototype::finishCreation(VM& vm, JSC::JSGlobalObject* globalThis)
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
     reifyStaticProperties(vm, JSBuffer::info(), JSBufferPrototypeTableValues, *this);
 
+    ALIAS("toLocaleString", "toString");
+
     ALIAS("readUintBE", "readUIntBE");
     ALIAS("readUintLE", "readUIntLE");
     ALIAS("readUint8", "readUInt8");

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1205,7 +1205,7 @@ for (let withOverridenBufferWrite of [false, true]) {
       it("toLocaleString()", () => {
         const buf = Buffer.from("test");
         expect(buf.toLocaleString()).toBe(buf.toString());
-        // expect(Buffer.prototype.toLocaleString).toBe(Buffer.prototype.toString);
+        expect(Buffer.prototype.toLocaleString).toBe(Buffer.prototype.toString);
       });
 
       it("alloc() should throw on invalid data", () => {


### PR DESCRIPTION
pulled out of https://github.com/oven-sh/bun/pull/15722

this expectation is also in `test-buffer-alloc.js` but there's other unrelated failures preventing that file from being merged yet
name suggests its mainly for `Buffer.alloc` but also depends on perfect `Buffer.prototype.write` among others