### PR TITLE
Don't run json files

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1524,12 +1524,16 @@ pub const RunCommand = struct {
         log("Try resolve `{s}` in `{s}`", .{ target_name, this_transpiler.fs.top_level_dir });
         if (this_transpiler.resolver.resolve(this_transpiler.fs.top_level_dir, target_name, .entry_point_run)) |resolved| {
             var resolved_mutable = resolved;
-            log("Resolved to: `{s}`", .{resolved_mutable.path().?.text});
-            return _bootAndHandleError(ctx, resolved_mutable.path().?.text);
+            if (!std.mem.endsWith(u8, resolved_mutable.path().?.text, ".json")) {
+                log("Resolved to: `{s}`", .{resolved_mutable.path().?.text});
+                return _bootAndHandleError(ctx, resolved_mutable.path().?.text);
+            }
         } else |_| if (this_transpiler.resolver.resolve(this_transpiler.fs.top_level_dir, try std.mem.join(ctx.allocator, "", &.{ "./", target_name }), .entry_point_run)) |resolved| {
             var resolved_mutable = resolved;
-            log("Resolved with `./` to: `{s}`", .{resolved_mutable.path().?.text});
-            return _bootAndHandleError(ctx, resolved_mutable.path().?.text);
+            if (!std.mem.endsWith(u8, resolved_mutable.path().?.text, ".json")) {
+                log("Resolved with `./` to: `{s}`", .{resolved_mutable.path().?.text});
+                return _bootAndHandleError(ctx, resolved_mutable.path().?.text);
+            }
         } else |_| {}
 
         // execute a node_modules/.bin/<X> command, or (run only) a system command like 'ls'

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1522,17 +1522,17 @@ pub const RunCommand = struct {
         // TODO: run module resolution here - try the next condition if the module can't be found
 
         log("Try resolve `{s}` in `{s}`", .{ target_name, this_transpiler.fs.top_level_dir });
-        if (this_transpiler.resolver.resolve(this_transpiler.fs.top_level_dir, target_name, .entry_point_run)) |resolved| {
+        if (this_transpiler.resolver.resolve(this_transpiler.fs.top_level_dir, target_name, .entry_point_run) catch
+            this_transpiler.resolver.resolve(this_transpiler.fs.top_level_dir, try std.mem.join(ctx.allocator, "", &.{ "./", target_name }), .entry_point_run)) |resolved|
+        {
             var resolved_mutable = resolved;
-            if (!std.mem.endsWith(u8, resolved_mutable.path().?.text, ".json")) {
-                log("Resolved to: `{s}`", .{resolved_mutable.path().?.text});
-                return _bootAndHandleError(ctx, resolved_mutable.path().?.text);
-            }
-        } else |_| if (this_transpiler.resolver.resolve(this_transpiler.fs.top_level_dir, try std.mem.join(ctx.allocator, "", &.{ "./", target_name }), .entry_point_run)) |resolved| {
-            var resolved_mutable = resolved;
-            if (!std.mem.endsWith(u8, resolved_mutable.path().?.text, ".json")) {
-                log("Resolved with `./` to: `{s}`", .{resolved_mutable.path().?.text});
-                return _bootAndHandleError(ctx, resolved_mutable.path().?.text);
+            const path = resolved_mutable.path().?;
+            const loader: bun.options.Loader = this_transpiler.options.loaders.get(path.name.ext) orelse .tsx;
+            if (loader.canBeRunByBun()) {
+                log("Resolved to: `{s}`", .{path.text});
+                return _bootAndHandleError(ctx, path.text);
+            } else {
+                log("Resolved file `{s}` but ignoring because loader is {s}", .{ path.text, @tagName(loader) });
             }
         } else |_| {}
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -697,7 +697,7 @@ pub const Loader = enum(u8) {
 
     pub fn canBeRunByBun(this: Loader) bool {
         return switch (this) {
-            .jsx, .js, .ts, .tsx, .json, .wasm, .bunsh => true,
+            .jsx, .js, .ts, .tsx, .wasm, .bunsh => true,
             else => false,
         };
     }

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -682,10 +682,18 @@ describe("'bun run' priority", async () => {
       },
       main: "main.js",
     }),
+    "nx.json": JSON.stringify({}),
     "§'.js": 'console.log("§\'.js")',
-    "node_modules": { ".bin": { "confabulate": `#!${bunExe()}\nconsole.log("node_modules/.bin/confabulate")` } },
+    "node_modules": {
+      ".bin": {
+        "confabulate": `#!${bunExe()}\nconsole.log("node_modules/.bin/confabulate")`,
+        "nx": `#!${bunExe()}\nconsole.log("node_modules/.bin/nx")`,
+      },
+    },
+    "no_run_json.json": JSON.stringify({}),
   });
   chmodSync(dir + "/node_modules/.bin/confabulate", 0o755);
+  chmodSync(dir + "/node_modules/.bin/nx", 0o755);
 
   const commands: {
     command: string[];
@@ -766,6 +774,25 @@ describe("'bun run' priority", async () => {
     { command: [dir + "/.secretscript"], stdout: ".secretscript.js", stderr: "" },
 
     {
+      command: ["no_run_json"],
+      stdout: "",
+      stderr: /error: Script not found "no_run_json"|EACCES/,
+      exitCode: 1,
+    },
+    {
+      command: ["no_run_json.json"],
+      stdout: "",
+      stderr: /error: Module not found "no_run_json\.json"|EACCES/,
+      exitCode: 1,
+    },
+    {
+      command: ["./no_run_json"],
+      stdout: "",
+      stderr: /error: Module not found "\.(\/|\\|\\\\)no_run_json"|EACCES/,
+      exitCode: 1,
+    },
+
+    {
       command: ["/absolute"],
       stdout: "",
       stderr: /error: Module not found "(\/|\\|\\\\)absolute"|EACCES/,
@@ -786,6 +813,7 @@ describe("'bun run' priority", async () => {
       : [
           // node_modules command
           { command: ["confabulate"], stdout: "node_modules/.bin/confabulate", stderr: "" },
+          { command: ["nx"], stdout: "node_modules/.bin/nx", stderr: "" },
 
           // system command
           { command: ["echo", "abc"], stdout: "abc", stderr: "", req_run: true },


### PR DESCRIPTION
### What does this PR do?

Fixes #16720, Fixes #16697

It preferred the `nx.json` / `turbo.json` files over the actual nx/turbo commands

It might make sense to partially revert the bun run change and go back to requiring file extensions on files to run rather than using module resolution