### PR TITLE
toSliced2 becomes toSlice to make sure that exceptions are handled properly

### DIFF
--- a/src/bake/FrameworkRouter.zig
+++ b/src/bake/FrameworkRouter.zig
@@ -1246,7 +1246,7 @@ pub const JSFrameworkRouter = struct {
             return global.throwInvalidArguments("parseRoutePattern takes two arguments", .{});
 
         const style_js, const filepath_js = frame.argumentsAsArray(2);
-        const filepath = try filepath_js.toSlice2(global, alloc);
+        const filepath = try filepath_js.toSlice(global, alloc);
         defer filepath.deinit();
         var style = try Style.fromJS(style_js, global);
         errdefer style.deinit();

--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -458,7 +458,7 @@ pub const Framework = struct {
 
                 const extensions: []const []const u8 = if (try fsr_opts.get(global, "extensions")) |exts_js| exts: {
                     if (exts_js.isString()) {
-                        const str = try exts_js.toSlice2(global, arena);
+                        const str = try exts_js.toSlice(global, arena);
                         defer str.deinit();
                         if (bun.strings.eqlComptime(str.slice(), "*")) {
                             break :exts &.{};
@@ -468,7 +468,7 @@ pub const Framework = struct {
                         var i_2: usize = 0;
                         const extensions = try arena.alloc([]const u8, exts_js.getLength(global));
                         while (it_2.next()) |array_item| : (i_2 += 1) {
-                            const slice = refs.track(try array_item.toSlice2(global, arena));
+                            const slice = refs.track(try array_item.toSlice(global, arena));
                             if (bun.strings.eqlComptime(slice, "*"))
                                 return global.throwInvalidArguments("'extensions' cannot include \"*\" as an extension. Pass \"*\" instead of the array.", .{});
 
@@ -493,7 +493,7 @@ pub const Framework = struct {
                         var i_2: usize = 0;
                         const dirs = try arena.alloc([]const u8, len);
                         while (it_2.next()) |array_item| : (i_2 += 1) {
-                            dirs[i_2] = refs.track(try array_item.toSlice2(global, arena));
+                            dirs[i_2] = refs.track(try array_item.toSlice(global, arena));
                         }
                         break :exts dirs;
                     }

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2098,7 +2098,7 @@ pub const Formatter = struct {
 
         switch (comptime Format) {
             .StringPossiblyFormatted => {
-                var str = value.toSlice(this.globalThis, bun.default_allocator);
+                var str = try value.toSlice(this.globalThis, bun.default_allocator);
                 defer str.deinit();
                 this.addForNewLine(str.len);
                 const slice = str.slice();

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -368,7 +368,7 @@ pub fn which(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
         return JSC.JSValue.jsNull();
     }
 
-    bin_str = path_arg.toSlice(globalThis, globalThis.bunVM().allocator);
+    bin_str = try path_arg.toSlice(globalThis, globalThis.bunVM().allocator);
     if (globalThis.hasException()) {
         return .zero;
     }
@@ -391,11 +391,11 @@ pub fn which(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
     if (arguments.nextEat()) |arg| {
         if (!arg.isEmptyOrUndefinedOrNull() and arg.isObject()) {
             if (try arg.get(globalThis, "PATH")) |str_| {
-                path_str = str_.toSlice(globalThis, globalThis.bunVM().allocator);
+                path_str = try str_.toSlice(globalThis, globalThis.bunVM().allocator);
             }
 
             if (try arg.get(globalThis, "cwd")) |str_| {
-                cwd_str = str_.toSlice(globalThis, globalThis.bunVM().allocator);
+                cwd_str = try str_.toSlice(globalThis, globalThis.bunVM().allocator);
             }
         }
     }
@@ -699,13 +699,13 @@ pub fn openInEditor(globalThis: js.JSContextRef, callframe: *JSC.CallFrame) bun.
     var column: ?string = null;
 
     if (arguments.nextEat()) |file_path_| {
-        path = file_path_.toSlice(globalThis, arguments.arena.allocator()).slice();
+        path = (try file_path_.toSlice(globalThis, arguments.arena.allocator())).slice();
     }
 
     if (arguments.nextEat()) |opts| {
         if (!opts.isUndefinedOrNull()) {
             if (try opts.getTruthy(globalThis, "editor")) |editor_val| {
-                var sliced = editor_val.toSlice(globalThis, arguments.arena.allocator());
+                var sliced = try editor_val.toSlice(globalThis, arguments.arena.allocator());
                 const prev_name = edit.name;
 
                 if (!strings.eqlLong(prev_name, sliced.slice(), true)) {
@@ -724,11 +724,11 @@ pub fn openInEditor(globalThis: js.JSContextRef, callframe: *JSC.CallFrame) bun.
             }
 
             if (try opts.getTruthy(globalThis, "line")) |line_| {
-                line = line_.toSlice(globalThis, arguments.arena.allocator()).slice();
+                line = (try line_.toSlice(globalThis, arguments.arena.allocator())).slice();
             }
 
             if (try opts.getTruthy(globalThis, "column")) |column_| {
-                column = column_.toSlice(globalThis, arguments.arena.allocator()).slice();
+                column = (try column_.toSlice(globalThis, arguments.arena.allocator())).slice();
             }
         }
     }
@@ -1411,7 +1411,7 @@ pub const Crypto = struct {
                     }
 
                     if (!globalThis.hasException()) {
-                        const slice = arguments[4].toSlice(globalThis, bun.default_allocator);
+                        const slice = try arguments[4].toSlice(globalThis, bun.default_allocator);
                         defer slice.deinit();
                         const name = slice.slice();
                         return globalThis.ERR_CRYPTO_INVALID_DIGEST("Invalid digest: {s}", .{name}).throw();
@@ -3233,7 +3233,7 @@ pub fn mmapFile(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.
     const path = brk: {
         if (args.nextEat()) |path| {
             if (path.isString()) {
-                const path_str = path.toSlice(globalThis, args.arena.allocator());
+                const path_str = try path.toSlice(globalThis, args.arena.allocator());
                 if (path_str.len > bun.MAX_PATH_BYTES) {
                     return globalThis.throwInvalidArguments("Path too long", .{});
                 }
@@ -3401,7 +3401,7 @@ const HashObject = struct {
                                 input = array_buffer.byteSlice();
                             },
                             else => {
-                                input_slice = arg.toSlice(globalThis, bun.default_allocator);
+                                input_slice = try arg.toSlice(globalThis, bun.default_allocator);
                                 input = input_slice.slice();
                             },
                         }
@@ -3588,7 +3588,7 @@ const TOMLObject = struct {
             return globalThis.throwInvalidArguments("Expected a string to parse", .{});
         }
 
-        var input_slice = arguments[0].toSlice(globalThis, bun.default_allocator);
+        var input_slice = try arguments[0].toSlice(globalThis, bun.default_allocator);
         defer input_slice.deinit();
         var source = logger.Source.initPathString("input.toml", input_slice.slice());
         const parse_result = TOMLParser.parse(&source, &log, allocator, false) catch {

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -230,7 +230,7 @@ pub const JSBundler = struct {
                     } else if (env == .true or (env.isNumber() and env.asNumber() == 1)) {
                         this.env_behavior = .load_all;
                     } else if (env.isString()) {
-                        const slice = try env.toSlice2(globalThis, bun.default_allocator);
+                        const slice = try env.toSlice(globalThis, bun.default_allocator);
                         defer slice.deinit();
                         if (strings.eqlComptime(slice.slice(), "inline")) {
                             this.env_behavior = .load_all;

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -660,7 +660,7 @@ fn transformOptionsFromJSC(globalObject: JSC.C.JSContextRef, temp_allocator: std
                         const replacementValue = JSC.JSObject.getIndex(value, globalThis, 1);
                         if (exportReplacementValue(replacementValue, globalThis)) |to_replace| {
                             const replacementKey = JSC.JSObject.getIndex(value, globalThis, 0);
-                            var slice = (try replacementKey.toSlice(globalThis, bun.default_allocator).cloneIfNeeded(bun.default_allocator));
+                            var slice = (try (try replacementKey.toSlice(globalThis, bun.default_allocator)).cloneIfNeeded(bun.default_allocator));
                             const replacement_name = slice.slice();
 
                             if (!JSLexer.isIdentifier(replacement_name)) {

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1691,7 +1691,7 @@ pub const InternalDNS = struct {
         defer hostname_slice.deinit();
 
         if (hostname_or_url.isString()) {
-            hostname_slice = hostname_or_url.toSlice(globalThis, bun.default_allocator);
+            hostname_slice = try hostname_or_url.toSlice(globalThis, bun.default_allocator);
         } else {
             return globalThis.throwInvalidArguments("hostname must be a string", .{});
         }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -912,7 +912,7 @@ pub const Listener = struct {
         if (!hostname.isString()) {
             return global.throwInvalidArguments("hostname pattern expects a string", .{});
         }
-        const host_str = hostname.toSlice(
+        const host_str = try hostname.toSlice(
             global,
             bun.default_allocator,
         );

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -677,7 +677,7 @@ pub const FFI = struct {
                     if (!value.isString()) {
                         return globalThis.throwInvalidArgumentTypeValue("flags", "array of strings", value);
                     }
-                    const slice = value.toSlice(globalThis, bun.default_allocator);
+                    const slice = try value.toSlice(globalThis, bun.default_allocator);
                     if (slice.len == 0) continue;
                     defer slice.deinit();
                     flags.append(' ') catch bun.outOfMemory();
@@ -1338,7 +1338,7 @@ pub const FFI = struct {
                     return ZigString.static("param must be a string (type name) or number").toErrorInstance(global);
                 }
 
-                var type_name = val.toSlice(global, allocator);
+                var type_name = try val.toSlice(global, allocator);
                 defer type_name.deinit();
                 abi_types.appendAssumeCapacity(ABIType.label.get(type_name.slice()) orelse {
                     abi_types.clearAndFree(allocator);
@@ -1370,7 +1370,7 @@ pub const FFI = struct {
                 }
             }
 
-            var ret_slice = ret_value.toSlice(global, allocator);
+            var ret_slice = try ret_value.toSlice(global, allocator);
             defer ret_slice.deinit();
             return_type = ABIType.label.get(ret_slice.slice()) orelse {
                 abi_types.clearAndFree(allocator);

--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -78,7 +78,7 @@ pub const FileSystemRouter = struct {
             if (!dir.isString()) {
                 return globalThis.throwInvalidArguments("Expected dir to be a string", .{});
             }
-            const root_dir_path_ = dir.toSlice(globalThis, globalThis.allocator());
+            const root_dir_path_ = try dir.toSlice(globalThis, globalThis.allocator());
             if (!(root_dir_path_.len == 0 or strings.eqlComptime(root_dir_path_.slice(), "."))) {
                 // resolve relative path if needed
                 const path = root_dir_path_.slice();
@@ -115,7 +115,7 @@ pub const FileSystemRouter = struct {
                     return globalThis.throwInvalidArguments("Expected fileExtensions to be an Array of strings", .{});
                 }
                 if (val.getLength(globalThis) == 0) continue;
-                extensions.appendAssumeCapacity((val.toSlice(globalThis, allocator).clone(allocator) catch unreachable).slice()[1..]);
+                extensions.appendAssumeCapacity(((try val.toSlice(globalThis, allocator)).clone(allocator) catch unreachable).slice()[1..]);
             }
         }
 
@@ -127,7 +127,7 @@ pub const FileSystemRouter = struct {
                 return globalThis.throwInvalidArguments("Expected assetPrefix to be a string", .{});
             }
 
-            asset_prefix_slice = asset_prefix.toSlice(globalThis, allocator).clone(allocator) catch unreachable;
+            asset_prefix_slice = (try asset_prefix.toSlice(globalThis, allocator)).clone(allocator) catch unreachable;
         }
         const orig_log = vm.transpiler.resolver.log;
         var log = Log.Log.init(allocator);
@@ -167,7 +167,7 @@ pub const FileSystemRouter = struct {
                 globalThis.allocator().destroy(arena);
                 return globalThis.throwInvalidArguments("Expected origin to be a string", .{});
             }
-            origin_str = origin.toSlice(globalThis, globalThis.allocator());
+            origin_str = try origin.toSlice(globalThis, globalThis.allocator());
         }
 
         if (log.errors + log.warnings > 0) {
@@ -299,7 +299,7 @@ pub const FileSystemRouter = struct {
 
         var path: ZigString.Slice = brk: {
             if (argument.isString()) {
-                break :brk argument.toSlice(globalThis, globalThis.allocator()).clone(globalThis.allocator()) catch unreachable;
+                break :brk (try argument.toSlice(globalThis, globalThis.allocator())).clone(globalThis.allocator()) catch unreachable;
             }
 
             if (argument.isCell()) {

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -39,7 +39,7 @@ const ScanOpts = struct {
     error_on_broken_symlinks: bool,
 
     fn parseCWD(globalThis: *JSGlobalObject, allocator: std.mem.Allocator, cwdVal: JSC.JSValue, absolute: bool, comptime fnName: string) bun.JSError![]const u8 {
-        const cwd_str_raw = cwdVal.toSlice(globalThis, allocator);
+        const cwd_str_raw = try cwdVal.toSlice(globalThis, allocator);
         if (cwd_str_raw.len == 0) return "";
 
         const cwd_str = cwd_str: {
@@ -403,7 +403,7 @@ pub fn match(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame
         return globalThis.throw("Glob.matchString: first argument is not a string", .{});
     }
 
-    var str = str_arg.toSlice(globalThis, arena.allocator());
+    var str = try str_arg.toSlice(globalThis, arena.allocator());
     defer str.deinit();
 
     if (this.is_ascii and isAllAscii(str.slice())) return JSC.JSValue.jsBoolean(globImpl.Ascii.match(this.pattern, str.slice()).matches());

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -1374,7 +1374,7 @@ pub const Comment = struct {
     ) callconv(.C) bool {
         if (this.comment == null)
             return false;
-        var text = value.toSlice(global, bun.default_allocator);
+        var text = value.toSlice(global, bun.default_allocator) catch return false;
         defer text.deinit();
         this.comment.?.setText(text.slice()) catch {
             global.throwValue(createLOLHTMLError(global)) catch {};
@@ -1517,7 +1517,7 @@ pub const EndTag = struct {
     ) callconv(.C) bool {
         if (this.end_tag == null)
             return false;
-        var text = value.toSlice(global, bun.default_allocator);
+        var text = value.toSlice(global, bun.default_allocator) catch return false;
         defer text.deinit();
         this.end_tag.?.setName(text.slice()) catch {
             global.throwValue(createLOLHTMLError(global)) catch {};
@@ -1826,8 +1826,7 @@ pub const Element = struct {
     ) bool {
         if (this.element == null)
             return false;
-
-        var text = value.toSlice(global, bun.default_allocator);
+        var text = value.toSlice(global, bun.default_allocator) catch return false;
         defer text.deinit();
 
         this.element.?.setTagName(text.slice()) catch {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -677,7 +677,7 @@ pub const ServerConfig = struct {
 
             // Required
             if (try obj.getTruthy(global, "keyFile")) |key_file_name| {
-                var sliced = key_file_name.toSlice(global, bun.default_allocator);
+                var sliced = try key_file_name.toSlice(global, bun.default_allocator);
                 defer sliced.deinit();
                 if (sliced.len > 0) {
                     result.key_file_name = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -769,7 +769,7 @@ pub const ServerConfig = struct {
             }
 
             if (try obj.getTruthy(global, "certFile")) |cert_file_name| {
-                var sliced = cert_file_name.toSlice(global, bun.default_allocator);
+                var sliced = try cert_file_name.toSlice(global, bun.default_allocator);
                 defer sliced.deinit();
                 if (sliced.len > 0) {
                     result.cert_file_name = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -895,7 +895,7 @@ pub const ServerConfig = struct {
             }
 
             if (try obj.getTruthy(global, "ciphers")) |ssl_ciphers| {
-                var sliced = ssl_ciphers.toSlice(global, bun.default_allocator);
+                var sliced = try ssl_ciphers.toSlice(global, bun.default_allocator);
                 defer sliced.deinit();
                 if (sliced.len > 0) {
                     result.ssl_ciphers = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -905,7 +905,7 @@ pub const ServerConfig = struct {
             }
 
             if (try obj.getTruthy(global, "serverName") orelse try obj.getTruthy(global, "servername")) |server_name| {
-                var sliced = server_name.toSlice(global, bun.default_allocator);
+                var sliced = try server_name.toSlice(global, bun.default_allocator);
                 defer sliced.deinit();
                 if (sliced.len > 0) {
                     result.server_name = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -994,7 +994,7 @@ pub const ServerConfig = struct {
             }
 
             if (try obj.getTruthy(global, "caFile")) |ca_file_name| {
-                var sliced = ca_file_name.toSlice(global, bun.default_allocator);
+                var sliced = try ca_file_name.toSlice(global, bun.default_allocator);
                 defer sliced.deinit();
                 if (sliced.len > 0) {
                     result.ca_file_name = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -1024,7 +1024,7 @@ pub const ServerConfig = struct {
                 }
 
                 if (try obj.getTruthy(global, "dhParamsFile")) |dh_params_file_name| {
-                    var sliced = dh_params_file_name.toSlice(global, bun.default_allocator);
+                    var sliced = try dh_params_file_name.toSlice(global, bun.default_allocator);
                     defer sliced.deinit();
                     if (sliced.len > 0) {
                         result.dh_params_file_name = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -1035,7 +1035,7 @@ pub const ServerConfig = struct {
                 }
 
                 if (try obj.getTruthy(global, "passphrase")) |passphrase| {
-                    var sliced = passphrase.toSlice(global, bun.default_allocator);
+                    var sliced = try passphrase.toSlice(global, bun.default_allocator);
                     defer sliced.deinit();
                     if (sliced.len > 0) {
                         result.passphrase = bun.default_allocator.dupeZ(u8, sliced.slice()) catch unreachable;
@@ -1216,7 +1216,7 @@ pub const ServerConfig = struct {
             if (global.hasException()) return error.JSError;
 
             if (try arg.getTruthy(global, "baseURI")) |baseURI| {
-                var sliced = baseURI.toSlice(global, bun.default_allocator);
+                var sliced = try baseURI.toSlice(global, bun.default_allocator);
 
                 if (sliced.len > 0) {
                     defer sliced.deinit();
@@ -1255,7 +1255,7 @@ pub const ServerConfig = struct {
                 if (id.isUndefinedOrNull()) {
                     args.allow_hot = false;
                 } else {
-                    const id_str = id.toSlice(
+                    const id_str = try id.toSlice(
                         global,
                         bun.default_allocator,
                     );
@@ -4903,7 +4903,7 @@ pub const ServerWebSocket = struct {
             return globalThis.throw("publish requires a topic string", .{});
         }
 
-        var topic_slice = topic_value.toSlice(globalThis, bun.default_allocator);
+        var topic_slice = try topic_value.toSlice(globalThis, bun.default_allocator);
         defer topic_slice.deinit();
         if (topic_slice.len == 0) {
             return globalThis.throw("publish requires a non-empty topic", .{});
@@ -4991,7 +4991,7 @@ pub const ServerWebSocket = struct {
             return globalThis.throw("publishText requires a topic string", .{});
         }
 
-        var topic_slice = topic_value.toSlice(globalThis, bun.default_allocator);
+        var topic_slice = try topic_value.toSlice(globalThis, bun.default_allocator);
         defer topic_slice.deinit();
 
         if (!compress_value.isBoolean() and !compress_value.isUndefined() and compress_value != .zero) {
@@ -5056,7 +5056,7 @@ pub const ServerWebSocket = struct {
             return globalThis.throw("publishBinary requires a topic string", .{});
         }
 
-        var topic_slice = topic_value.toSlice(globalThis, bun.default_allocator);
+        var topic_slice = try topic_value.toSlice(globalThis, bun.default_allocator);
         defer topic_slice.deinit();
         if (topic_slice.len == 0) {
             return globalThis.throw("publishBinary requires a non-empty topic", .{});
@@ -5700,7 +5700,7 @@ pub const ServerWebSocket = struct {
             return globalThis.throwInvalidArgumentTypeValue("topic", "string", args.ptr[0]);
         }
 
-        var topic = args.ptr[0].toSlice(globalThis, bun.default_allocator);
+        var topic = try args.ptr[0].toSlice(globalThis, bun.default_allocator);
         defer topic.deinit();
 
         if (topic.len == 0) {
@@ -5723,7 +5723,7 @@ pub const ServerWebSocket = struct {
             return globalThis.throwInvalidArgumentTypeValue("topic", "string", args.ptr[0]);
         }
 
-        var topic = args.ptr[0].toSlice(globalThis, bun.default_allocator);
+        var topic = try args.ptr[0].toSlice(globalThis, bun.default_allocator);
         defer topic.deinit();
 
         if (topic.len == 0) {
@@ -5750,7 +5750,7 @@ pub const ServerWebSocket = struct {
             return globalThis.throwInvalidArgumentTypeValue("topic", "string", args.ptr[0]);
         }
 
-        var topic = args.ptr[0].toSlice(globalThis, bun.default_allocator);
+        var topic = try args.ptr[0].toSlice(globalThis, bun.default_allocator);
         defer topic.deinit();
 
         if (topic.len == 0) {
@@ -6057,11 +6057,8 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 return globalThis.throwInvalidArguments("subscriberCount requires a topic name as a string", .{});
             }
 
-            var topic = arguments.ptr[0].toSlice(globalThis, bun.default_allocator);
+            var topic = try arguments.ptr[0].toSlice(globalThis, bun.default_allocator);
             defer topic.deinit();
-            if (globalThis.hasException()) {
-                return .zero;
-            }
 
             if (topic.len == 0) {
                 return JSValue.jsNumber(0);
@@ -6447,7 +6444,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             // TODO: set User-Agent header
             // TODO: unify with fetch() implementation.
             if (first_arg.isString()) {
-                const url_zig_str = arguments[0].toSlice(ctx, bun.default_allocator);
+                const url_zig_str = try arguments[0].toSlice(ctx, bun.default_allocator);
                 defer url_zig_str.deinit();
                 var temp_url_str = url_zig_str.slice();
 
@@ -6470,7 +6467,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 if (arguments.len >= 2 and arguments[1].isObject()) {
                     var opts = arguments[1];
                     if (opts.fastGet(ctx, .method)) |method_| {
-                        var slice_ = method_.toSlice(ctx, getAllocator(ctx));
+                        var slice_ = try method_.toSlice(ctx, getAllocator(ctx));
                         defer slice_.deinit();
                         method = HTTP.Method.which(slice_.slice()) orelse method;
                     }

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5023,26 +5023,8 @@ pub const JSValue = enum(i64) {
     }
 
     /// Convert a JSValue to a string, potentially calling `toString` on the
-    /// JSValue in JavaScript.
-    ///
-    /// This function can throw an exception in the `JSC::VM`. **If
-    /// the exception is not handled correctly, Bun will segfault**
-    ///
-    /// To handle exceptions, use `JSValue.toSliceOrNull`.
-    pub inline fn toSlice(this: JSValue, global: *JSGlobalObject, allocator: std.mem.Allocator) ZigString.Slice {
-        const str = bun.String.fromJS(this, global);
-        defer str.deref();
-
-        // This keeps the WTF::StringImpl alive if it was originally a latin1
-        // ASCII-only string.
-        //
-        // Otherwise, it will be cloned using the allocator.
-        return str.toUTF8(allocator);
-    }
-
-    /// Convert a JSValue to a string, potentially calling `toString` on the
     /// JSValue in JavaScript. Can throw an error.
-    pub fn toSlice2(this: JSValue, global: *JSGlobalObject, allocator: std.mem.Allocator) JSError!ZigString.Slice {
+    pub fn toSlice(this: JSValue, global: *JSGlobalObject, allocator: std.mem.Allocator) JSError!ZigString.Slice {
         const str = try bun.String.fromJS2(this, global);
         defer str.deref();
 

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -971,24 +971,24 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
 
     var root: []const u8 = "";
     if (try pathObject_ptr.getTruthy(globalObject, "root")) |jsValue| {
-        root = jsValue.toSlice(globalObject, allocator).slice();
+        root = (try jsValue.toSlice(globalObject, allocator)).slice();
     }
     var dir: []const u8 = "";
     if (try pathObject_ptr.getTruthy(globalObject, "dir")) |jsValue| {
-        dir = jsValue.toSlice(globalObject, allocator).slice();
+        dir = (try jsValue.toSlice(globalObject, allocator)).slice();
     }
     var base: []const u8 = "";
     if (try pathObject_ptr.getTruthy(globalObject, "base")) |jsValue| {
-        base = jsValue.toSlice(globalObject, allocator).slice();
+        base = (try jsValue.toSlice(globalObject, allocator)).slice();
     }
     // Prefix with _ to avoid shadowing the identifier in the outer scope.
     var _name: []const u8 = "";
     if (try pathObject_ptr.getTruthy(globalObject, "name")) |jsValue| {
-        _name = jsValue.toSlice(globalObject, allocator).slice();
+        _name = (try jsValue.toSlice(globalObject, allocator)).slice();
     }
     var ext: []const u8 = "";
     if (try pathObject_ptr.getTruthy(globalObject, "ext")) |jsValue| {
-        ext = jsValue.toSlice(globalObject, allocator).slice();
+        ext = (try jsValue.toSlice(globalObject, allocator)).slice();
     }
     return formatJS_T(u8, globalObject, allocator, isWindows, .{ .root = root, .dir = dir, .base = base, .ext = ext, .name = _name });
 }

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -995,7 +995,7 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
     }
     var _name: []const u8 = "";
     var _name_slice: ?JSC.ZigString.Slice = null;
-    deferif (_name_slice) |slice| slice.deinit();
+    defer if (_name_slice) |slice| slice.deinit();
 
     if (try pathObject_ptr.getTruthy(globalObject, "name")) |jsValue| {
         _name_slice = try jsValue.toSlice(globalObject, allocator);

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -970,25 +970,44 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
     const allocator = stack_fallback.get();
 
     var root: []const u8 = "";
+    var root_slice: ?JSC.ZigString.Slice = null;
+    if (root_slice) |slice| slice.deinit();
+
     if (try pathObject_ptr.getTruthy(globalObject, "root")) |jsValue| {
-        root = (try jsValue.toSlice(globalObject, allocator)).slice();
+        root_slice = try jsValue.toSlice(globalObject, allocator);
+        root = root_slice.?.slice();
     }
     var dir: []const u8 = "";
+    var dir_slice: ?JSC.ZigString.Slice = null;
+    if (dir_slice) |slice| slice.deinit();
+
     if (try pathObject_ptr.getTruthy(globalObject, "dir")) |jsValue| {
-        dir = (try jsValue.toSlice(globalObject, allocator)).slice();
+        dir_slice = try jsValue.toSlice(globalObject, allocator);
+        dir = dir_slice.?.slice();
     }
     var base: []const u8 = "";
+    var base_slice: ?JSC.ZigString.Slice = null;
+    if (base_slice) |slice| slice.deinit();
+
     if (try pathObject_ptr.getTruthy(globalObject, "base")) |jsValue| {
-        base = (try jsValue.toSlice(globalObject, allocator)).slice();
+        base_slice = try jsValue.toSlice(globalObject, allocator);
+        base = base_slice.?.slice();
     }
-    // Prefix with _ to avoid shadowing the identifier in the outer scope.
     var _name: []const u8 = "";
+    var _name_slice: ?JSC.ZigString.Slice = null;
+    if (_name_slice) |slice| slice.deinit();
+
     if (try pathObject_ptr.getTruthy(globalObject, "name")) |jsValue| {
-        _name = (try jsValue.toSlice(globalObject, allocator)).slice();
+        _name_slice = try jsValue.toSlice(globalObject, allocator);
+        _name = _name_slice.?.slice();
     }
     var ext: []const u8 = "";
+    var ext_slice: ?JSC.ZigString.Slice = null;
+    if (ext_slice) |slice| slice.deinit();
+
     if (try pathObject_ptr.getTruthy(globalObject, "ext")) |jsValue| {
-        ext = (try jsValue.toSlice(globalObject, allocator)).slice();
+        ext_slice = try jsValue.toSlice(globalObject, allocator);
+        ext = ext_slice.?.slice();
     }
     return formatJS_T(u8, globalObject, allocator, isWindows, .{ .root = root, .dir = dir, .base = base, .ext = ext, .name = _name });
 }

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -971,7 +971,7 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
 
     var root: []const u8 = "";
     var root_slice: ?JSC.ZigString.Slice = null;
-    if (root_slice) |slice| slice.deinit();
+    defer if (root_slice) |slice| slice.deinit();
 
     if (try pathObject_ptr.getTruthy(globalObject, "root")) |jsValue| {
         root_slice = try jsValue.toSlice(globalObject, allocator);
@@ -979,7 +979,7 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
     }
     var dir: []const u8 = "";
     var dir_slice: ?JSC.ZigString.Slice = null;
-    if (dir_slice) |slice| slice.deinit();
+    defer if (dir_slice) |slice| slice.deinit();
 
     if (try pathObject_ptr.getTruthy(globalObject, "dir")) |jsValue| {
         dir_slice = try jsValue.toSlice(globalObject, allocator);
@@ -987,7 +987,7 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
     }
     var base: []const u8 = "";
     var base_slice: ?JSC.ZigString.Slice = null;
-    if (base_slice) |slice| slice.deinit();
+    defer if (base_slice) |slice| slice.deinit();
 
     if (try pathObject_ptr.getTruthy(globalObject, "base")) |jsValue| {
         base_slice = try jsValue.toSlice(globalObject, allocator);
@@ -995,7 +995,7 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
     }
     var _name: []const u8 = "";
     var _name_slice: ?JSC.ZigString.Slice = null;
-    if (_name_slice) |slice| slice.deinit();
+    deferif (_name_slice) |slice| slice.deinit();
 
     if (try pathObject_ptr.getTruthy(globalObject, "name")) |jsValue| {
         _name_slice = try jsValue.toSlice(globalObject, allocator);
@@ -1003,7 +1003,7 @@ pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]J
     }
     var ext: []const u8 = "";
     var ext_slice: ?JSC.ZigString.Slice = null;
-    if (ext_slice) |slice| slice.deinit();
+    defer if (ext_slice) |slice| slice.deinit();
 
     if (try pathObject_ptr.getTruthy(globalObject, "ext")) |jsValue| {
         ext_slice = try jsValue.toSlice(globalObject, allocator);

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -741,9 +741,9 @@ pub const Expect = struct {
                 }
             }
         } else if (value.isStringLiteral() and expected.isStringLiteral()) {
-            const value_string = value.toSlice(globalThis, default_allocator);
+            const value_string = try value.toSlice(globalThis, default_allocator);
             defer value_string.deinit();
-            const expected_string = expected.toSlice(globalThis, default_allocator);
+            const expected_string = try expected.toSlice(globalThis, default_allocator);
             defer expected_string.deinit();
 
             if (expected_string.len == 0) { // edge case empty string is always contained
@@ -2302,7 +2302,7 @@ pub const Expect = struct {
                     // partial match
                     const expected_slice = try expected_value.toSliceOrNull(globalThis);
                     defer expected_slice.deinit();
-                    const received_slice = received_message.toSlice(globalThis, globalThis.allocator());
+                    const received_slice = try received_message.toSlice(globalThis, globalThis.allocator());
                     defer received_slice.deinit();
                     if (strings.contains(received_slice.slice(), expected_slice.slice())) return .undefined;
                 }
@@ -3528,9 +3528,9 @@ pub const Expect = struct {
         var pass = value.isString() and expected.isString();
 
         if (pass) {
-            const value_slice = value.toSlice(globalThis, default_allocator);
+            const value_slice = try value.toSlice(globalThis, default_allocator);
             defer value_slice.deinit();
-            const expected_slice = expected.toSlice(globalThis, default_allocator);
+            const expected_slice = try expected.toSlice(globalThis, default_allocator);
             defer expected_slice.deinit();
 
             const value_utf8 = value_slice.slice();

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1228,7 +1228,9 @@ pub const DescribeScope = struct {
         const allocator = getAllocator(globalThis);
 
         if (this.label.len > 0) {
-            allocator.free(this.label);
+            const label = this.label;
+            this.label = "";
+            allocator.free(label);
         }
         this.pending_tests.deinit(allocator);
         for (this.tests.items) |t| {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1237,7 +1237,7 @@ pub const DescribeScope = struct {
         }
 
         this.pending_tests.deinit(allocator);
-        for (this.tests.items) |t| {
+        for (this.tests.items) |*t| {
             t.deinit(globalThis);
         }
         this.tests.clearAndFree(allocator);

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -528,7 +528,7 @@ pub const Jest = struct {
         if (arguments.len < 1 or !arguments[0].isString()) {
             return globalObject.throw("Bun.jest() expects a string filename", .{});
         }
-        var str = arguments[0].toSlice(globalObject, bun.default_allocator);
+        var str = try arguments[0].toSlice(globalObject, bun.default_allocator);
         defer str.deinit();
         const slice = str.slice();
 
@@ -1753,7 +1753,7 @@ inline fn createScope(
     const label = if (description == .zero)
         ""
     else
-        (description.toSlice(globalThis, allocator).cloneIfNeeded(allocator) catch unreachable).slice();
+        ((try description.toSlice(globalThis, allocator)).cloneIfNeeded(allocator) catch unreachable).slice();
 
     var tag_to_use = tag;
 
@@ -2061,7 +2061,7 @@ fn eachBind(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSVa
             const label = if (description.isEmptyOrUndefinedOrNull())
                 ""
             else
-                (description.toSlice(globalThis, allocator).cloneIfNeeded(allocator) catch unreachable).slice();
+                ((try description.toSlice(globalThis, allocator)).cloneIfNeeded(allocator) catch unreachable).slice();
             const formattedLabel = try formatLabel(globalThis, label, function_args, test_idx);
 
             const tag = parent.tag;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1217,9 +1217,18 @@ pub const DescribeScope = struct {
                 _ = globalThis.bunVM().uncaughtException(globalThis, err, true);
             }
         }
+        const allocator = getAllocator(globalThis);
 
-        this.pending_tests.deinit(getAllocator(globalThis));
-        this.tests.clearAndFree(getAllocator(globalThis));
+        if (this.label.len > 0) {
+            allocator.free(this.label);
+        }
+        this.pending_tests.deinit(allocator);
+        for (this.tests.items) |t| {
+            if (t.label.len > 0) {
+                allocator.free(t.label);
+            }
+        }
+        this.tests.clearAndFree(allocator);
     }
 
     const ScopeStack = ObjectPool(std.ArrayListUnmanaged(*DescribeScope), null, true, 16);

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -592,6 +592,14 @@ pub const TestScope = struct {
         actual: u32 = 0,
     };
 
+    pub fn deinit(this: *TestScope) void {
+        if (this.label.len > 0) {
+            const label = this.label;
+            this.label = "";
+            bun.default_allocator.free(label);
+        }
+    }
+
     pub fn call(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         return createScope(globalThis, callframe, "test()", true, .pass);
     }
@@ -1224,9 +1232,7 @@ pub const DescribeScope = struct {
         }
         this.pending_tests.deinit(allocator);
         for (this.tests.items) |t| {
-            if (t.label.len > 0) {
-                allocator.free(t.label);
-            }
+            t.deinit();
         }
         this.tests.clearAndFree(allocator);
     }

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -933,7 +933,7 @@ pub const JestPrettyFormat = struct {
 
             switch (comptime Format) {
                 .StringPossiblyFormatted => {
-                    var str = value.toSlice(this.globalThis, bun.default_allocator);
+                    var str = try value.toSlice(this.globalThis, bun.default_allocator);
                     defer str.deinit();
                     this.addForNewLine(str.len);
                     const slice = str.slice();

--- a/src/bun.js/webcore.zig
+++ b/src/bun.js/webcore.zig
@@ -34,7 +34,7 @@ fn alert(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSErr
     if (has_message) {
         var state = std.heap.stackFallback(2048, bun.default_allocator);
         const allocator = state.get();
-        const message = arguments[0].toSlice(globalObject, allocator);
+        const message = try arguments[0].toSlice(globalObject, allocator);
         defer message.deinit();
 
         if (message.len > 0) {
@@ -88,7 +88,7 @@ fn confirm(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
 
         // 3. Set message to the result of optionally truncating message.
         // *  Not necessary so we won't do it.
-        const message = arguments[0].toSlice(globalObject, allocator);
+        const message = try arguments[0].toSlice(globalObject, allocator);
         defer message.deinit();
 
         output.writeAll(message.slice()) catch {
@@ -230,7 +230,7 @@ pub const Prompt = struct {
 
             // 3. Set message to the result of optionally truncating message.
             // *  Not necessary so we won't do it.
-            const message = arguments[0].toSlice(globalObject, allocator);
+            const message = try arguments[0].toSlice(globalObject, allocator);
             defer message.deinit();
 
             output.writeAll(message.slice()) catch {
@@ -251,7 +251,7 @@ pub const Prompt = struct {
         };
 
         if (has_default) {
-            const default_string = arguments[1].toSlice(globalObject, allocator);
+            const default_string = try arguments[1].toSlice(globalObject, allocator);
             defer default_string.deinit();
 
             output.print("[{s}] ", .{default_string.slice()}) catch {

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -251,7 +251,7 @@ pub fn constructS3FileWithS3CredentialsAndOptions(
                 inner: {
                     if (file_type.isString()) {
                         var allocator = bun.default_allocator;
-                        var str = file_type.toSlice(globalObject, bun.default_allocator);
+                        var str = try file_type.toSlice(globalObject, bun.default_allocator);
                         defer str.deinit();
                         const slice = str.slice();
                         if (!strings.isAllASCII(slice)) {
@@ -294,7 +294,7 @@ pub fn constructS3FileWithS3Credentials(
                 inner: {
                     if (file_type.isString()) {
                         var allocator = bun.default_allocator;
-                        var str = file_type.toSlice(globalObject, bun.default_allocator);
+                        var str = try file_type.toSlice(globalObject, bun.default_allocator);
                         defer str.deinit();
                         const slice = str.slice();
                         if (!strings.isAllASCII(slice)) {

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -1697,7 +1697,7 @@ pub const Blob = struct {
                 if (try options.get(globalThis, "type")) |content_type| {
                     inner: {
                         if (content_type.isString()) {
-                            var content_type_str = content_type.toSlice(globalThis, bun.default_allocator);
+                            var content_type_str = try content_type.toSlice(globalThis, bun.default_allocator);
                             defer content_type_str.deinit();
                             const slice = content_type_str.slice();
                             if (!strings.isAllASCII(slice)) {
@@ -1799,7 +1799,7 @@ pub const Blob = struct {
                     inner: {
                         if (file_type.isString()) {
                             var allocator = bun.default_allocator;
-                            var str = file_type.toSlice(globalObject, bun.default_allocator);
+                            var str = try file_type.toSlice(globalObject, bun.default_allocator);
                             defer str.deinit();
                             const slice = str.slice();
                             if (!strings.isAllASCII(slice)) {
@@ -3978,7 +3978,7 @@ pub const Blob = struct {
                     if (!content_type.isString()) {
                         return globalThis.throwInvalidArgumentType("write", "options.type", "string");
                     }
-                    var content_type_str = content_type.toSlice(globalThis, bun.default_allocator);
+                    var content_type_str = try content_type.toSlice(globalThis, bun.default_allocator);
                     defer content_type_str.deinit();
                     const slice = content_type_str.slice();
                     if (strings.isAllASCII(slice)) {
@@ -4322,7 +4322,7 @@ pub const Blob = struct {
                         if (!content_type.isString()) {
                             return globalThis.throwInvalidArgumentType("write", "options.type", "string");
                         }
-                        var content_type_str = content_type.toSlice(globalThis, bun.default_allocator);
+                        var content_type_str = try content_type.toSlice(globalThis, bun.default_allocator);
                         defer content_type_str.deinit();
                         const slice = content_type_str.slice();
                         if (strings.isAllASCII(slice)) {
@@ -4875,7 +4875,7 @@ pub const Blob = struct {
                         if (try options.get(globalThis, "type")) |content_type| {
                             inner: {
                                 if (content_type.isString()) {
-                                    var content_type_str = content_type.toSlice(globalThis, bun.default_allocator);
+                                    var content_type_str = try content_type.toSlice(globalThis, bun.default_allocator);
                                     defer content_type_str.deinit();
                                     const slice = content_type_str.slice();
                                     if (!strings.isAllASCII(slice)) {
@@ -5588,7 +5588,7 @@ pub const Blob = struct {
                 JSC.JSValue.JSType.StringObject,
                 JSC.JSValue.JSType.DerivedStringObject,
                 => {
-                    var sliced = current.toSlice(global, bun.default_allocator);
+                    var sliced = try current.toSlice(global, bun.default_allocator);
                     const allocator = sliced.allocator.get();
                     could_have_non_ascii = could_have_non_ascii or !sliced.allocator.isWTFAllocator();
                     joiner.push(sliced.slice(), allocator);
@@ -5614,7 +5614,7 @@ pub const Blob = struct {
                                 .StringObject,
                                 .DerivedStringObject,
                                 => {
-                                    var sliced = item.toSlice(global, bun.default_allocator);
+                                    var sliced = try item.toSlice(global, bun.default_allocator);
                                     const allocator = sliced.allocator.get();
                                     could_have_non_ascii = could_have_non_ascii or !sliced.allocator.isWTFAllocator();
                                     joiner.push(sliced.slice(), allocator);
@@ -5697,7 +5697,7 @@ pub const Blob = struct {
                 },
 
                 else => {
-                    var sliced = current.toSlice(global, bun.default_allocator);
+                    var sliced = try current.toSlice(global, bun.default_allocator);
                     if (global.hasException()) {
                         const end_result = try joiner.done(bun.default_allocator);
                         bun.default_allocator.free(end_result);

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -892,7 +892,7 @@ pub const TextDecoder = struct {
         if (arguments.len > 0) {
             // encoding
             if (arguments[0].isString()) {
-                var str = arguments[0].toSlice(globalThis, bun.default_allocator);
+                var str = try arguments[0].toSlice(globalThis, bun.default_allocator);
                 defer if (str.isAllocated()) str.deinit();
 
                 if (EncodingLabel.which(str.slice())) |label| {

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -619,7 +619,7 @@ pub const StreamStart = union(Tag) {
                         .FileSink = .{
                             .chunk_size = chunk_size,
                             .input_path = .{
-                                .path = path.toSlice(globalThis, globalThis.bunVM().allocator),
+                                .path = try path.toSlice(globalThis, globalThis.bunVM().allocator),
                             },
                         },
                     };

--- a/src/css/values/color_js.zig
+++ b/src/css/values/color_js.zig
@@ -232,7 +232,7 @@ pub fn jsFunctionColor(globalThis: *JSC.JSGlobalObject, callFrame: *JSC.CallFram
             };
         }
 
-        input = args[0].toSlice(globalThis, bun.default_allocator);
+        input = try args[0].toSlice(globalThis, bun.default_allocator);
 
         var parser_input = css.ParserInput.new(allocator, input.slice());
         var parser = css.Parser.new(&parser_input, null);

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -1258,7 +1258,7 @@ pub fn fromJS(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JS
     if (!alias_value.isString()) {
         return .undefined;
     }
-    const alias_slice = alias_value.toSlice(globalThis, allocator);
+    const alias_slice = try alias_value.toSlice(globalThis, allocator);
     defer alias_slice.deinit();
 
     if (alias_slice.len == 0) {
@@ -1266,7 +1266,7 @@ pub fn fromJS(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JS
     }
 
     const name_value = if (arguments.len > 1) arguments[1] else .undefined;
-    const name_slice = name_value.toSlice(globalThis, allocator);
+    const name_slice = try name_value.toSlice(globalThis, allocator);
     defer name_slice.deinit();
 
     var name = alias_slice.slice();

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -732,7 +732,7 @@ pub const OperatingSystem = enum(u16) {
         var operating_system = negatable(.none);
         var iter = args.ptr[0].arrayIterator(globalObject);
         while (iter.next()) |item| {
-            const slice = item.toSlice(globalObject, bun.default_allocator);
+            const slice = try item.toSlice(globalObject, bun.default_allocator);
             defer slice.deinit();
             operating_system.apply(slice.slice());
             if (globalObject.hasException()) return .zero;
@@ -849,7 +849,7 @@ pub const Architecture = enum(u16) {
         var architecture = negatable(.none);
         var iter = args.ptr[0].arrayIterator(globalObject);
         while (iter.next()) |item| {
-            const slice = item.toSlice(globalObject, bun.default_allocator);
+            const slice = try item.toSlice(globalObject, bun.default_allocator);
             defer slice.deinit();
             architecture.apply(slice.slice());
             if (globalObject.hasException()) return .zero;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

Removes old `toSlice` and only use `toSlice2` that now is just `toSlice`
### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
