### PR TITLE
ci: set build-zig timeout to 25 minutes

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -462,6 +462,7 @@ function getBuildZigStep(platform, options) {
     cancel_on_build_failing: isMergeQueue(),
     env: getBuildEnv(platform, options),
     command: `bun run build:ci --target bun-zig --toolchain ${toolchain}`,
+    timeout_in_minutes: 25,
   };
 }
 


### PR DESCRIPTION
the default timeout is 1 hour so this will make it auto-restart much quicker
most of the zig builds finish much quicker but sometimes linux takes a bit longer because of LTO
the ideal fix is figuring out why there's a hang/deadlock but in the meantime this prevents build time from ballooning
