### PR TITLE
Fix bug causing AbortSignal to sometimes collect too early

### DIFF
--- a/src/bun.js/bindings/webcore/AbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/AbortSignal.cpp
@@ -195,6 +195,7 @@ void AbortSignal::cleanNativeBindings(void* ref)
     });
 
     std::exchange(m_native_callbacks, WTFMove(callbacks));
+    this->eventListenersDidChange();
 }
 
 // https://dom.spec.whatwg.org/#abortsignal-follow
@@ -218,7 +219,7 @@ void AbortSignal::signalFollow(AbortSignal& signal)
 
 void AbortSignal::eventListenersDidChange()
 {
-    m_hasAbortEventListener = hasEventListeners(eventNames().abortEvent);
+    m_hasAbortEventListener = hasEventListeners(eventNames().abortEvent) or !m_native_callbacks.isEmpty();
 }
 
 uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAlgorithm>&& algorithm)


### PR DESCRIPTION
### What does this PR do?

When passing an AbortSignal to native code, we don't use EventTarget's event listeners. 

This means the JSAbortSignal can be collected too early. This reproduces mostly on Windows.

When the `onabort` callback is commented out, this test sometimes fails on Windows.
```js
 const server_url = `http://${server.hostname}:${server.port}`;
      try {
        const signal = timeout < 0 ? AbortSignal.abort() : AbortSignal.timeout(timeout);
        // signal.onabort = function() {
        //   console.log("Abort ran", new Date());
        // }
        const res = await fetch(server_url, {
          signal: signal,
        });

        const reader = res.body?.getReader();
        let results = [];
        while (true) {
          const { done, data } = await reader?.read();
          if (data) results.push(data);
          if (done) break;
        }
        console.log("Done ran", new Date());
        expect.unreachable();
      } catch (err: any) {
        if (timeout < 0) {
          if (err.name !== "AbortError") throw err;
          expect(err.message).toBe("The operation was aborted.");
        } else {
          if (err.name !== "TimeoutError") throw err;
          expect(err.message).toBe("The operation timed out.");
        }
      }
    });
```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
