### PR TITLE
Fix Windows EOF double free

### DIFF
--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -1017,6 +1017,8 @@ pub const WindowsBufferedReader = struct {
             .source = other.source,
         };
         other.flags.is_done = true;
+        other._offset = 0;
+        other.buffer().* = std.ArrayList(u8).init(bun.default_allocator);
         other.source = null;
         to.setParent(parent);
     }


### PR DESCRIPTION
### What does this PR do?

This logic now matches the logic on POSIX.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
