### PR TITLE
Remove unnecessary scope in fs stream

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -265,26 +265,26 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
     } as any;
     this.open();
   } else {
-    if (fastPath)
-      fast: {
-        // // there is a chance that this fd is not actually correct but it will be a number
-        // if (fastPath !== true) {
-        //   // @ts-expect-error undocumented. to make this public please make it a
-        //   // getter. couldn't figure that out sorry
-        //   this.fd = fastPath._getFd();
-        // } else {
-        //   if (fs.open !== open || fs.write !== write || fs.fsync !== fsync || fs.close !== close) {
-        //     this[kWriteStreamFastPath] = undefined;
-        //     break fast;
-        //   }
-        //   // @ts-expect-error
-        //   this.fd = (this[kWriteStreamFastPath] = Bun.file(this.path).writer())._getFd();
-        // }
-        callback();
-        this.emit("open", this.fd);
-        this.emit("ready");
-        return;
-      }
+    if (fastPath) {
+      // // there is a chance that this fd is not actually correct but it will be a number
+      // if (fastPath !== true) {
+      //   // @ts-expect-error undocumented. to make this public please make it a
+      //   // getter. couldn't figure that out sorry
+      //   this.fd = fastPath._getFd();
+      // } else {
+      //   if (fs.open !== open || fs.write !== write || fs.fsync !== fsync || fs.close !== close) {
+      //     this[kWriteStreamFastPath] = undefined;
+      //     break fast;
+      //   }
+      //   // @ts-expect-error
+      //   this.fd = (this[kWriteStreamFastPath] = Bun.file(this.path).writer())._getFd();
+      // }
+      callback();
+      this.emit("open", this.fd);
+      this.emit("ready");
+      return;
+    }
+
     this[kFs].open(this.path, this.flags, this.mode, (err, fd) => {
       if (err) {
         callback(err);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
