### PR TITLE
docs: add missing flags for `build-layer` and `publish-layer` scripts

### DIFF
--- a/packages/bun-lambda/README.md
+++ b/packages/bun-lambda/README.md
@@ -79,11 +79,14 @@ Once you've written your Lambda function, you need to configure a new Lambda fun
 
 Builds a Lambda layer for Bun and saves it to a `.zip` file.
 
-| Flag        | Description                                                          | Default                |
-| ----------- | -------------------------------------------------------------------- | ---------------------- |
-| `--arch`    | The architecture, either: "x64" or "aarch64"                         | aarch64                |
-| `--release` | The release of Bun, either: "latest", "canary", or a release "x.y.z" | latest                 |
-| `--output`  | The path to write the layer as a `.zip`.                             | ./bun-lambda-layer.zip |
+| Flag        | Description                                                          | Default                  |
+| ----------- | -------------------------------------------------------------------- | ------------------------ |
+| `--arch`    | The architecture, either: `x64` or `aarch64`                         | `aarch64`                |
+| `--clean`   | Clean the temporary directory before building                        | `false`                  |
+| `--keep`    | Keep the temporary directory after building                          | `false`                  |
+| `--output`  | The path to write the layer as a `.zip`                              | `./bun-lambda-layer.zip` |
+| `--release` | The release of Bun, either: `latest`, `canary`, or a release `x.y.z` | `latest`                 |
+| `--tmp`     | Directory to use for temporary files                                 | `/tmp/bun-lambda-layer`  |
 
 Example:
 
@@ -98,11 +101,19 @@ bun run build-layer -- \
 
 Builds a Lambda layer for Bun then publishes it to your AWS account.
 
-| Flag       | Description                               | Default |
-| ---------- | ----------------------------------------- | ------- |
-| `--layer`  | The layer name.                           | bun     |
-| `--region` | The region name, or "\*" for all regions. |         |
-| `--public` | If the layer should be public.            | false   |
+| Flag            | Description                                                          | Default                    |
+| --------------- | -------------------------------------------------------------------- | -------------------------- |
+| `--arch`        | The architecture, either: `x64` or `aarch64`                         | `aarch64`                  |
+| `--clean`       | Clean the temporary directory before building                        | `false`                    |
+| `--description` | Description for the Lambda layer                                     | Bun Runtime for AWS Lambda |
+| `--keep`        | Keep the temporary directory after building                          | `false`                    |
+| `--layer`       | The layer name                                                       | `bun`                      |
+| `--license`     | License information for the layer                                    | MIT                        |
+| `--output`      | The path to write the layer as a `.zip`                              | `./bun-lambda-layer.zip`   |
+| `--public`      | If the layer should be public                                        | `false`                    |
+| `--region`      | The region name, or `*` for all regions                              |                            |
+| `--release`     | The release of Bun, either: `latest`, `canary`, or a release `x.y.z` | `latest`                   |
+| `--tmp`         | Directory to use for temporary files                                 | `/tmp/bun-lambda-layer`    |
 
 Example:
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
