### PR TITLE
Fix memory leak in pathToFileURL

### DIFF
--- a/src/bun.js/bindings/DOMURL.cpp
+++ b/src/bun.js/bindings/DOMURL.cpp
@@ -57,6 +57,7 @@ static inline String redact(const String& input)
 
 inline DOMURL::DOMURL(URL&& completeURL)
     : m_url(WTFMove(completeURL))
+    , m_initialURLCostForGC(std::min(static_cast<short>(m_url.string().impl()->costDuringGC()), std::numeric_limits<short>::max()))
 {
     ASSERT(m_url.isValid());
 }

--- a/src/bun.js/bindings/DOMURL.h
+++ b/src/bun.js/bindings/DOMURL.h
@@ -65,6 +65,10 @@ public:
     {
         return sizeof(DOMURL) + m_url.string().sizeInBytes();
     }
+    size_t memoryCostForGC() const
+    {
+        return sizeof(DOMURL) + m_initialURLCostForGC;
+    }
 
 private:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const URL& base);
@@ -75,6 +79,7 @@ private:
 
     URL m_url;
     RefPtr<URLSearchParams> m_searchParams;
+    short m_initialURLCostForGC { 0 };
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1618,11 +1618,12 @@ static inline JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObj
     case WebCore::BufferEncodingType::base64url:
     case WebCore::BufferEncodingType::hex: {
         ret = Bun__encoding__toString(reinterpret_cast<const unsigned char*>(castedThis->vector()) + offset, length, lexicalGlobalObject, static_cast<uint8_t>(encoding));
+        RETURN_IF_EXCEPTION(scope, {});
         break;
     }
     default: {
         throwTypeError(lexicalGlobalObject, scope, "Unsupported encoding? This shouldn't happen"_s);
-        break;
+        return {};
     }
     }
 

--- a/src/bun.js/bindings/PathInlines.h
+++ b/src/bun.js/bindings/PathInlines.h
@@ -58,11 +58,11 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
 extern "C" BunString ResolvePath__joinAbsStringBufCurrentPlatformBunString(JSC::JSGlobalObject*, BunString);
 
 /// CWD is determined by the global object's current cwd.
-ALWAYS_INLINE WTF::String pathResolveWTFString(JSC::JSGlobalObject* globalToGetCwdFrom, WTF::String input)
+ALWAYS_INLINE WTF::String pathResolveWTFString(JSC::JSGlobalObject* globalToGetCwdFrom, const WTF::String& input)
 {
     if (isAbsolutePath(input))
         return input;
     BunString in = Bun::toString(input);
     BunString out = ResolvePath__joinAbsStringBufCurrentPlatformBunString(globalToGetCwdFrom, in);
-    return out.toWTFString();
+    return out.transferToWTFString();
 }

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5330,7 +5330,7 @@ pub const JSValue = enum(i64) {
         return getOwnTruthy(this, global, property);
     }
 
-    pub fn truthyPropertyValue(prop: JSValue) ?JSValue {
+    fn truthyPropertyValue(prop: JSValue) ?JSValue {
         return switch (prop) {
             .zero => unreachable,
 

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -69,6 +69,8 @@ typedef struct BunString {
     // It's only truly zero-copy if it was already a WTFStringImpl (which it is if it came from JS and we didn't use ZigString)
     WTF::String toWTFString(ZeroCopyTag) const;
 
+    WTF::String transferToWTFString();
+
     // This one usually will clone the raw bytes.
     WTF::String toWTFString() const;
 

--- a/src/bun.js/bindings/webcore/JSDOMURL.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMURL.cpp
@@ -171,6 +171,8 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMURLDOMConstructor::const
         RETURN_IF_EXCEPTION(throwScope, {});
     setSubclassStructureIfNeeded<DOMURL>(lexicalGlobalObject, callFrame, asObject(jsValue));
     RETURN_IF_EXCEPTION(throwScope, {});
+    auto* jsDOMURL = jsCast<JSDOMURL*>(jsValue.asCell());
+    vm.heap.reportExtraMemoryAllocated(jsDOMURL, jsDOMURL->wrapped().memoryCostForGC());
     return JSValue::encode(jsValue);
 }
 JSC_ANNOTATE_HOST_FUNCTION(JSDOMURLDOMConstructorConstruct, JSDOMURLDOMConstructor::construct);
@@ -787,6 +789,7 @@ void JSDOMURL::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_searchParams);
+    visitor.reportExtraMemoryVisited(thisObject->protectedWrapped()->memoryCostForGC());
 }
 
 DEFINE_VISIT_CHILDREN(JSDOMURL);

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -1464,9 +1464,9 @@ extern "C" void WebSocket__didAbruptClose(WebCore::WebSocket* webSocket, int32_t
 {
     webSocket->didFailWithErrorCode(errorCode);
 }
-extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t errorCode, const BunString* reason)
+extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t errorCode, BunString* reason)
 {
-    WTF::String wtf_reason = reason->toWTFString(BunString::ZeroCopy);
+    WTF::String wtf_reason = reason->transferToWTFString();
     webSocket->didClose(0, errorCode, WTFMove(wtf_reason));
 }
 

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -161,7 +161,7 @@ const CppWebSocket = opaque {
         defer loop.exit();
         WebSocket__didAbruptClose(this, reason);
     }
-    pub fn didClose(this: *CppWebSocket, code: u16, reason: *const bun.String) void {
+    pub fn didClose(this: *CppWebSocket, code: u16, reason: *bun.String) void {
         const loop = JSC.VirtualMachine.get().eventLoop();
         loop.enter();
         defer loop.exit();
@@ -1846,7 +1846,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             this.deref();
         }
 
-        fn dispatchClose(this: *WebSocket, code: u16, reason: *const bun.String) void {
+        fn dispatchClose(this: *WebSocket, code: u16, reason: *bun.String) void {
             var out = this.outgoing_websocket orelse return;
             this.poll_ref.unref(this.globalThis.bunVM());
             JSC.markBinding(@src());

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3332,7 +3332,7 @@ pub const Resolver = struct {
     pub export fn Resolver__propForRequireMainPaths(globalThis: *bun.JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
         bun.JSC.markBinding(@src());
 
-        const in_str = bun.String.createUTF8(".");
+        const in_str = bun.String.init(".");
         const r = &globalThis.bunVM().transpiler.resolver;
         return nodeModulePathsJSValue(r, in_str, globalThis);
     }

--- a/test/js/node/url/pathToFileURL-leak-fixture.js
+++ b/test/js/node/url/pathToFileURL-leak-fixture.js
@@ -1,0 +1,13 @@
+var longPath = Buffer.alloc(1021, "Z").toString();
+const isDebugBuildOfBun = globalThis?.Bun?.revision?.includes("debug");
+import { pathToFileURL } from "url";
+for (let i = 0; i < 1024 * (isDebugBuildOfBun ? 32 : 256); i++) {
+  pathToFileURL(longPath);
+}
+Bun.gc(true);
+const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;
+console.log("RSS", rss, "MB");
+if (rss > 250) {
+  // On macOS, this was 860 MB.
+  throw new Error("RSS is too high. Must be less than 250MB");
+}

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "bun:test";
+import path from "path";
+test("pathToFileURL doesn't leak memory", () => {
+  expect([path.join(import.meta.dir, "pathToFileURL-leak-fixture.js")]).toRun();
+});


### PR DESCRIPTION
### What does this PR do?

- Fix memory leak in pathToFileURL
- Report memory usage of URL's internal string to GC
- Ensure we don't increment the reference count of the joined file path without also decrementing it

### How did you verify your code works?

There is a memory leak test