### PR TITLE
Preserve zero indentation when updating inline snapshot

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -2699,26 +2699,27 @@ pub const Expect = struct {
         std.debug.assert(trimmed_buf.len == str_in.len);
         var src = str_in;
         var dst = trimmed_buf[0..];
-        const give_up: TrimResult = .{ .trimmed = str_in, .start_indent = null, .end_indent = null };
+        const give_up_1: TrimResult = .{ .trimmed = str_in, .start_indent = null, .end_indent = null };
         // if the line is all whitespace, trim fully
         // the first line containing a character determines the max trim count
 
         // read first line (should be all-whitespace)
-        const first_newline = std.mem.indexOf(u8, src, "\n") orelse return give_up;
-        for (src[0..first_newline]) |char| if (char != ' ' and char != '\t') return give_up;
+        const first_newline = std.mem.indexOf(u8, src, "\n") orelse return give_up_1;
+        for (src[0..first_newline]) |char| if (char != ' ' and char != '\t') return give_up_1;
         src = src[first_newline + 1 ..];
 
         // read first real line and get indent
         const indent_len = for (src, 0..) |char, i| {
             if (char != ' ' and char != '\t') break i;
         } else src.len;
-        if (indent_len == 0) return give_up; // no indent to trim; save time
         const indent_str = src[0..indent_len];
+        const give_up_2: TrimResult = .{ .trimmed = str_in, .start_indent = indent_str, .end_indent = indent_str };
+        if (indent_len == 0) return give_up_2; // no indent to trim; save time
         // we're committed now
         dst[0] = '\n';
         dst = dst[1..];
         src = src[indent_len..];
-        const second_newline = (std.mem.indexOf(u8, src, "\n") orelse return give_up) + 1;
+        const second_newline = (std.mem.indexOf(u8, src, "\n") orelse return give_up_2) + 1;
         @memcpy(dst[0..second_newline], src[0..second_newline]);
         src = src[second_newline..];
         dst = dst[second_newline..];
@@ -2744,13 +2745,13 @@ pub const Expect = struct {
                     continue;
                 }
                 // this line had less indentation than the first line, but wasn't empty. give up.
-                return give_up;
+                return give_up_2;
             } else {
                 // this line has the same or more indentation than the first line. copy it.
                 const line_newline = (std.mem.indexOf(u8, src, "\n") orelse {
                     // this is the last line. if it's not all whitespace, give up
                     for (src) |char| {
-                        if (char != ' ' and char != '\t') return give_up;
+                        if (char != ' ' and char != '\t') return give_up_2;
                     }
                     break;
                 }) + 1;
@@ -2759,8 +2760,8 @@ pub const Expect = struct {
                 dst = dst[line_newline..];
             }
         }
-        const end_indent = if (std.mem.lastIndexOfScalar(u8, str_in, '\n')) |c| c + 1 else return give_up; // there has to have been at least a single newline to get here
-        for (str_in[end_indent..]) |c| if (c != ' ' and c != 't') return give_up; // we already checked, but the last line is not all whitespace again
+        const end_indent = if (std.mem.lastIndexOfScalar(u8, str_in, '\n')) |c| c + 1 else return give_up_2; // there has to have been at least a single newline to get here
+        for (str_in[end_indent..]) |c| if (c != ' ' and c != 't') return give_up_2; // we already checked, but the last line is not all whitespace again
 
         // done
         return .{ .trimmed = trimmed_buf[0 .. trimmed_buf.len - dst.len], .start_indent = indent_str, .end_indent = str_in[end_indent..] };

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -834,6 +834,15 @@ Date)
 
                   indentation"
     \``)});
+    expect("keeps no\\n\\nindentation").toMatchInlineSnapshot(${v(`\`
+"no existing
+
+indentation" 
+\``, `\`
+"keeps no
+
+indentation"
+\``)});
         });
       `,
     );


### PR DESCRIPTION
### What does this PR do?

Forgot this case in #16685

```js
expect("keeps no\n\nindentation").toMatchInlineSnapshot(`
"no existing

indentation"
`);

// bun test -u

(this PR)

expect("keeps no\n\nindentation").toMatchInlineSnapshot(`
"keeps no

indentation"
`);

(vs after #16685 it would update to)

expect("keeps no\n\nindentation").toMatchInlineSnapshot(`
  "keeps no

  indentation"
`);
```
