### PR TITLE
feat(bunfig): add toggle to disable tsconfig features 

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1617,6 +1617,13 @@ pub const Api = struct {
         }
     };
 
+    /// Configures how the resolver behaves.
+    pub const ResolveOptions = struct {
+        /// Do not consider tsconfig paths. Used primarily for node
+        /// compatibility.
+        ignore_tsconfig: bool = false,
+    };
+
     pub const TransformOptions = struct {
         /// jsx
         jsx: ?Jsx = null,
@@ -1707,6 +1714,7 @@ pub const Api = struct {
         serve_minify_identifiers: ?bool = null,
         bunfig_path: []const u8,
 
+        /// FIXME: unused
         pub fn decode(reader: anytype) anyerror!TransformOptions {
             var this = std.mem.zeroes(TransformOptions);
 

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -232,9 +232,11 @@ pub const Run = struct {
         b.resolver.opts.global_cache = ctx.debug.global_cache;
         b.resolver.opts.prefer_offline_install = (ctx.debug.offline_mode_setting orelse .online) == .offline;
         b.resolver.opts.prefer_latest_install = (ctx.debug.offline_mode_setting orelse .online) == .latest;
+        b.resolver.opts.load_tsconfig_json = ctx.bundler_options.tsconfig.isEnabled();
         b.options.global_cache = b.resolver.opts.global_cache;
         b.options.prefer_offline_install = b.resolver.opts.prefer_offline_install;
         b.options.prefer_latest_install = b.resolver.opts.prefer_latest_install;
+        b.options.load_tsconfig_json = b.resolver.opts.load_tsconfig_json;
         b.resolver.env_loader = b.env;
 
         b.options.minify_identifiers = ctx.bundler_options.minify_identifiers;

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -28,6 +28,7 @@ pub const BundlePackageOverride = bun.StringArrayHashMapUnmanaged(options.Bundle
 const LoaderMap = bun.StringArrayHashMapUnmanaged(options.Loader);
 const JSONParser = bun.JSON;
 const Command = @import("cli.zig").Command;
+const TSConfigOptions = Command.ContextData.BundlerOptions.TSConfigOptions;
 const TOML = @import("./toml/toml_parser.zig").TOML;
 
 // TODO: replace Api.TransformOptions with Bunfig
@@ -216,6 +217,15 @@ pub const Bunfig = struct {
             if (json.get("origin")) |expr| {
                 try this.expectString(expr);
                 this.bunfig.origin = try expr.data.e_string.string(allocator);
+            }
+
+            if (json.get("tsconfig")) |tsconfig| {
+                // TODO: support object for fine-grained control
+                try this.expect(tsconfig, .e_boolean);
+                this.ctx.bundler_options.tsconfig = if (tsconfig.asBool().?)
+                    TSConfigOptions.on()
+                else
+                    TSConfigOptions.off();
             }
 
             if (comptime cmd == .RunCommand or cmd == .AutoCommand) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1562,6 +1562,28 @@ pub const Command = struct {
             compile_target: Cli.CompileTarget = .{},
             windows_hide_console: bool = false,
             windows_icon: ?[]const u8 = null,
+
+            /// tsconfig options.
+            tsconfig: TSConfigOptions = TSConfigOptions.on(),
+            pub const TSConfigOptions = packed struct(u8) {
+                /// Use [TSConfig/ paths](https://www.typescriptlang.org/tsconfig/#paths)
+                /// when resolving imports.
+                tsconfig_paths: bool = true,
+                _: u7 = 0,
+
+                pub fn off() TSConfigOptions {
+                    return .{ .tsconfig_paths = false };
+                }
+
+                pub fn on() TSConfigOptions {
+                    return .{ .tsconfig_paths = true };
+                }
+
+                /// Returns `true` if any options are enabled
+                pub fn isEnabled(self: TSConfigOptions) bool {
+                    return @as(u8, @bitCast(self)) > 0;
+                }
+            };
         };
 
         pub fn create(allocator: std.mem.Allocator, log: *logger.Log, comptime command: Command.Tag) anyerror!Context {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -819,8 +819,9 @@ pub const RunCommand = struct {
         this_transpiler.resolver.care_about_scripts = true;
         this_transpiler.resolver.store_fd = store_root_fd;
 
-        this_transpiler.resolver.opts.load_tsconfig_json = true;
-        this_transpiler.options.load_tsconfig_json = true;
+        const should_load_tsconfig = ctx.bundler_options.tsconfig.isEnabled();
+        this_transpiler.resolver.opts.load_tsconfig_json = should_load_tsconfig;
+        this_transpiler.options.load_tsconfig_json = should_load_tsconfig;
 
         this_transpiler.configureLinker();
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1627,8 +1627,8 @@ pub const Resolver = struct {
         }
 
         // First, check path overrides from the nearest enclosing TypeScript "tsconfig.json" file
-
-        if (dir_info.enclosing_tsconfig_json) |tsconfig| {
+        if (r.opts.load_tsconfig_json and dir_info.enclosing_tsconfig_json != null) {
+            const tsconfig = dir_info.enclosing_tsconfig_json.?;
             // Try path substitutions first
             if (tsconfig.paths.count() > 0) {
                 if (r.matchTSConfigPaths(tsconfig, import_path, kind)) |res| {
@@ -2095,6 +2095,7 @@ pub const Resolver = struct {
 
         return .{ .not_found = {} };
     }
+
     fn dirInfoForResolution(
         r: *ThisResolver,
         dir_path_maybe_trail_slash: string,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
