### PR TITLE
Introduce `server.abort(request: Request)` to abort an in-flight HTTP/HTTPS request

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4224,6 +4224,21 @@ declare module "bun" {
     requestIP(request: Request): SocketAddress | null;
 
     /**
+     * Abort an in-flight HTTP(s) request, triggering the `"abort"` event and leading to a TCP RST ("Connection reset by peer")
+     *
+     * @param request The request to abort
+     * @returns true if the request was aborted, false if it was already aborted or if the request is not in-flight
+     *
+     * If called multiple times, it will only return true the first time.
+     *
+     * The associated `AbortSignal` will be signaled, causing the `"abort"`
+     * event to fire. If a `ReadableStream` is attached to the `Response`, it will
+     * be cancelled. If the request body has a pending promise (like `.text()`), it will
+     * be rejected.
+     */
+    abort(request: Request): boolean;
+
+    /**
      * Reset the idleTimeout of the given Request to the number in seconds. 0 means no timeout.
      *
      * @example

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -121,6 +121,11 @@ public:
         return us_socket_close(SSL, (us_socket_t *) this, 0, nullptr);
     }
 
+    void abort() {
+        this->uncorkWithoutSending();
+        us_socket_close(SSL, (us_socket_t *) this, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, nullptr);
+    }
+
     void corkUnchecked() {
         /* What if another socket is corked? */
         getLoopData()->setCorkedSocket(this, SSL);

--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -25,6 +25,10 @@ function generate(name) {
         fn: "doReload",
         length: 2,
       },
+      abort: {
+        fn: "doAbort",
+        length: 1,
+      },
       "@@dispose": {
         fn: "dispose",
         length: 0,

--- a/src/bun.js/webcore/request.zig
+++ b/src/bun.js/webcore/request.zig
@@ -131,6 +131,14 @@ pub const Request = struct {
             return this.function.has();
         }
 
+        pub fn triggerAtTopOfEventLoop(this: *InternalJSEventCallback, eventType: EventType, globalThis: *JSC.JSGlobalObject) void {
+            if (this.function.get()) |callback| {
+                globalThis.bunVM().eventLoop().runCallback(callback, globalThis, .undefined, &.{JSC.JSValue.jsNumber(
+                    @intFromEnum(eventType),
+                )});
+            }
+        }
+
         pub fn trigger(this: *InternalJSEventCallback, eventType: EventType, globalThis: *JSC.JSGlobalObject) bool {
             if (this.function.get()) |callback| {
                 _ = callback.call(globalThis, JSC.JSValue.jsUndefined(), &.{JSC.JSValue.jsNumber(

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1207,6 +1207,16 @@ extern "C"
     }
   }
 
+  void uws_res_abort(int ssl, uws_res_r res) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->abort();
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->abort();
+    }
+  }
+
   void uws_res_end_without_body(int ssl, uws_res_r res, bool close_connection)
   {
     if (ssl)

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -3705,6 +3705,10 @@ pub fn NewApp(comptime ssl: bool) type {
                 return uws_res_has_responded(ssl_flag, res.downcast());
             }
 
+            pub fn abort(res: *Response) void {
+                uws_res_abort(ssl_flag, res.downcast());
+            }
+
             pub fn getNativeHandle(res: *Response) bun.FileDescriptor {
                 if (comptime Environment.isWindows) {
                     // on windows uSockets exposes SOCKET
@@ -4613,3 +4617,5 @@ pub fn onThreadExit() void {
 extern fn uws_app_clear_routes(ssl_flag: c_int, app: *uws_app_t) void;
 
 pub extern fn us_socket_upgrade_to_tls(s: *Socket, new_context: *SocketContext, sni: ?[*:0]const u8) ?*Socket;
+
+extern fn uws_res_abort(ssl_flag: c_int, res: *uws_res) void;

--- a/test/js/bun/http/bun-serve-abort.test.ts
+++ b/test/js/bun/http/bun-serve-abort.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test, mock } from "bun:test";
+import { bunEnv, bunExe, rejectUnauthorizedScope, tempDirWithFiles, tls } from "harness";
+
+describe("server.abort()", async () => {
+  test("after sleep", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        await Bun.sleep(0);
+        server.abort(request);
+        return new Response("Hello, world!");
+      },
+    });
+
+    expect(async () => {
+      const response = await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("before sleep", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        expect(server.abort(request)).toBe(true);
+        await Bun.sleep(0);
+        // calling it again should do nothing
+        expect(server.abort(request)).toBe(false);
+
+        return new Response("Hello, world!");
+      },
+    });
+
+    expect(async () => {
+      await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("slightly after response is returned", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        queueMicrotask(() => {
+          expect(server.abort(request)).toBe(true);
+        });
+        return new Response("hello!");
+      },
+    });
+
+    expect(async () => {
+      await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("after response was probably sent does nothing", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        setTimeout(() => {
+          expect(server.abort(request)).toBe(false);
+        }, 0);
+        return new Response("hello!");
+      },
+    });
+
+    const response = await fetch(`http://localhost:${server.port}`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("hello!");
+  });
+
+  test("triggers AbortSignal", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        const fn = mock(() => {
+          // already aborted.
+          expect(server.abort(request)).toBe(false);
+        });
+        request.signal.addEventListener("abort", fn);
+        expect(server.abort(request)).toBe(true);
+
+        // you can return undefined and it should not trigger an uncaught exception
+      },
+    });
+
+    expect(async () => {
+      await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("triggers AbortSignal after sleep", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        const fn = mock(() => {
+          // already aborted.
+          expect(server.abort(request)).toBe(false);
+        });
+        request.signal.addEventListener("abort", fn);
+
+        await Bun.sleep(0);
+        expect(server.abort(request)).toBe(true);
+
+        // you can return undefined and it should not trigger an uncaught exception
+      },
+    });
+
+    expect(async () => {
+      await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("works inside of a ReadableStream on the original Request with sleep", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              await Bun.sleep(0);
+              server.abort(request);
+              controller.close();
+            },
+          }),
+        );
+      },
+    });
+
+    expect(async () => {
+      await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("works inside of a ReadableStream on the original Request without sleep", async () => {
+    using server = Bun.serve({
+      port: 0,
+
+      async fetch(request, server) {
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              server.abort(request);
+              controller.close();
+            },
+          }),
+        );
+      },
+    });
+
+    expect(async () => {
+      await fetch(`http://localhost:${server.port}`);
+    }).toThrow("The socket connection was closed");
+  });
+
+  test("works inside of a ReadableStream on the original Request without sleep, with SSL", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: tls,
+      async fetch(request, server) {
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              server.abort(request);
+              controller.close();
+            },
+          }),
+        );
+      },
+    });
+
+    expect(async () => {
+      await fetch(`https://localhost:${server.port}`, {
+        tls: {
+          rejectUnauthorized: false,
+        },
+      });
+    }).toThrow("The socket connection was closed");
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Introduce `server.abort(request: Request)` to abort an in-flight HTTP/HTTPS request.

This immediately closes the TCP socket.

One subtlety here is we have to make sure that we don't call drain microtasks directly in the abort handler. Instead, we have to go through the event loop enter/exit - so that we don't drain microtasks inside of the .abort() function call itself.

### How did you verify your code works?

There are tests