### PR TITLE
Make passing an signal: AbortSignal.timeout to fetch implicitly set timeout: false

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5839,6 +5839,12 @@ extern "C" void JSC__JSGlobalObject__queueMicrotaskJob(JSC__JSGlobalObject* arg0
         WTFMove(microtaskArgs[3]));
 }
 
+extern "C" bool WebCore__AbortSignal__isTimeout(const WebCore__AbortSignal* arg0)
+{
+    const WebCore::AbortSignal* abortSignal = reinterpret_cast<const WebCore::AbortSignal*>(arg0);
+    return abortSignal->hasActiveTimeoutTimer();
+}
+
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__new(JSC__JSGlobalObject* globalObject)
 {
     Zig::GlobalObject* thisObject = JSC::jsCast<Zig::GlobalObject*>(globalObject);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -2224,6 +2224,11 @@ pub const AbortSignal = extern opaque {
     pub const name = "WebCore::AbortSignal";
     pub const namespace = "WebCore";
 
+    extern fn WebCore__AbortSignal__isTimeout(*const AbortSignal) bool;
+    pub fn isTimeout(this: *const AbortSignal) bool {
+        return WebCore__AbortSignal__isTimeout(this);
+    }
+
     pub fn listen(
         this: *AbortSignal,
         comptime Context: type,

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -3006,6 +3006,17 @@ pub const Fetch = struct {
             return JSPromise.rejectedPromiseValue(globalThis, err);
         }
 
+        // If you do AbortSignal.timeout
+        // and you don't set `timeout: false`
+        // you probably meant to use the AbortSignal's timeout instead.
+        if (!disable_timeout) {
+            if (signal) |signal_| {
+                if (signal_.isTimeout()) {
+                    disable_timeout = true;
+                }
+            }
+        }
+
         if (globalThis.hasException()) {
             is_error = true;
             return .zero;


### PR DESCRIPTION
### What does this PR do?

This makes passing an signal: AbortSignal.timeout to fetch implicitly set timeout: false

If you do 
```js
fetch(url, {signal: AbortSignal.timeout(60*1024*20)});
```

You expect the fetch call to timeout after 20 minutes. You don't expect it to timeout after 5 minutes because you forgot to set `timeout` to false.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
