### PR TITLE
Return default export when virtual module with `__esModule: true` is loaded via `require()`

### DIFF
--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -302,7 +302,8 @@ static JSValue handleVirtualModuleResult(
     ErrorableResolvedSource* res,
     BunString* specifier,
     BunString* referrer,
-    bool wasModuleMock = false)
+    bool wasModuleMock = false,
+    JSCommonJSModule *commonJSModule = nullptr)
 {
     auto onLoadResult = handleOnLoadResult(globalObject, virtualModuleResult, specifier, wasModuleMock);
     JSC::VM& vm = globalObject->vm();
@@ -364,6 +365,21 @@ static JSValue handleVirtualModuleResult(
 
     case OnLoadResultTypeObject: {
         JSC::JSObject* object = onLoadResult.value.object.getObject();
+        if (commonJSModule) {
+          const auto& __esModuleIdentifier = vm.propertyNames->__esModule;
+          JSValue esModuleValue = object->getIfPropertyExists(globalObject, __esModuleIdentifier);
+          RETURN_IF_EXCEPTION(scope, {});
+          if (esModuleValue && esModuleValue.toBoolean(globalObject)) {
+            JSValue defaultValue = object->getIfPropertyExists(globalObject, vm.propertyNames->defaultKeyword);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (defaultValue && !defaultValue.isUndefined()) {
+              commonJSModule->setExportsObject(defaultValue);
+              commonJSModule->hasEvaluated = true;
+              return rejectOrResolve(commonJSModule);
+            }
+          }
+        }
+
         JSC::ensureStillAliveHere(object);
         auto function = generateObjectModuleSourceCode(
             globalObject,
@@ -479,7 +495,7 @@ JSValue fetchCommonJSModule(
     // This is important for being able to trivially mock things like the filesystem.
     if (isBunTest) {
         if (JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, specifier, wasModuleMock)) {
-            JSPromise* promise = jsCast<JSPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer, wasModuleMock));
+            JSPromise* promise = jsCast<JSPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer, wasModuleMock, target));
             switch (promise->status(vm)) {
             case JSPromise::Status::Rejected: {
                 uint32_t promiseFlags = promise->internalField(JSPromise::Field::Flags).get().asUInt32AsAnyInt();
@@ -497,7 +513,11 @@ JSValue fetchCommonJSModule(
                     RELEASE_AND_RETURN(scope, {});
                 }
                 if (!wasModuleMock) {
-                    auto* jsSourceCode = jsCast<JSSourceCode*>(promise->result(vm));
+                    auto result = promise->result(vm);
+                    if (result == target) {
+                        RELEASE_AND_RETURN(scope, target);
+                    }
+                    auto* jsSourceCode = jsCast<JSSourceCode*>(result);
                     globalObject->moduleLoader()->provideFetch(globalObject, specifierValue, jsSourceCode->sourceCode());
                     RETURN_IF_EXCEPTION(scope, {});
                 }
@@ -561,7 +581,7 @@ JSValue fetchCommonJSModule(
     // When "bun test" is NOT enabled, disable users from overriding builtin modules
     if (!isBunTest) {
         if (JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, specifier, wasModuleMock)) {
-            JSPromise* promise = jsCast<JSPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer, wasModuleMock));
+            JSPromise* promise = jsCast<JSPromise*>(handleVirtualModuleResult<true>(globalObject, virtualModuleResult, res, specifier, referrer, wasModuleMock, target));
             switch (promise->status(vm)) {
             case JSPromise::Status::Rejected: {
                 uint32_t promiseFlags = promise->internalField(JSPromise::Field::Flags).get().asUInt32AsAnyInt();
@@ -579,7 +599,11 @@ JSValue fetchCommonJSModule(
                     RELEASE_AND_RETURN(scope, {});
                 }
                 if (!wasModuleMock) {
-                    auto* jsSourceCode = jsCast<JSSourceCode*>(promise->result(vm));
+                    auto result = promise->result(vm);
+                    if (result == target) {
+                        RELEASE_AND_RETURN(scope, target);
+                    }
+                    auto* jsSourceCode = jsCast<JSSourceCode*>(result);
                     globalObject->moduleLoader()->provideFetch(globalObject, specifierValue, jsSourceCode->sourceCode());
                     RETURN_IF_EXCEPTION(scope, {});
                 }

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -288,6 +288,41 @@ describe("module", () => {
       expect(there).toBeUndefined();
     }
   });
+
+  it("returns default exports from require() with __esModule: true", async () => {
+    Bun.plugin({
+      setup(builder) {
+        builder.module("my-virtual-module-sync", () => ({
+          exports: {
+            __esModule: true,
+            default: true,
+          },
+          loader: "object",
+        }));
+      },
+    });
+
+    {
+      const mod = require("my-virtual-module-sync");
+      expect(mod).toBe(true);
+    }
+
+    Bun.plugin({
+      setup(builder) {
+        builder.module("my-virtual-module-sync", () => ({
+          exports: {
+            default: true,
+          },
+          loader: "object",
+        }));
+      },
+    });
+
+    {
+      const mod = require("my-virtual-module-sync");
+      expect(mod.default).toBe(true);
+    }
+  });
 });
 
 describe("dynamic import", () => {


### PR DESCRIPTION
### What does this PR do?

Returns the default export of a virtual module loaded through `require()` when `__esModule: true` is set on the exports object.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code
- [x] I ran my tests locally and they pass (`bun-debug test plugins.test`)

I also manually verified that these changes work in a separate real-world scenario.

h/t to @Jarred-Sumner for the help with the initial code and direction