### PR TITLE
fix(node/http): re-export `WebSocket`, `CloseEvent`, and `MessageEvent`

### DIFF
--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -1947,6 +1947,7 @@ pub const Fetch = struct {
                 fetch_tasklet.signals.cert_errors = null;
             }
 
+            // This task gets queued on the HTTP thread.
             fetch_tasklet.http.?.* = http.AsyncHTTP.init(
                 fetch_options.memory_reporter.allocator(),
                 fetch_options.method,
@@ -1957,6 +1958,7 @@ pub const Fetch = struct {
                 fetch_tasklet.request_body.slice(),
                 http.HTTPClientResult.Callback.New(
                     *FetchTasklet,
+                    // handles response events (on headers, on body, etc.)
                     FetchTasklet.callback,
                 ).init(fetch_tasklet),
                 fetch_options.redirect_type,
@@ -2083,6 +2085,7 @@ pub const Fetch = struct {
             return node;
         }
 
+        /// Called from HTTP thread. Handles HTTP events received from socket.
         pub fn callback(task: *FetchTasklet, async_http: *http.AsyncHTTP, result: http.HTTPClientResult) void {
             // at this point only this thread is accessing result to is no race condition
             const is_done = !result.has_more;
@@ -2263,6 +2266,8 @@ pub const Fetch = struct {
         const Bun__fetch = JSC.toJSHostFunction(Bun__fetch_);
         @export(Bun__fetch, .{ .name = "Bun__fetch" });
     }
+
+    /// Implementation of `Bun.fetch`
     pub fn Bun__fetch_(
         ctx: *JSC.JSGlobalObject,
         callframe: *JSC.CallFrame,

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -79,7 +79,7 @@ function ERR_HTTP_SOCKET_ASSIGNED() {
 
 // TODO: add primordial for URL
 // Importing from node:url is unnecessary
-const { URL } = globalThis;
+const { URL, WebSocket, CloseEvent, MessageEvent } = globalThis;
 
 const globalReportError = globalThis.reportError;
 const setTimeout = globalThis.setTimeout;
@@ -2384,4 +2384,7 @@ export default {
   globalAgent,
   ClientRequest,
   OutgoingMessage,
+  WebSocket,
+  CloseEvent,
+  MessageEvent,
 };

--- a/test/js/node/test/parallel/test-http-import-websocket.js
+++ b/test/js/node/test/parallel/test-http-import-websocket.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const {
+  WebSocket: NodeHttpWebSocket,
+  CloseEvent: NodeHttpCloseEvent,
+  MessageEvent: NodeHttpMessageEvent
+} = require('node:http');
+
+// Compare with global objects
+assert.strictEqual(NodeHttpWebSocket, WebSocket);
+assert.strictEqual(NodeHttpCloseEvent, CloseEvent);
+assert.strictEqual(NodeHttpMessageEvent, MessageEvent);


### PR DESCRIPTION
### What does this PR do?
Re-exports `WebSocket`, `CloseEvent,` and `MessageEvent` globals from `node:http`.

### How did you verify your code works?
There is a test.
