### PR TITLE
fix(s3) fix queue and multipart flow

### DIFF
--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -260,7 +260,6 @@ pub const MultiPartUpload = struct {
             switch (state) {
                 .pending => {
                     this.freeAllocatedSlice();
-                    this.ctx.deref();
                 },
                 // if is not pending we will free later or is already freed
                 else => {},

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -246,8 +246,7 @@ pub const MultiPartUpload = struct {
             }, .{ .part = @ptrCast(&onPartResponse) }, this);
         }
         pub fn start(this: *@This()) void {
-            bun.assert(this.state != .not_assigned);
-            if (this.state != .pending or this.ctx.state != .multipart_completed or this.ctx.state == .finished) return;
+            if (this.state != .pending or this.ctx.state != .multipart_completed) return;
             this.ctx.ref();
             this.state = .started;
             this.perform();

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -153,11 +153,12 @@ pub const MultiPartUpload = struct {
         data: []const u8,
         ctx: *MultiPartUpload,
         allocated_size: usize,
-        state: enum {
-            pending,
-            started,
-            completed,
-            canceled,
+        state: enum(u8) {
+            not_assigned = 0,
+            pending = 1,
+            started = 2,
+            completed = 3,
+            canceled = 4,
         },
         partNumber: u16, // max is 10,000
         retry: u8, // auto retry, decrement until 0 and fail after this
@@ -245,6 +246,7 @@ pub const MultiPartUpload = struct {
             }, .{ .part = @ptrCast(&onPartResponse) }, this);
         }
         pub fn start(this: *@This()) void {
+            bun.assert(this.state != .not_assigned);
             if (this.state != .pending or this.ctx.state != .multipart_completed or this.ctx.state == .finished) return;
             this.ctx.ref();
             this.state = .started;

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -343,7 +343,15 @@ pub const MultiPartUpload = struct {
             // queueSize will never change and is small (max 255)
             const queue = bun.default_allocator.alloc(UploadPart, queueSize) catch bun.outOfMemory();
             // zero set just in case
-            @memset(queue, UploadPart{ .state = .not_assigned, .ctx = this });
+            @memset(queue, UploadPart{
+                .data = "",
+                .allocated_size = 0,
+                .partNumber = 0,
+                .ctx = this,
+                .index = 0,
+                .retry = 0,
+                .state = .not_assigned,
+            });
             this.queue = queue;
         }
         const data = if (needs_clone) bun.default_allocator.dupe(u8, chunk) catch bun.outOfMemory() else chunk;

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -9,8 +9,8 @@ const MultiPartUploadOptions = @import("./multipart_options.zig").MultiPartUploa
 const S3SimpleRequest = @import("./simple_request.zig");
 const executeSimpleS3Request = S3SimpleRequest.executeSimpleS3Request;
 const S3Error = @import("./error.zig").S3Error;
-// Buffer data until partSize is reached or the last chunk is received.
-//  If the buffer is smaller than partSize, it will be sent as a single request. Otherwise, a multipart upload will be initiated.
+// When we start the request we will buffer data until partSize is reached or the last chunk is received.
+// If the buffer is smaller than partSize, it will be sent as a single request. Otherwise, a multipart upload will be initiated.
 // If we send a single request it will retry until the maximum retry count is reached. The single request do not increase the reference count of MultiPartUpload, as they are the final step.
 // When sending a multipart upload, if there is space in the queue, the part is enqueued, and the request starts immediately.
 // If the queue is full, it waits to be drained before starting a new part request.

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -426,6 +426,7 @@ for (let credentials of allCredentials) {
 
               await writer.end();
               expect(await s3file.text()).toBe(mediumPayload.repeat(2));
+              s3file.delete();
             });
             it("should be able to upload large files in one go using Bun.write", async () => {
               {
@@ -441,6 +442,7 @@ for (let credentials of allCredentials) {
                 await s3File.write(bigPayload);
                 expect(s3File.size).toBeNaN();
                 expect(await s3File.text()).toBe(bigPayload);
+                s3File.delete();
               }
             }, 10_000);
           });
@@ -531,6 +533,7 @@ for (let credentials of allCredentials) {
 
                 expect(stat.lastModified).toBeDefined();
                 expect(await s3file.text()).toBe(bigPayload);
+                s3file.delete();
               }
             }, 10_000);
 
@@ -545,6 +548,7 @@ for (let credentials of allCredentials) {
                 expect(stat.lastModified).toBeDefined();
 
                 expect(await s3File.text()).toBe(bigPayload);
+                s3File.delete();
               }
             }, 10_000);
 
@@ -572,6 +576,7 @@ for (let credentials of allCredentials) {
                 }
                 expect(bytes).toBe(10);
                 expect(Buffer.concat(chunks)).toEqual(Buffer.from("Hello Bun!"));
+                s3file.delete();
               });
               it("should work with large files ", async () => {
                 const s3file = s3(tmp_filename + "-readable-stream-big", options);
@@ -597,6 +602,7 @@ for (let credentials of allCredentials) {
                   const SHA1_2 = Bun.SHA1.hash(bigishPayload, "hex");
                   expect(SHA1).toBe(SHA1_2);
                 }
+                s3file.delete();
               }, 30_000);
             });
           });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -325,7 +325,8 @@ for (let credentials of allCredentials) {
             for (let queueSize of [1, 5, 7, 10, 20]) {
               for (let payloadQuantity of [1, 5, 7, 10, 20]) {
                 for (let partSize of [5, 7, 10]) {
-                  for (let payload of [bigishPayload, mediumPayload]) {
+                  // the larger payload causes OOM in CI.
+                  for (let payload of [bigishPayload]) {
                     // lets skip tests with more than 10 parts on cloud providers
                     it.skipIf(credentials.service !== "MinIO")(
                       `should be able to upload large files using writer() in multiple parts with partSize=${partSize} queueSize=${queueSize} payloadQuantity=${payloadQuantity} payloadSize=${payload.length * payloadQuantity}`,
@@ -342,6 +343,7 @@ for (let credentials of allCredentials) {
                           await writer.end();
                           const stat = await s3File.stat();
                           expect(stat.size).toBe(Buffer.byteLength(payload) * payloadQuantity);
+                          s3File.delete();
                         }
                       },
                       30_000,

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -322,6 +322,21 @@ for (let credentials of allCredentials) {
                 expect(await s3File.text()).toBe(bigPayload);
               }
             }, 10_000);
+
+            it("should be able to upload large files using writer() in multiple parts", async () => {
+              {
+                const s3File = bucket.file(tmp_filename, options);
+                const writer = s3File.writer({
+                  queueSize: 10,
+                });
+                for (let i = 0; i < 10; i++) {
+                  writer.write(mediumPayload);
+                }
+                await writer.end();
+                const stat = await s3File.stat();
+                expect(stat.size).toBe(Buffer.byteLength(mediumPayload) * 10);
+              }
+            }, 30_000);
           });
         });
 

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -33,7 +33,6 @@ const allCredentials = [
 ];
 
 if (isDockerEnabled()) {
-  const minio_dir = tempDirWithFiles("minio", {});
   const result = child_process.spawnSync(
     "docker",
     [
@@ -49,8 +48,8 @@ if (isDockerEnabled()) {
       "MINIO_ROOT_USER=minioadmin",
       "-e",
       "MINIO_ROOT_PASSWORD=minioadmin",
-      "-v",
-      `${minio_dir}:/data`,
+      "--mount",
+      "type=tmpfs,destination=/data",
       "minio/minio",
       "server",
       "--console-address",
@@ -328,7 +327,7 @@ for (let credentials of allCredentials) {
                 for (let partSize of [5, 7, 10]) {
                   for (let payload of [bigishPayload, mediumPayload]) {
                     // lets skip tests with more than 10 parts on cloud providers
-                    it.skipIf(credentials.service !== "MinIO" && payloadQuantity > 10)(
+                    it.skipIf(credentials.service !== "MinIO")(
                       `should be able to upload large files using writer() in multiple parts with partSize=${partSize} queueSize=${queueSize} payloadQuantity=${payloadQuantity} payloadSize=${payload.length * payloadQuantity}`,
                       async () => {
                         {


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/16781
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
