### PR TITLE
fix: `Bun.deepEquals` on empty objects with the same prototype

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -664,7 +664,7 @@ JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, ui
 }
 
 template<bool isStrict, bool enableAsymmetricMatchers>
-std::optional<bool> specialObjectsDequal(JSC__JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope* scope, JSCell * _Nonnull c1, JSCell * _Nonnull c2);
+std::optional<bool> specialObjectsDequal(JSC__JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope* scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2);
 
 template<bool isStrict, bool enableAsymmetricMatchers>
 bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope* scope, bool addToStack)
@@ -743,8 +743,6 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     if (isSpecialEqual.has_value()) return std::move(*isSpecialEqual);
     JSObject* o1 = v1.getObject();
     JSObject* o2 = v2.getObject();
-
-
 
     bool v1Array = isArray(globalObject, v1);
     RETURN_IF_EXCEPTION(*scope, false);
@@ -1035,7 +1033,7 @@ bool Bun__deepEquals(JSC__JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 }
 
 template<bool isStrict, bool enableAsymmetricMatchers>
-std::optional<bool> specialObjectsDequal(JSC__JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope* scope, JSCell * _Nonnull c1, JSCell * _Nonnull c2)
+std::optional<bool> specialObjectsDequal(JSC__JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope* scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2)
 {
     uint8_t c1Type = c1->type();
     uint8_t c2Type = c2->type();
@@ -1214,7 +1212,7 @@ std::optional<bool> specialObjectsDequal(JSC__JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        JSC::JSArrayBufferView* left = jsCast<JSArrayBufferView* , JSCell>(c1);
+        JSC::JSArrayBufferView* left = jsCast<JSArrayBufferView*, JSCell>(c1);
         JSC::JSArrayBufferView* right = jsCast<JSArrayBufferView*, JSCell>(c2);
         size_t byteLength = left->byteLength();
 

--- a/test/js/bun/bun-object/deep-equals.spec.ts
+++ b/test/js/bun/bun-object/deep-equals.spec.ts
@@ -1,0 +1,58 @@
+describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
+  const deepEquals = (a: unknown, b: unknown) => Bun.deepEquals(a, b, strict);
+  it.each([
+    [1, 1],
+    [true, true],
+    [undefined, undefined],
+    [null, null],
+    ["foo", "foo"],
+    [{}, {}],
+    [{ a: 1 }, { a: 1 }],
+    [new Map(), new Map()],
+    [new Set(), new Set()],
+    [Symbol.for("foo"), Symbol.for("foo")],
+    [NaN, NaN],
+  ])("Bun.deepEquals(%p, %p) === true, regardless of strict modee", (a, b) => {
+    expect(Bun.deepEquals(a, b, true)).toBe(true);
+    expect(Bun.deepEquals(a, b, false)).toBe(true);
+  });
+
+  it.each([
+    [0, 1],
+    [-0, +0], //
+    [{ a: 1 }, { a: 2 }],
+    ["foo", "bar"],
+  ])("Bun.deepEquals(%p, %p) !== true, regardless of strict modee", (a, b) => {
+    expect(Bun.deepEquals(a, b, true)).toBe(false);
+    expect(Bun.deepEquals(a, b, false)).toBe(false);
+  });
+
+  // https://github.com/nodejs/node/issues/10258
+  it("fake dates are not equal", () => {
+    function FakeDate() {}
+    FakeDate.prototype = Date.prototype;
+    const a = new Date("2016");
+    const b = new FakeDate();
+    expect(deepEquals(a, b)).toBe(false);
+    expect(deepEquals(b, a)).toBe(false);
+  });
+
+  it("fake maps are not equal", () => {
+    function FakeMap() {}
+    FakeMap.prototype = Map.prototype;
+    const a = new Map();
+    const b = new FakeMap();
+    expect(deepEquals(a, b)).toBe(false);
+    expect(deepEquals(b, a)).toBe(false);
+  });
+
+  // we may change this in the future
+  it("functions that are not reference-equal are never equal", () => {
+    function foo() {}
+    function bar() {}
+    function baz(a) {}
+    expect(deepEquals(foo, foo)).toBe(true);
+    expect(deepEquals(foo, bar)).toBe(false);
+    expect(deepEquals(foo, baz)).toBe(false);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes this issue that was originally found in https://github.com/nodejs/node/issues/10258. Needed for `node:assert` compatibility.

```js
    function FakeDate() {}
    FakeDate.prototype = Date.prototype;
    const a = new Date("2016");
    const b = new FakeDate();
    expect(deepEquals(a, b)).toBe(false); // yay
    expect(deepEquals(b, a)).toBe(false); // :(
```

### How did you verify your code works?
There are tests
