### PR TITLE
test(sql) add more tests 

### DIFF
--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -616,6 +616,38 @@ if (isDockerEnabled()) {
     expect(result[0]?.x).toBe(1);
   });
 
+  test("should be able to execute different queries in the same connection #16774", async () => {
+    const sql = postgres({ ...options, max: 1, fetch_types: false });
+    const random_table_name = `test_user_${Math.random().toString(36).substring(2, 15)}`;
+    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_table_name)}  (id int, name text)`;
+
+    const promises: Array<Promise<any>> = [];
+    // POPULATE TABLE
+    for (let i = 0; i < 1_000; i++) {
+      promises.push(sql`insert into ${sql(random_table_name)} values (${i}, ${`test${i}`})`.execute());
+    }
+    await Promise.all(promises);
+
+    // QUERY TABLE using execute() to force executing the query immediately
+    {
+      for (let i = 0; i < 1_000; i++) {
+        // mix different parameters
+        switch (i % 3) {
+          case 0:
+            promises.push(sql`select "id", "name" from ${sql(random_table_name)} where "id" = ${i}`.execute());
+            break;
+          case 1:
+            promises.push(sql`select "id" from ${sql(random_table_name)} where "id" = ${i}`.execute());
+            break;
+          case 2:
+            promises.push(sql`select 1, "id", "name" from ${sql(random_table_name)} where "id" = ${i}`.execute());
+            break;
+        }
+      }
+      await Promise.all(promises);
+    }
+  });
+
   // test("Prepared transaction", async () => {
   //   await sql`create table test (a int)`;
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Tests
### How did you verify your code works?

CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
