### PR TITLE
fix(node:os): loadavg() return values on Darwin

### DIFF
--- a/src/c-headers-for-zig.h
+++ b/src/c-headers-for-zig.h
@@ -25,6 +25,7 @@
 #if DARWIN
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/sysctl.h>
 #elif LINUX
 #include <sys/statfs.h>
 #include <sys/stat.h>


### PR DESCRIPTION
### What does this PR do?

Corrects our `loadavg()` implementation for Darwin. The old one returned wrong values due to mismatching the layout of the struct we pass into `sysctlbyname`.

Fixes #16882

### How did you verify your code works?

Updated the test to check that the returned values are reasonably close to the true values from the `uptime` command

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
