### PR TITLE
Fix error when calling close() on a dgram socket multiple times

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -708,7 +708,7 @@ Socket.prototype.close = function (callback) {
   }
 
   state.receiving = false;
-  state.handle.socket?.close();
+  state.handle?.socket?.close();
   state.handle = null;
   defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, socketCloseNT, this);
 


### PR DESCRIPTION
### What does this PR do?

Prevents a property lookup on `null` when closing the same dgram socket multiple times.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Tried closing a socket multiple times.