### PR TITLE
Fix fetch with formdata on some servers

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -604,7 +604,7 @@ pub const Blob = struct {
 
         const store = Blob.Store.init(context.joiner.done(allocator) catch bun.outOfMemory(), allocator);
         var blob = Blob.initWithStore(store, globalThis);
-        blob.content_type = std.fmt.allocPrint(allocator, "multipart/form-data; boundary=\"{s}\"", .{boundary}) catch bun.outOfMemory();
+        blob.content_type = std.fmt.allocPrint(allocator, "multipart/form-data; boundary={s}", .{boundary}) catch bun.outOfMemory();
         blob.content_type_allocated = true;
         blob.content_type_was_set = true;
 

--- a/test/regression/issue/07917/7917.test.ts
+++ b/test/regression/issue/07917/7917.test.ts
@@ -1,0 +1,19 @@
+test("boundary does not have quotes (#7917)", async () => {
+  // for `content-type: multipart/form-data; boundary=...` / https://datatracker.ietf.org/doc/html/rfc2046#section-5.1
+  // the spec states that the boundary parameter accepts quotes, and both node and bun accept quotes when parsing
+  // the form data. however, some websites do not accept quotes and node does not quote it. this test ensures that the
+  // boundary is not quoted.
+
+  const form = new FormData();
+  form.append("filename[]", "document.tex");
+  form.append("filecontents[]", "\\documentclass{article}\\begin{document}Hello world\\end{document}");
+  form.append("return", "pdf");
+  const req = new Request("http://localhost:35411", {
+    method: "POST",
+    body: form,
+  });
+  const content_type = req.headers.get("content-type");
+  const val = await req.text();
+  const actual_boundary = val.split("\r")[0].slice(2);
+  expect(content_type).toEqual(`multipart/form-data; boundary=${actual_boundary}`);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #7917

Some servers do not accept the boundary property in content-type being quoted, and node does not quote it. Match node.