### PR TITLE
Fix formatting for extern "c"

### DIFF
--- a/.cursor/rules/javascriptcore-class.mdc
+++ b/.cursor/rules/javascriptcore-class.mdc
@@ -349,7 +349,7 @@ extern "C" JSC::EncodedJSValue Bun__JSBigIntStatsObjectConstructor(Zig::GlobalOb
 
 Zig:
 ```zig
-extern "C" fn Bun__JSBigIntStatsObjectConstructor(*JSC.JSGlobalObject) JSC.JSValue;
+extern "c" fn Bun__JSBigIntStatsObjectConstructor(*JSC.JSGlobalObject) JSC.JSValue;
 pub const getBigIntStatsConstructor =  Bun__JSBigIntStatsObjectConstructor;
 ```
 

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -446,7 +446,7 @@ pub const TimerObject = struct {
     pub usingnamespace JSC.Codegen.JSTimeout;
     pub usingnamespace bun.NewRefCounted(@This(), deinit, null);
 
-    extern "C" fn Bun__JSTimeout__call(encodedTimeoutValue: JSValue, globalObject: *JSC.JSGlobalObject) void;
+    extern "c" fn Bun__JSTimeout__call(encodedTimeoutValue: JSValue, globalObject: *JSC.JSGlobalObject) void;
 
     pub fn runImmediateTask(this: *TimerObject, vm: *VirtualMachine) void {
         if (this.has_cleared_timer) {

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -2042,16 +2042,16 @@ pub const sync = struct {
     }
 
     // Forward signals from parent to the child process.
-    extern "C" fn Bun__registerSignalsForForwarding() void;
-    extern "C" fn Bun__unregisterSignalsForForwarding() void;
+    extern "c" fn Bun__registerSignalsForForwarding() void;
+    extern "c" fn Bun__unregisterSignalsForForwarding() void;
 
     // The PID to forward signals to.
     // Set to 0 when unregistering.
-    extern "C" var Bun__currentSyncPID: i64;
+    extern "c" var Bun__currentSyncPID: i64;
 
     // Race condition: a signal could be sent before spawnProcessPosix returns.
     // We need to make sure to send it after the process is spawned.
-    extern "C" fn Bun__sendPendingSignalIfNecessary() void;
+    extern "c" fn Bun__sendPendingSignalIfNecessary() void;
 
     fn spawnPosix(
         options: *const Options,

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -81,8 +81,8 @@ const Offsets = extern struct {
     JSArrayBufferView__offsetOfVector: u32,
     JSCell__offsetOfType: u32,
 
-    extern "C" var Bun__FFI__offsets: Offsets;
-    extern "C" fn Bun__FFI__ensureOffsetsAreLoaded() void;
+    extern "c" var Bun__FFI__offsets: Offsets;
+    extern "c" fn Bun__FFI__ensureOffsetsAreLoaded() void;
     fn loadOnce() void {
         Bun__FFI__ensureOffsetsAreLoaded();
     }
@@ -165,27 +165,27 @@ pub const FFI = struct {
         };
 
         const stdarg = struct {
-            extern "C" fn ffi_vfprintf(*anyopaque, [*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_vprintf([*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_fprintf(*anyopaque, [*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_printf([*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_fscanf(*anyopaque, [*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_scanf([*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_sscanf([*:0]const u8, [*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_vsscanf([*:0]const u8, [*:0]const u8, ...) callconv(.C) c_int;
-            extern "C" fn ffi_fopen([*:0]const u8, [*:0]const u8) callconv(.C) *anyopaque;
-            extern "C" fn ffi_fclose(*anyopaque) callconv(.C) c_int;
-            extern "C" fn ffi_fgetc(*anyopaque) callconv(.C) c_int;
-            extern "C" fn ffi_fputc(c: c_int, *anyopaque) callconv(.C) c_int;
-            extern "C" fn ffi_feof(*anyopaque) callconv(.C) c_int;
-            extern "C" fn ffi_fileno(*anyopaque) callconv(.C) c_int;
-            extern "C" fn ffi_ungetc(c: c_int, *anyopaque) callconv(.C) c_int;
-            extern "C" fn ffi_ftell(*anyopaque) callconv(.C) c_long;
-            extern "C" fn ffi_fseek(*anyopaque, c_long, c_int) callconv(.C) c_int;
-            extern "C" fn ffi_fflush(*anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_vfprintf(*anyopaque, [*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_vprintf([*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_fprintf(*anyopaque, [*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_printf([*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_fscanf(*anyopaque, [*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_scanf([*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_sscanf([*:0]const u8, [*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_vsscanf([*:0]const u8, [*:0]const u8, ...) callconv(.C) c_int;
+            extern "c" fn ffi_fopen([*:0]const u8, [*:0]const u8) callconv(.C) *anyopaque;
+            extern "c" fn ffi_fclose(*anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_fgetc(*anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_fputc(c: c_int, *anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_feof(*anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_fileno(*anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_ungetc(c: c_int, *anyopaque) callconv(.C) c_int;
+            extern "c" fn ffi_ftell(*anyopaque) callconv(.C) c_long;
+            extern "c" fn ffi_fseek(*anyopaque, c_long, c_int) callconv(.C) c_int;
+            extern "c" fn ffi_fflush(*anyopaque) callconv(.C) c_int;
 
-            extern "C" fn calloc(nmemb: usize, size: usize) callconv(.C) ?*anyopaque;
-            extern "C" fn perror([*:0]const u8) callconv(.C) void;
+            extern "c" fn calloc(nmemb: usize, size: usize) callconv(.C) ?*anyopaque;
+            extern "c" fn perror([*:0]const u8) callconv(.C) void;
 
             const mac = if (Environment.isMac) struct {
                 var ffi_stdinp: *anyopaque = @extern(*anyopaque, .{ .name = "__stdinp" });
@@ -1471,7 +1471,7 @@ pub const FFI = struct {
             return val.return_type == ABIType.napi_value;
         }
 
-        extern "C" fn FFICallbackFunctionWrapper_destroy(*anyopaque) void;
+        extern "c" fn FFICallbackFunctionWrapper_destroy(*anyopaque) void;
 
         pub fn deinit(val: *Function, globalThis: *JSC.JSGlobalObject, allocator: std.mem.Allocator) void {
             JSC.markBinding(@src());

--- a/src/bun.js/base.zig
+++ b/src/bun.js/base.zig
@@ -408,7 +408,7 @@ pub const ArrayBuffer = extern struct {
         return Bun__createUint8ArrayForCopy(globalThis, bytes.ptr, bytes.len, false);
     }
 
-    extern "C" fn Bun__allocUint8ArrayForCopy(*JSC.JSGlobalObject, usize, **anyopaque) JSC.JSValue;
+    extern "c" fn Bun__allocUint8ArrayForCopy(*JSC.JSGlobalObject, usize, **anyopaque) JSC.JSValue;
     pub fn allocBuffer(globalThis: *JSC.JSGlobalObject, len: usize) struct { JSC.JSValue, []u8 } {
         var ptr: [*]u8 = undefined;
         const buffer = Bun__allocUint8ArrayForCopy(globalThis, len, @ptrCast(&ptr));
@@ -418,8 +418,8 @@ pub const ArrayBuffer = extern struct {
         return .{ buffer, ptr[0..len] };
     }
 
-    extern "C" fn Bun__createUint8ArrayForCopy(*JSC.JSGlobalObject, ptr: ?*const anyopaque, len: usize, buffer: bool) JSC.JSValue;
-    extern "C" fn Bun__createArrayBufferForCopy(*JSC.JSGlobalObject, ptr: ?*const anyopaque, len: usize) JSC.JSValue;
+    extern "c" fn Bun__createUint8ArrayForCopy(*JSC.JSGlobalObject, ptr: ?*const anyopaque, len: usize, buffer: bool) JSC.JSValue;
+    extern "c" fn Bun__createArrayBufferForCopy(*JSC.JSGlobalObject, ptr: ?*const anyopaque, len: usize) JSC.JSValue;
 
     pub fn fromTypedArray(ctx: JSC.C.JSContextRef, value: JSC.JSValue) ArrayBuffer {
         var out = std.mem.zeroes(ArrayBuffer);
@@ -429,7 +429,7 @@ pub const ArrayBuffer = extern struct {
         return out;
     }
 
-    extern "C" fn JSArrayBuffer__fromDefaultAllocator(*JSC.JSGlobalObject, ptr: [*]u8, len: usize) JSC.JSValue;
+    extern "c" fn JSArrayBuffer__fromDefaultAllocator(*JSC.JSGlobalObject, ptr: [*]u8, len: usize) JSC.JSValue;
     pub fn toJSFromDefaultAllocator(globalThis: *JSC.JSGlobalObject, bytes: []u8) JSC.JSValue {
         return JSArrayBuffer__fromDefaultAllocator(globalThis, bytes.ptr, bytes.len);
     }

--- a/src/bun.js/bindings/CPUFeatures.zig
+++ b/src/bun.js/bindings/CPUFeatures.zig
@@ -84,6 +84,6 @@ else
         }
     };
 
-extern "C" fn bun_cpu_features() u8;
+extern "c" fn bun_cpu_features() u8;
 
 const assert = bun.debugAssert;

--- a/src/bun.js/bindings/JSPropertyIterator.zig
+++ b/src/bun.js/bindings/JSPropertyIterator.zig
@@ -2,12 +2,12 @@ const bun = @import("root").bun;
 const JSC = bun.JSC;
 
 //extern "C" EncodedJSValue Bun__JSPropertyIterator__getNameAndValue(JSPropertyIterator* iter, JSC::JSGlobalObject* globalObject, JSC::JSObject* object, BunString* propertyName, size_t i)
-extern "C" fn Bun__JSPropertyIterator__create(globalObject: *JSC.JSGlobalObject, encodedValue: JSC.JSValue, *usize, own_properties_only: bool, only_non_index_properties: bool) ?*anyopaque;
-extern "C" fn Bun__JSPropertyIterator__getNameAndValue(iter: ?*anyopaque, globalObject: *JSC.JSGlobalObject, object: *anyopaque, propertyName: *bun.String, i: usize) JSC.JSValue;
-extern "C" fn Bun__JSPropertyIterator__getNameAndValueNonObservable(iter: ?*anyopaque, globalObject: *JSC.JSGlobalObject, object: *anyopaque, propertyName: *bun.String, i: usize) JSC.JSValue;
-extern "C" fn Bun__JSPropertyIterator__getName(iter: ?*anyopaque, propertyName: *bun.String, i: usize) void;
-extern "C" fn Bun__JSPropertyIterator__deinit(iter: ?*anyopaque) void;
-extern "C" fn Bun__JSPropertyIterator__getLongestPropertyName(iter: ?*anyopaque, globalObject: *JSC.JSGlobalObject, object: *anyopaque) usize;
+extern "c" fn Bun__JSPropertyIterator__create(globalObject: *JSC.JSGlobalObject, encodedValue: JSC.JSValue, *usize, own_properties_only: bool, only_non_index_properties: bool) ?*anyopaque;
+extern "c" fn Bun__JSPropertyIterator__getNameAndValue(iter: ?*anyopaque, globalObject: *JSC.JSGlobalObject, object: *anyopaque, propertyName: *bun.String, i: usize) JSC.JSValue;
+extern "c" fn Bun__JSPropertyIterator__getNameAndValueNonObservable(iter: ?*anyopaque, globalObject: *JSC.JSGlobalObject, object: *anyopaque, propertyName: *bun.String, i: usize) JSC.JSValue;
+extern "c" fn Bun__JSPropertyIterator__getName(iter: ?*anyopaque, propertyName: *bun.String, i: usize) void;
+extern "c" fn Bun__JSPropertyIterator__deinit(iter: ?*anyopaque) void;
+extern "c" fn Bun__JSPropertyIterator__getLongestPropertyName(iter: ?*anyopaque, globalObject: *JSC.JSGlobalObject, object: *anyopaque) usize;
 pub const JSPropertyIteratorOptions = struct {
     skip_empty_name: bool,
     include_value: bool,

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -192,7 +192,7 @@ pub const CachedBytecode = opaque {
         return null;
     }
 
-    extern "C" fn CachedBytecode__deref(this: *CachedBytecode) void;
+    extern "c" fn CachedBytecode__deref(this: *CachedBytecode) void;
     pub fn deref(this: *CachedBytecode) void {
         return CachedBytecode__deref(this);
     }
@@ -1332,7 +1332,7 @@ pub const FetchHeaders = opaque {
         });
     }
 
-    extern "C" fn WebCore__FetchHeaders__createFromJS(*JSC.JSGlobalObject, JSValue) ?*FetchHeaders;
+    extern "c" fn WebCore__FetchHeaders__createFromJS(*JSC.JSGlobalObject, JSValue) ?*FetchHeaders;
     /// Construct a `Headers` object from a JSValue.
     ///
     /// This can be:
@@ -2993,7 +2993,7 @@ pub const JSGlobalObject = opaque {
         return this.ERR_INVALID_ARG_VALUE("The \"{s}\" argument is invalid. Received {}", .{ argname, actual_string_value }).throw();
     }
 
-    extern "C" fn Bun__ErrorCode__determineSpecificType(*JSGlobalObject, JSValue) String;
+    extern "c" fn Bun__ErrorCode__determineSpecificType(*JSGlobalObject, JSValue) String;
 
     pub fn determineSpecificType(global: *JSGlobalObject, value: JSValue) JSError!String {
         const str = Bun__ErrorCode__determineSpecificType(global, value);
@@ -4245,7 +4245,7 @@ pub const JSValue = enum(i64) {
         @import("./headers.zig").JSC__JSValue__put(value, global, key, result);
     }
 
-    extern "C" fn JSC__JSValue__putBunString(value: JSValue, global: *JSGlobalObject, key: *const bun.String, result: JSC.JSValue) void;
+    extern "c" fn JSC__JSValue__putBunString(value: JSValue, global: *JSGlobalObject, key: *const bun.String, result: JSC.JSValue) void;
     fn putBunString(value: JSValue, global: *JSGlobalObject, key: *const bun.String, result: JSC.JSValue) void {
         if (comptime bun.Environment.isDebug)
             JSC.markBinding(@src());
@@ -4644,7 +4644,7 @@ pub const JSValue = enum(i64) {
         });
     }
 
-    extern "C" fn JSC__JSValue__hasOwnPropertyValue(JSValue, *JSGlobalObject, JSValue) bool;
+    extern "c" fn JSC__JSValue__hasOwnPropertyValue(JSValue, *JSGlobalObject, JSValue) bool;
     /// Calls `Object.hasOwnProperty(value)`.
     /// Returns true if the object has the property, false otherwise
     ///

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -2509,7 +2509,7 @@ pub const PosixSignalHandle = struct {
 
 pub const PosixSignalTask = struct {
     number: u8,
-    extern "C" fn Bun__onSignalForJS(number: i32, globalObject: *JSC.JSGlobalObject) void;
+    extern "c" fn Bun__onSignalForJS(number: i32, globalObject: *JSC.JSGlobalObject) void;
 
     pub usingnamespace bun.New(@This());
     pub fn runFromJSThread(number: u8, globalObject: *JSC.JSGlobalObject) void {

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1584,9 +1584,9 @@ pub const VirtualMachine = struct {
 
         pub const log = Output.scoped(.debugger, false);
 
-        extern "C" fn Bun__createJSDebugger(*JSGlobalObject) u32;
-        extern "C" fn Bun__ensureDebugger(u32, bool) void;
-        extern "C" fn Bun__startJSDebuggerThread(*JSGlobalObject, u32, *bun.String, c_int, bool) void;
+        extern "c" fn Bun__createJSDebugger(*JSGlobalObject) u32;
+        extern "c" fn Bun__ensureDebugger(u32, bool) void;
+        extern "c" fn Bun__startJSDebuggerThread(*JSGlobalObject, u32, *bun.String, c_int, bool) void;
         var futex_atomic: std.atomic.Value(u32) = undefined;
 
         pub fn waitForDebuggerIfNecessary(this: *VirtualMachine) void {

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -1459,7 +1459,7 @@ pub const ModuleLoader = struct {
             bun.default_allocator.free(this.string_buf);
         }
 
-        extern "C" fn Bun__onFulfillAsyncModule(
+        extern "c" fn Bun__onFulfillAsyncModule(
             globalObject: *JSGlobalObject,
             promiseValue: JSValue,
             res: *JSC.ErrorableResolvedSource,

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -2814,7 +2814,7 @@ pub fn resolveJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, allocato
     return if (isWindows) resolveWindowsJS_T(T, globalObject, paths, buf, buf2) else resolvePosixJS_T(T, globalObject, paths, buf, buf2);
 }
 
-extern "C" fn Process__getCachedCwd(*JSC.JSGlobalObject) JSC.JSValue;
+extern "c" fn Process__getCachedCwd(*JSC.JSGlobalObject) JSC.JSValue;
 
 pub fn resolve(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
     var arena = bun.ArenaAllocator.init(bun.default_allocator);

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1832,7 +1832,7 @@ pub fn reloadProcess(
         }
     } else if (comptime Environment.isPosix) {
         const on_before_reload_process_linux = struct {
-            pub extern "C" fn on_before_reload_process_linux() void;
+            pub extern "c" fn on_before_reload_process_linux() void;
         }.on_before_reload_process_linux;
 
         on_before_reload_process_linux();
@@ -3251,7 +3251,7 @@ pub fn NewThreadSafeRefCounted(comptime T: type, comptime deinit_fn: ?fn (self: 
 
 pub fn exitThread() noreturn {
     const exiter = struct {
-        pub extern "C" fn pthread_exit(?*anyopaque) noreturn;
+        pub extern "c" fn pthread_exit(?*anyopaque) noreturn;
         pub extern "kernel32" fn ExitThread(windows.DWORD) noreturn;
     };
 
@@ -3882,7 +3882,7 @@ pub fn tagName(comptime Enum: type, value: Enum) ?[:0]const u8 {
         if (@intFromEnum(value) == f.value) break f.name;
     } else null;
 }
-extern "C" fn Bun__ramSize() usize;
+extern "c" fn Bun__ramSize() usize;
 pub fn getTotalMemorySize() usize {
     return Bun__ramSize();
 }
@@ -4289,7 +4289,7 @@ pub const StackCheck = struct {
         Bun__StackCheck__initialize();
     }
 
-    extern "C" fn Bun__StackCheck__getMaxStack() usize;
+    extern "c" fn Bun__StackCheck__getMaxStack() usize;
     fn getStackEnd() usize {
         return Bun__StackCheck__getMaxStack();
     }

--- a/src/c.zig
+++ b/src/c.zig
@@ -488,11 +488,11 @@ pub fn dlopen(filename: [:0]const u8, flags: C.RTLD) ?*anyopaque {
     return std.c.dlopen(filename, flags);
 }
 
-pub extern "C" fn Bun__ttySetMode(fd: c_int, mode: c_int) c_int;
+pub extern "c" fn Bun__ttySetMode(fd: c_int, mode: c_int) c_int;
 
-pub extern "C" fn bun_initialize_process() void;
-pub extern "C" fn bun_restore_stdio() void;
-pub extern "C" fn open_as_nonblocking_tty(i32, i32) i32;
+pub extern "c" fn bun_initialize_process() void;
+pub extern "c" fn bun_restore_stdio() void;
+pub extern "c" fn open_as_nonblocking_tty(i32, i32) i32;
 
 pub extern fn strlen(ptr: [*c]const u8) usize;
 

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -868,7 +868,7 @@ pub fn handleSegfaultWindows(info: *windows.EXCEPTION_POINTERS) callconv(windows
     );
 }
 
-extern "C" fn gnu_get_libc_version() ?[*:0]const u8;
+extern "c" fn gnu_get_libc_version() ?[*:0]const u8;
 
 pub fn printMetadata(writer: anytype) !void {
     if (Output.enable_ansi_colors) {

--- a/src/darwin_c.zig
+++ b/src/darwin_c.zig
@@ -66,7 +66,7 @@ pub const COPYFILE_CONTINUE = @as(c_int, 0);
 pub const COPYFILE_SKIP = @as(c_int, 1);
 pub const COPYFILE_QUIT = @as(c_int, 2);
 
-pub extern "C" fn memmem(haystack: [*]const u8, haystacklen: usize, needle: [*]const u8, needlelen: usize) ?[*]const u8;
+pub extern "c" fn memmem(haystack: [*]const u8, haystacklen: usize, needle: [*]const u8, needlelen: usize) ?[*]const u8;
 
 // int clonefileat(int src_dirfd, const char * src, int dst_dirfd, const char * dst, int flags);
 pub extern "c" fn clonefileat(c_int, [*:0]const u8, c_int, [*:0]const u8, uint32_t: c_int) c_int;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -20,7 +20,7 @@ pub const Socket = opaque {
         debug("us_socket_write2({d}, {d}) = {d}", .{ first.len, second.len, rc });
         return rc;
     }
-    extern "C" fn us_socket_write2(ssl: i32, *Socket, header: ?[*]const u8, len: usize, payload: ?[*]const u8, usize) i32;
+    extern "c" fn us_socket_write2(ssl: i32, *Socket, header: ?[*]const u8, len: usize, payload: ?[*]const u8, usize) i32;
 };
 pub const ConnectingSocket = opaque {};
 const debug = bun.Output.scoped(.uws, false);

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -291,7 +291,7 @@ pub const Loop = struct {
         updateTimespec(&this.cached_now);
     }
 
-    extern "C" fn clock_gettime_monotonic(sec: *i64, nsec: *i64) c_int;
+    extern "c" fn clock_gettime_monotonic(sec: *i64, nsec: *i64) c_int;
     pub fn updateTimespec(timespec: *posix.timespec) void {
         if (comptime Environment.isLinux) {
             const rc = linux.clock_gettime(linux.CLOCK.MONOTONIC, timespec);

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -8527,7 +8527,7 @@ pub const Macro = struct {
             });
         }
 
-        extern "C" fn Bun__startMacro(function: *const anyopaque, *anyopaque) void;
+        extern "c" fn Bun__startMacro(function: *const anyopaque, *anyopaque) void;
     };
 };
 

--- a/src/linux_c.zig
+++ b/src/linux_c.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const bun = @import("root").bun;
-pub extern "C" fn memmem(haystack: [*]const u8, haystacklen: usize, needle: [*]const u8, needlelen: usize) ?[*]const u8;
+pub extern "c" fn memmem(haystack: [*]const u8, haystacklen: usize, needle: [*]const u8, needlelen: usize) ?[*]const u8;
 pub const SystemErrno = enum(u8) {
     SUCCESS = 0,
     EPERM = 1,
@@ -606,7 +606,7 @@ pub const RWFFlagSupport = enum(u8) {
     }
 };
 
-pub extern "C" fn sys_preadv2(
+pub extern "c" fn sys_preadv2(
     fd: c_int,
     iov: [*]const std.posix.iovec,
     iovcnt: c_int,
@@ -614,7 +614,7 @@ pub extern "C" fn sys_preadv2(
     flags: c_uint,
 ) isize;
 
-pub extern "C" fn sys_pwritev2(
+pub extern "c" fn sys_pwritev2(
     fd: c_int,
     iov: [*]const std.posix.iovec_const,
     iovcnt: c_int,
@@ -630,8 +630,8 @@ pub const RENAME_NOREPLACE = 1 << 0;
 pub const RENAME_EXCHANGE = 1 << 1;
 pub const RENAME_WHITEOUT = 1 << 2;
 
-pub extern "C" fn quick_exit(code: c_int) noreturn;
-pub extern "C" fn memrchr(ptr: [*]const u8, val: c_int, len: usize) ?[*]const u8;
+pub extern "c" fn quick_exit(code: c_int) noreturn;
+pub extern "c" fn memrchr(ptr: [*]const u8, val: c_int, len: usize) ?[*]const u8;
 
 export fn sys_epoll_pwait2(epfd: i32, events: ?[*]std.os.linux.epoll_event, maxevents: i32, timeout: ?*const std.os.linux.timespec, sigmask: ?*const std.os.linux.sigset_t) isize {
     return @bitCast(

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,8 +16,8 @@ comptime {
 }
 
 extern fn bun_warn_avx_missing(url: [*:0]const u8) void;
-pub extern "C" var _environ: ?*anyopaque;
-pub extern "C" var environ: ?*anyopaque;
+pub extern "c" var _environ: ?*anyopaque;
+pub extern "c" var environ: ?*anyopaque;
 pub fn main() void {
     bun.crash_handler.init();
 

--- a/src/output.zig
+++ b/src/output.zig
@@ -228,7 +228,7 @@ pub const Source = struct {
     };
 
     pub const Stdio = struct {
-        extern "C" var bun_is_stdio_null: [3]i32;
+        extern "c" var bun_is_stdio_null: [3]i32;
 
         pub fn isStderrNull() bool {
             return bun_is_stdio_null[2] == 1;

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -165,7 +165,7 @@ pub const ParseError = error{
     Lex,
 };
 
-extern "C" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: i32) i32;
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: i32) i32;
 
 fn setEnv(name: [*:0]const u8, value: [*:0]const u8) void {
     // TODO: windows

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3379,7 +3379,7 @@ pub fn existsAt(fd: bun.FileDescriptor, subpath: [:0]const u8) bool {
     @compileError("TODO: existsAtOSPath");
 }
 
-pub extern "C" fn is_executable_file(path: [*:0]const u8) bool;
+pub extern "c" fn is_executable_file(path: [*:0]const u8) bool;
 
 pub fn isExecutableFileOSPath(path: bun.OSPathSliceZ) bool {
     if (comptime Environment.isPosix) {


### PR DESCRIPTION
### What does this PR do?

https://github.com/oven-sh/zig/pull/3 should be landed first then edit `SetupZig.cmake` for new commit hash.

Should be
```zig
extern "c"
```
not 
```zig
extern "C"
```

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
