### PR TITLE
fix(sql) disable idle timeout when still processing data

### DIFF
--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1306,6 +1306,7 @@ pub const PostgresSQLConnection = struct {
         if (this.timer.state == .ACTIVE) {
             this.globalObject.bunVM().timer.remove(&this.timer);
         }
+        this.timer.state = .CANCELLED;
     }
     pub fn resetConnectionTimeout(this: *PostgresSQLConnection) void {
         // if we are processing data, don't reset the timeout, wait for the data to be processed

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2674,6 +2674,7 @@ pub const PostgresSQLConnection = struct {
 
         switch (comptime MessageType) {
             .DataRow => {
+                defer this.resetConnectionTimeout();
                 const request = this.current() orelse return error.ExpectedRequest;
                 var statement = request.statement orelse return error.ExpectedStatement;
                 var structure: JSValue = .undefined;

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -781,8 +781,11 @@ pub const PostgresSQLQuery = struct {
         this.thisValue.upgrade(globalObject);
 
         PostgresSQLQuery.targetSetCached(this_value, globalObject, query);
-
-        if (connection.flags.is_ready_for_query)
+        if (connection.flags.is_processing_data) {
+            if (connection.flags.is_ready_for_query) {
+                connection.flushData();
+            }
+        } else if (connection.flags.is_ready_for_query)
             connection.flushDataAndResetTimeout()
         else if (reset_timeout)
             connection.resetConnectionTimeout();

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1645,7 +1645,7 @@ pub const PostgresSQLConnection = struct {
 
         this.disableConnectionTimeout();
         defer {
-            if (this.status == .connected and this.requests.readableLength() == 0 and this.write_buffer.remaining().len == 0) {
+            if (this.status == .connected and !this.hasQueryRunning() and this.write_buffer.remaining().len == 0 and this.flags.is_ready_for_query) {
                 // Don't keep the process alive when there's nothing to do.
                 this.poll_ref.unref(vm);
             } else if (this.status == .connected) {

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1515,7 +1515,7 @@ pub const PostgresSQLConnection = struct {
         const loop = vm.eventLoop();
         loop.enter();
         defer loop.exit();
-        // this.poll_ref.unref(this.globalObject.bunVM());
+        this.poll_ref.unref(this.globalObject.bunVM());
 
         this.fail("Connection closed", error.ConnectionClosed);
     }

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2553,7 +2553,6 @@ pub const PostgresSQLConnection = struct {
     };
 
     fn advance(this: *PostgresSQLConnection) !void {
-        var any = false;
         while (this.requests.readableLength() > 0) {
             var req: *PostgresSQLQuery = this.requests.peekItem(0);
             switch (req.status) {
@@ -2567,7 +2566,6 @@ pub const PostgresSQLConnection = struct {
                             req.deref();
                             this.requests.discard(1);
 
-                            any = true;
                             continue;
                         },
                         .prepared => {
@@ -2585,7 +2583,6 @@ pub const PostgresSQLConnection = struct {
                                 continue;
                             };
                             req.status = .binding;
-                            any = true;
                             return;
                         },
                         .pending => {
@@ -2612,7 +2609,6 @@ pub const PostgresSQLConnection = struct {
                                 req.status = .binding;
                                 stmt.status = .parsing;
 
-                                any = true;
                                 return;
                             }
                             const connection_writer = this.writer();
@@ -2638,7 +2634,6 @@ pub const PostgresSQLConnection = struct {
                                 continue;
                             };
                             stmt.status = .parsing;
-                            any = true;
                             return;
                         },
                         .parsing => {
@@ -2656,7 +2651,6 @@ pub const PostgresSQLConnection = struct {
                 .success, .fail => {
                     req.deref();
                     this.requests.discard(1);
-                    any = true;
                     continue;
                 },
             }

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1645,7 +1645,7 @@ pub const PostgresSQLConnection = struct {
 
         this.disableConnectionTimeout();
         defer {
-            if (this.status == .connected and !this.hasQueryRunning() and this.write_buffer.remaining().len == 0 and this.flags.is_ready_for_query) {
+            if (this.status == .connected and !this.hasQueryRunning() and this.write_buffer.remaining().len == 0) {
                 // Don't keep the process alive when there's nothing to do.
                 this.poll_ref.unref(vm);
             } else if (this.status == .connected) {

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1387,15 +1387,7 @@ pub const PostgresSQLConnection = struct {
 
     pub fn onConnectionTimeout(this: *PostgresSQLConnection) JSC.BunTimer.EventLoopTimer.Arm {
         debug("onConnectionTimeout", .{});
-        if (this.flags.is_processing_data) {
-            // we are not done processing data yet, so we need to rearm the timer
-            const interval = this.getTimeoutInterval();
-            if (interval == 0) return .disarm;
 
-            return .{
-                .rearm = bun.timespec.msFromNow(@intCast(interval)),
-            };
-        }
         this.timer.state = .FIRED;
         if (this.getTimeoutInterval() == 0) {
             this.resetConnectionTimeout();

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1387,6 +1387,15 @@ pub const PostgresSQLConnection = struct {
 
     pub fn onConnectionTimeout(this: *PostgresSQLConnection) JSC.BunTimer.EventLoopTimer.Arm {
         debug("onConnectionTimeout", .{});
+        if (this.flags.is_processing_data) {
+            // we are not done processing data yet, so we need to rearm the timer
+            const interval = this.getTimeoutInterval();
+            if (interval == 0) return .disarm;
+
+            return .{
+                .rearm = bun.timespec.msFromNow(@intCast(interval)),
+            };
+        }
         this.timer.state = .FIRED;
         if (this.getTimeoutInterval() == 0) {
             this.resetConnectionTimeout();

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1046,7 +1046,6 @@ pub const PostgresRequest = struct {
     ) !void {
         while (true) {
             reader.markMessageStart();
-            connection.resetConnectionTimeout();
             switch (try reader.int(u8)) {
                 'D' => try connection.on(.DataRow, Context, reader),
                 'd' => try connection.on(.CopyData, Context, reader),

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -330,7 +330,6 @@ pub const PostgresSQLQuery = struct {
     } = .{},
 
     pub usingnamespace JSC.Codegen.JSPostgresSQLQuery;
-    const log = bun.Output.scoped(.PostgresSQLQuery, false);
     pub fn getTarget(this: *PostgresSQLQuery, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         const thisValue = this.thisValue.get();
         if (thisValue == .zero) {
@@ -715,7 +714,7 @@ pub const PostgresSQLQuery = struct {
                     .prepared => {
                         if (!connection.hasQueryRunning()) {
                             this.flags.binary = this.statement.?.fields.len > 0;
-                            log("bindAndExecute", .{});
+                            debug("bindAndExecute", .{});
                             // bindAndExecute will bind + execute, it will change to running after binding is complete
                             PostgresRequest.bindAndExecute(globalObject, this.statement.?, binding_value, columns_value, PostgresSQLConnection.Writer, writer) catch |err| {
                                 if (!globalObject.hasException())
@@ -738,7 +737,7 @@ pub const PostgresSQLQuery = struct {
             if (can_execute) {
                 // If it does not have params, we can write and execute immediately in one go
                 if (!has_params) {
-                    log("prepareAndQueryWithSignature", .{});
+                    debug("prepareAndQueryWithSignature", .{});
                     // prepareAndQueryWithSignature will write + bind + execute, it will change to running after binding is complete
                     PostgresRequest.prepareAndQueryWithSignature(globalObject, query_str.slice(), binding_value, PostgresSQLConnection.Writer, writer, &signature) catch |err| {
                         signature.deinit();
@@ -749,7 +748,7 @@ pub const PostgresSQLQuery = struct {
                     this.status = .binding;
                     did_write = true;
                 } else {
-                    log("writeQuery", .{});
+                    debug("writeQuery", .{});
                     PostgresRequest.writeQuery(query_str.slice(), signature.prepared_statement_name, signature.fields, PostgresSQLConnection.Writer, writer) catch |err| {
                         signature.deinit();
                         if (!globalObject.hasException())

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1387,6 +1387,10 @@ pub const PostgresSQLConnection = struct {
         debug("onConnectionTimeout", .{});
 
         this.timer.state = .FIRED;
+        if (this.flags.is_processing_data) {
+            return .disarm;
+        }
+
         if (this.getTimeoutInterval() == 0) {
             this.resetConnectionTimeout();
             return .disarm;

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1692,7 +1692,6 @@ pub const PostgresSQLConnection = struct {
             };
             return;
         } else {
-            this.read_buffer.head = this.last_message_start;
             this.read_buffer.write(bun.default_allocator, data) catch @panic("failed to write to read buffer");
             PostgresRequest.onData(this, Reader, this.bufferedReader()) catch |err| {
                 if (err != error.ShortRead) {
@@ -1708,6 +1707,7 @@ pub const PostgresSQLConnection = struct {
                         this.read_buffer.byte_list.len,
                     });
                 }
+                // reset the head so remaining bytes are available for the next read
                 this.read_buffer.head = this.last_message_start;
 
                 return;

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2553,9 +2553,7 @@ pub const PostgresSQLConnection = struct {
     };
 
     fn advance(this: *PostgresSQLConnection) !void {
-        defer this.updateRef();
         var any = false;
-        defer if (any) this.resetConnectionTimeout();
         while (this.requests.readableLength() > 0) {
             var req: *PostgresSQLQuery = this.requests.peekItem(0);
             switch (req.status) {

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -783,7 +783,7 @@ pub const PostgresSQLQuery = struct {
         PostgresSQLQuery.targetSetCached(this_value, globalObject, query);
         if (did_write) {
             connection.flushDataAndResetTimeout();
-        } else if (!connection.flags.is_processing_data) {
+        } else {
             connection.resetConnectionTimeout();
         }
         return .undefined;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -266,6 +266,25 @@ if (isDockerEnabled()) {
     expect(result).toEqual([{ x: 3 }]);
   });
 
+  test("should not timeout in long results", async () => {
+    await using sql = postgres({ ...options, max: 1, idleTimeout: 5 });
+    const random_name = "test_" + Math.random().toString(36).substring(2, 15);
+    await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text)`;
+    const promises: Promise<any>[] = [];
+    for (let i = 0; i < 10_000; i++) {
+      promises.push(sql`INSERT INTO ${sql(random_name)} VALUES (${i}, ${"test" + i})`);
+      if (i % 50 === 0 && i > 0) {
+        await Promise.all(promises);
+        promises.length = 0;
+      }
+    }
+    await Promise.all(promises);
+    await sql`SELECT * FROM ${sql(random_name)}`;
+    await sql`SELECT * FROM ${sql(random_name)}`;
+    await sql`SELECT * FROM ${sql(random_name)}`;
+    expect().pass();
+  });
+
   test("Handles numeric column names", async () => {
     // deliberately out of order
     const result = await sql`select 1 as "1", 2 as "2", 3 as "3", 0 as "0"`;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -267,28 +267,26 @@ if (isDockerEnabled()) {
   });
 
   test("should not timeout in long results", async () => {
-    await using sql = postgres({ ...options, max: 1, idleTimeout: 5 });
+    await using db = postgres({ ...options, max: 1, idleTimeout: 5 });
+    using sql = await db.reserve();
     const random_name = "test_" + Math.random().toString(36).substring(2, 15);
 
     await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text)`;
-    try {
-      const promises: Promise<any>[] = [];
-      for (let i = 0; i < 10_000; i++) {
-        promises.push(sql`INSERT INTO ${sql(random_name)} VALUES (${i}, ${"test" + i})`);
-        if (i % 50 === 0 && i > 0) {
-          await Promise.all(promises);
-          promises.length = 0;
-        }
+    const promises: Promise<any>[] = [];
+    for (let i = 0; i < 10_000; i++) {
+      promises.push(sql`INSERT INTO ${sql(random_name)} VALUES (${i}, ${"test" + i})`);
+      if (i % 50 === 0 && i > 0) {
+        await Promise.all(promises);
+        promises.length = 0;
       }
-      await Promise.all(promises);
-      await sql`SELECT * FROM ${sql(random_name)}`;
-      await sql`SELECT * FROM ${sql(random_name)}`;
-      await sql`SELECT * FROM ${sql(random_name)}`;
-    } finally {
-      await sql`DROP TABLE ${sql(random_name)}`;
     }
+    await Promise.all(promises);
+    await sql`SELECT * FROM ${sql(random_name)}`;
+    await sql`SELECT * FROM ${sql(random_name)}`;
+    await sql`SELECT * FROM ${sql(random_name)}`;
+
     expect().pass();
-  });
+  }, 10_000);
 
   test("Handles numeric column names", async () => {
     // deliberately out of order

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1,4 +1,4 @@
-import { sql, SQL } from "bun";
+import { sql, SQL, randomUUIDv7 } from "bun";
 const postgres = (...args) => new sql(...args);
 import { expect, test, mock, beforeAll, afterAll } from "bun:test";
 import { $ } from "bun";
@@ -269,7 +269,7 @@ if (isDockerEnabled()) {
   test("should not timeout in long results", async () => {
     await using db = postgres({ ...options, max: 1, idleTimeout: 5 });
     using sql = await db.reserve();
-    const random_name = "test_" + Math.random().toString(36).substring(2, 15);
+    const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
 
     await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text)`;
     const promises: Promise<any>[] = [];


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/16892
Fix: https://github.com/oven-sh/bun/issues/16999

Disable idle timeout when processing data, fix short read handling, remove unnecessary/dead code and small refactor
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
