### PR TITLE
Introduce `bun ./index.html`

### DIFF
--- a/docs/bundler/fullstack.md
+++ b/docs/bundler/fullstack.md
@@ -1,6 +1,6 @@
-As of Bun v1.1.44, we've added initial support for bundling frontend apps directly in Bun's HTTP server: `Bun.serve()`. Run your frontend and backend in the same app with no extra steps.
+Using `Bun.serve()`'s `static` option, you can run your frontend and backend in the same app with no extra steps.
 
-To get started, import your HTML files and pass them to the `static` option in `Bun.serve()`.
+To get started, import HTML files and pass them to the `static` option in `Bun.serve()`.
 
 ```ts
 import dashboard from "./dashboard.html";
@@ -33,7 +33,7 @@ const server = Bun.serve({
   },
 });
 
-console.log(`Listening on ${server.url}`)
+console.log(`Listening on ${server.url}`);
 ```
 
 ```bash
@@ -211,6 +211,7 @@ For example, enable TailwindCSS on your routes by installing and adding the `bun
 ```sh
 $ bun add bun-plugin-tailwind
 ```
+
 ```toml#bunfig.toml
 [serve.static]
 plugins = ["bun-plugin-tailwind"]

--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -284,6 +284,9 @@ All paths are resolved relative to your HTML file, making it easy to organize yo
 - No HMR support yet
 - Need more plugins
 - Need more configuration options for things like asset handling
+- Need a way to configure CORS, headers, etc.
+
+If you want to submit a PR, most of the [code is here](https://github.com/oven-sh/bun/blob/main/src/js/internal/html.ts).
 
 ## How this works
 

--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -286,7 +286,7 @@ All paths are resolved relative to your HTML file, making it easy to organize yo
 - Need more configuration options for things like asset handling
 - Need a way to configure CORS, headers, etc.
 
-If you want to submit a PR, most of the [code is here](https://github.com/oven-sh/bun/blob/main/src/js/internal/html.ts).
+If you want to submit a PR, most of the [code is here](https://github.com/oven-sh/bun/blob/main/src/js/internal/html.ts). You could even copy paste that file into your project and use it as a starting point.
 
 ## How this works
 

--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -278,3 +278,19 @@ Bun automatically handles all common web assets:
 - Any `<link>` tag with an `href` attribute pointing to a local file is rewritten to the new path, and hashed
 
 All paths are resolved relative to your HTML file, making it easy to organize your project however you want.
+
+## This is a work in progress
+
+- No HMR support yet
+- Need more plugins
+- Need more configuration options for things like asset handling
+
+## How this works
+
+This is a small wrapper around Bun's support for HTML imports in JavaScript.
+
+### Adding a backend to your frontend
+
+To add a backend to your frontend, you can use the `"static"` option in `Bun.serve`.
+
+Learn more in [the full-stack docs](/docs/bundler/fullstack).

--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -1,4 +1,4 @@
-As of Bun v1.1.43, Bun's bundler now has first-class support for HTML. Build static sites, landing pages, and web applications with zero configuration. Just point Bun at your HTML file and it handles everything else.
+Bun's bundler has first-class support for HTML. Build static sites, landing pages, and web applications with zero configuration. Just point Bun at your HTML file and it handles everything else.
 
 ```html#index.html
 <!doctype html>
@@ -13,45 +13,221 @@ As of Bun v1.1.43, Bun's bundler now has first-class support for HTML. Build sta
 </html>
 ```
 
-One command is all you need (won't be experimental after Bun v1.2):
+To get started, pass HTML files to `bun`.
+
+{% bunDevServerTerminal alt="bun ./index.html" path="./index.html" routes="" /%}
+
+Bun's development server provides powerful features with zero configuration:
+
+- **Automatic Bundling** - Bundles and serves your HTML, JavaScript, and CSS
+- **Multi-Entry Support** - Handles multiple HTML entry points and glob entry points
+- **Modern JavaScript** - TypeScript & JSX support out of the box
+- **Smart Configuration** - Reads `tsconfig.json` for paths, JSX options, experimental decorators, and more
+- **Plugins** - Plugins for TailwindCSS and more
+- **ESM & CommonJS** - Use ESM and CommonJS in your JavaScript, TypeScript, and JSX files
+- **CSS Bundling & Minification** - Bundles CSS from `<link>` tags and `@import` statements
+- **Asset Management**
+  - Automatic copying & hashing of images and assets
+  - Rewrites asset paths in JavaScript, CSS, and HTML
+
+## Single Page Apps (SPA)
+
+When you pass a single .html file to Bun, Bun will use it as a fallback route for all paths. This makes it perfect for single page apps that use client-side routing:
+
+{% bunDevServerTerminal alt="bun index.html" path="index.html" routes="" /%}
+
+Your React or other SPA will work out of the box — no configuration needed. All routes like `/about`, `/users/123`, etc. will serve the same HTML file, letting your client-side router handle the navigation.
+
+```html#index.html
+<!doctype html>
+<html>
+  <head>
+    <title>My SPA</title>
+    <script src="./app.tsx" type="module"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+## Multi-page apps (MPA)
+
+Some projects have several separate routes or HTML files as entry points. To support multiple entry points, pass them all to `bun`
+
+{% bunDevServerTerminal alt="bun ./index.html ./about.html" path="./index.html ./about.html" routes="[{\"path\": \"/\", \"file\": \"./index.html\"}, {\"path\": \"/about\", \"file\": \"./about.html\"}]" /%}
+
+This will serve:
+
+- `index.html` at `/`
+- `about.html` at `/about`
+
+### Glob patterns
+
+To specify multiple files, you can use glob patterns that end in `.html`:
+
+{% bunDevServerTerminal alt="bun ./**/*.html" path="./**/*.html" routes="[{\"path\": \"/\", \"file\": \"./index.html\"}, {\"path\": \"/about\", \"file\": \"./about.html\"}]" /%}
+
+### Path normalization
+
+The base path is chosen from the longest common prefix among all the files.
+
+{% bunDevServerTerminal alt="bun ./index.html ./about/index.html ./about/foo/index.html" path="./index.html ./about/index.html ./about/foo/index.html" routes="[{\"path\": \"/\", \"file\": \"./index.html\"}, {\"path\": \"/about\", \"file\": \"./about/index.html\"}, {\"path\": \"/about/foo\", \"file\": \"./about/foo/index.html\"}]" /%}
+
+## JavaScript, TypeScript, and JSX
+
+Bun's transpiler natively implements JavaScript, TypeScript, and JSX support. [Learn more about loaders in Bun](/docs/bundler/loaders).
+
+Bun's transpiler is also used at runtime.
+
+### ES Modules & CommonJS
+
+You can use ESM and CJS in your JavaScript, TypeScript, and JSX files. Bun will handle the transpilation and bundling automatically.
+
+There is no pre-build or separate optimization step. It's all done at the same time.
+
+Learn more about [module resolution in Bun](/docs/runtime/modules).
+
+## CSS
+
+Bun's CSS parser is also natively implemented (clocking in around 58,000 lines of Zig).
+
+It's also a CSS bundler. You can use `@import` in your CSS files to import other CSS files.
+
+For example:
+
+```css#styles.css
+@import "./abc.css";
+
+.container {
+  background-color: blue;
+}
+```
+
+```css#abc.css
+body {
+  background-color: red;
+}
+```
+
+This outputs:
+
+```css#styles.css
+body {
+  background-color: red;
+}
+
+.container {
+  background-color: blue;
+}
+```
+
+### Referencing local assets in CSS
+
+You can reference local assets in your CSS files.
+
+```css#styles.css
+body {
+  background-image: url("./logo.png");
+}
+```
+
+This will copy `./logo.png` to the output directory and rewrite the path in the CSS file to include a content hash.
+
+```css#styles.css
+body {
+  background-image: url("./logo-[ABC123].png");
+}
+```
+
+### Importing CSS in JavaScript
+
+To associate a CSS file with a JavaScript file, you can import it in your JavaScript file.
+
+```ts#app.ts
+import "./styles.css";
+import "./more-styles.css";
+```
+
+This generates `./app.css` and `./app.js` in the output directory. All CSS files imported from JavaScript will be bundled into a single CSS file per entry point. If you import the same CSS file from multiple JavaScript files, it will only be included once in the output CSS file.
+
+## Plugins
+
+The dev server supports plugins.
+
+### Tailwind CSS
+
+To use TailwindCSS, add the plugin to your `bunfig.toml`:
+
+```toml
+[serve.static]
+plugins = ["bun-plugin-tailwind"]
+```
+
+Then, reference TailwindCSS in your HTML via `<link>` tag, `@import` in CSS, or `import` in JavaScript.
+
+{% codetabs %}
+
+```html#index.html
+<!-- Reference TailwindCSS in your HTML -->
+<link rel="stylesheet" href="tailwindcss" />
+```
+
+```css#styles.css
+/* Import TailwindCSS in your CSS */
+@import "tailwindcss";
+```
+
+```ts#app.ts
+/* Import TailwindCSS in your JavaScript */
+import "tailwindcss";
+```
+
+{% /codetabs %}
+
+Only one of those are necessary, not all three.
+
+## Keyboard Shortcuts
+
+While the server is running:
+
+- `o + Enter` - Open in browser
+- `c + Enter` - Clear console
+- `q + Enter` (or Ctrl+C) - Quit server
+
+## Build for Production
+
+When you're ready to deploy, use `bun build` to create optimized production bundles:
 
 {% codetabs %}
 
 ```bash#CLI
-$ bun build ./index.html --outdir=dist
+$ bun build ./index.html --minify --outdir=dist
 ```
 
 ```ts#API
 Bun.build({
   entrypoints: ["./index.html"],
   outdir: "./dist",
+  minify: {
+    whitespace: true,
+    identifiers: true,
+    syntax: true,
+  }
 });
 ```
 
 {% /codetabs %}
 
-Bun automatically:
+Currently, plugins are only supported through `Bun.build`'s API or through `bunfig.toml` with the frontend dev server - not yet supported in `bun build`'s CLI.
 
-- Bundles, tree-shakes, and optimizes your JavaScript, JSX and TypeScript
-- Bundles and optimizes your CSS
-- Copies & hashes images and other assets
-- Updates all references to local files or packages in your HTML
-
-## Zero Config, Maximum Performance
-
-The HTML bundler is enabled by default after Bun v1.2+. Drop in your existing HTML files and Bun will handle:
-
-- **TypeScript & JSX** - Write modern JavaScript for browsers without the setup
-- **CSS** - Bundle CSS stylesheets directly from `<link rel="stylesheet">` or `@import`
-- **Images & Assets** - Automatic copying & hashing & rewriting of assets in JavaScript, CSS, and HTML
-
-## Watch mode
+### Watch Mode
 
 You can run `bun build --watch` to watch for changes and rebuild automatically.
 
 You've never seen a watch mode this fast.
 
-## Plugin API
+### Plugin API
 
 Need more control? Configure the bundler through the JavaScript API and use Bun's builtin `HTMLRewriter` to preprocess HTML.
 

--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -223,7 +223,7 @@ Currently, plugins are only supported through `Bun.build`'s API or through `bunf
 
 ### Watch Mode
 
-You can run `bun build --watch` to watch for changes and rebuild automatically.
+You can run `bun build --watch` to watch for changes and rebuild automatically. This works nicely for library development.
 
 You've never seen a watch mode this fast.
 

--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -214,7 +214,7 @@ export default {
     page("bundler", "`Bun.build`", {
       description: "Bundle code for consumption in the browser with Bun's native bundler.",
     }),
-    page("bundler/html", "HTML", {
+    page("bundler/html", "Frontend & static sites", {
       description: `Bundle html files with Bun's native bundler.`,
     }),
     page("bundler/fullstack", "Fullstack Dev Server", {

--- a/src/bun.js/api/server/HTMLBundle.zig
+++ b/src/bun.js/api/server/HTMLBundle.zig
@@ -68,6 +68,7 @@ pub const HTMLBundleRoute = struct {
     }
 
     pub fn init(html_bundle: *HTMLBundle) *HTMLBundleRoute {
+        html_bundle.ref();
         return HTMLBundleRoute.new(.{
             .html_bundle = html_bundle,
             .pending_responses = .{},

--- a/src/bun.js/bindings/HTMLEntryPoint.cpp
+++ b/src/bun.js/bindings/HTMLEntryPoint.cpp
@@ -1,0 +1,41 @@
+#include "root.h"
+
+#include "JavaScriptCore/CallData.h"
+#include <JavaScriptCore/ObjectConstructor.h>
+#include "InternalModuleRegistry.h"
+#include "ModuleLoader.h"
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/JSInternalPromise.h>
+
+namespace Bun {
+using namespace JSC;
+extern "C" JSInternalPromise* Bun__loadHTMLEntryPoint(Zig::GlobalObject* globalObject)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSInternalPromise* promise = JSInternalPromise::create(vm, globalObject->internalPromiseStructure());
+
+    JSValue htmlModule = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::InternalHtml);
+    if (UNLIKELY(scope.exception())) {
+        return promise->rejectWithCaughtException(globalObject, scope);
+    }
+
+    JSObject* htmlModuleObject = htmlModule.getObject();
+    if (UNLIKELY(!htmlModuleObject)) {
+        BUN_PANIC("Failed to load HTML entry point");
+    }
+
+    MarkedArgumentBuffer args;
+    JSValue result = JSC::call(globalObject, htmlModuleObject, args, "Failed to load HTML entry point"_s);
+    if (UNLIKELY(scope.exception())) {
+        return promise->rejectWithCaughtException(globalObject, scope);
+    }
+
+    promise = jsDynamicCast<JSInternalPromise*>(result);
+    if (UNLIKELY(!promise)) {
+        BUN_PANIC("Failed to load HTML entry point");
+    }
+    return promise;
+}
+
+}

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -42,6 +42,7 @@ pub const Run = struct {
     entry_path: string,
     arena: Arena,
     any_unhandled: bool = false,
+    is_html_entrypoint: bool = false,
 
     pub fn bootStandalone(ctx: Command.Context, entry_path: string, graph: bun.StandaloneModuleGraph) !void {
         JSC.markBinding(@src());
@@ -170,7 +171,7 @@ pub const Run = struct {
         return bun.shell.Interpreter.initAndRunFromFile(ctx, mini, entry_path);
     }
 
-    pub fn boot(ctx: Command.Context, entry_path: string) !void {
+    pub fn boot(ctx: Command.Context, entry_path: string, loader: ?bun.options.Loader) !void {
         JSC.markBinding(@src());
 
         if (!ctx.debug.loaded_bunfig) {
@@ -276,6 +277,8 @@ pub const Run = struct {
         vm.transpiler.env.loadTracy();
 
         doPreconnect(ctx.runtime_options.preconnect);
+
+        vm.main_is_html_entrypoint = (loader orelse vm.transpiler.options.loader(std.fs.path.extension(entry_path))) == .html;
 
         const callback = OpaqueWrap(Run, Run.start);
         vm.global.vm().holdAPILock(&run, callback);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2196,7 +2196,7 @@ pub const Command = struct {
                     var entry_point_buf: [bun.MAX_PATH_BYTES + trigger.len]u8 = undefined;
                     const cwd = try std.posix.getcwd(&entry_point_buf);
                     @memcpy(entry_point_buf[cwd.len..][0..trigger.len], trigger);
-                    try BunJS.Run.boot(ctx, entry_point_buf[0 .. cwd.len + trigger.len]);
+                    try BunJS.Run.boot(ctx, entry_point_buf[0 .. cwd.len + trigger.len], null);
                     return;
                 }
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1262,9 +1262,9 @@ pub const RunCommand = struct {
         Output.flush();
     }
 
-    fn _bootAndHandleError(ctx: Command.Context, path: string) bool {
+    fn _bootAndHandleError(ctx: Command.Context, path: string, loader: ?bun.options.Loader) bool {
         Global.configureAllocator(.{ .long_running = true });
-        Run.boot(ctx, ctx.allocator.dupe(u8, path) catch return false) catch |err| {
+        Run.boot(ctx, ctx.allocator.dupe(u8, path) catch return false, loader) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};
 
             Output.prettyErrorln("<r><red>error<r>: Failed to run <b>{s}<r> due to error <b>{s}<r>", .{
@@ -1348,7 +1348,7 @@ pub const RunCommand = struct {
             bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", ctx, .RunCommand) catch {};
         }
 
-        _ = _bootAndHandleError(ctx, absolute_script_path.?);
+        _ = _bootAndHandleError(ctx, absolute_script_path.?, null);
         return true;
     }
     pub fn exec(
@@ -1441,7 +1441,7 @@ pub const RunCommand = struct {
             @memcpy(entry_point_buf[cwd.len..][0..trigger.len], trigger);
             const entry_path = entry_point_buf[0 .. cwd.len + trigger.len];
 
-            Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch return false) catch |err| {
+            Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch return false, null) catch |err| {
                 ctx.log.print(Output.errorWriter()) catch {};
 
                 Output.prettyErrorln("<r><red>error<r>: Failed to run <b>{s}<r> due to error <b>{s}<r>", .{
@@ -1528,13 +1528,20 @@ pub const RunCommand = struct {
             var resolved_mutable = resolved;
             const path = resolved_mutable.path().?;
             const loader: bun.options.Loader = this_transpiler.options.loaders.get(path.name.ext) orelse .tsx;
-            if (loader.canBeRunByBun()) {
+            if (loader.canBeRunByBun() or loader == .html) {
                 log("Resolved to: `{s}`", .{path.text});
-                return _bootAndHandleError(ctx, path.text);
+                return _bootAndHandleError(ctx, path.text, loader);
             } else {
                 log("Resolved file `{s}` but ignoring because loader is {s}", .{ path.text, @tagName(loader) });
             }
-        } else |_| {}
+        } else |_| {
+            // Support globs for HTML entry points.
+            if (strings.hasSuffixComptime(target_name, ".html")) {
+                if (strings.containsChar(target_name, '*')) {
+                    return _bootAndHandleError(ctx, target_name, .html);
+                }
+            }
+        }
 
         // execute a node_modules/.bin/<X> command, or (run only) a system command like 'ls'
 
@@ -1623,7 +1630,7 @@ pub const RunCommand = struct {
             var entry_point_buf: [bun.MAX_PATH_BYTES + trigger.len]u8 = undefined;
             const cwd = try std.posix.getcwd(&entry_point_buf);
             @memcpy(entry_point_buf[cwd.len..][0..trigger.len], trigger);
-            try Run.boot(ctx, entry_point_buf[0 .. cwd.len + trigger.len]);
+            try Run.boot(ctx, entry_point_buf[0 .. cwd.len + trigger.len], null);
             return;
         }
 
@@ -1653,7 +1660,7 @@ pub const RunCommand = struct {
             );
         };
 
-        Run.boot(ctx, normalized_filename) catch |err| {
+        Run.boot(ctx, normalized_filename, null) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};
 
             Output.err(err, "Failed to run script \"<b>{s}<r>\"", .{std.fs.path.basename(normalized_filename)});
@@ -1728,7 +1735,7 @@ pub const BunXFastPath = struct {
             bun.reinterpretSlice(u8, &direct_launch_buffer),
             wpath,
         ) catch return;
-        Run.boot(ctx, utf8) catch |err| {
+        Run.boot(ctx, utf8, null) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};
             Output.err(err, "Failed to run bin \"<b>{s}<r>\"", .{std.fs.path.basename(utf8)});
             Global.exit(1);

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -1,9 +1,14 @@
+// This is the file that loads when you pass a, .html entry point to Bun.
 import type { HTMLBundle, Server } from "bun";
 const initital = performance.now();
 const argv = process.argv;
+
+// `import` cannot be used in this file and only Bun builtin modules can be used.
 const path = require("node:path");
+
 const env = Bun.env;
 
+// This function is called at startup.
 async function start() {
   let args: string[] = [];
   const cwd = process.cwd();

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -1,4 +1,5 @@
 import type { HTMLBundle, Server } from "bun";
+const initital = performance.now();
 const argv = process.argv;
 const path = require("node:path");
 const env = Bun.env;
@@ -172,7 +173,7 @@ async function start() {
       throw error;
     }
   }
-  const elapsed = (performance.now() / 1000).toFixed(2);
+  const elapsed = (performance.now() - initital).toFixed(2);
   const enableANSIColors = Bun.enableANSIColors;
   function printInitialMessage(isFirst: boolean) {
     if (enableANSIColors) {

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -1,0 +1,276 @@
+import type { HTMLBundle, Server } from "bun";
+const argv = process.argv;
+const path = require("node:path");
+const env = Bun.env;
+
+async function start() {
+  let args: string[] = [];
+  const cwd = process.cwd();
+
+  // Step 1. Resolve all HTML entry points
+  for (let i = 1, argvLength = argv.length; i < argvLength; i++) {
+    const arg = argv[i];
+    if (!arg.endsWith(".html")) {
+      continue;
+    }
+
+    if (arg.includes("*") || arg.includes("**") || arg.includes("{")) {
+      const glob = new Bun.Glob(arg);
+
+      for (const file of glob.scanSync(cwd)) {
+        let resolved = path.resolve(cwd, file);
+        try {
+          resolved = Bun.resolveSync(resolved, cwd);
+        } catch {
+          resolved = Bun.resolveSync("./" + resolved, cwd);
+        }
+
+        args.push(resolved);
+      }
+    } else {
+      let resolved = arg;
+      try {
+        resolved = Bun.resolveSync(arg, cwd);
+      } catch {
+        resolved = Bun.resolveSync("./" + arg, cwd);
+      }
+
+      args.push(resolved);
+    }
+
+    if (args.length > 1) {
+      args = [...new Set(args)];
+    }
+  }
+
+  // Add cwd to find longest common path
+  let needsPop = false;
+  if (args.length === 1) {
+    args.push(process.cwd());
+    needsPop = true;
+  }
+
+  // Find longest common path prefix to use as the base path when there are
+  // multiple entry points
+  const longestCommonPath = args.reduce((acc, curr) => {
+    if (!acc) return curr;
+    let i = 0;
+    while (i < acc.length && i < curr.length && acc[i] === curr[i]) i++;
+    return acc.slice(0, i);
+  });
+
+  if (needsPop) {
+    // Remove cwd from args
+    args.pop();
+  }
+
+  // Transform file paths into friendly URL paths
+  // - "index.html" -> "/"
+  // - "about/index.html" -> "/about"
+  // - "about/foo.html" -> "/about/foo"
+  // - "foo.html" -> "/foo"
+  const servePaths = args.map(arg => {
+    const basename = path.basename(arg);
+    const isIndexHtml = basename === "index.html";
+
+    let servePath = arg.startsWith(longestCommonPath) ? arg.slice(longestCommonPath.length) : arg;
+
+    if (isIndexHtml && servePath.length === 0) {
+      servePath = "/";
+    } else if (isIndexHtml) {
+      servePath = servePath.slice(0, -"index.html".length);
+    }
+
+    if (process.platform === "win32") {
+      servePath = servePath.replaceAll("\\", "/");
+    }
+
+    if (servePath.endsWith(".html")) {
+      servePath = servePath.slice(0, -".html".length);
+    }
+
+    if (servePath.endsWith("/")) {
+      servePath = servePath.slice(0, -1);
+    }
+
+    if (servePath.startsWith("/")) {
+      servePath = servePath.slice(1);
+    }
+
+    if (servePath === "/") servePath = "";
+
+    return servePath;
+  });
+
+  const htmlImports = await Promise.all(
+    args.map(arg => {
+      return import(arg).then(m => m.default);
+    }),
+  );
+
+  // If you're only providing one entry point, then match everything to it.
+  // (except for assets, which have higher precedence)
+  if (htmlImports.length === 1 && servePaths[0] === "") {
+    servePaths[0] = "*";
+  }
+
+  const staticRoutes = htmlImports.reduce(
+    (acc, htmlImport, index) => {
+      const html = htmlImport;
+      const servePath = servePaths[index];
+
+      acc["/" + servePath] = html;
+      return acc;
+    },
+    {} as Record<string, HTMLBundle>,
+  );
+  var server: Server;
+  getServer: {
+    try {
+      server = Bun.serve({
+        static: staticRoutes,
+        development: env.NODE_ENV !== "production",
+
+        // use the default port via existing port detection code.
+        // port: 3000,
+
+        fetch(req: Request) {
+          return new Response("Not found", { status: 404 });
+        },
+      });
+      break getServer;
+    } catch (error: any) {
+      if (error?.code === "EADDRINUSE") {
+        let defaultPort = parseInt(env.PORT || env.BUN_PORT || env.NODE_PORT || "3000", 10);
+        for (let remainingTries = 5; remainingTries > 0; remainingTries--) {
+          try {
+            server = Bun.serve({
+              static: staticRoutes,
+              development: env.NODE_ENV !== "production",
+
+              // Retry with a different port up to 4 times.
+              port: defaultPort++,
+
+              fetch(req: Request) {
+                return new Response("Not found", { status: 404 });
+              },
+            });
+            break getServer;
+          } catch (error: any) {
+            if (error?.code === "EADDRINUSE") {
+              continue;
+            }
+            throw error;
+          }
+        }
+      }
+
+      throw error;
+    }
+  }
+  const elapsed = (performance.now() / 1000).toFixed(2);
+  const enableANSIColors = Bun.enableANSIColors;
+  function printInitialMessage(isFirst: boolean) {
+    if (enableANSIColors) {
+      let topLine = `\n\x1b[1;34m\x1b[5mBun\x1b[0m \x1b[1;34mv${Bun.version}\x1b[0m`;
+      if (isFirst) {
+        topLine += ` \x1b[2mready in\x1b[0m \x1b[1m${elapsed}\x1b[0m ms`;
+      }
+      console.log(topLine + "\n");
+      console.log(`\x1b[1;34m➜\x1b[0m \x1b[36m${server!.url.href}\x1b[0m`);
+    } else {
+      let topLine = `\n  Bun v${Bun.version}`;
+      if (isFirst) {
+        topLine += ` ready in ${elapsed} ms`;
+      }
+      console.log(topLine + "\n");
+      console.log(`url: ${server!.url.href}`);
+    }
+    if (htmlImports.length > 1 || (servePaths[0] !== "" && servePaths[0] !== "*")) {
+      console.log("\nRoutes:");
+
+      const pairs: { route: string; importPath: string }[] = [];
+
+      for (let i = 0, length = servePaths.length; i < length; i++) {
+        const route = servePaths[i];
+        const importPath = args[i];
+        pairs.push({ route, importPath });
+      }
+      pairs.sort((a, b) => {
+        if (b.route === "") return 1;
+        if (a.route === "") return -1;
+        return a.route.localeCompare(b.route);
+      });
+      for (let i = 0, length = pairs.length; i < length; i++) {
+        const { route, importPath } = pairs[i];
+        const isLast = i === length - 1;
+        const prefix = isLast ? "  └── " : "  ├── ";
+        if (enableANSIColors) {
+          console.log(`${prefix}\x1b[36m/${route}\x1b[0m \x1b[2m→ ${path.relative(process.cwd(), importPath)}\x1b[0m`);
+        } else {
+          console.log(`${prefix}/${route} → ${path.relative(process.cwd(), importPath)}`);
+        }
+      }
+      console.log();
+    }
+
+    if (isFirst && process.stdin.isTTY) {
+      if (enableANSIColors) {
+        console.log();
+        console.log("\x1b[2mPress \x1b[2;36mh + Enter\x1b[39;2m to show shortcuts\x1b[0m");
+      } else {
+        console.log();
+        console.log("Press h + Enter to show shortcuts");
+      }
+    }
+  }
+
+  printInitialMessage(true);
+
+  // Keyboard shortcuts
+  if (process.stdin.isTTY) {
+    // Handle Ctrl+C and other termination signals
+    process.on("SIGINT", () => process.exit());
+    process.on("SIGHUP", () => process.exit());
+    process.on("SIGTERM", () => process.exit());
+    process.stdin.on("data", data => {
+      const key = data.toString().toLowerCase();
+
+      switch (key) {
+        case "\x03": // Ctrl+C
+        case "q\n":
+          process.exit();
+          break;
+
+        case "c\n":
+          console.clear();
+          printInitialMessage(false);
+          break;
+
+        case "o\n":
+          const url = server.url.toString();
+
+          if (process.platform === "darwin") {
+            // TODO: copy the AppleScript from create-react-app or Vite.
+            Bun.spawn(["open", url]).exited.catch(() => {});
+          } else if (process.platform === "win32") {
+            Bun.spawn(["start", url]).exited.catch(() => {});
+          } else {
+            Bun.spawn(["xdg-open", url]).exited.catch(() => {});
+          }
+          break;
+
+        case "h\n":
+          console.clear();
+          printInitialMessage(false);
+          console.log("\n  Shortcuts\x1b[2m:\x1b[0m\n");
+          console.log("  \x1b[2m→\x1b[0m   \x1b[36mc + Enter\x1b[0m   clear screen");
+          console.log("  \x1b[2m→\x1b[0m   \x1b[36mo + Enter\x1b[0m   open in browser");
+          console.log("  \x1b[2m→\x1b[0m   \x1b[36mq + Enter\x1b[0m   quit (or Ctrl+C)\n");
+          break;
+      }
+    });
+  }
+}
+
+export default start;

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -134,7 +134,15 @@ yourself with Bun.serve().
     const basename = path.basename(arg);
     const isIndexHtml = basename === "index.html";
 
-    let servePath = arg.startsWith(longestCommonPath) ? arg.slice(longestCommonPath.length) : arg;
+    let servePath = arg;
+    if (servePath.startsWith(longestCommonPath)) {
+      servePath = servePath.slice(longestCommonPath.length);
+    } else {
+      const relative = path.relative(longestCommonPath, servePath);
+      if (!relative.startsWith("..")) {
+        servePath = relative;
+      }
+    }
 
     if (isIndexHtml && servePath.length === 0) {
       servePath = "/";
@@ -295,7 +303,7 @@ yourself with Bun.serve().
     process.on("SIGHUP", () => process.exit());
     process.on("SIGTERM", () => process.exit());
     process.stdin.on("data", data => {
-      const key = data.toString().toLowerCase();
+      const key = data.toString().toLowerCase().replaceAll("\r\n", "\n");
 
       switch (key) {
         case "\x03": // Ctrl+C

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -43,6 +43,10 @@ async function start() {
     }
   }
 
+  if (args.length === 0) {
+    throw new Error("No HTML files found matching " + JSON.stringify(Bun.main));
+  }
+
   // Add cwd to find longest common path
   let needsPop = false;
   if (args.length === 1) {
@@ -211,7 +215,6 @@ async function start() {
           console.log(`${prefix}/${route} → ${path.relative(process.cwd(), importPath)}`);
         }
       }
-      console.log();
     }
 
     if (isFirst && process.stdin.isTTY) {

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -92,7 +92,7 @@ test("bun ./index.html", async () => {
 
   // Start the server by running bun with the HTML file
   await using process = Bun.spawn({
-    cmd: [bunExe(), join(dir, "index.html"), "--port=0"],
+    cmd: [bunExe(), "index.html", "--port=0"],
     env: {
       ...bunEnv,
       NODE_ENV: undefined,
@@ -210,7 +210,7 @@ test("bun ./index.html ./about.html", async () => {
 
   // Start the server by running bun with multiple HTML files
   await using process = Bun.spawn({
-    cmd: [bunExe(), join(dir, "index.html"), join(dir, "about.html"), "--port=0"],
+    cmd: [bunExe(), "index.html", "about.html", "--port=0"],
     env: {
       ...bunEnv,
       NODE_ENV: undefined,

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -89,7 +89,7 @@ test("bun ./index.html", async () => {
 
   // Start the server by running bun with the HTML file
   await using process = Bun.spawn({
-    cmd: [bunExe(), join(dir, "index.html")],
+    cmd: [bunExe(), join(dir, "index.html"), "--port=0"],
     env: {
       ...bunEnv,
       NODE_ENV: undefined,
@@ -207,7 +207,7 @@ test("bun ./index.html ./about.html", async () => {
 
   // Start the server by running bun with multiple HTML files
   await using process = Bun.spawn({
-    cmd: [bunExe(), join(dir, "index.html"), join(dir, "about.html")],
+    cmd: [bunExe(), join(dir, "index.html"), join(dir, "about.html"), "--port=0"],
     env: {
       ...bunEnv,
       NODE_ENV: undefined,
@@ -402,7 +402,7 @@ test("bun *.html", async () => {
 
   // Start the server using glob pattern
   await using process = Bun.spawn({
-    cmd: [bunExe(), "*.html"],
+    cmd: [bunExe(), "*.html", "--port=0"],
     env: {
       ...bunEnv,
       NODE_ENV: undefined,

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,0 +1,474 @@
+import type { Subprocess, Server } from "bun";
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+async function getServerUrl(process: Subprocess) {
+  // Read the port number from stdout
+  const decoder = new TextDecoder();
+  let serverUrl = "";
+  let text = "";
+  for await (const chunk of process.stdout) {
+    text += decoder.decode(chunk, { stream: true });
+    if (text.includes("http://")) {
+      serverUrl = text.trim();
+      serverUrl = serverUrl.slice(serverUrl.indexOf("http://"));
+
+      serverUrl = serverUrl.slice(0, serverUrl.indexOf("\n"));
+      if (URL.canParse(serverUrl)) {
+        break;
+      }
+
+      serverUrl = serverUrl.slice(0, serverUrl.indexOf("/n"));
+      serverUrl = serverUrl.slice(0, serverUrl.lastIndexOf("/"));
+      serverUrl = serverUrl.trim();
+
+      if (URL.canParse(serverUrl)) {
+        break;
+      }
+    }
+  }
+
+  if (!serverUrl) {
+    throw new Error("Could not find server URL in stdout");
+  }
+
+  return serverUrl;
+}
+
+test("bun ./index.html", async () => {
+  const dir = tempDirWithFiles("html-entry-test", {
+    "index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>HTML Entry Test</title>
+          <link rel="stylesheet" href="styles.css">
+          <script type="module" src="app.js"></script>
+        </head>
+        <body>
+          <div class="container">
+            <h1>Hello from Bun!</h1>
+            <button id="counter">Click me: 0</button>
+          </div>
+        </body>
+      </html>
+    `,
+    "styles.css": /*css*/ `
+      .container {
+        max-width: 800px;
+        margin: 2rem auto;
+        text-align: center;
+        font-family: system-ui, sans-serif;
+      }
+
+      button {
+        padding: 0.5rem 1rem;
+        font-size: 1.25rem;
+        border-radius: 0.25rem;
+        border: 2px solid #000;
+        background: #fff;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      button:hover {
+        background: #000;
+        color: #fff;
+      }
+    `,
+    "app.js": /*js*/ `
+      const button = document.getElementById('counter');
+      let count = 0;
+      button.addEventListener('click', () => {
+        count++;
+        button.textContent = \`Click me: \${count}\`;
+      });
+    `,
+  });
+
+  // Start the server by running bun with the HTML file
+  await using process = Bun.spawn({
+    cmd: [bunExe(), join(dir, "index.html")],
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+    },
+    cwd: dir,
+    stdout: "pipe",
+  });
+
+  const serverUrl = await getServerUrl(process);
+
+  try {
+    // Make a request to the server using the detected URL
+    const response = await fetch(serverUrl);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+
+    const html = await response.text();
+
+    // Verify the HTML content
+    expect(html).toContain("<title>HTML Entry Test</title>");
+    expect(html).toContain('<div class="container">');
+
+    // The bundler should have processed the CSS and JS files and injected them
+    expect(html).toMatch(/<link rel="stylesheet" crossorigin href="\/chunk-[a-z0-9]+\.css">/);
+    expect(html).toMatch(/<script type="module" crossorigin src="\/chunk-[a-z0-9]+\.js">/);
+
+    // Get and verify the bundled CSS
+    const cssMatch = html.match(/href="(\/chunk-[a-z0-9]+\.css)"/);
+    if (cssMatch) {
+      const cssResponse = await fetch(new URL(cssMatch[1], serverUrl).href);
+      expect(cssResponse.status).toBe(200);
+      expect(cssResponse.headers.get("content-type")).toContain("text/css");
+      const css = await cssResponse.text();
+      expect(css).toContain(".container");
+      expect(css).toContain("max-width: 800px");
+    }
+
+    // Get and verify the bundled JS
+    const jsMatch = html.match(/src="(\/chunk-[a-z0-9]+\.js)"/);
+    if (jsMatch) {
+      const jsResponse = await fetch(new URL(jsMatch[1], serverUrl).href);
+      expect(jsResponse.status).toBe(200);
+      expect(jsResponse.headers.get("content-type")).toContain("javascript");
+      const js = await jsResponse.text();
+      expect(js).toContain('document.getElementById("counter")');
+      expect(js).toContain("Click me:");
+    }
+  } finally {
+    // The process will be automatically cleaned up by 'await using'
+  }
+});
+
+test("bun ./index.html ./about.html", async () => {
+  const dir = tempDirWithFiles("html-multiple-entries-test", {
+    "index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Home Page</title>
+          <link rel="stylesheet" href="styles.css">
+          <script type="module" src="home.js"></script>
+        </head>
+        <body>
+          <div class="container">
+            <h1>Welcome Home</h1>
+            <a href="/about">About</a>
+            <button id="counter">Click me: 0</button>
+          </div>
+        </body>
+      </html>
+    `,
+    "about.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>About Page</title>
+          <link rel="stylesheet" href="styles.css">
+          <script type="module" src="about.js"></script>
+        </head>
+        <body>
+          <div class="container">
+            <h1>About Us</h1>
+            <a href="/">Home</a>
+            <p id="message">This is the about page</p>
+          </div>
+        </body>
+      </html>
+    `,
+    "styles.css": /*css*/ `
+      .container {
+        max-width: 800px;
+        margin: 2rem auto;
+        text-align: center;
+        font-family: system-ui, sans-serif;
+      }
+      a {
+        display: block;
+        margin: 1rem 0;
+        color: blue;
+      }
+    `,
+    "home.js": /*js*/ `
+      const button = document.getElementById('counter');
+      let count = 0;
+      button.addEventListener('click', () => {
+        count++;
+        button.textContent = \`Click me: \${count}\`;
+      });
+    `,
+    "about.js": /*js*/ `
+      const message = document.getElementById('message');
+      message.textContent += " - Updated via JS";
+    `,
+  });
+
+  // Start the server by running bun with multiple HTML files
+  await using process = Bun.spawn({
+    cmd: [bunExe(), join(dir, "index.html"), join(dir, "about.html")],
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+    },
+    cwd: dir,
+    stdout: "pipe",
+  });
+
+  const serverUrl = await getServerUrl(process);
+
+  if (!serverUrl) {
+    throw new Error("Could not find server URL in stdout");
+  }
+
+  try {
+    // Test the home page
+
+    const homeResponse = await fetch(serverUrl);
+    expect(homeResponse.status).toBe(200);
+    expect(homeResponse.headers.get("content-type")).toContain("text/html");
+
+    const homeHtml = await homeResponse.text();
+    expect(homeHtml).toContain("<title>Home Page</title>");
+    expect(homeHtml).toContain('<a href="/about">About</a>');
+    expect(homeHtml).toMatch(/<script type="module" crossorigin src="\/chunk-[a-z0-9]+\.js">/);
+
+    // Test the about page
+    const aboutResponse = await fetch(new URL("/about", serverUrl).href);
+    expect(aboutResponse.status).toBe(200);
+    expect(aboutResponse.headers.get("content-type")).toContain("text/html");
+
+    const aboutHtml = await aboutResponse.text();
+    expect(aboutHtml).toContain("<title>About Page</title>");
+    expect(aboutHtml).toContain('<a href="/">Home</a>');
+    expect(aboutHtml).toMatch(/<script type="module" crossorigin src="\/chunk-[a-z0-9]+\.js">/);
+
+    // Verify that both pages share the same CSS bundle
+    const homeMatch = homeHtml.match(/href="(\/chunk-[a-z0-9]+\.css)"/);
+    const aboutMatch = aboutHtml.match(/href="(\/chunk-[a-z0-9]+\.css)"/);
+    expect(homeMatch?.[1], "Both pages should share the same CSS bundle").toBe(aboutMatch?.[1]!);
+
+    // Verify the CSS bundle
+    if (homeMatch) {
+      const cssResponse = await fetch(new URL(homeMatch[1], serverUrl).href);
+      expect(cssResponse.status).toBe(200);
+      const css = await cssResponse.text();
+      expect(css).toContain(".container");
+      expect(css).toContain("max-width: 800px");
+    }
+
+    // Verify both JS bundles work
+    const homeJsMatch = homeHtml.match(/src="(\/chunk-[a-z0-9]+\.js)"/);
+    if (homeJsMatch) {
+      const jsResponse = await fetch(new URL(homeJsMatch[1], serverUrl).href);
+      expect(jsResponse.status).toBe(200);
+      const js = await jsResponse.text();
+      expect(js).toContain('document.getElementById("counter")');
+    }
+
+    const aboutJsMatch = aboutHtml.match(/src="(\/chunk-[a-z0-9]+\.js)"/);
+    if (aboutJsMatch) {
+      const jsResponse = await fetch(new URL(aboutJsMatch[1], serverUrl).href);
+      expect(jsResponse.status).toBe(200);
+      const js = await jsResponse.text();
+      expect(js).toContain('document.getElementById("message")');
+    }
+  } finally {
+    // The process will be automatically cleaned up by 'await using'
+  }
+});
+
+test("bun *.html", async () => {
+  const dir = tempDirWithFiles("html-glob-test", {
+    "index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Home Page</title>
+          <link rel="stylesheet" href="shared.css">
+          <script type="module" src="home.js"></script>
+        </head>
+        <body>
+          <nav>
+            <a href="/">Home</a>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+          </nav>
+          <div class="container">
+            <h1>Welcome Home</h1>
+            <button id="counter">Click me: 0</button>
+          </div>
+        </body>
+      </html>
+    `,
+    "about.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>About Page</title>
+          <link rel="stylesheet" href="shared.css">
+          <script type="module" src="about.js"></script>
+        </head>
+        <body>
+          <nav>
+            <a href="/">Home</a>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+          </nav>
+          <div class="container">
+            <h1>About Us</h1>
+            <p id="message">This is the about page</p>
+          </div>
+        </body>
+      </html>
+    `,
+    "contact.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Contact Page</title>
+          <link rel="stylesheet" href="shared.css">
+          <script type="module" src="contact.js"></script>
+        </head>
+        <body>
+          <nav>
+            <a href="/">Home</a>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+          </nav>
+          <div class="container">
+            <h1>Contact Us</h1>
+            <form id="contact-form">
+              <input type="text" placeholder="Name" />
+              <button type="submit">Send</button>
+            </form>
+          </div>
+        </body>
+      </html>
+    `,
+    "shared.css": /*css*/ `
+      nav {
+        padding: 1rem;
+        background: #f0f0f0;
+        text-align: center;
+      }
+      nav a {
+        margin: 0 1rem;
+        color: blue;
+      }
+      .container {
+        max-width: 800px;
+        margin: 2rem auto;
+        text-align: center;
+        font-family: system-ui, sans-serif;
+      }
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        max-width: 300px;
+        margin: 0 auto;
+      }
+      input, button {
+        padding: 0.5rem;
+        font-size: 1rem;
+      }
+    `,
+    "home.js": /*js*/ `
+      const button = document.getElementById('counter');
+      let count = 0;
+      button.addEventListener('click', () => {
+        count++;
+        button.textContent = \`Click me: \${count}\`;
+      });
+    `,
+    "about.js": /*js*/ `
+      const message = document.getElementById('message');
+      message.textContent += " - Updated via JS";
+    `,
+    "contact.js": /*js*/ `
+      const form = document.getElementById('contact-form');
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const input = form.querySelector('input');
+        alert(\`Thanks for your message, \${input.value}!\`);
+        input.value = '';
+      });
+    `,
+    // Add a non-HTML file to verify it's not picked up
+    "README.md": "# Test Project\nThis file should be ignored by the glob.",
+  });
+
+  // Start the server using glob pattern
+  await using process = Bun.spawn({
+    cmd: [bunExe(), "*.html"],
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+    },
+    cwd: dir,
+    stdout: "pipe",
+  });
+  console.log({ cwd: dir });
+  const serverUrl = await getServerUrl(process);
+
+  try {
+    // Test all three pages are served
+    const pages = ["", "about", "contact"];
+    const titles = ["Home Page", "About Page", "Contact Page"];
+
+    for (const [i, route] of pages.entries()) {
+      const response = await fetch(new URL(route, serverUrl).href);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+
+      const html = await response.text();
+      expect(html).toContain(`<title>${titles[i]}</title>`);
+      expect(html).toMatch(/<script type="module" crossorigin src="\/chunk-[a-z0-9]+\.js">/);
+      expect(html).toMatch(/<link rel="stylesheet" crossorigin href="\/chunk-[a-z0-9]+\.css">/);
+
+      // Verify navigation is present on all pages
+      expect(html).toContain('<a href="/">Home</a>');
+      expect(html).toContain('<a href="/about">About</a>');
+      expect(html).toContain('<a href="/contact">Contact</a>');
+    }
+
+    // Verify all pages share the same CSS bundle (deduplication)
+    const responses = await Promise.all(pages.map(route => fetch(new URL(route, serverUrl).href).then(r => r.text())));
+
+    const cssMatches = responses.map(html => html.match(/href="(\/chunk-[a-z0-9]+\.css)"/)?.[1]);
+    expect(
+      cssMatches.every(match => match === cssMatches[0]),
+      "All pages should share the same CSS bundle",
+    ).toBe(true);
+
+    // Verify the shared CSS bundle
+    const cssResponse = await fetch(new URL(cssMatches[0]!, serverUrl).href);
+    expect(cssResponse.status).toBe(200);
+    const css = await cssResponse.text();
+    expect(css).toContain("nav {");
+    expect(css).toContain(".container {");
+    expect(css).toContain("form {");
+
+    // Verify each page has its own JS functionality
+    const jsMatches = responses.map(html => html.match(/src="(\/chunk-[a-z0-9]+\.js)"/)?.[1]!);
+
+    // Home page JS
+    const homeJs = await fetch(new URL(jsMatches[0]!, serverUrl).href).then(r => r.text());
+    expect(homeJs).toContain('document.getElementById("counter")');
+    expect(homeJs).toContain("Click me:");
+
+    // About page JS
+    const aboutJs = await fetch(new URL(jsMatches[1]!, serverUrl).href).then(r => r.text());
+    expect(aboutJs).toContain('document.getElementById("message")');
+    expect(aboutJs).toContain("Updated via JS");
+
+    // Contact page JS
+    const contactJs = await fetch(new URL(jsMatches[2]!, serverUrl).href).then(r => r.text());
+    expect(contactJs).toContain('document.getElementById("contact-form")');
+    expect(contactJs).toContain("preventDefault");
+  } finally {
+    // The process will be automatically cleaned up by 'await using'
+  }
+});

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -9,7 +9,10 @@ async function getServerUrl(process: Subprocess) {
   let serverUrl = "";
   let text = "";
   for await (const chunk of process.stdout) {
-    text += decoder.decode(chunk, { stream: true });
+    const textChunk = decoder.decode(chunk, { stream: true });
+    text += textChunk;
+    console.log(textChunk);
+
     if (text.includes("http://")) {
       serverUrl = text.trim();
       serverUrl = serverUrl.slice(serverUrl.indexOf("http://"));

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1,4 +1,4 @@
-import { Subprocess } from "bun";
+import type { Subprocess, Server } from "bun";
 import { describe, test, expect } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
@@ -96,10 +96,15 @@ test("serve html", async () => {
     `,
   });
 
-  const { subprocess, port, hostname } = await waitForServer(dir, {
+  const {
+    subprocess: subprocess1,
+    port,
+    hostname,
+  } = await waitForServer(dir, {
     "/": join(dir, "index.html"),
     "/dashboard": join(dir, "dashboard.html"),
   });
+  await using subprocess = subprocess1;
 
   {
     const html = await (await fetch(`http://${hostname}:${port}/`)).text();
@@ -310,9 +315,14 @@ export default p;
 `,
     });
 
-    const { subprocess, port, hostname } = await waitForServer(dir, {
+    const {
+      subprocess: subprocess1,
+      port,
+      hostname,
+    } = await waitForServer(dir, {
       "/": join(dir, "index.html"),
     });
+    await using subprocess = subprocess1;
     const response = await fetch(`http://${hostname}:${port}/`);
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/html;charset=utf-8");
@@ -390,9 +400,14 @@ export default p;
 `,
     });
 
-    const { subprocess, port, hostname } = await waitForServer(dir, {
+    const {
+      subprocess: subprocess1,
+      port,
+      hostname,
+    } = await waitForServer(dir, {
       "/": join(dir, "index.html"),
     });
+    await using subprocess = subprocess1;
     const response = await fetch(`http://${hostname}:${port}/`);
     expect(response.status).toBe(500);
 
@@ -439,9 +454,14 @@ export default p;
 plugins = []`,
     });
 
-    const { subprocess, port, hostname } = await waitForServer(dir, {
+    const {
+      subprocess: subprocess1,
+      port,
+      hostname,
+    } = await waitForServer(dir, {
       "/": join(dir, "index.html"),
     });
+    await using subprocess = subprocess1;
     const response = await fetch(`http://${hostname}:${port}/`);
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/html");
@@ -510,7 +530,11 @@ export default {
     });
 
     console.log("Waiting for server");
-    const { subprocess, port, hostname } = await waitForServer(dir, {
+    const {
+      subprocess: subprocess1,
+      port,
+      hostname,
+    } = await waitForServer(dir, {
       "/": join(dir, "index.html"),
       "/about": join(dir, "about.html"),
       "/contact": join(dir, "contact.html"),
@@ -523,7 +547,7 @@ export default {
       "/ooga": join(dir, "ooga.html"),
     });
     console.log("done waiting for server");
-
+    await using subprocess = subprocess1;
     // Make concurrent requests to all routes while plugins are loading
     const responses = await Promise.all([
       fetch(`http://${hostname}:${port}/`),
@@ -594,3 +618,101 @@ async function waitForServer(
   });
   return defer.promise;
 }
+
+test("serve html error handling", async () => {
+  const dir = tempDirWithFiles("bun-serve-html-error-handling", {
+    "index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Error Page</title>
+        </head>
+        <body>
+          <h1>Error Page</h1>
+          <script type="module" src="error.js"></script>
+        </body>
+      </html>
+    `,
+    "error.js": /*js*/ `
+      throw new Error("Error on purpose");
+    `,
+  });
+  async function getServers() {
+    const path = join(dir, "index.html");
+
+    const { default: html } = await import(path);
+    let servers: Server[] = [];
+    for (let i = 0; i < 10; i++) {
+      servers.push(
+        Bun.serve({
+          port: 0,
+          static: {
+            "/": html,
+          },
+          development: true,
+          fetch(req) {
+            return new Response("Not found", { status: 404 });
+          },
+        }),
+      );
+    }
+
+    delete require.cache[path];
+
+    return servers;
+  }
+
+  {
+    let servers = await getServers();
+    Bun.gc();
+    await Bun.sleep(1);
+    for (const server of servers) {
+      await server.stop(true);
+    }
+    servers = [];
+    Bun.gc();
+  }
+
+  Bun.gc(true);
+});
+
+test("wildcard static routes", async () => {
+  const dir = tempDirWithFiles("bun-serve-html-error-handling", {
+    "index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>         
+        </head>
+        <body>
+          <title>Error Page</title>
+          <h1>Error Page</h1>
+          <script type="module" src="error.js"></script>
+        </body>
+      </html>
+    `,
+    "error.js": /*js*/ `
+      throw new Error("Error on purpose");
+    `,
+  });
+  const { default: html } = await import(join(dir, "index.html"));
+  for (let development of [true, false]) {
+    using server = Bun.serve({
+      port: 0,
+      static: {
+        "/*": html,
+      },
+      development,
+      fetch(req) {
+        return new Response("Not found", { status: 404 });
+      },
+    });
+
+    for (let url of [server.url, new URL("/potato", server.url)]) {
+      const response = await fetch(url);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+      const text = await response.text();
+      expect(text).toContain("<title>Error Page</title>");
+    }
+  }
+});


### PR DESCRIPTION
### What does this PR do?

This lets you start a frontend dev server by directly running `.html` files in Bun.

```sh
> bun index.html
Bun v1.2.3 ready in 0.03 ms

➜ http://localhost:3001/

Press h + Enter to show shortcuts
```


For multi-page apps, you can pass multiple routes explicitly.
<img width="472" alt="image" src="https://github.com/user-attachments/assets/d268b3b3-411b-4e04-aed8-7124d63a9222" />

You can also pass a glob.
<img width="446" alt="image" src="https://github.com/user-attachments/assets/b7417fcc-7380-4ead-9a76-0f71bc179cde" />

If you pass only one route, that route is matched as the fallback route so that you can use this with single-page apps that do client-side routing from a single shared entry point.

### How did you verify your code works?

There are tests
