### PR TITLE
docs(guides): add `.bun-version` to GitHub actions recipe

### DIFF
--- a/docs/guides/install/cicd.md
+++ b/docs/guides/install/cicd.md
@@ -38,4 +38,30 @@ jobs:
 
 ---
 
+Alternatively, you can define the Bun version in the `.bun-version` file, which should be committed to your repository.
+
+The `setup-bun` action will read the version from the `.bun-version` file.
+
+```
+# .bun-version
+latest
+```
+
+You can customize the path of the file using the `bun-version-file` option for the `setup-bun` action.
+
+```yaml-diff#workflow.yml
+name: my-workflow
+jobs:
+  my-job:
+    name: my-job
+    runs-on: ubuntu-latest
+    steps:
+      # ...
+      - uses: oven-sh/setup-bun@v2
++       with:
++         bun-version-file: "src/.bun-version"
+```
+
+---
+
 Refer to the [README.md](https://github.com/oven-sh/setup-bun) for complete documentation of the `setup-bun` GitHub Action.


### PR DESCRIPTION
### What does this PR do?

I was unable to find documentation around `.bun-version` (which [setup-bun@v2](https://github.com/oven-sh/setup-bun) supports) using the search function on the Bun site.

This PR proposes adding a section to the existing GitHub Actions guide.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
