### PR TITLE
fix(gitattributes): add github syntax highlighting for `.mdc` files

### DIFF
--- a/.cursor/rules/javascriptcore-class.mdc
+++ b/.cursor/rules/javascriptcore-class.mdc
@@ -1,6 +1,6 @@
 ---
-description: 'JavaScript class implemented in C++'
-globs: *.cpp
+description: JavaScript class implemented in C++
+globs: '*.cpp'
 ---
 
 # Implementing JavaScript classes in C++

--- a/.cursor/rules/javascriptcore-class.mdc
+++ b/.cursor/rules/javascriptcore-class.mdc
@@ -1,5 +1,5 @@
 ---
-description: JavaScript class implemented in C++
+description: 'JavaScript class implemented in C++'
 globs: *.cpp
 ---
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,8 @@
 *.json text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.lock text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.map text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.md text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.mdc text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.md text linguist-documentation eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.mdc text linguist-documentation linguist-language=markdown eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mjs text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mts text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 


### PR DESCRIPTION
### What does this PR do?

Add github syntax highlighting for `.mdc` files
