### PR TITLE
Fix test-fs-promises-writefile.js on windows

### DIFF
--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { tmpdirSync } from "harness";
 import { join } from "path";
+import fsPromises from "fs/promises";
 
 test("delete() and stat() should work with unicode paths", async () => {
   const testDir = tmpdirSync();
@@ -20,4 +21,18 @@ test("delete() and stat() should work with unicode paths", async () => {
   expect(await Bun.file(filename).delete()).toBe(undefined);
 
   expect(await Bun.file(filename).exists()).toBe(false);
+});
+
+test("writer.end() should not close the fd if it does not own the fd", async () => {
+  const testDir = tmpdirSync();
+  for (let i = 0; i < 30; i++) {
+    const fileHandle = await fsPromises.open(testDir + "/tmp.txt", "w", 0o666);
+    const fd = fileHandle.fd;
+
+    await Bun.file(fd).writer().end();
+    // @ts-ignore
+    await fsPromises.close(fd);
+    expect(await Bun.file(testDir + "/tmp.txt").text()).toBe("");
+    await Bun.sleep(50);
+  }
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky test failure of `test-fs-promises-writefile.js` on windows