### PR TITLE
fix `bunx` on windows with postinstall scripts

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1636,12 +1636,10 @@ pub const Command = struct {
             // if we are bunx, but NOT a symlink to bun. when we run `<self> install`, we dont
             // want to recursively run bunx. so this check lets us peek back into bun install.
             if (args_iter.next()) |next| {
-                if (bun.getRuntimeFeatureFlag("BUN_INTERNAL_BUNX_INSTALL")) {
-                    if (bun.strings.eqlComptime(next, "add")) {
-                        return .AddCommand;
-                    } else if (bun.strings.eqlComptime(next, "exec")) {
-                        return .ExecCommand;
-                    }
+                if (bun.strings.eqlComptime(next, "add") and bun.getRuntimeFeatureFlag("BUN_INTERNAL_BUNX_INSTALL")) {
+                    return .AddCommand;
+                } else if (bun.strings.eqlComptime(next, "exec") and bun.getRuntimeFeatureFlag("BUN_INTERNAL_BUNX_INSTALL")) {
+                    return .ExecCommand;
                 }
             }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1636,10 +1636,12 @@ pub const Command = struct {
             // if we are bunx, but NOT a symlink to bun. when we run `<self> install`, we dont
             // want to recursively run bunx. so this check lets us peek back into bun install.
             if (args_iter.next()) |next| {
-                if (bun.strings.eqlComptime(next, "add") and
-                    bun.getenvZ("BUN_INTERNAL_BUNX_INSTALL") != null)
-                {
-                    return .AddCommand;
+                if (bun.getRuntimeFeatureFlag("BUN_INTERNAL_BUNX_INSTALL")) {
+                    if (bun.strings.eqlComptime(next, "add")) {
+                        return .AddCommand;
+                    } else if (bun.strings.eqlComptime(next, "exec")) {
+                        return .ExecCommand;
+                    }
                 }
             }
 

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -713,9 +713,9 @@ pub const BunxCommand = struct {
             .stdout = .inherit,
             .stdin = .inherit,
 
-            .windows = if (Environment.isWindows) .{
-                .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(this_transpiler.env)),
-            },
+            // .windows = if (Environment.isWindows) .{
+            //     .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(this_transpiler.env)),
+            // },
         }) catch |err| {
             Output.prettyErrorln("<r><red>error<r>: bunx failed to install <b>{s}<r> due to error <b>{s}<r>", .{ install_param, @errorName(err) });
             Global.exit(1);

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -713,9 +713,9 @@ pub const BunxCommand = struct {
             .stdout = .inherit,
             .stdin = .inherit,
 
-            // .windows = if (Environment.isWindows) .{
-            //     .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(this_transpiler.env)),
-            // },
+            .windows = if (Environment.isWindows) .{
+                .loop = bun.JSC.EventLoopHandle.init(bun.JSC.MiniEventLoop.initGlobal(this_transpiler.env)),
+            },
         }) catch |err| {
             Output.prettyErrorln("<r><red>error<r>: bunx failed to install <b>{s}<r> due to error <b>{s}<r>", .{ install_param, @errorName(err) });
             Global.exit(1);

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { describe, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
 import { rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, tmpdirSync, readdirSorted } from "harness";
-import { readdirSync } from "node:fs";
+import { readdirSync, copyFileSync } from "node:fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
 
@@ -421,9 +421,7 @@ describe("bunx --no-install", () => {
   it("if the package is not installed, it should fail and print an error message", async () => {
     const [err, out, exited] = await run("--no-install", "http-server", "--version");
 
-    expect(err.trim()).toContain(
-      "Could not find an existing 'http-server' binary to run.",
-    );
+    expect(err.trim()).toContain("Could not find an existing 'http-server' binary to run.");
     expect(out).toHaveLength(0);
     expect(exited).toBe(1);
   });
@@ -469,4 +467,30 @@ describe("bunx --no-install", () => {
       expect(code).toBe(0);
     }
   });
+});
+
+it("should handle postinstall scripts correctly with symlinked bunx", async () => {
+  // Create a symlink to bun called "bunx"
+  const bunxPath = join(x_dir, "bunx" + (isWindows ? ".exe" : ""));
+  copyFileSync(bunExe(), bunxPath);
+
+  const subprocess = spawn({
+    cmd: ["bunx", "esbuild@latest", "--version"],
+    cwd: x_dir,
+    stdout: "pipe",
+    stdin: "inherit",
+    stderr: "pipe",
+    env: env,
+  });
+
+  let [err, out, exited] = await Promise.all([
+    new Response(subprocess.stderr).text(),
+    new Response(subprocess.stdout).text(),
+    subprocess.exited,
+  ]);
+
+  expect(err).not.toContain("error:");
+  expect(err).not.toContain("Cannot find module 'exec'");
+  expect(out.trim()).not.toContain(Bun.version);
+  expect(exited).toBe(0);
 });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -471,7 +471,7 @@ describe("bunx --no-install", () => {
 
 it("should handle postinstall scripts correctly with symlinked bunx", async () => {
   // Create a symlink to bun called "bunx"
-  const bunxPath = join(x_dir, "bunx" + (isWindows ? ".exe" : ""));
+  const bunxPath = join(x_dir, isWindows ? "bunx.exe" : "bunx");
   copyFileSync(bunExe(), bunxPath);
 
   const subprocess = spawn({
@@ -480,7 +480,10 @@ it("should handle postinstall scripts correctly with symlinked bunx", async () =
     stdout: "pipe",
     stdin: "inherit",
     stderr: "pipe",
-    env: env,
+    env: {
+      ...env,
+      PATH: `${x_dir}${isWindows ? ";" : ":"}${env.PATH || ""}`,
+    },
   });
 
   let [err, out, exited] = await Promise.all([

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -471,8 +471,8 @@ describe("bunx --no-install", () => {
 
 it("should handle postinstall scripts correctly with symlinked bunx", async () => {
   // Create a symlink to bun called "bunx"
-  const bunxPath = join(x_dir, isWindows ? "bunx.exe" : "bunx");
-  copyFileSync(bunExe(), bunxPath);
+  copyFileSync(bunExe(), join(x_dir, isWindows ? "bun.exe" : "bun"));
+  copyFileSync(bunExe(), join(x_dir, isWindows ? "bunx.exe" : "bunx"));
 
   const subprocess = spawn({
     cmd: ["bunx", "esbuild@latest", "--version"],


### PR DESCRIPTION
fixes #9841
<sub>fixes #15783, fixes #15562, fixes #14848, fixes #12336, fixes #10068<sub>

context behind change is it runs `<current-exe> exec` on windows which would be `bunx exec` but as that subcommand wasn't resolvable it just tried to run `exec` as a package:

https://github.com/oven-sh/bun/blob/1ccc13ecf79861eb0b5a697c0b5571772d42a28d/src/install/lifecycle_script_runner.zig#L166-L176

---

will try to add tests which fail without this