### PR TITLE
Support fs.stat, fs.existsSync, fs.readFile, fs.promises.stat, fs.promises.readFile in `bun build --compile`

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -81,14 +81,8 @@ pub const StandaloneModuleGraph = struct {
     pub fn findAssumeStandalonePath(this: *const StandaloneModuleGraph, name: []const u8) ?*File {
         if (Environment.isWindows) {
             var normalized_buf: bun.PathBuffer = undefined;
-            var input = name;
-            if (strings.hasPrefixComptime(input, bun.windows.nt_object_prefix_u8)) {
-                input = input[bun.windows.nt_object_prefix_u8.len..];
-            } else if (strings.hasPrefixComptime(input, bun.windows.long_path_prefix_u8)) {
-                input = input[bun.windows.long_path_prefix_u8.len..];
-            }
-
-            const normalized = bun.path.platformToPosixBuf(u8, name, &normalized_buf);
+            const input = strings.withoutNTPrefix(u8, name);
+            const normalized = bun.path.platformToPosixBuf(u8, input, &normalized_buf);
             return this.files.getPtr(normalized);
         }
         return this.files.getPtr(name);

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -51,6 +51,7 @@ pub const Run = struct {
 
         const graph_ptr = try bun.default_allocator.create(bun.StandaloneModuleGraph);
         graph_ptr.* = graph;
+        graph_ptr.set();
 
         js_ast.Expr.Data.Store.create();
         js_ast.Stmt.Data.Store.create();

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -4,7 +4,7 @@ import { rmSync } from "fs";
 import { itBundled } from "./expectBundled";
 import { isFlaky, isWindows } from "harness";
 
-describe.todoIf(isFlaky && isWindows)("bundler", () => {
+describe("bundler", () => {
   itBundled("compile/HelloWorld", {
     compile: true,
     files: {
@@ -440,6 +440,10 @@ describe.todoIf(isFlaky && isWindows)("bundler", () => {
         fs.readFileSync(big).toString("hex");
         await Bun.file(big).arrayBuffer();
         fs.readFileSync(small).toString("hex");
+        if ((await fs.promises.readFile(small)).length !== 31) throw "fail readFile";
+        if (fs.statSync(small).size !== 31) throw "fail statSync";
+        if (fs.statSync(big).size !== (4096 + (32 - 2))) throw "fail statSync";
+        if (((await fs.promises.stat(big)).size) !== (4096 + (32 - 2))) throw "fail stat";
         await Bun.file(small).arrayBuffer();
         console.log("PASS");
       `,


### PR DESCRIPTION
### What does this PR do?

Previously, only the sync version of node:fs `readFile` was supported for embedded files. now:
- `fs.promises.readFile`
- `fs.stat`
- `fs.promises.stat`
- `fs.statSync`
- `fs.existsSync`
- `fs.readFile`

This also fixes #17082, which was caused by using namespaced paths.



### How did you verify your code works?

Updated tests.