### PR TITLE
test: bump pglite version

### DIFF
--- a/test/bun.lock
+++ b/test/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@azure/service-bus": "7.9.4",
         "@duckdb/node-api": "1.1.3-alpha.7",
-        "@electric-sql/pglite": "0.2.15",
+        "@electric-sql/pglite": "0.2.16",
         "@grpc/grpc-js": "1.12.0",
         "@grpc/proto-loader": "0.7.10",
         "@napi-rs/canvas": "0.1.65",
@@ -156,7 +156,7 @@
 
     "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.1.3-alpha.7", "", { "os": "win32", "cpu": "x64" }, "sha512-5OqjpYRFdQATbniL0o8gF8Z92bBuINlXOve0o+qgM6W+nlIRp/cUHk6vWwYySZnF0AIHZ5JG7mngzJOLmA/kPQ=="],
 
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.2.15", "", {}, "sha512-Jiq31Dnk+rg8rMhcSxs4lQvHTyizNo5b269c1gCC3ldQ0sCLrNVPGzy+KnmonKy1ZArTUuXZf23/UamzFMKVaA=="],
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.2.16", "", {}, "sha512-dCSHpoOKuTxecaYhWDRp2yFTN3XWcMPMrBVl5yOR8VZEUprz4+R3iuU7BipmlsqBnBDO/6l9H/C2ZwJdunkWyw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@0.44.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ZX/etZEZw8DR7zAB1eVQT40lNo0jeqpb6dCgOvctB6FIQ5PoXfMuNY8+ayQfu8tNQbAB8gQWSSJupR8NxeiZXw=="],
 

--- a/test/js/third_party/@electric-sql/pglite/pglite.test.ts
+++ b/test/js/third_party/@electric-sql/pglite/pglite.test.ts
@@ -9,7 +9,7 @@ describe("pglite", () => {
           version:
             // since pglite is wasm, there is only one binary for all platforms. it always thinks it
             // is x86_64-pc-linux-gnu.
-            "PostgreSQL 16.4 on x86_64-pc-linux-gnu, compiled by emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.72 (437140d149d9c977ffc8b09dbaf9b0f5a02db190), 32-bit",
+            "PostgreSQL 16.4 on x86_64-pc-linux-gnu, compiled by emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.74 (1092ec30a3fb1d46b1782ff1b4db5094d3d06ae5), 32-bit",
         },
       ],
       fields: [{ name: "version", dataTypeID: 25 }],

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@azure/service-bus": "7.9.4",
     "@duckdb/node-api": "1.1.3-alpha.7",
-    "@electric-sql/pglite": "0.2.15",
+    "@electric-sql/pglite": "0.2.16",
     "@grpc/grpc-js": "1.12.0",
     "@grpc/proto-loader": "0.7.10",
     "@napi-rs/canvas": "0.1.65",


### PR DESCRIPTION
### What does this PR do?

Bumps the version of PGlite we test from 0.2.15 to 0.2.16. This test was introduced in #16188 because older versions of the IPInt Wasm interpreter had errors with PGlite ("Out of bounds memory access"). But it turns out 0.2.15 had another issue ("Out of bounds call_indirect") that affects (at least on macOS aarch64) all versions of Bun I've tried, regardless of the Wasm backend used (more discussion at electric-sql/pglite#486).

I'm still investigating why this test had not been failing in CI.

### How did you verify your code works?

Ran the new PGlite test.
