### PR TITLE
fix(sql) types

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2009,35 +2009,51 @@ declare module "bun" {
    */
   type SQLOptions = {
     /** Connection URL (can be string or URL object) */
-    url: URL | string;
+    url?: URL | string;
     /** Database server hostname */
-    host: string;
+    host?: string;
+    /** Database server hostname (alias for host) */
+    hostname?: string;
     /** Database server port number */
-    port: number | string;
+    port?: number | string;
     /** Database user for authentication */
-    username: string;
+    username?: string;
+    /** Database user for authentication (alias for username) */
+    user?: string;
     /** Database password for authentication */
-    password: string;
+    password?: string;
+    /** Database password for authentication (alias for password) */
+    pass?: string;
     /** Name of the database to connect to */
-    database: string;
+    database?: string;
+    /** Name of the database to connect to (alias for database) */
+    db?: string;
     /** Database adapter/driver to use */
-    adapter: string;
-    /** Maximum time in milliseconds to wait for connection to become available */
-    idleTimeout: number;
-    /** Maximum time in milliseconds to wait when establishing a connection */
-    connectionTimeout: number;
-    /** Maximum lifetime in milliseconds of a connection */
-    maxLifetime: number;
+    adapter?: string;
+    /** Maximum time in seconds to wait for connection to become available */
+    idleTimeout?: number;
+    /** Maximum time in seconds to wait for connection to become available (alias for idleTimeout) */
+    idle_timeout?: number;
+    /** Maximum time in seconds to wait when establishing a connection */
+    connectionTimeout?: number;
+    /** Maximum time in seconds to wait when establishing a connection (alias for connectionTimeout) */
+    connection_timeout?: number;
+    /** Maximum lifetime in seconds of a connection */
+    maxLifetime?: number;
+    /** Maximum lifetime in seconds of a connection (alias for maxLifetime) */
+    max_lifetime?: number;
     /** Whether to use TLS/SSL for the connection */
-    tls: boolean;
+    tls?: TLSOptions | boolean;
+    /** Whether to use TLS/SSL for the connection (alias for tls) */
+    ssl?: TLSOptions | boolean;
     /** Callback function executed when a connection is established */
-    onconnect: (client: SQL) => void;
+    onconnect?: (client: SQL) => void;
     /** Callback function executed when a connection is closed */
-    onclose: (client: SQL) => void;
+    onclose?: (client: SQL) => void;
     /** Maximum number of connections in the pool */
-    max: number;
+    max?: number;
     /** By default values outside i32 range are returned as strings. If this is true, values outside i32 range are returned as BigInts. */
-    bigint: boolean;
+    bigint?: boolean;
   };
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2018,12 +2018,8 @@ declare module "bun" {
     username?: string;
     /** Database password for authentication */
     password?: string;
-    /** Database password for authentication (alias for password) */
-    pass?: string;
     /** Name of the database to connect to */
     database?: string;
-    /** Name of the database to connect to (alias for database) */
-    db?: string;
     /** Database adapter/driver to use */
     adapter?: string;
     /** Maximum time in seconds to wait for connection to become available */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2012,14 +2012,10 @@ declare module "bun" {
     url?: URL | string;
     /** Database server hostname */
     host?: string;
-    /** Database server hostname (alias for host) */
-    hostname?: string;
     /** Database server port number */
     port?: number | string;
     /** Database user for authentication */
     username?: string;
-    /** Database user for authentication (alias for username) */
-    user?: string;
     /** Database password for authentication */
     password?: string;
     /** Database password for authentication (alias for password) */
@@ -2032,20 +2028,12 @@ declare module "bun" {
     adapter?: string;
     /** Maximum time in seconds to wait for connection to become available */
     idleTimeout?: number;
-    /** Maximum time in seconds to wait for connection to become available (alias for idleTimeout) */
-    idle_timeout?: number;
     /** Maximum time in seconds to wait when establishing a connection */
     connectionTimeout?: number;
-    /** Maximum time in seconds to wait when establishing a connection (alias for connectionTimeout) */
-    connection_timeout?: number;
     /** Maximum lifetime in seconds of a connection */
     maxLifetime?: number;
-    /** Maximum lifetime in seconds of a connection (alias for maxLifetime) */
-    max_lifetime?: number;
     /** Whether to use TLS/SSL for the connection */
     tls?: TLSOptions | boolean;
-    /** Whether to use TLS/SSL for the connection (alias for tls) */
-    ssl?: TLSOptions | boolean;
     /** Callback function executed when a connection is established */
     onconnect?: (client: SQL) => void;
     /** Callback function executed when a connection is closed */


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/16724
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
