### PR TITLE
 Move GC signal configuration to run earlier

### DIFF
--- a/misctools/lldb/lldb_commands
+++ b/misctools/lldb/lldb_commands
@@ -1,4 +1,12 @@
-process handle -p true -s false -n false SIGUSR1
+# Tell LLDB what to do when the debugged process receives SIGPWR:
+# pass it through to the process (-p), but do not stop the process (-s)
+# or notify the user (-n).
+#
+# JSC's garbage collector sends this signal (as configured by Bun at
+# main.zig:71) to the JS thread to suspend or resume it. So stopping
+# the process would just create noise when debugging any
+# long-running script.
+process handle -p true -s false -n false SIGPWR
 
 command script import misctools/lldb/lldb_pretty_printers.py
 type category enable zig.lang

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -162,7 +162,6 @@
 #include "JSS3File.h"
 #include "S3Error.h"
 #include "ProcessBindingBuffer.h"
-#include <JavaScriptCore/JSBasePrivate.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JavaScriptCore/RemoteInspectorServer.h"
@@ -239,22 +238,6 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         return;
     has_loaded_jsc = true;
     JSC::Config::enableRestrictedOptions();
-#if OS(LINUX)
-    {
-        // By default, JavaScriptCore's garbage collector sends SIGUSR1 to the JS thread to suspend
-        // and resume it in order to scan its stack memory. Whatever signal it uses can't be
-        // reliably intercepted by JS code, and several npm packages use SIGUSR1 for various
-        // features. We tell it to use SIGPWR instead, which we assume is unlikely to be reliable
-        // for its stated purpose. Mono's garbage collector also uses SIGPWR:
-        // https://www.mono-project.com/docs/advanced/embedding/#signal-handling
-        //
-        // This call needs to be before most of the other JSC initialization, as we can't
-        // reconfigure which signal is used once the signal handler has already been registered.
-        bool configure_signal_success = JSConfigureSignalForGC(SIGPWR);
-        ASSERT(configure_signal_success);
-        ASSERT(g_wtfConfig.sigThreadSuspendResume == SIGPWR);
-    }
-#endif
 
     std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
     WTF::initializeMainThread();

--- a/src/main.zig
+++ b/src/main.zig
@@ -69,7 +69,9 @@ pub fn main() void {
         // This call needs to be before any of the other JSC initialization, as we can't
         // reconfigure which signal is used once the signal handler has already been registered.
         const configure_signal_success = JSConfigureSignalForGC(std.posix.SIG.PWR);
-        bun.assert(configure_signal_success);
+        if (!configure_signal_success) {
+            Output.panic("Failed to configure signal for GC thread", .{});
+        }
     }
     bun.CLI.Cli.start(bun.default_allocator);
     bun.Global.exit(0);


### PR DESCRIPTION
### What does this PR do?

In #16865 we told JSC to use SIGPWR instead of SIGUSR1 to suspend/resume threads for garbage collection. This is because whatever signal it uses can't be relied on by JS code, and we don't want to break any libraries that use SIGUSR1. But the place where we ran that configuration was too late, and it would sometimes fail to reconfigure the signal because JSC had already been initialized by that point (so it would still use SIGUSR1). The case I discovered was `bun test --test-name-pattern`, because this creates a regex for the test filter, using JSC's regex implementation, and this regex is made before `JSCInitialize` had a chance to run. Now we run this configuration in `main()`, which should be early enough.

I also changed `lldb_commands` to use the right signal to make debugging on Linux more pleasant (see comment in that file).

### How did you verify your code works?

Tried using test filters and running the `14982.test.ts` that would hang before we initially fixed the signal issue.