### PR TITLE
`bun pm pack` support `"files"` starting with `./`

### DIFF
--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2129,6 +2129,12 @@ pub const PackCommand = struct {
                     @"has leading **/, (could start with '!')" = true;
                 }
 
+                // `./foo` matches the same as `foo`
+                if (strings.hasPrefixComptime(remain, "./")) {
+                    remain = remain["./".len..];
+                    if (remain.len == 0) return null;
+                }
+
                 const trailing_slash = remain[remain.len - 1] == '/';
                 if (trailing_slash) {
                     // trim trailing slash

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1361,7 +1361,7 @@ pub const PackCommand = struct {
                         while (files_array.next()) |files_entry| {
                             if (files_entry.asString(ctx.allocator)) |file_entry_str| {
                                 const normalized = bun.path.normalizeBuf(file_entry_str, &path_buf, .posix);
-                                const parsed = try Pattern.fromUTF8(ctx.allocator, try ctx.allocator.dupe(u8, normalized)) orelse continue;
+                                const parsed = try Pattern.fromUTF8(ctx.allocator, normalized) orelse continue;
                                 try includes.append(ctx.allocator, parsed);
                                 continue;
                             }

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1356,10 +1356,10 @@ pub const PackCommand = struct {
                         var includes: std.ArrayListUnmanaged(Pattern) = .{};
                         defer includes.deinit(ctx.allocator);
 
+                        var path_buf: PathBuffer = undefined;
                         var files_array = _files_array;
                         while (files_array.next()) |files_entry| {
                             if (files_entry.asString(ctx.allocator)) |file_entry_str| {
-                                var path_buf: PathBuffer = undefined;
                                 const normalized = bun.path.normalizeBuf(file_entry_str, &path_buf, .posix);
                                 const parsed = try Pattern.fromUTF8(ctx.allocator, try ctx.allocator.dupe(u8, normalized)) orelse continue;
                                 try includes.append(ctx.allocator, parsed);

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -943,12 +943,13 @@ describe("files", () => {
         JSON.stringify({
           name: "pack-files-3",
           version: "1.2.3",
-          files: ["./dist", "!./subdir", "!./dist/index.js"],
+          files: ["./dist", "!./subdir", "!./dist/index.js", "./////src//index.ts"],
         }),
       ),
       write(join(packageDir, "dist", "index.js"), "console.log('hello ./dist/index.js')"),
       write(join(packageDir, "subdir", "index.js"), "console.log('hello ./subdir/index.js')"),
       write(join(packageDir, "src", "dist", "index.js"), "console.log('hello ./src/dist/index.js')"),
+      write(join(packageDir, "src", "index.ts"), "console.log('hello ./src/index.ts')"),
     ]);
 
     await pack(packageDir, bunEnv);
@@ -956,6 +957,7 @@ describe("files", () => {
     expect(tarball.entries).toMatchObject([
       { "pathname": "package/package.json" },
       { "pathname": "package/dist/index.js" },
+      { "pathname": "package/src/index.ts" },
     ]);
   });
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -921,7 +921,7 @@ describe("files", () => {
       write(
         join(packageDir, "package.json"),
         JSON.stringify({
-          name: "pack-files-3",
+          name: "pack-files-2",
           version: "1.2.3",
           files: ["index.js"],
         }),
@@ -932,8 +932,26 @@ describe("files", () => {
     ]);
 
     await pack(packageDir, bunEnv);
-    const tarball = readTarball(join(packageDir, "pack-files-3-1.2.3.tgz"));
+    const tarball = readTarball(join(packageDir, "pack-files-2-1.2.3.tgz"));
     expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }, { "pathname": "package/index.js" }]);
+  });
+
+  test("matches './' as the root", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-files-3",
+          version: "1.2.3",
+          files: ["./dist"],
+        }),
+      ),
+      write(join(packageDir, "dist", "index.js"), "console.log('hello ./dist/index.js')"),
+    ]);
+
+    await pack(packageDir, bunEnv);
+    const tarball = readTarball(join(packageDir, "pack-files-3-1.2.3.tgz"));
+    expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }, { "pathname": "package/dist/index.js" }]);
   });
 
   test("recursive only if leading **/", async () => {
@@ -941,7 +959,7 @@ describe("files", () => {
       write(
         join(packageDir, "package.json"),
         JSON.stringify({
-          name: "pack-files-2",
+          name: "pack-files-4",
           version: "1.2.123",
           files: ["**/index.js"],
         }),
@@ -953,7 +971,7 @@ describe("files", () => {
     ]);
 
     await pack(packageDir, bunEnv);
-    const tarball = readTarball(join(packageDir, "pack-files-2-1.2.123.tgz"));
+    const tarball = readTarball(join(packageDir, "pack-files-4-1.2.123.tgz"));
     expect(tarball.entries).toMatchObject([
       { "pathname": "package/package.json" },
       { "pathname": "package/index.js" },

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -943,15 +943,20 @@ describe("files", () => {
         JSON.stringify({
           name: "pack-files-3",
           version: "1.2.3",
-          files: ["./dist"],
+          files: ["./dist", "!./subdir", "!./dist/index.js"],
         }),
       ),
       write(join(packageDir, "dist", "index.js"), "console.log('hello ./dist/index.js')"),
+      write(join(packageDir, "subdir", "index.js"), "console.log('hello ./subdir/index.js')"),
+      write(join(packageDir, "src", "dist", "index.js"), "console.log('hello ./src/dist/index.js')"),
     ]);
 
     await pack(packageDir, bunEnv);
     const tarball = readTarball(join(packageDir, "pack-files-3-1.2.3.tgz"));
-    expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }, { "pathname": "package/dist/index.js" }]);
+    expect(tarball.entries).toMatchObject([
+      { "pathname": "package/package.json" },
+      { "pathname": "package/dist/index.js" },
+    ]);
   });
 
   test("recursive only if leading **/", async () => {


### PR DESCRIPTION
### What does this PR do?

fixes #17134

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

made a test + tested with `npm` for intended outcomes
* note that `!./` actually doesn't do anything on npm