### PR TITLE
Enable lto in zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -86,7 +86,6 @@ const BunBuildOptions = struct {
             b.build_root.path.?,
             this.codegen_path,
         }) catch @panic("OOM"));
-        opts.addOption(bool, "lto", this.lto);
 
         opts.addOption(bool, "codegen_embed", this.shouldEmbedCode());
         opts.addOption(u32, "canary_revision", this.canary_revision orelse 0);
@@ -239,6 +238,8 @@ pub fn build(b: *Build) !void {
             b.option([]const u8, "reported_nodejs_version", "Reported Node.js version") orelse
                 "0.0.0-unset",
         ),
+
+        .lto = b.option(bool, "lto", "Enable LTO") orelse false,
 
         .sha = sha: {
             const sha_buildoption = b.option([]const u8, "sha", "Force the git sha");

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -546,8 +546,9 @@ if(NOT "${REVISION}" STREQUAL "")
 endif()
 
 if(ENABLE_LTO)
-  set(ZIG_FLAGS_BUN ${ZIG_FLAGS_BUN} -flto)
+  set(ZIG_FLAGS_BUN ${ZIG_FLAGS_BUN} -Dlto=true)
 endif()
+
 
 register_command(
   TARGET

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -545,6 +545,10 @@ if(NOT "${REVISION}" STREQUAL "")
   set(ZIG_FLAGS_BUN ${ZIG_FLAGS_BUN} -Dsha=${REVISION})
 endif()
 
+if(ENABLE_LTO)
+  set(ZIG_FLAGS_BUN ${ZIG_FLAGS_BUN} -flto)
+endif()
+
 register_command(
   TARGET
     bun-zig


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
