### PR TITLE
fix: bash completion script

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -43,22 +43,13 @@ _read_scripts_in_package_json() {
 
     [[ "${package_json}" =~ "\"scripts\""[[:space:]]*":"[[:space:]]*\{(.*)\} ]] && {
         local package_json_compreply;
-        local matched="${BASH_REMATCH[@]:1}";
-        local scripts="${matched%%\}*}";
-        scripts="${scripts//@(\"|\')/}";
-        readarray -td, scripts <<<"${scripts}";
-        for completion in "${scripts[@]}"; do
-            package_json_compreply+=( "${completion%:*}" );
-        done
+        readarray -t package_json_compreply < <(bun -e 'import("package.json").then(p=>Object.keys(p.scripts).forEach(k=>console.log(k)))')
         COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
     }
 
     # when a script is passed as an option, do not show other scripts as part of the completion anymore
     local re_prev_script="(^| )${prev}($| )";
-    [[
-        ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
-    ]] && {
+    [[ "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ]] && {
         local re_script=$(echo ${package_json_compreply[@]} | sed 's/[^ ]*/(&)/g');
         local new_reply=$(echo "${COMPREPLY[@]}" | sed -E "s/$re_script//");
         COMPREPLY=( $(compgen -W "${new_reply}" -- "${cur_word}") );

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -43,7 +43,7 @@ _read_scripts_in_package_json() {
 
     [[ "${package_json}" =~ "\"scripts\""[[:space:]]*":"[[:space:]]*\{(.*)\} ]] && {
         local package_json_compreply;
-        readarray -t package_json_compreply < <(bun -e 'import("package.json").then(p=>Object.keys(p.scripts).forEach(k=>console.log(k)))')
+        readarray -t package_json_compreply < <(bun -e 'import("./package.json").then(p=>Object.keys(p.scripts).forEach(k=>console.log(k)))')
         COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
     }
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -149,7 +149,6 @@ _bun_completions() {
                 "${GLOBAL_OPTIONS[*]}" \
                 "${GLOBAL_OPTIONS[SHORT_OPTIONS]}"
 
-            _read_scripts_in_package_json;
             _subcommand_comp_reply "${cur_word}" "${SUBCOMMANDS}";
 
             # determine if completion should be continued

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -39,13 +39,7 @@ _read_scripts_in_package_json() {
         [[ "${COMP_WORDS[${line}]}" == "--cwd" ]] && working_dir="${COMP_WORDS[$((line + 1))]}";
     done
 
-    [[ -f "${working_dir}/package.json" ]] && package_json=$(<"${working_dir}/package.json");
-
-    [[ "${package_json}" =~ "\"scripts\""[[:space:]]*":"[[:space:]]*\{(.*)\} ]] && {
-        local package_json_compreply;
-        readarray -t package_json_compreply < <(bun -e 'import("./package.json").then(p=>Object.keys(p.scripts).forEach(k=>console.log(k)))')
-        COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
-    }
+    COMPREPLY+=( $(compgen -W "$(bun getcompletes s)" -- "${cur_word}") );
 
     # when a script is passed as an option, do not show other scripts as part of the completion anymore
     local re_prev_script="(^| )${prev}($| )";


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

https://github.com/oven-sh/bun/issues/6037

Fixed the bash completion script to complete scripts in package.json.

- `local scripts="${matched%%\}*}";` didn't work if scripts contained `}` characters.
- Since `re_comp_word_script` was not defined, the condition `( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )` was always true and completions for scripts were removed.

---

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

package.json
![image](https://github.com/user-attachments/assets/3531100a-60e6-43ff-b681-2075971053c9)

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/00ad9f39-a195-4e23-90c4-b1a781834447) | ![image](https://github.com/user-attachments/assets/5d9d6ec8-266c-4b91-9123-ba910c626fb4) |
| ![image](https://github.com/user-attachments/assets/3855ce2d-707a-4523-9af0-cce602ca4a25) | ![image](https://github.com/user-attachments/assets/9769dba3-fa19-4547-bf45-ab3a51a55036) |

