### PR TITLE
docs(shell): fix incorrect output on "awaiting" example

### DIFF
--- a/docs/runtime/shell.md
+++ b/docs/runtime/shell.md
@@ -56,9 +56,9 @@ By default, `await`ing will return stdout and stderr as `Buffer`s.
 ```js
 import { $ } from "bun";
 
-const { stdout, stderr } = await $`echo "Hello World!"`.quiet();
+const { stdout, stderr } = await $`echo "Hello!"`.quiet();
 
-console.log(stdout); // Buffer(6) [ 72, 101, 108, 108, 111, 32 ]
+console.log(stdout); // Buffer(7) [ 72, 101, 108, 108, 111, 33, 10 ]
 console.log(stderr); // Buffer(0) []
 ```
 


### PR DESCRIPTION
### Fix "awaiting" example on bun shell docs

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

The `stdout` buffer log was not matching the string of the example. This is fixed by adjusting the message and de log output.