### PR TITLE
fix(sql) decode options from URI properly

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1058,10 +1058,9 @@ class SQLArrayParameter {
   }
 }
 
-function getDBFromURL(url) {
-  const name = (url?.pathname ?? "").slice(1);
-  if (name) {
-    return decodeURIComponent(name);
+function decodeIfValid(value) {
+  if (value) {
+    return decodeURIComponent(value);
   }
   return null;
 }
@@ -1123,8 +1122,8 @@ function loadOptions(o) {
     // object overrides url
     hostname ||= url.hostname;
     port ||= url.port;
-    username ||= url.username;
-    password ||= url.password;
+    username ||= decodeIfValid(url.username);
+    password ||= decodeIfValid(url.password);
     adapter ||= url.protocol;
 
     if (adapter[adapter.length - 1] === ":") {
@@ -1141,18 +1140,11 @@ function loadOptions(o) {
       }
     }
     query = query.trim();
-    // handle special characters in username, password, and database
-    if (username) {
-      username = decodeURIComponent(username);
-    }
-    if (password) {
-      password = decodeURIComponent(password);
-    }
   }
   hostname ||= o.hostname || o.host || env.PGHOST || "localhost";
   port ||= Number(o.port || env.PGPORT || 5432);
   username ||= o.username || o.user || env.PGUSERNAME || env.PGUSER || env.USER || env.USERNAME || "postgres";
-  database ||= o.database || o.db || getDBFromURL(url) || env.PGDATABASE || username;
+  database ||= o.database || o.db || decodeIfValid((url?.pathname ?? "").slice(1)) || env.PGDATABASE || username;
   password ||= o.password || o.pass || env.PGPASSWORD || "";
 
   tls ||= o.tls || o.ssl;

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1058,6 +1058,13 @@ class SQLArrayParameter {
   }
 }
 
+function getDBFromURL(url) {
+  const name = (url?.pathname ?? "").slice(1);
+  if (name) {
+    return decodeURIComponent(name);
+  }
+  return null;
+}
 function loadOptions(o) {
   var hostname,
     port,
@@ -1110,7 +1117,7 @@ function loadOptions(o) {
   } else if (typeof o === "string") {
     url = new URL(o);
   }
-
+  o ||= {};
   if (url) {
     ({ hostname, port, username, password, adapter } = o);
     // object overrides url
@@ -1134,13 +1141,20 @@ function loadOptions(o) {
       }
     }
     query = query.trim();
+    // handle special characters in username, password, and database
+    if (username) {
+      username = decodeURIComponent(username);
+    }
+    if (password) {
+      password = decodeURIComponent(password);
+    }
   }
-  o ||= {};
   hostname ||= o.hostname || o.host || env.PGHOST || "localhost";
   port ||= Number(o.port || env.PGPORT || 5432);
   username ||= o.username || o.user || env.PGUSERNAME || env.PGUSER || env.USER || env.USERNAME || "postgres";
-  database ||= o.database || o.db || (url?.pathname ?? "").slice(1) || env.PGDATABASE || username;
+  database ||= o.database || o.db || getDBFromURL(url) || env.PGDATABASE || username;
   password ||= o.password || o.pass || env.PGPASSWORD || "";
+
   tls ||= o.tls || o.ssl;
   adapter ||= o.adapter || "postgres";
   max = o.max;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -159,6 +159,12 @@ if (isDockerEnabled()) {
     max: 1,
   };
 
+  test("should handle encoded chars in password and username when using url #17155", () => {
+    const sql = new Bun.SQL("postgres://bun%40bunbun:bunbun%40bun@127.0.0.1:5432/bun%40bun");
+    expect(sql.options.username).toBe("bun@bunbun");
+    expect(sql.options.password).toBe("bunbun@bun");
+    expect(sql.options.database).toBe("bun@bun");
+  });
   test("Connects with no options", async () => {
     // we need at least the usename and port
     await using sql = postgres({ max: 1, port: container.port, username: login.username });


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/17155
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
