### PR TITLE
Allow external zig in CMake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,23 @@ $ build/debug/bun-debug --version
 x.y.z_debug
 ```
 
+<details>
+<summary>Custom Zig Toolchain</summary>
+If you require a custom Zig toolchain you can set the `ZIG_EXECUTABLE`,
+`ZIG_LIB_DIR` CMake options to point to your custom Zig installation:
+
+**Note: Bun uses a [custom version of the Zig
+toolchain](https://github.com/oven-sh/zig/tree/014-dev)**. _If you need to to
+use a custom toolchain, it is recommended to fork our Zig fork and make your
+changes there. The commit we are based off is available in `SetupZig.cmake`._
+
+```bash
+bun run build \
+  -DZIG_EXECUTABLE=/path/to/zig/zig \
+  -DZIG_LIB_DIR=/path/to/zig/lib
+```
+</details>
+
 ## VSCode
 
 VSCode is the recommended IDE for working on Bun, as it has been configured. Once opening, you can run `Extensions: Show Recommended Extensions` to install the recommended extensions for Zig and C++. ZLS is automatically configured.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Adds the ability to override the Zig command in use. This is useful for testing patches or odd systems like Asahi which rely on hacks or switching out to a locally built Zig.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Configure cmake and set `-DZIG_EXECUTABLE`. Grep for `--zig-lib-dir` and saw the same path as `zig env | jq .lib_dir` says.

Example:
```sh
$ grep -r '\--zig-lib-dir'
CMakeFiles/bun-zig.dir/build.make:	cd /home/ross/bun-workspace/bun && /nix/store/kbi2k2h2q395ip75iq0zfra7p14cz0wx-zig-0.14.0-git+f70ec2f/bin/zig build obj --cache-dir /home/ross/bun-workspace/bun/build/cache/zig/local --global-cache-dir /home/ross/bun-workspace/bun/build/cache/zig/global --zig-lib-dir /nix/store/kbi2k2h2q395ip75iq0zfra7p14cz0wx-zig-0.14.0-git+f70ec2f/lib/zig --prefix /home/ross/bun-workspace/bun/build -Dobj_format=obj -Dtarget=aarch64-linux-gnu -Doptimize=ReleaseFast -Dcpu=native -Denable_logs=false -Dversion=1.2.3 -Dreported_nodejs_version=22.6.0 -Dcanary=1 -Dcodegen_path=/home/ross/bun-workspace/bun/build/codegen -Dcodegen_embed=true -Denable_asan=false --prominent-compile-errors -Dsha=9fd96c1be33fb612c7bc11ffb7cea565e868f879
```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
