### PR TITLE
Use prctl on Linux for process.title

### DIFF
--- a/src/bun.js/bindings/exports.zig
+++ b/src/bun.js/bindings/exports.zig
@@ -373,24 +373,9 @@ pub const Process = extern struct {
     pub const shim = Shimmer("Bun", "Process", @This());
     pub const name = "Process";
     pub const namespace = shim.namespace;
-    var title_mutex = bun.Mutex{};
 
-    pub fn getTitle(_: *JSGlobalObject, title: *ZigString) callconv(.C) void {
-        title_mutex.lock();
-        defer title_mutex.unlock();
-        const str = bun.CLI.Bun__Node__ProcessTitle;
-        title.* = ZigString.init(str orelse "bun");
-    }
-
-    // TODO: https://github.com/nodejs/node/blob/master/deps/uv/src/unix/darwin-proctitle.c
-    pub fn setTitle(globalObject: *JSGlobalObject, newvalue: *ZigString) callconv(.C) JSValue {
-        title_mutex.lock();
-        defer title_mutex.unlock();
-        if (bun.CLI.Bun__Node__ProcessTitle) |_| bun.default_allocator.free(bun.CLI.Bun__Node__ProcessTitle.?);
-        bun.CLI.Bun__Node__ProcessTitle = newvalue.dupe(bun.default_allocator) catch bun.outOfMemory();
-        return newvalue.toJS(globalObject);
-    }
-
+    pub const getTitle = JSC.Node.Process.getTitle;
+    pub const setTitle = JSC.Node.Process.setTitle;
     pub const getArgv = JSC.Node.Process.getArgv;
     pub const getCwd = JSC.Node.Process.getCwd;
     pub const setCwd = JSC.Node.Process.setCwd;

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -9,7 +9,7 @@
 #ifdef __cplusplus
   #define AUTO_EXTERN_C extern "C"
   #ifdef WIN32
-    #define AUTO_EXTERN_C_ZIG extern "C" 
+    #define AUTO_EXTERN_C_ZIG extern "C"
   #else
     #define AUTO_EXTERN_C_ZIG extern "C" __attribute__((weak))
   #endif
@@ -226,7 +226,7 @@ CPP_DECL void WebCore__AbortSignal__cleanNativeBindings(WebCore__AbortSignal* ar
 CPP_DECL JSC__JSValue WebCore__AbortSignal__create(JSC__JSGlobalObject* arg0);
 CPP_DECL WebCore__AbortSignal* WebCore__AbortSignal__fromJS(JSC__JSValue JSValue0);
 CPP_DECL WebCore__AbortSignal* WebCore__AbortSignal__ref(WebCore__AbortSignal* arg0);
-CPP_DECL WebCore__AbortSignal* WebCore__AbortSignal__signal(WebCore__AbortSignal* arg0, JSC__JSGlobalObject*,  uint8_t abortReason); 
+CPP_DECL WebCore__AbortSignal* WebCore__AbortSignal__signal(WebCore__AbortSignal* arg0, JSC__JSGlobalObject*,  uint8_t abortReason);
 CPP_DECL JSC__JSValue WebCore__AbortSignal__toJS(WebCore__AbortSignal* arg0, JSC__JSGlobalObject* arg1);
 CPP_DECL void WebCore__AbortSignal__unref(WebCore__AbortSignal* arg0);
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1877,6 +1877,16 @@ pub const Dirent = struct {
 };
 
 pub const Process = struct {
+    // TODO: https://github.com/nodejs/node/blob/main/deps/uv/src/unix/darwin-proctitle.c
+    pub fn setTitle(globalObject: *JSC.JSGlobalObject, newvalue: *JSC.ZigString) callconv(.C) JSC.JSValue {
+        @import("../../process.zig").setTitle(globalObject.allocator(), newvalue.byteSlice());
+        return newvalue.toJS(globalObject);
+    }
+
+    pub fn getTitle(globalObject: *JSC.JSGlobalObject, out: *JSC.ZigString) callconv(.C) void {
+        out.* = JSC.ZigString.init(@import("../../process.zig").getTitle(globalObject.allocator()));
+    }
+
     pub fn getArgv0(globalObject: *JSC.JSGlobalObject) callconv(.C) JSC.JSValue {
         return JSC.ZigString.fromUTF8(bun.argv[0]).toJS(globalObject);
     }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -813,7 +813,7 @@ pub const Arguments = struct {
                 Bun__Node__ProcessThrowDeprecation = true;
             }
             if (args.option("--title")) |title| {
-                Bun__Node__ProcessTitle = title;
+                @import("./process.zig").setTitle(allocator, title);
             }
             if (args.flag("--zero-fill-buffers")) {
                 Bun__Node__ZeroFillBuffers = true;

--- a/src/process.zig
+++ b/src/process.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const bun = @import("root").bun;
+
+var title_mutex = bun.Mutex{};
+
+pub fn setTitle(allocator: std.mem.Allocator, value: []const u8) void {
+    if (builtin.os.tag == .linux) {
+        const trunc = allocator.dupeZ(u8, value[0..@min(value.len, 16)]) catch bun.outOfMemory();
+        defer allocator.free(trunc);
+
+        // TODO: we should handle the error differently
+        _ = std.posix.prctl(std.posix.PR.SET_NAME, .{@intFromPtr(value.ptr)}) catch @panic("Bad syscall");
+    } else {
+        title_mutex.lock();
+        defer title_mutex.unlock();
+        if (bun.CLI.Bun__Node__ProcessTitle) |_| bun.default_allocator.free(bun.CLI.Bun__Node__ProcessTitle.?);
+        bun.CLI.Bun__Node__ProcessTitle = allocator.dupe(u8, bun.default_allocator) catch bun.outOfMemory();
+    }
+}
+
+pub fn getTitle(allocator: std.mem.Allocator) []const u8 {
+    title_mutex.lock();
+    defer title_mutex.unlock();
+    if (builtin.os.tag == .linux) {
+        var buffer: [16]u8 = [_]u8{0} ** 16;
+        // TODO: we should handle the error differently
+        _ = std.posix.prctl(std.posix.PR.GET_NAME, .{@intFromPtr(&buffer)}) catch @panic("Bad syscall");
+
+        if (bun.CLI.Bun__Node__ProcessTitle) |_| bun.default_allocator.free(bun.CLI.Bun__Node__ProcessTitle.?);
+        bun.CLI.Bun__Node__ProcessTitle = allocator.dupe(u8, std.mem.sliceTo(&buffer, 0)) catch bun.outOfMemory();
+    }
+
+    return bun.CLI.Bun__Node__ProcessTitle orelse "bun";
+}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Partially resolves #14255 by adding `setTitle` / `getTitle` into `JSC.Node.Process` and using `prctl` on Linux to get/set the process title.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Run `bun -e "process.title='foo'; console.log(process.title)"`. `cat /proc/$(pidof bun)/comm` will say foo.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
