### PR TITLE
Fix lexing out of bounds by one 

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -391,6 +391,8 @@ function getBuildEnv(target, options) {
     ENABLE_ASSERTIONS: release ? "OFF" : "ON",
     ENABLE_LOGS: release ? "OFF" : "ON",
     ABI: abi === "musl" ? "musl" : undefined,
+
+    CMAKE_TLS_VERIFY: "0",
   };
 }
 

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -803,6 +803,9 @@ fn NewLexer_(
         }
 
         inline fn nextCodepoint(it: *LexerType) CodePoint {
+            if (it.current >= it.source.contents.len) {
+                return -1;
+            }
             const cp_len = strings.wtf8ByteSequenceLengthWithInvalid(it.source.contents.ptr[it.current]);
             const slice = if (!(cp_len + it.current > it.source.contents.len)) it.source.contents[it.current .. cp_len + it.current] else "";
 

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -798,6 +798,9 @@ fn NewLexer_(
         }
 
         inline fn nextCodepointSlice(it: *LexerType) []const u8 {
+            if (it.current >= it.source.contents.len) {
+                return "";
+            }
             const cp_len = strings.wtf8ByteSequenceLengthWithInvalid(it.source.contents.ptr[it.current]);
             return if (!(cp_len + it.current > it.source.contents.len)) it.source.contents[it.current .. cp_len + it.current] else "";
         }

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -807,6 +807,7 @@ fn NewLexer_(
 
         inline fn nextCodepoint(it: *LexerType) CodePoint {
             if (it.current >= it.source.contents.len) {
+                it.end = it.source.contents.len;
                 return -1;
             }
             const cp_len = strings.wtf8ByteSequenceLengthWithInvalid(it.source.contents.ptr[it.current]);


### PR DESCRIPTION
### What does this PR do?
When when lex the last token, the current position is set to the length of the source contents. We need to check for this situation each time we step forward.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
