### PR TITLE
Fix assertion failure that occurs with debugger in websocket server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,19 +7,6 @@
   // - "cppvsdbg" is used instead of "lldb" on Windows, because "lldb" is too slow
   "version": "0.2.0",
   "configurations": [
-    {
-      "type": "bun",
-      "request": "launch",
-      "name": "[js] bun test [file]",
-      "runtime": "${workspaceFolder}/build/debug/bun-debug",
-      "args": ["test", "${file}"],
-      "cwd": "${workspaceFolder}",
-      "env": {
-        "BUN_DEBUG_QUIET_LOGS": "1",
-        "BUN_DEBUG_jest": "1",
-        "BUN_GARBAGE_COLLECTOR_LEVEL": "1",
-      },
-    },
     // bun test [file]
     {
       "type": "lldb",

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -4955,15 +4955,8 @@ pub const ServerWebSocket = struct {
         }
 
         {
-            var js_string = message_value.toString(globalThis);
-            if (globalThis.hasException()) {
-                return .zero;
-            }
-            const view = js_string.view(globalThis);
-            const slice = view.toSlice(bun.default_allocator);
+            const slice = try message_value.toSlice(globalThis, bun.default_allocator);
             defer slice.deinit();
-
-            defer js_string.ensureStillAlive();
 
             const buffer = slice.slice();
 
@@ -5024,15 +5017,8 @@ pub const ServerWebSocket = struct {
             return globalThis.throw("publishText requires a non-empty message", .{});
         }
 
-        var js_string = message_value.toString(globalThis);
-        if (globalThis.hasException()) {
-            return .zero;
-        }
-        const view = js_string.view(globalThis);
-        const slice = view.toSlice(bun.default_allocator);
+        const slice = try message_value.toSlice(globalThis, bun.default_allocator);
         defer slice.deinit();
-
-        defer js_string.ensureStillAlive();
 
         const buffer = slice.slice();
 
@@ -5278,15 +5264,8 @@ pub const ServerWebSocket = struct {
         }
 
         {
-            var js_string = message_value.toString(globalThis);
-            if (globalThis.hasException()) {
-                return .zero;
-            }
-            const view = js_string.view(globalThis);
-            const slice = view.toSlice(bun.default_allocator);
+            const slice = try message_value.toSlice(globalThis, bun.default_allocator);
             defer slice.deinit();
-
-            defer js_string.ensureStillAlive();
 
             const buffer = slice.slice();
             switch (this.websocket().send(buffer, .text, compress, true)) {
@@ -5338,15 +5317,8 @@ pub const ServerWebSocket = struct {
             return globalThis.throw("sendText expects a string", .{});
         }
 
-        var js_string = message_value.toString(globalThis);
-        if (globalThis.hasException()) {
-            return .zero;
-        }
-        const view = js_string.view(globalThis);
-        const slice = view.toSlice(bun.default_allocator);
+        const slice = try message_value.toSlice(globalThis, bun.default_allocator);
         defer slice.deinit();
-
-        defer js_string.ensureStillAlive();
 
         const buffer = slice.slice();
         switch (this.websocket().send(buffer, .text, compress, true)) {
@@ -6184,15 +6156,8 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             }
 
             {
-                var js_string = message_value.toString(globalThis);
-                if (globalThis.hasException()) {
-                    return .zero;
-                }
-                const view = js_string.view(globalThis);
-                const slice = view.toSlice(bun.default_allocator);
+                const slice = try message_value.toSlice(globalThis, bun.default_allocator);
                 defer slice.deinit();
-
-                defer js_string.ensureStillAlive();
 
                 const buffer = slice.slice();
                 return JSValue.jsNumber(


### PR DESCRIPTION
### What does this PR do?

Fix assertion failure that occurs with debugger in websocket server

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
