### PR TITLE
Fix latest version display from update-sqlite

### DIFF
--- a/.github/workflows/update-sqlite3.yml
+++ b/.github/workflows/update-sqlite3.yml
@@ -55,7 +55,7 @@ jobs:
 
           # Convert numeric version to semantic version for display
           LATEST_MAJOR=$((10#$LATEST_VERSION_NUM / 1000000))
-          LATEST_MINOR=$((($LATEST_VERSION_NUM / 1000) % 1000))
+          LATEST_MINOR=$((($LATEST_VERSION_NUM / 10000) % 100))
           LATEST_PATCH=$((10#$LATEST_VERSION_NUM % 1000))
           LATEST_VERSION="$LATEST_MAJOR.$LATEST_MINOR.$LATEST_PATCH"
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fixes the case where the minor version of latest sqlite version is displayed incorrectly. For example, 3.49.0 was displayed as 3.490.0 #17201

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
