### PR TITLE
fix: __dirname and __filename collisions

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -3540,8 +3540,15 @@ pub const Parser = struct {
                 var declared_symbols = DeclaredSymbol.List.initCapacity(p.allocator, count) catch unreachable;
                 var decls = p.allocator.alloc(G.Decl, count) catch unreachable;
                 if (uses_dirname) {
+                    const unique_dir_name = try std.fmt.allocPrint(
+                        p.allocator,
+                        "__dirname_{x}",
+                        .{std.hash.Wyhash.hash(0, p.source.path.name.dir)},
+                    );
+                    const dir_ref = p.declareSymbol(.other, logger.Loc.Empty, unique_dir_name) catch unreachable;
+
                     decls[0] = .{
-                        .binding = p.b(B.Identifier{ .ref = p.dirname_ref }, logger.Loc.Empty),
+                        .binding = p.b(B.Identifier{ .ref = dir_ref }, logger.Loc.Empty),
                         .value = p.newExpr(
                             E.String{
                                 .data = p.source.path.name.dir,
@@ -3549,11 +3556,19 @@ pub const Parser = struct {
                             logger.Loc.Empty,
                         ),
                     };
+                    p.symbols.items[p.dirname_ref.innerIndex()].link = dir_ref;
                     declared_symbols.appendAssumeCapacity(.{ .ref = p.dirname_ref, .is_top_level = true });
                 }
                 if (uses_filename) {
+                    const unique_filename_name = try std.fmt.allocPrint(
+                        p.allocator,
+                        "__filename_{x}",
+                        .{std.hash.Wyhash.hash(0, p.source.path.text)},
+                    );
+                    const file_ref = p.declareSymbol(.other, logger.Loc.Empty, unique_filename_name) catch unreachable;
+
                     decls[@as(usize, @intFromBool(uses_dirname))] = .{
-                        .binding = p.b(B.Identifier{ .ref = p.filename_ref }, logger.Loc.Empty),
+                        .binding = p.b(B.Identifier{ .ref = file_ref }, logger.Loc.Empty),
                         .value = p.newExpr(
                             E.String{
                                 .data = p.source.path.text,
@@ -3561,6 +3576,7 @@ pub const Parser = struct {
                             logger.Loc.Empty,
                         ),
                     };
+                    p.symbols.items[p.filename_ref.innerIndex()].link = file_ref;
                     declared_symbols.appendAssumeCapacity(.{ .ref = p.filename_ref, .is_top_level = true });
                 }
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, realpathSync } from "fs";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import path, { join } from "path";
 import assert from "assert";
 import { buildNoThrow } from "./buildNoThrow";
+import { tmpdirSync } from "harness";
 
 describe("Bun.build", () => {
   test("css works", async () => {
@@ -610,5 +611,50 @@ describe("Bun.build", () => {
     // Verify our plugin modified the HTML
     const html = build.outputs.find(o => o.type === "text/html;charset=utf-8");
     expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
+  });
+
+  test("__dirname and __filename don't conflict across modules", async () => {
+    let testDir = tmpdirSync();
+
+    await Bun.write(join(testDir, "./nested/index.ts"), `
+      export function nested() {
+        console.log(__filename);
+        console.log(__dirname);
+      }
+    `);
+
+    await Bun.write(join(testDir, "index.ts"), `
+      import { nested } from "./nested/index.ts";
+      console.log(__filename);
+      console.log(__dirname);
+      nested();
+    `);
+
+    testDir = realpathSync(testDir);
+
+    // Output the code to a single file
+    await Bun.build({
+      entrypoints: [join(testDir, "index.ts")],
+      outdir: join(testDir, "out"),
+    });
+
+    const builtCode = await Bun.file(join(testDir, "out/index.js")).text();
+
+    // The instances of __dirname and __filename should be inlined with unique
+    // identifiers so that they don't collide with each other
+    expect(builtCode).toInclude(JSON.stringify(join(testDir, "index.ts")));
+    expect(builtCode).toInclude(JSON.stringify(join(testDir, "")));
+    expect(builtCode).toInclude(JSON.stringify(join(testDir, "nested/index.ts")));
+    expect(builtCode).toInclude(JSON.stringify(join(testDir, "nested")));
+
+    expect(builtCode).toMatch(/__filename_[a-f0-9]+/);
+    expect(builtCode).toMatch(/__dirname_[a-f0-9]+/);
+
+    const dirnameMatches = builtCode.match(/__dirname_[a-f0-9]+/g);
+    const filenameMatches = builtCode.match(/__filename_[a-f0-9]+/g);
+    expect(dirnameMatches?.length).toBeGreaterThan(1);
+    expect(filenameMatches?.length).toBeGreaterThan(1);
+    expect(new Set(dirnameMatches).size).toBeGreaterThan(1);
+    expect(new Set(filenameMatches).size).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?

This PR resolves issues with `__dirname` and `__filename` collisions (https://github.com/oven-sh/bun/issues/17188) by creating unique variables when `__dirname` or `__filename` are used in a bundle.

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
- [x] Used the debug build to test the fix

### Reproduction

When multiple files utilize `__dirname`/`__filename` Bun hoists the values to the top of the module code. However, since it is a `var` it can be overwritten effectively making it so only `__dirname`/`__filename` values collide.

#### Before

```
// test2/test.ts
var __dirname = "/Users/anthony/dev/test/test2", __filename = "/Users/anthony/dev/test/test2/test.ts";
function test() {
  console.log(__filename);
  console.log(__dirname);
}

// index.ts
var __dirname = "/Users/anthony/dev/test", __filename = "/Users/anthony/dev/test/index.ts";
console.log(__filename);
console.log(__dirname);
test();
```

In this single JS output, `__dirname` ends up evaluating to `/Users/anthony/dev/test` in both places it is called because that is the last value the var is assigned to.

#### After

The collision no longer occurs because usages of `__dirname` and `__filename` get unique values.

```
// test2/test.ts
var __dirname_af38e5cdfa6876c9 = "/Users/anthony/dev/test/test2", __filename_9b03b912cc9c01cd = "/Users/anthony/dev/test/test2/test.ts";
function test() {
  console.log(__filename_9b03b912cc9c01cd);
  console.log(__dirname_af38e5cdfa6876c9);
}

// index.ts
var __dirname_58f1efdc5b67fffe = "/Users/anthony/dev/test", __filename_c508108910e49d6d = "/Users/anthony/dev/test/index.ts";
console.log(__filename_c508108910e49d6d);
console.log(__dirname_58f1efdc5b67fffe);
test();
```
