### PR TITLE
Support `BUN_PUBLIC_*` and other env options in HTML imports

### DIFF
--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -21,7 +21,7 @@ else()
 endif()
 
 optionx(ZIG_VERSION STRING "The zig version of the compiler to download" DEFAULT "0.14.0-dev.2987+183bb8b08")
-optionx(ZIG_COMMIT STRING "The zig commit to use in oven-sh/zig" DEFAULT "63f8ed52c011beafde83216efba766492491ef4b")
+optionx(ZIG_COMMIT STRING "The zig commit to use in oven-sh/zig" DEFAULT "02c57c7ee3b8fde7528c74dd06490834d2d6fae9")
 optionx(ZIG_TARGET STRING "The zig target to use" DEFAULT ${DEFAULT_ZIG_TARGET})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/docs/cli/bun-create.md
+++ b/docs/cli/bun-create.md
@@ -8,7 +8,7 @@ If you're looking to create a brand new empty project, use [`bun init`](https://
 
 ## From a React component
 
-`bun create ./MyComponent.tsx` turns a React component into a complete dev environment with hot reload and production builds in one command.
+`bun create ./MyComponent.tsx` turns an existing React component into a complete dev environment with hot reload and production builds in one command.
 
 ```bash
 $ bun create ./MyComponent.jsx # .tsx also supported

--- a/docs/cli/bun-create.md
+++ b/docs/cli/bun-create.md
@@ -2,9 +2,96 @@
 **Note** — You don’t need `bun create` to use Bun. You don’t need any configuration at all. This command exists to make getting started a bit quicker and easier.
 {% /callout %}
 
-Template a new Bun project with `bun create`. This is a flexible command that can be used to create a new project with a `create-<template>` npm package, a GitHub repo, or a local template.
+Template a new Bun project with `bun create`. This is a flexible command that can be used to create a new project from a React component, a `create-<template>` npm package, a GitHub repo, or a local template.
 
 If you're looking to create a brand new empty project, use [`bun init`](https://bun.sh/docs/cli/init).
+
+## From a React component
+
+`bun create ./MyComponent.tsx` turns a React component into a complete dev environment with hot reload and production builds in one command.
+
+```bash
+$ bun create ./MyComponent.jsx # .tsx also supported
+```
+
+{% raw %}
+
+<video style="aspect-ratio: 2062 / 1344; width: 100%; height: 100%; object-fit: contain;"  loop autoplay muted playsinline>
+  <source src="/bun-create-shadcn.mp4" style="width: 100%; height: 100%; object-fit: contain;" type="video/mp4">
+</video>
+
+{% /raw %}
+
+{% callout %}
+🚀 **Create React App Successor** — `bun create <component>` provides everything developers loved about Create React App, but with modern tooling, faster builds, and backend support.
+{% /callout %}
+
+#### How this works
+
+When you run `bun create <component>`, Bun:
+
+1. Uses [Bun's JavaScript bundler](https://bun.sh/docs/bundler) to analyze your module graph.
+2. Collects all the dependencies needed to run the component.
+3. Scans the exports of the entry point for a React component.
+4. Generates a `package.json` file with the dependencies and scripts needed to run the component.
+5. Installs any missing dependencies using [`bun install --only-missing`](https://bun.sh/docs/cli/install).
+6. Generates the following files:
+   - `${component}.html`
+   - `${component}.client.tsx` (entry point for the frontend)
+   - `${component}.css` (css file)
+7. Starts a frontend dev server automatically.
+
+### Using TailwindCSS with Bun
+
+[TailwindCSS](https://tailwindcss.com/) is an extremely popular utility-first CSS framework used to style web applications.
+
+When you run `bun create <component>`, Bun scans your JSX/TSX file for TailwindCSS class names (and any files it imports). If it detects TailwindCSS class names, it will add the following dependencies to your `package.json`:
+
+```json#package.json
+{
+  "dependencies": {
+    "tailwindcss": "^4",
+    "bun-plugin-tailwind": "latest"
+  }
+}
+```
+
+We also configure `bunfig.toml` to use Bun's TailwindCSS plugin with `Bun.serve()`
+
+```toml#bunfig.toml
+[serve.static]
+plugins = ["bun-plugin-tailwind"]
+```
+
+And a `${component}.css` file with `@import "tailwindcss";` at the top:
+
+```css#MyComponent.css
+@import "tailwindcss";
+```
+
+### Using `shadcn/ui` with Bun
+
+[`shadcn/ui`](https://ui.shadcn.com/) is an extremely popular component library tool for building web applications.
+
+`bun create <component>` scans for any shadcn/ui components imported from `@/components/ui`.
+
+If it finds any, it runs:
+
+```bash
+# Assuming bun detected imports to @/components/ui/accordion and @/components/ui/button
+$ bunx shadcn@canary add accordion button # and any other components
+```
+
+Since `shadcn/ui` itself uses TailwindCSS, `bun create` also adds the necessary TailwindCSS dependencies to your `package.json` and configures `bunfig.toml` to use Bun's TailwindCSS plugin with `Bun.serve()` as described above.
+
+Additionally, we setup the following:
+
+- `tsconfig.json` to alias `"@/*"` to `"src/*"` or `.` (depending on if there is a `src/` directory)
+- `components.json` so that shadcn/ui knows its a shadcn/ui project
+- `styles/globals.css` file that configures Tailwind v4 in the way that shadcn/ui expects
+- `${component}.build.ts` file that builds the component for production with `bun-plugin-tailwind` configured
+
+`bun create ./MyComponent.jsx` is one of the easiest ways to run code generated from LLMs like [Claude](https://claude.ai) or ChatGPT locally.
 
 ## From `npm`
 

--- a/root.zig
+++ b/root.zig
@@ -11,3 +11,21 @@ pub const completions = struct {
 
 pub const JavaScriptCore = @import("./src/jsc.zig");
 pub const C = @import("./src/c.zig");
+
+// -- Zig Standard Library Additions --
+pub fn copyForwards(comptime T: type, dest: []T, source: []const T) void {
+    if (source.len == 0) {
+        return;
+    }
+    bun.copy(T, dest[0..source.len], source);
+}
+pub fn copyBackwards(comptime T: type, dest: []T, source: []const T) void {
+    if (source.len == 0) {
+        return;
+    }
+    bun.copy(T, dest[0..source.len], source);
+}
+pub fn eqlBytes(src: []const u8, dest: []const u8) bool {
+    return bun.C.memcmp(src.ptr, dest.ptr, src.len) == 0;
+}
+// -- End Zig Standard Library Additions --

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1705,6 +1705,11 @@ pub const Api = struct {
         serve_minify_syntax: ?bool = null,
         serve_minify_whitespace: ?bool = null,
         serve_minify_identifiers: ?bool = null,
+        serve_env_behavior: DotEnvBehavior = ._none,
+        serve_env_prefix: ?[]const u8 = null,
+        serve_splitting: bool = false,
+        serve_public_path: ?[]const u8 = null,
+
         bunfig_path: []const u8,
 
         pub fn decode(reader: anytype) anyerror!TransformOptions {

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -407,14 +407,22 @@ pub fn init(options: Options) bun.JSOOM!*DevServer {
 
     dev.watcher_atomics = WatcherAtomics.init(dev);
 
-    dev.framework.initBundler(allocator, &dev.log, .development, .server, &dev.server_transpiler) catch |err|
+    dev.framework.initBundler(allocator, &dev.log, .development, .server, &dev.server_transpiler, &dev.bundler_options.server) catch |err|
         return global.throwError(err, generic_action);
     dev.server_transpiler.options.dev_server = dev;
-    dev.framework.initBundler(allocator, &dev.log, .development, .client, &dev.client_transpiler) catch |err|
+    dev.framework.initBundler(
+        allocator,
+        &dev.log,
+        .development,
+        .client,
+        &dev.client_transpiler,
+        &dev.bundler_options.client,
+    ) catch |err|
         return global.throwError(err, generic_action);
     dev.client_transpiler.options.dev_server = dev;
+
     if (separate_ssr_graph) {
-        dev.framework.initBundler(allocator, &dev.log, .development, .ssr, &dev.ssr_transpiler) catch |err|
+        dev.framework.initBundler(allocator, &dev.log, .development, .ssr, &dev.ssr_transpiler, &dev.bundler_options.ssr) catch |err|
             return global.throwError(err, generic_action);
         dev.ssr_transpiler.options.dev_server = dev;
     }

--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -652,8 +652,10 @@ pub const Framework = struct {
             // TODO: follow user configuration
             else => .none,
         };
-        out.options.env.behavior = bundler_options.env;
-        out.options.env.prefix = bundler_options.env_prefix orelse "";
+        if (bundler_options.env != ._none) {
+            out.options.env.behavior = bundler_options.env;
+            out.options.env.prefix = bundler_options.env_prefix orelse "";
+        }
         out.resolver.opts = out.options;
 
         out.configureLinker();

--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -156,6 +156,9 @@ const BuildConfigSubset = struct {
     ignoreDCEAnnotations: ?bool = null,
     conditions: bun.StringArrayHashMapUnmanaged(void) = .{},
     drop: bun.StringArrayHashMapUnmanaged(void) = .{},
+    env: bun.Schema.Api.DotEnvBehavior = ._none,
+    env_prefix: ?[]const u8 = null,
+
     // TODO: plugins
 
     pub fn loadFromJs(config: *BuildConfigSubset, value: JSValue, arena: Allocator) !void {
@@ -588,8 +591,9 @@ pub const Framework = struct {
         allocator: std.mem.Allocator,
         log: *bun.logger.Log,
         mode: Mode,
-        comptime renderer: Graph,
+        renderer: Graph,
         out: *bun.transpiler.Transpiler,
+        bundler_options: *const BuildConfigSubset,
     ) !void {
         out.* = try bun.Transpiler.init(
             allocator, // TODO: this is likely a memory leak
@@ -648,6 +652,9 @@ pub const Framework = struct {
             // TODO: follow user configuration
             else => .none,
         };
+        out.options.env.behavior = bundler_options.env;
+        out.options.env.prefix = bundler_options.env_prefix orelse "";
+        out.resolver.opts = out.options;
 
         out.configureLinker();
         try out.configureDefines();

--- a/src/bake/production.zig
+++ b/src/bake/production.zig
@@ -174,10 +174,10 @@ pub fn buildWithVm(ctx: bun.CLI.Command.Context, cwd: []const u8, vm: *VirtualMa
     var client_transpiler: bun.transpiler.Transpiler = undefined;
     var server_transpiler: bun.transpiler.Transpiler = undefined;
     var ssr_transpiler: bun.transpiler.Transpiler = undefined;
-    try framework.initBundler(allocator, vm.log, .production_static, .server, &server_transpiler);
-    try framework.initBundler(allocator, vm.log, .production_static, .client, &client_transpiler);
+    try framework.initBundler(allocator, vm.log, .production_static, .server, &server_transpiler, &options.bundler_options.server);
+    try framework.initBundler(allocator, vm.log, .production_static, .client, &client_transpiler, &options.bundler_options.client);
     if (separate_ssr_graph) {
-        try framework.initBundler(allocator, vm.log, .production_static, .ssr, &ssr_transpiler);
+        try framework.initBundler(allocator, vm.log, .production_static, .ssr, &ssr_transpiler, &options.bundler_options.ssr);
     }
 
     if (ctx.bundler_options.bake_debug_disable_minify) {

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -372,7 +372,7 @@ pub const JSBundler = struct {
             }
 
             // if (try config.getOptional(globalThis, "dir", ZigString.Slice)) |slice| {
-            //     defer slice.deinit();
+        //     defer slice.deinit();
             //     this.appendSliceExact(slice.slice()) catch unreachable;
             // } else {
             //     this.appendSliceExact(globalThis.bunVM().transpiler.fs.top_level_dir) catch unreachable;

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -372,7 +372,7 @@ pub const JSBundler = struct {
             }
 
             // if (try config.getOptional(globalThis, "dir", ZigString.Slice)) |slice| {
-        //     defer slice.deinit();
+            //     defer slice.deinit();
             //     this.appendSliceExact(slice.slice()) catch unreachable;
             // } else {
             //     this.appendSliceExact(globalThis.bunVM().transpiler.fs.top_level_dir) catch unreachable;

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -6,7 +6,6 @@ const JSValue = JSC.JSValue;
 const JSGlobalObject = JSC.JSGlobalObject;
 const Debugger = JSC.Debugger;
 const Environment = bun.Environment;
-const Async = @import("async");
 const uv = bun.windows.libuv;
 const StatWatcherScheduler = @import("../node/node_fs_stat_watcher.zig").StatWatcherScheduler;
 const Timer = @This();

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1189,6 +1189,20 @@ pub const ServerConfig = struct {
                         .frontend_only = true,
                         .bundler_options = bun.bake.SplitBundlerOptions.empty,
                     };
+
+                    switch (vm.transpiler.options.transform_options.serve_env_behavior) {
+                        .prefix => {
+                            args.bake.?.bundler_options.client.env_prefix = vm.transpiler.options.transform_options.serve_env_prefix;
+                            args.bake.?.bundler_options.client.env = .prefix;
+                        },
+                        .load_all => {
+                            args.bake.?.bundler_options.client.env = .load_all;
+                        },
+                        .disable => {
+                            args.bake.?.bundler_options.client.env = .disable;
+                        },
+                        else => {},
+                    }
                 }
             }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3855,11 +3855,15 @@ pub fn OrdinalT(comptime Int: type) type {
 pub const Ordinal = OrdinalT(c_int);
 
 pub fn memmove(output: []u8, input: []const u8) void {
-    if (comptime Environment.allow_assert) {
-        assert(output.len >= input.len and output.len > 0);
+    if (output.len == 0) {
+        return;
     }
 
-    if (comptime Environment.isNative) {
+    if (comptime Environment.allow_assert) {
+        assert(output.len >= input.len);
+    }
+
+    if (Environment.isNative and !@inComptime()) {
         C.memmove(output.ptr, input.ptr, input.len);
     } else {
         for (input, output) |input_byte, *out| {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3855,19 +3855,11 @@ pub fn OrdinalT(comptime Int: type) type {
 pub const Ordinal = OrdinalT(c_int);
 
 pub fn memmove(output: []u8, input: []const u8) void {
-    if (@intFromPtr(output.ptr) == @intFromPtr(input.ptr) or output.len == 0) return;
     if (comptime Environment.allow_assert) {
         assert(output.len >= input.len and output.len > 0);
     }
 
-    const does_input_or_output_overlap = (@intFromPtr(input.ptr) < @intFromPtr(output.ptr) and
-        @intFromPtr(input.ptr) + input.len > @intFromPtr(output.ptr)) or
-        (@intFromPtr(output.ptr) < @intFromPtr(input.ptr) and
-        @intFromPtr(output.ptr) + output.len > @intFromPtr(input.ptr));
-
-    if (!does_input_or_output_overlap) {
-        @memcpy(output[0..input.len], input);
-    } else if (comptime Environment.isNative) {
+    if (comptime Environment.isNative) {
         C.memmove(output.ptr, input.ptr, input.len);
     } else {
         for (input, output) |input_byte, *out| {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -658,33 +658,68 @@ pub const Bunfig = struct {
 
                         // TODO: accept entire config object.
                         this.bunfig.serve_plugins = plugins;
-                        if (serve_obj.get("minify")) |minify| {
-                            if (minify.asBool()) |value| {
-                                this.bunfig.serve_minify_syntax = value;
-                                this.bunfig.serve_minify_whitespace = value;
-                                this.bunfig.serve_minify_identifiers = value;
-                            } else if (minify.isObject()) {
-                                if (minify.get("syntax")) |syntax| {
-                                    this.bunfig.serve_minify_syntax = syntax.asBool() orelse false;
-                                }
+                    }
 
-                                if (minify.get("whitespace")) |whitespace| {
-                                    this.bunfig.serve_minify_whitespace = whitespace.asBool() orelse false;
-                                }
-
-                                if (minify.get("identifiers")) |identifiers| {
-                                    this.bunfig.serve_minify_identifiers = identifiers.asBool() orelse false;
-                                }
-                            } else {
-                                try this.addError(minify.loc, "Expected minify to be boolean or object");
+                    if (serve_obj.get("minify")) |minify| {
+                        if (minify.asBool()) |value| {
+                            this.bunfig.serve_minify_syntax = value;
+                            this.bunfig.serve_minify_whitespace = value;
+                            this.bunfig.serve_minify_identifiers = value;
+                        } else if (minify.isObject()) {
+                            if (minify.get("syntax")) |syntax| {
+                                this.bunfig.serve_minify_syntax = syntax.asBool() orelse false;
                             }
+
+                            if (minify.get("whitespace")) |whitespace| {
+                                this.bunfig.serve_minify_whitespace = whitespace.asBool() orelse false;
+                            }
+
+                            if (minify.get("identifiers")) |identifiers| {
+                                this.bunfig.serve_minify_identifiers = identifiers.asBool() orelse false;
+                            }
+                        } else {
+                            try this.addError(minify.loc, "Expected minify to be boolean or object");
                         }
+                    }
+                    this.bunfig.bunfig_path = bun.default_allocator.dupe(u8, this.source.path.text) catch bun.outOfMemory();
 
-                        // Here! The type is ?[]const u8, not ![]const u8
-                        const slice = try serve_obj.asString(allocator);
-                        _ = strings.indexOfChar(slice, '*');
+                    if (serve_obj.get("publicPath")) |public_path| {
+                        if (public_path.asString(allocator)) |value| {
+                            this.bunfig.serve_public_path = value;
+                        }
+                    }
 
-                        this.bunfig.bunfig_path = bun.default_allocator.dupe(u8, this.source.path.text) catch bun.outOfMemory();
+                    if (serve_obj.get("env")) |env| {
+                        switch (env.data) {
+                            .e_null => {
+                                this.bunfig.serve_env_behavior = .disable;
+                            },
+                            .e_boolean => |boolean| {
+                                this.bunfig.serve_env_behavior = if (boolean.value) .load_all else .disable;
+                            },
+                            .e_string => |str| {
+                                if (str.eqlComptime("inline")) {
+                                    this.bunfig.serve_env_behavior = .load_all;
+                                } else if (str.eqlComptime("disable")) {
+                                    this.bunfig.serve_env_behavior = .disable;
+                                } else {
+                                    const slice = try str.string(allocator);
+                                    if (strings.indexOfChar(slice, '*')) |asterisk| {
+                                        if (asterisk > 0) {
+                                            this.bunfig.serve_env_prefix = slice[0..asterisk];
+                                            this.bunfig.serve_env_behavior = .prefix;
+                                        } else {
+                                            this.bunfig.serve_env_behavior = .load_all;
+                                        }
+                                    } else {
+                                        try this.addError(env.loc, "Invalid env behavior, must be 'inline', 'disable', or a string with a '*' character");
+                                    }
+                                }
+                            },
+                            else => {
+                                try this.addError(env.loc, "Invalid env behavior, must be 'inline', 'disable', or a string with a '*' character");
+                            },
+                        }
                     }
                 }
             }

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -679,6 +679,11 @@ pub const Bunfig = struct {
                                 try this.addError(minify.loc, "Expected minify to be boolean or object");
                             }
                         }
+
+                        // Here! The type is ?[]const u8, not ![]const u8
+                        const slice = try serve_obj.asString(allocator);
+                        _ = strings.indexOfChar(slice, '*');
+
                         this.bunfig.bunfig_path = bun.default_allocator.dupe(u8, this.source.path.text) catch bun.outOfMemory();
                     }
                 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2457,21 +2457,31 @@ pub const Command = struct {
                 },
                 Command.Tag.CreateCommand => {
                     const intro_text =
-                        \\<b>Usage<r>:
-                        \\  <b><green>bun create<r> <magenta>\<template\><r> <cyan>[...flags]<r> <blue>dest<r>
-                        \\  <b><green>bun create<r> <magenta>\<username/repo\><r> <cyan>[...flags]<r> <blue>dest<r>
+                        \\<b>Usage<r><d>:<r>
+                        \\  <b><green>bun create<r> <magenta>\<MyReactComponent.(jsx|tsx)\><r> 
+                        \\  <b><green>bun create<r> <magenta>\<template\><r> <cyan>[...flags]<r> <blue>dest<r> 
+                        \\  <b><green>bun create<r> <magenta>\<github-org/repo\><r> <cyan>[...flags]<r> <blue>dest<r>
                         \\
-                        \\<b>Environment variables:<r>
-                        \\  <cyan>GITHUB_TOKEN<r>             <d>Supply a token to download code from GitHub with a higher rate limit<r>
-                        \\  <cyan>GITHUB_API_DOMAIN<r>        <d>Configure custom/enterprise GitHub domain. Default "api.github.com".<r>
-                        \\  <cyan>NPM_CLIENT<r>               <d>Absolute path to the npm client executable<r>
+                        \\<b>Environment variables<r>:
+                        \\  <cyan>GITHUB_TOKEN<r>         <d>Supply a token to download code from GitHub with a higher rate limit<r>
+                        \\  <cyan>GITHUB_API_DOMAIN<r>    <d>Configure custom/enterprise GitHub domain. Default "api.github.com"<r>
+                        \\  <cyan>NPM_CLIENT<r>           <d>Absolute path to the npm client executable<r>
+                        \\  <cyan>BUN_CREATE_DIR<r>       <d>Custom path for global templates (default: $HOME/.bun-create)<r>
                     ;
 
                     const outro_text =
-                        \\If given a GitHub repository name, Bun will download it and use it as a template,
-                        \\otherwise it will run <b><magenta>bunx create-\<template\><r> with the given arguments.
+                        \\<b>React Component Projects<r><d>:<r>
+                        \\  Creates a complete frontend dev environment that starts a hot-reloading dev server
+                        \\  automatically. Supports TailwindCSS and shadcn/ui with zero configuration.
                         \\
-                        \\Learn more about creating new projects: <magenta>https://bun.sh/docs/cli/bun-create<r>
+                        \\  <b><magenta>bun create \<MyReactComponent.(jsx|tsx)\><r>
+                        \\
+                        \\<b>Templates<r><d>:<r>
+                        \\  • NPM: Runs <b><magenta>bunx create-\<template\><r> with given arguments
+                        \\  • GitHub: Downloads repository contents as template
+                        \\  • Local: Uses templates from $HOME/.bun-create/\<name\> or ./.bun-create/\<name\>
+                        \\
+                        \\Learn more: <magenta>https://bun.sh/docs/cli/bun-create<r>
                         \\
                     ;
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2471,8 +2471,9 @@ pub const Command = struct {
 
                     const outro_text =
                         \\<b>React Component Projects<r><d>:<r>
-                        \\  Creates a complete frontend dev environment that starts a hot-reloading dev server
-                        \\  automatically. Supports TailwindCSS and shadcn/ui with zero configuration.
+                        \\  • Sets up a complete frontend dev environment from an existing React component
+                        \\  • Automatically starts a hot-reloading dev server
+                        \\  • Auto-detects & configures TailwindCSS and shadcn/ui
                         \\
                         \\  <b><magenta>bun create \<MyReactComponent.(jsx|tsx)\><r>
                         \\

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -2462,7 +2462,7 @@ pub const Command = struct {
                         \\  <b><green>bun create<r> <magenta>\<template\><r> <cyan>[...flags]<r> <blue>dest<r> 
                         \\  <b><green>bun create<r> <magenta>\<github-org/repo\><r> <cyan>[...flags]<r> <blue>dest<r>
                         \\
-                        \\<b>Environment variables<r>:
+                        \\<b>Environment variables<r><d>:<r>
                         \\  <cyan>GITHUB_TOKEN<r>         <d>Supply a token to download code from GitHub with a higher rate limit<r>
                         \\  <cyan>GITHUB_API_DOMAIN<r>    <d>Configure custom/enterprise GitHub domain. Default "api.github.com"<r>
                         \\  <cyan>NPM_CLIENT<r>           <d>Absolute path to the npm client executable<r>
@@ -2471,7 +2471,7 @@ pub const Command = struct {
 
                     const outro_text =
                         \\<b>React Component Projects<r><d>:<r>
-                        \\  • Sets up a complete frontend dev environment from an existing React component
+                        \\  • Turn an existing React component into a complete frontend dev environment
                         \\  • Automatically starts a hot-reloading dev server
                         \\  • Auto-detects & configures TailwindCSS and shadcn/ui
                         \\


### PR DESCRIPTION
### What does this PR do?


This lets you specify `env` in `[serve.static]` within bunfig.toml, matching the behavior of `Bun.build`.

This means you can inject environment variables based on a prefix like `REACT_APP_`

### How did you verify your code works?

Updated a test