### PR TITLE
node:fs: windows: fix integer cast truncating bits when using too large of a mode

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1536,7 +1536,7 @@ pub const FileSystemFlags = enum(c_int) {
                 return ctx.throwValue(ctx.ERR_OUT_OF_RANGE("The value of \"flags\" is out of range. It must be an integer. Received {d}", .{val.asNumber()}).toJS());
             }
             const number = val.coerce(i32, ctx);
-            return @as(FileSystemFlags, @enumFromInt(@as(Mode, @intCast(@max(number, 0)))));
+            return @as(FileSystemFlags, @enumFromInt(@max(number, 0)));
         }
 
         const jsType = val.jsType();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3646,3 +3646,17 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
     });
   }
 });
+
+it("overflowing mode doesn't crash", () => {
+  // this is easiest to test on windows since mode_t is a u16 there
+  expect(() => openSync("./a.txt", 65 * 1024)).toThrow(
+    expect.objectContaining({
+      name: "Error",
+      message: `ENOENT: no such file or directory, open './a.txt'`,
+      code: "ENOENT",
+      syscall: "open",
+      // errno: -4058,
+      path: "./a.txt",
+    }),
+  );
+});


### PR DESCRIPTION
fixes https://github.com/oven-sh/bun/issues/17248