### PR TITLE
fix(sql) fix fragments containing fragments + concat syntax for parameters

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -923,7 +923,7 @@ function normalizeStrings(strings, values) {
       }
 
       for (var i = 1; i < count; i++) {
-        out += " " + strings[i];
+        out += strings[i];
       }
 
       return out;

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -930,7 +930,7 @@ function normalizeStrings(strings, values) {
     }
 
     for (var i = 1; i < count; i++) {
-      // this space in betweenis important
+      // this space in between is important
       out += `$${i} ${strings[i]}`;
     }
     return out;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -870,7 +870,7 @@ if (isDockerEnabled()) {
     }),
   ]);
 
-  test("should handle sub fragments", async () => {
+  test("should handle nested fragments", async () => {
     await using sql = postgres({ ...options, max: 1 });
     const random_name = sql("test_" + randomUUIDv7("hex").replaceAll("-", ""));
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -870,7 +870,7 @@ if (isDockerEnabled()) {
     }),
   ]);
 
-  test("should work with fragmetns", async () => {
+  test("should work with fragments", async () => {
     await using sql = postgres({ ...options, max: 1 });
     const random_name = sql("test_" + randomUUIDv7("hex").replaceAll("-", ""));
     await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${random_name} (id int, hotel_id int, created_at timestamp)`;


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/17215
<!-- **Please explain what your changes do**, example: -->

The following query should work:

```ts
await sql`CREATE TABLE IF NOT EXISTS alerts (id int, hotel_id int, created_at timestamp)`;
await sql`INSERT INTO alerts VALUES (1, 1, '2024-01-01 10:00:00')`;
await sql`INSERT INTO alerts VALUES (2, 1, '2024-01-02 10:00:00')`;
await sql`INSERT INTO alerts VALUES (3, 2, '2024-01-03 10:00:00')`;

// fragment containing another scape fragment for the field name
const orderBy = (field_name: string) => sql`ORDER BY ${sql(field_name)} DESC`;

// dynamic information
const sortBy = { should_sort: true, field: "created_at" };
const user = { hotel_id: 1 };

// query containing the fragments
const results = await sql`
SELECT alerts.*
FROM alerts
WHERE alerts.hotel_id = ${user.hotel_id} 
${sortBy.should_sort ? orderBy(sortBy.field) : sql``}`;
console.log(results);
```
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
