### PR TITLE
`bun init` - html template option

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1679,7 +1679,7 @@ pub const CreateCommand = struct {
             pub fn onAnalyze(this: *@This(), result: *bun.bundle_v2.BundleV2.DependenciesScanner.Result) anyerror!void {
                 this.node.end();
 
-                try SourceFileProjectGenerator.generate(this.ctx, this.example_tag, this.entry_point, result);
+                try SourceFileProjectGenerator.generate(this.entry_point, result);
             }
         };
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -32,14 +32,14 @@ fn setRawInput(b: bool) !void {
 
         const handle = std.io.getStdIn().handle;
         var flags: u32 = undefined;
-        if (std.windows.kernel32.GetConsoleMode(handle, &flags) == 0) return error.NotATerminal;
+        if (std.os.windows.kernel32.GetConsoleMode(handle, &flags) == 0) return error.NotATerminal;
         if (b) {
             flags &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT);
         } else {
             flags |= ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT;
         }
 
-        std.debug.assert(std.windows.kernel32.SetConsoleMode(handle, flags) != 0);
+        std.debug.assert(std.os.windows.kernel32.SetConsoleMode(handle, flags) != 0);
     } else {
         var t: std.posix.termios = try std.posix.tcgetattr(std.posix.STDIN_FILENO);
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -24,16 +24,7 @@ const JSPrinter = bun.js_printer;
 const exists = bun.sys.exists;
 const existsZ = bun.sys.existsZ;
 
-// makes read return error.WouldBlock instead of blocking if no input is available
-// posix only
-fn setNonblock(b: bool) !void {
-    var flags: std.posix.O = @bitCast(@as(u32, @intCast(try std.posix.fcntl(std.posix.STDIN_FILENO, std.posix.F.GETFL, 0))));
-    flags.NONBLOCK = b;
-    _ = try std.posix.fcntl(std.posix.STDIN_FILENO, std.posix.F.SETFL, @as(u32, @bitCast(flags)));
-}
-
-// makes it so that no newline character is required for forwarding the input
-// also makes it so that input characters are not printed to the console
+// make terminal input raw
 fn setRawInput(b: bool) !void {
     if (comptime Environment.isWindows) {
         const ENABLE_ECHO_INPUT: u32 = 0x0004;

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -91,8 +91,6 @@ pub const InitCommand = struct {
         default: bool,
     ) !bool {
         Output.prettyln(label, .{});
-        // Output.pretty("\n", .{});
-        // Output.pretty(" <d>(y/n):<r> \n", .{});
         Output.flush();
 
         const original_mode: if (Environment.isWindows) ?bun.windows.DWORD else void = if (comptime Environment.isWindows)
@@ -216,11 +214,12 @@ pub const InitCommand = struct {
         };
         setRawInput(false) catch unreachable;
 
-        for (0..opts.len + 2) |_| {
+        for (0..opts.len + 1) |_| {
             Output.pretty("\x1B[A", .{});
         }
         Output.pretty(label, .{});
         Output.prettyln(" {s}", .{opts[val]});
+        Output.prettyln("\x1B[J\x1B[A", .{});
         Output.prettyln("\x1B[J\x1B[A", .{});
         Output.flush();
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -104,7 +104,7 @@ pub const InitCommand = struct {
 
         Output.flush();
         try setRawInput(true);
-
+        defer setRawInput(false) catch unreachable;
         const reader = std.io.getStdIn().reader();
         const val: bool = brk: {
             var selected = default;
@@ -138,10 +138,8 @@ pub const InitCommand = struct {
 
                     else => continue,
                 }
-                Output.flush();
             }
         };
-        setRawInput(false) catch unreachable;
 
         Output.pretty("\r\x1B[A\r\x1B[K", .{});
         Output.pretty(label, .{});
@@ -157,6 +155,9 @@ pub const InitCommand = struct {
         default: usize,
     ) !usize {
         Output.prettyln(label, .{});
+        for (0..opts.len) |_| {
+            Output.prettyln("", .{});
+        }
         Output.flush();
 
         const original_mode: if (Environment.isWindows) ?bun.windows.DWORD else void = if (comptime Environment.isWindows)
@@ -170,12 +171,17 @@ pub const InitCommand = struct {
 
         Output.flush();
         try setRawInput(true);
+        defer setRawInput(false) catch unreachable;
 
         const reader = std.io.getStdIn().reader();
         const val: usize = brk: {
             var selected = default;
 
             while (true) {
+                for (0..opts.len) |_| {
+                    Output.pretty("\x1B[A", .{});
+                }
+
                 for (opts, 0..) |option, i| {
                     if (i == selected) {
                         Output.prettyln("<r><green>●<r> {s}", .{option});
@@ -206,13 +212,8 @@ pub const InitCommand = struct {
                     },
                     else => continue,
                 }
-
-                for (0..opts.len) |_| {
-                    Output.pretty("\x1B[A", .{});
-                }
             }
         };
-        setRawInput(false) catch unreachable;
 
         for (0..opts.len + 1) |_| {
             Output.pretty("\x1B[A", .{});

--- a/src/create/SourceFileProjectGenerator.zig
+++ b/src/create/SourceFileProjectGenerator.zig
@@ -252,7 +252,13 @@ fn generateFiles(allocator: std.mem.Allocator, entry_point: string, dependencies
             // Create all template files
             inline for (0..files.len) |index| {
                 const file = &files[index];
-                const file_name = try stringWithReplacements(file.name, basename, normalized_name, react_component_export orelse "App", allocator);
+                var file_name = try stringWithReplacements(file.name, basename, normalized_name, react_component_export orelse "App", allocator);
+
+                if (strings.eqlComptime(file.name, "REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx") and !strings.eqlComptime(extension, ".tsx")) {
+                    // replace the extension with the extension of the file
+                    file_name = try std.fmt.allocPrint(allocator, "{s}{s}", .{ file_name[0 .. file_name.len - extension.len], extension });
+                }
+
                 if (file.overwrite or !bun.sys.exists(file_name)) {
                     switch (createFile(file_name, try stringWithReplacements(file.content, basename, normalized_name, react_component_export orelse "", default_allocator))) {
                         .result => |new| {

--- a/src/create/SourceFileProjectGenerator.zig
+++ b/src/create/SourceFileProjectGenerator.zig
@@ -1,5 +1,5 @@
 // Generate project files based on the entry point and dependencies
-pub fn generate(_: Command.Context, _: Example.Tag, entry_point: string, result: *BundleV2.DependenciesScanner.Result) !void {
+pub fn generate(entry_point: string, result: *BundleV2.DependenciesScanner.Result) !void {
     const react_component_export = findReactComponentExport(result.bundle_v2) orelse {
         Output.errGeneric("No component export found in <b>{s}<r>", .{bun.fmt.quote(entry_point)});
         Output.flush();

--- a/src/create/SourceFileProjectGenerator.zig
+++ b/src/create/SourceFileProjectGenerator.zig
@@ -726,7 +726,7 @@ const ReactTailwindSpa = struct {
     pub const files = &[_]TemplateFile{
         .{
             .name = "REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx",
-            .content = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx"),
+            .content = shared_app_tsx,
             .reason = .bun,
             .overwrite = false,
         },
@@ -767,6 +767,7 @@ const ReactTailwindSpa = struct {
 
 const shared_build_ts = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.build.ts");
 const shared_client_tsx = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.client.tsx");
+const shared_app_tsx = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx");
 const shared_html = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.html");
 const shared_package_json = @embedFile("projects/react-shadcn-spa/package.json");
 const shared_bunfig_toml = @embedFile("projects/react-shadcn-spa/bunfig.toml");
@@ -776,7 +777,7 @@ const ReactSpa = struct {
     pub const files = &[_]TemplateFile{
         .{
             .name = "REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx",
-            .content = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx"),
+            .content = shared_app_tsx,
             .reason = .bun,
             .overwrite = false,
         },
@@ -816,7 +817,7 @@ const ReactShadcnSpa = struct {
     pub const files = &[_]TemplateFile{
         .{
             .name = "REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx",
-            .content = @embedFile("projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx"),
+            .content = shared_app_tsx,
             .reason = .bun,
             .overwrite = false,
         },

--- a/src/create/projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx
+++ b/src/create/projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 
-export default function REPLACE_ME_WITH_YOUR_REACT_COMPONENT_EXPORT() {
+export function REPLACE_ME_WITH_YOUR_REACT_COMPONENT_EXPORT() {
   const [count, setCount] = useState(0);
 
   return (
@@ -10,6 +10,4 @@ export default function REPLACE_ME_WITH_YOUR_REACT_COMPONENT_EXPORT() {
       <button onClick={() => setCount(count + 1)}>Count: {count}</button>
     </div>
   );
-}
-
-export { REPLACE_ME_WITH_YOUR_REACT_COMPONENT_EXPORT };
+};

--- a/src/create/projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx
+++ b/src/create/projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useState } from "react";
+
+export default function REPLACE_ME_WITH_YOUR_REACT_COMPONENT_EXPORT() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="container">
+      <h1>Hello from Bun!</h1>
+      <button onClick={() => setCount(count + 1)}>Count: {count}</button>
+    </div>
+  );
+}
+
+export { REPLACE_ME_WITH_YOUR_REACT_COMPONENT_EXPORT };

--- a/src/create/projects/react-shadcn-spa/package.json
+++ b/src/create/projects/react-shadcn-spa/package.json
@@ -5,5 +5,9 @@
   "scripts": {
     "dev": "bun './**/*.html'",
     "build": "bun 'REPLACE_ME_WITH_YOUR_APP_FILE_NAME.build.ts'"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "latest"
   }
 }

--- a/src/output.zig
+++ b/src/output.zig
@@ -861,6 +861,7 @@ pub const color_map = ComptimeStringMap(string, .{
     &.{ "red", CSI ++ "31m" },
     &.{ "green", CSI ++ "32m" },
     &.{ "yellow", CSI ++ "33m" },
+    &.{ "orange", CSI ++ "33m" ++ CSI ++ "38;5;208m" },
     &.{ "blue", CSI ++ "34m" },
     &.{ "magenta", CSI ++ "35m" },
     &.{ "cyan", CSI ++ "36m" },

--- a/test/cli/create/__snapshots__/create-jsx.test.ts.snap
+++ b/test/cli/create/__snapshots__/create-jsx.test.ts.snap
@@ -18,19 +18,27 @@ create  index.css          css
 create  index.html         html
 create  index.client.tsx   bun
 create  package.json       npm
-📦 Auto-installing 3 detected dependencies
-$ bun --only-missing install classnames react-dom@19 react@19
+📦 Auto-installing 7 detected dependencies
+$ bun --only-missing install classnames react-dom@19 react@19 @types/react@19 @types/react-dom@19 @types/bun@latest typescript@^5.0.0
 bun add v*.*.*
 installed classnames@*.*.*
 installed react-dom@*.*.*
 installed react@*.*.*
-4 packages installed [*ms]
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+installed @types/bun@*.*.*
+installed typescript@*.*.* with binaries:
+- tsc
+- tsserver
+13 packages installed [*ms]
 --------------------------------
 ✨ React project configured
 Development - frontend dev server with hot reload
 bun dev
 Production - build optimized assets
 bun run build
+Component - your main react component
+./index.jsx
 Happy bunning! 🐇
 Bun v*.*.* dev server ready in *.** ms
 url: http://[SERVER_URL]/"
@@ -55,20 +63,26 @@ create  index.html         html
 create  index.client.tsx   bun
 create  bunfig.toml        bun
 create  package.json       npm
-📦 Auto-installing 4 detected dependencies
-$ bun --only-missing install tailwindcss bun-plugin-tailwind react-dom@19 react@19
+📦 Auto-installing 8 detected dependencies
+$ bun --only-missing install tailwindcss bun-plugin-tailwind react-dom@19 react@19 @types/react@19 @types/react-dom@19 @types/bun@latest typescript@^5.0.0
 bun add v*.*.*
++ @types/bun@*.*.*
++ typescript@*.*.*
 installed tailwindcss@*.*.*
 installed bun-plugin-tailwind@*.*.*
 installed react-dom@*.*.*
 installed react@*.*.*
-7 packages installed [*ms]
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+15 packages installed [*ms]
 --------------------------------
 ✨ React + Tailwind project configured
 Development - frontend dev server with hot reload
 bun dev
 Production - build optimized assets
 bun run build
+Component - your main react component
+./index.tsx
 Happy bunning! 🐇
 Bun v*.*.* dev server ready in *.** ms
 url: http://[SERVER_URL]/"
@@ -86,9 +100,11 @@ create  bunfig.toml          bun
 create  package.json         npm
 create  tsconfig.json        tsc
 create  components.json      shadcn
-📦 Auto-installing 9 detected dependencies
-$ bun --only-missing install lucide-react tailwindcss bun-plugin-tailwind tailwindcss-animate class-variance-authority clsx tailwind-merge react@^18 react-dom@^18
+📦 Auto-installing 14 detected dependencies
+$ bun --only-missing install lucide-react tailwindcss bun-plugin-tailwind tailwindcss-animate class-variance-authority clsx tailwind-merge lucide-react react@^18 react-dom@^18 @types/react@^18 @types/react-dom@^18 @types/bun@latest typescript@^5.0.0
 bun add v*.*.*
++ @types/bun@*.*.*
++ typescript@*.*.*
 installed lucide-react@*.*.*
 installed tailwindcss@*.*.*
 installed bun-plugin-tailwind@*.*.*
@@ -98,7 +114,9 @@ installed clsx@*.*.*
 installed tailwind-merge@*.*.*
 installed react@*.*.*
 installed react-dom@*.*.*
-14 packages installed [*ms]
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+23 packages installed [*ms]
 😎 Setting up shadcn/ui components
 $ bun x shadcn@canary add -y button badge card
 - components/ui/button.tsx
@@ -110,6 +128,8 @@ Development - frontend dev server with hot reload
 bun dev
 Production - build optimized assets
 bun run build
+Component - your main react component
+./index.tsx
 Happy bunning! 🐇
 Bun v*.*.* dev server ready in *.** ms
 url: http://[SERVER_URL]/"
@@ -133,19 +153,27 @@ create  index.css          css
 create  index.html         html
 create  index.client.tsx   bun
 create  package.json       npm
-📦 Auto-installing 3 detected dependencies
-$ bun --only-missing install classnames react-dom@19 react@19
+📦 Auto-installing 7 detected dependencies
+$ bun --only-missing install classnames react-dom@19 react@19 @types/react@19 @types/react-dom@19 @types/bun@latest typescript@^5.0.0
 bun add v*.*.*
 installed classnames@*.*.*
 installed react-dom@*.*.*
 installed react@*.*.*
-4 packages installed [*ms]
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+installed @types/bun@*.*.*
+installed typescript@*.*.* with binaries:
+- tsc
+- tsserver
+13 packages installed [*ms]
 --------------------------------
 ✨ React project configured
 Development - frontend dev server with hot reload
 bun dev
 Production - build optimized assets
 bun run build
+Component - your main react component
+./index.jsx
 Happy bunning! 🐇
 Bun v*.*.* ready in *.** ms
 url: http://[SERVER_URL]/"
@@ -170,20 +198,26 @@ create  index.html         html
 create  index.client.tsx   bun
 create  bunfig.toml        bun
 create  package.json       npm
-📦 Auto-installing 4 detected dependencies
-$ bun --only-missing install tailwindcss bun-plugin-tailwind react-dom@19 react@19
+📦 Auto-installing 8 detected dependencies
+$ bun --only-missing install tailwindcss bun-plugin-tailwind react-dom@19 react@19 @types/react@19 @types/react-dom@19 @types/bun@latest typescript@^5.0.0
 bun add v*.*.*
++ @types/bun@*.*.*
++ typescript@*.*.*
 installed tailwindcss@*.*.*
 installed bun-plugin-tailwind@*.*.*
 installed react-dom@*.*.*
 installed react@*.*.*
-7 packages installed [*ms]
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+15 packages installed [*ms]
 --------------------------------
 ✨ React + Tailwind project configured
 Development - frontend dev server with hot reload
 bun dev
 Production - build optimized assets
 bun run build
+Component - your main react component
+./index.tsx
 Happy bunning! 🐇
 Bun v*.*.* ready in *.** ms
 url: http://[SERVER_URL]/"
@@ -201,9 +235,11 @@ create  bunfig.toml          bun
 create  package.json         npm
 create  tsconfig.json        tsc
 create  components.json      shadcn
-📦 Auto-installing 9 detected dependencies
-$ bun --only-missing install lucide-react tailwindcss bun-plugin-tailwind tailwindcss-animate class-variance-authority clsx tailwind-merge react@^18 react-dom@^18
+📦 Auto-installing 14 detected dependencies
+$ bun --only-missing install lucide-react tailwindcss bun-plugin-tailwind tailwindcss-animate class-variance-authority clsx tailwind-merge lucide-react react@^18 react-dom@^18 @types/react@^18 @types/react-dom@^18 @types/bun@latest typescript@^5.0.0
 bun add v*.*.*
++ @types/bun@*.*.*
++ typescript@*.*.*
 installed lucide-react@*.*.*
 installed tailwindcss@*.*.*
 installed bun-plugin-tailwind@*.*.*
@@ -213,7 +249,9 @@ installed clsx@*.*.*
 installed tailwind-merge@*.*.*
 installed react@*.*.*
 installed react-dom@*.*.*
-14 packages installed [*ms]
+installed @types/react@*.*.*
+installed @types/react-dom@*.*.*
+23 packages installed [*ms]
 😎 Setting up shadcn/ui components
 $ bun x shadcn@canary add -y button badge card
 - components/ui/button.tsx
@@ -225,6 +263,8 @@ Development - frontend dev server with hot reload
 bun dev
 Production - build optimized assets
 bun run build
+Component - your main react component
+./index.tsx
 Happy bunning! 🐇
 Bun v*.*.* ready in *.** ms
 url: http://[SERVER_URL]/"


### PR DESCRIPTION
### What does this PR do?

extend the `bun create ./component.tsx` thing for `bun init`

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

tested on linux, and will test with production CI build on windows too