### PR TITLE
fix(sql) add `prepare: false` option and sql``.simple()

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2054,6 +2054,8 @@ declare module "bun" {
     max?: number;
     /** By default values outside i32 range are returned as strings. If this is true, values outside i32 range are returned as BigInts. */
     bigint?: boolean;
+    /** Automatic creation of prepared statements, defaults to true */
+    prepare?: boolean;
   };
 
   /**
@@ -2067,6 +2069,8 @@ declare module "bun" {
     cancelled: boolean;
     /** Cancels the executing query */
     cancel(): SQLQuery;
+    /** Execute as a simple query, no parameters are allowed but can execute multiple commands separated by semicolons */
+    simple(): SQLQuery;
     /** Executes the query */
     execute(): SQLQuery;
     /** Returns the raw query result */

--- a/src/bun.js/api/postgres.classes.ts
+++ b/src/bun.js/api/postgres.classes.ts
@@ -72,6 +72,10 @@ export default [
         fn: "setMode",
         length: 1,
       },
+      setPendingValue: {
+        fn: "setPendingValue",
+        length: 1,
+      },
     },
     values: ["pendingValue", "target", "columns", "binding"],
     estimatedSize: true,

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -175,7 +175,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_POSTGRES_INVALID_TRANSACTION_STATE", Error, "PostgresError"],
   ["ERR_POSTGRES_QUERY_CANCELLED", Error, "PostgresError"],
   ["ERR_POSTGRES_UNSAFE_TRANSACTION", Error, "PostgresError"],
-
   // S3
   ["ERR_S3_MISSING_CREDENTIALS", Error],
   ["ERR_S3_INVALID_METHOD", Error],

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -6540,10 +6540,10 @@ pub const CallFrame = opaque {
     /// arguments(n).mut() -> `var args = argumentsAsArray(n); &args`
     pub fn arguments_old(self: *const CallFrame, comptime max: usize) Arguments(max) {
         const slice = self.arguments();
-        comptime bun.assert(max <= 13);
+        comptime bun.assert(max <= 14);
         return switch (@as(u4, @min(slice.len, max))) {
             0 => .{ .ptr = undefined, .len = 0 },
-            inline 1...13 => |count| Arguments(max).init(comptime @min(count, max), slice.ptr),
+            inline 1...14 => |count| Arguments(max).init(comptime @min(count, max), slice.ptr),
             else => unreachable,
         };
     }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -47,6 +47,7 @@ const _strings = Symbol("strings");
 const _values = Symbol("values");
 const _poolSize = Symbol("poolSize");
 const _flags = Symbol("flags");
+const _results = Symbol("results");
 const PublicPromise = Promise;
 type TransactionCallback = (sql: (strings: string, ...values: any[]) => Query) => Promise<any>;
 
@@ -90,6 +91,7 @@ enum SQLQueryFlags {
   allowUnsafeTransaction = 1 << 0,
   unsafe = 1 << 1,
   bigint = 1 << 2,
+  simple = 1 << 3,
 }
 
 function getQueryHandle(query) {
@@ -102,6 +104,7 @@ function getQueryHandle(query) {
         query[_flags] & SQLQueryFlags.allowUnsafeTransaction,
         query[_poolSize],
         query[_flags] & SQLQueryFlags.bigint,
+        query[_flags] & SQLQueryFlags.simple,
       );
     } catch (err) {
       query[_queryStatus] |= QueryStatus.error | QueryStatus.invalidHandle;
@@ -144,6 +147,7 @@ class Query extends PublicPromise {
     this[_strings] = strings;
     this[_values] = values;
     this[_flags] = allowUnsafeTransaction;
+    this[_results] = null;
   }
 
   async [_run](async: boolean) {
@@ -237,6 +241,11 @@ class Query extends PublicPromise {
     return this;
   }
 
+  simple() {
+    this[_flags] |= SQLQueryFlags.simple;
+    return this;
+  }
+
   values() {
     const handle = getQueryHandle(this);
     if (!handle) return this;
@@ -266,7 +275,51 @@ class Query extends PublicPromise {
 Object.defineProperty(Query, Symbol.species, { value: PublicPromise });
 Object.defineProperty(Query, Symbol.toStringTag, { value: "Query" });
 init(
-  function onResolvePostgresQuery(query, result, commandTag, count, queries) {
+  function onResolvePostgresQuery(query, result, commandTag, count, queries, is_last) {
+    /// simple queries
+    if (query[_flags] & SQLQueryFlags.simple) {
+      // simple can have multiple results or a single result
+      if (is_last) {
+        if (queries) {
+          const queriesIndex = queries.indexOf(query);
+          if (queriesIndex !== -1) {
+            queries.splice(queriesIndex, 1);
+          }
+        }
+        try {
+          query.resolve(query[_results]);
+        } catch (e) {}
+        return;
+      }
+      $assert(result instanceof SQLResultArray, "Invalid result array");
+      // prepare for next query
+      query[_handle].setPendingValue(new SQLResultArray());
+
+      if (typeof commandTag === "string") {
+        if (commandTag.length > 0) {
+          result.command = commandTag;
+        }
+      } else {
+        result.command = cmds[commandTag];
+      }
+
+      result.count = count || 0;
+      const last_result = query[_results];
+
+      if (!last_result) {
+        query[_results] = result;
+      } else {
+        if (last_result instanceof SQLResultArray) {
+          // multiple results
+          query[_results] = [last_result, result];
+        } else {
+          // 3 or more results
+          last_result.push(result);
+        }
+      }
+      return;
+    }
+    /// prepared statements
     $assert(result instanceof SQLResultArray, "Invalid result array");
     if (typeof commandTag === "string") {
       if (commandTag.length > 0) {
@@ -277,14 +330,12 @@ init(
     }
 
     result.count = count || 0;
-
     if (queries) {
       const queriesIndex = queries.indexOf(query);
       if (queriesIndex !== -1) {
         queries.splice(queriesIndex, 1);
       }
     }
-
     try {
       query.resolve(result);
     } catch (e) {}
@@ -857,6 +908,7 @@ function createConnection(
     idleTimeout = 0,
     connectionTimeout = 30 * 1000,
     maxLifetime = 0,
+    prepare = true,
   },
   onConnected,
   onClose,
@@ -879,6 +931,7 @@ function createConnection(
     idleTimeout,
     connectionTimeout,
     maxLifetime,
+    !!prepare,
   );
 }
 
@@ -1033,7 +1086,7 @@ function handleQueryFragment(strings, values) {
 
   return { final_strings, final_values };
 }
-function doCreateQuery(strings, values, allowUnsafeTransaction, poolSize, bigint) {
+function doCreateQuery(strings, values, allowUnsafeTransaction, poolSize, bigint, simple) {
   let columns;
 
   let { final_strings, final_values } = handleQueryFragment(strings, values);
@@ -1053,7 +1106,7 @@ function doCreateQuery(strings, values, allowUnsafeTransaction, poolSize, bigint
       }
     }
   }
-  return createQuery(sqlString, final_values, new SQLResultArray(), columns, !!bigint);
+  return createQuery(sqlString, final_values, new SQLResultArray(), columns, !!bigint, !!simple);
 }
 
 class SQLArrayParameter {
@@ -1111,7 +1164,8 @@ function loadOptions(o) {
     onconnect,
     onclose,
     max,
-    bigint;
+    bigint,
+    prepare;
   const env = Bun.env || {};
   var sslMode: SSLMode = SSLMode.disable;
 
@@ -1188,6 +1242,7 @@ function loadOptions(o) {
   maxLifetime ??= o.maxLifetime;
   maxLifetime ??= o.max_lifetime;
   bigint ??= o.bigint;
+  prepare ??= o.prepare;
 
   onconnect ??= o.onconnect;
   onclose ??= o.onclose;
@@ -1271,7 +1326,7 @@ function loadOptions(o) {
     default:
       throw new Error(`Unsupported adapter: ${adapter}. Only \"postgres\" is supported for now`);
   }
-  const ret: any = { hostname, port, username, password, database, tls, query, sslMode, adapter };
+  const ret: any = { hostname, port, username, password, database, tls, query, sslMode, adapter, prepare, bigint };
   if (idleTimeout != null) {
     ret.idleTimeout = idleTimeout;
   }
@@ -1288,8 +1343,6 @@ function loadOptions(o) {
     ret.onclose = onclose;
   }
   ret.max = max || 10;
-
-  ret.bigint = bigint;
 
   return ret;
 }
@@ -1368,13 +1421,11 @@ function SQL(o, e = {}) {
 
   function unsafeQuery(strings, values) {
     try {
-      return new Query(
-        strings,
-        values,
-        connectionInfo.bigint ? SQLQueryFlags.bigint | SQLQueryFlags.unsafe : SQLQueryFlags.unsafe,
-        connectionInfo.max,
-        queryFromPoolHandler,
-      );
+      let flags = connectionInfo.bigint ? SQLQueryFlags.bigint | SQLQueryFlags.unsafe : SQLQueryFlags.unsafe;
+      if ((values?.length ?? 0) === 0) {
+        flags |= SQLQueryFlags.simple;
+      }
+      return new Query(strings, values, flags, connectionInfo.max, queryFromPoolHandler);
     } catch (err) {
       return Promise.reject(err);
     }
@@ -1418,12 +1469,17 @@ function SQL(o, e = {}) {
   }
   function unsafeQueryFromTransaction(strings, values, pooledConnection, transactionQueries) {
     try {
+      let flags = connectionInfo.bigint
+        ? SQLQueryFlags.allowUnsafeTransaction | SQLQueryFlags.unsafe | SQLQueryFlags.bigint
+        : SQLQueryFlags.allowUnsafeTransaction | SQLQueryFlags.unsafe;
+
+      if ((values?.length ?? 0) === 0) {
+        flags |= SQLQueryFlags.simple;
+      }
       const query = new Query(
         strings,
         values,
-        connectionInfo.bigint
-          ? SQLQueryFlags.allowUnsafeTransaction | SQLQueryFlags.unsafe | SQLQueryFlags.bigint
-          : SQLQueryFlags.allowUnsafeTransaction | SQLQueryFlags.unsafe,
+        flags,
         connectionInfo.max,
         queryFromTransactionHandler.bind(pooledConnection, transactionQueries),
       );
@@ -2048,7 +2104,6 @@ function SQL(o, e = {}) {
   sql.unsafe = (string, args = []) => {
     return unsafeQuery(string, args);
   };
-
   sql.reserve = () => {
     if (pool.closed) {
       return Promise.reject(connectionClosedError());

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -931,7 +931,7 @@ function createConnection(
     idleTimeout,
     connectionTimeout,
     maxLifetime,
-    !!prepare,
+    !prepare,
   );
 }
 
@@ -1164,8 +1164,8 @@ function loadOptions(o) {
     onconnect,
     onclose,
     max,
-    bigint,
-    prepare;
+    bigint;
+  let prepare = true;
   const env = Bun.env || {};
   var sslMode: SSLMode = SSLMode.disable;
 
@@ -1242,7 +1242,10 @@ function loadOptions(o) {
   maxLifetime ??= o.maxLifetime;
   maxLifetime ??= o.max_lifetime;
   bigint ??= o.bigint;
-  prepare ??= o.prepare;
+  // we need to explicitly set prepare to false if it is false
+  if (o.prepare === false) {
+    prepare = false;
+  }
 
   onconnect ??= o.onconnect;
   onclose ??= o.onclose;

--- a/src/sql/postgres/postgres_protocol.zig
+++ b/src/sql/postgres/postgres_protocol.zig
@@ -1255,6 +1255,14 @@ pub const Flush = [_]u8{'H'} ++ toBytes(Int32(4));
 pub const SSLRequest = toBytes(Int32(8)) ++ toBytes(Int32(80877103));
 pub const NoData = [_]u8{'n'} ++ toBytes(Int32(4));
 
+pub fn writeQuery(query: []const u8, comptime Context: type, writer: NewWriter(Context)) !void {
+    const count: u32 = @sizeOf((u32)) + @as(u32, @intCast(query.len)) + 1;
+    const header = [_]u8{
+        'Q',
+    } ++ toBytes(Int32(count));
+    try writer.write(&header);
+    try writer.string(query);
+}
 pub const SASLInitialResponse = struct {
     mechanism: Data = .{ .empty = {} },
     data: Data = .{ .empty = {} },
@@ -1405,30 +1413,6 @@ pub const Describe = struct {
         });
         try writer.string(message);
         try length.write();
-    }
-
-    pub const write = writeWrap(@This(), writeInternal).write;
-};
-
-pub const Query = struct {
-    message: Data = .{ .empty = {} },
-
-    pub fn deinit(this: *@This()) void {
-        this.message.deinit();
-    }
-
-    pub fn writeInternal(
-        this: *const @This(),
-        comptime Context: type,
-        writer: NewWriter(Context),
-    ) !void {
-        const message = this.message.slice();
-        const count: u32 = @sizeOf((u32)) + message.len + 1;
-        const header = [_]u8{
-            'Q',
-        } ++ toBytes(Int32(count));
-        try writer.write(&header);
-        try writer.string(message);
     }
 
     pub const write = writeWrap(@This(), writeInternal).write;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1288,6 +1288,14 @@ if (isDockerEnabled()) {
     expect(await sql.unsafe("select 1 as x")).toEqual([{ x: 1 }]);
   });
 
+  test("simple query with multiple statements", async () => {
+    const result = await sql`select 1 as x;select 2 as x`.simple();
+    expect(result).toBeDefined();
+    expect(result.length).toEqual(2);
+    expect(result[0][0].x).toEqual(1);
+    expect(result[1][0].x).toEqual(2);
+  });
+
   // t('unsafe simple includes columns', async() => {
   //   return ['x', (await sql.unsafe('select 1 as x').values()).columns[0].name]
   // })
@@ -1304,21 +1312,13 @@ if (isDockerEnabled()) {
   //   ]
   // })
 
-  test.todo("simple query using unsafe with multiple statements", async () => {
-    // bun always uses prepared statements, so this is not supported
-    //     PostgresError: cannot insert multiple commands into a prepared statement
-    //  errno: "42601",
-    //   code: "ERR_POSTGRES_SYNTAX_ERROR"
-    expect(await sql.unsafe("select 1 as x;select 2 as x")).toEqual([{ x: 1 }, { x: 2 }]);
-    // return ["1,2", (await sql.unsafe("select 1 as x;select 2 as x")).map(x => x[0].x).join()];
+  test("simple query using unsafe with multiple statements", async () => {
+    const result = await sql.unsafe("select 1 as x;select 2 as x");
+    expect(result).toBeDefined();
+    expect(result.length).toEqual(2);
+    expect(result[0][0].x).toEqual(1);
+    expect(result[1][0].x).toEqual(2);
   });
-
-  // t('simple query using simple() with multiple statements', async() => {
-  //   return [
-  //     '1,2',
-  //     (await sql`select 1 as x;select 2 as x`.simple()).map(x => x[0].x).join()
-  //   ]
-  // })
 
   // t('listen and notify', async() => {
   //   const sql = postgres(options)

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -24,8 +24,18 @@ for (const options of [
     prepare: false,
     transactionPool: true,
   },
+
+  {
+    url: TLS_POSTGRES_DATABASE_URL,
+    tls: true,
+    adapter: "postgresql",
+    max: 1,
+    bigint: true,
+    prepare: false,
+    transactionPool: false,
+  },
 ]) {
-  describe(`${options.transactionPool ? "Transaction Pooling" : "Prepared Statements"}`, () => {
+  describe(`${options.transactionPool ? "Transaction Pooling" : `Prepared Statements (${options.prepare ? "on" : "off"})`}`, () => {
     test("default sql", async () => {
       expect(sql.reserve).toBeDefined();
       expect(sql.options).toBeDefined();

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -85,7 +85,7 @@ for (const options of [
       ).toBe("22P02");
     });
 
-    test.only("Transaction rolls back", async () => {
+    test("Transaction rolls back", async () => {
       await using sql = new SQL(options);
       const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
@@ -103,7 +103,7 @@ for (const options of [
       expect((await sql`select a from ${sql(random_name)}`).count).toBe(0);
     });
 
-    test.only("Transaction throws on uncaught savepoint", async () => {
+    test("Transaction throws on uncaught savepoint", async () => {
       await using sql = new SQL(options);
       const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -72,7 +72,7 @@ for (const options of [
 
     test("Transaction throws", async () => {
       await using sql = new SQL(options);
-      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       expect(
@@ -85,9 +85,9 @@ for (const options of [
       ).toBe("22P02");
     });
 
-    test("Transaction rolls back", async () => {
+    test.only("Transaction rolls back", async () => {
       await using sql = new SQL(options);
-      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
 
@@ -103,9 +103,9 @@ for (const options of [
       expect((await sql`select a from ${sql(random_name)}`).count).toBe(0);
     });
 
-    test("Transaction throws on uncaught savepoint", async () => {
+    test.only("Transaction throws on uncaught savepoint", async () => {
       await using sql = new SQL(options);
-      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       expect(
         await sql
@@ -122,7 +122,7 @@ for (const options of [
 
     test("Transaction throws on uncaught named savepoint", async () => {
       await using sql = new SQL(options);
-      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       expect(
         await sql
@@ -139,7 +139,7 @@ for (const options of [
 
     test("Transaction succeeds on caught savepoint", async () => {
       await using sql = new SQL(options);
-      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       try {
         await sql.begin(async sql => {
@@ -230,7 +230,7 @@ for (const options of [
 
     test("Transaction waits", async () => {
       await using sql = new SQL({ ...options, max: 2 });
-      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       await sql.begin(async sql => {
         await sql`insert into ${sql(random_name)} values(1)`;

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -1,240 +1,259 @@
-import { test, expect, mock } from "bun:test";
+import { test, expect, describe } from "bun:test";
 import { getSecret } from "harness";
-import { SQL, sql, postgres } from "bun";
+import { SQL, sql, postgres, randomUUIDv7 } from "bun";
 
 const TLS_POSTGRES_DATABASE_URL = getSecret("TLS_POSTGRES_DATABASE_URL");
-const options = {
-  url: TLS_POSTGRES_DATABASE_URL,
-  tls: true,
-  adapter: "postgresql",
-  max: 1,
-  bigint: true,
-};
+const PG_TRANSACTION_POOL_SUPABASE_URL = getSecret("PG_TRANSACTION_POOL_SUPABASE_URL");
 
-if (TLS_POSTGRES_DATABASE_URL) {
-  test("default sql", async () => {
-    expect(sql.reserve).toBeDefined();
-    expect(sql.options).toBeDefined();
-    expect(sql[Symbol.asyncDispose]).toBeDefined();
-    expect(sql.begin).toBeDefined();
-    expect(sql.beginDistributed).toBeDefined();
-    expect(sql.distributed).toBeDefined();
-    expect(sql.unsafe).toBeDefined();
-    expect(sql.end).toBeDefined();
-    expect(sql.close).toBeDefined();
-    expect(sql.transaction).toBeDefined();
-    expect(sql.distributed).toBeDefined();
-    expect(sql.unsafe).toBeDefined();
-    expect(sql.commitDistributed).toBeDefined();
-    expect(sql.rollbackDistributed).toBeDefined();
-  });
-  test("default postgres", async () => {
-    expect(postgres.reserve).toBeDefined();
-    expect(postgres.options).toBeDefined();
-    expect(postgres[Symbol.asyncDispose]).toBeDefined();
-    expect(postgres.begin).toBeDefined();
-    expect(postgres.beginDistributed).toBeDefined();
-    expect(postgres.distributed).toBeDefined();
-    expect(postgres.unsafe).toBeDefined();
-    expect(postgres.end).toBeDefined();
-    expect(postgres.close).toBeDefined();
-    expect(postgres.transaction).toBeDefined();
-    expect(postgres.distributed).toBeDefined();
-    expect(postgres.unsafe).toBeDefined();
-    expect(postgres.commitDistributed).toBeDefined();
-    expect(postgres.rollbackDistributed).toBeDefined();
-  });
-  test("tls (explicit)", async () => {
-    await using sql = new SQL(options);
-    const [{ one, two }] = await sql`SELECT 1 as one, '2' as two`;
-    expect(one).toBe(1);
-    expect(two).toBe("2");
-    await sql.close();
-  });
+for (const options of [
+  {
+    url: TLS_POSTGRES_DATABASE_URL,
+    tls: true,
+    adapter: "postgresql",
+    max: 1,
+    bigint: true,
+    prepare: true,
+  },
+  {
+    url: PG_TRANSACTION_POOL_SUPABASE_URL,
+    tls: true,
+    adapter: "postgresql",
+    max: 1,
+    bigint: true,
+    prepare: false,
+  },
+]) {
+  describe(`${options.prepare === false ? "Transaction Pooling" : "Prepared Statements"}`, () => {
+    test("default sql", async () => {
+      expect(sql.reserve).toBeDefined();
+      expect(sql.options).toBeDefined();
+      expect(sql[Symbol.asyncDispose]).toBeDefined();
+      expect(sql.begin).toBeDefined();
+      expect(sql.beginDistributed).toBeDefined();
+      expect(sql.distributed).toBeDefined();
+      expect(sql.unsafe).toBeDefined();
+      expect(sql.end).toBeDefined();
+      expect(sql.close).toBeDefined();
+      expect(sql.transaction).toBeDefined();
+      expect(sql.distributed).toBeDefined();
+      expect(sql.unsafe).toBeDefined();
+      expect(sql.commitDistributed).toBeDefined();
+      expect(sql.rollbackDistributed).toBeDefined();
+    });
+    test("default postgres", async () => {
+      expect(postgres.reserve).toBeDefined();
+      expect(postgres.options).toBeDefined();
+      expect(postgres[Symbol.asyncDispose]).toBeDefined();
+      expect(postgres.begin).toBeDefined();
+      expect(postgres.beginDistributed).toBeDefined();
+      expect(postgres.distributed).toBeDefined();
+      expect(postgres.unsafe).toBeDefined();
+      expect(postgres.end).toBeDefined();
+      expect(postgres.close).toBeDefined();
+      expect(postgres.transaction).toBeDefined();
+      expect(postgres.distributed).toBeDefined();
+      expect(postgres.unsafe).toBeDefined();
+      expect(postgres.commitDistributed).toBeDefined();
+      expect(postgres.rollbackDistributed).toBeDefined();
+    });
+    test("tls (explicit)", async () => {
+      await using sql = new SQL(options);
+      const [{ one, two }] = await sql`SELECT 1 as one, '2' as two`;
+      expect(one).toBe(1);
+      expect(two).toBe("2");
+      await sql.close();
+    });
 
-  test("Throws on illegal transactions", async () => {
-    await using sql = new SQL({ ...options, max: 2 });
-    const error = await sql`BEGIN`.catch(e => e);
-    return expect(error.code).toBe("ERR_POSTGRES_UNSAFE_TRANSACTION");
-  });
+    test("Throws on illegal transactions", async () => {
+      await using sql = new SQL({ ...options, max: 2 });
+      const error = await sql`BEGIN`.catch(e => e);
+      return expect(error.code).toBe("ERR_POSTGRES_UNSAFE_TRANSACTION");
+    });
 
-  test("Transaction throws", async () => {
-    await using sql = new SQL(options);
-    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS test (a int)`;
-    expect(
+    test("Transaction throws", async () => {
+      await using sql = new SQL(options);
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+
+      await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
+      expect(
+        await sql
+          .begin(async sql => {
+            await sql`insert into ${sql(random_name)} values(1)`;
+            await sql`insert into ${sql(random_name)} values('hej')`;
+          })
+          .catch(e => e.errno),
+      ).toBe("22P02");
+    });
+
+    test("Transaction rolls back", async () => {
+      await using sql = new SQL(options);
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+
+      await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
+
       await sql
         .begin(async sql => {
-          await sql`insert into test values(1)`;
-          await sql`insert into test values('hej')`;
+          await sql`insert into ${sql(random_name)} values(1)`;
+          await sql`insert into ${sql(random_name)} values('hej')`;
         })
-        .catch(e => e.errno),
-    ).toBe("22P02");
-  });
+        .catch(() => {
+          /* ignore */
+        });
 
-  test("Transaction rolls back", async () => {
-    await using sql = new SQL(options);
-    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS test (a int)`;
+      expect((await sql`select a from ${sql(random_name)}`).count).toBe(0);
+    });
 
-    await sql
-      .begin(async sql => {
-        await sql`insert into test values(1)`;
-        await sql`insert into test values('hej')`;
-      })
-      .catch(() => {
-        /* ignore */
+    test("Transaction throws on uncaught savepoint", async () => {
+      await using sql = new SQL(options);
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
+      expect(
+        await sql
+          .begin(async sql => {
+            await sql`insert into ${sql(random_name)} values(1)`;
+            await sql.savepoint(async sql => {
+              await sql`insert into ${sql(random_name)} values(2)`;
+              throw new Error("fail");
+            });
+          })
+          .catch(err => err.message),
+      ).toBe("fail");
+    });
+
+    test("Transaction throws on uncaught named savepoint", async () => {
+      await using sql = new SQL(options);
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
+      expect(
+        await sql
+          .begin(async sql => {
+            await sql`insert into ${sql(random_name)} values(1)`;
+            await sql.savepoint("watpoint", async sql => {
+              await sql`insert into ${sql(random_name)} values(2)`;
+              throw new Error("fail");
+            });
+          })
+          .catch(() => "fail"),
+      ).toBe("fail");
+    });
+
+    test("Transaction succeeds on caught savepoint", async () => {
+      await using sql = new SQL(options);
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`CREATE TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
+      try {
+        await sql.begin(async sql => {
+          await sql`insert into ${sql(random_name)} values(1)`;
+          await sql
+            .savepoint(async sql => {
+              await sql`insert into ${sql(random_name)} values(2)`;
+              throw new Error("please rollback");
+            })
+            .catch(() => {
+              /* ignore */
+            });
+          await sql`insert into ${sql(random_name)} values(3)`;
+        });
+        expect((await sql`select count(1) from ${sql(random_name)}`)[0].count).toBe(2n);
+      } finally {
+        await sql`DROP TABLE IF EXISTS ${sql(random_name)}`;
+      }
+    });
+
+    test("Savepoint returns Result", async () => {
+      let result;
+      await using sql = new SQL(options);
+      await sql.begin(async t => {
+        result = await t.savepoint(s => s`select 1 as x`);
       });
+      expect(result[0]?.x).toBe(1);
+    });
 
-    expect((await sql`select a from test`).count).toBe(0);
-  });
+    test("Transaction requests are executed implicitly", async () => {
+      await using sql = new SQL(options);
+      expect(
+        (
+          await sql.begin(sql => [
+            sql`select set_config('bun_sql.test', 'testing', true)`,
+            sql`select current_setting('bun_sql.test') as x`,
+          ])
+        )[1][0].x,
+      ).toBe("testing");
+    });
 
-  test("Transaction throws on uncaught savepoint", async () => {
-    await using sql = new SQL(options);
-    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS test (a int)`;
-    expect(
-      await sql
-        .begin(async sql => {
-          await sql`insert into test values(1)`;
-          await sql.savepoint(async sql => {
-            await sql`insert into test values(2)`;
-            throw new Error("fail");
-          });
-        })
-        .catch(err => err.message),
-    ).toBe("fail");
-  });
+    test("Uncaught transaction request errors bubbles to transaction", async () => {
+      await using sql = new SQL(options);
+      expect(
+        await sql
+          .begin(sql => [sql`select wat`, sql`select current_setting('bun_sql.test') as x, ${1} as a`])
+          .catch(e => e.errno || e),
+      ).toBe("42703");
+    });
 
-  test("Transaction throws on uncaught named savepoint", async () => {
-    await using sql = new SQL(options);
-    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS test (a int)`;
-    expect(
-      await sql
-        .begin(async sql => {
-          await sql`insert into test values(1)`;
-          await sql.savepoit("watpoint", async sql => {
-            await sql`insert into test values(2)`;
-            throw new Error("fail");
-          });
-        })
-        .catch(() => "fail"),
-    ).toBe("fail");
-  });
+    test("Transaction rejects with rethrown error", async () => {
+      await using sql = new SQL(options);
+      expect(
+        await sql
+          .begin(async sql => {
+            try {
+              await sql`select exception`;
+            } catch (ex) {
+              throw new Error("WAT");
+            }
+          })
+          .catch(e => e.message),
+      ).toBe("WAT");
+    });
 
-  test("Transaction succeeds on caught savepoint", async () => {
-    await using sql = new SQL(options);
-    const table_id = `test_random${Bun.randomUUIDv7().toString().replace(/-/g, "_")}`;
-    await sql`CREATE TABLE IF NOT EXISTS ${sql(table_id)} (a int)`;
-    try {
+    test("Parallel transactions", async () => {
+      await using sql = new SQL({ ...options, max: 2 });
+
+      expect(
+        (await Promise.all([sql.begin(sql => sql`select 1 as count`), sql.begin(sql => sql`select 1 as count`)]))
+          .map(x => x[0].count)
+          .join(""),
+      ).toBe("11");
+    });
+
+    test("Many transactions at beginning of connection", async () => {
+      await using sql = new SQL({ ...options, max: 2 });
+      const xs = await Promise.all(Array.from({ length: 30 }, () => sql.begin(sql => sql`select 1`)));
+      return expect(xs.length).toBe(30);
+    });
+
+    test("Transactions array", async () => {
+      await using sql = new SQL(options);
+      expect(
+        (await sql.begin(sql => [sql`select 1 as count`, sql`select 1 as count`])).map(x => x[0].count).join(""),
+      ).toBe("11");
+    });
+
+    test("Transaction waits", async () => {
+      await using sql = new SQL({ ...options, max: 2 });
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       await sql.begin(async sql => {
-        await sql`insert into ${sql(table_id)} values(1)`;
+        await sql`insert into ${sql(random_name)} values(1)`;
         await sql
           .savepoint(async sql => {
-            await sql`insert into ${sql(table_id)} values(2)`;
+            await sql`insert into ${sql(random_name)} values(2)`;
             throw new Error("please rollback");
           })
           .catch(() => {
             /* ignore */
           });
-        await sql`insert into ${sql(table_id)} values(3)`;
+        await sql`insert into ${sql(random_name)} values(3)`;
       });
-      expect((await sql`select count(1) from ${sql(table_id)}`)[0].count).toBe(2n);
-    } finally {
-      await sql`DROP TABLE IF EXISTS ${sql(table_id)}`;
-    }
-  });
-
-  test("Savepoint returns Result", async () => {
-    let result;
-    await using sql = new SQL(options);
-    await sql.begin(async t => {
-      result = await t.savepoint(s => s`select 1 as x`);
+      expect(
+        (
+          await Promise.all([
+            sql.begin(async sql => await sql`select 1 as count`),
+            sql.begin(async sql => await sql`select 1 as count`),
+          ])
+        )
+          .map(x => x[0].count)
+          .join(""),
+      ).toBe("11");
     });
-    expect(result[0]?.x).toBe(1);
-  });
-
-  test("Transaction requests are executed implicitly", async () => {
-    await using sql = new SQL(options);
-    expect(
-      (
-        await sql.begin(sql => [
-          sql`select set_config('bun_sql.test', 'testing', true)`,
-          sql`select current_setting('bun_sql.test') as x`,
-        ])
-      )[1][0].x,
-    ).toBe("testing");
-  });
-
-  test("Uncaught transaction request errors bubbles to transaction", async () => {
-    await using sql = new SQL(options);
-    expect(
-      await sql
-        .begin(sql => [sql`select wat`, sql`select current_setting('bun_sql.test') as x, ${1} as a`])
-        .catch(e => e.errno || e),
-    ).toBe("42703");
-  });
-
-  test("Transaction rejects with rethrown error", async () => {
-    await using sql = new SQL(options);
-    expect(
-      await sql
-        .begin(async sql => {
-          try {
-            await sql`select exception`;
-          } catch (ex) {
-            throw new Error("WAT");
-          }
-        })
-        .catch(e => e.message),
-    ).toBe("WAT");
-  });
-
-  test("Parallel transactions", async () => {
-    await using sql = new SQL({ ...options, max: 2 });
-
-    expect(
-      (await Promise.all([sql.begin(sql => sql`select 1 as count`), sql.begin(sql => sql`select 1 as count`)]))
-        .map(x => x[0].count)
-        .join(""),
-    ).toBe("11");
-  });
-
-  test("Many transactions at beginning of connection", async () => {
-    await using sql = new SQL({ ...options, max: 2 });
-    const xs = await Promise.all(Array.from({ length: 30 }, () => sql.begin(sql => sql`select 1`)));
-    return expect(xs.length).toBe(30);
-  });
-
-  test("Transactions array", async () => {
-    await using sql = new SQL(options);
-    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS test (a int)`;
-    expect(
-      (await sql.begin(sql => [sql`select 1 as count`, sql`select 1 as count`])).map(x => x[0].count).join(""),
-    ).toBe("11");
-  });
-
-  test("Transaction waits", async () => {
-    await using sql = new SQL({ ...options, max: 2 });
-    await sql`CREATE TEMPORARY TABLE IF NOT EXISTS test (a int)`;
-    await sql.begin(async sql => {
-      await sql`insert into test values(1)`;
-      await sql
-        .savepoint(async sql => {
-          await sql`insert into test values(2)`;
-          throw new Error("please rollback");
-        })
-        .catch(() => {
-          /* ignore */
-        });
-      await sql`insert into test values(3)`;
-    });
-    expect(
-      (
-        await Promise.all([
-          sql.begin(async sql => await sql`select 1 as count`),
-          sql.begin(async sql => await sql`select 1 as count`),
-        ])
-      )
-        .map(x => x[0].count)
-        .join(""),
-    ).toBe("11");
   });
 }

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -72,7 +72,7 @@ for (const options of [
 
     test("Transaction throws", async () => {
       await using sql = new SQL(options);
-      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       expect(
@@ -87,7 +87,7 @@ for (const options of [
 
     test("Transaction rolls back", async () => {
       await using sql = new SQL(options);
-      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
 
@@ -105,7 +105,7 @@ for (const options of [
 
     test("Transaction throws on uncaught savepoint", async () => {
       await using sql = new SQL(options);
-      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       expect(
         await sql
@@ -122,7 +122,7 @@ for (const options of [
 
     test("Transaction throws on uncaught named savepoint", async () => {
       await using sql = new SQL(options);
-      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       expect(
         await sql
@@ -139,7 +139,7 @@ for (const options of [
 
     test("Transaction succeeds on caught savepoint", async () => {
       await using sql = new SQL(options);
-      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       try {
         await sql.begin(async sql => {
@@ -230,7 +230,7 @@ for (const options of [
 
     test("Transaction waits", async () => {
       await using sql = new SQL({ ...options, max: 2 });
-      const random_name = ("test_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
       await sql.begin(async sql => {
         await sql`insert into ${sql(random_name)} values(1)`;

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -13,6 +13,7 @@ for (const options of [
     max: 1,
     bigint: true,
     prepare: true,
+    transactionPool: false,
   },
   {
     url: PG_TRANSACTION_POOL_SUPABASE_URL,
@@ -21,9 +22,10 @@ for (const options of [
     max: 1,
     bigint: true,
     prepare: false,
+    transactionPool: true,
   },
 ]) {
-  describe(`${options.prepare === false ? "Transaction Pooling" : "Prepared Statements"}`, () => {
+  describe(`${options.transactionPool ? "Transaction Pooling" : "Prepared Statements"}`, () => {
     test("default sql", async () => {
       expect(sql.reserve).toBeDefined();
       expect(sql.options).toBeDefined();
@@ -70,7 +72,7 @@ for (const options of [
       return expect(error.code).toBe("ERR_POSTGRES_UNSAFE_TRANSACTION");
     });
 
-    test("Transaction throws", async () => {
+    test.skipIf(options.transactionPool)("Transaction throws", async () => {
       await using sql = new SQL(options);
       const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
@@ -85,7 +87,7 @@ for (const options of [
       ).toBe("22P02");
     });
 
-    test("Transaction rolls back", async () => {
+    test.skipIf(options.transactionPool)("Transaction rolls back", async () => {
       await using sql = new SQL(options);
       const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
 
@@ -103,7 +105,7 @@ for (const options of [
       expect((await sql`select a from ${sql(random_name)}`).count).toBe(0);
     });
 
-    test("Transaction throws on uncaught savepoint", async () => {
+    test.skipIf(options.transactionPool)("Transaction throws on uncaught savepoint", async () => {
       await using sql = new SQL(options);
       const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
@@ -120,7 +122,7 @@ for (const options of [
       ).toBe("fail");
     });
 
-    test("Transaction throws on uncaught named savepoint", async () => {
+    test.skipIf(options.transactionPool)("Transaction throws on uncaught named savepoint", async () => {
       await using sql = new SQL(options);
       const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;
@@ -228,7 +230,7 @@ for (const options of [
       ).toBe("11");
     });
 
-    test("Transaction waits", async () => {
+    test.skipIf(options.transactionPool)("Transaction waits", async () => {
       await using sql = new SQL({ ...options, max: 2 });
       const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
       await sql`CREATE TEMPORARY TABLE IF NOT EXISTS ${sql(random_name)} (a int)`;


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/17029
Fix: https://github.com/oven-sh/bun/issues/17044
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
