### PR TITLE
fix(napi): memory leak when creating strings

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -340,15 +340,8 @@ pub export fn napi_create_string_latin1(env: napi_env, str: ?[*]const u8, length
 
     log("napi_create_string_latin1: {s}", .{slice});
 
-    if (slice.len == 0) {
-        result.set(env, bun.String.empty.toJS(env.toJS()));
-        return env.ok();
-    }
-
-    var string, const bytes = bun.String.createUninitialized(.latin1, slice.len);
+    var string = bun.String.createWTF(.latin1, slice) catch bun.outOfMemory();
     defer string.deref();
-
-    @memcpy(bytes, slice);
 
     result.set(env, string.toJS(env.toJS()));
     return env.ok();
@@ -401,12 +394,8 @@ pub export fn napi_create_string_utf16(env: napi_env, str: ?[*]const char16_t, l
     if (comptime bun.Environment.allow_assert)
         log("napi_create_string_utf16: {d} {any}", .{ slice.len, bun.fmt.FormatUTF16{ .buf = slice[0..@min(slice.len, 512)] } });
 
-    if (slice.len == 0) {
-        result.set(env, bun.String.empty.toJS(env.toJS()));
-    }
-
-    var string, const chars = bun.String.createUninitialized(.utf16, slice.len);
-    @memcpy(chars, slice);
+    var string = bun.String.createWTF(.utf16, slice) catch bun.outOfMemory();
+    defer string.deref();
 
     result.set(env, string.transferToJS(env.toJS()));
     return env.ok();

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -178,6 +178,12 @@ describe("napi", () => {
     });
   });
 
+  describe("napi_create_string_*", () => {
+    it("ut16 strings", () => {
+      checkSameOutput("test_napi_create_string_utf16");
+    });
+  });
+
   it("#1288", async () => {
     const result = checkSameOutput("self", []);
     expect(result).toBe("hello world!");


### PR DESCRIPTION
### What does this PR do?
Fixes two bugs in NAPI:
1. `napi_create_string_utf16` not `deref`ing newly created strings, leading to a memory leak
2. `napi_create_string_utf16` not correctly returning when passed a 0-length buffer. This would cause `createUninitialized` to get called, triggering an assertion failure.

### How did you verify your code works?
I added a test