### PR TITLE
node:buffer: fix write

### DIFF
--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -613,7 +613,8 @@ export function writeUIntBE(this: BufferExt, value, offset, byteLength) {
 export function writeFloatLE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 4);
+  // prettier-ignore
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 3] === undefined) require("internal/buffer").checkBounds(this, offset, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, true);
   return offset + 4;
 }
@@ -621,7 +622,8 @@ export function writeFloatLE(this: BufferExt, value, offset) {
 export function writeFloatBE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 4);
+  // prettier-ignore
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 3] === undefined) require("internal/buffer").checkBounds(this, offset, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, false);
   return offset + 4;
 }
@@ -629,7 +631,8 @@ export function writeFloatBE(this: BufferExt, value, offset) {
 export function writeDoubleLE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 8);
+  // prettier-ignore
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, true);
   return offset + 8;
 }
@@ -637,7 +640,8 @@ export function writeDoubleLE(this: BufferExt, value, offset) {
 export function writeDoubleBE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 8);
+  // prettier-ignore
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, false);
   return offset + 8;
 }

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -296,14 +296,22 @@ export function readBigUInt64BE(this: BufferExt, offset) {
 
 export function writeInt8(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
-  require("internal/buffer").writeU_Int8(this, value, offset, -0x80, 0x7f);
+  value = +value;
+  const min = -0x80;
+  const max = 0x7f;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined) require("internal/buffer").writeU_Int8(this, value, offset, min, max);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt8(offset, value);
   return offset + 1;
 }
 
 export function writeUInt8(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
-  require("internal/buffer").writeU_Int8(this, value, offset, 0, 0xff);
+  value = +value;
+  const min = 0;
+  const max = 0xff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined) require("internal/buffer").writeU_Int8(this, value, offset, min, max);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint8(offset, value);
   return offset + 1;
 }
@@ -311,7 +319,10 @@ export function writeUInt8(this: BufferExt, value, offset) {
 export function writeInt16LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 2);
+  const min = -0x8000;
+  const max = 0x7fff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 1] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, true);
   return offset + 2;
 }
@@ -319,7 +330,10 @@ export function writeInt16LE(this: BufferExt, value, offset) {
 export function writeInt16BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 2);
+  const min = -0x8000;
+  const max = 0x7fff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 1] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, false);
   return offset + 2;
 }
@@ -327,7 +341,10 @@ export function writeInt16BE(this: BufferExt, value, offset) {
 export function writeUInt16LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 2);
+  const min = 0;
+  const max = 0xffff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 1] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, true);
   return offset + 2;
 }
@@ -335,7 +352,10 @@ export function writeUInt16LE(this: BufferExt, value, offset) {
 export function writeUInt16BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 2);
+  const min = 0;
+  const max = 0xffff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 1] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, false);
   return offset + 2;
 }
@@ -343,7 +363,10 @@ export function writeUInt16BE(this: BufferExt, value, offset) {
 export function writeInt32LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 4);
+  const min = -0x80000000;
+  const max = 0x7fffffff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 3] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, true);
   return offset + 4;
 }
@@ -351,7 +374,10 @@ export function writeInt32LE(this: BufferExt, value, offset) {
 export function writeInt32BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 4);
+  const min = -0x80000000;
+  const max = 0x7fffffff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 3] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, false);
   return offset + 4;
 }
@@ -359,7 +385,10 @@ export function writeInt32BE(this: BufferExt, value, offset) {
 export function writeUInt32LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 4);
+  const min = 0;
+  const max = 0xffffffff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 3] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, true);
   return offset + 4;
 }
@@ -367,7 +396,10 @@ export function writeUInt32LE(this: BufferExt, value, offset) {
 export function writeUInt32BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 4);
+  const min = 0;
+  const max = 0xffffffff;
+  // prettier-ignore
+  if (typeof offset !== "number" || value < min || value > max || this[offset] === undefined || this[offset + 3] === undefined) require("internal/buffer").checkInt(this, value, offset, min, max, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, false);
   return offset + 4;
 }

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -311,7 +311,7 @@ export function writeUInt8(this: BufferExt, value, offset) {
 export function writeInt16LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 1);
+  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, true);
   return offset + 2;
 }
@@ -319,7 +319,7 @@ export function writeInt16LE(this: BufferExt, value, offset) {
 export function writeInt16BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 1);
+  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, false);
   return offset + 2;
 }
@@ -327,7 +327,7 @@ export function writeInt16BE(this: BufferExt, value, offset) {
 export function writeUInt16LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 1);
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, true);
   return offset + 2;
 }
@@ -335,7 +335,7 @@ export function writeUInt16LE(this: BufferExt, value, offset) {
 export function writeUInt16BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 1);
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 2);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, false);
   return offset + 2;
 }
@@ -343,7 +343,7 @@ export function writeUInt16BE(this: BufferExt, value, offset) {
 export function writeInt32LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 3);
+  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, true);
   return offset + 4;
 }
@@ -351,7 +351,7 @@ export function writeInt32LE(this: BufferExt, value, offset) {
 export function writeInt32BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 3);
+  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, false);
   return offset + 4;
 }
@@ -359,7 +359,7 @@ export function writeInt32BE(this: BufferExt, value, offset) {
 export function writeUInt32LE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 3);
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, true);
   return offset + 4;
 }
@@ -367,7 +367,7 @@ export function writeUInt32LE(this: BufferExt, value, offset) {
 export function writeUInt32BE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 3);
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, false);
   return offset + 4;
 }
@@ -384,7 +384,7 @@ export function writeIntLE(this: BufferExt, value, offset, byteLength) {
     case 5:
     case 6: {
       const max = 2 ** (8 * byteLength - 1) - 1;
-      require("internal/buffer").checkInt(this, value, offset, -max - 1, max, byteLength - 1);
+      require("internal/buffer").checkInt(this, value, offset, -max - 1, max, byteLength);
       break;
     }
     default: {
@@ -436,7 +436,7 @@ export function writeIntBE(this: BufferExt, value, offset, byteLength) {
     case 5:
     case 6: {
       const max = 2 ** (8 * byteLength - 1) - 1;
-      require("internal/buffer").checkInt(this, value, offset, -max - 1, max, byteLength - 1);
+      require("internal/buffer").checkInt(this, value, offset, -max - 1, max, byteLength);
       break;
     }
     default: {
@@ -487,7 +487,7 @@ export function writeUIntLE(this: BufferExt, value, offset, byteLength) {
     case 4:
     case 5:
     case 6: {
-      require("internal/buffer").checkInt(this, value, offset, 0, 2 ** (8 * byteLength) - 1, byteLength - 1);
+      require("internal/buffer").checkInt(this, value, offset, 0, 2 ** (8 * byteLength) - 1, byteLength);
       break;
     }
     default: {
@@ -538,7 +538,7 @@ export function writeUIntBE(this: BufferExt, value, offset, byteLength) {
     case 4:
     case 5:
     case 6: {
-      require("internal/buffer").checkInt(this, value, offset, 0, 2 ** (8 * byteLength) - 1, byteLength - 1);
+      require("internal/buffer").checkInt(this, value, offset, 0, 2 ** (8 * byteLength) - 1, byteLength);
       break;
     }
     default: {
@@ -581,7 +581,7 @@ export function writeUIntBE(this: BufferExt, value, offset, byteLength) {
 export function writeFloatLE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 3);
+  require("internal/buffer").checkBounds(this, offset, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, true);
   return offset + 4;
 }
@@ -589,7 +589,7 @@ export function writeFloatLE(this: BufferExt, value, offset) {
 export function writeFloatBE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 3);
+  require("internal/buffer").checkBounds(this, offset, 4);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, false);
   return offset + 4;
 }
@@ -597,7 +597,7 @@ export function writeFloatBE(this: BufferExt, value, offset) {
 export function writeDoubleLE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 7);
+  require("internal/buffer").checkBounds(this, offset, 8);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, true);
   return offset + 8;
 }
@@ -605,7 +605,7 @@ export function writeDoubleLE(this: BufferExt, value, offset) {
 export function writeDoubleBE(this: BufferExt, value, offset) {
   if (offset === undefined) offset = 0;
   value = +value;
-  require("internal/buffer").checkBounds(this, offset, 7);
+  require("internal/buffer").checkBounds(this, offset, 8);
   (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, false);
   return offset + 8;
 }

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -295,96 +295,103 @@ export function readBigUInt64BE(this: BufferExt, offset) {
 }
 
 export function writeInt8(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt8(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-  );
+  if (offset === undefined) offset = 0;
+  require("internal/buffer").writeU_Int8(this, value, offset, -0x80, 0x7f);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt8(offset, value);
   return offset + 1;
 }
 
 export function writeUInt8(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint8(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-  );
+  if (offset === undefined) offset = 0;
+  require("internal/buffer").writeU_Int8(this, value, offset, 0, 0xff);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint8(offset, value);
   return offset + 1;
 }
 
 export function writeInt16LE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 1);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, true);
   return offset + 2;
 }
 
 export function writeInt16BE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, -0x8000, 0x7fff, 1);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt16(offset, value, false);
   return offset + 2;
 }
 
 export function writeUInt16LE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 1);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, true);
   return offset + 2;
 }
 
 export function writeUInt16BE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffff, 1);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint16(offset, value, false);
   return offset + 2;
 }
 
 export function writeInt32LE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 3);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, true);
   return offset + 4;
 }
 
 export function writeInt32BE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, -0x80000000, 0x7fffffff, 3);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setInt32(offset, value, false);
   return offset + 4;
 }
 
 export function writeUInt32LE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 3);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, true);
   return offset + 4;
 }
 
 export function writeUInt32BE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkInt(this, value, offset, 0, 0xffffffff, 3);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setUint32(offset, value, false);
   return offset + 4;
 }
 
 export function writeIntLE(this: BufferExt, value, offset, byteLength) {
   const view = (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength));
+  value = +value;
 
+  switch (byteLength) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6: {
+      const max = 2 ** (8 * byteLength - 1) - 1;
+      require("internal/buffer").checkInt(this, value, offset, -max - 1, max, byteLength - 1);
+      break;
+    }
+    default: {
+      require("internal/buffer").boundsError(byteLength, 6, "byteLength");
+      break;
+    }
+  }
   switch (byteLength) {
     case 1: {
       view.setInt8(offset, value);
@@ -413,16 +420,30 @@ export function writeIntLE(this: BufferExt, value, offset, byteLength) {
       view.setInt16(offset + 4, Math.floor(value * 2 ** -32), true);
       break;
     }
-    default: {
-      throw new RangeError("byteLength must be >= 1 and <= 6");
-    }
   }
   return offset + byteLength;
 }
 
 export function writeIntBE(this: BufferExt, value, offset, byteLength) {
   const view = (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength));
+  value = +value;
 
+  switch (byteLength) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6: {
+      const max = 2 ** (8 * byteLength - 1) - 1;
+      require("internal/buffer").checkInt(this, value, offset, -max - 1, max, byteLength - 1);
+      break;
+    }
+    default: {
+      require("internal/buffer").boundsError(byteLength, 6, "byteLength");
+      break;
+    }
+  }
   switch (byteLength) {
     case 1: {
       view.setInt8(offset, value);
@@ -451,16 +472,29 @@ export function writeIntBE(this: BufferExt, value, offset, byteLength) {
       view.setInt16(offset, Math.floor(value * 2 ** -32), false);
       break;
     }
-    default: {
-      throw new RangeError("byteLength must be >= 1 and <= 6");
-    }
   }
   return offset + byteLength;
 }
 
 export function writeUIntLE(this: BufferExt, value, offset, byteLength) {
   const view = (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength));
+  value = +value;
 
+  switch (byteLength) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6: {
+      require("internal/buffer").checkInt(this, value, offset, 0, 2 ** (8 * byteLength) - 1, byteLength - 1);
+      break;
+    }
+    default: {
+      require("internal/buffer").boundsError(byteLength, 6, "byteLength");
+      break;
+    }
+  }
   switch (byteLength) {
     case 1: {
       view.setUint8(offset, value);
@@ -489,16 +523,29 @@ export function writeUIntLE(this: BufferExt, value, offset, byteLength) {
       view.setUint16(offset + 4, Math.floor(value * 2 ** -32), true);
       break;
     }
-    default: {
-      throw new RangeError("byteLength must be >= 1 and <= 6");
-    }
   }
   return offset + byteLength;
 }
 
 export function writeUIntBE(this: BufferExt, value, offset, byteLength) {
   const view = (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength));
+  value = +value;
 
+  switch (byteLength) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6: {
+      require("internal/buffer").checkInt(this, value, offset, 0, 2 ** (8 * byteLength) - 1, byteLength - 1);
+      break;
+    }
+    default: {
+      require("internal/buffer").boundsError(byteLength, 6, "byteLength");
+      break;
+    }
+  }
   switch (byteLength) {
     case 1: {
       view.setUint8(offset, value);
@@ -527,46 +574,39 @@ export function writeUIntBE(this: BufferExt, value, offset, byteLength) {
       view.setUint16(offset, Math.floor(value * 2 ** -32), false);
       break;
     }
-    default: {
-      throw new RangeError("byteLength must be >= 1 and <= 6");
-    }
   }
   return offset + byteLength;
 }
 
 export function writeFloatLE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkBounds(this, offset, 3);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, true);
   return offset + 4;
 }
 
 export function writeFloatBE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkBounds(this, offset, 3);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat32(offset, value, false);
   return offset + 4;
 }
 
 export function writeDoubleLE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkBounds(this, offset, 7);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, true);
   return offset + 8;
 }
 
 export function writeDoubleBE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  value = +value;
+  require("internal/buffer").checkBounds(this, offset, 7);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setFloat64(offset, value, false);
   return offset + 8;
 }
 

--- a/src/js/internal/buffer.ts
+++ b/src/js/internal/buffer.ts
@@ -34,7 +34,6 @@ function checkInt(buf, value, offset, min, max, byteLength) {
 }
 
 function writeU_Int8(buf, value, offset, min, max) {
-  value = +value;
   // `checkInt()` can not be used here because it checks two entries.
   validateNumber(offset, "offset");
   if (value > max || value < min) {

--- a/src/js/internal/buffer.ts
+++ b/src/js/internal/buffer.ts
@@ -11,19 +11,19 @@ function boundsError(value, length, type?) {
 
 function checkBounds(buf, offset, byteLength) {
   validateNumber(offset, "offset");
-  if (buf[offset] === undefined || buf[offset + byteLength] === undefined)
-    boundsError(offset, buf.length - (byteLength + 1));
+  if (buf[offset] === undefined || buf[offset + byteLength - 1] === undefined)
+    boundsError(offset, buf.length - byteLength);
 }
 
 function checkInt(buf, value, offset, min, max, byteLength) {
   if (value > max || value < min) {
     const n = typeof min === "bigint" ? "n" : "";
     let range;
-    if (byteLength > 3) {
+    if (byteLength > 4) {
       if (min === 0 || min === 0n) {
-        range = `>= 0${n} and < 2${n} ** ${(byteLength + 1) * 8}${n}`;
+        range = `>= 0${n} and < 2${n} ** ${byteLength * 8}${n}`;
       } else {
-        range = `>= -(2${n} ** ${(byteLength + 1) * 8 - 1}${n}) and ` + `< 2${n} ** ${(byteLength + 1) * 8 - 1}${n}`;
+        range = `>= -(2${n} ** ${byteLength * 8 - 1}${n}) and ` + `< 2${n} ** ${byteLength * 8 - 1}${n}`;
       }
     } else {
       range = `>= ${min}${n} and <= ${max}${n}`;

--- a/src/js/internal/buffer.ts
+++ b/src/js/internal/buffer.ts
@@ -1,4 +1,4 @@
-const { validateNumber, validateInteger } = require("internal/validators");
+const { validateNumber } = require("internal/validators");
 
 function boundsError(value, length, type?) {
   if (Math.floor(value) !== value) {
@@ -9,6 +9,43 @@ function boundsError(value, length, type?) {
   throw $ERR_OUT_OF_RANGE(type || "offset", `>= ${type ? 1 : 0} and <= ${length}`, value);
 }
 
+function checkBounds(buf, offset, byteLength) {
+  validateNumber(offset, "offset");
+  if (buf[offset] === undefined || buf[offset + byteLength] === undefined)
+    boundsError(offset, buf.length - (byteLength + 1));
+}
+
+function checkInt(buf, value, offset, min, max, byteLength) {
+  if (value > max || value < min) {
+    const n = typeof min === "bigint" ? "n" : "";
+    let range;
+    if (byteLength > 3) {
+      if (min === 0 || min === 0n) {
+        range = `>= 0${n} and < 2${n} ** ${(byteLength + 1) * 8}${n}`;
+      } else {
+        range = `>= -(2${n} ** ${(byteLength + 1) * 8 - 1}${n}) and ` + `< 2${n} ** ${(byteLength + 1) * 8 - 1}${n}`;
+      }
+    } else {
+      range = `>= ${min}${n} and <= ${max}${n}`;
+    }
+    throw $ERR_OUT_OF_RANGE("value", range, value);
+  }
+  checkBounds(buf, offset, byteLength);
+}
+
+function writeU_Int8(buf, value, offset, min, max) {
+  value = +value;
+  // `checkInt()` can not be used here because it checks two entries.
+  validateNumber(offset, "offset");
+  if (value > max || value < min) {
+    throw $ERR_OUT_OF_RANGE("value", `>= ${min} and <= ${max}`, value);
+  }
+  if (buf[offset] === undefined) boundsError(offset, buf.length - 1);
+}
+
 export default {
   boundsError,
+  checkBounds,
+  checkInt,
+  writeU_Int8,
 };

--- a/test/js/node/test/parallel/test-buffer-write-fast.js
+++ b/test/js/node/test/parallel/test-buffer-write-fast.js
@@ -1,0 +1,40 @@
+// Flags: --no-warnings --allow-natives-syntax
+'use strict';
+
+const common = require('../common');
+if ('Bun' in globalThis) common.skip('uses internals');
+const assert = require('assert');
+
+function testFastUtf8Write() {
+  {
+    const buf = Buffer.from('\x80');
+
+    assert.strictEqual(buf[0], 194);
+    assert.strictEqual(buf[1], 128);
+  }
+
+  {
+    const buf = Buffer.alloc(64);
+    const newBuf = buf.subarray(0, buf.write('éñüçßÆ'));
+    assert.deepStrictEqual(newBuf, Buffer.from([195, 169, 195, 177, 195, 188, 195, 167, 195, 159, 195, 134]));
+  }
+
+  {
+    const buf = Buffer.alloc(64);
+    const newBuf = buf.subarray(0, buf.write('¿'));
+    assert.deepStrictEqual(newBuf, Buffer.from([194, 191]));
+  }
+
+  {
+    const buf = Buffer.from(new ArrayBuffer(34), 0, 16);
+    const str = Buffer.from([50, 83, 127, 39, 104, 8, 74, 65, 108, 123, 5, 4, 82, 10, 7, 53]).toString();
+    const newBuf = buf.subarray(0, buf.write(str));
+    assert.deepStrictEqual(newBuf, Buffer.from([ 50, 83, 127, 39, 104, 8, 74, 65, 108, 123, 5, 4, 82, 10, 7, 53]));
+  }
+}
+
+// node --expose-internals --allow-natives-syntax -p "eval('%PrepareFunctionForOptimization(Buffer.prototype.utf8Write)')"
+eval('%PrepareFunctionForOptimization(Buffer.prototype.utf8Write)');
+testFastUtf8Write();
+eval('%OptimizeFunctionOnNextCall(Buffer.prototype.utf8Write)');
+testFastUtf8Write();

--- a/test/js/node/test/parallel/test-buffer-writedouble.js
+++ b/test/js/node/test/parallel/test-buffer-writedouble.js
@@ -1,0 +1,133 @@
+'use strict';
+
+// Tests to verify doubles are correctly written
+
+require('../common');
+const assert = require('assert');
+
+const buffer = Buffer.allocUnsafe(16);
+
+buffer.writeDoubleBE(2.225073858507201e-308, 0);
+buffer.writeDoubleLE(2.225073858507201e-308, 8);
+assert.ok(buffer.equals(new Uint8Array([
+  0x00, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x00,
+])));
+
+buffer.writeDoubleBE(1.0000000000000004, 0);
+buffer.writeDoubleLE(1.0000000000000004, 8);
+assert.ok(buffer.equals(new Uint8Array([
+  0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+  0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f,
+])));
+
+buffer.writeDoubleBE(-2, 0);
+buffer.writeDoubleLE(-2, 8);
+assert.ok(buffer.equals(new Uint8Array([
+  0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0,
+])));
+
+buffer.writeDoubleBE(1.7976931348623157e+308, 0);
+buffer.writeDoubleLE(1.7976931348623157e+308, 8);
+assert.ok(buffer.equals(new Uint8Array([
+  0x7f, 0xef, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xef, 0x7f,
+])));
+
+buffer.writeDoubleBE(0 * -1, 0);
+buffer.writeDoubleLE(0 * -1, 8);
+assert.ok(buffer.equals(new Uint8Array([
+  0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+])));
+
+buffer.writeDoubleBE(Infinity, 0);
+buffer.writeDoubleLE(Infinity, 8);
+
+assert.ok(buffer.equals(new Uint8Array([
+  0x7F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F,
+])));
+
+assert.strictEqual(buffer.readDoubleBE(0), Infinity);
+assert.strictEqual(buffer.readDoubleLE(8), Infinity);
+
+buffer.writeDoubleBE(-Infinity, 0);
+buffer.writeDoubleLE(-Infinity, 8);
+
+assert.ok(buffer.equals(new Uint8Array([
+  0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF,
+])));
+
+assert.strictEqual(buffer.readDoubleBE(0), -Infinity);
+assert.strictEqual(buffer.readDoubleLE(8), -Infinity);
+
+buffer.writeDoubleBE(NaN, 0);
+buffer.writeDoubleLE(NaN, 8);
+
+// JS only knows a single NaN but there exist two platform specific
+// implementations. Therefore, allow both quiet and signalling NaNs.
+if (buffer[1] === 0xF7) {
+  assert.ok(buffer.equals(new Uint8Array([
+    0x7F, 0xF7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF7, 0x7F,
+  ])));
+} else {
+  assert.ok(buffer.equals(new Uint8Array([
+    0x7F, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F,
+  ])));
+}
+
+assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
+assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
+
+// OOB in writeDouble{LE,BE} should throw.
+{
+  const small = Buffer.allocUnsafe(1);
+
+  ['writeDoubleLE', 'writeDoubleBE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
+    assert.throws(
+      () => small[fn](11.11, 0),
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        name: 'RangeError',
+        message: 'Attempt to access memory outside buffer bounds'
+      });
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
+      assert.throws(
+        () => small[fn](23, off),
+        { code: 'ERR_INVALID_ARG_TYPE' });
+    });
+
+    [Infinity, -1, 9].forEach((offset) => {
+      assert.throws(
+        () => buffer[fn](23, offset),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "offset" is out of range. ' +
+                     `It must be >= 0 and <= 8. Received ${offset}`
+        });
+    });
+
+    [NaN, 1.01].forEach((offset) => {
+      assert.throws(
+        () => buffer[fn](42, offset),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "offset" is out of range. ' +
+                   `It must be an integer. Received ${offset}`
+        });
+    });
+  });
+}

--- a/test/js/node/test/parallel/test-buffer-writefloat.js
+++ b/test/js/node/test/parallel/test-buffer-writefloat.js
@@ -1,0 +1,117 @@
+'use strict';
+
+// Tests to verify floats are correctly written
+
+require('../common');
+const assert = require('assert');
+
+const buffer = Buffer.allocUnsafe(8);
+
+buffer.writeFloatBE(1, 0);
+buffer.writeFloatLE(1, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0x3f, 0x80, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3f ])));
+
+buffer.writeFloatBE(1 / 3, 0);
+buffer.writeFloatLE(1 / 3, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0x3e, 0xaa, 0xaa, 0xab, 0xab, 0xaa, 0xaa, 0x3e ])));
+
+buffer.writeFloatBE(3.4028234663852886e+38, 0);
+buffer.writeFloatLE(3.4028234663852886e+38, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0x7f, 0x7f, 0xff, 0xff, 0xff, 0xff, 0x7f, 0x7f ])));
+
+buffer.writeFloatLE(1.1754943508222875e-38, 0);
+buffer.writeFloatBE(1.1754943508222875e-38, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0x00, 0x00, 0x80, 0x00, 0x00, 0x80, 0x00, 0x00 ])));
+
+buffer.writeFloatBE(0 * -1, 0);
+buffer.writeFloatLE(0 * -1, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 ])));
+
+buffer.writeFloatBE(Infinity, 0);
+buffer.writeFloatLE(Infinity, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0x7F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x80, 0x7F ])));
+
+assert.strictEqual(buffer.readFloatBE(0), Infinity);
+assert.strictEqual(buffer.readFloatLE(4), Infinity);
+
+buffer.writeFloatBE(-Infinity, 0);
+buffer.writeFloatLE(-Infinity, 4);
+assert.ok(buffer.equals(
+  new Uint8Array([ 0xFF, 0x80, 0x00, 0x00, 0x00, 0x00, 0x80, 0xFF ])));
+
+assert.strictEqual(buffer.readFloatBE(0), -Infinity);
+assert.strictEqual(buffer.readFloatLE(4), -Infinity);
+
+buffer.writeFloatBE(NaN, 0);
+buffer.writeFloatLE(NaN, 4);
+
+// JS only knows a single NaN but there exist two platform specific
+// implementations. Therefore, allow both quiet and signalling NaNs.
+if (buffer[1] === 0xBF) {
+  assert.ok(
+    buffer.equals(new Uint8Array(
+      [ 0x7F, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xBF, 0x7F ])));
+} else {
+  assert.ok(
+    buffer.equals(new Uint8Array(
+      [ 0x7F, 0xC0, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x7F ])));
+}
+
+assert.ok(Number.isNaN(buffer.readFloatBE(0)));
+assert.ok(Number.isNaN(buffer.readFloatLE(4)));
+
+// OOB in writeFloat{LE,BE} should throw.
+{
+  const small = Buffer.allocUnsafe(1);
+
+  ['writeFloatLE', 'writeFloatBE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
+    assert.throws(
+      () => small[fn](11.11, 0),
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        name: 'RangeError',
+        message: 'Attempt to access memory outside buffer bounds'
+      });
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
+      assert.throws(
+        () => small[fn](23, off),
+        { code: 'ERR_INVALID_ARG_TYPE' }
+      );
+    });
+
+    [Infinity, -1, 5].forEach((offset) => {
+      assert.throws(
+        () => buffer[fn](23, offset),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "offset" is out of range. ' +
+                   `It must be >= 0 and <= 4. Received ${offset}`
+        }
+      );
+    });
+
+    [NaN, 1.01].forEach((offset) => {
+      assert.throws(
+        () => buffer[fn](42, offset),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "offset" is out of range. ' +
+                   `It must be an integer. Received ${offset}`
+        });
+    });
+  });
+}

--- a/test/js/node/test/parallel/test-buffer-writeint.js
+++ b/test/js/node/test/parallel/test-buffer-writeint.js
@@ -1,0 +1,268 @@
+'use strict';
+
+// Tests to verify signed integers are correctly written
+
+require('../common');
+const assert = require('assert');
+const errorOutOfBounds = {
+  code: 'ERR_OUT_OF_RANGE',
+  name: 'RangeError',
+  message: new RegExp('^The value of "value" is out of range\\. ' +
+                      'It must be >= -\\d+ and <= \\d+\\. Received .+$')
+};
+
+// Test 8 bit
+{
+  const buffer = Buffer.alloc(2);
+
+  buffer.writeInt8(0x23, 0);
+  buffer.writeInt8(-5, 1);
+  assert.ok(buffer.equals(new Uint8Array([ 0x23, 0xfb ])));
+
+  /* Make sure we handle min/max correctly */
+  buffer.writeInt8(0x7f, 0);
+  buffer.writeInt8(-0x80, 1);
+  assert.ok(buffer.equals(new Uint8Array([ 0x7f, 0x80 ])));
+
+  assert.throws(() => {
+    buffer.writeInt8(0x7f + 1, 0);
+  }, errorOutOfBounds);
+  assert.throws(() => {
+    buffer.writeInt8(-0x80 - 1, 0);
+  }, errorOutOfBounds);
+
+  // Verify that default offset works fine.
+  buffer.writeInt8(23, undefined);
+  buffer.writeInt8(23);
+
+  ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
+    assert.throws(
+      () => buffer.writeInt8(23, off),
+      { code: 'ERR_INVALID_ARG_TYPE' });
+  });
+
+  [NaN, Infinity, -1, 1.01].forEach((off) => {
+    assert.throws(
+      () => buffer.writeInt8(23, off),
+      { code: 'ERR_OUT_OF_RANGE' });
+  });
+}
+
+// Test 16 bit
+{
+  const buffer = Buffer.alloc(4);
+
+  buffer.writeInt16BE(0x0023, 0);
+  buffer.writeInt16LE(0x0023, 2);
+  assert.ok(buffer.equals(new Uint8Array([ 0x00, 0x23, 0x23, 0x00 ])));
+
+  buffer.writeInt16BE(-5, 0);
+  buffer.writeInt16LE(-5, 2);
+  assert.ok(buffer.equals(new Uint8Array([ 0xff, 0xfb, 0xfb, 0xff ])));
+
+  buffer.writeInt16BE(-1679, 0);
+  buffer.writeInt16LE(-1679, 2);
+  assert.ok(buffer.equals(new Uint8Array([ 0xf9, 0x71, 0x71, 0xf9 ])));
+
+  /* Make sure we handle min/max correctly */
+  buffer.writeInt16BE(0x7fff, 0);
+  buffer.writeInt16BE(-0x8000, 2);
+  assert.ok(buffer.equals(new Uint8Array([ 0x7f, 0xff, 0x80, 0x00 ])));
+
+  buffer.writeInt16LE(0x7fff, 0);
+  buffer.writeInt16LE(-0x8000, 2);
+  assert.ok(buffer.equals(new Uint8Array([ 0xff, 0x7f, 0x00, 0x80 ])));
+
+  ['writeInt16BE', 'writeInt16LE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
+    assert.throws(() => {
+      buffer[fn](0x7fff + 1, 0);
+    }, errorOutOfBounds);
+    assert.throws(() => {
+      buffer[fn](-0x8000 - 1, 0);
+    }, errorOutOfBounds);
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
+      assert.throws(
+        () => buffer[fn](23, off),
+        { code: 'ERR_INVALID_ARG_TYPE' });
+    });
+
+    [NaN, Infinity, -1, 1.01].forEach((off) => {
+      assert.throws(
+        () => buffer[fn](23, off),
+        { code: 'ERR_OUT_OF_RANGE' });
+    });
+  });
+}
+
+// Test 32 bit
+{
+  const buffer = Buffer.alloc(8);
+
+  buffer.writeInt32BE(0x23, 0);
+  buffer.writeInt32LE(0x23, 4);
+  assert.ok(buffer.equals(new Uint8Array([
+    0x00, 0x00, 0x00, 0x23, 0x23, 0x00, 0x00, 0x00,
+  ])));
+
+  buffer.writeInt32BE(-5, 0);
+  buffer.writeInt32LE(-5, 4);
+  assert.ok(buffer.equals(new Uint8Array([
+    0xff, 0xff, 0xff, 0xfb, 0xfb, 0xff, 0xff, 0xff,
+  ])));
+
+  buffer.writeInt32BE(-805306713, 0);
+  buffer.writeInt32LE(-805306713, 4);
+  assert.ok(buffer.equals(new Uint8Array([
+    0xcf, 0xff, 0xfe, 0xa7, 0xa7, 0xfe, 0xff, 0xcf,
+  ])));
+
+  /* Make sure we handle min/max correctly */
+  buffer.writeInt32BE(0x7fffffff, 0);
+  buffer.writeInt32BE(-0x80000000, 4);
+  assert.ok(buffer.equals(new Uint8Array([
+    0x7f, 0xff, 0xff, 0xff, 0x80, 0x00, 0x00, 0x00,
+  ])));
+
+  buffer.writeInt32LE(0x7fffffff, 0);
+  buffer.writeInt32LE(-0x80000000, 4);
+  assert.ok(buffer.equals(new Uint8Array([
+    0xff, 0xff, 0xff, 0x7f, 0x00, 0x00, 0x00, 0x80,
+  ])));
+
+  ['writeInt32BE', 'writeInt32LE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
+    assert.throws(() => {
+      buffer[fn](0x7fffffff + 1, 0);
+    }, errorOutOfBounds);
+    assert.throws(() => {
+      buffer[fn](-0x80000000 - 1, 0);
+    }, errorOutOfBounds);
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
+      assert.throws(
+        () => buffer[fn](23, off),
+        { code: 'ERR_INVALID_ARG_TYPE' });
+    });
+
+    [NaN, Infinity, -1, 1.01].forEach((off) => {
+      assert.throws(
+        () => buffer[fn](23, off),
+        { code: 'ERR_OUT_OF_RANGE' });
+    });
+  });
+}
+
+// Test 48 bit
+{
+  const value = 0x1234567890ab;
+  const buffer = Buffer.allocUnsafe(6);
+  buffer.writeIntBE(value, 0, 6);
+  assert.ok(buffer.equals(new Uint8Array([
+    0x12, 0x34, 0x56, 0x78, 0x90, 0xab,
+  ])));
+
+  buffer.writeIntLE(value, 0, 6);
+  assert.ok(buffer.equals(new Uint8Array([
+    0xab, 0x90, 0x78, 0x56, 0x34, 0x12,
+  ])));
+}
+
+// Test Int
+{
+  const data = Buffer.alloc(8);
+
+  // Check byteLength.
+  ['writeIntBE', 'writeIntLE'].forEach((fn) => {
+    ['', '0', null, {}, [], () => {}, true, false, undefined].forEach((bl) => {
+      assert.throws(
+        () => data[fn](23, 0, bl),
+        { code: 'ERR_INVALID_ARG_TYPE' });
+    });
+
+    [Infinity, -1].forEach((byteLength) => {
+      assert.throws(
+        () => data[fn](23, 0, byteLength),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          message: 'The value of "byteLength" is out of range. ' +
+                   `It must be >= 1 and <= 6. Received ${byteLength}`
+        }
+      );
+    });
+
+    [NaN, 1.01].forEach((byteLength) => {
+      assert.throws(
+        () => data[fn](42, 0, byteLength),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "byteLength" is out of range. ' +
+                   `It must be an integer. Received ${byteLength}`
+        });
+    });
+  });
+
+  // Test 1 to 6 bytes.
+  for (let i = 1; i <= 6; i++) {
+    ['writeIntBE', 'writeIntLE'].forEach((fn) => {
+      const min = -(2 ** (i * 8 - 1));
+      const max = 2 ** (i * 8 - 1) - 1;
+      let range = `>= ${min} and <= ${max}`;
+      if (i > 4) {
+        range = `>= -(2 ** ${i * 8 - 1}) and < 2 ** ${i * 8 - 1}`;
+      }
+      [min - 1, max + 1].forEach((val) => {
+        const received = val;
+        assert.throws(() => {
+          data[fn](val, 0, i);
+        }, {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "value" is out of range. ' +
+                   `It must be ${range}. Received ${received}`
+        });
+      });
+
+      ['', '0', null, {}, [], () => {}, true, false, undefined].forEach((o) => {
+        assert.throws(
+          () => data[fn](min, o, i),
+          {
+            code: 'ERR_INVALID_ARG_TYPE',
+            name: 'TypeError'
+          });
+      });
+
+      [Infinity, -1, -4294967295].forEach((offset) => {
+        assert.throws(
+          () => data[fn](min, offset, i),
+          {
+            code: 'ERR_OUT_OF_RANGE',
+            name: 'RangeError',
+            message: 'The value of "offset" is out of range. ' +
+                     `It must be >= 0 and <= ${8 - i}. Received ${offset}`
+          });
+      });
+
+      [NaN, 1.01].forEach((offset) => {
+        assert.throws(
+          () => data[fn](max, offset, i),
+          {
+            code: 'ERR_OUT_OF_RANGE',
+            name: 'RangeError',
+            message: 'The value of "offset" is out of range. ' +
+                     `It must be an integer. Received ${offset}`
+          });
+      });
+    });
+  }
+}

--- a/test/js/node/test/parallel/test-buffer-writeuint.js
+++ b/test/js/node/test/parallel/test-buffer-writeuint.js
@@ -1,0 +1,228 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// We need to check the following things:
+//  - We are correctly resolving big endian (doesn't mean anything for 8 bit)
+//  - Correctly resolving little endian (doesn't mean anything for 8 bit)
+//  - Correctly using the offsets
+//  - Correctly interpreting values that are beyond the signed range as unsigned
+
+{ // OOB
+  const data = Buffer.alloc(8);
+  ['UInt8', 'UInt16BE', 'UInt16LE', 'UInt32BE', 'UInt32LE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    data[`write${fn}`](23, undefined);
+    data[`write${fn}`](23);
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
+      assert.throws(
+        () => data[`write${fn}`](23, o),
+        { code: 'ERR_INVALID_ARG_TYPE' });
+    });
+
+    [NaN, Infinity, -1, 1.01].forEach((o) => {
+      assert.throws(
+        () => data[`write${fn}`](23, o),
+        { code: 'ERR_OUT_OF_RANGE' });
+    });
+  });
+}
+
+{ // Test 8 bit
+  const data = Buffer.alloc(4);
+
+  data.writeUInt8(23, 0);
+  data.writeUInt8(23, 1);
+  data.writeUInt8(23, 2);
+  data.writeUInt8(23, 3);
+  assert.ok(data.equals(new Uint8Array([23, 23, 23, 23])));
+
+  data.writeUInt8(23, 0);
+  data.writeUInt8(23, 1);
+  data.writeUInt8(23, 2);
+  data.writeUInt8(23, 3);
+  assert.ok(data.equals(new Uint8Array([23, 23, 23, 23])));
+
+  data.writeUInt8(255, 0);
+  assert.strictEqual(data[0], 255);
+
+  data.writeUInt8(255, 0);
+  assert.strictEqual(data[0], 255);
+}
+
+// Test 16 bit
+{
+  let value = 0x2343;
+  const data = Buffer.alloc(4);
+
+  data.writeUInt16BE(value, 0);
+  assert.ok(data.equals(new Uint8Array([0x23, 0x43, 0, 0])));
+
+  data.writeUInt16BE(value, 1);
+  assert.ok(data.equals(new Uint8Array([0x23, 0x23, 0x43, 0])));
+
+  data.writeUInt16BE(value, 2);
+  assert.ok(data.equals(new Uint8Array([0x23, 0x23, 0x23, 0x43])));
+
+  data.writeUInt16LE(value, 0);
+  assert.ok(data.equals(new Uint8Array([0x43, 0x23, 0x23, 0x43])));
+
+  data.writeUInt16LE(value, 1);
+  assert.ok(data.equals(new Uint8Array([0x43, 0x43, 0x23, 0x43])));
+
+  data.writeUInt16LE(value, 2);
+  assert.ok(data.equals(new Uint8Array([0x43, 0x43, 0x43, 0x23])));
+
+  value = 0xff80;
+  data.writeUInt16LE(value, 0);
+  assert.ok(data.equals(new Uint8Array([0x80, 0xff, 0x43, 0x23])));
+
+  data.writeUInt16BE(value, 0);
+  assert.ok(data.equals(new Uint8Array([0xff, 0x80, 0x43, 0x23])));
+
+  value = 0xfffff;
+  ['writeUInt16BE', 'writeUInt16LE'].forEach((fn) => {
+    assert.throws(
+      () => data[fn](value, 0),
+      {
+        code: 'ERR_OUT_OF_RANGE',
+        message: 'The value of "value" is out of range. ' +
+                 `It must be >= 0 and <= 65535. Received ${value}`
+      }
+    );
+  });
+}
+
+// Test 32 bit
+{
+  const data = Buffer.alloc(6);
+  const value = 0xe7f90a6d;
+
+  data.writeUInt32BE(value, 0);
+  assert.ok(data.equals(new Uint8Array([0xe7, 0xf9, 0x0a, 0x6d, 0, 0])));
+
+  data.writeUInt32BE(value, 1);
+  assert.ok(data.equals(new Uint8Array([0xe7, 0xe7, 0xf9, 0x0a, 0x6d, 0])));
+
+  data.writeUInt32BE(value, 2);
+  assert.ok(data.equals(new Uint8Array([0xe7, 0xe7, 0xe7, 0xf9, 0x0a, 0x6d])));
+
+  data.writeUInt32LE(value, 0);
+  assert.ok(data.equals(new Uint8Array([0x6d, 0x0a, 0xf9, 0xe7, 0x0a, 0x6d])));
+
+  data.writeUInt32LE(value, 1);
+  assert.ok(data.equals(new Uint8Array([0x6d, 0x6d, 0x0a, 0xf9, 0xe7, 0x6d])));
+
+  data.writeUInt32LE(value, 2);
+  assert.ok(data.equals(new Uint8Array([0x6d, 0x6d, 0x6d, 0x0a, 0xf9, 0xe7])));
+}
+
+// Test 48 bit
+{
+  const value = 0x1234567890ab;
+  const data = Buffer.allocUnsafe(6);
+  data.writeUIntBE(value, 0, 6);
+  assert.ok(data.equals(new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x90, 0xab])));
+
+  data.writeUIntLE(value, 0, 6);
+  assert.ok(data.equals(new Uint8Array([0xab, 0x90, 0x78, 0x56, 0x34, 0x12])));
+}
+
+// Test UInt
+{
+  const data = Buffer.alloc(8);
+  let val = 0x100;
+
+  // Check byteLength.
+  ['writeUIntBE', 'writeUIntLE'].forEach((fn) => {
+    ['', '0', null, {}, [], () => {}, true, false, undefined].forEach((bl) => {
+      assert.throws(
+        () => data[fn](23, 0, bl),
+        { code: 'ERR_INVALID_ARG_TYPE' });
+    });
+
+    [Infinity, -1].forEach((byteLength) => {
+      assert.throws(
+        () => data[fn](23, 0, byteLength),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          message: 'The value of "byteLength" is out of range. ' +
+                   `It must be >= 1 and <= 6. Received ${byteLength}`
+        }
+      );
+    });
+
+    [NaN, 1.01].forEach((byteLength) => {
+      assert.throws(
+        () => data[fn](42, 0, byteLength),
+        {
+          code: 'ERR_OUT_OF_RANGE',
+          name: 'RangeError',
+          message: 'The value of "byteLength" is out of range. ' +
+                   `It must be an integer. Received ${byteLength}`
+        });
+    });
+  });
+
+  // Test 1 to 6 bytes.
+  for (let i = 1; i <= 6; i++) {
+    const range = i < 5 ? `= ${val - 1}` : ` 2 ** ${i * 8}`;
+    const received = val;
+    ['writeUIntBE', 'writeUIntLE'].forEach((fn) => {
+      assert.throws(() => {
+        data[fn](val, 0, i);
+      }, {
+        code: 'ERR_OUT_OF_RANGE',
+        name: 'RangeError',
+        message: 'The value of "value" is out of range. ' +
+                 `It must be >= 0 and <${range}. Received ${received}`
+      });
+
+      ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
+        assert.throws(
+          () => data[fn](23, o, i),
+          {
+            code: 'ERR_INVALID_ARG_TYPE',
+            name: 'TypeError'
+          });
+      });
+
+      [Infinity, -1, -4294967295].forEach((offset) => {
+        assert.throws(
+          () => data[fn](val - 1, offset, i),
+          {
+            code: 'ERR_OUT_OF_RANGE',
+            name: 'RangeError',
+            message: 'The value of "offset" is out of range. ' +
+                     `It must be >= 0 and <= ${8 - i}. Received ${offset}`
+          });
+      });
+
+      [NaN, 1.01].forEach((offset) => {
+        assert.throws(
+          () => data[fn](val - 1, offset, i),
+          {
+            code: 'ERR_OUT_OF_RANGE',
+            name: 'RangeError',
+            message: 'The value of "offset" is out of range. ' +
+                     `It must be an integer. Received ${offset}`
+          });
+      });
+    });
+
+    val *= 0x100;
+  }
+}
+
+for (const fn of [
+  'UInt8', 'UInt16LE', 'UInt16BE', 'UInt32LE', 'UInt32BE', 'UIntLE', 'UIntBE',
+  'BigUInt64LE', 'BigUInt64BE',
+]) {
+  const p = Buffer.prototype;
+  const lowerFn = fn.replace(/UInt/, 'Uint');
+  assert.strictEqual(p[`write${fn}`], p[`write${lowerFn}`]);
+  assert.strictEqual(p[`read${fn}`], p[`read${lowerFn}`]);
+}


### PR DESCRIPTION
pulled out of https://github.com/oven-sh/bun/pull/15722

regression bench:
`bun ./bench/snippets/buffer.js`
macos 15.3 aarch64 on m3 max
baseline bun is 1.2.2

<img width="2009" alt="image" src="https://github.com/user-attachments/assets/cea6e7b2-fb61-4c01-91cf-d89b635d980c" />
