### PR TITLE
Handle rejected promises in `EventLoop.autoTick`

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1514,6 +1514,7 @@ pub const EventLoop = struct {
 
         this.flushImmediateQueue();
         ctx.onAfterEventLoop();
+        this.global.handleRejectedPromises();
     }
 
     pub fn flushImmediateQueue(this: *EventLoop) void {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import fs from "fs";
 import { gcTick, tls, tmpdirSync } from "harness";
 import path, { join } from "path";
+import { setImmediate as setImmediatePromise } from "timers/promises";
 var setTimeoutAsync = (fn, delay) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -43,19 +44,23 @@ describe("HTMLRewriter", () => {
     ).toThrow("test");
   });
 
-  it("async error inside element handler", async () => {
+  it("async error inside element handler", () => {
+    let caught = false;
     try {
-      await new HTMLRewriter()
+      new HTMLRewriter()
         .on("div", {
           async element(element) {
-            await Bun.sleep(0);
+            await setImmediatePromise();
             throw new Error("test");
           },
         })
         .transform(new Response("<div>hello</div>"));
       expect.unreachable();
     } catch (e) {
+      caught = true;
       expect(e.message).toBe("test");
+    } finally {
+      expect(caught).toBeTrue();
     }
   });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -44,13 +44,33 @@ describe("HTMLRewriter", () => {
     ).toThrow("test");
   });
 
-  it("async error inside element handler", () => {
+  it("fast async error inside element handler", () => {
     let caught = false;
     try {
       new HTMLRewriter()
         .on("div", {
           async element(element) {
             await setImmediatePromise();
+            throw new Error("test");
+          },
+        })
+        .transform(new Response("<div>hello</div>"));
+      expect.unreachable();
+    } catch (e) {
+      caught = true;
+      expect(e.message).toBe("test");
+    } finally {
+      expect(caught).toBeTrue();
+    }
+  });
+
+  it("slow async error inside element handler", () => {
+    let caught = false;
+    try {
+      new HTMLRewriter()
+        .on("div", {
+          async element(element) {
+            await Bun.sleep(1);
             throw new Error("test");
           },
         })


### PR DESCRIPTION
### What does this PR do?

Adds a call to `this.global.handleRejectedPromises()` inside `EventLoop.autoTick()`. This fixes a failure exposed on #16855. That PR happened to change `Bun.sleep(0)` to sleep for 0ms instead of 1ms, which made `html-rewriter.test.js` fail because if the `element` callback rejects too quickly, the exception would seem to be handled twice (the `catch` block would run, but the exception would also appear globally as an uncaught rejected promise).

I changed the test to use `await setImmediatePromise()` instead of `await Bun.sleep(0)`, which exposes the problem without depending on any timers changes, and I fixed this issue by adding the `handleRejectedPromises()` call.

### How did you verify your code works?

Ran the `HTMLRewriter` test
