### PR TITLE
Chloe/hmr4

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -4226,6 +4226,21 @@ pub fn IncrementalGraph(side: bake.Side) type {
                         // knowledge of the boundary between them.
                         .js, .unknown => if (!data.flags.is_hmr_root) {
                             try entry_points.appendJs(alloc, path, .client);
+
+                            // TODO(@paperclover): do not loop here
+                            var it = g.first_dep.items[index].unwrap();
+                            while (it) |edge_index| {
+                                const entry = g.edges.items[edge_index.get()];
+                                const dep = entry.dependency;
+                                g.stale_files.set(dep.get());
+
+                                const dep_file = values[dep.get()];
+                                if (dep_file.flags.is_css_root) {
+                                    try entry_points.appendCss(alloc, keys[dep.get()]);
+                                }
+
+                                it = entry.next_dependency.unwrap();
+                            }
                         },
                     },
                     .server => {

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -5616,6 +5616,8 @@ pub fn startReloadBundle(dev: *DevServer, event: *HotReloadEvent) bun.OOM!void {
 
     event.processFileList(dev, &entry_points, temp_alloc);
     if (entry_points.set.count() == 0) {
+        // TODO: Files which become disconnected from the incremental graph
+        // should be removed from the watcher.
         Output.debugWarn("nothing to bundle. watcher may potentially be watching too many files.", .{});
         Output.debugWarn("modified files: {s}", .{
             bun.fmt.fmtSlice(event.files.keys(), ", "),

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -1359,7 +1359,7 @@ fn generateHTMLPayload(dev: *DevServer, route_bundle_index: RouteBundle.Index, r
 
     const payload_size = bundled_html.len +
         ("<link rel=\"stylesheet\" href=\"" ++ asset_prefix ++ "/0000000000000000.css\">").len * css_ids.len +
-        "<script type=\"module\" crossorigin src=\"\"></script>".len +
+        "<script type=\"module\" crossorigin async src=\"\"></script>".len +
         client_prefix.len + "/".len +
         display_name.len +
         "-0000000000000000.js".len;
@@ -1375,7 +1375,7 @@ fn generateHTMLPayload(dev: *DevServer, route_bundle_index: RouteBundle.Index, r
     }
     array.appendSliceAssumeCapacity(before_body_end);
     // Insert the client script tag before "</body>"
-    array.appendSliceAssumeCapacity("<script type=\"module\" crossorigin src=\"");
+    array.appendSliceAssumeCapacity("<script type=\"module\" crossorigin async src=\"");
     array.appendSliceAssumeCapacity(client_prefix);
     array.appendSliceAssumeCapacity("/");
     array.appendSliceAssumeCapacity(display_name);
@@ -4228,11 +4228,8 @@ pub fn IncrementalGraph(side: bake.Side) type {
                             &source_map_strings,
                         ) catch |err| {
                             switch (err) {
-                                error.IncompleteUTF8 => {
-                                    @panic("Unexpected: asset with incomplete UTF-8 as file path");
-                                },
-                                // TODO: file an issue. This shouldn't be necessary.
-                                else => |e| return e,
+                                error.IncompleteUTF8 => @panic("Unexpected: source file with incomplete UTF-8 as file path"),
+                                error.OutOfMemory => |e| return e,
                             }
                         };
                     } else {
@@ -4242,11 +4239,8 @@ pub fn IncrementalGraph(side: bake.Side) type {
                         // -> file:///C:/path/to/file.js
                         bun.strings.percentEncodeWrite(path, &source_map_strings) catch |err| {
                             switch (err) {
-                                error.IncompleteUTF8 => {
-                                    @panic("Unexpected: asset with incomplete UTF-8 as file path");
-                                },
-                                // TODO: file an issue. This shouldn't be necessary.
-                                else => |e| return e,
+                                error.IncompleteUTF8 => @panic("Unexpected: source file with incomplete UTF-8 as file path"),
+                                error.OutOfMemory => |e| return e,
                             }
                         };
                     }
@@ -4255,11 +4249,8 @@ pub fn IncrementalGraph(side: bake.Side) type {
                     try source_map_strings.appendSlice("\"bun://");
                     bun.strings.percentEncodeWrite(path, &source_map_strings) catch |err| {
                         switch (err) {
-                            error.IncompleteUTF8 => {
-                                @panic("Unexpected: asset with incomplete UTF-8 as file path");
-                            },
-                            // TODO: file an issue. This shouldn't be necessary.
-                            else => |e| return e,
+                            error.IncompleteUTF8 => @panic("Unexpected: source file with incomplete UTF-8 as file path"),
+                            error.OutOfMemory => |e| return e,
                         }
                     };
                     try source_map_strings.appendSlice("\"");

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -4288,6 +4288,8 @@ pub fn IncrementalGraph(side: bake.Side) type {
 
                                 it = entry.next_dependency.unwrap();
                             }
+
+                            try entry_points.appendJs(alloc, path, .client);
                         },
                         // When re-bundling SCBs, only bundle the server. Otherwise
                         // the bundler gets confused and bundles both sides without

--- a/src/bake/hmr-runtime-client.ts
+++ b/src/bake/hmr-runtime-client.ts
@@ -104,14 +104,14 @@ const ws = initWebSocket(
           // Skip to the last route
           let nextRouteId = reader.i32();
           while (nextRouteId != null && nextRouteId !== -1) {
-            reader.string32();
-            reader.cursor += 16 * reader.u32();
+            reader.cursor += 16 * Math.max(0, reader.i32());
             nextRouteId = reader.i32();
           }
           break;
         } else {
           // Skip to the next route
-          reader.cursor += 16 * reader.u32();
+          const i = reader.i32();
+          reader.cursor += 16 * Math.max(0, i);
         }
       } while (true);
       // List 3

--- a/src/bake/hmr-runtime-client.ts
+++ b/src/bake/hmr-runtime-client.ts
@@ -104,7 +104,8 @@ const ws = initWebSocket(
           // Skip to the last route
           let nextRouteId = reader.i32();
           while (nextRouteId != null && nextRouteId !== -1) {
-            reader.cursor += 16 * Math.max(0, reader.i32());
+            const i = reader.i32();
+            reader.cursor += 16 * Math.max(0, i);
             nextRouteId = reader.i32();
           }
           break;

--- a/src/css/css_internals.zig
+++ b/src/css/css_internals.zig
@@ -135,7 +135,7 @@ pub fn testingImpl(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame, c
                 .targets = .{
                     .browsers = minify_options.targets.browsers,
                 },
-            }, &import_records)) {
+            }, .initOutsideOfBundler(&import_records))) {
                 .result => |result| result,
                 .err => |err| {
                     return err.toJSString(alloc, globalThis);
@@ -314,10 +314,14 @@ pub fn attrTest(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.
             minify_options.targets = targets;
             stylesheet.minify(alloc, minify_options);
 
-            const result = stylesheet.toCss(alloc, bun.css.PrinterOptions{
-                .minify = minify,
-                .targets = targets,
-            }, &import_records) catch |e| {
+            const result = stylesheet.toCss(
+                alloc,
+                bun.css.PrinterOptions{
+                    .minify = minify,
+                    .targets = targets,
+                },
+                .initOutsideOfBundler(&import_records),
+            ) catch |e| {
                 bun.handleErrorReturnTrace(e, @errorReturnTrace());
                 return .undefined;
             };

--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -87,6 +87,7 @@ pub const Printer = css_printer.Printer;
 pub const PrinterOptions = css_printer.PrinterOptions;
 pub const targets = @import("./targets.zig");
 pub const Targets = css_printer.Targets;
+pub const ImportInfo = css_printer.ImportInfo;
 // pub const Features = css_printer.Features;
 
 const context = @import("./context.zig");
@@ -122,7 +123,7 @@ pub const Feature = compat.Feature;
 pub const fmtPrinterError = errors_.fmtPrinterError;
 
 pub const PrintErr = error{
-    lol,
+    CSSPrintError,
 };
 
 pub fn OOM(e: anyerror) noreturn {
@@ -2851,11 +2852,11 @@ pub fn StyleSheet(comptime AtRule: type) type {
             return .{ .result = {} };
         }
 
-        pub fn toCssWithWriter(this: *const @This(), allocator: Allocator, writer: anytype, options: css_printer.PrinterOptions, import_records: ?*const bun.BabyList(ImportRecord)) PrintResult(ToCssResultInternal) {
+        pub fn toCssWithWriter(this: *const @This(), allocator: Allocator, writer: anytype, options: css_printer.PrinterOptions, import_info: ?bun.css.ImportInfo) PrintResult(ToCssResultInternal) {
             const W = @TypeOf(writer);
 
-            var printer = Printer(@TypeOf(writer)).new(allocator, std.ArrayList(u8).init(allocator), writer, options, import_records);
-            const result = this.toCssWithWriterImpl(allocator, W, &printer, options, import_records) catch {
+            var printer = Printer(@TypeOf(writer)).new(allocator, std.ArrayList(u8).init(allocator), writer, options, import_info);
+            const result = this.toCssWithWriterImpl(allocator, W, &printer, options) catch {
                 bun.assert(printer.error_kind != null);
                 return .{
                     .err = printer.error_kind.?,
@@ -2865,8 +2866,7 @@ pub fn StyleSheet(comptime AtRule: type) type {
             return .{ .result = result };
         }
 
-        pub fn toCssWithWriterImpl(this: *const @This(), allocator: Allocator, comptime W: type, printer: *Printer(W), options: css_printer.PrinterOptions, import_records: ?*const bun.BabyList(ImportRecord)) PrintErr!ToCssResultInternal {
-            _ = import_records; // autofix
+        pub fn toCssWithWriterImpl(this: *const @This(), allocator: Allocator, comptime W: type, printer: *Printer(W), options: css_printer.PrinterOptions) PrintErr!ToCssResultInternal {
             const project_root = options.project_root;
 
             // #[cfg(feature = "sourcemap")]
@@ -2915,12 +2915,12 @@ pub fn StyleSheet(comptime AtRule: type) type {
             }
         }
 
-        pub fn toCss(this: *const @This(), allocator: Allocator, options: css_printer.PrinterOptions, import_records: ?*const bun.BabyList(ImportRecord)) PrintResult(ToCssResult) {
+        pub fn toCss(this: *const @This(), allocator: Allocator, options: css_printer.PrinterOptions, import_info: ?bun.css.ImportInfo) PrintResult(ToCssResult) {
             // TODO: this is not necessary
             // Make sure we always have capacity > 0: https://github.com/napi-rs/napi-rs/issues/1124.
             var dest = ArrayList(u8).initCapacity(allocator, 1) catch unreachable;
             const writer = dest.writer(allocator);
-            const result = switch (toCssWithWriter(this, allocator, writer, options, import_records)) {
+            const result = switch (toCssWithWriter(this, allocator, writer, options, import_info)) {
                 .result => |v| v,
                 .err => |e| return .{ .err = e },
             };
@@ -3146,7 +3146,7 @@ pub const StyleAttribute = struct {
         } };
     }
 
-    pub fn toCss(this: *const StyleAttribute, allocator: Allocator, options: PrinterOptions, import_records: *bun.BabyList(ImportRecord)) PrintErr!ToCssResult {
+    pub fn toCss(this: *const StyleAttribute, allocator: Allocator, options: PrinterOptions, import_info: ?ImportInfo) PrintErr!ToCssResult {
         // #[cfg(feature = "sourcemap")]
         // assert!(
         //   options.source_map.is_none(),
@@ -3155,7 +3155,7 @@ pub const StyleAttribute = struct {
 
         var dest = ArrayList(u8){};
         const writer = dest.writer(allocator);
-        var printer = Printer(@TypeOf(writer)).new(allocator, std.ArrayList(u8).init(allocator), writer, options, import_records);
+        var printer = Printer(@TypeOf(writer)).new(allocator, std.ArrayList(u8).init(allocator), writer, options, import_info);
         printer.sources = &this.sources;
 
         try this.declarations.toCss(@TypeOf(writer), &printer);
@@ -6514,14 +6514,14 @@ pub const to_css = struct {
         comptime T: type,
         this: *const T,
         options: PrinterOptions,
-        import_records: ?*const bun.BabyList(ImportRecord),
+        import_info: ?ImportInfo,
     ) PrintErr![]const u8 {
         var s = ArrayList(u8){};
         errdefer s.deinit(allocator);
         const writer = s.writer(allocator);
         const W = @TypeOf(writer);
         // PERF: think about how cheap this is to create
-        var printer = Printer(W).new(allocator, std.ArrayList(u8).init(allocator), writer, options, import_records);
+        var printer = Printer(W).new(allocator, std.ArrayList(u8).init(allocator), writer, options, import_info);
         defer printer.deinit();
         switch (T) {
             CSSString => try CSSStringFns.toCss(this, W, &printer),

--- a/src/css/printer.zig
+++ b/src/css/printer.zig
@@ -80,6 +80,24 @@ pub const Features = css.targets.Features;
 
 const Browsers = css.targets.Browsers;
 
+pub const ImportInfo = struct {
+    import_records: *const bun.BabyList(bun.ImportRecord),
+    /// bundle_v2.graph.ast.items(.url_for_css)
+    ast_urls_for_css: []const []const u8,
+    /// bundle_v2.graph.input_files.items(.unique_key_for_additional_file)
+    ast_unique_key_for_additional_file: []const []const u8,
+
+    /// Only safe to use when outside the bundler. As in, the import records
+    /// were not resolved to source indices. This will out-of-bounds otherwise.
+    pub fn initOutsideOfBundler(records: *bun.BabyList(bun.ImportRecord)) ImportInfo {
+        return .{
+            .import_records = records,
+            .ast_urls_for_css = &.{},
+            .ast_unique_key_for_additional_file = &.{},
+        };
+    }
+};
+
 /// A `Printer` represents a destination to output serialized CSS, as used in
 /// the [ToCss](super::traits::ToCss) trait. It can wrap any destination that
 /// implements [std::fmt::Write](std::fmt::Write), such as a [String](String).
@@ -114,7 +132,7 @@ pub fn Printer(comptime Writer: type) type {
         ctx: ?*const css.StyleContext = null,
         scratchbuf: std.ArrayList(u8),
         error_kind: ?css.PrinterError = null,
-        import_records: ?*const bun.BabyList(bun.ImportRecord),
+        import_info: ?ImportInfo = null,
         public_path: []const u8,
         /// NOTE This should be the same mimalloc heap arena allocator
         allocator: Allocator,
@@ -144,23 +162,23 @@ pub fn Printer(comptime Writer: type) type {
         }
 
         /// Add an error related to std lib fmt errors
-        pub fn addFmtError(this: *This) PrintErr!void {
+        pub fn addFmtError(this: *This) PrintErr {
             this.error_kind = css.PrinterError{
                 .kind = .fmt_error,
                 .loc = null,
             };
-            return PrintErr.lol;
+            return PrintErr.CSSPrintError;
         }
 
-        pub fn addNoImportRecordError(this: *This) PrintErr!void {
+        pub fn addNoImportRecordError(this: *This) PrintErr {
             this.error_kind = css.PrinterError{
                 .kind = .no_import_records,
                 .loc = null,
             };
-            return PrintErr.lol;
+            return PrintErr.CSSPrintError;
         }
 
-        pub fn addInvalidCssModulesPatternInGridError(this: *This) PrintErr!void {
+        pub fn addInvalidCssModulesPatternInGridError(this: *This) PrintErr {
             this.error_kind = css.PrinterError{
                 .kind = .invalid_css_modules_pattern_in_grid,
                 .loc = css.ErrorLocation{
@@ -169,7 +187,7 @@ pub fn Printer(comptime Writer: type) type {
                     .column = this.loc.column,
                 },
             };
-            return PrintErr.lol;
+            return PrintErr.CSSPrintError;
         }
 
         /// Returns an error of the given kind at the provided location in the current source file.
@@ -187,7 +205,7 @@ pub fn Printer(comptime Writer: type) type {
                     .column = loc.column,
                 } else null,
             };
-            return PrintErr.lol;
+            return PrintErr.CSSPrintError;
         }
 
         pub fn deinit(this: *This) void {
@@ -204,22 +222,22 @@ pub fn Printer(comptime Writer: type) type {
             scratchbuf: std.ArrayList(u8),
             dest: Writer,
             options: PrinterOptions,
-            import_records: ?*const bun.BabyList(bun.ImportRecord),
+            import_info: ?ImportInfo,
         ) This {
             return .{
                 .sources = null,
                 .dest = dest,
                 .minify = options.minify,
                 .targets = options.targets,
-                .dependencies = if (options.analyze_dependencies != null) ArrayList(css.Dependency){} else null,
+                .dependencies = if (options.analyze_dependencies != null) .empty else null,
                 .remove_imports = options.analyze_dependencies != null and options.analyze_dependencies.?.remove_imports,
                 .pseudo_classes = options.pseudo_classes,
-                .indentation_buf = std.ArrayList(u8).init(allocator),
-                .import_records = import_records,
+                .indentation_buf = .init(allocator),
+                .import_info = import_info,
                 .scratchbuf = scratchbuf,
                 .allocator = allocator,
                 .public_path = options.public_path,
-                .loc = Location{
+                .loc = .{
                     .source_index = 0,
                     .line = 0,
                     .column = 1,
@@ -228,14 +246,13 @@ pub fn Printer(comptime Writer: type) type {
         }
 
         pub inline fn getImportRecords(this: *This) PrintErr!*const bun.BabyList(bun.ImportRecord) {
-            if (this.import_records) |import_records| return import_records;
-            try this.addNoImportRecordError();
-            unreachable;
+            if (this.import_info) |info| return info.import_records;
+            return this.addNoImportRecordError();
         }
 
         pub fn printImportRecord(this: *This, import_record_idx: u32) PrintErr!void {
-            if (this.import_records) |import_records| {
-                const import_record = import_records.at(import_record_idx);
+            if (this.import_info) |info| {
+                const import_record = info.import_records.at(import_record_idx);
                 const a, const b = bun.bundle_v2.cheapPrefixNormalizer(this.public_path, import_record.path.text);
                 try this.writeStr(a);
                 try this.writeStr(b);
@@ -245,13 +262,27 @@ pub fn Printer(comptime Writer: type) type {
         }
 
         pub inline fn importRecord(this: *Printer(Writer), import_record_idx: u32) PrintErr!*const bun.ImportRecord {
-            if (this.import_records) |import_records| return import_records.at(import_record_idx);
-            try this.addNoImportRecordError();
-            unreachable;
+            if (this.import_info) |info| return info.import_records.at(import_record_idx);
+            return this.addNoImportRecordError();
         }
 
         pub inline fn getImportRecordUrl(this: *This, import_record_idx: u32) PrintErr![]const u8 {
-            return (try this.importRecord(import_record_idx)).path.text;
+            const import_info = this.import_info orelse return this.addNoImportRecordError();
+            const record = import_info.import_records.at(import_record_idx);
+            if (record.source_index.isValid()) {
+                // It has an inlined url for CSS
+                const urls_for_css = import_info.ast_urls_for_css[record.source_index.get()];
+                if (urls_for_css.len > 0) {
+                    return urls_for_css;
+                }
+                // It is a chunk URL
+                const unique_key_for_additional_file = import_info.ast_unique_key_for_additional_file[record.source_index.get()];
+                if (unique_key_for_additional_file.len > 0) {
+                    return unique_key_for_additional_file;
+                }
+            }
+            // External URL stays as-is
+            return record.path.text;
         }
 
         pub fn context(this: *const Printer(Writer)) ?*const css.StyleContext {

--- a/src/css/properties/transform.zig
+++ b/src/css/properties/transform.zig
@@ -81,7 +81,7 @@ pub const TransformList = struct {
                 scratchbuf,
                 base_writer,
                 css.PrinterOptions.defaultWithMinify(true),
-                dest.import_records,
+                dest.import_info,
             );
             defer p.deinit();
 

--- a/src/css/selectors/parser.zig
+++ b/src/css/selectors/parser.zig
@@ -927,7 +927,7 @@ pub const PseudoClass = union(enum) {
         const writer = s.writer(dest.allocator);
         const W2 = @TypeOf(writer);
         const scratchbuf = std.ArrayList(u8).init(dest.allocator);
-        var printer = Printer(W2).new(dest.allocator, scratchbuf, writer, css.PrinterOptions.default(), dest.import_records);
+        var printer = Printer(W2).new(dest.allocator, scratchbuf, writer, css.PrinterOptions.default(), dest.import_info);
         try serialize.serializePseudoClass(this, W2, &printer, null);
         return dest.writeStr(s.items);
     }
@@ -2598,7 +2598,7 @@ pub const PseudoElement = union(enum) {
         const writer = s.writer(dest.allocator);
         const W2 = @TypeOf(writer);
         const scratchbuf = std.ArrayList(u8).init(dest.allocator);
-        var printer = Printer(W2).new(dest.allocator, scratchbuf, writer, css.PrinterOptions.default(), dest.import_records);
+        var printer = Printer(W2).new(dest.allocator, scratchbuf, writer, css.PrinterOptions.default(), dest.import_info);
         try serialize.serializePseudoElement(this, W2, &printer, null);
         return dest.writeStr(s.items);
     }

--- a/src/css/selectors/selector.zig
+++ b/src/css/selectors/selector.zig
@@ -708,7 +708,7 @@ pub const serialize = struct {
                     const writer = id.writer();
                     css.serializer.serializeIdentifier(v.value, writer) catch return dest.addFmtError();
 
-                    const s = try css.to_css.string(dest.allocator, CSSString, &v.value, css.PrinterOptions.default(), dest.import_records);
+                    const s = try css.to_css.string(dest.allocator, CSSString, &v.value, css.PrinterOptions.default(), dest.import_info);
 
                     if (id.items.len > 0 and id.items.len < s.len) {
                         try dest.writeStr(id.items);

--- a/src/css/values/url.zig
+++ b/src/css/values/url.zig
@@ -117,8 +117,6 @@ pub const Url = struct {
             var buf = ArrayList(u8){};
             // PERF(alloc) we could use stack fallback here?
             var bufw = buf.writer(dest.allocator);
-            const BufW = @TypeOf(bufw);
-            _ = BufW; // autofix
             defer buf.deinit(dest.allocator);
             css.Token.toCssGeneric(&css.Token{ .unquoted_url = url }, &bufw) catch return dest.addFmtError();
 
@@ -140,7 +138,7 @@ pub const Url = struct {
             try dest.writeStr(buf.items);
         } else {
             try dest.writeStr("url(");
-            css.serializer.serializeString(import_record.path.text, dest) catch return dest.addFmtError();
+            css.serializer.serializeString(url, dest) catch return dest.addFmtError();
             try dest.writeChar(')');
         }
     }

--- a/src/css/values/url.zig
+++ b/src/css/values/url.zig
@@ -111,7 +111,7 @@ pub const Url = struct {
         }
 
         const import_record = try dest.importRecord(this.import_record_idx);
-        const url = import_record.path.text;
+        const url = try dest.getImportRecordUrl(this.import_record_idx);
 
         if (dest.minify and !import_record.is_internal) {
             var buf = ArrayList(u8){};

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -7165,7 +7165,7 @@ pub const BundledAst = struct {
         };
     }
 
-    /// TODO: I don't like having to do this extra allocation. Is there a way to only do this if we know it is imported by a CSS file?
+    /// TODO: Move this from being done on all parse tasks into the start of the linker. This currently allocates base64 encoding for every small file loaded thing.
     pub fn addUrlForCss(
         this: *BundledAst,
         allocator: std.mem.Allocator,

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -284,8 +284,8 @@ devTest("multiple stylesheets importing same dependency", {
       `,
     );
 
-    await c1.style(".shared").color.expect.toBe("yellow");
-    await c2.style(".shared").color.expect.toBe("yellow");
+    await c1.style(".shared").color.expect.toBe("#ff0");
+    await c2.style(".shared").color.expect.toBe("#ff0");
   },
 });
 devTest("removing and re-adding css import", {

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,6 +1,6 @@
 // CSS tests concern bundling bugs with CSS files
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, imageFixtures, minimalFramework, reactRefreshStub } from "../dev-server-harness";
+import { devTest, emptyHtmlFile, imageFixtures, reactRefreshStub } from "../dev-server-harness";
 import assert from "node:assert";
 
 devTest("css file with syntax error does not kill old styles", {
@@ -143,7 +143,7 @@ devTest("css import another css file", {
   async test(dev) {
     await using c = await dev.client("/");
     // Verify initial build
-    await c.style("h1").color.expect.toBe("blue");
+    await c.style("h1").color.expect.toBe("#00f");
     await c.style("body").color.expect.toBe("red");
 
     // Hot reload
@@ -164,7 +164,7 @@ devTest("css import another css file", {
     await c.style("body").color.expect.toBe("red");
   },
 });
-devTest("asset referenced in css functions", {
+devTest("asset referenced in css", {
   files: {
     "index.html": emptyHtmlFile({
       styles: ["styles.css"],
@@ -210,6 +210,10 @@ devTest("circular css imports handle hot reload", {
   files: {
     "index.html": emptyHtmlFile({
       styles: ["a.css"],
+      body: `
+        <div class="a">hello</div>
+        <div class="b">hello</div>
+      `,
     }),
     "a.css": `
       @import "./b.css";
@@ -241,9 +245,17 @@ devTest("multiple stylesheets importing same dependency", {
   files: {
     "first.html": emptyHtmlFile({
       styles: ["first.css"],
+      body: `
+        <div class="first">hello</div>
+        <div class="shared">hello</div>
+      `,
     }),
     "second.html": emptyHtmlFile({
-      styles: ["first.css"],
+      styles: ["second.css"],
+      body: `
+        <div class="second">hello</div>
+        <div class="shared">hello</div>
+      `,
     }),
     "first.css": `
       @import "./shared.css";
@@ -261,7 +273,7 @@ devTest("multiple stylesheets importing same dependency", {
     await using c1 = await dev.client("/first");
     await using c2 = await dev.client("/second");
     await c1.style(".first").color.expect.toBe("red");
-    await c2.style(".second").color.expect.toBe("blue");
+    await c2.style(".second").color.expect.toBe("#00f");
     await c1.style(".shared").color.expect.toBe("green");
     await c2.style(".shared").color.expect.toBe("green");
 
@@ -329,7 +341,7 @@ devTest("removing and re-adding css import", {
       `,
     );
     await client.style(".colored").color.expect.toBe("#00f");
-    await client.style(".main").backgroundColor.expect.toBe("white");
+    await client.style(".main").backgroundColor.expect.toBe("#fff");
   },
 });
 

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -737,7 +737,7 @@ test("serve html with JSX runtime in development mode", async () => {
   const response = await fetch(server.url);
   expect(response.status).toBe(200);
   const htmlText = await response.text();
-  const jsSrc = htmlText.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1]!;
+  const jsSrc = htmlText.match(/<script type="module" crossorigin async src="([^"]+)"/)?.[1]!;
   const js = await (await fetch(new URL(jsSrc, server.url))).text();
 
   // Development mode should use jsxDEV


### PR DESCRIPTION
Fixes #17330
Fixes #17329

note: css printer takes in ImportInfo which contains import records + some bundler information, instead of just import records. this prevents mutating path.text while bundling.
