### PR TITLE
refactor: remove BunString.fromJSRef

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -65,14 +65,6 @@ extern "C" bool BunString__fromJS(JSC::JSGlobalObject* globalObject, JSC::Encode
     return bunString->tag != BunStringTag::Dead;
 }
 
-extern "C" bool BunString__fromJSRef(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, BunString* bunString)
-{
-
-    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
-    *bunString = Bun::toStringRef(globalObject, value);
-    return bunString->tag != BunStringTag::Dead;
-}
-
 extern "C" BunString BunString__createAtom(const char* bytes, size_t length)
 {
     ASSERT(simdutf::validate_ascii(bytes, length));

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -1019,7 +1019,8 @@ pub const PostgresRequest = struct {
                 },
 
                 else => {
-                    const str = try String.fromJSRef(value, globalObject);
+                    const str = try String.fromJS2(value, globalObject);
+                    if (str.tag == .Dead) return error.OutOfMemory;
                     defer str.deref();
                     const slice = str.toUTF8WithoutRef(bun.default_allocator);
                     defer slice.deinit();

--- a/src/string.zig
+++ b/src/string.zig
@@ -742,20 +742,6 @@ pub const String = extern struct {
         }
     }
 
-    pub fn fromJSRef(value: bun.JSC.JSValue, globalObject: *JSC.JSGlobalObject) bun.JSError!String {
-        JSC.markBinding(@src());
-
-        var out: String = String.dead;
-        if (BunString__fromJSRef(globalObject, value, &out)) {
-            return out;
-        } else {
-            if (comptime bun.Environment.isDebug) {
-                bun.assert(globalObject.hasException());
-            }
-            return error.JSError;
-        }
-    }
-
     pub fn tryFromJS(value: bun.JSC.JSValue, globalObject: *JSC.JSGlobalObject) ?String {
         JSC.markBinding(@src());
 
@@ -1078,7 +1064,6 @@ pub const String = extern struct {
     extern fn BunString__toJSWithLength(globalObject: *JSC.JSGlobalObject, in: *const String, usize) JSC.JSValue;
     extern fn BunString__toJSDOMURL(globalObject: *JSC.JSGlobalObject, in: *String) JSC.JSValue;
     extern fn Bun__parseDate(*JSC.JSGlobalObject, *String) f64;
-    extern fn BunString__fromJSRef(globalObject: *JSC.JSGlobalObject, value: bun.JSC.JSValue, out: *String) bool;
     extern fn BunString__toWTFString(this: *String) void;
     extern fn BunString__createUTF8ForJS(globalObject: *JSC.JSGlobalObject, ptr: [*]const u8, len: usize) JSC.JSValue;
 


### PR DESCRIPTION
### What does this PR do?
Removes `bun.String.fromJSRef`. This method is a footgun. I've left `Bun::toStringRef` as is.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Changes are covered by existing tests.