### PR TITLE
fix: avoid warning when only a few fields of SQLOptions are provided

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2250,12 +2250,12 @@ declare module "bun" {
      * @example
      * const sql = new SQL("postgres://localhost:5432/mydb", { idleTimeout: 1000 });
      */
-    new (connectionString: string | URL, options: SQLOptions): SQL;
+    new (connectionString: string | URL, options: Partial<SQLOptions>): SQL;
     /** Creates a new SQL client instance with options
      * @example
      * const sql = new SQL({ url: "postgres://localhost:5432/mydb", idleTimeout: 1000 });
      */
-    new (options?: SQLOptions): SQL;
+    new (options?: Partial<SQLOptions>): SQL;
     /** Executes a SQL query using template literals
      * @example
      * const [user] = await sql`select * from users where id = ${1}`;


### PR DESCRIPTION
VSCode (or VSCodium) will give us this warning when we doesn't provide all fields of `SQLOptions` to the ctor of `SQL`.

### What does this PR do?

Avoid the warning message in VSCodium when we don't provide all fields of `SQLOptions` to create a `SQL`.

### How did you verify your code works?

I modified the Bun code in my node_modules/ folder, and the red wavy underline is now gone.