### PR TITLE
fix(sql) docs

### DIFF
--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -451,7 +451,7 @@ try {
 
 ## Prepared Statements
 
-By default, Bun's SQL client automatically creates prepared statements for queries where it can be inferred that the query is static. This provides better performance. However, you can disable prepared statements by setting `prepare: false` in the connection options:
+By default, Bun's SQL client automatically creates named prepared statements for queries where it can be inferred that the query is static. This provides better performance. However, you can change this behavior by setting `prepare: false` in the connection options:
 
 ```ts
 const sql = new SQL({

--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -185,7 +185,7 @@ Note that simple queries cannot use parameters (`${value}`). If you need paramet
 
 ### Unsafe Queries
 
-You can use the `sql.unsafe` function to execute raw SQL strings. Use this with caution, as it will not escape user input. Executing multiple commands with `sql.unsafe` is allowed if no parameters are used.
+You can use the `sql.unsafe` function to execute raw SQL strings. Use this with caution, as it will not escape user input. Executing more than one command per query is allowed if no parameters are used.
 
 ```ts
 // Multiple commands without parameters

--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -185,11 +185,19 @@ Note that simple queries cannot use parameters (`${value}`). If you need paramet
 
 ### Unsafe Queries
 
-You can use the `sql.unsafe` function to execute raw SQL strings. Use this with caution, as it will not escape user input.
+You can use the `sql.unsafe` function to execute raw SQL strings. Use this with caution, as it will not escape user input. Executing multiple commands with `sql.unsafe` is allowed if no parameters are used.
 
 ```ts
+// Multiple commands without parameters
+const result = await sql.unsafe(`
+  SELECT ${userColumns} FROM users;
+  SELECT ${accountColumns} FROM accounts;
+`);
+
+// Using parameters (only one command is allowed)
 const result = await sql.unsafe(
-  "SELECT " + columns + " FROM users WHERE id = " + id,
+  "SELECT " + dangerous + " FROM users WHERE id = $1",
+  [id],
 );
 ```
 

--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -456,11 +456,11 @@ By default, Bun's SQL client automatically creates prepared statements for queri
 ```ts
 const sql = new SQL({
   // ... other options ...
-  prepare: false,
+  prepare: false, // Disable persisting named prepared statements on the server
 });
 ```
 
-When `prepared: false` is set:
+When `prepare: false` is set:
 
 Queries are still executed using the "extended" protocol, but they are executed using [unnamed prepared statements](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY), an unnamed prepared statement lasts only until the next Parse statement specifying the unnamed statement as destination is issued.
 
@@ -468,7 +468,7 @@ Queries are still executed using the "extended" protocol, but they are executed 
 - Each query is parsed and planned from scratch by the server
 - Queries will not be [pipelined](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-PIPELINING)
 
-You might want to use `prepared: false` when:
+You might want to use `prepare: false` when:
 
 - Using PGBouncer in transaction mode (though since PGBouncer 1.21.0, protocol-level named prepared statements are supported when configured properly)
 - Debugging query execution plans


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
