### PR TITLE
fix(sql) calling not tagged throw errors

### DIFF
--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -520,6 +520,7 @@ The client provides typed errors for different failure scenarios:
 | `ERR_POSTGRES_SERVER_ERROR`          | General error from PostgreSQL server       |
 | `ERR_POSTGRES_INVALID_QUERY_BINDING` | Invalid parameter binding                  |
 | `ERR_POSTGRES_QUERY_CANCELLED`       | Query was cancelled                        |
+| `ERR_POSTGRES_NOT_TAGGED_CALL`       | Query was called without a tagged call     |
 
 ### Data Type Errors
 

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -175,6 +175,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_POSTGRES_INVALID_TRANSACTION_STATE", Error, "PostgresError"],
   ["ERR_POSTGRES_QUERY_CANCELLED", Error, "PostgresError"],
   ["ERR_POSTGRES_UNSAFE_TRANSACTION", Error, "PostgresError"],
+  ["ERR_POSTGRES_NOT_TAGGED_CALL", Error, "PostgresError"],
   // S3
   ["ERR_S3_MISSING_CREDENTIALS", Error],
   ["ERR_S3_INVALID_METHOD", Error],

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -21,7 +21,11 @@ const enum SSLMode {
 function connectionClosedError() {
   return $ERR_POSTGRES_CONNECTION_CLOSED("Connection closed");
 }
+function notTaggedCallError() {
+  return $ERR_POSTGRES_NOT_TAGGED_CALL("Query not called as a tagged template literal");
+}
 hideFromStack(connectionClosedError);
+hideFromStack(notTaggedCallError);
 
 enum SQLQueryResultMode {
   objects = 0,
@@ -92,6 +96,7 @@ enum SQLQueryFlags {
   unsafe = 1 << 1,
   bigint = 1 << 2,
   simple = 1 << 3,
+  notTagged = 1 << 4,
 }
 
 function getQueryHandle(query) {
@@ -131,13 +136,19 @@ class Query extends PublicPromise {
     return `PostgresQuery { ${active ? "active" : ""} ${cancelled ? "cancelled" : ""} ${executed ? "executed" : ""} ${error ? "error" : ""} }`;
   }
 
-  constructor(strings, values, allowUnsafeTransaction, poolSize, handler) {
+  constructor(strings, values, flags, poolSize, handler) {
     var resolve_, reject_;
     super((resolve, reject) => {
       resolve_ = resolve;
       reject_ = reject;
     });
-
+    if (typeof strings === "string") {
+      if (!(flags & SQLQueryFlags.unsafe)) {
+        // identifier (cannot be executed in safe mode)
+        flags |= SQLQueryFlags.notTagged;
+        strings = escapeIdentifier(strings);
+      }
+    }
     this[_resolve] = resolve_;
     this[_reject] = reject_;
     this[_handle] = null;
@@ -146,7 +157,8 @@ class Query extends PublicPromise {
     this[_poolSize] = poolSize;
     this[_strings] = strings;
     this[_values] = values;
-    this[_flags] = allowUnsafeTransaction;
+    this[_flags] = flags;
+
     this[_results] = null;
   }
 
@@ -154,6 +166,10 @@ class Query extends PublicPromise {
     const { [_handler]: handler, [_queryStatus]: status } = this;
 
     if (status & (QueryStatus.executed | QueryStatus.error | QueryStatus.cancelled | QueryStatus.invalidHandle)) {
+      return;
+    }
+    if (this[_flags] & SQLQueryFlags.notTagged) {
+      this.reject(notTaggedCallError());
       return;
     }
     this[_queryStatus] |= QueryStatus.executed;
@@ -254,6 +270,9 @@ class Query extends PublicPromise {
   }
 
   then() {
+    if (this[_flags] & SQLQueryFlags.notTagged) {
+      throw notTaggedCallError();
+    }
     this[_run](true);
     const result = super.$then.$apply(this, arguments);
     $markPromiseAsHandled(result);
@@ -261,6 +280,9 @@ class Query extends PublicPromise {
   }
 
   catch() {
+    if (this[_flags] & SQLQueryFlags.notTagged) {
+      throw notTaggedCallError();
+    }
     this[_run](true);
     const result = super.catch.$apply(this, arguments);
     $markPromiseAsHandled(result);
@@ -268,6 +290,9 @@ class Query extends PublicPromise {
   }
 
   finally() {
+    if (this[_flags] & SQLQueryFlags.notTagged) {
+      throw notTaggedCallError();
+    }
     this[_run](true);
     return super.finally.$apply(this, arguments);
   }
@@ -1009,10 +1034,6 @@ function handleQueryFragment(strings, values) {
         let sub_strings = value[_strings];
         var is_unsafe = value[_flags] & SQLQueryFlags.unsafe;
         if (typeof sub_strings === "string") {
-          if (!is_unsafe) {
-            // identifier
-            sub_strings = escapeIdentifier(sub_strings);
-          }
           if (final_strings.length === 0) {
             // we are the first value
             let final_string_value = strings[strings_idx] + sub_strings;
@@ -1558,9 +1579,9 @@ function SQL(o, e = {}) {
       assertValidTransactionName(name);
       switch (adapter) {
         case "postgres":
-          return await reserved_sql(`COMMIT PREPARED '${name}'`);
+          return await reserved_sql.unsafe(`COMMIT PREPARED '${name}'`);
         case "mysql":
-          return await reserved_sql(`XA COMMIT '${name}'`);
+          return await reserved_sql.unsafe(`XA COMMIT '${name}'`);
         case "mssql":
           throw Error(`MSSQL distributed transaction is automatically committed.`);
         case "sqlite":
@@ -1574,9 +1595,9 @@ function SQL(o, e = {}) {
       const adapter = connectionInfo.adapter;
       switch (adapter) {
         case "postgres":
-          return await reserved_sql(`ROLLBACK PREPARED '${name}'`);
+          return await reserved_sql.unsafe(`ROLLBACK PREPARED '${name}'`);
         case "mysql":
-          return await reserved_sql(`XA ROLLBACK '${name}'`);
+          return await reserved_sql.unsafe(`XA ROLLBACK '${name}'`);
         case "mssql":
           throw Error(`MSSQL distributed transaction is automatically rolled back.`);
         case "sqlite":
@@ -1841,11 +1862,11 @@ function SQL(o, e = {}) {
     const onClose = onTransactionDisconnected.bind(state);
     pooledConnection.onClose(onClose);
 
-    function run_internal_transaction_sql(strings, ...values) {
+    function run_internal_transaction_sql(string) {
       if (state.connectionState & ReservedConnectionState.closed) {
         return Promise.reject(connectionClosedError());
       }
-      return queryFromTransaction(strings, values, pooledConnection, state.queries);
+      return unsafeQueryFromTransaction(string, [], pooledConnection, state.queries);
     }
     function transaction_sql(strings, ...values) {
       if (
@@ -1886,9 +1907,9 @@ function SQL(o, e = {}) {
       assertValidTransactionName(name);
       switch (adapter) {
         case "postgres":
-          return await transaction_sql(`COMMIT PREPARED '${name}'`);
+          return await run_internal_transaction_sql(`COMMIT PREPARED '${name}'`);
         case "mysql":
-          return await transaction_sql(`XA COMMIT '${name}'`);
+          return await run_internal_transaction_sql(`XA COMMIT '${name}'`);
         case "mssql":
           throw Error(`MSSQL distributed transaction is automatically committed.`);
         case "sqlite":
@@ -1901,9 +1922,9 @@ function SQL(o, e = {}) {
       assertValidTransactionName(name);
       switch (adapter) {
         case "postgres":
-          return await transaction_sql(`ROLLBACK PREPARED '${name}'`);
+          return await run_internal_transaction_sql(`ROLLBACK PREPARED '${name}'`);
         case "mysql":
-          return await transaction_sql(`XA ROLLBACK '${name}'`);
+          return await run_internal_transaction_sql(`XA ROLLBACK '${name}'`);
         case "mssql":
           throw Error(`MSSQL distributed transaction is automatically rolled back.`);
         case "sqlite":
@@ -2124,9 +2145,9 @@ function SQL(o, e = {}) {
     const adapter = connectionInfo.adapter;
     switch (adapter) {
       case "postgres":
-        return await sql(`ROLLBACK PREPARED '${name}'`);
+        return await sql.unsafe(`ROLLBACK PREPARED '${name}'`);
       case "mysql":
-        return await sql(`XA ROLLBACK '${name}'`);
+        return await sql.unsafe(`XA ROLLBACK '${name}'`);
       case "mssql":
         throw Error(`MSSQL distributed transaction is automatically rolled back.`);
       case "sqlite":
@@ -2144,9 +2165,9 @@ function SQL(o, e = {}) {
     const adapter = connectionInfo.adapter;
     switch (adapter) {
       case "postgres":
-        return await sql(`COMMIT PREPARED '${name}'`);
+        return await sql.unsafe(`COMMIT PREPARED '${name}'`);
       case "mysql":
-        return await sql(`XA COMMIT '${name}'`);
+        return await sql.unsafe(`XA COMMIT '${name}'`);
       case "mssql":
         throw Error(`MSSQL distributed transaction is automatically committed.`);
       case "sqlite":

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -699,7 +699,6 @@ if (isDockerEnabled()) {
       await sql.beginDistributed("tx1", async sql => {
         await sql`insert into test values(1)`;
       });
-
       await sql.commitDistributed("tx1");
       expect((await sql`select count(1) from test`)[0].count).toBe("1");
     } finally {
@@ -1556,45 +1555,47 @@ if (isDockerEnabled()) {
     expect(await sql`select 1; select 2`.catch(e => e.errno)).toBe("42601");
   });
 
-  // t('await sql() throws not tagged error', async() => {
-  //   let error
-  //   try {
-  //     await sql('select 1')
-  //   } catch (e) {
-  //     error = e.code
-  //   }
-  //   return ['NOT_TAGGED_CALL', error]
-  // })
+  test("await sql() throws not tagged error", async () => {
+    try {
+      await sql("select 1");
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.code).toBe("ERR_POSTGRES_NOT_TAGGED_CALL");
+    }
+  });
 
-  // t('sql().then throws not tagged error', async() => {
-  //   let error
-  //   try {
-  //     sql('select 1').then(() => { /* noop */ })
-  //   } catch (e) {
-  //     error = e.code
-  //   }
-  //   return ['NOT_TAGGED_CALL', error]
-  // })
+  test("sql().then throws not tagged error", async () => {
+    try {
+      await sql("select 1").then(() => {
+        /* noop */
+      });
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.code).toBe("ERR_POSTGRES_NOT_TAGGED_CALL");
+    }
+  });
 
-  // t('sql().catch throws not tagged error', async() => {
-  //   let error
-  //   try {
-  //     await sql('select 1')
-  //   } catch (e) {
-  //     error = e.code
-  //   }
-  //   return ['NOT_TAGGED_CALL', error]
-  // })
+  test("sql().catch throws not tagged error", async () => {
+    try {
+      sql("select 1").catch(() => {
+        /* noop */
+      });
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.code).toBe("ERR_POSTGRES_NOT_TAGGED_CALL");
+    }
+  });
 
-  // t('sql().finally throws not tagged error', async() => {
-  //   let error
-  //   try {
-  //     sql('select 1').finally(() => { /* noop */ })
-  //   } catch (e) {
-  //     error = e.code
-  //   }
-  //   return ['NOT_TAGGED_CALL', error]
-  // })
+  test("sql().finally throws not tagged error", async () => {
+    try {
+      sql("select 1").finally(() => {
+        /* noop */
+      });
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.code).toBe("ERR_POSTGRES_NOT_TAGGED_CALL");
+    }
+  });
 
   test("little bobby tables", async () => {
     const name = "Robert'); DROP TABLE students;--";


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/17403
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
