### PR TITLE
fix(install): don't allow overriding workspaces

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -5204,8 +5204,9 @@ pub const PackageManager = struct {
                 }
             }
 
-            // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>"
-            if (dependency.version.tag != .npm or !dependency.version.value.npm.is_alias and this.lockfile.hasOverrides()) {
+            // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>" or
+            // if it's a workspaceOnly dependency
+            if (!dependency.behavior.isWorkspaceOnly() and (dependency.version.tag != .npm or !dependency.version.value.npm.is_alias and this.lockfile.hasOverrides())) {
                 if (this.lockfile.overrides.get(name_hash)) |new| {
                     debug("override: {s} -> {s}", .{ this.lockfile.str(&dependency.version.literal), this.lockfile.str(&new.literal) });
                     name, name_hash = switch (new.tag) {

--- a/test/cli/install/overrides.test.ts
+++ b/test/cli/install/overrides.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, expect, setDefaultTimeout, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
+import { write } from "bun";
 
 beforeAll(() => {
   setDefaultTimeout(1000 * 60 * 5);
@@ -185,4 +186,64 @@ test("overrides reset when removed", async () => {
   expect(versionOf(tmp, "node_modules/bytes/package.json")).not.toBe("1.0.0");
 
   ensureLockfileDoesntChangeOnBunI(tmp);
+});
+
+test("overrides do not apply to workspaces", async () => {
+  const tmp = tmpdirSync();
+  await Promise.all([
+    write(
+      join(tmp, "package.json"),
+      JSON.stringify({ name: "monorepo-root", workspaces: ["packages/*"], overrides: { "pkg1": "file:pkg2" } }),
+    ),
+    write(
+      join(tmp, "packages", "pkg1", "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        version: "1.1.1",
+      }),
+    ),
+    write(
+      join(tmp, "pkg2", "package.json"),
+      JSON.stringify({
+        name: "pkg2",
+        version: "2.2.2",
+      }),
+    ),
+  ]);
+
+  let { exited, stderr } = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: tmp,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "inherit",
+  });
+
+  expect(await exited).toBe(0);
+  expect(await Bun.readableStreamToText(stderr)).toContain("Saved lockfile");
+
+  // --frozen-lockfile works
+  ({ exited, stderr } = Bun.spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: tmp,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "inherit",
+  }));
+
+  expect(await exited).toBe(0);
+  expect(await Bun.readableStreamToText(stderr)).not.toContain("Frozen lockfile");
+
+  // lockfile is not changed
+
+  ({ exited, stderr } = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: tmp,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "inherit",
+  }));
+
+  expect(await exited).toBe(0);
+  expect(await Bun.readableStreamToText(stderr)).not.toContain("Saved lockfile");
 });


### PR DESCRIPTION
### What does this PR do?
Workspace dependencies from `"dev/peer/optiona/dependencies"` can override, but the workspaces themselves should not allow this.

Fixes #17192
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
