### PR TITLE
fix(sql) allow more than 64 columns

### DIFF
--- a/src/bun.js/bindings/SQLClient.cpp
+++ b/src/bun.js/bindings/SQLClient.cpp
@@ -27,6 +27,18 @@
 namespace Bun {
 using namespace JSC;
 
+typedef struct ExternColumnIdentifier {
+    uint8_t tag;
+    union {
+        uint32_t index;
+        BunString name;
+    };
+
+    bool isIndexedColumn() const { return tag == 1; }
+    bool isNamedColumn() const { return tag == 2; }
+    bool isDuplicateColumn() const { return tag == 0; }
+} ExternColumnIdentifier;
+
 typedef struct DataCellArray {
     struct DataCell* cells;
     uint32_t length;
@@ -286,11 +298,14 @@ static JSC::JSValue toJS(JSC::VM& vm, JSC::JSGlobalObject* globalObject, DataCel
     }
 }
 
-static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t count, JSC::JSGlobalObject* globalObject, Bun::BunStructureFlags flags, BunResultMode result_mode)
+static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t count, JSC::JSGlobalObject* globalObject, Bun::BunStructureFlags flags, BunResultMode result_mode, ExternColumnIdentifier* namesPtr, uint32_t namesCount)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-
+    std::optional<std::span<ExternColumnIdentifier>> names = std::nullopt;
+    if (namesPtr && namesCount > 0) {
+        names = std::span<ExternColumnIdentifier>(namesPtr, namesCount);
+    }
     switch (result_mode) {
     case BunResultMode::Objects: // objects
 
@@ -317,7 +332,14 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                 ASSERT(!cell.isDuplicateColumn());
                 ASSERT(!cell.isIndexedColumn());
                 ASSERT(cell.isNamedColumn());
-                object->putDirectOffset(vm, i, value);
+                if (i >= JSC::JSFinalObject::maxInlineCapacity) {
+                    if (names.has_value()) {
+                        auto name = names.value()[i - JSC::JSFinalObject::maxInlineCapacity];
+                        object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
+                    }
+                } else {
+                    object->putDirectOffset(vm, i, value);
+                }
             }
         } else if (flags.hasIndexedColumns() && !flags.hasNamedColumns() && !flags.hasDuplicateColumns()) {
             for (uint32_t i = 0; i < count; i++) {
@@ -352,7 +374,16 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                     ASSERT(!cell.isIndexedColumn());
                     ASSERT(!cell.isDuplicateColumn());
                     ASSERT(cell.index < count);
-                    object->putDirectOffset(vm, structureOffsetIndex++, value);
+
+                    if (structureOffsetIndex >= JSC::JSFinalObject::maxInlineCapacity) {
+                        if (names.has_value()) {
+                            auto name = names.value()[structureOffsetIndex - JSC::JSFinalObject::maxInlineCapacity];
+                            object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
+                        }
+                    } else {
+                        object->putDirectOffset(vm, structureOffsetIndex, value);
+                    }
+                    structureOffsetIndex++;
                 } else if (cell.isDuplicateColumn()) {
                     // skip it!
                 }
@@ -381,9 +412,9 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
         return jsUndefined();
     }
 }
-static JSC::JSValue toJS(JSC::JSArray* array, JSC::Structure* structure, DataCell* cells, uint32_t count, JSC::JSGlobalObject* globalObject, Bun::BunStructureFlags flags, BunResultMode result_mode)
+static JSC::JSValue toJS(JSC::JSArray* array, JSC::Structure* structure, DataCell* cells, uint32_t count, JSC::JSGlobalObject* globalObject, Bun::BunStructureFlags flags, BunResultMode result_mode, ExternColumnIdentifier* namesPtr, uint32_t namesCount)
 {
-    JSValue value = toJS(structure, cells, count, globalObject, flags, result_mode);
+    JSValue value = toJS(structure, cells, count, globalObject, flags, result_mode, namesPtr, namesCount);
     if (value.isEmpty())
         return {};
 
@@ -403,43 +434,35 @@ static JSC::JSValue toJS(JSC::JSArray* array, JSC::Structure* structure, DataCel
 extern "C" EncodedJSValue JSC__constructObjectFromDataCell(
     JSC::JSGlobalObject* globalObject,
     EncodedJSValue encodedArrayValue,
-    EncodedJSValue encodedStructureValue, DataCell* cells, uint32_t count, uint32_t flags, uint8_t result_mode)
+    EncodedJSValue encodedStructureValue, DataCell* cells, uint32_t count, uint32_t flags, uint8_t result_mode, ExternColumnIdentifier* namesPtr, uint32_t namesCount)
 {
     JSValue arrayValue = JSValue::decode(encodedArrayValue);
     JSValue structureValue = JSValue::decode(encodedStructureValue);
     auto* array = arrayValue ? jsDynamicCast<JSC::JSArray*>(arrayValue) : nullptr;
     auto* structure = jsDynamicCast<JSC::Structure*>(structureValue);
-    return JSValue::encode(toJS(array, structure, cells, count, globalObject, Bun::BunStructureFlags(flags), BunResultMode(result_mode)));
+    return JSValue::encode(toJS(array, structure, cells, count, globalObject, Bun::BunStructureFlags(flags), BunResultMode(result_mode), namesPtr, namesCount));
 }
 
-typedef struct ExternColumnIdentifier {
-    uint8_t tag;
-    union {
-        uint32_t index;
-        BunString name;
-    };
-
-    bool isIndexedColumn() const { return tag == 1; }
-    bool isNamedColumn() const { return tag == 2; }
-    bool isDuplicateColumn() const { return tag == 0; }
-} ExternColumnIdentifier;
-
-extern "C" EncodedJSValue JSC__createStructure(JSC::JSGlobalObject* globalObject, JSC::JSCell* owner, uint32_t inlineCapacity, ExternColumnIdentifier* namesPtr)
+extern "C" EncodedJSValue JSC__createStructure(JSC::JSGlobalObject* globalObject, JSC::JSCell* owner, uint32_t capacity, ExternColumnIdentifier* namesPtr)
 {
     auto& vm = JSC::getVM(globalObject);
 
     PropertyNameArray propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-    std::span<ExternColumnIdentifier> names(namesPtr, inlineCapacity);
+    std::span<ExternColumnIdentifier> names(namesPtr, capacity);
     uint32_t nonDuplicateCount = 0;
-    for (uint32_t i = 0; i < inlineCapacity; i++) {
+
+    for (uint32_t i = 0; i < capacity; i++) {
         ExternColumnIdentifier& name = names[i];
         if (name.isNamedColumn()) {
             propertyNames.add(Identifier::fromString(vm, name.name.toWTFString()));
         }
         nonDuplicateCount += !name.isDuplicateColumn();
+        if (nonDuplicateCount == JSFinalObject::maxInlineCapacity) {
+            break;
+        }
     }
 
-    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), std::min(nonDuplicateCount, JSFinalObject::maxInlineCapacity));
+    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), nonDuplicateCount);
     if (owner) {
         vm.writeBarrier(owner, structure);
     } else {
@@ -450,7 +473,8 @@ extern "C" EncodedJSValue JSC__createStructure(JSC::JSGlobalObject* globalObject
     if (names.size() > 0) {
         PropertyOffset offset = 0;
         uint32_t indexInPropertyNamesArray = 0;
-        for (uint32_t i = 0; i < inlineCapacity; i++) {
+        uint32_t propertyNamesSize = propertyNames.size();
+        for (uint32_t i = 0; i < capacity && indexInPropertyNamesArray < propertyNamesSize; i++) {
             ExternColumnIdentifier& name = names[i];
             if (name.isNamedColumn()) {
                 structure = structure->addPropertyTransition(vm, structure, propertyNames[indexInPropertyNamesArray++], 0, offset);
@@ -476,4 +500,5 @@ extern "C" void JSC__putDirectOffset(JSC::VM* vm, JSC::EncodedJSValue object, ui
 {
     JSValue::decode(object).getObject()->putDirectOffset(*vm, offset, JSValue::decode(value));
 }
+extern "C" uint32_t JSC__JSObject__maxInlineCapacity = JSC::JSFinalObject::maxInlineCapacity;
 }

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -21,10 +21,12 @@ const String = bun.String;
 const ErrorableString = JSC.ErrorableString;
 const JSError = bun.JSError;
 const OOM = bun.OOM;
-
+pub extern const JSC__JSObject__maxInlineCapacity: c_uint;
 pub const JSObject = extern struct {
     pub const shim = Shimmer("JSC", "JSObject", @This());
     const cppFn = shim.cppFn;
+    // lets make zig know that in comptime and assert at runtime on main.zig
+    pub const maxInlineCapacity = if (bun.Environment.isDebug) 62 else 64;
 
     pub fn toJS(obj: *JSObject) JSValue {
         return JSValue.fromCell(obj);
@@ -100,7 +102,7 @@ pub const JSObject = extern struct {
         }
     }
 
-    extern fn JSC__createStructure(*JSC.JSGlobalObject, *JSC.JSCell, u32, names: [*]ExternColumnIdentifier, flags: u32) JSC.JSValue;
+    extern fn JSC__createStructure(*JSC.JSGlobalObject, *JSC.JSCell, u32, names: [*]ExternColumnIdentifier) JSC.JSValue;
 
     pub const ExternColumnIdentifier = extern struct {
         tag: u8 = 0,
@@ -122,9 +124,9 @@ pub const JSObject = extern struct {
             }
         }
     };
-    pub fn createStructure(global: *JSGlobalObject, owner: JSC.JSValue, length: u32, names: [*]ExternColumnIdentifier, flags: u32) JSValue {
+    pub fn createStructure(global: *JSGlobalObject, owner: JSC.JSValue, length: u32, names: [*]ExternColumnIdentifier) JSValue {
         JSC.markBinding(@src());
-        return JSC__createStructure(global, owner.asCell(), length, names, flags);
+        return JSC__createStructure(global, owner.asCell(), length, names);
     }
 
     const InitializeCallback = *const fn (ctx: *anyopaque, obj: *JSObject, global: *JSGlobalObject) callconv(.C) void;

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,7 +56,10 @@ pub fn main() void {
     if (Environment.isX64 and Environment.enableSIMD and Environment.isPosix) {
         bun_warn_avx_missing(@import("./cli/upgrade_command.zig").Version.Bun__githubBaselineURL.ptr);
     }
+    bun.assert(bun.JSC.JSObject.maxInlineCapacity == bun.JSC.JSC__JSObject__maxInlineCapacity);
+
     bun.StackCheck.configureThread();
+
     bun.CLI.Cli.start(bun.default_allocator);
     bun.Global.exit(0);
 }

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -3259,10 +3259,31 @@ pub const PostgresSQLConnection = struct {
                 u32,
                 Flags,
                 u8, // result_mode
+                ?[*]JSC.JSObject.ExternColumnIdentifier, // names
+                u32, // names count
             ) JSValue;
 
-            pub fn toJS(this: *Putter, globalObject: *JSC.JSGlobalObject, array: JSValue, structure: JSValue, flags: Flags, result_mode: PostgresSQLQueryResultMode) JSValue {
-                return JSC__constructObjectFromDataCell(globalObject, array, structure, this.list.ptr, @truncate(this.fields.len), flags, @intFromEnum(result_mode));
+            pub fn toJS(this: *Putter, globalObject: *JSC.JSGlobalObject, array: JSValue, structure: JSValue, flags: Flags, result_mode: PostgresSQLQueryResultMode, cached_structure: ?PostgresCachedStructure) JSValue {
+                var names: ?[*]JSC.JSObject.ExternColumnIdentifier = null;
+                var names_count: u32 = 0;
+                if (cached_structure) |c| {
+                    if (c.fields) |f| {
+                        names = f.ptr;
+                        names_count = @truncate(f.len);
+                    }
+                }
+
+                return JSC__constructObjectFromDataCell(
+                    globalObject,
+                    array,
+                    structure,
+                    this.list.ptr,
+                    @truncate(this.fields.len),
+                    flags,
+                    @intFromEnum(result_mode),
+                    names,
+                    names_count,
+                );
             }
 
             fn putImpl(this: *Putter, index: u32, optional_bytes: ?*Data, comptime is_raw: bool) !bool {
@@ -3446,12 +3467,12 @@ pub const PostgresSQLConnection = struct {
                 const request = this.current() orelse return error.ExpectedRequest;
                 var statement = request.statement orelse return error.ExpectedStatement;
                 var structure: JSValue = .undefined;
+                var cached_structure: ?PostgresCachedStructure = null;
                 // explict use switch without else so if new modes are added, we don't forget to check for duplicate fields
                 switch (request.flags.result_mode) {
                     .objects => {
-                        // check for duplicate fields
-                        statement.checkForDuplicateFields();
-                        structure = statement.structure(this.js_value, this.globalObject);
+                        cached_structure = statement.structure(this.js_value, this.globalObject);
+                        structure = cached_structure.?.jsValue() orelse .undefined;
                     },
                     .raw, .values => {
                         // no need to check for duplicate fields or structure
@@ -3466,17 +3487,17 @@ pub const PostgresSQLConnection = struct {
                     .globalObject = this.globalObject,
                 };
 
-                var stack_buf: [64]DataCell = undefined;
+                var stack_buf: [JSC.JSObject.maxInlineCapacity]DataCell = undefined;
                 var cells: []DataCell = stack_buf[0..@min(statement.fields.len, stack_buf.len)];
+                var free_cells = false;
                 defer {
                     for (cells[0..putter.count]) |*cell| {
                         cell.deinit();
                     }
+                    if (free_cells) bun.default_allocator.free(cells);
                 }
 
-                var free_cells = false;
-                defer if (free_cells) bun.default_allocator.free(cells);
-                if (statement.fields.len >= 64) {
+                if (statement.fields.len >= JSC.JSObject.maxInlineCapacity) {
                     cells = try bun.default_allocator.alloc(DataCell, statement.fields.len);
                     free_cells = true;
                 }
@@ -3503,7 +3524,7 @@ pub const PostgresSQLConnection = struct {
                 bun.assert(thisValue != .zero);
                 const pending_value = PostgresSQLQuery.pendingValueGetCached(thisValue) orelse .zero;
                 pending_value.ensureStillAlive();
-                const result = putter.toJS(this.globalObject, pending_value, structure, statement.fields_flags, request.flags.result_mode);
+                const result = putter.toJS(this.globalObject, pending_value, structure, statement.fields_flags, request.flags.result_mode, cached_structure);
 
                 if (pending_value == .zero) {
                     PostgresSQLQuery.pendingValueSetCached(thisValue, this.globalObject, result);
@@ -3906,8 +3927,37 @@ pub const PostgresSQLConnection = struct {
     }
 };
 
+pub const PostgresCachedStructure = struct {
+    structure: JSC.Strong = .{},
+    // only populated if more than JSC.JSObject.maxInlineCapacity fields otherwise the structure will contain all fields inlined
+    fields: ?[]JSC.JSObject.ExternColumnIdentifier = null,
+
+    pub fn has(this: *@This()) bool {
+        return this.structure.has();
+    }
+
+    pub fn jsValue(this: *const @This()) ?JSC.JSValue {
+        return this.structure.get();
+    }
+
+    pub fn set(this: *@This(), globalObject: *JSC.JSGlobalObject, value: JSC.JSValue, fields: ?[]JSC.JSObject.ExternColumnIdentifier) void {
+        this.structure.set(globalObject, value);
+        this.fields = fields;
+    }
+
+    pub fn deinit(this: *@This()) void {
+        this.structure.deinit();
+        if (this.fields) |fields| {
+            this.fields = null;
+            for (fields) |*name| {
+                name.deinit();
+            }
+            bun.default_allocator.free(fields);
+        }
+    }
+};
 pub const PostgresSQLStatement = struct {
-    cached_structure: JSC.Strong = .{},
+    cached_structure: PostgresCachedStructure = .{},
     ref_count: u32 = 1,
     fields: []protocol.FieldDescription = &[_]protocol.FieldDescription{},
     parameters: []const int4 = &[_]int4{},
@@ -4024,43 +4074,55 @@ pub const PostgresSQLStatement = struct {
         bun.default_allocator.destroy(this);
     }
 
-    pub fn structure(this: *PostgresSQLStatement, owner: JSValue, globalObject: *JSC.JSGlobalObject) JSValue {
-        return this.cached_structure.get() orelse {
-            const ids = bun.default_allocator.alloc(JSC.JSObject.ExternColumnIdentifier, this.fields.len) catch return .undefined;
-            this.checkForDuplicateFields();
-            defer {
-                for (ids) |*name| {
-                    name.deinit();
-                }
-                bun.default_allocator.free(ids);
-            }
+    pub fn structure(this: *PostgresSQLStatement, owner: JSValue, globalObject: *JSC.JSGlobalObject) PostgresCachedStructure {
+        if (this.cached_structure.has()) {
+            return this.cached_structure;
+        }
+        this.checkForDuplicateFields();
 
-            for (this.fields, ids) |*field, *id| {
-                id.tag = switch (field.name_or_index) {
-                    .name => 2,
-                    .index => 1,
-                    .duplicate => 0,
-                };
-                switch (field.name_or_index) {
-                    .name => |name| {
-                        id.value.name = String.createUTF8(name.slice());
-                    },
-                    .index => |index| {
-                        id.value.index = index;
-                    },
-                    .duplicate => {},
-                }
+        // lets avoid most allocations
+        var stack_ids: [JSC.JSObject.maxInlineCapacity]JSC.JSObject.ExternColumnIdentifier = undefined;
+        // lets de duplicate the fields early
+        var nonDuplicatedCount = this.fields.len;
+        for (this.fields) |*field| {
+            if (field.name_or_index == .duplicate) {
+                nonDuplicatedCount -= 1;
             }
-            const structure_ = JSC.JSObject.createStructure(
-                globalObject,
-                owner,
-                @truncate(ids.len),
-                ids.ptr,
-                @bitCast(this.fields_flags),
-            );
-            this.cached_structure.set(globalObject, structure_);
-            return structure_;
-        };
+        }
+        const ids = stack_ids[0..@min(nonDuplicatedCount, stack_ids.len)];
+        // only keep in the heap the fields that exceed the inline capacity
+        const heap_ids = if (nonDuplicatedCount < stack_ids.len) null else bun.default_allocator.alloc(JSC.JSObject.ExternColumnIdentifier, nonDuplicatedCount - JSC.JSObject.maxInlineCapacity) catch bun.outOfMemory();
+
+        var i: usize = 0;
+        for (this.fields) |*field| {
+            if (field.name_or_index == .duplicate) continue;
+
+            var id: *JSC.JSObject.ExternColumnIdentifier = if (i >= ids.len) &heap_ids.?[i - ids.len] else &ids[i];
+            switch (field.name_or_index) {
+                .name => |name| {
+                    id.value.name = String.createAtomIfPossible(name.slice());
+                },
+                .index => |index| {
+                    id.value.index = index;
+                },
+                .duplicate => unreachable,
+            }
+            id.tag = switch (field.name_or_index) {
+                .name => 2,
+                .index => 1,
+                .duplicate => 0,
+            };
+            i += 1;
+        }
+        const structure_ = JSC.JSObject.createStructure(
+            globalObject,
+            owner,
+            @truncate(ids.len),
+            ids.ptr,
+        );
+
+        this.cached_structure.set(globalObject, structure_, heap_ids);
+        return this.cached_structure;
     }
 };
 


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/17398
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
