### PR TITLE
node: fix test-buffer-bigint64.js

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -2385,6 +2385,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigInt64LE, (JSGlobalObj
     if (bigint->sign() && limb - 0x8000000000000000 > 0x7fffffffffffffff) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "value"_s, ">= -(2n ** 63n) and < 2n ** 63n"_s, valueVal);
     int64_t value = static_cast<int64_t>(limb);
 
+    if (offsetVal.isUndefined()) offsetVal = jsNumber(0);
     if (UNLIKELY(!offsetVal.isNumber())) return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "offset"_s, "number"_s, offsetVal);
     auto offsetD = offsetVal.asNumber();
     if (UNLIKELY(std::fmod(offsetD, 1.0) != 0)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
@@ -2416,6 +2417,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigInt64BE, (JSGlobalObj
     if (bigint->sign() && limb - 0x8000000000000000 > 0x7fffffffffffffff) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "value"_s, ">= -(2n ** 63n) and < 2n ** 63n"_s, valueVal);
     int64_t value = static_cast<int64_t>(limb);
 
+    if (offsetVal.isUndefined()) offsetVal = jsNumber(0);
     if (UNLIKELY(!offsetVal.isNumber())) return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "offset"_s, "number"_s, offsetVal);
     auto offsetD = offsetVal.asNumber();
     if (UNLIKELY(std::fmod(offsetD, 1.0) != 0)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
@@ -2445,6 +2447,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigUInt64LE, (JSGlobalOb
     if (UNLIKELY(bigint->length() > 1)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "value"_s, ">= 0n and < 2n ** 64n"_s, valueVal);
     uint64_t value = valueVal.toBigUInt64(lexicalGlobalObject);
 
+    if (offsetVal.isUndefined()) offsetVal = jsNumber(0);
     if (UNLIKELY(!offsetVal.isNumber())) return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "offset"_s, "number"_s, offsetVal);
     auto offsetD = offsetVal.asNumber();
     if (UNLIKELY(std::fmod(offsetD, 1.0) != 0)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);
@@ -2474,6 +2477,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigUInt64BE, (JSGlobalOb
     if (UNLIKELY(bigint->length() > 1)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "value"_s, ">= 0n and < 2n ** 64n"_s, valueVal);
     uint64_t value = valueVal.toBigUInt64(lexicalGlobalObject);
 
+    if (offsetVal.isUndefined()) offsetVal = jsNumber(0);
     if (UNLIKELY(!offsetVal.isNumber())) return Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "offset"_s, "number"_s, offsetVal);
     auto offsetD = offsetVal.asNumber();
     if (UNLIKELY(std::fmod(offsetD, 1.0) != 0)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, "an integer"_s, offsetVal);

--- a/src/bun.js/bindings/JSBuffer.h
+++ b/src/bun.js/bindings/JSBuffer.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "JavaScriptCore/ArrayBuffer.h"
 #include "root.h"
 
 #include <JavaScriptCore/JSGlobalObject.h>

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -658,46 +658,6 @@ export function writeDoubleBE(this: BufferExt, value, offset) {
   return offset + 8;
 }
 
-// prettier-ignore
-export function writeBigInt64LE(this: BufferExt, value, offset) {
-  if (offset === undefined) offset = 0;
-  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
-  if (value < -0x8000000000000000n || value > 0x7fffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", ">= -(2n ** 63n) and < 2n ** 63n", value);
-  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(offset, value, true);
-  return offset + 8;
-}
-
-// prettier-ignore
-export function writeBigInt64BE(this: BufferExt, value, offset) {
-  if (offset === undefined) offset = 0;
-  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
-  if (value < -0x8000000000000000n || value > 0x7fffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", ">= -(2n ** 63n) and < 2n ** 63n", value);
-  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(offset, value, false);
-  return offset + 8;
-}
-
-// prettier-ignore
-export function writeBigUInt64LE(this: BufferExt, value, offset) {
-  if (offset === undefined) offset = 0;
-  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
-  if (value < 0n || value > 0xffffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", `>= 0n and < 2n ** 64n`, value);
-  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(offset, value, true);
-  return offset + 8;
-}
-
-// prettier-ignore
-export function writeBigUInt64BE(this: BufferExt, value, offset) {
-  if (offset === undefined) offset = 0;
-  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
-  if (value < 0n || value > 0xffffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", `>= 0n and < 2n ** 64n`, value);
-  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(offset, value, false);
-  return offset + 8;
-}
-
 export function toJSON(this: BufferExt) {
   const type = "Buffer";
   const data = Array.from(this);

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -279,18 +279,30 @@ export function readDoubleBE(this: BufferExt, offset) {
 }
 
 export function readBigInt64LE(this: BufferExt, offset) {
+  if (offset === undefined) offset = 0;
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined)
+    $checkBufferRead(this, offset, 8);
   return (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).getBigInt64(offset, true);
 }
 
 export function readBigInt64BE(this: BufferExt, offset) {
+  if (offset === undefined) offset = 0;
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined)
+    $checkBufferRead(this, offset, 8);
   return (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).getBigInt64(offset, false);
 }
 
 export function readBigUInt64LE(this: BufferExt, offset) {
+  if (offset === undefined) offset = 0;
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined)
+    $checkBufferRead(this, offset, 8);
   return (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).getBigUint64(offset, true);
 }
 
 export function readBigUInt64BE(this: BufferExt, offset) {
+  if (offset === undefined) offset = 0;
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined)
+    $checkBufferRead(this, offset, 8);
   return (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).getBigUint64(offset, false);
 }
 
@@ -646,39 +658,43 @@ export function writeDoubleBE(this: BufferExt, value, offset) {
   return offset + 8;
 }
 
+// prettier-ignore
 export function writeBigInt64LE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
+  if (value < -0x8000000000000000n || value > 0x7fffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", ">= -(2n ** 63n) and < 2n ** 63n", value);
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(offset, value, true);
   return offset + 8;
 }
 
+// prettier-ignore
 export function writeBigInt64BE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
+  if (value < -0x8000000000000000n || value > 0x7fffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", ">= -(2n ** 63n) and < 2n ** 63n", value);
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigInt64(offset, value, false);
   return offset + 8;
 }
 
+// prettier-ignore
 export function writeBigUInt64LE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    true,
-  );
+  if (offset === undefined) offset = 0;
+  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
+  if (value < 0n || value > 0xffffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", `>= 0n and < 2n ** 64n`, value);
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(offset, value, true);
   return offset + 8;
 }
 
+// prettier-ignore
 export function writeBigUInt64BE(this: BufferExt, value, offset) {
-  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(
-    offset === undefined ? (offset = 0) : offset,
-    value,
-    false,
-  );
+  if (offset === undefined) offset = 0;
+  if (typeof value !== "bigint") throw $ERR_INVALID_ARG_TYPE("value", "bigint", value);
+  if (value < 0n || value > 0xffffffffffffffffn) throw $ERR_OUT_OF_RANGE("value", `>= 0n and < 2n ** 64n`, value);
+  if (typeof offset !== "number" || this[offset] === undefined || this[offset + 7] === undefined) require("internal/buffer").checkBounds(this, offset, 8);
+  (this.$dataView ||= new DataView(this.buffer, this.byteOffset, this.byteLength)).setBigUint64(offset, value, false);
   return offset + 8;
 }
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2889,8 +2889,8 @@ for (let withOverridenBufferWrite of [false, true]) {
         shouldBeSame("writeUint16LE", "writeUInt16LE", 1000);
         shouldBeSame("writeUint32BE", "writeUInt32BE", 1000);
         shouldBeSame("writeUint32LE", "writeUInt32LE", 1000);
-        shouldBeSame("writeBigUint64BE", "writeBigUInt64BE", BigInt(1000));
-        shouldBeSame("writeBigUint64LE", "writeBigUInt64LE", BigInt(1000));
+        shouldBeSame("writeBigUint64BE", "writeBigUInt64BE", 1000n);
+        shouldBeSame("writeBigUint64LE", "writeBigUInt64LE", 1000n);
       });
 
       it("construct buffer from UTF16, issue #3914", () => {

--- a/test/js/node/test/parallel/test-buffer-bigint64.js
+++ b/test/js/node/test/parallel/test-buffer-bigint64.js
@@ -1,0 +1,55 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const buf = Buffer.allocUnsafe(8);
+
+['LE', 'BE'].forEach(function(endianness) {
+  // Should allow simple BigInts to be written and read
+  let val = 123456789n;
+  buf[`writeBigInt64${endianness}`](val, 0);
+  let rtn = buf[`readBigInt64${endianness}`](0);
+  assert.strictEqual(val, rtn);
+
+  // Should allow INT64_MAX to be written and read
+  val = 0x7fffffffffffffffn;
+  buf[`writeBigInt64${endianness}`](val, 0);
+  rtn = buf[`readBigInt64${endianness}`](0);
+  assert.strictEqual(val, rtn);
+
+  // Should read and write a negative signed 64-bit integer
+  val = -123456789n;
+  buf[`writeBigInt64${endianness}`](val, 0);
+  assert.strictEqual(val, buf[`readBigInt64${endianness}`](0));
+
+  // Should read and write an unsigned 64-bit integer
+  val = 123456789n;
+  buf[`writeBigUInt64${endianness}`](val, 0);
+  assert.strictEqual(val, buf[`readBigUInt64${endianness}`](0));
+
+  // Should throw a RangeError upon INT64_MAX+1 being written
+  assert.throws(function() {
+    const val = 0x8000000000000000n;
+    buf[`writeBigInt64${endianness}`](val, 0);
+  }, RangeError);
+
+  // Should throw a RangeError upon UINT64_MAX+1 being written
+  assert.throws(function() {
+    const val = 0x10000000000000000n;
+    buf[`writeBigUInt64${endianness}`](val, 0);
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "value" is out of range. It must be ' +
+      '>= 0n and < 2n ** 64n. Received 18446744073709551616n'
+  });
+
+  // Should throw a TypeError upon invalid input
+  assert.throws(function() {
+    buf[`writeBigInt64${endianness}`]('bad', 0);
+  }, TypeError);
+
+  // Should throw a TypeError upon invalid input
+  assert.throws(function() {
+    buf[`writeBigUInt64${endianness}`]('bad', 0);
+  }, TypeError);
+});


### PR DESCRIPTION
pulled out of https://github.com/oven-sh/bun/pull/15722

now faster than before (this branch relative to 1.2.2)

<img width="965" alt="image" src="https://github.com/user-attachments/assets/f4b17b21-6cbc-4204-b59d-389015582eb9" />