### PR TITLE
Fix hosting destructured decl with movable initializer

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -13131,7 +13131,6 @@ pub const LinkerContext = struct {
                     const ExportHoist = struct {
                         decls: std.ArrayListUnmanaged(G.Decl),
                         allocator: std.mem.Allocator,
-                        next_value: ?Expr = null,
 
                         pub fn wrapIdentifier(w: *@This(), loc: Logger.Loc, ref: Ref) Expr {
                             w.decls.append(
@@ -13144,7 +13143,7 @@ pub const LinkerContext = struct {
                                         },
                                         loc,
                                     ),
-                                    .value = w.next_value,
+                                    .value = null,
                                 },
                             ) catch bun.outOfMemory();
 
@@ -13170,16 +13169,20 @@ pub const LinkerContext = struct {
                                     for (local.decls.slice()) |*decl| {
                                         if (decl.value) |initializer| {
                                             const can_be_moved = initializer.canBeMoved();
-                                            hoist.next_value = if (can_be_moved) initializer else null;
-                                            const binding = decl.binding.toExpr(&hoist);
-                                            if (!can_be_moved) {
+                                            if (can_be_moved) {
+                                                // if the value can be moved, move the decl directly to preserve destructuring
+                                                // ie `const { main } = class { static main() {} }` => `var {main} = class { static main() {} }`
+                                                hoist.decls.append(hoist.allocator, decl.*) catch bun.outOfMemory();
+                                            } else {
+                                                // if the value cannot be moved, add every destructuring key seperately
+                                                // ie `var { append } = { append() {} }` => `var append; __esm(() => ({ append } = { append() {} }))`
+                                                const binding = decl.binding.toExpr(&hoist);
                                                 value = value.joinWithComma(
                                                     binding.assign(initializer),
                                                     temp_allocator,
                                                 );
                                             }
                                         } else {
-                                            hoist.next_value = null;
                                             _ = decl.binding.toExpr(&hoist);
                                         }
                                     }
@@ -13199,8 +13202,6 @@ pub const LinkerContext = struct {
                                         stmts.outside_wrapper_prefix.append(stmt) catch bun.outOfMemory();
                                         continue;
                                     }
-
-                                    hoist.next_value = null;
 
                                     break :stmt Stmt.allocateExpr(
                                         temp_allocator,

--- a/test/regression/issue/17454/destructure_string.test.ts
+++ b/test/regression/issue/17454/destructure_string.test.ts
@@ -1,0 +1,5 @@
+import { $ } from "bun";
+test("destructure string does not become string", async () => {
+  const result = await $`bun build --target=node f2.ts | bun -`.cwd(import.meta.dir).text();
+  expect(result).toBe("[Function: replace]\n");
+});

--- a/test/regression/issue/17454/f2.ts
+++ b/test/regression/issue/17454/f2.ts
@@ -1,0 +1,2 @@
+const contents_esm = await import("./repro");
+console.log(contents_esm.replace);

--- a/test/regression/issue/17454/repro.ts
+++ b/test/regression/issue/17454/repro.ts
@@ -1,0 +1,1 @@
+export const { replace } = "error!";


### PR DESCRIPTION
Fixes #17454

When hoisting a destructured decl with a movable initializer, it would copy the value into each key.

```ts
// a.ts
export const {a, b, c: [d, e, f]} = "hello!";
// b.ts
console.log(await import("./a"));
// bun build b.ts
  // before:
    var a = "hello!", b = "hello!", d = "hello!", e = "hello!", f = "hello!";
  // after:
    var { a, b, c: [d, e, f] } = "hello!";
```