### PR TITLE
Fix toml build errors in Bun.build()

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -4116,8 +4116,13 @@ pub const ParseTask = struct {
             .toml => {
                 const trace = tracer(@src(), "ParseTOML");
                 defer trace.end();
-                const root = try TOML.parse(&source, log, allocator, false);
-                return JSAst.init((try js_parser.newLazyExportAST(allocator, transpiler.options.define, opts, log, root, &source, "")).?);
+                var temp_log = bun.logger.Log.init(allocator);
+                defer {
+                    temp_log.cloneToWithRecycled(log, true) catch bun.outOfMemory();
+                    temp_log.msgs.clearAndFree();
+                }
+                const root = try TOML.parse(&source, &temp_log, allocator, false);
+                return JSAst.init((try js_parser.newLazyExportAST(allocator, transpiler.options.define, opts, &temp_log, root, &source, "")).?);
             },
             .text => {
                 const root = Expr.init(E.String, E.String{

--- a/test/js/bun/resolve/toml/crash/not.toml
+++ b/test/js/bun/resolve/toml/crash/not.toml
@@ -1,0 +1,1 @@
+export const a = "demo";

--- a/test/js/bun/resolve/toml/crash/toml-crash.test.ts
+++ b/test/js/bun/resolve/toml/crash/toml-crash.test.ts
@@ -1,0 +1,8 @@
+test("toml import error has correct lineText", async () => {
+  const result = await Bun.build({
+    entrypoints: [import.meta.dirname + "/not.toml"],
+    throw: false,
+    target: "bun",
+  });
+  expect(result.logs[0].position!.lineText).toBe('export const a = "demo";');
+});


### PR DESCRIPTION
### What does this PR do?

```
test("toml import error has correct lineText", async () => {
  const result = await Bun.build({
    entrypoints: [import.meta.dirname + "/not.toml"],
    throw: false,
    target: "bun",
  });
  expect(result.logs[0].position!.lineText).toBe('export const a = "demo";');
});

// not.toml:
export const a = "demo";
```