### PR TITLE
docs: update arch contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ $ wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 18 all
 ```
 
 ```bash#Arch
-$ sudo pacman -S llvm clang lld
+$ sudo pacman -S llvm clang18 lld
 ```
 
 ```bash#Fedora


### PR DESCRIPTION
### What does this PR do?

Arch needs `clang18` instead of `clang` now, since `clang` is version 19.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes