### PR TITLE
 Introduce `bun ./file.sql`

### DIFF
--- a/src/bun.js/bindings/SQLEntryPoint.cpp
+++ b/src/bun.js/bindings/SQLEntryPoint.cpp
@@ -1,0 +1,41 @@
+#include "root.h"
+
+#include "JavaScriptCore/CallData.h"
+#include <JavaScriptCore/ObjectConstructor.h>
+#include "InternalModuleRegistry.h"
+#include "ModuleLoader.h"
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/JSInternalPromise.h>
+
+namespace Bun {
+using namespace JSC;
+extern "C" JSInternalPromise* Bun__loadSQLEntryPoint(Zig::GlobalObject* globalObject)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSInternalPromise* promise = JSInternalPromise::create(vm, globalObject->internalPromiseStructure());
+
+    JSValue sqlModule = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::InternalSql);
+    if (UNLIKELY(scope.exception())) {
+        return promise->rejectWithCaughtException(globalObject, scope);
+    }
+
+    JSObject* sqlModuleObject = sqlModule.getObject();
+    if (UNLIKELY(!sqlModuleObject)) {
+        BUN_PANIC("Failed to load SQL entry point");
+    }
+
+    MarkedArgumentBuffer args;
+    JSValue result = JSC::call(globalObject, sqlModuleObject, args, "Failed to load SQL entry point"_s);
+    if (UNLIKELY(scope.exception())) {
+        return promise->rejectWithCaughtException(globalObject, scope);
+    }
+
+    promise = jsDynamicCast<JSInternalPromise*>(result);
+    if (UNLIKELY(!promise)) {
+        BUN_PANIC("Failed to load SQL entry point");
+    }
+    return promise;
+}
+
+}

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -280,6 +280,7 @@ pub const Run = struct {
         doPreconnect(ctx.runtime_options.preconnect);
 
         vm.main_is_html_entrypoint = (loader orelse vm.transpiler.options.loader(std.fs.path.extension(entry_path))) == .html;
+        vm.main_is_sql_entrypoint = (loader orelse vm.transpiler.options.loader(std.fs.path.extension(entry_path))) == .sql;
 
         const callback = OpaqueWrap(Run, Run.start);
         vm.global.vm().holdAPILock(&run, callback);

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -4174,7 +4174,7 @@ pub const ParseTask = struct {
                 return ast;
             },
             // TODO:
-            .dataurl, .base64, .bunsh => {
+            .dataurl, .base64, .bunsh, .sql => {
                 return try getEmptyAST(log, transpiler, opts, allocator, source, E.String);
             },
             .file, .wasm => {
@@ -8572,7 +8572,7 @@ pub const LinkerContext = struct {
                                 .{@tagName(loader)},
                             ) catch bun.outOfMemory();
                         },
-                        .css, .file, .toml, .wasm, .base64, .dataurl, .text, .bunsh => {},
+                        .css, .file, .toml, .wasm, .base64, .dataurl, .text, .bunsh, .sql => {},
                     }
                 }
             }

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1528,7 +1528,7 @@ pub const RunCommand = struct {
             var resolved_mutable = resolved;
             const path = resolved_mutable.path().?;
             const loader: bun.options.Loader = this_transpiler.options.loaders.get(path.name.ext) orelse .tsx;
-            if (loader.canBeRunByBun() or loader == .html) {
+            if (loader.canBeRunByBun() or loader == .html or loader == .sql) {
                 log("Resolved to: `{s}`", .{path.text});
                 return _bootAndHandleError(ctx, path.text, loader);
             } else {
@@ -1539,6 +1539,10 @@ pub const RunCommand = struct {
             if (strings.hasSuffixComptime(target_name, ".html")) {
                 if (strings.containsChar(target_name, '*')) {
                     return _bootAndHandleError(ctx, target_name, .html);
+                }
+            } else if (strings.hasSuffixComptime(target_name, ".sql")) {
+                if (strings.containsChar(target_name, '*')) {
+                    return _bootAndHandleError(ctx, target_name, .sql);
                 }
             }
         }

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -2,7 +2,7 @@
 // It imports the entry points and initializes a server.
 import type { HTMLBundle, Server } from "bun";
 const initial = performance.now();
-const argv = process.argv;
+const argv = [...process.execArgv, ...process.argv.slice(1)];
 
 // `import` cannot be used in this file and only Bun builtin modules can be used.
 const path = require("node:path");
@@ -17,7 +17,7 @@ async function start() {
   let port: number | undefined = undefined;
 
   // Step 1. Resolve all HTML entry points
-  for (let i = 1, argvLength = argv.length; i < argvLength; i++) {
+  for (let i = 0, argvLength = argv.length; i < argvLength; i++) {
     const arg = argv[i];
 
     if (!arg.endsWith(".html")) {

--- a/src/js/internal/sql.ts
+++ b/src/js/internal/sql.ts
@@ -1,0 +1,105 @@
+// This is the file that loads when you pass a '.sql' entry point to Bun.
+// It imports the entry points and executes them.
+
+// `import` cannot be used in this file and only Bun builtin modules can be used.
+const path = require("node:path");
+
+const initial = performance.now();
+
+async function start() {
+  const cwd = process.cwd();
+  const args = process.argv.slice(1);
+
+  // Find SQL files to execute
+  let sqlFiles: string[] = [];
+  for (const arg of args) {
+    if (!arg.endsWith(".sql")) {
+      if (arg === "--help") {
+        console.log(`
+Bun v${Bun.version} (sql)
+
+Usage:
+  bun [...sql-files]
+
+Examples:
+  bun query.sql
+  bun ./queries/*.sql
+  
+This is a small wrapper around Bun.sql() that automatically executes SQL files.
+`);
+        process.exit(0);
+      }
+      continue;
+    }
+
+    if (arg.includes("*") || arg.includes("**") || arg.includes("{")) {
+      const glob = new Bun.Glob(arg);
+
+      for (const file of glob.scanSync(cwd)) {
+        let resolved = path.resolve(cwd, file);
+        if (resolved.includes(path.sep + "node_modules" + path.sep)) {
+          continue;
+        }
+        try {
+          resolved = Bun.resolveSync(resolved, cwd);
+        } catch {
+          resolved = Bun.resolveSync("./" + resolved, cwd);
+        }
+
+        if (resolved.includes(path.sep + "node_modules" + path.sep)) {
+          continue;
+        }
+
+        sqlFiles.push(resolved);
+      }
+    } else {
+      let resolved = arg;
+      try {
+        resolved = Bun.resolveSync(arg, cwd);
+      } catch {
+        resolved = Bun.resolveSync("./" + arg, cwd);
+      }
+
+      if (resolved.includes(path.sep + "node_modules" + path.sep)) {
+        continue;
+      }
+
+      sqlFiles.push(resolved);
+    }
+
+    if (args.length > 1) {
+      sqlFiles = [...new Set(sqlFiles)];
+    }
+  }
+
+  if (sqlFiles.length === 0) {
+    throw new Error("No SQL files found matching " + JSON.stringify(Bun.main));
+  }
+
+  // Execute each SQL file
+  for (const file of sqlFiles) {
+    const { default: sql } = await import(file, { with: { type: "text" } });
+
+    if (sqlFiles.length > 1) {
+      console.log(`${file.replace(cwd + "/", "")}:`);
+    }
+
+    const results = await Bun.sql.unsafe(sql);
+
+    if (results.length === 0) {
+      if (sqlFiles.length > 1) console.log("Empty output\n");
+    } else {
+      console.table(results);
+      console.log();
+    }
+  }
+
+  const elapsed = (performance.now() - initial).toFixed(2);
+  if (sqlFiles.length > 1) {
+    console.log(`Executed ${sqlFiles.length} SQL ${sqlFiles.length === 1 ? "file" : "files"} in ${elapsed}ms`);
+  } else {
+    console.log(`Executed SQL in ${elapsed}ms`);
+  }
+}
+
+export default start;

--- a/src/options.zig
+++ b/src/options.zig
@@ -645,6 +645,7 @@ pub const Loader = enum(u8) {
     sqlite,
     sqlite_embedded,
     html,
+    sql,
 
     pub fn disableHTML(this: Loader) Loader {
         return switch (this) {
@@ -765,6 +766,7 @@ pub const Loader = enum(u8) {
         .{ "sqlite", .sqlite },
         .{ "sqlite_embedded", .sqlite_embedded },
         .{ "html", .html },
+        .{ "sql", .sql },
     });
 
     pub const api_names = bun.ComptimeStringMap(Api.Loader, .{
@@ -816,7 +818,7 @@ pub const Loader = enum(u8) {
             .tsx => .tsx,
             .css => .css,
             .html => .html,
-            .file, .bunsh => .file,
+            .file, .bunsh, .sql => .file,
             .json => .json,
             .toml => .toml,
             .wasm => .wasm,
@@ -904,7 +906,9 @@ const default_loaders_posix = .{
     .{ ".node", .napi },
     .{ ".txt", .text },
     .{ ".text", .text },
+
     .{ ".html", .html },
+    .{ ".sql", .sql },
     .{ ".jsonc", .json },
 };
 const default_loaders_win32 = default_loaders_posix ++ .{
@@ -1303,7 +1307,7 @@ pub fn definesFromTransformOptions(
     );
 }
 
-const default_loader_ext_bun = [_]string{ ".node", ".html" };
+const default_loader_ext_bun = [_]string{ ".node", ".html", ".sql" };
 const default_loader_ext = [_]string{
     ".jsx",   ".json",
     ".js",    ".mjs",

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -773,7 +773,7 @@ pub const Transpiler = struct {
                 output_file.value = .{ .buffer = .{ .allocator = alloc, .bytes = result.code } };
             },
 
-            .html, .bunsh, .sqlite_embedded, .sqlite, .wasm, .file, .napi => {
+            .html, .bunsh, .sqlite_embedded, .sqlite, .wasm, .file, .napi, .sql => {
                 const hashed_name = try transpiler.linker.getHashedFilename(file_path, null);
                 var pathname = try transpiler.allocator.alloc(u8, hashed_name.len + file_path.name.ext.len);
                 bun.copy(u8, pathname, hashed_name);

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -10883,12 +10883,12 @@ describe("bun run sql", () => {
     const output = stdout.toString();
     const error = stderr.toString();
 
+    expect(error).toBe("");
+    expect(exitCode).toBe(0);
+
     expect(output).toContain("│ num │");
     expect(output).toContain("│ 1   │");
     expect(output).toContain("Executed SQL in");
-
-    expect(exitCode).toBe(0);
-    expect(error).toBe("");
   });
 
   test("executes multiple SQL files", async () => {
@@ -10904,14 +10904,14 @@ describe("bun run sql", () => {
     const output = stdout.toString();
     const error = stderr.toString();
 
+    expect(error).toBe("");
+    expect(exitCode).toBe(0);
+
     expect(output).toContain("query1.sql:");
     expect(output).toContain("│ 2   │");
     expect(output).toContain("query2.sql:");
     expect(output).toContain("│ 3   │");
     expect(output).toContain("Executed 2 SQL files in");
-
-    expect(exitCode).toBe(0);
-    expect(error).toBe("");
   });
 
   test("executes SQL files using glob pattern", async () => {
@@ -10927,14 +10927,14 @@ describe("bun run sql", () => {
     const output = stdout.toString();
     const error = stderr.toString();
 
+    expect(error).toBe("");
+    expect(exitCode).toBe(0);
+
     expect(output).toContain("query1.sql:");
     expect(output).toContain("│ 2   │");
     expect(output).toContain("query2.sql:");
     expect(output).toContain("│ 3   │");
     expect(output).toContain("Executed 2 SQL files in");
-
-    expect(exitCode).toBe(0);
-    expect(error).toBe("");
   });
 
   test("shows help message with --help flag", async () => {
@@ -10972,6 +10972,7 @@ describe("bun run sql", () => {
     const output = stdout.toString();
     const error = stderr.toString();
 
+    // expect(error).toBe("");
     // expect(error).toContain("No SQL files found");
     expect(exitCode).not.toBe(0);
   });
@@ -10982,16 +10983,15 @@ describe("bun run sql", () => {
     await write(
       join(dir, "sql.sql"),
       `
-      DROP TABLE IF EXISTS userss;
-      CREATE TABLE IF NOT EXISTS userss (
+      CREATE TEMPORARY TABLE IF NOT EXISTS users (
         id INTEGER PRIMARY KEY,
         name TEXT NOT NULL,
         email TEXT UNIQUE NOT NULL
       );
-      INSERT INTO userss (id, name, email) VALUES (1, 'John Doe', 'john@example.com');
-      INSERT INTO userss (id, name, email) VALUES (2, 'Jane Smith', 'jane@example.com');
+      INSERT INTO users (id, name, email) VALUES (1, 'John Doe', 'john@example.com');
+      INSERT INTO users (id, name, email) VALUES (2, 'Jane Smith', 'jane@example.com');
 
-      SELECT * FROM userss;
+      SELECT * FROM users;
       `,
     );
 
@@ -11007,19 +11007,18 @@ describe("bun run sql", () => {
     const output = stdout.toString();
     const error = stderr.toString();
 
+    expect(error).toBe("");
     expect(output.slice(0, output.lastIndexOf("\n\n"))).toMatchInlineSnapshot(`
       "┌───┬──────────────┬───────┬────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────┐
       │   │ command      │ count │ 0                                                      │ 1                                                        │
       ├───┼──────────────┼───────┼────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────┤
-      │ 0 │ DROP TABLE   │ 0     │                                                        │                                                          │
-      │ 1 │ CREATE TABLE │ 0     │                                                        │                                                          │
+      │ 0 │ CREATE TABLE │ 0     │                                                        │                                                          │
+      │ 1 │ INSERT       │ 1     │                                                        │                                                          │
       │ 2 │ INSERT       │ 1     │                                                        │                                                          │
-      │ 3 │ INSERT       │ 1     │                                                        │                                                          │
-      │ 4 │ SELECT       │ 2     │ { id: 1, name: "John Doe", email: "john@example.com" } │ { id: 2, name: "Jane Smith", email: "jane@example.com" } │
+      │ 3 │ SELECT       │ 2     │ { id: 1, name: "John Doe", email: "john@example.com" } │ { id: 2, name: "Jane Smith", email: "jane@example.com" } │
       └───┴──────────────┴───────┴────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────┘"
     `);
 
     expect(exitCode).toBe(0);
-    expect(error).toBe("");
   });
 });


### PR DESCRIPTION
### What does this PR do?

Like #16993, but for running the `sql` file automatically and displays in nice table.

Prints: 
```ts
# bun *.sql
test.sql:
┌───┬──────────────┬───────┬────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────┐
│   │ command      │ count │ 0                                                      │ 1                                                        │
├───┼──────────────┼───────┼────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────┤
│ 0 │ DROP TABLE   │ 0     │                                                        │                                                          │
│ 1 │ CREATE TABLE │ 0     │                                                        │                                                          │
│ 2 │ INSERT       │ 2     │                                                        │                                                          │
│ 3 │ SELECT       │ 2     │ { id: 1, name: "John Doe", email: "john@example.com" } │ { id: 2, name: "Jane Smith", email: "jane@example.com" } │
└───┴──────────────┴───────┴────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────┘

test copy.sql:
┌───┬────┬────────────┬──────────────────┐
│   │ id │ name       │ email            │
├───┼────┼────────────┼──────────────────┤
│ 0 │ 1  │ John Doe   │ john@example.com │
│ 1 │ 2  │ Jane Smith │ jane@example.com │
└───┴────┴────────────┴──────────────────┘

Executed 2 SQL files in 606.66ms
```
when given these files:
```sql
-- test.sql
DROP TABLE IF EXISTS users;

CREATE TABLE IF NOT EXISTS users (
  id INTEGER PRIMARY KEY,
  name TEXT NOT NULL,
  email TEXT UNIQUE NOT NULL
);

INSERT INTO users (id, name, email) VALUES 
  (1, 'John Doe', 'john@example.com'),
  (2, 'Jane Smith', 'jane@example.com');

SELECT * FROM users; 
```
```sql
-- test copy.sql
SELECT * FROM users; 
```

---

**concerns:** if you have drop table or other dangerous sql files around, this could make it too easy to accidentally run...


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
manual + made tests