### PR TITLE
Use bun.sys more instead of std.fs

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1246,7 +1246,7 @@ pub const FileSystem = struct {
 
                 const read_buf = try file.preadAll(buf, 0).unwrap();
                 const prev_file_pos = if (comptime Environment.isWindows) try file.getPos().unwrap() else 0;
-                if (comptime Environment.isWindows) try file.seekTo(@intCast(prev_file_pos));
+                if (comptime Environment.isWindows) try file.seekTo(@intCast(prev_file_pos)).unwrap();
                 file_contents = buf[0..read_buf];
 
                 if (strings.BOM.detect(file_contents)) |bom| {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1244,8 +1244,8 @@ pub const FileSystem = struct {
                 // stick a zero at the end
                 buf[size] = 0;
 
-                const prev_file_pos = if (comptime Environment.isWindows) try file.getPos() else 0;
                 const read_buf = try file.preadAll(buf, 0).unwrap();
+                const prev_file_pos = if (comptime Environment.isWindows) try file.getPos().unwrap() else 0;
                 if (comptime Environment.isWindows) try file.seekTo(prev_file_pos);
                 file_contents = buf[0..read_buf];
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1246,7 +1246,7 @@ pub const FileSystem = struct {
 
                 const read_buf = try file.preadAll(buf, 0).unwrap();
                 const prev_file_pos = if (comptime Environment.isWindows) try file.getPos().unwrap() else 0;
-                if (comptime Environment.isWindows) try file.seekTo(prev_file_pos);
+                if (comptime Environment.isWindows) try file.seekTo(@intCast(prev_file_pos));
                 file_contents = buf[0..read_buf];
 
                 if (strings.BOM.detect(file_contents)) |bom| {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2101,6 +2101,14 @@ pub fn pread(fd: bun.FileDescriptor, buf: []u8, offset: i64) Maybe(usize) {
         }
     }
 
+    if (comptime Environment.isWindows) {
+        if (bun.FDImpl.decode(fd).kind == .uv) {
+            return sys_uv.pread(fd, buf, offset);
+        }
+
+        return bun.C.readFile(fd, buf, @as(u64, @intCast(offset)));
+    }
+
     const ioffset = @as(i64, @bitCast(offset)); // the OS treats this as unsigned
     while (true) {
         const rc = pread_sym(fd.cast(), buf.ptr, adjusted_len, ioffset);

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -4032,6 +4032,19 @@ pub const File = struct {
         return bun.sys.lseek(this.handle, offset, std.posix.SEEK.SET);
     }
 
+    pub fn getPos(this: File) Maybe(usize) {
+        if (comptime Environment.isWindows) {
+            const rc = std.os.windows.kernel32.SetFilePointerEx(this.handle.cast(), 0, null, std.os.windows.FILE_CURRENT);
+            if (Maybe(void).errnoSys(rc, .lseek)) |err| {
+                return err;
+            }
+
+            // Windows casts as unsigned
+            return .{ .result = @as(u32, @bitCast(rc)) };
+        }
+        return bun.sys.lseek(this.handle, 0, std.posix.SEEK.CUR);
+    }
+
     pub fn preadAll(this: File, buf: []u8, offset: usize) Maybe(usize) {
         var total: usize = 0;
         while (true) {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -4035,7 +4035,7 @@ pub const File = struct {
     pub fn getPos(this: File) Maybe(usize) {
         if (comptime Environment.isWindows) {
             const rc = std.os.windows.kernel32.SetFilePointerEx(this.handle.cast(), 0, null, std.os.windows.FILE_CURRENT);
-            if (Maybe(void).errnoSys(rc, .lseek)) |err| {
+            if (Maybe(usize).errnoSys(rc, .lseek)) |err| {
                 return err;
             }
 

--- a/src/windows_c.zig
+++ b/src/windows_c.zig
@@ -1330,6 +1330,32 @@ pub fn moveOpenedFileAt(
         Maybe(void).errno(rc, .NtSetInformationFile);
 }
 
+/// If buffer's length exceeds what a Windows DWORD integer can hold, it will be broken into
+/// multiple non-atomic reads.
+pub fn readFile(in_hFile: bun.FileDescriptor, buffer: []u8, offset: ?u64) Maybe(usize) {
+    const want_read_count: w.DWORD = @min(@as(w.DWORD, std.math.maxInt(w.DWORD)), buffer.len);
+    var amt_read: w.DWORD = undefined;
+    var overlapped_data: w.OVERLAPPED = undefined;
+    const overlapped: ?*w.OVERLAPPED = if (offset) |off| blk: {
+        overlapped_data = .{
+            .Internal = 0,
+            .InternalHigh = 0,
+            .DUMMYUNIONNAME = .{
+                .DUMMYSTRUCTNAME = .{
+                    .Offset = @as(u32, @truncate(off)),
+                    .OffsetHigh = @as(u32, @truncate(off >> 32)),
+                },
+            },
+            .hEvent = null,
+        };
+        break :blk &overlapped_data;
+    } else null;
+    if (w.kernel32.ReadFile(in_hFile.cast(), buffer.ptr, want_read_count, &amt_read, overlapped) == 0) {
+        return .{ .err = bun.sys.Error.fromCode(bun.windows.getLastErrno(), .read) };
+    }
+    return .{ .result = amt_read };
+}
+
 /// Same as moveOpenedFileAt but allows new_path to be a path relative to new_dir_fd.
 ///
 /// Aka: moveOpenedFileAtLoose(fd, dir, ".\\a\\relative\\not-normalized-path.txt", false);


### PR DESCRIPTION
### What does this PR do?

Use bun.sys more instead of std.fs:
- We cannot use any unreachable when reading files. 
- std.fs isn't consistently using the $NOCANCEL variants of libc functions. `pread` for example is used instead of `pread$NOCANCEL`.

### How did you verify your code works?

CI. This is a somewhat risky PR if we were relying on errors from std