### PR TITLE
Avoid animations for `prefers-reduced-motion` in `bun init` templates

### DIFF
--- a/src/init/react-app/src/index.css
+++ b/src/init/react-app/src/index.css
@@ -178,3 +178,10 @@ code {
 .response-area::placeholder {
   color: rgba(251, 240, 223, 0.4);
 }
+@media (prefers-reduced-motion) {
+  *,
+  ::before,
+  ::after {
+    animation: none !important;
+  }
+}

--- a/src/init/react-shadcn/src/index.css
+++ b/src/init/react-shadcn/src/index.css
@@ -41,3 +41,11 @@ body::before {
     transform: rotate(360deg);
   }
 }
+
+@media (prefers-reduced-motion) {
+  *,
+  ::before,
+  ::after {
+    animation: none !important;
+  }
+}

--- a/src/init/react-tailwind/src/index.css
+++ b/src/init/react-tailwind/src/index.css
@@ -40,3 +40,11 @@ body::before {
     transform: rotate(360deg);
   }
 }
+
+@media (prefers-reduced-motion) {
+  *,
+  ::before,
+  ::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Respects `prefers-reduced-motion` in `bun init` templates by turning off all animations.

### How did you verify your code works?

Manual/visual tests.