### PR TITLE
Introduce dedicated I/O threadpool for Bun.build on macOS & Windows

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -849,7 +849,7 @@ pub const JSBundler = struct {
 
                 if (this.was_file) {
                     // Faster path: skip the extra threadpool dispatch
-                    this.bv2.graph.pool.pool.schedule(bun.ThreadPool.Batch.from(&this.parse_task.task));
+                    this.bv2.graph.pool.worker_pool.schedule(bun.ThreadPool.Batch.from(&this.parse_task.task));
                     this.deinit();
                     return;
                 }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -204,10 +204,10 @@ pub const ThreadPool = struct {
         }
 
         switch (parse_task.stage) {
-            .needs_source_code => {
+            .needs_parse => {
                 this.pool.schedule(.from(&parse_task.task));
             },
-            .needs_parse => {
+            .needs_source_code => {
                 this.io_pool.schedule(.from(&parse_task.task));
             },
         }

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -376,6 +376,24 @@ pub fn schedule(self: *ThreadPool, batch: Batch) void {
     forceSpawn(self);
 }
 
+pub fn scheduleInsideThreadPool(self: *ThreadPool, batch: Batch) void {
+    // Sanity check
+    if (batch.len == 0) {
+        return;
+    }
+
+    // Extract out the Node's from the Tasks
+    const list = Node.List{
+        .head = &batch.head.?.node,
+        .tail = &batch.tail.?.node,
+    };
+
+    // Push the task Nodes to the most appropriate queue
+    self.run_queue.push(list);
+
+    forceSpawn(self);
+}
+
 pub fn forceSpawn(self: *ThreadPool) void {
     // Try to notify a thread
     const is_waking = false;
@@ -646,6 +664,7 @@ pub const Thread = struct {
         self.idle_queue.push(list);
     }
     var counter: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
+
     /// Thread entry point which runs a worker for the ThreadPool
     fn run(thread_pool: *ThreadPool) void {
         {


### PR DESCRIPTION
### What does this PR do?

```ts
❯ hyperfine "bun build --outdir=dist ./src/index.jsx --minify --sourcemap" "bun-1.2.3 build --outdir=dist ./src/index.jsx --minify --sourcemap" --warmup=10
Benchmark 1: bun build --outdir=dist ./src/index.jsx --minify --sourcemap
  Time (mean ± σ):     375.6 ms ±   5.0 ms    [User: 499.3 ms, System: 657.6 ms]
  Range (min … max):   370.1 ms … 383.2 ms    10 runs

Benchmark 2: bun-1.2.3 build --outdir=dist ./src/index.jsx --minify --sourcemap
  Time (mean ± σ):     653.9 ms ±   9.6 ms    [User: 581.8 ms, System: 5420.3 ms]
  Range (min … max):   637.5 ms … 668.6 ms    10 runs

Summary
  bun build --outdir=dist ./src/index.jsx --minify --sourcemap ran
    1.74 ± 0.03 times faster than bun-1.2.3 build --outdir=dist ./src/index.jsx --minify --sourcemap

```

On the `bun init` shadcn app:

```ts
❯ hyperfine "bun ./build.ts" "bun-1.2.3 ./build.ts"
Benchmark 1: bun ./build.ts
  Time (mean ± σ):     156.8 ms ±   2.1 ms    [User: 364.6 ms, System: 462.6 ms]
  Range (min … max):   153.6 ms … 161.6 ms    18 runs

Benchmark 2: bun-1.2.3 ./build.ts
  Time (mean ± σ):     176.1 ms ±   2.9 ms    [User: 351.9 ms, System: 776.0 ms]
  Range (min … max):   172.5 ms … 182.2 ms    17 runs

Summary
  bun ./build.ts ran
    1.12 ± 0.02 times faster than bun-1.2.3 ./build.ts
```

### How did you verify your code works?

Existing tests should cover this. Left two runtime feature flags in to explicitly turn on/off this behavior, so that we can later write more specific tests if needed.