### PR TITLE
fix(Glob): avoid exiting `skip_brace` early

### DIFF
--- a/src/glob/match.zig
+++ b/src/glob/match.zig
@@ -384,6 +384,7 @@ fn matchBraceBranch(state: *State, glob: []const u8, path: []const u8, open_brac
 
 fn skipBranch(state: *State, glob: []const u8) void {
     var in_brackets = false;
+    const end_brace_depth = state.brace_depth - 1;
     while (state.glob_index < glob.len) {
         switch (glob[state.glob_index]) {
             '{' => if (!in_brackets) {
@@ -391,8 +392,10 @@ fn skipBranch(state: *State, glob: []const u8) void {
             },
             '}' => if (!in_brackets) {
                 state.brace_depth -= 1;
-                state.glob_index += 1;
-                return;
+                if (state.brace_depth == end_brace_depth) {
+                    state.glob_index += 1;
+                    return;
+                }
             },
             '[' => if (!in_brackets) {
                 in_brackets = true;

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -117,6 +117,9 @@ describe("Glob.match", () => {
     glob = new Glob("{a,b}/c/{d,e}/**/*est.ts");
     expect(glob.match("a/c/d/one/two/three.test.ts"));
 
+    glob = new Glob("{a,{d,e}b}/c");
+    expect(glob.match("a/c")).toBeTrue();
+
     glob = new Glob("{**/a,**/b}");
     expect(glob.match("b")).toBeTrue();
 


### PR DESCRIPTION
### What does this PR do?

Related to https://github.com/shulaoda/fast-glob/pull/10

Fixed the issue with `skipBranch` in `Glob`. @dylan-conway cc

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I included a test for the new code.
