### PR TITLE
Generate .dwp files for debug symbols on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 *.db
 *.dmg
 *.dSYM
+*.dwo
 *.generated.ts
 *.jsb
 *.lib

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -78,7 +78,7 @@ if(WIN32)
     DESCRIPTION "Enable debug symbols (.pdb)"
     /Z7
   )
-elseif(APPLE)
+elseif(APPLE OR LINUX)
   register_compiler_flags(
     DESCRIPTION "Enable debug symbols (.dSYM)"
     -gdwarf-4

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1179,25 +1179,6 @@ if(NOT BUN_CPP_ONLY)
       OUTPUTS
         ${BUILD_PATH}/${bunStripExe}
     )
-
-    if(LINUX AND CMAKE_DWP_PROGRAM AND BUN_LINK_ONLY)
-      register_command(
-        TARGET
-          ${bun}
-        TARGET_PHASE
-          POST_BUILD
-        COMMENT
-          "Generating ${bunStrip}.dwp"
-        COMMAND
-          ${CMAKE_DWP_PROGRAM}
-            -e ${bunStripExe}
-            -o ${bunStrip}.dwp
-        CWD
-          ${BUILD_PATH}
-        OUTPUTS
-          ${BUILD_PATH}/${bunStrip}.dwp
-      )
-    endif()
   endif()
 
   register_command(
@@ -1273,7 +1254,7 @@ if(NOT BUN_CPP_ONLY)
         "Generating ${bun}.dwp"
       COMMAND
         ${CMAKE_DWP_PROGRAM}
-          -e ${bunExe}
+          -e ${bun}
           -o ${bun}.dwp
       CWD
         ${BUILD_PATH}
@@ -1298,13 +1279,13 @@ if(NOT BUN_CPP_ONLY)
       list(APPEND bunFiles ${bun}.dSYM)
     elseif(LINUX AND CMAKE_DWP_PROGRAM)
       file(GLOB DWO_FILES "${BUILD_PATH}/*.dwo")
-      list(APPEND bunFiles ${DWO_FILES} ${bun}.dwp)
+      list(APPEND bunFiles ${DWO_FILES})
+      list(APPEND bunFiles ${bun}.dwp)
     endif()
 
     if(APPLE OR LINUX)
       list(APPEND bunFiles ${bun}.linker-map)
     endif()
-
 
     register_command(
       TARGET

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1156,7 +1156,7 @@ if(NOT BUN_CPP_ONLY)
   if(bunStrip)
     if(LINUX)
       # For split DWARF, we need to keep the .gnu_debuglink section
-      set(LINUX_STRIP_FLAGS ${CMAKE_STRIP_FLAGS} --keep-section=.gnu_debuglink)
+      set(CMAKE_STRIP_FLAGS ${CMAKE_STRIP_FLAGS} --keep-section=.gnu_debuglink)
     endif()
 
     register_command(
@@ -1169,7 +1169,7 @@ if(NOT BUN_CPP_ONLY)
       COMMAND
         ${CMAKE_STRIP}
           ${bunExe}
-          $<IF:$<BOOL:${LINUX}>,${LINUX_STRIP_FLAGS},${CMAKE_STRIP_FLAGS}>
+          ${CMAKE_STRIP_FLAGS}
           --strip-all
           --strip-debug
           --discard-all

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1214,8 +1214,6 @@ if(NOT BUN_CPP_ONLY)
         --revision
     CWD
       ${BUILD_PATH}
-    SOURCES
-      ${BUILD_PATH}/${bunExe}
   )
 
   if(CI)

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -836,7 +836,7 @@ if(NOT WIN32)
     -faddrsig
   )
 
-  if(LINUX)
+  if(LINUX AND CMAKE_DWP_PROGRAM)
     target_compile_options(${bun} PUBLIC
       -gsplit-dwarf
     )
@@ -1180,7 +1180,7 @@ if(NOT BUN_CPP_ONLY)
         ${BUILD_PATH}/${bunStripExe}
     )
 
-    if(LINUX)
+    if(LINUX AND CMAKE_DWP_PROGRAM AND BUN_LINK_ONLY)
       register_command(
         TARGET
           ${bun}
@@ -1214,6 +1214,8 @@ if(NOT BUN_CPP_ONLY)
         --revision
     CWD
       ${BUILD_PATH}
+    SOURCES
+      ${BUILD_PATH}/${bunExe}
   )
 
   if(CI)
@@ -1263,7 +1265,7 @@ if(NOT BUN_CPP_ONLY)
     )
   endif()
 
-  if(LINUX)
+  if(LINUX AND CMAKE_DWP_PROGRAM)
     register_command(
       TARGET
         ${bun}
@@ -1296,7 +1298,7 @@ if(NOT BUN_CPP_ONLY)
       list(APPEND bunFiles ${bun}.pdb)
     elseif(APPLE)
       list(APPEND bunFiles ${bun}.dSYM)
-    elseif(LINUX)
+    elseif(LINUX AND CMAKE_DWP_PROGRAM)
       file(GLOB DWO_FILES "${BUILD_PATH}/*.dwo")
       list(APPEND bunFiles ${DWO_FILES} ${bun}.dwp)
     endif()

--- a/cmake/tools/SetupLLVM.cmake
+++ b/cmake/tools/SetupLLVM.cmake
@@ -123,6 +123,14 @@ else()
       REQUIRED
         ON
     )
+    find_command(
+      VARIABLE
+        CMAKE_DWP_PROGRAM
+      COMMAND
+        llvm-dwp
+      REQUIRED
+        ON
+    )
   else()
     find_llvm_command(CMAKE_STRIP llvm-strip)
   endif()

--- a/cmake/tools/SetupLLVM.cmake
+++ b/cmake/tools/SetupLLVM.cmake
@@ -129,7 +129,7 @@ else()
       COMMAND
         llvm-dwp
       REQUIRED
-        ON
+        OFF
     )
   else()
     find_llvm_command(CMAKE_STRIP llvm-strip)


### PR DESCRIPTION
### What does this PR do?

Generate .dwp files for debug symbols

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
