### PR TITLE
Try CPU pinning on Linux

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -311,26 +311,38 @@ pub const ThreadPool = struct {
             if (Environment.isLinux) {
                 if (!bun.getRuntimeFeatureFlag("BUN_FEATURE_FLAG_NO_CPU_AFFINITY")) {
                     const Affinity = struct {
+                        var cpu_index: usize = 0;
                         threadlocal var has_set_affinity_on_thread: bool = false;
 
                         pub fn pin() void {
                             if (!has_set_affinity_on_thread) {
                                 has_set_affinity_on_thread = true;
-                                var cpu: usize = 0;
-                                if (std.os.linux.getcpu(&cpu, null) == 0) {
-                                    var set = std.mem.zeroes(std.os.linux.cpu_set_t);
-                                    const word_index = cpu / @bitSizeOf(usize);
-                                    const bit_index = cpu % @bitSizeOf(usize);
-                                    set[word_index] = @as(usize, 1) << @as(u6, @intCast(bit_index));
 
-                                    std.os.linux.sched_setaffinity(0, &set) catch |err| {
-                                        Output.debugWarn("Failed to set affinity for worker thread: {s}", .{@errorName(err)});
-                                        return;
-                                    };
-                                    debug("Pinned worker thread to CPU {d}", .{cpu});
-                                } else {
-                                    Output.debugWarn("Failed to get CPU for worker thread", .{});
+                                // Get available CPUs
+                                var set = std.mem.zeroes(std.os.linux.cpu_set_t);
+                                if (std.os.linux.sched_getaffinity(0, @sizeOf(std.os.linux.cpu_set_t), &set) != 0) {
+                                    Output.debugWarn("Failed to get CPU affinity mask", .{});
+                                    return;
                                 }
+
+                                // Count available CPUs and get next CPU in round-robin
+                                const available_cpus = std.os.linux.CPU_COUNT(set);
+                                if (available_cpus == 0) return;
+
+                                const cpu = @atomicRmw(usize, &cpu_index, .Add, 1, .monotonic) % available_cpus;
+
+                                // Pin to that CPU
+                                var new_set = std.mem.zeroes(std.os.linux.cpu_set_t);
+                                const word_index = cpu / @bitSizeOf(usize);
+                                const bit_index = cpu % @bitSizeOf(usize);
+                                new_set[word_index] = @as(usize, 1) << @as(u6, @intCast(bit_index));
+
+                                std.os.linux.sched_setaffinity(0, &new_set) catch |err| {
+                                    Output.debugWarn("Failed to set affinity for worker thread: {s}", .{@errorName(err)});
+                                    return;
+                                };
+
+                                debug("Pinned worker thread to CPU {d}", .{cpu});
                             }
                         }
                     };

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -329,7 +329,7 @@ pub const ThreadPool = struct {
                                 const available_cpus = std.os.linux.CPU_COUNT(set);
                                 if (available_cpus == 0) return;
 
-                                const cpu = cpu_index.fetchAdd(1, .monotonic) % available_cpus;
+                                const cpu = (cpu_index.fetchAdd(1, .monotonic) + 1) % available_cpus;
 
                                 // Pin to that CPU
                                 var new_set = std.mem.zeroes(std.os.linux.cpu_set_t);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
