### PR TITLE
fix: invalid json import regression

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 763e836175f705b3acb6fcd29270e68dd15d08bb)
+  set(WEBKIT_VERSION b9c0b519db002bf8cf69532dab853abf4121eaf6)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)

--- a/src/bun.js/bindings/Base64Helpers.cpp
+++ b/src/bun.js/bindings/Base64Helpers.cpp
@@ -19,7 +19,7 @@ ExceptionOr<String> atob(const String& encodedString)
         const auto span = encodedString.span16();
         size_t expected_length = simdutf::latin1_length_from_utf16(span.size());
         std::span<LChar> ptr;
-        WTF::String convertedString = WTF::String::createUninitialized(expected_length, ptr);
+        WTF::String convertedString = WTF::String::tryCreateUninitialized(expected_length, ptr);
         if (UNLIKELY(convertedString.isNull())) {
             return WebCore::Exception { OutOfMemoryError };
         }
@@ -35,7 +35,7 @@ ExceptionOr<String> atob(const String& encodedString)
     const auto span = encodedString.span8();
     size_t result_length = simdutf::maximal_binary_length_from_base64(reinterpret_cast<const char*>(span.data()), encodedString.length());
     std::span<LChar> ptr;
-    WTF::String outString = WTF::String::createUninitialized(result_length, ptr);
+    WTF::String outString = WTF::String::tryCreateUninitialized(result_length, ptr);
     if (UNLIKELY(outString.isNull())) {
         return WebCore::Exception { OutOfMemoryError };
     }

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -662,6 +662,17 @@ WTF::String BunString::toWTFString(ZeroCopyTag) const
     return WTF::String();
 }
 
+WTF::String BunString::toWTFString(NonNullTag) const
+{
+    WTF::String res = toWTFString(ZeroCopy);
+    if (res.isNull()) {
+        // TODO(dylan-conway): also use emptyString in toWTFString(ZeroCopy) and toWTFString. This will
+        // require reviewing each call site for isNull() checks and most likely changing them to isEmpty()
+        return WTF::emptyString();
+    }
+    return res;
+}
+
 WTF::String BunString::transferToWTFString()
 {
     if (this->tag == BunStringTag::ZigString) {

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -213,7 +213,11 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
         auto pair = *it;
         StringView nameView = StringView(std::span { reinterpret_cast<const LChar*>(pair.first.data()), pair.first.length() });
         std::span<LChar> data;
-        auto value = String::createUninitialized(pair.second.length(), data);
+        auto value = String::tryCreateUninitialized(pair.second.length(), data);
+        if (UNLIKELY(value.isNull())) {
+            throwOutOfMemoryError(globalObject, scope);
+            return JSValue::encode({});
+        }
         if (pair.second.length() > 0)
             memcpy(data.data(), pair.second.data(), pair.second.length());
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1733,7 +1733,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBTOA,
     if (!encodedString.is8Bit()) {
         std::span<LChar> ptr;
         unsigned length = encodedString.length();
-        auto dest = WTF::String::createUninitialized(length, ptr);
+        auto dest = WTF::String::tryCreateUninitialized(length, ptr);
         if (UNLIKELY(dest.isNull())) {
             throwOutOfMemoryError(globalObject, throwScope);
             return {};

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2509,19 +2509,6 @@ void JSC__JSValue___then(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1, JSC__
     }
 }
 
-JSC__JSValue JSC__JSValue__parseJSON(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1)
-{
-    JSC::JSValue jsValue = JSC::JSValue::decode(JSValue0);
-
-    JSC::JSValue result = JSC::JSONParse(arg1, jsValue.toWTFString(arg1));
-
-    if (!result) {
-        result = JSC::JSValue(JSC::createSyntaxError(arg1->globalObject(), "Failed to parse JSON"_s));
-    }
-
-    return JSC::JSValue::encode(result);
-}
-
 JSC__JSValue JSC__JSGlobalObject__getCachedObject(JSC__JSGlobalObject* globalObject, const ZigString* arg1)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -5873,13 +5873,6 @@ pub const JSValue = enum(i64) {
         });
     }
 
-    pub fn parseJSON(this: JSValue, globalObject: *JSGlobalObject) JSValue {
-        return cppFn("parseJSON", .{
-            this,
-            globalObject,
-        });
-    }
-
     pub fn stringIncludes(this: JSValue, globalObject: *JSGlobalObject, other: JSValue) bool {
         return cppFn("stringIncludes", .{ this, globalObject, other });
     }

--- a/src/bun.js/bindings/decodeURIComponentSIMD.cpp
+++ b/src/bun.js/bindings/decodeURIComponentSIMD.cpp
@@ -284,7 +284,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDecodeURIComponentSIMD, (JSC::JSGlobalObject 
             const auto span = string.span16();
             size_t expected_length = simdutf::latin1_length_from_utf16(span.size());
             std::span<LChar> ptr;
-            WTF::String convertedString = WTF::String::createUninitialized(expected_length, ptr);
+            WTF::String convertedString = WTF::String::tryCreateUninitialized(expected_length, ptr);
             if (UNLIKELY(convertedString.isNull())) {
                 throwVMError(globalObject, scope, createOutOfMemoryError(globalObject));
                 return {};

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -53,6 +53,7 @@ typedef struct BunString {
     BunStringImpl impl;
 
     enum ZeroCopyTag { ZeroCopy };
+    enum NonNullTag { NonNull };
 
     // If it's not a WTFStringImpl, this does nothing
     inline void ref();
@@ -68,6 +69,10 @@ typedef struct BunString {
     // if it was a ZigString, it still allocates a WTF::StringImpl.
     // It's only truly zero-copy if it was already a WTFStringImpl (which it is if it came from JS and we didn't use ZigString)
     WTF::String toWTFString(ZeroCopyTag) const;
+
+    // If the string is empty, this will ensure m_impl is non-null by
+    // using shared static emptyString.
+    WTF::String toWTFString(NonNullTag) const;
 
     WTF::String transferToWTFString();
 

--- a/test/regression/issue/17605.test.ts
+++ b/test/regression/issue/17605.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test";
+import { tmpdirSync } from "harness";
+import { write } from "bun";
+import { join } from "path";
+
+test("empty and invalid JSON import do not crash", async () => {
+  const testDir = tmpdirSync("empty-and-invalid-json-import-do-not-crash");
+
+  await Promise.all([
+    write(join(testDir, "empty.json"), ""),
+    write(
+      join(testDir, "invalid.json"),
+      `
+{
+  "a": 1
+  "b": 2
+}`,
+    ),
+  ]);
+
+  expect(async () => {
+    await import(join(testDir, "empty.json"));
+  }).toThrow("JSON Parse error: Unexpected EOF");
+
+  expect(async () => {
+    await import(join(testDir, "invalid.json"));
+  }).toThrow("JSON Parse error: Expected '}'");
+
+  expect(async () => {
+    const json = require(join(testDir, "empty.json"));
+  }).toThrow("JSON Parse error: Unexpected EOF");
+
+  expect(async () => {
+    const json = require(join(testDir, "invalid.json"));
+  }).toThrow("JSON Parse error: Expected '}'");
+});

--- a/test/regression/issue/17605.test.ts
+++ b/test/regression/issue/17605.test.ts
@@ -19,18 +19,18 @@ test("empty and invalid JSON import do not crash", async () => {
   ]);
 
   expect(async () => {
-    await import(join(testDir, "empty.json"));
+    await import(join(testDir, "empty.json") + "?0");
   }).toThrow("JSON Parse error: Unexpected EOF");
 
   expect(async () => {
-    await import(join(testDir, "invalid.json"));
+    await import(join(testDir, "invalid.json") + "?1");
   }).toThrow("JSON Parse error: Expected '}'");
 
-  expect(async () => {
+  expect(() => {
     const json = require(join(testDir, "empty.json"));
   }).toThrow("JSON Parse error: Unexpected EOF");
 
-  expect(async () => {
+  expect(() => {
     const json = require(join(testDir, "invalid.json"));
   }).toThrow("JSON Parse error: Expected '}'");
 });


### PR DESCRIPTION
### What does this PR do?
`JSONParseWithException` expects the input `StringImpl` to be non-null, otherwise it will return null without an exception.

fixes #17605 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test for invalid and empty json with `import` and `require`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
