### PR TITLE
Add bun pm pack --filename for Yarn compatibility

### DIFF
--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -12,8 +12,11 @@ Options for the `pack` command:
 
 - `--dry-run`: Perform all tasks except writing the tarball to disk.
 - `--destination`: Specify the directory where the tarball will be saved.
+- `--filename`: Specify an exact file name for the tarball to be saved at.
 - `--ignore-scripts`: Skip running pre/postpack and prepare scripts.
 - `--gzip-level`: Set a custom compression level for gzip, ranging from 0 to 9 (default is 9).
+
+> Note `--filename` and `--destination` cannot be used at the same time
 
 ## bin
 

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1407,7 +1407,7 @@ pub const PackCommand = struct {
                     Output.pretty("\n{}\n", .{fmtTarballFilename(package_name, package_version, .normalize)});
                 } else {
                     var dest_buf: PathBuffer = undefined;
-                    const abs_tarball_dest, _ = absTarballDestination(
+                    const abs_tarball_dest, _ = tarballDestination(
                         ctx.manager.options.pack_destination,
                         ctx.manager.options.pack_filename,
                         abs_workspace_path,
@@ -1445,7 +1445,7 @@ pub const PackCommand = struct {
 
             if (comptime for_publish) {
                 var dest_buf: bun.PathBuffer = undefined;
-                const abs_tarball_dest, _ = absTarballDestination(
+                const abs_tarball_dest, _ = tarballDestination(
                     ctx.manager.options.pack_destination,
                     ctx.manager.options.pack_filename,
                     abs_workspace_path,
@@ -1528,7 +1528,7 @@ pub const PackCommand = struct {
         }
 
         var dest_buf: PathBuffer = undefined;
-        const abs_tarball_dest, const abs_tarball_dest_dir_end = absTarballDestination(
+        const abs_tarball_dest, const abs_tarball_dest_dir_end = tarballDestination(
             ctx.manager.options.pack_destination,
             ctx.manager.options.pack_filename,
             abs_workspace_path,
@@ -1798,7 +1798,7 @@ pub const PackCommand = struct {
         }
     }
 
-    fn absTarballDestination(
+    fn tarballDestination(
         pack_destination: string,
         pack_filename: string,
         abs_workspace_path: string,

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1403,12 +1403,13 @@ pub const PackCommand = struct {
             printArchivedFilesAndPackages(ctx, root_dir, true, &pack_queue, 0);
 
             if (comptime !for_publish) {
-                if (manager.options.pack_destination.len == 0) {
+                if (manager.options.pack_destination.len == 0 and manager.options.pack_filename.len == 0) {
                     Output.pretty("\n{}\n", .{fmtTarballFilename(package_name, package_version, .normalize)});
                 } else {
                     var dest_buf: PathBuffer = undefined;
                     const abs_tarball_dest, _ = absTarballDestination(
                         ctx.manager.options.pack_destination,
+                        ctx.manager.options.pack_filename,
                         abs_workspace_path,
                         package_name,
                         package_version,
@@ -1446,6 +1447,7 @@ pub const PackCommand = struct {
                 var dest_buf: bun.PathBuffer = undefined;
                 const abs_tarball_dest, _ = absTarballDestination(
                     ctx.manager.options.pack_destination,
+                    ctx.manager.options.pack_filename,
                     abs_workspace_path,
                     package_name,
                     package_version,
@@ -1528,6 +1530,7 @@ pub const PackCommand = struct {
         var dest_buf: PathBuffer = undefined;
         const abs_tarball_dest, const abs_tarball_dest_dir_end = absTarballDestination(
             ctx.manager.options.pack_destination,
+            ctx.manager.options.pack_filename,
             abs_workspace_path,
             package_name,
             package_version,
@@ -1739,7 +1742,7 @@ pub const PackCommand = struct {
         );
 
         if (comptime !for_publish) {
-            if (manager.options.pack_destination.len == 0) {
+            if (manager.options.pack_destination.len == 0 and manager.options.pack_filename.len == 0) {
                 Output.pretty("\n{}\n", .{fmtTarballFilename(package_name, package_version, .normalize)});
             } else {
                 Output.pretty("\n{s}\n", .{abs_tarball_dest});
@@ -1797,32 +1800,56 @@ pub const PackCommand = struct {
 
     fn absTarballDestination(
         pack_destination: string,
+        pack_filename: string,
         abs_workspace_path: string,
         package_name: string,
         package_version: string,
         dest_buf: []u8,
     ) struct { stringZ, usize } {
-        const tarball_destination_dir = bun.path.joinAbsStringBuf(
-            abs_workspace_path,
-            dest_buf,
-            &.{pack_destination},
-            .auto,
-        );
-
-        const tarball_name = std.fmt.bufPrint(dest_buf[strings.withoutTrailingSlash(tarball_destination_dir).len..], "/{}\x00", .{
-            fmtTarballFilename(package_name, package_version, .normalize),
-        }) catch {
-            Output.errGeneric("archive destination name too long: \"{s}/{}\"", .{
-                strings.withoutTrailingSlash(tarball_destination_dir),
-                fmtTarballFilename(package_name, package_version, .normalize),
+        if (pack_filename.len > 0 and pack_destination.len > 0) {
+            Output.errGeneric("cannot use both filename and destination at the same time with tarball: filename \"{s}\" and destination \"{s}\"", .{
+                strings.withoutTrailingSlash(pack_filename),
+                strings.withoutTrailingSlash(pack_destination),
             });
             Global.crash();
-        };
+        }
+        if (pack_destination.len > 0) {
+            const tarball_destination_dir = bun.path.joinAbsStringBuf(
+                abs_workspace_path,
+                dest_buf,
+                &.{pack_destination},
+                .auto,
+            );
 
-        return .{
-            dest_buf[0 .. strings.withoutTrailingSlash(tarball_destination_dir).len + tarball_name.len - 1 :0],
-            tarball_destination_dir.len,
-        };
+            const tarball_name = std.fmt.bufPrint(dest_buf[strings.withoutTrailingSlash(tarball_destination_dir).len..], "/{}\x00", .{
+                fmtTarballFilename(package_name, package_version, .normalize),
+            }) catch {
+                Output.errGeneric("archive destination name too long: \"{s}/{}\"", .{
+                    strings.withoutTrailingSlash(tarball_destination_dir),
+                    fmtTarballFilename(package_name, package_version, .normalize),
+                });
+                Global.crash();
+            };
+
+            return .{
+                dest_buf[0 .. strings.withoutTrailingSlash(tarball_destination_dir).len + tarball_name.len - 1 :0],
+                tarball_destination_dir.len,
+            };
+        } else {
+            const tarball_name = std.fmt.bufPrint(dest_buf[0..], "{s}\x00", .{
+                pack_filename,
+            }) catch {
+                Output.errGeneric("archive filename too long: \"{s}\"", .{
+                    pack_filename,
+                });
+                Global.crash();
+            };
+
+            return .{
+                dest_buf[0 .. tarball_name.len - 1 :0],
+                0,
+            };
+        }
     }
 
     pub fn fmtTarballFilename(package_name: string, package_version: string, style: TarballNameFormatter.Style) TarballNameFormatter {

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1813,7 +1813,21 @@ pub const PackCommand = struct {
             });
             Global.crash();
         }
-        if (pack_destination.len > 0) {
+        if (pack_filename.len > 0) {
+            const tarball_name = std.fmt.bufPrint(dest_buf[0..], "{s}\x00", .{
+                pack_filename,
+            }) catch {
+                Output.errGeneric("archive filename too long: \"{s}\"", .{
+                    pack_filename,
+                });
+                Global.crash();
+            };
+
+            return .{
+                dest_buf[0 .. tarball_name.len - 1 :0],
+                0,
+            };
+        } else {
             const tarball_destination_dir = bun.path.joinAbsStringBuf(
                 abs_workspace_path,
                 dest_buf,
@@ -1834,36 +1848,6 @@ pub const PackCommand = struct {
             return .{
                 dest_buf[0 .. strings.withoutTrailingSlash(tarball_destination_dir).len + tarball_name.len - 1 :0],
                 tarball_destination_dir.len,
-            };
-        } else if (pack_destination.len > 0) {
-            const tarball_name = std.fmt.bufPrint(dest_buf[0..], "{s}\x00", .{
-                pack_filename,
-            }) catch {
-                Output.errGeneric("archive filename too long: \"{s}\"", .{
-                    pack_filename,
-                });
-                Global.crash();
-            };
-
-            return .{
-                dest_buf[0 .. tarball_name.len - 1 :0],
-                0,
-            };
-        } else {
-            const tarball_name = std.fmt.bufPrint(dest_buf[0..], "{s}-{s}.tgz\x00", .{
-                package_name,
-                package_version,
-            }) catch {
-                Output.errGeneric("archive filename too long: \"{s}-{s}.tgz\"", .{
-                    package_name,
-                    package_version,
-                });
-                Global.crash();
-            };
-
-            return .{
-                dest_buf[0 .. tarball_name.len - 1 :0],
-                0,
             };
         }
     }

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1835,12 +1835,28 @@ pub const PackCommand = struct {
                 dest_buf[0 .. strings.withoutTrailingSlash(tarball_destination_dir).len + tarball_name.len - 1 :0],
                 tarball_destination_dir.len,
             };
-        } else {
+        } else if (pack_destination.len > 0) {
             const tarball_name = std.fmt.bufPrint(dest_buf[0..], "{s}\x00", .{
                 pack_filename,
             }) catch {
                 Output.errGeneric("archive filename too long: \"{s}\"", .{
                     pack_filename,
+                });
+                Global.crash();
+            };
+
+            return .{
+                dest_buf[0 .. tarball_name.len - 1 :0],
+                0,
+            };
+        } else {
+            const tarball_name = std.fmt.bufPrint(dest_buf[0..], "{s}-{s}.tgz\x00", .{
+                package_name,
+                package_version,
+            }) catch {
+                Output.errGeneric("archive filename too long: \"{s}-{s}.tgz\"", .{
+                    package_name,
+                    package_version,
                 });
                 Global.crash();
             };

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -118,6 +118,7 @@ pub const PackageManagerCommand = struct {
             \\  <b><green>bun pm<r> <blue>pack<r>               create a tarball of the current workspace
             \\  <d>├<r> <cyan>--dry-run<r>               do everything except for writing the tarball to disk
             \\  <d>├<r> <cyan>--destination<r>           the directory the tarball will be saved in
+            \\  <d>├<r> <cyan>--filename<r>              the name of the tarball
             \\  <d>├<r> <cyan>--ignore-scripts<r>        don't run pre/postpack and prepare scripts
             \\  <d>└<r> <cyan>--gzip-level<r>            specify a custom compression level for gzip (0-9, default is 9)
             \\  <b><green>bun pm<r> <blue>bin<r>                print the path to bin folder

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7164,6 +7164,7 @@ pub const PackageManager = struct {
 
         filter_patterns: []const string = &.{},
         pack_destination: string = "",
+        pack_filename: string = "",
         pack_gzip_level: ?string = null,
         // json_output: bool = false,
 
@@ -7577,6 +7578,7 @@ pub const PackageManager = struct {
 
                 this.filter_patterns = cli.filters;
                 this.pack_destination = cli.pack_destination;
+                this.pack_filename = cli.pack_filename;
                 this.pack_gzip_level = cli.pack_gzip_level;
                 // this.json_output = cli.json_output;
 
@@ -9643,6 +9645,7 @@ pub const PackageManager = struct {
         clap.parseParam("-a, --all") catch unreachable,
         // clap.parseParam("--filter <STR>...                      Pack each matching workspace") catch unreachable,
         clap.parseParam("--destination <STR>                    The directory the tarball will be saved in") catch unreachable,
+        clap.parseParam("--filename <STR>                       The filename of the tarball") catch unreachable,
         clap.parseParam("--gzip-level <STR>                     Specify a custom compression level for gzip. Default is 9.") catch unreachable,
         clap.parseParam("<POS> ...                         ") catch unreachable,
     });
@@ -9690,6 +9693,7 @@ pub const PackageManager = struct {
     const pack_params: []const ParamType = &(shared_params ++ [_]ParamType{
         // clap.parseParam("--filter <STR>...                      Pack each matching workspace") catch unreachable,
         clap.parseParam("--destination <STR>                    The directory the tarball will be saved in") catch unreachable,
+        clap.parseParam("--filename <STR>                       The filename of the tarball") catch unreachable,
         clap.parseParam("--gzip-level <STR>                     Specify a custom compression level for gzip. Default is 9.") catch unreachable,
         clap.parseParam("<POS> ...                              ") catch unreachable,
     });
@@ -9734,6 +9738,7 @@ pub const PackageManager = struct {
         filters: []const string = &.{},
 
         pack_destination: string = "",
+        pack_filename: string = "",
         pack_gzip_level: ?string = null,
 
         development: bool = false,
@@ -10154,6 +10159,9 @@ pub const PackageManager = struct {
                 if (comptime subcommand != .publish) {
                     if (args.option("--destination")) |dest| {
                         cli.pack_destination = dest;
+                    }
+                    if (args.option("--filename")) |file| {
+                        cli.pack_filename = file;
                     }
                 }
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -336,6 +336,21 @@ describe("flags", () => {
     });
   }
 
+  test("--filename and --destination", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-dest-test",
+          version: "1.1.1",
+        }),
+      ),
+      write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+    ]);
+
+    expect(async () => await pack(packageDir, bunEnv, "--filename=test.tgz", "--destination=packed")).toThrowError();
+  });
+
   test("--ignore-scripts", async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -284,6 +284,39 @@ describe("flags", () => {
     });
   }
 
+  const filenameTests = [
+    {
+      "filename": "test.tgz",
+    },
+    {
+      "filename": "no-extension",
+    },
+    {
+      "filename": "no-extension.tar",
+    },
+  ];
+
+  for (const { filename } of filenameTests) {
+    test(`--filename="${filename}"`, async () => {
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "pack-dest-test",
+            version: "1.1.1",
+          }),
+        ),
+        write(join(packageDir, "index.js"), "console.log('hello ./index.js')"),
+      ]);
+
+      const dest = join(packageDir, filename);
+      await pack(packageDir, bunEnv, `--filename=${filename}`);
+
+      const tarball = readTarball(dest);
+      expect(tarball.entries).toHaveLength(2);
+    });
+  }
+
   test("--ignore-scripts", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
### What does this PR do?

This adds support for `bun pm pack --filename` which behaves like `yarn pack --filename` and fixes #17495

- [x] Code changes

### How did you verify your code works?

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] Manual testing of this against yarn and buns `--destination` flag to make sure it works the same, handles `--filename` and `--destination` at the same time with a clear error and `--filename` is a compatible drop in swap with the yarn command

