### PR TITLE
Don't pass bare Exceptions to JS in node:net

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1572,7 +1572,7 @@ fn NewSocket(comptime ssl: bool) type {
             const globalObject = handlers.globalObject;
             const this_value = this.getThisValue(globalObject);
             _ = callback.call(globalObject, this_value, &.{this_value}) catch |err| {
-                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeException(err) });
+                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeError(err) });
             };
         }
         pub fn onTimeout(
@@ -1598,7 +1598,7 @@ fn NewSocket(comptime ssl: bool) type {
             const globalObject = handlers.globalObject;
             const this_value = this.getThisValue(globalObject);
             _ = callback.call(globalObject, this_value, &.{this_value}) catch |err| {
-                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeException(err) });
+                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeError(err) });
             };
         }
 
@@ -1843,7 +1843,7 @@ fn NewSocket(comptime ssl: bool) type {
             const globalObject = handlers.globalObject;
             const this_value = this.getThisValue(globalObject);
             _ = callback.call(globalObject, this_value, &.{this_value}) catch |err| {
-                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeException(err) });
+                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeError(err) });
             };
         }
 
@@ -1956,7 +1956,7 @@ fn NewSocket(comptime ssl: bool) type {
                 this_value,
                 js_error,
             }) catch |e| {
-                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeException(e) });
+                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeError(e) });
             };
         }
 
@@ -1988,7 +1988,7 @@ fn NewSocket(comptime ssl: bool) type {
                 this_value,
                 output_value,
             }) catch |err| {
-                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeException(err) });
+                _ = handlers.callErrorHandler(this_value, &.{ this_value, globalObject.takeError(err) });
             };
         }
 

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -3247,7 +3247,20 @@ pub const JSGlobalObject = opaque {
         }
 
         return this.tryTakeException() orelse {
-            @panic("A JavaScript exception was thrown, however it was cleared before it could be read.");
+            @panic("A JavaScript exception was thrown, but it was cleared before it could be read.");
+        };
+    }
+
+    pub fn takeError(this: *JSGlobalObject, proof: bun.JSError) JSValue {
+        switch (proof) {
+            error.JSError => {},
+            error.OutOfMemory => this.throwOutOfMemory() catch {},
+        }
+
+        return (this.tryTakeException() orelse {
+            @panic("A JavaScript exception was thrown, but it was cleared before it could be read.");
+        }).toError() orelse {
+            @panic("Couldn't convert a JavaScript exception to an Error instance.");
         };
     }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where bare Exception objects would be passed to node:net's JavaScript code, causing unusual behavior.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

I ran a Node test (test-http-request-host-header.js) modified to include:
```js
const server = http.createServer(common.mustNotCall((req, res) => {
  res.writeHead(200);
  res.end();
}));

// From RFC 7230 5.4 https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
// A server MUST respond with a 400 (Bad Request) status code to any
// HTTP/1.1 request message that lacks a Host header field
server.listen(0, common.mustCall(() => {
  let data = "";
  // This test has been modified to send requests via node:net instead of node:http.
  // This is because Bun's node:http implementation will automatically add a Host header
  // to any request that lacks one, but this test needs to be able to send a request
  // with no Host header.
  const socket = new net.Socket();

  socket.connect(server.address().port, server.address().address, common.mustCall(() => {
    socket.write('GET / HTTP/1.1\r\n\r\n');
  }));

  socket.on('data', common.mustCall((buffer) => {
    data += buffer.toString('utf8');
  }));

  socket.on('end', common.mustCall(() => {
    server.close();
    const cr = data.indexOf('\r');
    assert.notStrictEqual(cr, -1);
    assert.strictEqual(data.slice(0, cr), 'HTTP/1.1 400 Bad Request');
  }));

  socket.on('error', common.mustNotCall());
}));
```