### PR TITLE
fix(sql) custom types

### DIFF
--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2840,7 +2840,7 @@ pub const PostgresSQLConnection = struct {
         }
 
         pub fn fromBytes(binary: bool, bigint: bool, oid: int4, bytes: []const u8, globalObject: *JSC.JSGlobalObject) !DataCell {
-            const oid_tag = if (std.math.maxInt(short) < oid) @as(types.Tag, @enumFromInt(@as(short, @intCast(oid)))) else .text;
+            const oid_tag = if (std.math.maxInt(short) < oid) .text else @as(types.Tag, @enumFromInt(@as(short, @intCast(oid))));
             switch (oid_tag) {
                 // TODO: .int2_array, .float8_array
                 inline .int4_array, .float4_array => |tag| {

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2840,7 +2840,8 @@ pub const PostgresSQLConnection = struct {
         }
 
         pub fn fromBytes(binary: bool, bigint: bool, oid: int4, bytes: []const u8, globalObject: *JSC.JSGlobalObject) !DataCell {
-            switch (@as(types.Tag, @enumFromInt(@as(short, @intCast(oid))))) {
+            const oid_tag = if (std.math.maxInt(short) < oid) @as(types.Tag, @enumFromInt(@as(short, @intCast(oid)))) else .text;
+            switch (oid_tag) {
                 // TODO: .int2_array, .float8_array
                 inline .int4_array, .float4_array => |tag| {
                     if (binary) {


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/16753
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
