### PR TITLE
node: remove NotImplementedError exception in perf_hooks

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -169,10 +169,12 @@ export default {
   PerformanceObserverEntryList,
   PerformanceNodeTiming,
   monitorEventLoopDelay() {
-    throwNotImplemented("perf_hooks.monitorEventLoopDelay");
+    // TODO: node:perf_hooks.monitorEventLoopDelay -- https://github.com/oven-sh/bun/issues/17650
+    // throwNotImplemented("perf_hooks.monitorEventLoopDelay");
   },
   createHistogram() {
-    throwNotImplemented("perf_hooks.createHistogram");
+    // TODO: node:perf_hooks.createHistogram -- https://github.com/oven-sh/bun/issues/8815
+    // throwNotImplemented("perf_hooks.createHistogram");
   },
   PerformanceResourceTiming,
 };

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 import perf from "perf_hooks";
 
 test("stubs", () => {
-  expect(() => perf.monitorEventLoopDelay()).toThrow();
-  expect(() => perf.createHistogram()).toThrow();
+  expect(() => perf.monitorEventLoopDelay()).not.toThrow();
+  expect(() => perf.createHistogram()).not.toThrow();
   expect(perf.performance.nodeTiming).toBeObject();
 
   expect(perf.performance.now()).toBeNumber();


### PR DESCRIPTION
Closes https://github.com/oven-sh/bun/issues/9432
Closes https://github.com/oven-sh/bun/issues/14457
