### PR TITLE
chore: Try banning undefined field defaults

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -7,6 +7,7 @@ env:
   BUN_VERSION: "1.2.0"
 
 on:
+  pull_request:
   workflow_call:
 
 jobs:

--- a/packages/bun-internal-test/src/banned.json
+++ b/packages/bun-internal-test/src/banned.json
@@ -14,5 +14,6 @@
   "std.StringHashMapUnmanaged(": "bun.StringHashMapUnmanaged has a faster `eql`",
   "std.StringHashMap(": "bun.StringHashMaphas a faster `eql`",
   "std.enums.tagName(": "Use bun.tagName instead",
+  "= undefined,": "Do not set a field's default value to `undefined`",
   "": ""
 }


### PR DESCRIPTION
### What does this PR do?

Adds `= undefined,` to the list of banned words, which should catch struct fields with a default of `undefined`
