### PR TITLE
feat(build): `PluginBuilder` supports method chaining

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5536,12 +5536,14 @@ declare module "bun" {
      *   },
      * });
      * ```
+     *
+     * @returns `this` for method chaining
      */
-    onStart(callback: OnStartCallback): void;
+    onStart(callback: OnStartCallback): this;
     onBeforeParse(
       constraints: PluginConstraints,
       callback: { napiModule: unknown; symbol: string; external?: unknown | undefined },
-    ): void;
+    ): this;
     /**
      * Register a callback to load imports with a specific import specifier
      * @param constraints The constraints to apply the plugin to
@@ -5556,8 +5558,10 @@ declare module "bun" {
      *   },
      * });
      * ```
+     *
+     * @returns `this` for method chaining
      */
-    onLoad(constraints: PluginConstraints, callback: OnLoadCallback): void;
+    onLoad(constraints: PluginConstraints, callback: OnLoadCallback): this;
     /**
      * Register a callback to resolve imports matching a filter and/or namespace
      * @param constraints The constraints to apply the plugin to
@@ -5572,8 +5576,10 @@ declare module "bun" {
      *   },
      * });
      * ```
+     *
+     * @returns `this` for method chaining
      */
-    onResolve(constraints: PluginConstraints, callback: OnResolveCallback): void;
+    onResolve(constraints: PluginConstraints, callback: OnResolveCallback): this;
     /**
      * The config object passed to `Bun.build` as is. Can be mutated.
      */
@@ -5604,8 +5610,10 @@ declare module "bun" {
      * const { foo } = require("hello:world");
      * console.log(foo); // "bar"
      * ```
+     *
+     * @returns `this` for method chaining
      */
-    module(specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>): void;
+    module(specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>): this;
   }
 
   interface BunPlugin {

--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -94,7 +94,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
     plugin.append(vm, filter->regExp(), func.getObject(), namespaceString);
     callback(ctx, globalObject);
 
-    return JSValue::encode(jsUndefined());
+    return JSValue::encode(callframe->thisValue());
 }
 
 static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe)
@@ -150,7 +150,7 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
     global->requireMap()->remove(globalObject, moduleIdValue);
     global->esmRegistryMap()->remove(globalObject, moduleIdValue);
 
-    return JSValue::encode(jsUndefined());
+    return JSValue::encode(callframe->thisValue());
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target, BunPlugin::Base& plugin, void* ctx, OnAppendPluginCallback callback)
@@ -204,7 +204,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
     plugin.append(vm, filter->regExp(), jsCast<JSObject*>(func), namespaceString);
     callback(ctx, globalObject);
 
-    return JSValue::encode(jsUndefined());
+    return JSValue::encode(callframe->thisValue());
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginGlobal(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target)
@@ -260,6 +260,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionAppendOnResolvePluginBrowser, (JSC::JSGlobalO
     return jsFunctionAppendOnResolvePluginGlobal(globalObject, callframe, BunPluginTargetBrowser);
 }
 
+/// `Bun.plugin()`
 static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -38,6 +38,7 @@
 
 namespace Bun {
 
+extern "C" void CrashHandler__setInsideNativePlugin(const char* plugin_name);
 extern "C" int OnBeforeParsePlugin__isDone(void* context);
 extern "C" void OnBeforeParseResult__reset(OnBeforeParseResult* result);
 #define WRAP_BUNDLER_PLUGIN(argName) jsDoubleNumber(std::bit_cast<double>(reinterpret_cast<uintptr_t>(argName)))
@@ -189,6 +190,7 @@ DEFINE_VISIT_CHILDREN(JSBundlerPlugin);
 
 const JSC::ClassInfo JSBundlerPlugin::s_info = { "BundlerPlugin"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBundlerPlugin) };
 
+/// `BundlerPlugin.prototype.addFilter(filter: RegExp, namespace: string, isOnLoad: 0 | 1): void`
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     JSBundlerPlugin* thisObject = jsCast<JSBundlerPlugin*>(callFrame->thisValue());
@@ -272,8 +274,6 @@ bool BundlerPlugin::FilterRegExp::match(JSC::VM& vm, const String& path)
     Yarr::MatchingContextHolder regExpContext(vm, usesPatternContextBuffer, nullptr, Yarr::MatchFrom::CompilerThread);
     return regex.match(path) != -1;
 }
-
-extern "C" void CrashHandler__setInsideNativePlugin(const char* plugin_name);
 
 int BundlerPlugin::NativePluginList::call(JSC::VM& vm, BundlerPlugin* plugin, int* shouldContinue, void* bunContextPtr, const BunString* namespaceStr, const BunString* pathString, OnBeforeParseArguments* onBeforeParseArgs, OnBeforeParseResult* onBeforeParseResult)
 {

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -97,7 +97,11 @@ values;`,
         {
           name: "xXx123_foo_counter_321xXx",
           setup(build) {
-            build.onBeforeParse({ filter: /\.ts/ }, { napiModule, symbol: "plugin_impl", external });
+            const chainedThis = build.onBeforeParse(
+              { filter: /\.ts/ },
+              { napiModule, symbol: "plugin_impl", external },
+            );
+            expect(chainedThis).toBe(build);
 
             build.onLoad({ filter: /lmao\.json/ }, async ({ defer }) => {
               await defer();

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -16,20 +16,22 @@ declare global {
 plugin({
   name: "url text file loader",
   setup(builder) {
-    builder.onResolve({ namespace: "http", filter: /.*/ }, ({ path }) => {
+    var chainedThis = builder.onResolve({ namespace: "http", filter: /.*/ }, ({ path }) => {
       return {
         path,
         namespace: "url",
       };
     });
+    expect(chainedThis).toBe(builder);
 
-    builder.onLoad({ filter: /.*/, namespace: "url" }, async ({ path, namespace }) => {
+    chainedThis = builder.onLoad({ filter: /.*/, namespace: "url" }, async ({ path, namespace }) => {
       const res = await fetch("http://" + path);
       return {
         exports: { default: await res.text() },
         loader: "object",
       };
     });
+    expect(chainedThis).toBe(builder);
   },
 });
 


### PR DESCRIPTION
### What does this PR do?

`onLoad`, `onResolve`, etc. now supports method chaining.
```ts
Bun.plugin({
  setup(builder) {
    builder
      .onLoad(doOnLoad)
      .onResolve(doOnResolve)
      .module(doModule);
  }
});
```

### How did you verify your code works?
I've added tests.
