### PR TITLE
feat(build): plugins can be factory functions

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -266,18 +266,6 @@ static inline JSC::JSValue setupBunPlugin(JSC::VM& vm, JSC::JSGlobalObject* glob
     ASSERT(options);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (options->isCallable()) {
-        JSC::MarkedArgumentBuffer argList;
-        auto callData = getCallData(options);
-        JSC::JSValue ret = JSC::call(globalObject, JSValue(options), callData, JSValue(globalObject), argList);
-        RETURN_IF_EXCEPTION(throwScope, {});
-        options = ret.getObject();
-        if (!options) {
-            JSC::throwTypeError(globalObject, throwScope, "plugin needs an object as first argument"_s);
-            return {};
-        }
-    }
-
     JSC::JSValue setupFunctionValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "setup"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (!setupFunctionValue || setupFunctionValue.isUndefinedOrNull() || !setupFunctionValue.isCell() || !setupFunctionValue.isCallable()) {

--- a/src/bun.js/bindings/bindings.zig
+++ b/src/bun.js/bindings/bindings.zig
@@ -3063,6 +3063,10 @@ pub const JSGlobalObject = opaque {
         }
     }
 
+    pub inline fn throwTypeError(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) bun.JSError {
+        return this.throwValue(this.createTypeErrorInstance(fmt, args));
+    }
+
     pub fn createTypeErrorInstance(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
         if (comptime std.meta.fieldNames(@TypeOf(args)).len > 0) {
             var stack_fallback = std.heap.stackFallback(1024 * 4, this.allocator());

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -76,10 +76,17 @@ export function loadAndResolvePluginsForServe(
       if (!pluginModuleRaw || !pluginModuleRaw.default) {
         throw new TypeError(`Expected "${plugins[i]}" to be a module which default exports a bundler plugin.`);
       }
-      let pluginModule = pluginModuleRaw.default;
+      let pluginModule: BunPlugin | (() => BunPlugin) = pluginModuleRaw.default;
+      $assert(pluginModule); // checked above
+
+      if (typeof pluginModule === "function") {
+        pluginModule = pluginModule.$call(globalThis);
+      }
+
       if (!pluginModule || pluginModule.name === undefined || pluginModule.setup === undefined) {
         throw new TypeError(`"${plugins[i]}" is not a valid bundler plugin.`);
       }
+
       onstart_promises_array = await runSetupFn.$apply(bundlerPlugin, [
         pluginModule.setup,
         config,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,5 +1,5 @@
 import type { BunPlugin } from "bun";
-import { describe, expect, test } from "bun:test";
+import { describe, beforeAll, afterAll, expect, test } from "bun:test";
 import { readFileSync, writeFileSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import path, { join } from "path";
@@ -670,6 +670,7 @@ describe("Bun.build", () => {
       expect(async () => {
         await Bun.build({
           entrypoints: [index],
+          // @ts-expect-error
           plugins: [async () => coffeePlugin()],
         });
       }).toThrow(/does not support async plugin/);

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,5 +1,5 @@
 import type { BunPlugin } from "bun";
-import { describe, beforeAll, afterAll, expect, test } from "bun:test";
+import { describe, beforeAll, afterAll, expect, test, it } from "bun:test";
 import { readFileSync, writeFileSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import path, { join } from "path";


### PR DESCRIPTION
### What does this PR do?
Make `Bun.build()` and `Bun.plugin` support factory functions that return a `BunPlugin`

### Use Case
Say that I have some configurable plugin
```ts
// bun-plugin-svelte/index.ts
import { BunPlugin } fron "bun";
import { CompilerOptions } from "svelte/compiler";

export interface Options {
  compilerOptions?: CompilerOptions;
}

export default function SveltePlugin(options?: Options): BunPlugin {
  // ...
}
```

When using `Bun.build`, I may do something like
```js
// build.ts

import SveltePlugin from "bun-plugin-svelte";

await Bun.build({
  // ...
  plugins: [
    SveltePlugin({ compilerOptions: { /* ... */ } }),
  ],
});
```

Now, lets say I want a dev server
```toml
# bunfig.toml
[serve.static]
plugins = ["bun-plugin-svelte"]
```

Before, the dev server would throw an error and exit unsuccessfully because it could not find a `setup()` method. Now, it will detect plugins, call them, and use the result as the plugin options.

### Future TODO
It would be nice to support configuring plugins from `bunfig.toml`.

```toml
# bunfig.toml
[serve.static.plugins.bun-plugin-svelte]
compilerOptions = { ... }
```

### How did you verify your code works?

I've added tests
