### PR TITLE
node: fix buffer.writeBigInt return value

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -2417,7 +2417,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigInt64LE, (JSGlobalObj
     if (UNLIKELY(offset > byteLength - 8)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, byteLength - 8, offsetVal);
 
     write_int64_le(static_cast<uint8_t*>(castedThis->vector()) + offset, value);
-    return JSValue::encode(jsNumber(offset));
+    return JSValue::encode(jsNumber(offset + 8));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigInt64BE, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -2449,7 +2449,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigInt64BE, (JSGlobalObj
     if (UNLIKELY(offset > byteLength - 8)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, byteLength - 8, offsetVal);
 
     write_int64_be(static_cast<uint8_t*>(castedThis->vector()) + offset, value);
-    return JSValue::encode(jsNumber(offset));
+    return JSValue::encode(jsNumber(offset + 8));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigUInt64LE, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -2479,7 +2479,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigUInt64LE, (JSGlobalOb
     if (UNLIKELY(offset > byteLength - 8)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, byteLength - 8, offsetVal);
 
     write_int64_le(static_cast<uint8_t*>(castedThis->vector()) + offset, value);
-    return JSValue::encode(jsNumber(offset));
+    return JSValue::encode(jsNumber(offset + 8));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigUInt64BE, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -2509,7 +2509,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_writeBigUInt64BE, (JSGlobalOb
     if (UNLIKELY(offset > byteLength - 8)) return Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, byteLength - 8, offsetVal);
 
     write_int64_be(static_cast<uint8_t*>(castedThis->vector()) + offset, value);
-    return JSValue::encode(jsNumber(offset));
+    return JSValue::encode(jsNumber(offset + 8));
 }
 
 /* */

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -940,11 +940,24 @@ for (let withOverridenBufferWrite of [false, true]) {
 
       it("offset returns are correct", () => {
         const b = Buffer.allocUnsafe(16);
-        expect(b.writeUInt32LE(0, 0)).toBe(4);
-        expect(b.writeUInt16LE(0, 4)).toBe(6);
-        expect(b.writeUInt8(0, 6)).toBe(7);
-        expect(b.writeInt8(0, 7)).toBe(8);
-        expect(b.writeDoubleLE(0, 8)).toBe(16);
+        expect(b.writeInt8(0, 2)).toBe(3);
+        expect(b.writeUInt8(0, 2)).toBe(3);
+        expect(b.writeInt16LE(0, 2)).toBe(4);
+        expect(b.writeInt16BE(0, 2)).toBe(4);
+        expect(b.writeUInt16LE(0, 2)).toBe(4);
+        expect(b.writeUInt16BE(0, 2)).toBe(4);
+        expect(b.writeInt32LE(0, 2)).toBe(6);
+        expect(b.writeInt32BE(0, 2)).toBe(6);
+        expect(b.writeUInt32LE(0, 2)).toBe(6);
+        expect(b.writeUInt32BE(0, 2)).toBe(6);
+        expect(b.writeFloatLE(0, 2)).toBe(6);
+        expect(b.writeFloatBE(0, 2)).toBe(6);
+        expect(b.writeDoubleLE(0, 2)).toBe(10);
+        expect(b.writeDoubleBE(0, 2)).toBe(10);
+        expect(b.writeBigInt64LE(0n, 2)).toBe(10);
+        expect(b.writeBigInt64BE(0n, 2)).toBe(10);
+        expect(b.writeBigUInt64LE(0n, 2)).toBe(10);
+        expect(b.writeBigUInt64BE(0n, 2)).toBe(10);
       });
 
       it("unmatched surrogates should not produce invalid utf8 output", () => {

--- a/test/js/node/test/parallel/test-buffer-bigint64.js
+++ b/test/js/node/test/parallel/test-buffer-bigint64.js
@@ -2,7 +2,7 @@
 require('../common');
 const assert = require('assert');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.allocUnsafe(9);
 
 ['LE', 'BE'].forEach(function(endianness) {
   // Should allow simple BigInts to be written and read
@@ -26,6 +26,11 @@ const buf = Buffer.allocUnsafe(8);
   val = 123456789n;
   buf[`writeBigUInt64${endianness}`](val, 0);
   assert.strictEqual(val, buf[`readBigUInt64${endianness}`](0));
+
+  assert.strictEqual(buf[`writeBigUInt64${endianness}`](val, 0), 8);
+  assert.strictEqual(buf[`writeBigInt64${endianness}`](val, 0), 8);
+  assert.strictEqual(buf[`writeBigUInt64${endianness}`](val, 1), 9);
+  assert.strictEqual(buf[`writeBigInt64${endianness}`](val, 1), 9);
 
   // Should throw a RangeError upon INT64_MAX+1 being written
   assert.throws(function() {


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/17694

converted these methods from JS to C++ in https://github.com/oven-sh/bun/pull/17452 and missed the offset addition during review. added new test coverage