### PR TITLE
Fix VSCode Extension to Support Next.js Route Group File Paths on CodeLens Actions

### DIFF
--- a/packages/bun-vscode/src/features/tests/index.ts
+++ b/packages/bun-vscode/src/features/tests/index.ts
@@ -167,7 +167,7 @@ export function registerTestRunner(context: vscode.ExtensionContext) {
       let command = customScript;
 
       if (filePath.length !== 0) {
-        command += ` ${filePath}`;
+        command += ` "${filePath}"`;
       }
 
       if (testName && testName.length) {


### PR DESCRIPTION
### What does this PR do?

This PR wraps the `filePath` with quotes in the code lens test runner for the vscode extension.

### Why?  
When developing in next.js, there is a concept of [Route Groups](https://nextjs.org/docs/app/building-your-application/routing/route-groups), which contain parenthesis in the file path.  Having these in the file path breaks the code lens action and results in the test not being found.

Failure:
![image](https://github.com/user-attachments/assets/0ae9ed76-2f14-4213-aaf7-8426117b46e9)

Fixed (wrapped in quotes):
![image](https://github.com/user-attachments/assets/1bf3e920-a60f-4bb9-bdbe-0ce6b92b6784)


### How did you verify your code works?
Manual testing.  Additionally, it's a very simple change with zero complexity.

### Tests
I searched the codebase for existing tests for the vscode extension; however, I didn't find any.  
As such, no additional tests were added for this change.