### PR TITLE
fix(sql) fix state being set to prepared too soon

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1295,7 +1295,6 @@ function doCreateQuery(strings, values, allowUnsafeTransaction, poolSize, bigint
       }
     }
   }
-
   return createQuery(sqlString, final_values, new SQLResultArray(), undefined, !!bigint, !!simple);
 }
 

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -3611,7 +3611,7 @@ pub const PostgresSQLConnection = struct {
                 try reader.eatMessage(protocol.ParseComplete);
                 const request = this.current() orelse return error.ExpectedRequest;
                 if (request.statement) |statement| {
-                    // if we have params wait for row description
+                    // if we have params wait for parameter description
                     if (statement.status == .parsing and statement.signature.fields.len == 0) {
                         statement.status = .prepared;
                     }

--- a/test/bun.lock
+++ b/test/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@azure/service-bus": "7.9.4",
         "@duckdb/node-api": "1.1.3-alpha.7",
-        "@electric-sql/pglite": "0.2.16",
+        "@electric-sql/pglite": "0.2.17",
         "@grpc/grpc-js": "1.12.0",
         "@grpc/proto-loader": "0.7.10",
         "@happy-dom/global-registrator": "17.0.3",
@@ -52,6 +52,7 @@
         "nodemailer": "6.9.3",
         "pg": "8.11.1",
         "pg-connection-string": "2.6.1",
+        "pg-gateway": "^0.3.0-beta.4",
         "pino": "9.4.0",
         "pino-pretty": "11.2.2",
         "postgres": "3.3.5",
@@ -171,7 +172,7 @@
 
     "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.1.3-alpha.7", "", { "os": "win32", "cpu": "x64" }, "sha512-5OqjpYRFdQATbniL0o8gF8Z92bBuINlXOve0o+qgM6W+nlIRp/cUHk6vWwYySZnF0AIHZ5JG7mngzJOLmA/kPQ=="],
 
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.2.16", "", {}, "sha512-dCSHpoOKuTxecaYhWDRp2yFTN3XWcMPMrBVl5yOR8VZEUprz4+R3iuU7BipmlsqBnBDO/6l9H/C2ZwJdunkWyw=="],
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.2.17", "", {}, "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@0.44.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ZX/etZEZw8DR7zAB1eVQT40lNo0jeqpb6dCgOvctB6FIQ5PoXfMuNY8+ayQfu8tNQbAB8gQWSSJupR8NxeiZXw=="],
 
@@ -1664,6 +1665,8 @@
     "pg-cloudflare": ["pg-cloudflare@1.1.1", "", {}, "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q=="],
 
     "pg-connection-string": ["pg-connection-string@2.6.1", "", {}, "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="],
+
+    "pg-gateway": ["pg-gateway@0.3.0-beta.4", "", {}, "sha512-CTjsM7Z+0Nx2/dyZ6r8zRsc3f9FScoD5UAOlfUx1Fdv/JOIWvRbF7gou6l6vP+uypXQVoYPgw8xZDXgMGvBa4Q=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 

--- a/test/js/third_party/pg-gateway/package.json
+++ b/test/js/third_party/pg-gateway/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pg-gateway",
+  "dependencies": {
+    "@electric-sql/pglite": "0.2.17",
+    "pg-gateway": "0.3.0-beta.4"
+  }
+}

--- a/test/js/third_party/pg-gateway/pglite.test.ts
+++ b/test/js/third_party/pg-gateway/pglite.test.ts
@@ -1,0 +1,90 @@
+import { PGlite } from "@electric-sql/pglite";
+import { SQL, randomUUIDv7 } from "bun";
+import net, { AddressInfo } from "node:net";
+import { fromNodeSocket } from "pg-gateway/node";
+import { expect, test } from "bun:test";
+import { once } from "events";
+test("pglite should be able to query using pg-gateway and Bun.SQL", async () => {
+  const name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+  const dataDir = `memory://${name}`;
+  const db = new PGlite(dataDir);
+
+  // Wait for the database to initialize
+  await db.waitReady;
+
+  // Create a simple test table
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS test_table (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL
+    );
+    
+    INSERT INTO test_table (name) VALUES ('Test 1'), ('Test 2'), ('Test 3');
+  `);
+
+  // Create a simple server using pg-gateway
+  const server = net.createServer(async socket => {
+    await fromNodeSocket(socket, {
+      serverVersion: "16.3",
+      auth: {
+        method: "trust",
+      },
+      async onStartup() {
+        // Wait for PGlite to be ready before further processing
+        await db.waitReady;
+      },
+      async onMessage(data, { isAuthenticated }: { isAuthenticated: boolean }) {
+        // Only forward messages to PGlite after authentication
+        if (!isAuthenticated) {
+          return;
+        }
+
+        return await db.execProtocolRaw(data);
+      },
+    });
+  });
+
+  // Start listening
+  await once(server.listen(0), "listening");
+
+  const port = (server.address() as AddressInfo).port;
+
+  await using sql = new SQL({
+    hostname: "localhost",
+    port: port,
+    database: name,
+    max: 1,
+  });
+
+  {
+    // prepared statement without parameters
+    const result = await sql`SELECT * FROM test_table WHERE id = 1`;
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({ id: 1, name: "Test 1" });
+  }
+
+  {
+    // using prepared statement
+    const result = await sql`SELECT * FROM test_table WHERE id = ${1}`;
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({ id: 1, name: "Test 1" });
+  }
+
+  {
+    // using simple query
+    const result = await sql`SELECT * FROM test_table WHERE id = 1`.simple();
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({ id: 1, name: "Test 1" });
+  }
+
+  {
+    // using unsafe with parameters
+    const result = await sql.unsafe("SELECT * FROM test_table WHERE id = $1", [1]);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({ id: 1, name: "Test 1" });
+  }
+});

--- a/test/package.json
+++ b/test/package.json
@@ -57,7 +57,7 @@
     "nodemailer": "6.9.3",
     "pg": "8.11.1",
     "pg-connection-string": "2.6.1",
-    "pg-gateway": "^0.3.0-beta.4",
+    "pg-gateway": "0.3.0-beta.4",
     "pino": "9.4.0",
     "pino-pretty": "11.2.2",
     "postgres": "3.3.5",

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@azure/service-bus": "7.9.4",
     "@duckdb/node-api": "1.1.3-alpha.7",
-    "@electric-sql/pglite": "0.2.16",
+    "@electric-sql/pglite": "0.2.17",
     "@grpc/grpc-js": "1.12.0",
     "@grpc/proto-loader": "0.7.10",
     "@happy-dom/global-registrator": "17.0.3",
@@ -57,6 +57,7 @@
     "nodemailer": "6.9.3",
     "pg": "8.11.1",
     "pg-connection-string": "2.6.1",
+    "pg-gateway": "^0.3.0-beta.4",
     "pino": "9.4.0",
     "pino-pretty": "11.2.2",
     "postgres": "3.3.5",


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/17720
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
