### PR TITLE
Fix Jest globals not being available in non-entrypoint files

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -474,7 +474,7 @@ pub const RuntimeTranspilerStore = struct {
                 .virtual_source = null,
                 .dont_bundle_twice = true,
                 .allow_commonjs = true,
-                .inject_jest_globals = transpiler.options.rewrite_jest_for_tests and is_main,
+                .inject_jest_globals = transpiler.options.rewrite_jest_for_tests,
                 .set_breakpoint_on_first_line = vm.debugger != null and
                     vm.debugger.?.set_breakpoint_on_first_line and
                     is_main and
@@ -1623,7 +1623,7 @@ pub const ModuleLoader = struct {
                     .virtual_source = virtual_source,
                     .dont_bundle_twice = true,
                     .allow_commonjs = true,
-                    .inject_jest_globals = jsc_vm.transpiler.options.rewrite_jest_for_tests and is_main,
+                    .inject_jest_globals = jsc_vm.transpiler.options.rewrite_jest_for_tests,
                     .keep_json_and_toml_as_one_statement = true,
                     .allow_bytecode_cache = true,
                     .set_breakpoint_on_first_line = is_main and

--- a/test/regression/issue/12034/12034.fixture.ts
+++ b/test/regression/issue/12034/12034.fixture.ts
@@ -1,0 +1,25 @@
+// A fixture that tests that Jest globals are injected into the global scope
+// even when the file is NOT the entrypoint of the test.
+
+test.each([
+  ["expect", expect],
+  ["test", test],
+  ["describe", describe],
+  ["it", it],
+  ["beforeEach", beforeEach],
+  ["afterEach", afterEach],
+  ["beforeAll", beforeAll],
+  ["afterAll", afterAll],
+  ["jest", jest],
+])("that %s is defined", (_, global) => {
+  expect(global).toBeDefined();
+});
+
+expect.extend({
+  toBeOne(actual) {
+    return {
+      pass: actual === 1,
+      message: () => `expected ${actual} to be 1`,
+    };
+  },
+});

--- a/test/regression/issue/12034/12034.test.js
+++ b/test/regression/issue/12034/12034.test.js
@@ -3,6 +3,6 @@
 import "./12034.fixture";
 
 test("that an imported file can use Jest globals", () => {
-  // "toBeOne" is defined using `expect.extend` in the fixture file
   expect(1).toBeOne();
+  expect(2).not.toBeOne();
 });

--- a/test/regression/issue/12034/12034.test.js
+++ b/test/regression/issue/12034/12034.test.js
@@ -1,0 +1,8 @@
+// This fixture tests that Jest global variables are injected into the global scope
+// even when the file is NOT the entrypoint of the test.
+import "./12034.fixture";
+
+test("that an imported file can use Jest globals", () => {
+  // "toBeOne" is defined using `expect.extend` in the fixture file
+  expect(1).toBeOne();
+});


### PR DESCRIPTION
Fixes #12034

#### `entry.test.js`
```js
import "./fixture.js"

test("can use Jest globals in other files", () => {
  expect(1).toBeOne();
});
```


#### `fixture.js`
```js
expect.extend({
  toBeOne(actual) {
    return {
      pass: actual === 1,
      message: () => `expected ${actual} to be 1`,
    };
  },
});
```

Before:
```js
# Unhandled error between tests
-------------------------------
1 | // A fixture that tests that Jest globals are injected into the global scope
2 | // even when the file is NOT the entrypoint of the test.
3 | 
4 | expect.extend({
    ^
ReferenceError: Can't find variable: expect
```

After:
```js
✓ that an imported file can use Jest globals [0.29ms]

 10 pass
 0 fail
 10 expect() calls
Ran 10 tests across 1 files. [166.00ms]
```

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

CI

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
