### PR TITLE
fix: automatically enable coverage when --coverage-reporter is specified

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -539,6 +539,9 @@ pub const Arguments = struct {
             }
 
             if (args.options("--coverage-reporter").len > 0) {
+                // Enable coverage automatically if a coverage reporter is specified
+                ctx.test_options.coverage.enabled = true;
+
                 ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false };
                 for (args.options("--coverage-reporter")) |reporter| {
                     if (bun.strings.eqlComptime(reporter, "text")) {

--- a/test/regression/issue/17502.test.ts
+++ b/test/regression/issue/17502.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { tempDirWithFiles } from "harness";
+
+test("--coverage-reporter automatically enables --coverage", () => {
+  const dir = tempDirWithFiles("cov-reporter-auto-enables", {
+    "demo.test.ts": `
+    export function sum(a, b) {
+      return a + b;
+    }
+
+    test("sum", () => {
+      expect(sum(1, 2)).toBe(3);
+    });
+    `,
+  });
+
+  // Only specify --coverage-reporter without --coverage
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage-reporter", "text", "./demo.test.ts"], {
+    cwd: dir,
+    env: {
+      ...bunEnv,
+    },
+    stdio: [null, null, "pipe"],
+  });
+
+  // If coverage is enabled, we should see coverage output
+  expect(result.stderr.toString("utf-8")).toContain("File");
+  expect(result.stderr.toString("utf-8")).toContain("% Funcs");
+  expect(result.stderr.toString("utf-8")).toContain("% Lines");
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+});


### PR DESCRIPTION
## Description
This PR automatically enables coverage when \`--coverage-reporter\` is specified, improving the user experience by not requiring an explicit \`--coverage\` flag.

## Changes
- Modified \`src/cli.zig\` to automatically enable coverage when a coverage reporter is specified
- Added a regression test to verify this functionality

## Related Issues
Fixes #17502

## Testing
- Verified that coverage is automatically enabled when a coverage reporter is specified
- Added regression test that confirms the expected behavior
