### PR TITLE
return null rather than process.stdin on child process

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1134,7 +1134,7 @@ class ChildProcess extends EventEmitter {
             return require("internal/fs/streams").writableFromFileSink(stdin);
           }
           case "inherit":
-            return process.stdin || null;
+            return null;
           case "destroyed":
             return new ShimmedStdin();
           default:


### PR DESCRIPTION
### What does this PR do?

Fixes BUN-10870, Fixes https://github.com/shadcn-ui/ui/issues/6145, Fixes https://github.com/shadcn-ui/ui/issues/4778, Fixes https://github.com/shadcn-ui/ui/issues/5421

- `bunx --bun shadcn@latest init` runs `npx create-next-app` with node symlinked to bun
  - npx has `#!/usr/bin/env node`, this would resolve to bun so npx would run with bun
  - npx immediately exits with code 1, but create-next-app spawns and completes successfully
  - npx runs `if (child.stdin) { child.stdin.end() }`
    - the child process was spawned with `inherit`, so it has no stdin
    - bun was returning `process.stdin` in that case, rather than `null` like node
    - BUN-10874 `process.stdin.end` is `Infinity` rather than a function
  - TypeError: Infinity is not a function
  - npx catches this error and exits immediately with code 1
- shadcn init fails