### PR TITLE
fix(ipc): check for empty IPC messages

### DIFF
--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -222,7 +222,6 @@ const json = struct {
                 bun.String.createExternal(json_data, true, &was_ascii_string_freed, jsonIPCDataStringFreeCB)
             else
                 bun.String.fromUTF8(json_data);
-            bun.assert(str.tag != .Dead);
 
             defer {
                 str.deref();

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -210,6 +210,8 @@ const json = struct {
                 },
             }
 
+            if (json_data.len == 0) return IPCDecodeError.NotEnoughBytes;
+
             const is_ascii = bun.strings.isAllASCII(json_data);
             var was_ascii_string_freed = false;
 
@@ -220,6 +222,8 @@ const json = struct {
                 bun.String.createExternal(json_data, true, &was_ascii_string_freed, jsonIPCDataStringFreeCB)
             else
                 bun.String.fromUTF8(json_data);
+            bun.assert(str.tag != .Dead);
+
             defer {
                 str.deref();
                 if (is_ascii and !was_ascii_string_freed) {


### PR DESCRIPTION
### What does this PR do?
I'm seeing the `len != 0` assertion in `bun.String.createExternal` fail when running `parallel/test-child-process-fork.js`. This is almost certainly being reached via `.fork()`, causing confusing upstream bugs.

### How did you verify your code works?
