### PR TITLE
improv: display String objects similar to node

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2134,6 +2134,25 @@ pub const Formatter = struct {
                     return;
                 }
 
+                if (jsType == .StringObject) {
+                    if (enable_ansi_colors) {
+                        writer.print(comptime Output.prettyFmt("<r><green>", enable_ansi_colors), .{});
+                    }
+                    defer if (comptime enable_ansi_colors)
+                        writer.writeAll(Output.prettyFmt("<r>", true));
+
+                    writer.print("[String: ", .{});
+
+                    if (str.isUTF16()) {
+                        try this.printAs(.JSON, Writer, writer_, value, .StringObject, enable_ansi_colors);
+                    } else {
+                        JSPrinter.writeJSONString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
+                    }
+
+                    writer.print("]", .{});
+                    return;
+                }
+
                 if (jsType == .RegExpObject and enable_ansi_colors) {
                     writer.print(comptime Output.prettyFmt("<r><red>", enable_ansi_colors), .{});
                 }

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -18,6 +18,8 @@ Symbol(Symbol Description)
 2000-06-27T02:24:34.304Z
 [String: "Hello"]
 [String: "Hello 👋🏼"]
+[Number: 5]
+[Boolean: true]
 [ 123, 456, 789 ]
 {
   name: "foo",

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -16,6 +16,8 @@ Infinity
 -Infinity
 Symbol(Symbol Description)
 2000-06-27T02:24:34.304Z
+[String: "Hello"]
+[String: "Hello 👋🏼"]
 [ 123, 456, 789 ]
 {
   name: "foo",

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -14,6 +14,8 @@ console.log(Infinity);
 console.log(-Infinity);
 console.log(Symbol("Symbol Description"));
 console.log(new Date(Math.pow(2, 34) * 56));
+console.log(new String("Hello"));
+console.log(new String("Hello 👋🏼"));
 console.log([123, 456, 789]);
 console.log({ name: "foo" });
 console.log({ a: 123, b: 456, c: 789 });

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -16,6 +16,8 @@ console.log(Symbol("Symbol Description"));
 console.log(new Date(Math.pow(2, 34) * 56));
 console.log(new String("Hello"));
 console.log(new String("Hello 👋🏼"));
+console.log(new Number(5));
+console.log(new Boolean(true));
 console.log([123, 456, 789]);
 console.log({ name: "foo" });
 console.log({ a: 123, b: 456, c: 789 });


### PR DESCRIPTION
### What does this PR do?
This commit adds special condition to print String Objects as `[String "<string>"]` in green. This is the same as node.
This fixes #17663 
- [x] Code changes

### How did you verify your code works?
Ran a script locally to ensure that the output is similar to Node
<img width="890" alt="image" src="https://github.com/user-attachments/assets/56256c88-823e-4484-9017-241209270c8e" />


- [x] I included a test for the new code, or an existing test covers it
