### PR TITLE
fix(node:http/Bun.serve) Allow Strict-Transport-Security in http

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -193,7 +193,6 @@ fn writeHeaders(
     ctxLog("writeHeaders", .{});
     headers.fastRemove(.ContentLength);
     headers.fastRemove(.TransferEncoding);
-    if (!ssl) headers.fastRemove(.StrictTransportSecurity);
     if (resp_ptr) |resp| {
         headers.toUWSResponse(ssl, resp);
     }

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1099,5 +1099,20 @@ describe("HEAD requests #15355", () => {
       expect(response.headers.get("content-length")).toBe("11");
       expect(await response.text()).toBe("");
     });
+
+    test("should allow Strict-Transport-Security", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("Hello World", {
+            status: 200,
+            headers: { "Strict-Transport-Security": "max-age=31536000" },
+          });
+        },
+      });
+      const response = await fetch(server.url, { method: "HEAD" });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("strict-transport-security")).toBe("max-age=31536000");
+    });
   });
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2555,3 +2555,15 @@ it("client should use content-length if only one write is called", async () => {
   expect(chunks[0]?.toString()).toBe("Hello World BUN!");
   expect(Buffer.concat(chunks).toString()).toBe("Hello World BUN!");
 });
+
+it("should allow Strict-Transport-Security when using node:http", async () => {
+  await using server = http.createServer((req, res) => {
+    res.writeHead(200, { "Strict-Transport-Security": "max-age=31536000" });
+    res.end();
+  });
+  server.listen(0, "localhost");
+  await once(server, "listening");
+  const response = await fetch(`http://localhost:${server.address().port}`);
+  expect(response.status).toBe(200);
+  expect(response.headers.get("strict-transport-security")).toBe("max-age=31536000");
+});


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/13228

The Strict-Transport-Security header is ignored by the browser when your site has only been accessed using HTTP. Once your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS-capable and will honor the Strict-Transport-Security header. Browsers do this as attackers may intercept HTTP connections to the site and inject or remove the header.

Some users will use Bun.serve/node:http without HTTPS and proxy it using NGINX or similar tools, so is important to enable the header to be sent over http.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
