### PR TITLE
chore: disable TimerList logging by default

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -27,7 +27,7 @@ pub const TimeoutMap = std.AutoArrayHashMapUnmanaged(
 /// Array of linked lists of EventLoopTimers. Each list holds all the timers that will fire in the
 /// same millisecond, in the order they will fire.
 const TimerList = struct {
-    const log = bun.Output.scoped(.TimerList, false);
+    const log = bun.Output.scoped(.TimerList, true);
     // there might be a better data structure we could use here (the current one has some O(n) cases
     // to remove and add new lists), but cursory testing showed similar performance to the old
     // heap implementation


### PR DESCRIPTION
### What does this PR do?

Disables `timerlist` debug logs introduced in #16855. They are especially spammy even next to the rest of the debug logs, as simple Bun invocations can still create a lot of timers:

![image](https://github.com/user-attachments/assets/8c5a01c9-950c-4801-95a5-b0005975cf23)

### How did you verify your code works?

Ran `bun-debug` with debug logs enabled
