### PR TITLE
fix(install): loading `bun.lock` with workspace overrides

### DIFF
--- a/src/install/bun.lock.zig
+++ b/src/install/bun.lock.zig
@@ -1476,7 +1476,7 @@ pub fn parseIntoBinaryLockfile(
             try bundled_pkgs.put(pkg_path, {});
         }
 
-        for (pkgs_expr.data.e_object.properties.slice()) |prop| {
+        next_pkg_key: for (pkgs_expr.data.e_object.properties.slice()) |prop| {
             const key = prop.key.?;
             const value = prop.value.?;
 
@@ -1573,7 +1573,25 @@ pub fn parseIntoBinaryLockfile(
                             if (comptime Environment.isDebug) {
                                 bun.assertWithLocation(!strings.eqlLong(pkg_path, pkg_names[workspace_pkg_id].slice(string_buf.bytes.items), true), @src());
                             }
+
+                            // found the workspace this key belongs to. for example both `pkg1` and `another-pkg1` should map
+                            // to the same package id:
+                            //
+                            // "workspaces": {
+                            //   "": {},
+                            //   "packages/pkg1": {
+                            //     "name": "pkg1",
+                            //   },
+                            // },
+                            // "overrides": {
+                            //   "some-pkg": "workspace:packages/pkg1",
+                            // },
+                            // "packages": {
+                            //   "pkg1": "workspace:packages/pkg1",
+                            //   "another-pkg1": "workspaces:packages/pkg1",
+                            // },
                             entry.value_ptr.* = workspace_pkg_id;
+                            continue :next_pkg_key;
                         }
                     }
 

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1627,7 +1627,7 @@ describe("install --filter", () => {
   });
 });
 
-test.only("can override npm package with workspace package under a different name", async () => {
+test("can override npm package with workspace package under a different name", async () => {
   await Promise.all([
     write(
       packageJson,

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1626,3 +1626,58 @@ describe("install --filter", () => {
     await checkWorkspace();
   });
 });
+
+test.only("can override npm package with workspace package under a different name", async () => {
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "one-dep": "1.0.0",
+        },
+        overrides: {
+          "no-deps": "workspace:packages/pkg1",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "pkg1", "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        version: "2.2.2",
+      }),
+    ),
+  ]);
+
+  var { exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "pkg1",
+    version: "2.2.2",
+  });
+
+  // another install can use the existing bun.lock successfully
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  ({ exited } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "pkg1",
+    version: "2.2.2",
+  });
+});


### PR DESCRIPTION
### What does this PR do?
There was a missing continue before hitting the error
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
