### PR TITLE
fix(us): memory leak when getting x509 certificate stores

### DIFF
--- a/packages/bun-usockets/src/internal/safety.h
+++ b/packages/bun-usockets/src/internal/safety.h
@@ -1,0 +1,35 @@
+#ifndef __US_SAFETY_H__
+#define __US_SAFETY_H__
+
+
+#if (defined(ASSERT) && ASSERT) || (defined(ASSERT_ENABLED) && ASSERT_ENABLED)
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <assert.h>
+
+/**
+ * Ownership of this pointer has been transferred elsewhere. This pointer is no
+ * longer usable.
+ */
+#define MOVED(ptr) ptr = NULL
+
+#else
+
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
+#include <assert.h>
+
+/*
+ * Ownership of this pointer has been transferred elsewhere. This pointer is no
+ * longer usable.
+ */
+#define MOVED(ptr)
+
+#endif // ASSERT
+
+#endif // __US_SAFETY_H__


### PR DESCRIPTION
### What does this PR do?
Part of #17777.

- fixes a leak in `us_get_default_ca_store` where x509 certificates were having their reference count incremented twice
- fixes several leaks in `create_ssl_context_from_bun_options` where resources were not being freed in case of errors.

### How did you verify your code works?
