### PR TITLE
Fix incorrect string indexing in Git config parsing

### DIFF
--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -110,7 +110,7 @@ const SloppyGlobalGitConfig = struct {
                 }
             } else {
                 if (!found_askpass) {
-                    if (line.len > "core.askpass".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.askpass".len], "core.askpass") and switch (line["sshCommand".len]) {
+                    if (line.len > "core.askpass".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.askpass".len], "core.askpass") and switch (line["core.askpass".len]) {
                         ' ', '\t', '=' => true,
                         else => false,
                     }) {
@@ -120,7 +120,7 @@ const SloppyGlobalGitConfig = struct {
                 }
 
                 if (!found_ssh_command) {
-                    if (line.len > "core.sshCommand".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.sshCommand".len], "core.sshCommand") and switch (line["sshCommand".len]) {
+                    if (line.len > "core.sshCommand".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.sshCommand".len], "core.sshCommand") and switch (line["core.sshCommand".len]) {
                         ' ', '\t', '=' => true,
                         else => false,
                     }) {


### PR DESCRIPTION
## Summary
- Fixed bug where the code was using "sshCommand".len instead of the correct "core.askpass".len and "core.sshCommand".len when indexing into config lines
- This would cause the code to check the wrong character position when validating Git config entries

## Test plan
- Verify Git config parsing works correctly with various config formats

🤖 Generated with [Claude Code](https://claude.ai/code)