### PR TITLE
docs: How to disable hot reloading (but otherwise keep dev mode)

### DIFF
--- a/docs/bundler/fullstack.md
+++ b/docs/bundler/fullstack.md
@@ -203,6 +203,13 @@ When `development` is `true`, Bun will:
 - Include the `SourceMap` header in the response so that devtools can show the original source code
 - Disable minification
 - Re-bundle assets on each request to a .html file
+- Client-side hot reload! ([New in Bun v1.2.3](https://bun.sh/blog/bun-v1.2.3#develop-frontend-apps-with-bun-index-html))
+
+Hot reloading can be disabled, but with other dev features still active (so the behaviour of Bun versions prior to v1.2.3) like this:
+
+```js-diff
+development: { hmr: false },
+```
 
 #### Production mode
 
@@ -309,5 +316,4 @@ This works similarly to how [`Bun.build` processes HTML files](/docs/bundler/htm
 
 ## This is a work in progress
 
-- ~Client-side hot reloading isn't wired up yet. It will be in the future.~ New in Bun v1.2.3
 - This doesn't support `bun build` yet. It also will in the future.


### PR DESCRIPTION
This is useful when hot reload doesn't quite work just yet, e.g. in the case of what I'm hitting in https://github.com/enola-dev/enola/issues/1143 (any help & tips on that would be very welcome BTW).

### What does this PR do?

- [X] Documentation (only)