### PR TITLE
Check if path exists before returning from opendirSync

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1021,6 +1021,10 @@ function _toUnixTimestamp(time: any, name = "time") {
 function opendirSync(path, options) {
   // TODO: validatePath
   // validateString(path, "path");
+  if (!fs.existsSync(path)) {
+    throw new Error("ENOENT");
+  }
+
   return new Dir(1, path, options);
 }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -19,6 +19,7 @@ import fs, {
   mkdtempSync,
   openAsBlob,
   openSync,
+  opendirSync,
   promises,
   statfsSync,
   statfs,
@@ -570,6 +571,13 @@ describe("copyFileSync", () => {
       });
     });
   }
+});
+
+describe("opendirSync", () => {
+  it("should throw ENOENT on a nonexistent directory", () => {
+    const dirName = Math.random().toString(8);
+    expect(() => opendirSync(dirName)).toThrow("ENOENT");
+  })
 });
 
 describe("mkdirSync", () => {


### PR DESCRIPTION
Closes #17581

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [x] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

One thing I don't quite see a pattern for yet is returning a system error (e.g. `ENOENT`) from JS code, but it seems like the typical way to do that is by putting the implementation into the Zig code. 

I figured I'd raise the PR while I look at how to do that in case there's a way to do it from JS though
