### PR TITLE
Update nodejs-apis.md -> node:util compatible methods

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -142,7 +142,7 @@ Some methods are not optimized yet.
 
 ### [`node:util`](https://nodejs.org/api/util.html)
 
-🟡 Missing `MIMEParams` `MIMEType` `debug` `getSystemErrorMap` `transferableAbortController` `transferableAbortSignal` `stripVTControlCharacters`
+🟡 Missing `getCallSite` `getCallSites` `getSystemErrorMap` `getSystemErrorMessage` `transferableAbortSignal` `transferableAbortController` `MIMEType` `MIMEParams`
 
 ### [`node:v8`](https://nodejs.org/api/v8.html)
 


### PR DESCRIPTION
### What does this PR do?

This updates the [docs for node:util compatibility](https://bun.sh/docs/runtime/nodejs-apis#node-util) based on what's currently supported according to the source code: https://github.com/oven-sh/bun/blob/078318f33cdd399093560500b82f9385a9672fd8/src/js/node/util.ts#L324-L356

`getCallSite`, `getCallSites`, and `getSystemErrorMessage` were added as **missing**
`stripVTControlCharacters` was **removed** (since it's now implemented)

Also the list is now is in the same order as the source code (which is in turn "in order of `node --print 'Object.keys(util)'`")

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
