### PR TITLE
refactor: add `debug` module

### DIFF
--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -113,7 +113,7 @@ pub const Value = union(enum) {
                 );
             },
             .pending => unreachable,
-            else => |tag| bun.todoPanic(@src(), "handle .{s}", .{@tagName(tag)}),
+            else => |tag| bun.debug.todoPanic(@src(), "handle .{s}", .{@tagName(tag)}),
         };
     }
 };

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -460,7 +460,7 @@ pub const StandaloneModuleGraph = struct {
                 graph.files.deinit();
             }
 
-            bun.assert_eql(graph.files.count(), modules.items.len);
+            bun.debug.assert_eql(graph.files.count(), modules.items.len);
         }
 
         return output_bytes;

--- a/src/allocators/mimalloc_arena.zig
+++ b/src/allocators/mimalloc_arena.zig
@@ -90,7 +90,7 @@ const ArenaRegistry = struct {
             if (entry.found_existing) {
                 const expected = entry.value_ptr.*;
                 if (expected != received) {
-                    bun.unreachablePanic("Arena created on wrong thread! Expected: {d} received: {d}", .{
+                    bun.debug.unreachablePanic("Arena created on wrong thread! Expected: {d} received: {d}", .{
                         expected,
                         received,
                     });
@@ -105,11 +105,11 @@ const ArenaRegistry = struct {
             registry.mutex.lock();
             defer registry.mutex.unlock();
             const expected = registry.arenas.get(arena.heap.?) orelse {
-                bun.unreachablePanic("Arena not registered!", .{});
+                bun.debug.unreachablePanic("Arena not registered!", .{});
             };
             const received = std.Thread.getCurrentId();
             if (expected != received) {
-                bun.unreachablePanic("Arena accessed on wrong thread! Expected: {d} received: {d}", .{
+                bun.debug.unreachablePanic("Arena accessed on wrong thread! Expected: {d} received: {d}", .{
                     expected,
                     received,
                 });
@@ -122,7 +122,7 @@ const ArenaRegistry = struct {
             registry.mutex.lock();
             defer registry.mutex.unlock();
             if (!registry.arenas.swapRemove(arena.heap.?)) {
-                bun.unreachablePanic("Arena not registered!", .{});
+                bun.debug.unreachablePanic("Arena not registered!", .{});
             }
         }
     }

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -701,7 +701,7 @@ pub fn deinit(dev: *DevServer) void {
         },
         .current_bundle = {
             if (dev.current_bundle) |_| {
-                bun.debugAssert(false); // impossible to de-initialize this state correctly.
+                bun.debug.debugAssert(false); // impossible to de-initialize this state correctly.
             }
         },
         .next_bundle = {
@@ -710,7 +710,7 @@ pub fn deinit(dev: *DevServer) void {
                 defer dev.deferred_request_pool.put(request);
                 // TODO: deinitializing in this state is almost certainly an assertion failure.
                 // This code is shipped in release because it is only reachable by experimenntal server components.
-                bun.debugAssert(request.data.handler != .server_handler);
+                bun.debug.debugAssert(request.data.handler != .server_handler);
                 request.data.deinit();
                 r = request.next;
             }
@@ -4035,7 +4035,7 @@ pub fn IncrementalGraph(side: bake.Side) type {
                 .client => {
                     if (file.flags.kind == .css) {
                         // It is only possible to find CSS roots by tracing.
-                        bun.debugAssert(file.flags.is_css_root);
+                        bun.debug.debugAssert(file.flags.is_css_root);
 
                         if (goal == .find_css) {
                             try g.current_css_files.append(g.owner().allocator, file.cssAssetId());
@@ -4698,7 +4698,7 @@ pub fn IncrementalGraph(side: bake.Side) type {
                 j.pushStatic(",");
                 const quoted_slice = map.quotedContents();
                 if (quoted_slice.len == 0) {
-                    bun.debugAssert(false); // vlq without source contents!
+                    bun.debug.debugAssert(false); // vlq without source contents!
                     const ptr: bun.StringPointer = .{
                         .offset = @intCast(j.len + ",\"".len),
                         .length = 0,
@@ -5180,7 +5180,7 @@ const DirectoryWatchStore = struct {
                             },
                             .NOTDIR => return error.Ignore, // ignore
                             else => {
-                                bun.todoPanic(@src(), "log watcher error", .{});
+                                bun.debug.todoPanic(@src(), "log watcher error", .{});
                             },
                         },
                     },
@@ -5910,7 +5910,7 @@ const HmrSocket = struct {
             s.dev.routeBundlePtr(old).active_viewers -= 1;
         }
 
-        bun.debugAssert(s.dev.active_websocket_connections.remove(s));
+        bun.debug.debugAssert(s.dev.active_websocket_connections.remove(s));
         s.dev.allocator.destroy(s);
     }
 };
@@ -7419,7 +7419,7 @@ const AutoArrayHashMapUnmanaged = std.AutoArrayHashMapUnmanaged;
 const bun = @import("root").bun;
 const Environment = bun.Environment;
 const assert = bun.assert;
-const assert_eql = bun.assert_eql;
+const assert_eql = bun.debug.assert_eql;
 const DynamicBitSetUnmanaged = bun.bit_set.DynamicBitSetUnmanaged;
 
 const bake = bun.bake;

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -3010,7 +3010,7 @@ pub const H2FrameParser = struct {
         }
         pub fn write(this: *MemoryWriter, data: []const u8) !usize {
             const pending = this.buffer[this.offset..];
-            bun.debugAssert(pending.len >= data.len);
+            bun.debug.debugAssert(pending.len >= data.len);
             @memcpy(pending[0..data.len], data);
             this.offset += data.len;
             return data.len;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -2319,8 +2319,8 @@ fn NewSocket(comptime ssl: bool) type {
                     } else {
                         // Otherwise, let's move the temporary buffer back.
                         const len = @as(usize, @intCast(this.buffered_data_for_node_net.len)) - wrote;
-                        bun.debugAssert(len <= this.buffered_data_for_node_net.len);
-                        bun.debugAssert(len <= this.buffered_data_for_node_net.cap);
+                        bun.debug.debugAssert(len <= this.buffered_data_for_node_net.len);
+                        bun.debug.debugAssert(len <= this.buffered_data_for_node_net.cap);
                         bun.C.memmove(this.buffered_data_for_node_net.ptr, this.buffered_data_for_node_net.ptr[wrote..], len);
                         this.buffered_data_for_node_net.len = @truncate(len);
                     }
@@ -2346,7 +2346,7 @@ fn NewSocket(comptime ssl: bool) type {
                 return .{ .success = .{} };
             }
 
-            bun.debugAssert(this.buffered_data_for_node_net.len == 0);
+            bun.debug.debugAssert(this.buffered_data_for_node_net.len == 0);
             var encoding_value: JSC.JSValue = args[3];
             if (args[2].isString()) {
                 encoding_value = args[2];

--- a/src/bun.js/api/bun/socket/SocketAddress.zig
+++ b/src/bun.js/api/bun/socket/SocketAddress.zig
@@ -148,7 +148,7 @@ pub fn parse(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError
         break :blk if (port32 > std.math.maxInt(u16)) 0 else @intCast(port32);
     };
     bun.assert(host.tag != .Dead);
-    bun.debugAssert(host.length() >= 2);
+    bun.debug.debugAssert(host.length() >= 2);
 
     // NOTE: parsed host cannot be used as presentation string. e.g.
     // - "[::1]" -> "::1"
@@ -351,8 +351,8 @@ pub fn intoDTO(this: *SocketAddress, global: *JSC.JSGlobalObject) JSC.JSValue {
 /// - Port is a valid `in_port_t` (between 0 and 2^16) in host byte order.
 pub fn createDTO(globalObject: *JSC.JSGlobalObject, addr_: []const u8, port_: i32, is_ipv6: bool) JSC.JSValue {
     if (comptime bun.Environment.isDebug) {
-        bun.assertWithLocation(port_ >= 0 and port_ <= std.math.maxInt(i32), @src());
-        bun.assertWithLocation(addr_.len > 0, @src());
+        bun.debug.assertWithLocation(port_ >= 0 and port_ <= std.math.maxInt(i32), @src());
+        bun.debug.assertWithLocation(addr_.len > 0, @src());
     }
 
     return JSSocketAddressDTO__create(
@@ -401,10 +401,10 @@ pub fn address(this: *SocketAddress) bun.String {
         std.debug.panic("Invariant violation: SocketAddress created with invalid IPv6 address ({any})", .{this._addr});
     });
     if (comptime bun.Environment.isDebug) {
-        bun.assertWithLocation(bun.strings.isAllASCII(formatted), @src());
+        bun.debug.assertWithLocation(bun.strings.isAllASCII(formatted), @src());
     }
     const presentation = bun.JSC.WebCore.Encoder.toBunStringComptime(formatted, .latin1);
-    bun.debugAssert(presentation.tag != .Dead);
+    bun.debug.debugAssert(presentation.tag != .Dead);
     this._presentation = presentation;
     return presentation;
 }
@@ -502,12 +502,12 @@ fn pton(global: *JSC.JSGlobalObject, comptime af: c_int, addr: [:0]const u8, dst
 }
 
 inline fn asV4(this: *const SocketAddress) *const inet.sockaddr_in {
-    bun.debugAssert(this.family() == AF.INET);
+    bun.debug.debugAssert(this.family() == AF.INET);
     return &this._addr.sin;
 }
 
 inline fn asV6(this: *const SocketAddress) *const inet.sockaddr_in6 {
-    bun.debugAssert(this.family() == AF.INET6);
+    bun.debug.debugAssert(this.family() == AF.INET6);
     return &this._addr.sin6;
 }
 

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1382,11 +1382,11 @@ pub const Subprocess = struct {
                         // unbalanced to do so, leading to a use-after-free.
                         // So, let's not do that.
                         // https://github.com/oven-sh/bun/pull/14092
-                        bun.debugAssert(!subprocess.flags.deref_on_stdin_destroyed);
+                        bun.debug.debugAssert(!subprocess.flags.deref_on_stdin_destroyed);
                         const debug_ref_count: if (Environment.isDebug) u32 else u0 = if (Environment.isDebug) subprocess.ref_count else 0;
                         pipe.onAttachedProcessExit();
                         if (comptime Environment.isDebug) {
-                            bun.debugAssert(subprocess.ref_count == debug_ref_count);
+                            bun.debug.debugAssert(subprocess.ref_count == debug_ref_count);
                         }
                         return pipe.toJS(globalThis);
                     } else {

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -334,7 +334,7 @@ pub const FFI = struct {
             }, true) catch |e| switch (e) {
                 error.OutOfMemory => return error.OutOfMemory,
                 else => {
-                    bun.debugAssert(this.hasDeferredErrors());
+                    bun.debug.debugAssert(this.hasDeferredErrors());
                     return error.DeferredErrors;
                 },
             };
@@ -412,7 +412,7 @@ pub const FFI = struct {
 
             for (this.include_dirs.items) |include_dir| {
                 state.addSysIncludePath(include_dir) catch {
-                    bun.debugAssert(this.hasDeferredErrors());
+                    bun.debug.debugAssert(this.hasDeferredErrors());
                     return error.DeferredErrors;
                 };
             }
@@ -466,7 +466,7 @@ pub const FFI = struct {
             try this.errorCheck();
 
             const relocation_size = state.relocate(null) catch {
-                bun.debugAssert(this.hasDeferredErrors());
+                bun.debug.debugAssert(this.hasDeferredErrors());
                 return error.DeferredErrors;
             };
 
@@ -476,7 +476,7 @@ pub const FFI = struct {
             _ = dangerouslyRunWithoutJitProtections(TCC.Error!usize, TCC.State.relocate, .{ state, bytes.ptr }) catch return error.DeferredErrors;
 
             // if errors got added, we would have returned in the relocation catch.
-            bun.debugAssert(this.deferred_errors.items.len == 0);
+            bun.debug.debugAssert(this.deferred_errors.items.len == 0);
 
             for (this.symbols.map.keys(), this.symbols.map.values()) |symbol, *function| {
                 // FIXME: why are we duping here? can we at least use a stack
@@ -531,7 +531,7 @@ pub const FFI = struct {
         pub fn deinit(this: *StringArray) void {
             for (this.items) |item| {
                 // Attempting to free an empty null-terminated slice will crash if it was a default value
-                bun.debugAssert(item.len > 0);
+                bun.debug.debugAssert(item.len > 0);
 
                 bun.default_allocator.free(@constCast(item));
             }
@@ -1557,7 +1557,7 @@ pub const FFI = struct {
 
             CompilerRT.inject(state);
             state.addSymbol(this.base_name.?, this.symbol_from_dynamic_library.?) catch {
-                bun.debugAssert(this.step == .failed);
+                bun.debug.debugAssert(this.step == .failed);
                 return;
             };
 

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -885,7 +885,7 @@ fn HandlerCallback(
             // All of these start with a ref_count of 2.
             // 1. For this scope.
             // 2. For the JS value.
-            bun.debugAssert(wrapper.ref_count == 2);
+            bun.debug.debugAssert(wrapper.ref_count == 2);
 
             defer {
                 @field(wrapper, field_name) = null;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -153,7 +153,7 @@ fn getContentType(headers: ?*JSC.FetchHeaders, blob: *const JSC.WebCore.AnyBlob,
 
 fn validateRouteName(global: *JSC.JSGlobalObject, path: []const u8) !void {
     // Already validated by the caller
-    bun.debugAssert(path.len > 0 and path[0] == '/');
+    bun.debug.debugAssert(path.len > 0 and path[0] == '/');
 
     // For now, we don't support params that start with a number.
     // Mostly because it makes the params object more complicated to implement and it's easier to cut scope this way for now.
@@ -1501,7 +1501,7 @@ pub const ServerConfig = struct {
                         init_ctx.arena.deinit();
                     }
                 } else {
-                    bun.debugAssert(init_ctx.arena.state.end_index == 0 and
+                    bun.debug.debugAssert(init_ctx.arena.state.end_index == 0 and
                         init_ctx.arena.state.buffer_list.first == null);
                     init_ctx.arena.deinit();
                 }
@@ -4493,7 +4493,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
 
         pub fn onRequestBodyReadableStreamAvailable(ptr: *anyopaque, globalThis: *JSC.JSGlobalObject, readable: JSC.WebCore.ReadableStream) void {
             var this = bun.cast(*RequestContext, ptr);
-            bun.debugAssert(this.request_body_readable_stream_ref.held.impl == null);
+            bun.debug.debugAssert(this.request_body_readable_stream_ref.held.impl == null);
             this.request_body_readable_stream_ref = JSC.WebCore.ReadableStream.Strong.init(readable, globalThis);
         }
 
@@ -6478,9 +6478,9 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
         }
 
         pub fn jsValueAssertAlive(server: *ThisServer) JSC.JSValue {
-            bun.debugAssert(server.listener != null); // this assertion is only valid while listening
+            bun.debug.debugAssert(server.listener != null); // this assertion is only valid while listening
             return server.js_value.get() orelse brk: {
-                bun.debugAssert(false);
+                bun.debug.debugAssert(false);
                 break :brk .undefined; // safe-ish
             };
         }

--- a/src/bun.js/api/server/HTMLBundle.zig
+++ b/src/bun.js/api/server/HTMLBundle.zig
@@ -356,7 +356,7 @@ pub const Route = struct {
                     const blob = JSC.WebCore.AnyBlob{ .Blob = output_file.toBlob(bun.default_allocator, globalThis) catch bun.outOfMemory() };
                     var headers = JSC.WebCore.Headers{ .allocator = bun.default_allocator };
                     const content_type = blob.Blob.contentTypeOrMimeType() orelse brk: {
-                        bun.debugAssert(false); // should be populated by `output_file.toBlob`
+                        bun.debug.debugAssert(false); // should be populated by `output_file.toBlob`
                         break :brk output_file.loader.toMimeType(&.{}).value;
                     };
                     headers.append("Content-Type", content_type) catch bun.outOfMemory();
@@ -488,7 +488,7 @@ pub const Route = struct {
 
         pub fn onAborted(this: *PendingResponse, resp: HTTPResponse) void {
             _ = resp; // autofix
-            bun.debugAssert(this.is_response_pending == true);
+            bun.debug.debugAssert(this.is_response_pending == true);
             this.is_response_pending = false;
 
             // Technically, this could be the final ref count, but we don't want to risk it

--- a/src/bun.js/api/server/StaticRoute.zig
+++ b/src/bun.js/api/server/StaticRoute.zig
@@ -190,7 +190,7 @@ pub fn onHEADRequest(this: *StaticRoute, req: *uws.Request, resp: AnyResponse) v
 }
 
 pub fn onHEAD(this: *StaticRoute, resp: AnyResponse) void {
-    bun.debugAssert(this.server != null);
+    bun.debug.debugAssert(this.server != null);
     this.ref();
     if (this.server) |server| {
         server.onPendingRequest();
@@ -212,7 +212,7 @@ pub fn onRequest(this: *StaticRoute, req: *uws.Request, resp: AnyResponse) void 
 }
 
 pub fn on(this: *StaticRoute, resp: AnyResponse) void {
-    bun.debugAssert(this.server != null);
+    bun.debug.debugAssert(this.server != null);
     this.ref();
     if (this.server) |server| {
         server.onPendingRequest();

--- a/src/bun.js/bindings/AbortSignal.zig
+++ b/src/bun.js/bindings/AbortSignal.zig
@@ -105,7 +105,7 @@ pub const AbortSignal = extern opaque {
         var reason: u8 = 0;
         const js_reason = WebCore__AbortSignal__reasonIfAborted(this, global, &reason);
         if (reason > 0) {
-            bun.debugAssert(js_reason == .undefined);
+            bun.debug.debugAssert(js_reason == .undefined);
             return .{ .common = @enumFromInt(reason) };
         }
         if (js_reason == .zero) {

--- a/src/bun.js/bindings/CPUFeatures.zig
+++ b/src/bun.js/bindings/CPUFeatures.zig
@@ -86,4 +86,4 @@ else
 
 extern "c" fn bun_cpu_features() u8;
 
-const assert = bun.debugAssert;
+const assert = bun.debug.debugAssert;

--- a/src/bun.js/bindings/CommonStrings.zig
+++ b/src/bun.js/bindings/CommonStrings.zig
@@ -26,8 +26,8 @@ pub const CommonStrings = struct {
         );
         bun.assert(str != .zero);
         if (comptime bun.Environment.isDebug) {
-            bun.assertWithLocation(str != .zero, @src());
-            bun.assertWithLocation(str.isStringLiteral(), @src());
+            bun.debug.assertWithLocation(str != .zero, @src());
+            bun.debug.assertWithLocation(str.isStringLiteral(), @src());
         }
         return str;
     }

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -359,7 +359,7 @@ pub const JSGlobalObject = opaque {
         // If we're throwing JSError, that means either:
         // - We're throwing an exception while another exception is already active
         // - We're incorrectly returning JSError from a function that did not throw.
-        bun.debugAssert(err != error.JSError);
+        bun.debug.debugAssert(err != error.JSError);
 
         // Avoid tiny extra allocation
         var stack = std.heap.stackFallback(128, bun.default_allocator);

--- a/src/bun.js/bindings/JSPropertyIterator.zig
+++ b/src/bun.js/bindings/JSPropertyIterator.zig
@@ -50,7 +50,7 @@ pub fn JSPropertyIterator(comptime options: JSPropertyIteratorOptions) type {
                 return error.JSError;
             }
             if (iter.len > 0) {
-                bun.debugAssert(iter.impl != null);
+                bun.debug.debugAssert(iter.impl != null);
             }
             return iter;
         }

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -730,7 +730,7 @@ pub const JSValue = enum(i64) {
     /// If the object is a subclass of the type or has mutated the structure, return null.
     /// Note: this may return null for direct instances of the type if the user adds properties to the object.
     pub fn asDirect(value: JSValue, comptime ZigType: type) ?*ZigType {
-        bun.debugAssert(value.isCell()); // you must have already checked this.
+        bun.debug.debugAssert(value.isCell()); // you must have already checked this.
 
         return ZigType.fromJSDirect(value);
     }

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -2239,7 +2239,7 @@ pub const AnyEventLoop = union(enum) {
     ) void {
         switch (this.*) {
             .js => {
-                bun.todoPanic(@src(), "AnyEventLoop.enqueueTaskConcurrent", .{});
+                bun.debug.todoPanic(@src(), "AnyEventLoop.enqueueTaskConcurrent", .{});
                 // const TaskType = AnyTask.New(Context, Callback);
                 // @field(ctx, field) = TaskType.init(ctx);
                 // var concurrent = bun.default_allocator.create(ConcurrentTask) catch unreachable;

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -338,8 +338,8 @@ pub const RuntimeTranspilerStore = struct {
                 const out = this.non_threadsafe_input_specifier;
                 this.non_threadsafe_input_specifier = String.empty;
 
-                bun.debugAssert(resolved_source.source_url.isEmpty());
-                bun.debugAssert(resolved_source.specifier.isEmpty());
+                bun.debug.debugAssert(resolved_source.source_url.isEmpty());
+                bun.debug.debugAssert(resolved_source.specifier.isEmpty());
                 resolved_source.source_url = out.createIfDifferent(this.path.text);
                 resolved_source.specifier = out.dupeRef();
                 break :brk out;

--- a/src/bun.js/node/node_assert_binding.zig
+++ b/src/bun.js/node/node_assert_binding.zig
@@ -44,8 +44,8 @@ pub fn myersDiff(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
     const expected_str = try expected_arg.toBunString(global);
     defer expected_str.deref();
 
-    bun.assertWithLocation(actual_str.tag != .Dead, @src());
-    bun.assertWithLocation(expected_str.tag != .Dead, @src());
+    bun.debug.assertWithLocation(actual_str.tag != .Dead, @src());
+    bun.debug.assertWithLocation(expected_str.tag != .Dead, @src());
 
     return assert.myersDiff(
         allocator,

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -211,7 +211,7 @@ pub const Async = struct {
                         if (mode == 0) mode = 0o644;
 
                         const rc = uv.uv_fs_open(loop, &task.req, path.ptr, flags, mode, &uv_callback);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv open({s}, {d}, {d}) = scheduled", .{ path, flags, mode });
                     },
                     .close => {
@@ -226,7 +226,7 @@ pub const Async = struct {
                         }
 
                         const rc = uv.uv_fs_close(loop, &task.req, fd, &uv_callback);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv close({d}) = scheduled", .{fd});
                     },
                     .read => {
@@ -239,7 +239,7 @@ pub const Async = struct {
                         buf = buf[0..@min(buf.len, args.length)];
 
                         const rc = uv.uv_fs_read(loop, &task.req, fd, &.{B(buf)}, 1, args.position orelse -1, &uv_callback);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv read({d}) = scheduled", .{fd});
                     },
                     .write => {
@@ -252,7 +252,7 @@ pub const Async = struct {
                         buf = buf[0..@min(buf.len, args.length)];
 
                         const rc = uv.uv_fs_write(loop, &task.req, fd, &.{B(buf)}, 1, args.position orelse -1, &uv_callback);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv write({d}) = scheduled", .{fd});
                     },
                     .readv => {
@@ -265,7 +265,7 @@ pub const Async = struct {
                         for (bufs) |b| sum += b.slice().len;
 
                         const rc = uv.uv_fs_read(loop, &task.req, fd, bufs.ptr, @intCast(bufs.len), pos, &uv_callback);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv readv({d}, {*}, {d}, {d}, {d} total bytes) = scheduled", .{ fd, bufs.ptr, bufs.len, pos, sum });
                     },
                     .writev => {
@@ -285,14 +285,14 @@ pub const Async = struct {
                         for (bufs) |b| sum += b.slice().len;
 
                         const rc = uv.uv_fs_write(loop, &task.req, fd, bufs.ptr, @intCast(bufs.len), pos, &uv_callback);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv writev({d}, {*}, {d}, {d}, {d} total bytes) = scheduled", .{ fd, bufs.ptr, bufs.len, pos, sum });
                     },
                     .statfs => {
                         const args_: Arguments.StatFS = task.args;
                         const path = args_.path.sliceZ(&this.node_fs.sync_error_buf);
                         const rc = uv.uv_fs_statfs(loop, &task.req, path.ptr, &uv_callbackreq);
-                        bun.debugAssert(rc == .zero);
+                        bun.debug.debugAssert(rc == .zero);
                         log("uv statfs({s}) = ~~", .{path});
                     },
                     else => comptime unreachable,

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -513,7 +513,7 @@ pub const PathWatcherManager = struct {
 
         fn run(this: *DirectoryRegisterTask) void {
             if (comptime Environment.isWindows) {
-                return bun.todo(@src(), {});
+                return bun.debug.todo(@src(), {});
             }
 
             var buf: bun.PathBuffer = undefined;

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -2217,7 +2217,7 @@ pub fn StatFSType(comptime big: bool) type {
 
                     const result = JSC.JSValue.jsDoubleNumber(@as(f64, @floatFromInt(value)));
                     if (Environment.isDebug) {
-                        bun.assert_eql(result.asNumber(), @as(f64, @floatFromInt(value)));
+                        bun.debug.assert_eql(result.asNumber(), @as(f64, @floatFromInt(value)));
                     }
                     return result;
                 }

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -5159,7 +5159,7 @@ pub const Blob = struct {
         // TODO: remove this field, make it a boolean.
         if (this.allocator) |alloc| {
             this.allocator = null;
-            bun.debugAssert(alloc.vtable == bun.default_allocator.vtable);
+            bun.debug.debugAssert(alloc.vtable == bun.default_allocator.vtable);
             this.destroy();
         }
     }

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -493,7 +493,7 @@ pub const TextEncoderStreamEncoder = struct {
 
         if (comptime Environment.isDebug) {
             // wrap in comptime if so simdutf isn't called in a release build here.
-            bun.debugAssert(buffer.items.len == (bun.simdutf.length.utf8.from.latin1(input) + prepend_replacement_len));
+            bun.debug.debugAssert(buffer.items.len == (bun.simdutf.length.utf8.from.latin1(input) + prepend_replacement_len));
         }
 
         return JSC.JSUint8Array.fromBytes(globalObject, buffer.items);
@@ -525,7 +525,7 @@ pub const TextEncoderStreamEncoder = struct {
                     const converted = strings.utf16CodepointWithFFFD([]const u16, &.{ lead, maybe_trail });
                     // shouldn't fail because `u16IsTrail` is true and `pending_lead_surrogate` is always
                     // a valid lead.
-                    bun.debugAssert(!converted.fail);
+                    bun.debug.debugAssert(!converted.fail);
 
                     const sequence = strings.wtf8Sequence(converted.code_point);
 
@@ -736,7 +736,7 @@ pub const TextDecoder = struct {
         if (remain.len != 0 and i == remain.len - 1) {
             this.lead_byte = remain[i];
         } else {
-            bun.assertWithLocation(i == remain.len, @src());
+            bun.debug.assertWithLocation(i == remain.len, @src());
         }
 
         if (comptime flush) {
@@ -852,7 +852,7 @@ pub const TextDecoder = struct {
                     return ZigString.toExternalU16(decoded.ptr, decoded.len, globalThis);
                 }
 
-                bun.debugAssert(input.len == 0 or !deinit);
+                bun.debug.debugAssert(input.len == 0 or !deinit);
 
                 // Experiment: using mimalloc directly is slightly slower
                 return ZigString.init(input).toJS(globalThis);

--- a/src/bun.js/webcore/response.zig
+++ b/src/bun.js/webcore/response.zig
@@ -867,12 +867,12 @@ pub const Fetch = struct {
 
         pub fn ref(this: *FetchTasklet) void {
             const count = this.ref_count.fetchAdd(1, .monotonic);
-            bun.debugAssert(count > 0);
+            bun.debug.debugAssert(count > 0);
         }
 
         pub fn deref(this: *FetchTasklet) void {
             const count = this.ref_count.fetchSub(1, .monotonic);
-            bun.debugAssert(count > 0);
+            bun.debug.debugAssert(count > 0);
 
             if (count == 1) {
                 this.deinit();
@@ -881,7 +881,7 @@ pub const Fetch = struct {
 
         pub fn derefFromThread(this: *FetchTasklet) void {
             const count = this.ref_count.fetchSub(1, .monotonic);
-            bun.debugAssert(count > 0);
+            bun.debug.debugAssert(count > 0);
 
             if (count == 1) {
                 // this is really unlikely to happen, but can happen

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -5225,7 +5225,7 @@ pub const ByteStream = struct {
     pub fn onPull(this: *@This(), buffer: []u8, view: JSC.JSValue) StreamResult {
         JSC.markBinding(@src());
         bun.assert(buffer.len > 0);
-        bun.debugAssert(this.buffer_action == null);
+        bun.debug.debugAssert(this.buffer_action == null);
 
         if (this.buffer.items.len > 0) {
             bun.assert(this.value() == .zero);

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3394,6 +3394,15 @@ noinline fn assertionFailure() noreturn {
     }
 }
 
+noinline fn assertionFailureAtLocation(src: std.builtin.SourceLocation) noreturn {
+    if (@inComptime()) {
+        @compileError(std.fmt.comptimePrint("assertion failure"));
+    } else {
+        @branchHint(.cold);
+        Output.panic(ASSERTION_FAILURE_MSG ++ "at {s}:{d}:{d}", .{ src.file, src.line, src.column });
+    }
+}
+
 noinline fn assertionFailureWithMsg(comptime msg: []const u8, args: anytype) noreturn {
     if (@inComptime()) {
         @compileError(std.fmt.comptimePrint("assertion failure: " ++ msg, args));
@@ -3495,7 +3504,7 @@ pub fn assertWithLocation(value: bool, src: std.builtin.SourceLocation) callconv
 
     if (!value) {
         if (comptime Environment.isDebug) unreachable;
-        assertionFailureWithMsg("{s}:{d}:{d}", .{ src.file, src.line, src.column });
+        assertionFailureAtLocation(src);
     }
 }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3404,7 +3404,7 @@ noinline fn assertionFailureWithMsg(comptime msg: []const u8, args: anytype) nor
 }
 
 /// Like `assert`, but checks only run in debug builds.
-/// 
+///
 /// Please wrap expensive checks in an `if` statement.
 /// ```zig
 /// if (comptime bun.Environment.isDebug) {
@@ -3423,21 +3423,21 @@ pub fn debugAssert(cheap_value_only_plz: bool) callconv(callconv_inline) void {
 }
 
 /// Asserts that some condition holds. Assertions are stripped in release builds.
-/// 
+///
 /// Please use `assertf` in new code.
-/// 
+///
 /// Be careful what expressions you pass to this function; if the compiler cannot
 /// determine that `ok` has no side effects, the argument expression may not be removed
 /// from the binary. This includes calls to extern functions.
-/// 
+///
 /// Wrap expensive checks in an `if` statement.
 /// ```zig
 /// if (comptime bun.Environment.allow_assert) {
 ///   const expensive = doExpensiveCheck();
-///   bun.assert(expensive);  
+///   bun.assert(expensive);
 /// }
 /// ```
-/// 
+///
 /// Use `assertRelease` for assertions that should not be stripped in release builds.
 pub fn assert(ok: bool) callconv(callconv_inline) void {
     if (comptime !Environment.allow_assert) {
@@ -3451,21 +3451,21 @@ pub fn assert(ok: bool) callconv(callconv_inline) void {
 }
 
 /// Asserts that some condition holds. Assertions are stripped in release builds.
-/// 
+///
 /// Please note that messages will be shown to users in crash reports.
-/// 
+///
 /// Be careful what expressions you pass to this function; if the compiler cannot
 /// determine that `ok` has no side effects, the argument expression may not be removed
 /// from the binary. This includes calls to extern functions.
-/// 
+///
 /// Wrap expensive checks in an `if` statement.
 /// ```zig
 /// if (comptime bun.Environment.allow_assert) {
 ///   const expensive = doExpensiveCheck();
-///   bun.assert(expensive, "Something happened: {}", .{ expensive });  
+///   bun.assert(expensive, "Something happened: {}", .{ expensive });
 /// }
 /// ```
-/// 
+///
 /// Use `assertRelease` for assertions that should not be stripped in release builds.
 pub fn assertf(ok: bool, comptime format: []const u8, args: anytype) callconv(callconv_inline) void {
     if (comptime !Environment.allow_assert) {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1409,7 +1409,7 @@ pub const BundleV2 = struct {
                 const keys = named_exports_array[source_id].keys();
                 const client_manifest_items = try alloc.alloc(G.Property, keys.len);
 
-                if (!sc.separate_ssr_graph) bun.todoPanic(@src(), "separate_ssr_graph=false", .{});
+                if (!sc.separate_ssr_graph) bun.debug.todoPanic(@src(), "separate_ssr_graph=false", .{});
 
                 const client_path = server.newExpr(E.String{
                     .data = try std.fmt.allocPrint(alloc, "{}S{d:0>8}", .{
@@ -1461,7 +1461,7 @@ pub const BundleV2 = struct {
                     }),
                 });
             } else {
-                bun.todoPanic(@src(), "\"use server\"", .{});
+                bun.debug.todoPanic(@src(), "\"use server\"", .{});
             }
         }
 
@@ -3568,7 +3568,7 @@ pub const BundleV2 = struct {
                     ((result.use_directive == .client) != (result.ast.target == .browser)))
                 {
                     if (result.use_directive == .server)
-                        bun.todoPanic(@src(), "\"use server\"", .{});
+                        bun.debug.todoPanic(@src(), "\"use server\"", .{});
 
                     const reference_source_index, const ssr_index = if (this.framework.?.server_components.?.separate_ssr_graph) brk: {
                         // Enqueue two files, one in server graph, one in ssr graph.
@@ -3842,7 +3842,7 @@ pub const DeferredBatchTask = struct {
     const AnyTask = JSC.AnyTask.New(@This(), runOnJSThread);
 
     pub fn init(this: *DeferredBatchTask) void {
-        if (comptime Environment.isDebug) bun.debugAssert(!this.running);
+        if (comptime Environment.isDebug) bun.debug.debugAssert(!this.running);
         this.* = .{
             .running = if (comptime Environment.isDebug) false else 0,
         };
@@ -4732,7 +4732,7 @@ pub const ParseTask = struct {
 
             pub fn getWrapper(result: *OnBeforeParseResult) *OnBeforeParseResultWrapper {
                 const wrapper: *OnBeforeParseResultWrapper = @fieldParentPtr("result", result);
-                bun.debugAssert(wrapper.check == 42069);
+                bun.debug.debugAssert(wrapper.check == 42069);
                 return wrapper;
             }
         };
@@ -5106,7 +5106,7 @@ pub const ParseTask = struct {
             task.side_effects = .no_side_effects__empty_ast;
         }
 
-        // bun.debugAssert(ast.parts.len > 0); // when parts.len == 0, it is assumed to be pending/failed. empty ast has at least 1 part.
+        // bun.debug.debugAssert(ast.parts.len > 0); // when parts.len == 0, it is assumed to be pending/failed. empty ast has at least 1 part.
 
         step.* = .resolve;
 
@@ -6089,7 +6089,7 @@ const LinkerGraph = struct {
                             this.is_scb_bitset.set(ref_id);
                         },
                         .server => {
-                            bun.todoPanic(@src(), "um", .{});
+                            bun.debug.todoPanic(@src(), "um", .{});
                         },
                     }
                 }
@@ -9785,7 +9785,7 @@ pub const LinkerContext = struct {
                         }
                     },
                     else => {},
-                    // else => bun.unreachablePanic("Unexpected output format", .{}),
+                    // else => bun.debug.unreachablePanic("Unexpected output format", .{}),
                 }
             }
         }
@@ -10600,7 +10600,7 @@ pub const LinkerContext = struct {
         conditions: *const BabyList(bun.css.ImportConditions),
     ) void {
         var dummy_import_records = bun.BabyList(bun.ImportRecord){};
-        defer bun.debugAssert(dummy_import_records.len == 0);
+        defer bun.debug.debugAssert(dummy_import_records.len == 0);
 
         var i: usize = conditions.len;
         while (i > 0) {
@@ -12955,7 +12955,7 @@ pub const LinkerContext = struct {
                                             stmt.data.s_class.class.class_name = s.default_name;
                                         },
 
-                                        else => bun.unreachablePanic(
+                                        else => bun.debug.unreachablePanic(
                                             "Unexpected type {any} in source file {s}",
                                             .{
                                                 stmt2.data,
@@ -13173,7 +13173,7 @@ pub const LinkerContext = struct {
         if (c.options.output_format == .internal_bake_dev) brk: {
             if (part_range.source_index.isRuntime()) {
                 @branchHint(.cold);
-                bun.debugAssert(c.dev_server == null);
+                bun.debug.debugAssert(c.dev_server == null);
                 break :brk; // this is from `bun build --format=internal_bake_dev`
             }
 

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -107,7 +107,7 @@ pub const Fs = struct {
         } else if (buffer == &this.macro_shared_buffer) {
             this.macro_shared_buffer = MutableString.initEmpty(bun.default_allocator);
         } else {
-            bun.unreachablePanic("resetSharedBuffer: invalid buffer", .{});
+            bun.debug.unreachablePanic("resetSharedBuffer: invalid buffer", .{});
         }
     }
 

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -502,7 +502,7 @@ pub const BuildCommand = struct {
                     continue;
                 };
 
-                bun.debugAssert(!std.fs.path.isAbsolute(f.dest_path));
+                bun.debug.debugAssert(!std.fs.path.isAbsolute(f.dest_path));
 
                 const rel_path = bun.strings.trimPrefixComptime(u8, f.dest_path, "./");
 

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -360,7 +360,7 @@ pub const PackCommand = struct {
                     },
                     .file => {
                         const dedupe_entry = try subpath_dedupe.getOrPut(entry_subpath);
-                        bun.assertWithLocation(!dedupe_entry.found_existing, @src());
+                        bun.debug.assertWithLocation(!dedupe_entry.found_existing, @src());
                         if (dedupe_entry.found_existing) continue;
 
                         try pack_queue.add(entry_subpath);
@@ -413,7 +413,7 @@ pub const PackCommand = struct {
                 // make sure depths are in order
                 if (ignores.items.len > 0) {
                     for (1..ignores.items.len) |i| {
-                        bun.assertWithLocation(ignores.items[i - 1].depth < ignores.items[i].depth, @src());
+                        bun.debug.assertWithLocation(ignores.items[i - 1].depth < ignores.items[i].depth, @src());
                     }
                 }
             }
@@ -551,7 +551,7 @@ pub const PackCommand = struct {
                     const entry_name = try entrySubpath(ctx.allocator, _entry_name, sub_entry.name.slice());
 
                     for (ctx.bundled_deps.items) |*dep| {
-                        bun.assertWithLocation(dep.from_root_package_json, @src());
+                        bun.debug.assertWithLocation(dep.from_root_package_json, @src());
                         if (!strings.eqlLong(entry_name, dep.name, true)) continue;
 
                         const entry_subpath = try entrySubpath(ctx.allocator, "node_modules", entry_name);
@@ -581,7 +581,7 @@ pub const PackCommand = struct {
             } else {
                 const entry_name = _entry_name;
                 for (ctx.bundled_deps.items) |*dep| {
-                    bun.assertWithLocation(dep.from_root_package_json, @src());
+                    bun.debug.assertWithLocation(dep.from_root_package_json, @src());
                     if (!strings.eqlLong(entry_name, dep.name, true)) continue;
 
                     const entry_subpath = try entrySubpath(ctx.allocator, "node_modules", entry_name);
@@ -613,7 +613,7 @@ pub const PackCommand = struct {
         while (additional_bundled_deps.popOrNull()) |bundled_dir_info| {
             const dir_subpath = bundled_dir_info[1];
             const maybe_slash = strings.lastIndexOfChar(dir_subpath, '/');
-            bun.assertWithLocation(maybe_slash != null, @src());
+            bun.debug.assertWithLocation(maybe_slash != null, @src());
             const dep_name: string = if (maybe_slash) |slash| dir_subpath[slash + 1 ..] else dir_subpath;
 
             try ctx.bundled_deps.append(ctx.allocator, .{
@@ -811,7 +811,7 @@ pub const PackCommand = struct {
                 // make sure depths are in order
                 if (ignores.items.len > 0) {
                     for (1..ignores.items.len) |i| {
-                        bun.assertWithLocation(ignores.items[i - 1].depth < ignores.items[i].depth, @src());
+                        bun.debug.assertWithLocation(ignores.items[i - 1].depth < ignores.items[i].depth, @src());
                     }
                 }
             }
@@ -850,7 +850,7 @@ pub const PackCommand = struct {
 
                 switch (entry.kind) {
                     .file => {
-                        bun.assertWithLocation(entry_subpath.len > 0, @src());
+                        bun.debug.assertWithLocation(entry_subpath.len > 0, @src());
                         try pack_queue.add(entry_subpath);
                     },
                     .directory => {

--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -258,7 +258,7 @@ pub const TrustCommand = struct {
                     const alias = dep.name.slice(buf);
                     const package_id = pm.lockfile.buffers.resolutions.items[dep_id];
                     if (comptime Environment.allow_assert) {
-                        bun.assertWithLocation(package_id != Install.invalid_package_id, @src());
+                        bun.debug.assertWithLocation(package_id != Install.invalid_package_id, @src());
                     }
                     const resolution = &resolutions[package_id];
                     var package_scripts = scripts[package_id];
@@ -381,7 +381,7 @@ pub const TrustCommand = struct {
         // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
         const names = package_names_to_add.keys();
         if (comptime Environment.allow_assert) {
-            bun.assertWithLocation(names.len > 0, @src());
+            bun.debug.assertWithLocation(names.len > 0, @src());
         }
 
         // could be null if these are the first packages to be trusted
@@ -436,7 +436,7 @@ pub const TrustCommand = struct {
         pm.root_package_json_file.close();
 
         if (comptime Environment.allow_assert) {
-            bun.assertWithLocation(total_scripts_ran > 0, @src());
+            bun.debug.assertWithLocation(total_scripts_ran > 0, @src());
         }
 
         Output.pretty(" <green>{d}<r> script{s} ran across {d} package{s} ", .{

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -876,7 +876,7 @@ pub const PublishCommand = struct {
         shasum: sha.SHA1.Digest,
         integrity: sha.SHA512.Digest,
     ) OOM!string {
-        bun.assertWithLocation(json.isObject(), @src());
+        bun.debug.assertWithLocation(json.isObject(), @src());
 
         const registry = manager.scopeForPackageName(package_name);
 
@@ -1370,7 +1370,7 @@ pub const PublishCommand = struct {
             try buf.ensureUnusedCapacity(ctx.allocator, encoded_tarball_len);
             buf.items.len += encoded_tarball_len;
             const count = bun.simdutf.base64.encode(ctx.tarball_bytes, buf.items[buf.items.len - encoded_tarball_len ..], false);
-            bun.assertWithLocation(count == encoded_tarball_len, @src());
+            bun.debug.assertWithLocation(count == encoded_tarball_len, @src());
 
             try writer.print("\",\"length\":{d}}}}}}}", .{
                 ctx.tarball_bytes.len,

--- a/src/css/media_query.zig
+++ b/src/css/media_query.zig
@@ -1057,7 +1057,7 @@ pub fn QueryFeature(comptime FeatureId: type) type {
                     .result => |v| v,
                 };
                 _ = blah;
-                bun.debugAssert(feature_name.eql(&name));
+                bun.debug.debugAssert(feature_name.eql(&name));
             }
 
             if (!name.valueType().allowsRanges() or !value.checkType(name.valueType())) {

--- a/src/css/printer.zig
+++ b/src/css/printer.zig
@@ -196,7 +196,7 @@ pub fn Printer(comptime Writer: type) type {
             kind: css.PrinterErrorKind,
             maybe_loc: ?css.dependencies.Location,
         ) PrintErr!void {
-            bun.debugAssert(this.error_kind == null);
+            bun.debug.debugAssert(this.error_kind == null);
             this.error_kind = css.PrinterError{
                 .kind = kind,
                 .loc = if (maybe_loc) |loc| css.ErrorLocation{
@@ -530,7 +530,7 @@ pub fn Printer(comptime Writer: type) type {
         }
 
         fn writeIndent(this: *This) PrintErr!void {
-            bun.debugAssert(!this.minify);
+            bun.debug.debugAssert(!this.minify);
             if (this.indent_amt > 0) {
                 // try this.writeStr(this.getIndent(this.ident));
                 this.dest.writeByteNTimes(' ', this.indent_amt) catch return this.addFmtError();

--- a/src/css/properties/size.zig
+++ b/src/css/properties/size.zig
@@ -148,7 +148,7 @@ pub const Size = union(enum) {
                 } else if (vp.eql(css.VendorPrefix{ .moz = true })) {
                     try dest.writeStr("-moz-available");
                 } else {
-                    bun.unreachablePanic("Unexpected vendor prefixes", .{});
+                    bun.debug.unreachablePanic("Unexpected vendor prefixes", .{});
                 }
             },
             .fit_content_function => |l| {
@@ -308,7 +308,7 @@ pub const MaxSize = union(enum) {
                 } else if (css.VendorPrefix.eql(vp, css.VendorPrefix{ .moz = true })) {
                     try dest.writeStr("-moz-available");
                 } else {
-                    bun.unreachablePanic("Unexpected vendor prefixes", .{});
+                    bun.debug.unreachablePanic("Unexpected vendor prefixes", .{});
                 }
             },
             .fit_content_function => |l| {

--- a/src/css/selectors/parser.zig
+++ b/src/css/selectors/parser.zig
@@ -269,7 +269,7 @@ fn compute_simple_selector_specifity(
 ) void {
     switch (simple_selector.*) {
         .combinator => {
-            bun.unreachablePanic("Found combinator in simple selectors vector?", .{});
+            bun.debug.unreachablePanic("Found combinator in simple selectors vector?", .{});
         },
         .part, .pseudo_element, .local_name => {
             specifity.element_selectors += 1;
@@ -1624,7 +1624,7 @@ pub fn GenericSelectorList(comptime Impl: type) type {
                     if (input.next().asValue()) |tok| {
                         if (tok.* == .comma) break;
                         // Shouldn't have got a selector if getting here.
-                        bun.debugAssert(!was_ok);
+                        bun.debug.debugAssert(!was_ok);
                     }
                     return .{ .result = .{ .v = values } };
                 }
@@ -1684,7 +1684,7 @@ pub fn GenericSelectorList(comptime Impl: type) type {
                     if (input.next().asValue()) |tok| {
                         if (tok.* == .comma) break;
                         // Shouldn't have got a selector if getting here.
-                        bun.debugAssert(!was_ok);
+                        bun.debug.debugAssert(!was_ok);
                     }
                     return .{ .result = .{ .v = values } };
                 }
@@ -2708,7 +2708,7 @@ pub fn parse_type_selector(
             sink.pushSimpleSelector(.explicit_any_namespace);
         },
         .implicit_no_namespace => {
-            bun.unreachablePanic("Should not be returned with in_attr_selector = false", .{});
+            bun.debug.unreachablePanic("Should not be returned with in_attr_selector = false", .{});
         },
     }
 
@@ -2982,7 +2982,7 @@ pub fn parse_attribute_selector(comptime Impl: type, parser: *SelectorParser, in
             .none => |t| return .{ .err = input.newCustomError(SelectorParseErrorKind.intoDefaultParserError(.{ .no_qualified_name_in_attribute_selector = t })) },
             .some => |qname| {
                 if (qname[1] == null) {
-                    bun.unreachablePanic("", .{});
+                    bun.debug.unreachablePanic("", .{});
                 }
                 const ns: QNamePrefix(Impl) = qname[0];
                 const ln = qname[1].?;
@@ -2992,7 +2992,7 @@ pub fn parse_attribute_selector(comptime Impl: type, parser: *SelectorParser, in
                         .explicit_namespace => |x| .{ .specific = .{ .prefix = x[0], .url = x[1] } },
                         .explicit_any_namespace => .any,
                         .implicit_any_namespace, .implicit_default_namespace => {
-                            bun.unreachablePanic("Not returned with in_attr_selector = true", .{});
+                            bun.debug.unreachablePanic("Not returned with in_attr_selector = true", .{});
                         },
                     },
                     ln,
@@ -3350,7 +3350,7 @@ pub fn parse_is_or_where(
     comptime func: anytype,
     args_: anytype,
 ) Result(GenericComponent(Impl)) {
-    bun.debugAssert(parser.parseIsAndWhere());
+    bun.debug.debugAssert(parser.parseIsAndWhere());
     // https://drafts.csswg.org/selectors/#matches-pseudo:
     //
     //     Pseudo-elements cannot be represented by the matches-any

--- a/src/css/selectors/selector.zig
+++ b/src/css/selectors/selector.zig
@@ -543,7 +543,7 @@ pub const serialize = struct {
         var first = true;
         var combinators_exhausted = false;
         while (compound_selectors.next()) |_compound_| {
-            bun.debugAssert(!combinators_exhausted);
+            bun.debug.debugAssert(!combinators_exhausted);
             var compound = _compound_;
 
             // Skip implicit :scope in relative selectors (e.g. :has(:scope > foo) -> :has(> foo))
@@ -1226,7 +1226,7 @@ pub const tocss_servo = struct {
 
         var combinators_exhausted = false;
         while (compound_selectors.next()) |compound| {
-            bun.debugAssert(!combinators_exhausted);
+            bun.debug.debugAssert(!combinators_exhausted);
 
             // https://drafts.csswg.org/cssom/#serializing-selectors
             if (compound.len == 0) continue;
@@ -1416,12 +1416,12 @@ pub const tocss_servo = struct {
                 const nth_data = nth_of_data.nthData();
                 try nth_data.writeStart(W, dest, true);
                 // A selector must be a function to hold An+B notation
-                bun.debugAssert(nth_data.is_function);
+                bun.debug.debugAssert(nth_data.is_function);
                 try nth_data.writeAffine(W, dest);
                 // Only :nth-child or :nth-last-child can be of a selector list
-                bun.debugAssert(nth_data.ty == .child or nth_data.ty == .last_child);
+                bun.debug.debugAssert(nth_data.ty == .child or nth_data.ty == .last_child);
                 // The selector list should not be empty
-                bun.debugAssert(nth_of_data.selectors.len != 0);
+                bun.debug.debugAssert(nth_of_data.selectors.len != 0);
                 try dest.writeStr(" of ");
                 try tocss_servo.toCss_SelectorList(nth_of_data.selectors, W, dest);
                 try dest.writeChar(')');

--- a/src/css/small_list.zig
+++ b/src/css/small_list.zig
@@ -496,7 +496,7 @@ pub fn SmallList(comptime T: type, comptime N: comptime_int) type {
 
         pub fn appendAssumeCapacity(this: *@This(), item: T) void {
             var ptr, const len_ptr, const capp = this.tripleMut();
-            bun.debugAssert(len_ptr.* < capp);
+            bun.debug.debugAssert(len_ptr.* < capp);
             ptr[len_ptr.*] = item;
             len_ptr.* += 1;
         }

--- a/src/css/values/calc.zig
+++ b/src/css/values/calc.zig
@@ -182,13 +182,13 @@ pub fn Calc(comptime V: type) type {
                 Angle => return switch (this) {
                     .value => |v| v.*,
                     // TODO: give a better error message
-                    else => bun.unreachablePanic("", .{}),
+                    else => bun.debug.unreachablePanic("", .{}),
                 },
                 CSSNumber => return switch (this) {
                     .value => |v| v.*,
                     .number => |n| n,
                     // TODO: give a better error message
-                    else => bun.unreachablePanic("", .{}),
+                    else => bun.debug.unreachablePanic("", .{}),
                 },
                 Length => return Length{
                     .calc = bun.create(allocator, Calc(Length), this),
@@ -196,12 +196,12 @@ pub fn Calc(comptime V: type) type {
                 Percentage => return switch (this) {
                     .value => |v| v.*,
                     // TODO: give a better error message
-                    else => bun.unreachablePanic("", .{}),
+                    else => bun.debug.unreachablePanic("", .{}),
                 },
                 Time => return switch (this) {
                     .value => |v| v.*,
                     // TODO: give a better error message
-                    else => bun.unreachablePanic("", .{}),
+                    else => bun.debug.unreachablePanic("", .{}),
                 },
                 DimensionPercentage(LengthValue) => return DimensionPercentage(LengthValue){ .calc = bun.create(
                     allocator,
@@ -766,7 +766,7 @@ pub fn Calc(comptime V: type) type {
                                         // sign() alwasy resolves to a number.
                                         return .{
                                             .result = This{
-                                                // .number = css.generic.trySign(V, &new_v) orelse bun.unreachablePanic("sign always resolved to a number.", .{}),
+                                                // .number = css.generic.trySign(V, &new_v) orelse bun.debug.unreachablePanic("sign always resolved to a number.", .{}),
                                                 .number = css.generic.trySign(V, &new_v) orelse @panic("sign() always resolves to a number."),
                                             },
                                         };

--- a/src/css/values/color.zig
+++ b/src/css/values/color.zig
@@ -389,7 +389,7 @@ pub const CssColor = union(enum) {
 
         const check_converted = struct {
             fn run(color: *const CssColor) bool {
-                bun.debugAssert(color.* != .light_dark and color.* != .current_color and color.* != .system);
+                bun.debug.debugAssert(color.* != .light_dark and color.* != .current_color and color.* != .system);
                 return switch (color.*) {
                     .rgba => T == RGBA,
                     .lab => |lab| switch (lab.*) {
@@ -488,7 +488,7 @@ pub const CssColor = union(enum) {
             ColorFallbackKind.RGB.asBits() => this.toRGB(allocator).?,
             ColorFallbackKind.P3.asBits() => this.toP3(allocator).?,
             ColorFallbackKind.LAB.asBits() => this.toLAB(allocator).?,
-            else => bun.unreachablePanic("Expected RGBA, P3, LAB fallback. This is a bug in Bun.", .{}),
+            else => bun.debug.unreachablePanic("Expected RGBA, P3, LAB fallback. This is a bug in Bun.", .{}),
         };
     }
 
@@ -2731,7 +2731,7 @@ pub const ColorFallbackKind = packed struct(u8) {
         const s = switch (this.asBits()) {
             ColorFallbackKind.P3.asBits() => "color(display-p3 0 0 0)",
             ColorFallbackKind.LAB.asBits() => "lab(0% 0 0)",
-            else => bun.unreachablePanic("Expected P3 or LAB. This is a bug in Bun.", .{}),
+            else => bun.debug.unreachablePanic("Expected P3 or LAB. This is a bug in Bun.", .{}),
         };
 
         return css.SupportsCondition{

--- a/src/css/values/gradient.zig
+++ b/src/css/values/gradient.zig
@@ -1573,7 +1573,7 @@ pub fn parseItems(comptime D: type, input: *css.Parser) Result(ArrayList(Gradien
 
         if (input.next().asValue()) |tok| {
             if (tok.* == .comma) continue;
-            bun.unreachablePanic("expected a comma after parsing a gradient", .{});
+            bun.debug.unreachablePanic("expected a comma after parsing a gradient", .{});
         } else {
             break;
         }

--- a/src/css/values/percentage.zig
+++ b/src/css/values/percentage.zig
@@ -16,7 +16,7 @@ pub const Percentage = struct {
         if (input.tryParse(Calc(Percentage).parse, .{}).asValue()) |calc_value| {
             if (calc_value == .value) return .{ .result = calc_value.value.* };
             // Percentages are always compatible, so they will always compute to a value.
-            bun.unreachablePanic("Percentages are always compatible, so they will always compute to a value.", .{});
+            bun.debug.unreachablePanic("Percentages are always compatible, so they will always compute to a value.", .{});
         }
 
         const percent = switch (input.expectPercentage()) {

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -1834,7 +1834,7 @@ pub const Error = enum(i32) {
             .MEMORY => Error.ENOMEM,
             .SERVICE => Error.ESERVICE,
             .SYSTEM => Error.ESERVFAIL,
-            else => bun.todo(@src(), Error.ENOTIMP),
+            else => bun.debug.todo(@src(), Error.ENOTIMP),
         };
     }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -2620,7 +2620,7 @@ pub const create_bun_socket_error_t = enum(c_int) {
     pub fn toJS(this: create_bun_socket_error_t, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         return switch (this) {
             .none => brk: {
-                bun.debugAssert(false);
+                bun.debug.debugAssert(false);
                 break :brk .null;
             },
             .load_ca_file => globalObject.ERR_BORINGSSL("Failed to load CA file", .{}).toJS(),

--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -537,7 +537,7 @@ pub fn GlobWalker_(
 
             pub fn deinit(this: *Iterator) void {
                 defer {
-                    bun.debugAssert(this.fds_open == 0);
+                    bun.debug.debugAssert(this.fds_open == 0);
                 }
                 this.closeCwdFd();
                 switch (this.iter_state) {
@@ -556,7 +556,7 @@ pub fn GlobWalker_(
                 }
 
                 if (comptime count_fds) {
-                    bun.debugAssert(this.fds_open == 0);
+                    bun.debug.debugAssert(this.fds_open == 0);
                 }
             }
 
@@ -576,7 +576,7 @@ pub fn GlobWalker_(
                 if (comptime count_fds) {
                     this.fds_open += 1;
                     // If this is over 2 then this means that there is a bug in the iterator code
-                    bun.debugAssert(this.fds_open <= 2);
+                    bun.debug.debugAssert(this.fds_open <= 2);
                 }
             }
 

--- a/src/glob/match.zig
+++ b/src/glob/match.zig
@@ -439,7 +439,7 @@ inline fn unescape(c: *u8, glob: []const u8, glob_index: *u32) bool {
 /// `c` must point to a u32 initialized to `glob[glob_index]`
 /// `clen` must point to a u8 initialized to 1
 inline fn getUnicode(c: *u32, clen: *u8, glob: []const u8, glob_index: *u32) bool {
-    bun.debugAssert(clen.* == 1);
+    bun.debug.debugAssert(clen.* == 1);
     switch (c.*) {
         // ascii range excluding backslash
         0x0...('\\' - 1), '\\' + 1...0x7F => {

--- a/src/http/websocket_http_client.zig
+++ b/src/http/websocket_http_client.zig
@@ -250,7 +250,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
 
         pub fn deinit(this: *HTTPClient) void {
             this.clearData();
-            bun.debugAssert(this.tcp.isDetached());
+            bun.debug.debugAssert(this.tcp.isDetached());
             this.destroy();
         }
 

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -407,7 +407,7 @@ pub const Parser = struct {
     ///
     /// npm/ini uses a regex pattern that will select the inner most ${...}
     fn parseEnvSubstitution(this: *Parser, val: []const u8, start: usize, i: usize, unesc: *std.ArrayList(u8)) OOM!?usize {
-        bun.debugAssert(val[i] == '$');
+        bun.debug.debugAssert(val[i] == '$');
         var esc = false;
         if (i + "{}".len < val.len and val[i + 1] == '{') {
             var found_closing = false;

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -278,7 +278,7 @@ pub const Bin = extern struct {
         writer: anytype,
         writeIndent: *const fn (anytype, *u32) @TypeOf(writer).Error!void,
     ) @TypeOf(writer).Error!void {
-        bun.debugAssert(this.tag != .none);
+        bun.debug.debugAssert(this.tag != .none);
         if (comptime style == .single_line) {
             switch (this.tag) {
                 .none => {},
@@ -614,10 +614,10 @@ pub const Bin = extern struct {
         }
 
         fn linkBinOrCreateShim(this: *Linker, abs_target: [:0]const u8, abs_dest: [:0]const u8, global: bool) void {
-            bun.assertWithLocation(std.fs.path.isAbsolute(abs_target), @src());
-            bun.assertWithLocation(std.fs.path.isAbsolute(abs_dest), @src());
-            bun.assertWithLocation(abs_target[abs_target.len - 1] != std.fs.path.sep, @src());
-            bun.assertWithLocation(abs_dest[abs_dest.len - 1] != std.fs.path.sep, @src());
+            bun.debug.assertWithLocation(std.fs.path.isAbsolute(abs_target), @src());
+            bun.debug.assertWithLocation(std.fs.path.isAbsolute(abs_dest), @src());
+            bun.debug.assertWithLocation(abs_target[abs_target.len - 1] != std.fs.path.sep, @src());
+            bun.debug.assertWithLocation(abs_dest[abs_dest.len - 1] != std.fs.path.sep, @src());
 
             if (this.seen) |seen| {
                 // Skip seen destinations for this tree
@@ -707,7 +707,7 @@ pub const Bin = extern struct {
             defer bunx_file.close();
 
             const rel_target = path.relativeBufZ(this.rel_buf, path.dirname(abs_dest, .auto), abs_target);
-            bun.assertWithLocation(strings.hasPrefixComptime(rel_target, "..\\"), @src());
+            bun.debug.assertWithLocation(strings.hasPrefixComptime(rel_target, "..\\"), @src());
 
             const rel_target_w = strings.toWPathNormalized(&target_buf, rel_target["..\\".len..]);
 
@@ -775,7 +775,7 @@ pub const Bin = extern struct {
             const abs_dest_dir = path.dirname(abs_dest, .auto);
             const rel_target = path.relativeBufZ(this.rel_buf, abs_dest_dir, abs_target);
 
-            bun.assertWithLocation(strings.hasPrefixComptime(rel_target, ".."), @src());
+            bun.debug.assertWithLocation(strings.hasPrefixComptime(rel_target, ".."), @src());
 
             switch (bun.sys.symlink(rel_target, abs_dest)) {
                 .err => |err| {
@@ -807,7 +807,7 @@ pub const Bin = extern struct {
                     }
 
                     // beyond this error can only be `.EXIST`
-                    bun.assertWithLocation(err.getErrno() == .EXIST, @src());
+                    bun.debug.assertWithLocation(err.getErrno() == .EXIST, @src());
                 },
                 .result => return,
             }
@@ -865,7 +865,7 @@ pub const Bin = extern struct {
             const package_dir = this.buildTargetPackageDir();
             var abs_dest_buf_remain = this.buildDestinationDir(global);
 
-            bun.assertWithLocation(this.bin.tag != .none, @src());
+            bun.debug.assertWithLocation(this.bin.tag != .none, @src());
 
             switch (this.bin.tag) {
                 .none => {},
@@ -973,7 +973,7 @@ pub const Bin = extern struct {
             const package_dir = this.buildTargetPackageDir();
             var abs_dest_buf_remain = this.buildDestinationDir(global);
 
-            bun.assertWithLocation(this.bin.tag != .none, @src());
+            bun.debug.assertWithLocation(this.bin.tag != .none, @src());
 
             switch (this.bin.tag) {
                 .none => {},

--- a/src/install/bun.lock.zig
+++ b/src/install/bun.lock.zig
@@ -717,7 +717,7 @@ pub const Stringifier = struct {
         }
 
         if (optional_peers_buf.items.len > 0) {
-            bun.debugAssert(any);
+            bun.debug.debugAssert(any);
             try writer.writeAll(
                 \\, "optionalPeers": [
             );
@@ -919,7 +919,7 @@ pub const Stringifier = struct {
             }
         }
         if (optional_peers_buf.items.len > 0) {
-            bun.debugAssert(any);
+            bun.debug.debugAssert(any);
             try writer.writeAll(
                 \\,
                 \\
@@ -1571,7 +1571,7 @@ pub fn parseIntoBinaryLockfile(
                         const workspace_pkg_id: PackageID = @intCast(_workspace_pkg_id);
                         if (res.eql(&pkg_resolutions[workspace_pkg_id], string_buf.bytes.items, string_buf.bytes.items)) {
                             if (comptime Environment.isDebug) {
-                                bun.assertWithLocation(!strings.eqlLong(pkg_path, pkg_names[workspace_pkg_id].slice(string_buf.bytes.items), true), @src());
+                                bun.debug.assertWithLocation(!strings.eqlLong(pkg_path, pkg_names[workspace_pkg_id].slice(string_buf.bytes.items), true), @src());
                             }
 
                             // found the workspace this key belongs to. for example both `pkg1` and `another-pkg1` should map

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -134,7 +134,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
         // Not sure where this case hits yet.
         // BUN-2WQ
         Output.warn("Extracting nameless packages is not supported yet. Please open an issue on GitHub with reproduction steps.", .{});
-        bun.debugAssert(false);
+        bun.debug.debugAssert(false);
         break :brk "unnamed-package";
     };
     const basename = brk: {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -1113,7 +1113,7 @@ pub fn NewPackageInstall(comptime kind: PkgInstallKind) type {
             this: *@This(),
             root_node_modules_dir: std.fs.Dir,
         ) bool {
-            bun.debugAssert(!this.patch.isNull());
+            bun.debug.debugAssert(!this.patch.isNull());
 
             // hash from the .patch file, to be checked against bun tag
             const patchfile_contents_hash = this.patch.patch_contents_hash;
@@ -2352,7 +2352,7 @@ pub fn NewPackageInstall(comptime kind: PkgInstallKind) type {
                                 var buf = &PackageManager.cached_package_folder_name_buf;
 
                                 if (comptime Environment.isDebug) {
-                                    bun.assertWithLocation(bun.isSliceInBuffer(this.cache_dir_subpath, buf), @src());
+                                    bun.debug.assertWithLocation(bun.isSliceInBuffer(this.cache_dir_subpath, buf), @src());
                                 }
 
                                 const subpath_len = strings.withoutTrailingSlash(this.cache_dir_subpath).len;
@@ -2922,7 +2922,7 @@ pub const PackageManager = struct {
             abs_package_json_path: anytype,
             comptime opts: GetJSONOptions,
         ) GetResult {
-            bun.assertWithLocation(std.fs.path.isAbsolute(abs_package_json_path), @src());
+            bun.debug.assertWithLocation(std.fs.path.isAbsolute(abs_package_json_path), @src());
 
             var buf: if (Environment.isWindows) bun.PathBuffer else void = undefined;
             const path = if (comptime !Environment.isWindows)
@@ -2985,7 +2985,7 @@ pub const PackageManager = struct {
             source: logger.Source,
             comptime opts: GetJSONOptions,
         ) GetResult {
-            bun.assertWithLocation(std.fs.path.isAbsolute(source.path.text), @src());
+            bun.debug.assertWithLocation(std.fs.path.isAbsolute(source.path.text), @src());
 
             var buf: if (Environment.isWindows) bun.PathBuffer else void = undefined;
             const path = if (comptime !Environment.isWindows)
@@ -4044,7 +4044,7 @@ pub const PackageManager = struct {
         const cache_path = this.cachedNPMPackageFolderNamePrint(&cache_path_buf, package_name, version, null);
 
         if (comptime Environment.allow_assert) {
-            bun.assertWithLocation(cache_path[package_name.len] == '@', @src());
+            bun.debug.assertWithLocation(cache_path[package_name.len] == '@', @src());
         }
 
         cache_path_buf[package_name.len] = std.fs.path.sep;
@@ -4379,7 +4379,7 @@ pub const PackageManager = struct {
             // Do we need to download the tarball?
             .extract => extract: {
                 const task_id = Task.Id.forNPMPackage(this.lockfile.str(&name), package.resolution.value.npm.version);
-                bun.debugAssert(!this.network_dedupe_map.contains(task_id));
+                bun.debug.debugAssert(!this.network_dedupe_map.contains(task_id));
 
                 break :extract .{
                     .package = package,
@@ -8797,7 +8797,7 @@ pub const PackageManager = struct {
                 return error.MissingPackageJSON;
             };
 
-            bun.assertWithLocation(strings.eqlLong(original_package_json_path_buf.items[0..this_cwd.len], this_cwd, true), @src());
+            bun.debug.assertWithLocation(strings.eqlLong(original_package_json_path_buf.items[0..this_cwd.len], this_cwd, true), @src());
             original_package_json_path_buf.items.len = this_cwd.len;
             original_package_json_path_buf.appendSliceAssumeCapacity(std.fs.path.sep_str ++ "package.json");
             original_package_json_path_buf.appendAssumeCapacity(0);
@@ -12633,7 +12633,7 @@ pub const PackageManager = struct {
             comptime log_level: Options.LogLevel,
         ) void {
             if (comptime Environment.allow_assert) {
-                bun.assertWithLocation(tree_id != Lockfile.Tree.invalid_id, @src());
+                bun.debug.assertWithLocation(tree_id != Lockfile.Tree.invalid_id, @src());
             }
 
             const tree = &this.trees[tree_id];
@@ -12690,11 +12690,11 @@ pub const PackageManager = struct {
             const lockfile = this.lockfile;
             const string_buf = lockfile.buffers.string_bytes.items;
             while (tree.binaries.removeOrNull()) |dep_id| {
-                bun.assertWithLocation(dep_id < lockfile.buffers.dependencies.items.len, @src());
+                bun.debug.assertWithLocation(dep_id < lockfile.buffers.dependencies.items.len, @src());
                 const package_id = lockfile.buffers.resolutions.items[dep_id];
-                bun.assertWithLocation(package_id != invalid_package_id, @src());
+                bun.debug.assertWithLocation(package_id != invalid_package_id, @src());
                 const bin = this.bins[package_id];
-                bun.assertWithLocation(bin.tag != .none, @src());
+                bun.debug.assertWithLocation(bin.tag != .none, @src());
 
                 const alias = lockfile.buffers.dependencies.items[dep_id].name.slice(string_buf);
 
@@ -13065,9 +13065,9 @@ pub const PackageManager = struct {
             comptime log_level: Options.LogLevel,
         ) usize {
             if (comptime Environment.allow_assert) {
-                bun.assertWithLocation(resolution_tag != .root, @src());
-                bun.assertWithLocation(resolution_tag != .workspace, @src());
-                bun.assertWithLocation(package_id != 0, @src());
+                bun.debug.assertWithLocation(resolution_tag != .root, @src());
+                bun.debug.assertWithLocation(resolution_tag != .workspace, @src());
+                bun.debug.assertWithLocation(package_id != 0, @src());
             }
             var count: usize = 0;
             const scripts = brk: {
@@ -13103,7 +13103,7 @@ pub const PackageManager = struct {
             };
 
             if (comptime Environment.allow_assert) {
-                bun.assertWithLocation(scripts.filled, @src());
+                bun.debug.assertWithLocation(scripts.filled, @src());
             }
 
             switch (resolution_tag) {
@@ -13372,7 +13372,7 @@ pub const PackageManager = struct {
             if (needs_install) {
                 if (!remove_patch and resolution.tag.canEnqueueInstallTask() and installer.packageMissingFromCache(this.manager, package_id, resolution.tag)) {
                     if (comptime Environment.allow_assert) {
-                        bun.assertWithLocation(resolution.canEnqueueInstallTask(), @src());
+                        bun.debug.assertWithLocation(resolution.canEnqueueInstallTask(), @src());
                     }
 
                     const context: TaskCallbackContext = .{
@@ -14162,17 +14162,17 @@ pub const PackageManager = struct {
                     if (comptime Environment.allow_assert) {
                         if (trees.len > 0) {
                             // last tree should only depend on one other
-                            bun.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(trees.len - 1).count() == 1, @src());
+                            bun.debug.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(trees.len - 1).count() == 1, @src());
                             // and it should be itself
-                            bun.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(trees.len - 1).isSet(trees.len - 1), @src());
+                            bun.debug.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(trees.len - 1).isSet(trees.len - 1), @src());
 
                             // root tree should always depend on all trees
-                            bun.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(0).count() == trees.len, @src());
+                            bun.debug.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(0).count() == trees.len, @src());
                         }
 
                         // a tree should always depend on itself
                         for (0..trees.len) |j| {
-                            bun.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(j).isSet(j), @src());
+                            bun.debug.assertWithLocation(tree_ids_to_trees_the_id_depends_on.at(j).isSet(j), @src());
                         }
                     }
 
@@ -14808,7 +14808,7 @@ pub const PackageManager = struct {
                             var iter = lockfile.patched_dependencies.iterator();
                             while (iter.next()) |entry| {
                                 const pkg_name_and_version_hash = entry.key_ptr.*;
-                                bun.debugAssert(entry.value_ptr.patchfile_hash_is_null);
+                                bun.debug.debugAssert(entry.value_ptr.patchfile_hash_is_null);
                                 const gop = try manager.lockfile.patched_dependencies.getOrPut(manager.lockfile.allocator, pkg_name_and_version_hash);
                                 if (!gop.found_existing) {
                                     gop.value_ptr.* = .{

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1641,7 +1641,7 @@ pub const PackageManifest = struct {
                     const sliced_version = SlicedString.init(version_name, version_name);
                     const parsed_version = Semver.Version.parse(sliced_version);
 
-                    if (Environment.allow_assert) bun.assertWithLocation(parsed_version.valid, @src());
+                    if (Environment.allow_assert) bun.debug.assertWithLocation(parsed_version.valid, @src());
                     if (!parsed_version.valid) {
                         log.addErrorFmt(&source, prop.value.?.loc, allocator, "Failed to parse dependency {s}", .{version_name}) catch unreachable;
                         continue;
@@ -1852,15 +1852,15 @@ pub const PackageManifest = struct {
                     var sliced_version = SlicedString.init(version_name, version_name);
                     var parsed_version = Semver.Version.parse(sliced_version);
 
-                    if (Environment.allow_assert) bun.assertWithLocation(parsed_version.valid, @src());
+                    if (Environment.allow_assert) bun.debug.assertWithLocation(parsed_version.valid, @src());
                     // We only need to copy the version tags if it contains pre and/or build
                     if (parsed_version.version.tag.hasBuild() or parsed_version.version.tag.hasPre()) {
                         const version_string = string_builder.append(String, version_name);
                         sliced_version = version_string.sliced(string_buf);
                         parsed_version = Semver.Version.parse(sliced_version);
                         if (Environment.allow_assert) {
-                            bun.assertWithLocation(parsed_version.valid, @src());
-                            bun.assertWithLocation(parsed_version.version.tag.hasBuild() or parsed_version.version.tag.hasPre(), @src());
+                            bun.debug.assertWithLocation(parsed_version.valid, @src());
+                            bun.debug.assertWithLocation(parsed_version.version.tag.hasBuild() or parsed_version.version.tag.hasPre(), @src());
                         }
                     }
                     if (!parsed_version.valid) continue;
@@ -2203,13 +2203,13 @@ pub const PackageManifest = struct {
                                 if (comptime Environment.allow_assert) {
                                     const dependencies_list = @field(package_version, pair.field);
 
-                                    bun.assertWithLocation(dependencies_list.name.off < all_extern_strings.len, @src());
-                                    bun.assertWithLocation(dependencies_list.value.off < all_extern_strings.len, @src());
-                                    bun.assertWithLocation(dependencies_list.name.off + dependencies_list.name.len < all_extern_strings.len, @src());
-                                    bun.assertWithLocation(dependencies_list.value.off + dependencies_list.value.len < all_extern_strings.len, @src());
+                                    bun.debug.assertWithLocation(dependencies_list.name.off < all_extern_strings.len, @src());
+                                    bun.debug.assertWithLocation(dependencies_list.value.off < all_extern_strings.len, @src());
+                                    bun.debug.assertWithLocation(dependencies_list.name.off + dependencies_list.name.len < all_extern_strings.len, @src());
+                                    bun.debug.assertWithLocation(dependencies_list.value.off + dependencies_list.value.len < all_extern_strings.len, @src());
 
-                                    bun.assertWithLocation(std.meta.eql(dependencies_list.name.get(all_extern_strings), this_names), @src());
-                                    bun.assertWithLocation(std.meta.eql(dependencies_list.value.get(version_extern_strings), this_versions), @src());
+                                    bun.debug.assertWithLocation(std.meta.eql(dependencies_list.name.get(all_extern_strings), this_names), @src());
+                                    bun.debug.assertWithLocation(std.meta.eql(dependencies_list.value.get(version_extern_strings), this_versions), @src());
                                     var j: usize = 0;
                                     const name_dependencies = dependencies_list.name.get(all_extern_strings);
 
@@ -2217,31 +2217,31 @@ pub const PackageManifest = struct {
                                         if (optional_peer_dep_names.items.len == 0) {
                                             while (j < name_dependencies.len) : (j += 1) {
                                                 const dep_name = name_dependencies[j];
-                                                bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_names[j].slice(string_buf)), @src());
-                                                bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].key.?.asString(allocator).?), @src());
+                                                bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_names[j].slice(string_buf)), @src());
+                                                bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].key.?.asString(allocator).?), @src());
                                             }
 
                                             j = 0;
                                             while (j < dependencies_list.value.len) : (j += 1) {
                                                 const dep_name = dependencies_list.value.get(version_extern_strings)[j];
 
-                                                bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_versions[j].slice(string_buf)), @src());
-                                                bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].value.?.asString(allocator).?), @src());
+                                                bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_versions[j].slice(string_buf)), @src());
+                                                bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].value.?.asString(allocator).?), @src());
                                             }
                                         }
                                     } else {
                                         while (j < name_dependencies.len) : (j += 1) {
                                             const dep_name = name_dependencies[j];
-                                            bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_names[j].slice(string_buf)), @src());
-                                            bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].key.?.asString(allocator).?), @src());
+                                            bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_names[j].slice(string_buf)), @src());
+                                            bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].key.?.asString(allocator).?), @src());
                                         }
 
                                         j = 0;
                                         while (j < dependencies_list.value.len) : (j += 1) {
                                             const dep_name = dependencies_list.value.get(version_extern_strings)[j];
 
-                                            bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_versions[j].slice(string_buf)), @src());
-                                            bun.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].value.?.asString(allocator).?), @src());
+                                            bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), this_versions[j].slice(string_buf)), @src());
+                                            bun.debug.assertWithLocation(std.mem.eql(u8, dep_name.slice(string_buf), items[j].value.?.asString(allocator).?), @src());
                                         }
                                     }
                                 }
@@ -2294,8 +2294,8 @@ pub const PackageManifest = struct {
                 };
 
                 if (comptime Environment.allow_assert) {
-                    bun.assertWithLocation(std.meta.eql(result.pkg.dist_tags.versions.get(all_semver_versions), dist_tag_versions[0..dist_tag_i]), @src());
-                    bun.assertWithLocation(std.meta.eql(result.pkg.dist_tags.tags.get(all_extern_strings), extern_strings_slice[0..dist_tag_i]), @src());
+                    bun.debug.assertWithLocation(std.meta.eql(result.pkg.dist_tags.versions.get(all_semver_versions), dist_tag_versions[0..dist_tag_i]), @src());
+                    bun.debug.assertWithLocation(std.meta.eql(result.pkg.dist_tags.tags.get(all_extern_strings), extern_strings_slice[0..dist_tag_i]), @src());
                 }
 
                 extern_strings = extern_strings[dist_tag_i..];
@@ -2404,13 +2404,13 @@ pub const PackageManifest = struct {
                             const first = semver_versions_[0];
                             const second = semver_versions_[1];
                             const order = second.order(first, string_buf, string_buf);
-                            bun.assertWithLocation(order == .gt, @src());
+                            bun.debug.assertWithLocation(order == .gt, @src());
                         }
                     }
                 }
             },
             else => {
-                bun.assertWithLocation(max_versions_count == 0, @src());
+                bun.debug.assertWithLocation(max_versions_count == 0, @src());
             },
         }
 
@@ -2418,7 +2418,7 @@ pub const PackageManifest = struct {
             const src = std.mem.sliceAsBytes(all_tarball_url_strings[0 .. all_tarball_url_strings.len - tarball_url_strings.len]);
             if (src.len > 0) {
                 var dst = std.mem.sliceAsBytes(all_extern_strings[all_extern_strings.len - extern_strings.len ..]);
-                bun.assertWithLocation(dst.len >= src.len, @src());
+                bun.debug.assertWithLocation(dst.len >= src.len, @src());
                 @memcpy(dst[0..src.len], src);
             }
 

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -213,7 +213,7 @@ pub const PatchTask = struct {
                     debug("pkg: {s} extract", .{pkg.name.slice(manager.lockfile.buffers.string_bytes.items)});
 
                     const task_id = Task.Id.forNPMPackage(manager.lockfile.str(&pkg.name), pkg.resolution.value.npm.version);
-                    bun.debugAssert(!manager.network_dedupe_map.contains(task_id));
+                    bun.debug.debugAssert(!manager.network_dedupe_map.contains(task_id));
 
                     const network_task = try manager.generateNetworkTaskForTarball(
                         // TODO: not just npm package

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -3200,7 +3200,7 @@ pub const Stmt = struct {
             pub inline fn assert() void {
                 if (comptime Environment.allow_assert) {
                     if (instance == null and memory_allocator == null)
-                        bun.unreachablePanic("Store must be init'd", .{});
+                        bun.debug.unreachablePanic("Store must be init'd", .{});
                 }
             }
 
@@ -3410,7 +3410,7 @@ pub const Expr = struct {
     /// Sets the value of a property, creating it if it doesn't exist.
     /// `expr` must be an object.
     pub fn set(expr: *Expr, allocator: std.mem.Allocator, name: string, value: Expr) OOM!void {
-        bun.assertWithLocation(expr.isObject(), @src());
+        bun.debug.assertWithLocation(expr.isObject(), @src());
         for (0..expr.data.e_object.properties.len) |i| {
             const prop = &expr.data.e_object.properties.ptr[i];
             const key = prop.key orelse continue;
@@ -3435,7 +3435,7 @@ pub const Expr = struct {
     /// Sets the value of a property to a string, creating it if it doesn't exist.
     /// `expr` must be an object.
     pub fn setString(expr: *Expr, allocator: std.mem.Allocator, name: string, value: string) OOM!void {
-        bun.assertWithLocation(expr.isObject(), @src());
+        bun.debug.assertWithLocation(expr.isObject(), @src());
         for (0..expr.data.e_object.properties.len) |i| {
             const prop = &expr.data.e_object.properties.ptr[i];
             const key = prop.key orelse continue;
@@ -3602,7 +3602,7 @@ pub const Expr = struct {
 
     pub inline fn asUtf8StringLiteral(expr: *const Expr) ?string {
         if (expr.data == .e_string) {
-            bun.debugAssert(expr.data.e_string.next == null);
+            bun.debug.debugAssert(expr.data.e_string.next == null);
             return expr.data.e_string.data;
         }
         return null;
@@ -5290,7 +5290,7 @@ pub const Expr = struct {
         e_inlined_enum: *E.InlinedEnum,
 
         comptime {
-            bun.assert_eql(@sizeOf(Data), 24); // Do not increase the size of Expr
+            bun.debug.assert_eql(@sizeOf(Data), 24); // Do not increase the size of Expr
         }
 
         pub fn as(data: Data, comptime tag: Tag) ?@FieldType(Data, @tagName(tag)) {
@@ -6280,7 +6280,7 @@ pub const Expr = struct {
             pub inline fn assert() void {
                 if (comptime Environment.allow_assert) {
                     if (instance == null and memory_allocator == null)
-                        bun.unreachablePanic("Store must be init'd", .{});
+                        bun.debug.unreachablePanic("Store must be init'd", .{});
                 }
             }
 
@@ -8679,7 +8679,7 @@ pub const ServerComponentBoundary = struct {
                     real_source_index,
                     Adapter{ .list = l.list },
                 ) orelse return null;
-                bun.unsafeAssert(l.list.capacity > 0); // optimize MultiArrayList.Slice.items
+                bun.debug.unsafeAssert(l.list.capacity > 0); // optimize MultiArrayList.Slice.items
                 return l.list.items(.reference_source_index)[i];
             }
 
@@ -8700,7 +8700,7 @@ pub const ServerComponentBoundary = struct {
             }
 
             pub fn eql(adapt: Adapter, a: Index.Int, _: void, b_index: usize) bool {
-                bun.unsafeAssert(adapt.list.capacity > 0); // optimize MultiArrayList.Slice.items
+                bun.debug.unsafeAssert(adapt.list.capacity > 0); // optimize MultiArrayList.Slice.items
                 return a == adapt.list.items(.source_index)[b_index];
             }
         };

--- a/src/js_lexer.zig
+++ b/src/js_lexer.zig
@@ -276,9 +276,9 @@ fn NewLexer_(
             this.comments_to_preserve_before = comments_to_preserve_before;
             this.temp_buffer_u16 = temp_buffer_u16;
 
-            bun.debugAssert(all_comments.items.len >= original.all_comments.items.len);
-            bun.debugAssert(comments_to_preserve_before.items.len >= original.comments_to_preserve_before.items.len);
-            bun.debugAssert(temp_buffer_u16.items.len == 0 and original.temp_buffer_u16.items.len == 0);
+            bun.debug.debugAssert(all_comments.items.len >= original.all_comments.items.len);
+            bun.debug.debugAssert(comments_to_preserve_before.items.len >= original.comments_to_preserve_before.items.len);
+            bun.debug.debugAssert(temp_buffer_u16.items.len == 0 and original.temp_buffer_u16.items.len == 0);
 
             this.all_comments.items.len = original.all_comments.items.len;
             this.comments_to_preserve_before.items.len = original.comments_to_preserve_before.items.len;

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -23344,13 +23344,13 @@ fn NewParser_(
             bun.assert(p.current_scope == p.module_scope);
 
             if (p.options.features.server_components == .wrap_exports_for_server_reference)
-                bun.todoPanic(@src(), "registerServerReference", .{});
+                bun.debug.todoPanic(@src(), "registerServerReference", .{});
 
             const module_path = p.newExpr(E.String{
                 .data = if (p.options.jsx.development)
                     p.source.path.pretty
                 else
-                    bun.todoPanic(@src(), "TODO: unique_key here", .{}),
+                    bun.debug.todoPanic(@src(), "TODO: unique_key here", .{}),
             }, logger.Loc.Empty);
 
             // registerClientReference(

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -3439,7 +3439,7 @@ fn NewPrinter(
 
             if (item.kind != .normal) {
                 if (comptime is_json) {
-                    bun.unreachablePanic("item.kind must be normal in json, received: {any}", .{item.kind});
+                    bun.debug.unreachablePanic("item.kind must be normal in json, received: {any}", .{item.kind});
                 }
 
                 switch (item.value.?.data) {

--- a/src/modules/debug.zig
+++ b/src/modules/debug.zig
@@ -1,0 +1,183 @@
+//! Assertions, panics, and other utilities
+const std = @import("std");
+const bun = @import("root").bun;
+
+// TODO: isolate from "bun.zig"
+const Output = bun.Output;
+const Environment = bun.Environment;
+const callconv_inline = bun.callconv_inline;
+
+const ASSERTION_FAILURE_MSG = "Internal assertion failure";
+noinline fn assertionFailure() noreturn {
+    if (@inComptime()) {
+        @compileError("assertion failure");
+    } else {
+        @branchHint(.cold);
+        Output.panic(ASSERTION_FAILURE_MSG, .{});
+    }
+}
+
+noinline fn assertionFailureAtLocation(src: std.builtin.SourceLocation) noreturn {
+    if (@inComptime()) {
+        @compileError(std.fmt.comptimePrint("assertion failure"));
+    } else {
+        @branchHint(.cold);
+        Output.panic(ASSERTION_FAILURE_MSG ++ "at {s}:{d}:{d}", .{ src.file, src.line, src.column });
+    }
+}
+
+noinline fn assertionFailureWithMsg(comptime msg: []const u8, args: anytype) noreturn {
+    if (@inComptime()) {
+        @compileError(std.fmt.comptimePrint("assertion failure: " ++ msg, args));
+    } else {
+        @branchHint(.cold);
+        Output.panic(ASSERTION_FAILURE_MSG ++ ": " ++ msg, .args);
+    }
+}
+
+/// Like `assert`, but checks only run in debug builds.
+///
+/// Please wrap expensive checks in an `if` statement.
+/// ```zig
+/// if (comptime bun.Environment.isDebug) {
+///   const expensive = doExpensiveCheck();
+///   bun.debug.debugAssert(expensive);
+/// }
+/// ```
+pub fn debugAssert(cheap_value_only_plz: bool) callconv(callconv_inline) void {
+    if (comptime !Environment.isDebug) {
+        return;
+    }
+
+    if (!cheap_value_only_plz) {
+        unreachable;
+    }
+}
+
+/// Asserts that some condition holds. Assertions are stripped in release builds.
+///
+/// Please use `assertf` in new code.
+///
+/// Be careful what expressions you pass to this function; if the compiler cannot
+/// determine that `ok` has no side effects, the argument expression may not be removed
+/// from the binary. This includes calls to extern functions.
+///
+/// Wrap expensive checks in an `if` statement.
+/// ```zig
+/// if (comptime bun.Environment.allow_assert) {
+///   const expensive = doExpensiveCheck();
+///   bun.assert(expensive);
+/// }
+/// ```
+///
+/// Use `assertRelease` for assertions that should not be stripped in release builds.
+pub fn assert(ok: bool) callconv(callconv_inline) void {
+    if (comptime !Environment.allow_assert) {
+        return;
+    }
+
+    if (!ok) {
+        if (comptime Environment.isDebug) unreachable;
+        assertionFailure();
+    }
+}
+
+/// Asserts that some condition holds. Assertions are stripped in release builds.
+///
+/// Please note that messages will be shown to users in crash reports.
+///
+/// Be careful what expressions you pass to this function; if the compiler cannot
+/// determine that `ok` has no side effects, the argument expression may not be removed
+/// from the binary. This includes calls to extern functions.
+///
+/// Wrap expensive checks in an `if` statement.
+/// ```zig
+/// if (comptime bun.Environment.allow_assert) {
+///   const expensive = doExpensiveCheck();
+///   bun.assert(expensive, "Something happened: {}", .{ expensive });
+/// }
+/// ```
+///
+/// Use `assertRelease` for assertions that should not be stripped in release builds.
+pub fn assertf(ok: bool, comptime format: []const u8, args: anytype) callconv(callconv_inline) void {
+    if (comptime !Environment.allow_assert) {
+        return;
+    }
+
+    if (!ok) {
+        if (comptime Environment.isDebug) unreachable;
+        assertionFailureWithMsg(format, args);
+    }
+}
+
+/// Asserts that some condition holds. These assertions are not stripped
+/// in any build mode. Use `assert` to have assertions stripped in release
+/// builds.
+pub fn releaseAssert(ok: bool, comptime msg: []const u8, args: anytype) callconv(callconv_inline) void {
+    if (!ok) {
+        @branchHint(.unlikely);
+        Output.panic(ASSERTION_FAILURE_MSG ++ ": " ++ msg, args);
+    }
+}
+
+pub fn assertWithLocation(value: bool, src: std.builtin.SourceLocation) callconv(callconv_inline) void {
+    if (comptime !Environment.allow_assert) {
+        return;
+    }
+
+    if (!value) {
+        if (comptime Environment.isDebug) unreachable;
+        assertionFailureAtLocation(src);
+    }
+}
+
+/// This has no effect on the real code but capturing 'a' and 'b' into
+/// parameters makes assertion failures much easier inspect in a debugger.
+pub inline fn assert_eql(a: anytype, b: anytype) void {
+    if (@inComptime()) {
+        if (a != b) {
+            @compileLog(a);
+            @compileLog(b);
+            @compileError("A != B");
+        }
+    }
+    if (!Environment.allow_assert) return;
+    if (a != b) {
+        Output.panic("Assertion failure: {any} != {any}", .{ a, b });
+    }
+}
+
+/// This has no effect on the real code but capturing 'a' and 'b' into
+/// parameters makes assertion failures much easier inspect in a debugger.
+pub fn assert_neql(a: anytype, b: anytype) callconv(callconv_inline) void {
+    return assert(a != b);
+}
+
+pub fn unsafeAssert(condition: bool) callconv(callconv_inline) void {
+    if (!condition) unreachable;
+}
+
+/// Do not use this function, call std.debug.panic directly.
+///
+/// This function used to panic in debug, and be `unreachable` in release
+/// however, if something is possibly reachable, it should not be marked unreachable.
+/// It now panics in all release modes.
+pub inline fn unreachablePanic(comptime fmts: []const u8, args: anytype) noreturn {
+    @branchHint(.cold);
+    std.debug.panic(fmts, args);
+}
+
+const TODO_LOG = Output.scoped(.TODO, false);
+pub inline fn todo(src: std.builtin.SourceLocation, value: anytype) @TypeOf(value) {
+    if (comptime Environment.allow_assert) {
+        TODO_LOG("{s}() at {s}:{d}:{d}", .{ src.fn_name, src.file, src.line, src.column });
+    }
+
+    return value;
+}
+
+pub fn todoPanic(src: std.builtin.SourceLocation, comptime format: []const u8, args: anytype) noreturn {
+    @branchHint(.cold);
+    bun.Analytics.Features.todo_panic = 1;
+    Output.panic("TODO: " ++ format ++ " ({s}:{d})", args ++ .{ src.file, src.line });
+}

--- a/src/output.zig
+++ b/src/output.zig
@@ -468,16 +468,6 @@ pub fn isVerbose() bool {
     return false;
 }
 
-// var _source_for_test: if (Environment.isTest) Source else void = undefined;
-// var _source_for_test_set = false;
-// pub fn initTest() void {
-//     if (_source_for_test_set) return;
-//     _source_for_test_set = true;
-//     const in = std.io.getStdErr();
-//     const out = std.io.getStdOut();
-//     _source_for_test = Source.init(File.from(out), File.from(in));
-//     Source.set(&_source_for_test);
-// }
 pub fn enableBuffering() void {
     if (comptime Environment.isNative) enable_buffering = true;
 }

--- a/src/output.zig
+++ b/src/output.zig
@@ -86,7 +86,7 @@ pub const Source = struct {
 
     pub fn configureThread() void {
         if (source_set) return;
-        bun.debugAssert(stdout_stream_set);
+        bun.debug.debugAssert(stdout_stream_set);
         source = Source.init(stdout_stream, stderr_stream);
         bun.StackCheck.configureThread();
     }
@@ -491,23 +491,23 @@ pub const WriterType: type = @TypeOf(Source.StreamType.quietWriter(undefined));
 
 // TODO: investigate migrating this to the buffered one.
 pub fn errorWriter() WriterType {
-    bun.debugAssert(source_set);
+    bun.debug.debugAssert(source_set);
     return source.error_stream.quietWriter();
 }
 
 pub fn errorWriterBuffered() Source.BufferedStream.Writer {
-    bun.debugAssert(source_set);
+    bun.debug.debugAssert(source_set);
     return source.buffered_error_stream.writer();
 }
 
 // TODO: investigate returning the buffered_error_stream
 pub fn errorStream() Source.StreamType {
-    bun.debugAssert(source_set);
+    bun.debug.debugAssert(source_set);
     return source.error_stream;
 }
 
 pub fn writer() WriterType {
-    bun.debugAssert(source_set);
+    bun.debug.debugAssert(source_set);
     return source.stream.quietWriter();
 }
 
@@ -670,7 +670,7 @@ pub fn debug(comptime fmt: string, args: anytype) void {
 }
 
 pub inline fn _debug(comptime fmt: string, args: anytype) void {
-    bun.debugAssert(source_set);
+    bun.debug.debugAssert(source_set);
     println(fmt, args);
 }
 
@@ -681,7 +681,7 @@ pub noinline fn print(comptime fmt: string, args: anytype) callconv(std.builtin.
         std.fmt.format(source.stream.writer(), fmt, args) catch unreachable;
         root.console_log(root.Uint8Array.fromSlice(source.stream.buffer[0..source.stream.pos]));
     } else {
-        bun.debugAssert(source_set);
+        bun.debug.debugAssert(source_set);
 
         // There's not much we can do if this errors. Especially if it's something like BrokenPipe.
         if (enable_buffering) {
@@ -1182,7 +1182,7 @@ pub fn enableScopedDebugWriter() void {
 extern "c" fn getpid() c_int;
 
 pub fn initScopedDebugWriterAtStartup() void {
-    bun.debugAssert(source_set);
+    bun.debug.debugAssert(source_set);
 
     if (bun.getenvZ("BUN_DEBUG")) |path| {
         if (path.len > 0 and !strings.eql(path, "0") and !strings.eql(path, "false")) {

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -282,7 +282,7 @@ pub const PatchFile = struct {
             while (iter.next()) |line| : (i += 1) {
                 lines.append(bun.default_allocator, line) catch bun.outOfMemory();
             }
-            bun.debugAssert(i == file_line_count);
+            bun.debug.debugAssert(i == file_line_count);
         }
 
         for (patch.hunks.items) |*hunk| {
@@ -1003,7 +1003,7 @@ const PatchLinesParser = struct {
         // index 2de83dd..842652c 100644
         //       ^
         //       we expect that we are here
-        bun.debugAssert(!bun.strings.hasPrefix(line, "index "));
+        bun.debug.debugAssert(!bun.strings.hasPrefix(line, "index "));
 
         // From @pnpm/patch-package the regex is this:
         // const match = line.match(/(\w+)\.\.(\w+)/)

--- a/src/ref_count.zig
+++ b/src/ref_count.zig
@@ -102,7 +102,7 @@ pub fn NewThreadSafeRefCounted(comptime T: type, comptime deinit_fn: ?fn (self: 
         pub fn ref(self: *T) void {
             const ref_count = self.ref_count.fetchAdd(1, .seq_cst);
             if (bun.Environment.isDebug) log("0x{x} ref {d} + 1 = {d}", .{ @intFromPtr(self), ref_count, ref_count - 1 });
-            bun.debugAssert(ref_count > 0);
+            bun.debug.debugAssert(ref_count > 0);
         }
 
         pub fn deref(self: *T) void {

--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -660,7 +660,7 @@ pub const NumberRenamer = struct {
 
     pub fn nameForSymbol(renamer: *NumberRenamer, ref: Ref) string {
         if (ref.isSourceContentsSlice()) {
-            bun.unreachablePanic("Unexpected unbound symbol!\n{any}", .{ref});
+            bun.debug.unreachablePanic("Unexpected unbound symbol!\n{any}", .{ref});
         }
 
         const resolved = renamer.symbols.follow(ref);

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2347,7 +2347,7 @@ pub const Resolver = struct {
             }
         }
 
-        bun.unreachablePanic("TODO: implement enqueueDependencyToResolve for non-root packages", .{});
+        bun.debug.unreachablePanic("TODO: implement enqueueDependencyToResolve for non-root packages", .{});
     }
 
     fn handleESMResolution(r: *ThisResolver, esm_resolution_: ESModule.Resolution, abs_package_path: string, kind: ast.ImportKind, package_json: *PackageJSON, package_subpath: string) ?MatchResult {
@@ -2616,7 +2616,7 @@ pub const Resolver = struct {
             if ((input_path.len == 2 and input_path[1] == ':') or
                 (input_path.len == 3 and input_path[1] == ':' and input_path[2] == '.'))
             {
-                bun.unsafeAssert(input_path.ptr == &win32_normalized_dir_info_cache_buf);
+                bun.debug.unsafeAssert(input_path.ptr == &win32_normalized_dir_info_cache_buf);
                 win32_normalized_dir_info_cache_buf[2] = '\\';
                 input_path.len = 3;
             }

--- a/src/semver/SemverString.zig
+++ b/src/semver/SemverString.zig
@@ -295,7 +295,7 @@ pub const String = extern struct {
     pub fn initInline(
         in: string,
     ) String {
-        bun.assertWithLocation(canInline(in), @src());
+        bun.debug.assertWithLocation(canInline(in), @src());
         return switch (in.len) {
             0 => .{},
             1 => .{ .bytes = .{ in[0], 0, 0, 0, 0, 0, 0, 0 } },

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -3994,9 +3994,9 @@ const SPECIAL_CHARS_TABLE: bun.bit_set.IntegerBitSet(256) = brk: {
     }
     break :brk table;
 };
-pub fn assertSpecialChar(c: u8) void {
-    bun.assert(@inComptime());
-    bun.assert(SPECIAL_CHARS_TABLE.isSet(c));
+
+pub fn assertSpecialChar(comptime c: u8) void {
+    comptime bun.assert(SPECIAL_CHARS_TABLE.isSet(c));
 }
 /// Characters that need to be backslashed inside double quotes
 const BACKSLASHABLE_CHARS = [_]u8{ '$', '`', '"', '\\' };

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -3995,7 +3995,7 @@ const SPECIAL_CHARS_TABLE: bun.bit_set.IntegerBitSet(256) = brk: {
     break :brk table;
 };
 pub fn assertSpecialChar(c: u8) void {
-    bun.assertComptime();
+    bun.assert(@inComptime());
     bun.assert(SPECIAL_CHARS_TABLE.isSet(c));
 }
 /// Characters that need to be backslashed inside double quotes

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -87,7 +87,7 @@ pub fn postgresErrorToJS(globalObject: *JSC.JSGlobalObject, message: ?[]const u8
             return globalObject.takeException(globalObject.throwOutOfMemory());
         },
         error.ShortRead => {
-            bun.unreachablePanic("Assertion failed: ShortRead should be handled by the caller in postgres", .{});
+            bun.debug.unreachablePanic("Assertion failed: ShortRead should be handled by the caller in postgres", .{});
         },
     };
     if (message) |msg| {
@@ -1165,7 +1165,7 @@ pub const PostgresRequest = struct {
                 'd' => try connection.on(.CopyData, Context, reader),
                 'S' => {
                     if (connection.tls_status == .message_sent) {
-                        bun.debugAssert(connection.tls_status.message_sent == 8);
+                        bun.debug.debugAssert(connection.tls_status.message_sent == 8);
                         connection.tls_status = .ssl_ok;
                         connection.setupTLS();
                         return;

--- a/src/string.zig
+++ b/src/string.zig
@@ -1265,6 +1265,6 @@ pub const SliceWithUnderlyingString = struct {
 };
 
 comptime {
-    bun.assert_eql(@sizeOf(bun.String), 24);
-    bun.assert_eql(@alignOf(bun.String), 8);
+    bun.debug.assert_eql(@sizeOf(bun.String), 24);
+    bun.debug.assert_eql(@alignOf(bun.String), 8);
 }

--- a/src/string/MutableString.zig
+++ b/src/string/MutableString.zig
@@ -61,7 +61,7 @@ pub fn writableNBytes(self: *MutableString, amount: usize) Allocator.Error![]u8 
 }
 
 pub fn write(self: *MutableString, bytes: anytype) Allocator.Error!usize {
-    bun.debugAssert(bytes.len == 0 or !bun.isSliceInBuffer(bytes, self.list.allocatedSlice()));
+    bun.debug.debugAssert(bytes.len == 0 or !bun.isSliceInBuffer(bytes, self.list.allocatedSlice()));
     try self.list.appendSlice(self.allocator, bytes);
     return bytes.len;
 }

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -520,7 +520,7 @@ pub inline fn indexOf(self: string, str: string) ?usize {
     const start = bun.C.memmem(self_ptr, self_len, str_ptr, str_len) orelse return null;
 
     const i = @intFromPtr(start) - @intFromPtr(self_ptr);
-    bun.unsafeAssert(i < self_len);
+    bun.debug.unsafeAssert(i < self_len);
     return @as(usize, @intCast(i));
 }
 
@@ -547,7 +547,7 @@ pub const SplitIterator = struct {
     /// Returns a slice of the first field. This never fails.
     /// Call this only to get the first field and then use `next` to get all subsequent fields.
     pub fn first(self: *Self) []const u8 {
-        bun.unsafeAssert(self.index.? == 0);
+        bun.debug.unsafeAssert(self.index.? == 0);
         return self.next().?;
     }
 
@@ -635,7 +635,7 @@ pub const StringOrTinyString = struct {
     } = .{},
 
     comptime {
-        bun.unsafeAssert(@sizeOf(@This()) == 32);
+        bun.debug.unsafeAssert(@sizeOf(@This()) == 32);
     }
 
     pub inline fn slice(this: *const StringOrTinyString) []const u8 {
@@ -1118,8 +1118,8 @@ pub fn eqlCaseInsensitiveASCII(a: string, b: string, comptime check_len: bool) b
         if (a.len == 0) return true;
     }
 
-    bun.unsafeAssert(b.len > 0);
-    bun.unsafeAssert(a.len > 0);
+    bun.debug.unsafeAssert(b.len > 0);
+    bun.debug.unsafeAssert(a.len > 0);
 
     return bun.C.strncasecmp(a.ptr, b.ptr, a.len) == 0;
 }
@@ -1869,14 +1869,14 @@ pub fn utf16Codepoint(comptime Type: type, input: Type) UTF16Replacement {
 /// this is used for an assertion, and PosixToWinNormalizer can help make
 /// an absolute path contain a drive letter.
 pub fn isWindowsAbsolutePathMissingDriveLetter(comptime T: type, chars: []const T) bool {
-    bun.unsafeAssert(bun.path.Platform.windows.isAbsoluteT(T, chars));
-    bun.unsafeAssert(chars.len > 0);
+    bun.debug.unsafeAssert(bun.path.Platform.windows.isAbsoluteT(T, chars));
+    bun.debug.unsafeAssert(chars.len > 0);
 
     // 'C:\hello' -> false
     // This is the most common situation, so we check it first
     if (!(chars[0] == '/' or chars[0] == '\\')) {
-        bun.unsafeAssert(chars.len > 2);
-        bun.unsafeAssert(chars[1] == ':');
+        bun.debug.unsafeAssert(chars.len > 2);
+        bun.debug.unsafeAssert(chars[1] == ':');
         return false;
     }
 
@@ -1904,10 +1904,10 @@ pub fn isWindowsAbsolutePathMissingDriveLetter(comptime T: type, chars: []const 
 }
 
 pub fn fromWPath(buf: []u8, utf16: []const u16) [:0]const u8 {
-    bun.unsafeAssert(buf.len > 0);
+    bun.debug.unsafeAssert(buf.len > 0);
     const to_copy = trimPrefixComptime(u16, utf16, bun.windows.long_path_prefix);
     const encode_into_result = copyUTF16IntoUTF8(buf[0 .. buf.len - 1], []const u16, to_copy, false);
-    bun.unsafeAssert(encode_into_result.written < buf.len);
+    bun.debug.unsafeAssert(encode_into_result.written < buf.len);
     buf[encode_into_result.written] = 0;
     return buf[0..encode_into_result.written :0];
 }
@@ -2021,7 +2021,7 @@ pub fn addNTPathPrefixIfNeeded(wbuf: []u16, utf16: []const u16) [:0]u16 {
 pub const toNTDir = toNTPath;
 
 pub fn toExtendedPathNormalized(wbuf: []u16, utf8: []const u8) [:0]const u16 {
-    bun.unsafeAssert(wbuf.len > 4);
+    bun.debug.unsafeAssert(wbuf.len > 4);
     wbuf[0..4].* = bun.windows.long_path_prefix;
     return wbuf[0 .. toWPathNormalized(wbuf[4..], utf8).len + 4 :0];
 }
@@ -2076,7 +2076,7 @@ pub fn toPathNormalized(buf: []u8, utf8: []const u8) [:0]const u8 {
 }
 
 pub fn normalizeSlashesOnlyT(comptime T: type, buf: []T, path: []const T, comptime desired_slash: u8, comptime always_copy: bool) []const T {
-    comptime bun.unsafeAssert(desired_slash == '/' or desired_slash == '\\');
+    comptime bun.debug.unsafeAssert(desired_slash == '/' or desired_slash == '\\');
     const undesired_slash = if (desired_slash == '/') '\\' else '/';
 
     if (bun.strings.containsCharT(T, path, undesired_slash)) {
@@ -2175,7 +2175,7 @@ pub fn assertIsValidWindowsPath(comptime T: type, path: []const T) void {
 }
 
 pub fn toWPathMaybeDir(wbuf: []u16, utf8: []const u8, comptime add_trailing_lash: bool) [:0]u16 {
-    bun.unsafeAssert(wbuf.len > 0);
+    bun.debug.unsafeAssert(wbuf.len > 0);
 
     var result = bun.simdutf.convert.utf8.to.utf16.with_errors.le(
         utf8,
@@ -2200,7 +2200,7 @@ pub fn toWPathMaybeDir(wbuf: []u16, utf8: []const u8, comptime add_trailing_lash
     return wbuf[0..result.count :0];
 }
 pub fn toPathMaybeDir(buf: []u8, utf8: []const u8, comptime add_trailing_lash: bool) [:0]u8 {
-    bun.unsafeAssert(buf.len > 0);
+    bun.debug.unsafeAssert(buf.len > 0);
 
     var len = utf8.len;
     @memcpy(buf[0..len], utf8[0..len]);
@@ -2296,7 +2296,7 @@ pub fn toUTF8ListWithType(list_: std.ArrayList(u8), comptime Type: type, utf16: 
         // which uses 3 bytes for invalid surrogates, causing the length to not
         // match from simdutf.
         // if (Environment.allow_assert) {
-        //     bun.unsafeAssert(buf.items.len == length);
+        //     bun.debug.unsafeAssert(buf.items.len == length);
         // }
 
         return buf;
@@ -4166,8 +4166,8 @@ pub fn firstNonASCIIWithType(comptime Type: type, slice: Type) ?u32 {
 
         if (comptime Environment.enableSIMD) {
             // these assertions exist more so for LLVM
-            bun.unsafeAssert(remaining.len < ascii_vector_size);
-            bun.unsafeAssert(@intFromPtr(remaining.ptr + ascii_vector_size) > @intFromPtr(remaining_end));
+            bun.debug.unsafeAssert(remaining.len < ascii_vector_size);
+            bun.debug.unsafeAssert(@intFromPtr(remaining.ptr + ascii_vector_size) > @intFromPtr(remaining_end));
         }
 
         if (remaining.len >= size) {
@@ -4180,9 +4180,9 @@ pub fn firstNonASCIIWithType(comptime Type: type, slice: Type) ?u32 {
                     remaining.len -= @intFromPtr(remaining.ptr) - @intFromPtr(remaining_start);
                     const first_set_byte = @ctz(mask) / 8;
                     if (comptime Environment.isDebug) {
-                        bun.unsafeAssert(remaining[first_set_byte] > 127);
+                        bun.debug.unsafeAssert(remaining[first_set_byte] > 127);
                         for (0..first_set_byte) |j| {
-                            bun.unsafeAssert(remaining[j] <= 127);
+                            bun.debug.unsafeAssert(remaining[j] <= 127);
                         }
                     }
 
@@ -4606,8 +4606,8 @@ fn byte2hex(char: u8) u8 {
 
 pub fn encodeBytesToHex(destination: []u8, source: []const u8) usize {
     if (comptime Environment.allow_assert) {
-        bun.unsafeAssert(destination.len > 0);
-        bun.unsafeAssert(source.len > 0);
+        bun.debug.unsafeAssert(destination.len > 0);
+        bun.debug.unsafeAssert(source.len > 0);
     }
     const to_write = if (destination.len < source.len * 2)
         destination.len - destination.len % 2
@@ -4914,7 +4914,7 @@ pub fn firstNonASCII16(comptime Slice: type, slice: Slice) ?u32 {
             remaining.len -= (@intFromPtr(remaining.ptr) - @intFromPtr(remaining_start)) / 2;
         }
 
-        bun.unsafeAssert(remaining.len < ascii_u16_vector_size);
+        bun.debug.unsafeAssert(remaining.len < ascii_u16_vector_size);
     }
 
     var i: usize = (@intFromPtr(remaining.ptr) - @intFromPtr(remaining_start)) / 2;
@@ -5565,14 +5565,14 @@ pub fn moveAllSlices(comptime Type: type, container: *Type, from: string, to: st
 
 pub fn moveSlice(slice: string, from: string, to: string) string {
     if (comptime Environment.allow_assert) {
-        bun.unsafeAssert(from.len <= to.len and from.len >= slice.len);
+        bun.debug.unsafeAssert(from.len <= to.len and from.len >= slice.len);
         // assert we are in bounds
-        bun.unsafeAssert(
+        bun.debug.unsafeAssert(
             (@intFromPtr(from.ptr) + from.len) >=
                 @intFromPtr(slice.ptr) + slice.len and
                 (@intFromPtr(from.ptr) <= @intFromPtr(slice.ptr)),
         );
-        bun.unsafeAssert(eqlLong(from, to[0..from.len], false)); // data should be identical
+        bun.debug.unsafeAssert(eqlLong(from, to[0..from.len], false)); // data should be identical
     }
 
     const ptr_offset = @intFromPtr(slice.ptr) - @intFromPtr(from.ptr);
@@ -5688,7 +5688,7 @@ pub fn concatWithLength(
         @memcpy(remain[0..arg.len], arg);
         remain = remain[arg.len..];
     }
-    bun.unsafeAssert(remain.len == 0); // all bytes should be used
+    bun.debug.unsafeAssert(remain.len == 0); // all bytes should be used
     return out;
 }
 
@@ -5762,7 +5762,7 @@ pub fn concatIfNeeded(
 
         remain = remain[arg.len..];
     }
-    bun.unsafeAssert(remain.len == 0);
+    bun.debug.unsafeAssert(remain.len == 0);
 }
 
 /// This will simply ignore invalid UTF-8 and just do it

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -357,12 +357,12 @@ pub const Error = struct {
         // because we're intending to pass them to writer.print()
         // which will convert them back into UTF*.
         var that = self.withoutPath().toShellSystemError();
-        bun.debugAssert(that.path.tag != .WTFStringImpl);
-        bun.debugAssert(that.dest.tag != .WTFStringImpl);
+        bun.debug.debugAssert(that.path.tag != .WTFStringImpl);
+        bun.debug.debugAssert(that.dest.tag != .WTFStringImpl);
         that.path = bun.String.fromUTF8(self.path);
         that.dest = bun.String.fromUTF8(self.dest);
-        bun.debugAssert(that.path.tag != .WTFStringImpl);
-        bun.debugAssert(that.dest.tag != .WTFStringImpl);
+        bun.debug.debugAssert(that.path.tag != .WTFStringImpl);
+        bun.debug.debugAssert(that.dest.tag != .WTFStringImpl);
 
         return that.format(fmt, opts, writer);
     }


### PR DESCRIPTION
### What does this PR do?
Moves assertion and panic related functions into `debug.zig`. This is part of a larger effort to organize our code, starting with "leaf" modules.

This is a stacked PR. please merge #17859 first.