### PR TITLE
feat(test): add `test.failing`

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -402,6 +402,22 @@ declare module "bun:test" {
       options?: number | TestOptions,
     ): void;
     /**
+     * Marks this test as failing.
+     *
+     * Use `test.failing` when you are writing a test and expecting it to fail.
+     * These tests will behave the other way normal tests do. If failing test
+     * will throw any errors then it will pass. If it does not throw it will
+     * fail.
+     *
+     * `test.failing` is very similar to {@link test.todo} except that it always
+     * runs, regardless of the `--todo` flag.
+     *
+     * @param label the label for the test
+     * @param fn the test function
+     * @param options the test timeout or options
+     */
+    failing(label: string, fn?: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void)): void;
+    /**
      * Runs this test, if `condition` is true.
      *
      * This is the opposite of `test.skipIf()`.
@@ -1060,7 +1076,7 @@ declare module "bun:test" {
 
     /**
      * Asserts that an `object` contains all the provided keys.
-     * 
+     *
      * @example
      * expect({ a: 'foo', b: 'bar', c: 'baz' }).toContainKeys(['a', 'b']);
      * expect({ a: 'foo', b: 'bar', c: 'baz' }).toContainKeys(['a', 'b', 'c']);

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -261,12 +261,14 @@ pub const TestRunner = struct {
         pub const ID = u32;
         pub const List = std.MultiArrayList(Test);
 
-        pub const Status = enum(u3) {
+        pub const Status = enum(u4) {
             pending,
             pass,
             fail,
             skip,
             todo,
+            /// A test marked as `.failing()` actually passed
+            fail_because_failing_test_passed,
             fail_because_todo_passed,
             fail_because_expected_has_assertions,
             fail_because_expected_assertion_count,
@@ -327,40 +329,20 @@ pub const Jest = struct {
             ZigString.static("test"),
             test_fn,
         );
-        test_fn.put(
-            globalObject,
-            ZigString.static("only"),
-            JSC.NewFunction(globalObject, ZigString.static("only"), 2, ThisTestScope.only, false),
-        );
-        test_fn.put(
-            globalObject,
-            ZigString.static("skip"),
-            JSC.NewFunction(globalObject, ZigString.static("skip"), 2, ThisTestScope.skip, false),
-        );
-        test_fn.put(
-            globalObject,
-            ZigString.static("todo"),
-            JSC.NewFunction(globalObject, ZigString.static("todo"), 2, ThisTestScope.todo, false),
-        );
+
+        inline for (.{ "only", "skip", "todo", "failing", "skipIf", "todoIf", "each" }) |method_name| {
+            const name = ZigString.static(method_name);
+            test_fn.put(
+                globalObject,
+                name,
+                JSC.NewFunction(globalObject, name, 2, @field(ThisTestScope, method_name), false),
+            );
+        }
+
         test_fn.put(
             globalObject,
             ZigString.static("if"),
             JSC.NewFunction(globalObject, ZigString.static("if"), 2, ThisTestScope.callIf, false),
-        );
-        test_fn.put(
-            globalObject,
-            ZigString.static("skipIf"),
-            JSC.NewFunction(globalObject, ZigString.static("skipIf"), 2, ThisTestScope.skipIf, false),
-        );
-        test_fn.put(
-            globalObject,
-            ZigString.static("todoIf"),
-            JSC.NewFunction(globalObject, ZigString.static("todoIf"), 2, ThisTestScope.todoIf, false),
-        );
-        test_fn.put(
-            globalObject,
-            ZigString.static("each"),
-            JSC.NewFunction(globalObject, ZigString.static("each"), 2, ThisTestScope.each, false),
         );
 
         module.put(
@@ -369,40 +351,25 @@ pub const Jest = struct {
             test_fn,
         );
         const describe = JSC.NewFunction(globalObject, ZigString.static("describe"), 2, ThisDescribeScope.call, false);
-        describe.put(
-            globalObject,
-            ZigString.static("only"),
-            JSC.NewFunction(globalObject, ZigString.static("only"), 2, ThisDescribeScope.only, false),
-        );
-        describe.put(
-            globalObject,
-            ZigString.static("skip"),
-            JSC.NewFunction(globalObject, ZigString.static("skip"), 2, ThisDescribeScope.skip, false),
-        );
-        describe.put(
-            globalObject,
-            ZigString.static("todo"),
-            JSC.NewFunction(globalObject, ZigString.static("todo"), 2, ThisDescribeScope.todo, false),
-        );
+        inline for (.{
+            "only",
+            "skip",
+            "todo",
+            "skipIf",
+            "todoIf",
+            "each",
+        }) |method_name| {
+            const name = ZigString.static(method_name);
+            describe.put(
+                globalObject,
+                name,
+                JSC.NewFunction(globalObject, name, 2, @field(ThisDescribeScope, method_name), false),
+            );
+        }
         describe.put(
             globalObject,
             ZigString.static("if"),
             JSC.NewFunction(globalObject, ZigString.static("if"), 2, ThisDescribeScope.callIf, false),
-        );
-        describe.put(
-            globalObject,
-            ZigString.static("skipIf"),
-            JSC.NewFunction(globalObject, ZigString.static("skipIf"), 2, ThisDescribeScope.skipIf, false),
-        );
-        describe.put(
-            globalObject,
-            ZigString.static("todoIf"),
-            JSC.NewFunction(globalObject, ZigString.static("todoIf"), 2, ThisDescribeScope.todoIf, false),
-        );
-        describe.put(
-            globalObject,
-            ZigString.static("each"),
-            JSC.NewFunction(globalObject, ZigString.static("each"), 2, ThisDescribeScope.each, false),
         );
 
         module.put(
@@ -602,6 +569,10 @@ pub const TestScope = struct {
         return createScope(globalThis, callframe, "test()", true, .pass);
     }
 
+    pub fn failing(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
+        return createScope(globalThis, callframe, "test()", true, .fail);
+    }
+
     pub fn only(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         return createScope(globalThis, callframe, "test.only()", true, .only);
     }
@@ -741,13 +712,15 @@ pub const TestScope = struct {
         initial_value = callJSFunctionForTestRunner(vm, vm.global, this.func, this.func_arg);
 
         if (initial_value.isAnyError()) {
-            _ = vm.uncaughtException(vm.global, initial_value, true);
-
-            if (this.tag == .todo) {
-                return .{ .todo = {} };
+            if (this.tag != .fail) {
+                _ = vm.uncaughtException(vm.global, initial_value, true);
             }
 
-            return .{ .fail = expect.active_test_expectation_counter.actual };
+            return switch (this.tag) {
+                .todo => .{ .todo = {} },
+                .fail => .{ .pass = expect.active_test_expectation_counter.actual },
+                else => .{ .fail = expect.active_test_expectation_counter.actual },
+            };
         }
 
         if (initial_value.asAnyPromise()) |promise| {
@@ -764,15 +737,19 @@ pub const TestScope = struct {
             }
             switch (promise.status(vm.global.vm())) {
                 .rejected => {
-                    if (!promise.isHandled(vm.global.vm())) {
+                    if (!promise.isHandled(vm.global.vm()) and this.tag != .fail) {
                         _ = vm.unhandledRejection(vm.global, promise.result(vm.global.vm()), promise.asValue(vm.global));
                     }
 
-                    if (this.tag == .todo) {
-                        return .{ .todo = {} };
-                    }
-
-                    return .{ .fail = expect.active_test_expectation_counter.actual };
+                    return switch (this.tag) {
+                        .todo => .{ .todo = {} },
+                        .fail => fail: {
+                            promise.setHandled(vm.global.vm());
+                            
+                            break :fail .{ .pass = expect.active_test_expectation_counter.actual };
+                        },
+                        else => .{ .fail = expect.active_test_expectation_counter.actual },
+                    };
                 },
                 .pending => {
                     task.promise_state = .pending;
@@ -791,7 +768,7 @@ pub const TestScope = struct {
         }
 
         if (this.func_has_callback) {
-            return .{ .pending = {} };
+            return Result{ .pending = {} };
         }
 
         if (expect.active_test_expectation_counter.expected > 0 and expect.active_test_expectation_counter.expected < expect.active_test_expectation_counter.actual) {
@@ -802,7 +779,10 @@ pub const TestScope = struct {
             return .{ .fail = expect.active_test_expectation_counter.actual };
         }
 
-        return .{ .pass = expect.active_test_expectation_counter.actual };
+        return if (this.tag == .fail)
+            .{ .fail_because_failing_test_passed = expect.active_test_expectation_counter.actual }
+        else
+            .{ .pass = expect.active_test_expectation_counter.actual };
     }
 
     pub const name = "TestScope";
@@ -1257,6 +1237,7 @@ pub fn wrapTestFunction(comptime name: []const u8, comptime func: JSC.JSHostZigF
 /// outside of
 pub const WrappedTestScope = struct {
     pub const call = wrapTestFunction("test", TestScope.call);
+    pub const failing = wrapTestFunction("test", TestScope.failing);
     pub const only = wrapTestFunction("test", TestScope.only);
     pub const skip = wrapTestFunction("test", TestScope.skip);
     pub const todo = wrapTestFunction("test", TestScope.todo);
@@ -1587,6 +1568,17 @@ pub const TestRunnerTask = struct {
                 elapsed,
                 describe,
             ),
+            .fail_because_failing_test_passed => |count| {
+                Output.prettyErrorln("  <d>^<r> <red>this test is marked as failing but it passed.<r> <d>Remove `.failing` if tested behavior now works", .{});
+                Jest.runner.?.reportFailure(
+                    test_id,
+                    this.source_file_path,
+                    test_.label,
+                    count,
+                    elapsed,
+                    describe,
+                );
+            },
             .fail_because_expected_has_assertions => {
                 Output.err(error.AssertionError, "received <red>0 assertions<r>, but expected <green>at least one assertion<r> to be called\n", .{});
                 Output.flush();
@@ -1676,6 +1668,7 @@ pub const Result = union(TestRunner.Test.Status) {
     fail: u32,
     skip: void,
     todo: void,
+    fail_because_failing_test_passed: u32,
     fail_because_todo_passed: u32,
     fail_because_expected_has_assertions: void,
     fail_because_expected_assertion_count: Counter,

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -745,7 +745,7 @@ pub const TestScope = struct {
                         .todo => .{ .todo = {} },
                         .fail => fail: {
                             promise.setHandled(vm.global.vm());
-                            
+
                             break :fail .{ .pass = expect.active_test_expectation_counter.actual };
                         },
                         else => .{ .fail = expect.active_test_expectation_counter.actual },

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -378,6 +378,14 @@ pub const JunitReporter = struct {
                 //     try this.contents.appendSlice(bun.default_allocator, "\"");
                 // }
             },
+            .fail_because_failing_test_passed => {
+                this.testcases_metrics.failures += 1;
+                try this.contents.writer(bun.default_allocator).print(
+                    \\>
+                    \\      <failure message="test marked with .failing() did not throw" type="AssertionError"/>
+                    \\    </testcase>
+                , .{});
+            },
             .fail_because_expected_assertion_count => {
                 this.testcases_metrics.failures += 1;
                 // TODO: add the failure message

--- a/test/js/bun/test/fixtures/failing-test-fails.fixture.ts
+++ b/test/js/bun/test/fixtures/failing-test-fails.fixture.ts
@@ -1,0 +1,7 @@
+test.failing("Fixme, this doesnt work", () => {
+  expect(1).toBe(2);
+});
+
+test.failing("This one rejects", async () => {
+  expect(1).toBe(2);
+});

--- a/test/js/bun/test/fixtures/failing-test-passes.fixture.ts
+++ b/test/js/bun/test/fixtures/failing-test-passes.fixture.ts
@@ -1,0 +1,7 @@
+test.failing("This should fail but it doesnt", () => {
+  expect(1).toBe(1);
+});
+
+test.failing("This should fail but it doesnt (async)", async () => {
+  expect(1).toBe(1);
+});

--- a/test/js/bun/test/fixtures/failing-test-timeout.fixture.ts
+++ b/test/js/bun/test/fixtures/failing-test-timeout.fixture.ts
@@ -1,0 +1,4 @@
+jest.setTimeout(5);
+test.failing("timeouts still count as failures", async () => {
+  await Bun.sleep(1000);
+});

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -1,0 +1,41 @@
+import path from "path";
+import { bunExe } from "harness";
+import { $ } from "bun";
+import { fail } from "assert";
+
+const fixtureDir = path.join(import.meta.dir, "fixtures");
+describe("test.failing", () => {
+  it("is a function", () => {
+    expect(test.failing).toBeFunction();
+  });
+
+  it("is an alias for it.failing", () => {
+    expect(it.failing).toBe(test.failing);
+  });
+
+  it("passes if an error is thrown or a promise rejects ", async () => {
+    const result = await $.cwd(fixtureDir)`${bunExe()} test ./failing-test-fails.fixture.ts`.quiet();
+    const stderr = result.stderr.toString();
+    expect(stderr).toContain(" 2 pass\n");
+  });
+
+  it("fails if no error is thrown or promise resolves", async () => {
+    const result = await $.cwd(fixtureDir).nothrow()`${bunExe()} test ./failing-test-passes.fixture.ts`.quiet();
+    const stderr = result.stderr.toString();
+    if (result.exitCode === 0) {
+      fail("Expected exit code to be non-zero\n\n" + stderr);
+    }
+    expect(stderr).toContain(" 2 fail\n");
+    expect(stderr).toContain("this test is marked as failing but it passed");
+  });
+
+  it("timeouts stll count as failures", async () => {
+    const result = await $.cwd(fixtureDir).nothrow()`${bunExe()} test ./failing-test-timeout.fixture.ts`.quiet();
+    const stderr = result.stderr.toString();
+    if (result.exitCode === 0) {
+      fail("Expected exit code to be non-zero\n\n" + stderr);
+    }
+    expect(stderr).toContain(" 1 fail\n");
+    expect(stderr).toContain("timed out after 5ms");
+  });
+});

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -36,6 +36,6 @@ describe("test.failing", () => {
       fail("Expected exit code to be non-zero\n\n" + stderr);
     }
     expect(stderr).toContain(" 1 fail\n");
-    expect(stderr).toContain("timed out after 5ms");
+    expect(stderr).toMatch(/timed out after \d+ms/i);
   });
 });

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -13,6 +13,10 @@ describe("test.failing", () => {
     expect(it.failing).toBe(test.failing);
   });
 
+  it("requires a test function (unlike test.todo)", () => {
+    expect(() => test.failing("test name")).toThrow(/expects a function/i);
+  });
+
   it("passes if an error is thrown or a promise rejects ", async () => {
     const result = await $.cwd(fixtureDir)`${bunExe()} test ./failing-test-fails.fixture.ts`.quiet();
     const stderr = result.stderr.toString();


### PR DESCRIPTION
### What does this PR do?
> Part of #1825

Adds [`test.failing`](https://jestjs.io/docs/api#testfailingname-fn-timeout).

```ts
// add.ts
function add(a, b) {
  // TODO: implement me
  return a;
}

// add.test.ts
describe("add(a, b)", () => {
  it.failing("0 + 0 = 0", () => { // this test will fail
    expect(add(0, 0)).toBe(0);
  });

  it.failing("1 + 1 = 2", () => { // this test will pass
    expect(add(1, 1)).toBe(2);
  });
});
```

### How did you verify your code works?
There are tests
