### PR TITLE
refactor: move `JSValue.get` to `JSObject`

### DIFF
--- a/src/bun.js/bindings/JSObject.zig
+++ b/src/bun.js/bindings/JSObject.zig
@@ -15,7 +15,7 @@ pub const JSObject = extern struct {
     }
 
     /// Non-objects will be runtime-coerced to objects.
-    /// 
+    ///
     /// For cells this is `toObjectSlow`, for other types it's `toObjectSlowCase`.
     pub fn fromJS(value: JSValue, globalThis: JSValue) *JSObject {
         return JSValue.toObject(value, globalThis);
@@ -128,7 +128,6 @@ pub const JSObject = extern struct {
         };
     }
     extern fn JSC__JSObject__getIfPropertyExistsImpl(object: *JSObject, global: *JSGlobalObject, ptr: [*]const u8, len: u32) JSValue;
-
 
     pub fn fastGetWithError(this: *JSObject, global: *JSGlobalObject, builtin_name: JSValue.BuiltinName) bun.JSError!?JSValue {
         return switch (JSC__JSObject__fastGet(this, global, @intFromEnum(builtin_name))) {

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -145,6 +145,8 @@ typedef void* JSClassRef;
 
 CPP_DECL JSC__JSValue JSC__JSObject__create(JSC__JSGlobalObject* arg0, size_t arg1, void* arg2, void(* ArgFn3)(void* arg0, JSC__JSObject* arg1, JSC__JSGlobalObject* arg2));
 CPP_DECL size_t JSC__JSObject__getArrayLength(JSC__JSObject* arg0);
+CPP_DECL JSC__JSValue JSC__JSObject__fastGet(JSC__JSObject* object, JSC__JSGlobalObject* arg1, unsigned char arg2);
+CPP_DECL JSC__JSValue JSC__JSObject__getIfPropertyExistsImpl(JSC__JSObject* object, JSC__JSGlobalObject* arg1, const unsigned char* arg2, uint32_t arg3);
 CPP_DECL JSC__JSValue JSC__JSObject__getDirect(JSC__JSObject* arg0, JSC__JSGlobalObject* arg1, const ZigString* arg2);
 CPP_DECL JSC__JSValue JSC__JSObject__getIndex(JSC__JSValue JSValue0, JSC__JSGlobalObject* arg1, uint32_t arg2);
 CPP_DECL void JSC__JSObject__putRecord(JSC__JSObject* arg0, JSC__JSGlobalObject* arg1, ZigString* arg2, ZigString* arg3, size_t arg4);


### PR DESCRIPTION
### What does this PR do?
> part of #15141

This lets us leverage the type system to only call `.get` on known `JSObject`s.

### How did you verify your code works?
Existing tests cover all changes.
