### PR TITLE
fix(runtime): error stack traces missing column numbers

### DIFF
--- a/src/bun.js/bindings/CallSite.cpp
+++ b/src/bun.js/bindings/CallSite.cpp
@@ -164,14 +164,11 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
             sb.append(mySourceURL->getString(globalObject));
         }
 
-        if (line && column) {
+        if (line) {
             sb.append(':');
             sb.append(line.value().oneBasedInt());
             sb.append(':');
-            sb.append(column.value().oneBasedInt());
-        } else if (line) {
-            sb.append(':');
-            sb.append(line.value().oneBasedInt());
+            sb.append(column ? column.value().oneBasedInt() : 1);
         }
 
         if (functionName.length() > 0) {


### PR DESCRIPTION
### What does this PR do?
Fixes callsite printing in stack traces to always print a column number whenever a line number is printed. It now defaults to 1.

Some existing libraries will parse stack traces to look for a line/column number. In node, column numbers default to `1` and are always present when line numbers are. This PR fixes this incompatibility.