### PR TITLE
rm unused PackageJSON.hash field

### DIFF
--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -470,7 +470,7 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
         const dirpath = std.fs.path.dirname(package_json_path) orelse Global.crash();
         const path = bun.strings.withoutTrailingSlash(dirpath);
 
-        const pkgjson = bun.PackageJSON.parse(&this_transpiler.resolver, dirpath, .zero, null, .include_scripts, .main, .no_hash) orelse {
+        const pkgjson = bun.PackageJSON.parse(&this_transpiler.resolver, dirpath, .zero, null, .include_scripts, .main) orelse {
             Output.warn("Failed to read package.json\n", .{});
             continue;
         };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1611,7 +1611,6 @@ pub const RunCommand = struct {
         }
 
         if (log_errors) {
-            ctx.log.print(Output.errorWriter()) catch {};
             const ext = std.fs.path.extension(target_name);
             const default_loader = options.defaultLoaders.get(ext);
             if (default_loader != null and default_loader.?.isJavaScriptLikeOrJSON() or target_name.len > 0 and (target_name[0] == '.' or target_name[0] == '/' or std.fs.path.isAbsolute(target_name))) {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1611,6 +1611,7 @@ pub const RunCommand = struct {
         }
 
         if (log_errors) {
+            ctx.log.print(Output.errorWriter()) catch {};
             const ext = std.fs.path.extension(target_name);
             const default_loader = options.defaultLoaders.get(ext);
             if (default_loader != null and default_loader.?.isJavaScriptLikeOrJSON() or target_name.len > 0 and (target_name[0] == '.' or target_name[0] == '/' or std.fs.path.isAbsolute(target_name))) {

--- a/src/node_fallbacks.zig
+++ b/src/node_fallbacks.zig
@@ -46,7 +46,6 @@ pub const FallbackModule = struct {
                 .name = name,
                 .version = version,
                 .module_type = .esm,
-                .hash = @as(u32, @truncate(bun.hash(name ++ "@" ++ version))),
                 .main_fields = undefined,
                 .browser_map = undefined,
                 .source = logger.Source.initPathString(import_path ++ name ++ "/package.json", ""),

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1015,7 +1015,8 @@ pub const PackageJSON = struct {
         if (generate_hash) {
             if (package_json.name.len > 0 and package_json.version.len > 0) {
                 package_json.generateHash() catch {
-                    r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "{s}: Package name \"{s}...\" (truncated) is too long to generate hash. The maximum length is 214 characters", .{ package_json_path, package_json.name[0..50] }) catch unreachable;
+                    r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "{s}: Package name \"{s}...\" (truncated) is too long. The maximum length is 214 characters", .{ package_json_path, package_json.name[0..50] }) catch unreachable;
+                    return null;
                 };
             }
         }

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1015,7 +1015,7 @@ pub const PackageJSON = struct {
         if (generate_hash) {
             if (package_json.name.len > 0 and package_json.version.len > 0) {
                 package_json.generateHash() catch {
-                    r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "{s}: Package name \"{s}...\" (truncated) is too long. The maximum length is 214 characters", .{ package_json_path, package_json.name[0..50] }) catch unreachable;
+                    r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "{s}: Package name \"{s}...\" (truncated) is too long. The maximum length is 214 characters.", .{ package_json_path, package_json.name[0..50] }) catch unreachable;
                     return null;
                 };
             }

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -58,22 +58,6 @@ pub const PackageJSON = struct {
 
     pub usingnamespace bun.New(@This());
 
-    pub fn generateHash(package_json: *PackageJSON) !void {
-        if (package_json.name.len > 214) return error.InvalidPackageName;
-        var hashy: [1024]u8 = undefined;
-        @memset(&hashy, 0);
-        var used: usize = 0;
-        bun.copy(u8, &hashy, package_json.name);
-        used = package_json.name.len;
-
-        hashy[used] = '@';
-        used += 1;
-        bun.copy(u8, hashy[used..], package_json.version);
-        used += package_json.version.len;
-
-        package_json.hash = std.hash.Murmur3_32.hash(hashy[0..used]);
-    }
-
     const node_modules_path = std.fs.path.sep_str ++ "node_modules" ++ std.fs.path.sep_str;
 
     pub fn nameForImport(this: *const PackageJSON, allocator: std.mem.Allocator) !string {
@@ -104,7 +88,6 @@ pub const PackageJSON = struct {
     main_fields: MainFieldMap,
     module_type: options.ModuleType,
     version: string = "",
-    hash: u32 = 0xDEADBEEF,
 
     scripts: ?*ScriptsMap = null,
     config: ?*bun.StringArrayHashMap(string) = null,
@@ -173,10 +156,6 @@ pub const PackageJSON = struct {
             };
         }
     };
-
-    pub inline fn isAppPackage(this: *const PackageJSON) bool {
-        return this.hash == 0xDEADBEEF;
-    }
 
     fn loadDefineDefaults(
         env: *options.Env,
@@ -604,9 +583,7 @@ pub const PackageJSON = struct {
         package_id: ?Install.PackageID,
         comptime include_scripts_: enum { ignore_scripts, include_scripts },
         comptime include_dependencies: enum { main, local, none },
-        comptime generate_hash_: enum { generate_hash, no_hash },
     ) ?PackageJSON {
-        const generate_hash = generate_hash_ == .generate_hash;
         const include_scripts = include_scripts_ == .include_scripts;
 
         // TODO: remove this extra copy
@@ -660,7 +637,6 @@ pub const PackageJSON = struct {
         var package_json = PackageJSON{
             .name = "",
             .version = "",
-            .hash = 0xDEADBEEF,
             .source = json_source,
             .module_type = .unknown,
             .browser_map = BrowserMap.init(allocator, false),
@@ -1009,15 +985,6 @@ pub const PackageJSON = struct {
             }
             if (json.asPropertyStringMap("config", allocator)) |config| {
                 package_json.config = config;
-            }
-        }
-
-        if (generate_hash) {
-            if (package_json.name.len > 0 and package_json.version.len > 0) {
-                package_json.generateHash() catch {
-                    r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "{s}: Package name \"{s}...\" (truncated) is too long. The maximum length is 214 characters.", .{ package_json_path, package_json.name[0..50] }) catch unreachable;
-                    return null;
-                };
             }
         }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2564,7 +2564,6 @@ pub const Resolver = struct {
                 package_id,
                 .ignore_scripts,
                 if (allow_dependencies) .local else .none,
-                .generate_hash,
             ) orelse return null;
         } else {
             pkg = PackageJSON.parse(
@@ -2574,7 +2573,6 @@ pub const Resolver = struct {
                 package_id,
                 .include_scripts,
                 if (allow_dependencies) .local else .none,
-                .generate_hash,
             ) orelse return null;
         }
 


### PR DESCRIPTION
### What does this PR do?

fix #9020 

generating package_json.hash uses a fixed buffer size which causes a crash when the package name is too long.
The hash value is never used though, so this patch removes the field altogether.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I ran `bun run boo` with the `package.json` file provided in #9020  and again with the same file after truncating the name to a legal size and ensured no crash.
