### PR TITLE
Revert "Upgrade mimalloc" due to memory usage regression

### DIFF
--- a/cmake/targets/BuildMimalloc.cmake
+++ b/cmake/targets/BuildMimalloc.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     oven-sh/mimalloc
   COMMIT
-    7a4d7b8d18f8159a808aade63eb93ea6abd06924
+    1beadf9651a7bfdec6b5367c380ecc3fe1c40d1a
 )
 
 set(MIMALLOC_CMAKE_ARGS
@@ -31,7 +31,13 @@ if(ENABLE_VALGRIND)
   list(APPEND MIMALLOC_CMAKE_ARGS -DMI_VALGRIND=ON)
 endif()
 
-if(DEBUG)
+if(WIN32)
+  if(DEBUG)
+    set(MIMALLOC_LIBRARY mimalloc-static-debug)
+  else()
+    set(MIMALLOC_LIBRARY mimalloc-static)
+  endif()
+elseif(DEBUG)
   set(MIMALLOC_LIBRARY mimalloc-debug)
 else()
   set(MIMALLOC_LIBRARY mimalloc)


### PR DESCRIPTION
Reverts oven-sh/bun#17817

```
❯ PORT=3002 bun-17818 .next/standalone/server.js
   ▲ Next.js 15.1.3
   - Local:        http://localhost:3002
   - Network:      http://0.0.0.0:3002

 ✓ Starting...
 ✓ Ready in 32ms
RSS 92.9609375 MB
RSS 273.0859375 MB
RSS 239.91796875 MB
RSS 233.41015625 MB
RSS 218.15234375 MB
RSS 220.48828125 MB
RSS 219.65234375 MB
RSS 218.45703125 MB
RSS 221.90234375 MB
RSS 219.0078125 MB
RSS 219.41015625 MB
RSS 216.6953125 MB
RSS 215.1640625 MB
RSS 189.078125 MB
RSS 173.5390625 MB                                             RSS 165.8359375 MB
RSS 160.96875 MB
^CRSS 148.39453125 MB

…test-64-minimal in nexta on  main [!] via 🍞 v1.2.5 took 19s
❯ PORT=3002 bun-17817 .next/standalone/server.js
   ▲ Next.js 15.1.3
   - Local:        http://localhost:3002
   - Network:      http://0.0.0.0:3002

 ✓ Starting...
 ✓ Ready in 33ms
RSS 133.3046875 MB
RSS 368.91015625 MB
RSS 333.6171875 MB
RSS 323.2265625 MB
RSS 314.796875 MB
RSS 320.6953125 MB
RSS 315.375 MB
RSS 311.828125 MB
RSS 314.1171875 MB
RSS 316.96875 MB
RSS 314.54296875 MB
RSS 313.296875 MB
RSS 312.51171875 MB
RSS 268.35546875 MB
RSS 268.0703125 MB
RSS 256.73046875 MB
RSS 246.0703125 MB
RSS 246.3203125 MB
RSS 246.3203125 MB
^C⏎