### PR TITLE
Do not idle in the event loop if there are pending immediate tasks

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -202,8 +202,6 @@ pub const All = struct {
                     return true;
                 },
             }
-
-            unreachable;
         }
 
         return false;

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -176,14 +176,18 @@ pub const All = struct {
         if (this.active_timer_count == 0) {
             return false;
         }
+        if (vm.event_loop.immediate_tasks.count > 0 or vm.event_loop.next_immediate_tasks.count > 0) {
+            spec.* = .{ .nsec = 0, .sec = 0 };
+            return true;
+        }
 
-        var now: timespec = undefined;
-        var has_set_now: bool = false;
+        var maybe_now: ?timespec = null;
         while (this.timers.peek()) |min| {
-            if (!has_set_now) {
-                now = timespec.now();
-                has_set_now = true;
-            }
+            const now = maybe_now orelse now: {
+                const real_now = timespec.now();
+                maybe_now = real_now;
+                break :now real_now;
+            };
 
             switch (now.order(&min.next)) {
                 .gt, .eq => {

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1507,7 +1507,7 @@ pub const EventLoop = struct {
             var event_loop_sleep_timer = if (comptime Environment.isDebug) std.time.Timer.start() catch unreachable;
             // for the printer, this is defined:
             var timespec: bun.timespec = if (Environment.isDebug) .{ .sec = 0, .nsec = 0 } else undefined;
-            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
+            loop.tickWithTimeout(if (this.immediate_tasks.count == 0 and ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
 
             if (comptime Environment.isDebug) {
                 log("tick {}, timeout: {}", .{ std.fmt.fmtDuration(event_loop_sleep_timer.read()), std.fmt.fmtDuration(timespec.ns()) });

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1507,7 +1507,7 @@ pub const EventLoop = struct {
             var event_loop_sleep_timer = if (comptime Environment.isDebug) std.time.Timer.start() catch unreachable;
             // for the printer, this is defined:
             var timespec: bun.timespec = if (Environment.isDebug) .{ .sec = 0, .nsec = 0 } else undefined;
-            loop.tickWithTimeout(if (this.immediate_tasks.count == 0 and ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
+            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
 
             if (comptime Environment.isDebug) {
                 log("tick {}, timeout: {}", .{ std.fmt.fmtDuration(event_loop_sleep_timer.read()), std.fmt.fmtDuration(timespec.ns()) });
@@ -1593,7 +1593,7 @@ pub const EventLoop = struct {
             this.processGCTimer();
             var timespec: bun.timespec = undefined;
 
-            loop.tickWithTimeout(if (this.immediate_tasks.count == 0 and ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
+            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
         } else {
             loop.tickWithoutIdle();
         }

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1593,7 +1593,7 @@ pub const EventLoop = struct {
             this.processGCTimer();
             var timespec: bun.timespec = undefined;
 
-            loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
+            loop.tickWithTimeout(if (this.immediate_tasks.count == 0 and ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
         } else {
             loop.tickWithoutIdle();
         }

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -230,7 +230,8 @@ describe("clear", () => {
 });
 
 describe.each(["with", "without"])("setImmediate %s timers running", mode => {
-  it.skipIf(isWindows && mode == "with")(
+  // TODO(@190n) #17901 did not fix this for Windows
+  it.todoIf(isWindows && mode == "with")(
     "has reasonable performance when nested",
     async () => {
       const process = Bun.spawn({

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test, mock } from "bun:test";
 import { clearInterval, clearTimeout, promises, setInterval, setTimeout, setImmediate } from "node:timers";
 import { promisify } from "util";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import jsc from "bun:jsc";
 import path from "node:path";
 
@@ -229,10 +229,10 @@ describe("clear", () => {
   });
 });
 
-describe("setImmediate", () => {
-  it.each(["with", "without"])(
-    "has reasonable performance when nested %s timers running",
-    async mode => {
+describe.each(["with", "without"])("setImmediate %s timers running", mode => {
+  it.skipIf(isWindows && mode == "with")(
+    "has reasonable performance when nested",
+    async () => {
       const process = Bun.spawn({
         cmd: [bunExe(), path.join(__dirname, "setImmediate-fixture.ts"), mode + "-interval"],
         stdout: "pipe",

--- a/test/js/node/timers/setImmediate-fixture.ts
+++ b/test/js/node/timers/setImmediate-fixture.ts
@@ -1,6 +1,24 @@
+const createInterval =
+  process.argv[2] == "with-interval"
+    ? true
+    : process.argv[2] == "without-interval"
+      ? false
+      : (() => {
+          throw new Error("bad argument");
+        })();
+
+let interval: Timer | undefined;
+if (createInterval) {
+  interval = setInterval(() => {}, 1000);
+}
+
 let i = 0;
 setImmediate(function callback() {
   i++;
   console.log("callback");
-  if (i < 5000) setImmediate(callback);
+  if (i < 5000) {
+    setImmediate(callback);
+  } else if (interval) {
+    clearInterval(interval);
+  }
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #17725. The presence of a `setInterval` timer would make us idle in `us_loop_run_bun_tick` on every run of the event loop for a dozen ms or so, but that's not a good idea when we have immediate tasks to run. This PR makes us skip the timeout if there are immediate tasks, similar to what we already do if there is a short timer (in terms of the effect on idling, immediates are like 0ms timers).

Todo:

- [ ] see how much we can benefit JSZip
- [ ] fix Windows failure

### How did you verify your code works?

Ran the `node:timers` tests, and extended our own tests to cover a use case like #17725.