### PR TITLE
vscode extention - support test names with special characters

### DIFF
--- a/packages/bun-vscode/example/example.test.ts
+++ b/packages/bun-vscode/example/example.test.ts
@@ -28,4 +28,9 @@ describe("example", () => {
       };
     }).toThrow();
   });
+
+  test("can run with special chars :)", () => {
+    // if this test runs, it's a success.
+    // a failure is if it's either skipped or fails the runner
+  })
 });

--- a/packages/bun-vscode/src/features/tests/index.ts
+++ b/packages/bun-vscode/src/features/tests/index.ts
@@ -73,6 +73,16 @@ class TestCodeLensProvider implements vscode.CodeLensProvider {
 const DEFAULT_FILE_PATTERN = "**/*{.test.,.spec.,_test_,_spec_}{js,ts,tsx,jsx,mts,cts}";
 
 /**
+ * Escape any special characters in the input string, so that regex-matching on it
+ * will work as expected.
+ * i.e `new Regex(escapeRegex("hi (:").test("hi (:")` will return true, instead of throwing
+ * an invalid regex error.
+ */
+function escapeRegex(testName: string) {
+  return testName.replaceAll(/[^a-zA-Z0-9_+\-'"\ ]/g, "\\$&");
+}
+
+/**
  * This function registers a CodeLens provider for test files. It is used to display the "Run" and "Watch" buttons.
  */
 export function registerTestCodeLens(context: vscode.ExtensionContext) {
@@ -171,11 +181,12 @@ export function registerTestRunner(context: vscode.ExtensionContext) {
       }
 
       if (testName && testName.length) {
+        const escapedTestName = escapeRegex(testName);
         if (customScriptSetting.length) {
           // escape the quotes in the test name
-          command += ` -t "${testName}"`;
+          command += ` -t "${escapedTestName}"`;
         } else {
-          command += ` -t "${testName}"`;
+          command += ` -t "${escapedTestName}"`;
         }
       }
 

--- a/packages/bun-vscode/src/features/tests/index.ts
+++ b/packages/bun-vscode/src/features/tests/index.ts
@@ -73,16 +73,6 @@ class TestCodeLensProvider implements vscode.CodeLensProvider {
 const DEFAULT_FILE_PATTERN = "**/*{.test.,.spec.,_test_,_spec_}{js,ts,tsx,jsx,mts,cts}";
 
 /**
- * Escape any special characters in the input string, so that regex-matching on it
- * will work as expected.
- * i.e `new Regex(escapeRegex("hi (:").test("hi (:")` will return true, instead of throwing
- * an invalid regex error.
- */
-function escapeRegex(testName: string) {
-  return testName.replaceAll(/[^a-zA-Z0-9_+\-'"\ ]/g, "\\$&");
-}
-
-/**
  * This function registers a CodeLens provider for test files. It is used to display the "Run" and "Watch" buttons.
  */
 export function registerTestCodeLens(context: vscode.ExtensionContext) {
@@ -212,4 +202,15 @@ export function registerTestRunner(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(runTestCommand);
   context.subscriptions.push(watchTestCommand);
+}
+
+
+/**
+ * Escape any special characters in the input string, so that regex-matching on it
+ * will work as expected.
+ * i.e `new RegExp(escapeRegex("hi (:").test("hi (:")` will return true, instead of throwing
+ * an invalid regex error.
+ */
+function escapeRegex(source: string) {
+  return source.replaceAll(/[^a-zA-Z0-9_+\-'"\ ]/g, "\\$&");
 }


### PR DESCRIPTION
### What does this PR do?

This escapes test names when running them via the VsCode CodeLens commands "Run Test" or "Watch Test". With this change, tests with names like `parse {` or `something (something)` run as expected, instead of failing the runner in the former case or getting skipped in the latter case.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

Manual testing. Added a test called `can run with special chars :)` to the extension's example project, and verified that it's being run when clicking the "Run Test" action.

https://github.com/user-attachments/assets/65456ede-4255-4c57-aaaa-f44981d3c30e

The VsCode extension isn't covered by CI tests, and a PR like this doesn't seem like the place to introduce them.