### PR TITLE
fix(node/net): infinite loop when `connect` is called without args

### DIFF
--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -1341,6 +1341,29 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         }
         case 2: {
             JSValue arg0 = callFrame->argument(1);
+            // ["foo", "bar", "baz"] -> 'The "foo", "bar", or "baz" argument must be specified'
+            if (auto* arr = jsDynamicCast<JSC::JSArray*>(arg0)) {
+                ASSERT(arr->length() > 0);
+                WTF::StringBuilder builder;
+                builder.append("The "_s);
+                for (unsigned i = 0, length = arr->length(); i < length; i++) {
+                    JSValue index = arr->getIndex(globalObject, i);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    if (i == length - 1) builder.append("or "_s);
+                    builder.append('"');
+                    auto* jsString = index.toString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    auto str = jsString->view(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    builder.append(str);
+                    builder.append('"');
+                    if (i != length - 1) builder.append(',');
+                    builder.append(' ');
+                }
+                builder.append("argument must be specified"_s);
+                return JSC::JSValue::encode(createError(globalObject, error, builder.toString()));
+            }
+
             auto* jsString = arg0.toString(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             auto str0 = jsString->view(globalObject);

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -605,6 +605,12 @@ declare function $ERR_STREAM_DESTROYED(method: string): Error;
 declare function $ERR_METHOD_NOT_IMPLEMENTED(method: string): Error;
 declare function $ERR_STREAM_ALREADY_FINISHED(method: string): Error;
 declare function $ERR_MISSING_ARGS(a1: string, a2?: string): TypeError;
+/**
+ * `The "foo" or "bar" or "baz" argument must be specified`
+ *
+ * Panics if `oneOf` is empty.
+ */
+declare function $ERR_MISSING_ARGS(oneOf: string[]): TypeError;
 declare function $ERR_INVALID_RETURN_VALUE(expected_type: string, name: string, actual_value: any): TypeError;
 
 declare function $ERR_IPC_DISCONNECTED(): Error;

--- a/src/js/internal/net.ts
+++ b/src/js/internal/net.ts
@@ -1,4 +1,10 @@
 const [addServerName, upgradeDuplexToTLS, isNamedPipeSocket] = $zig("socket.zig", "createNodeTLSBinding");
 const { SocketAddress } = $zig("node_net_binding.zig", "createBinding");
 
-export default { addServerName, upgradeDuplexToTLS, isNamedPipeSocket, SocketAddress };
+export default {
+  addServerName,
+  upgradeDuplexToTLS,
+  isNamedPipeSocket,
+  SocketAddress,
+  normalizedArgsSymbol: Symbol("normalizedArgs"),
+};

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -653,8 +653,11 @@ const Socket = (function (InternalSocket) {
       connection.destroy();
     }
 
-    connect(...args) {
+    public connect(...args) {
       const [options, connectListener] = normalizeArgs(args);
+      if (options.port === undefined && options.path == null) {
+        throw $ERR_MISSING_ARGS(["options", "port", "path"]);
+      }
       let connection = this.#socket;
 
       let upgradeDuplex = false;
@@ -1607,9 +1610,9 @@ function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
 }
 
-function normalizeArgs(args) {
-  while (args[args.length - 1] == null) args.pop();
-  let arr;
+function normalizeArgs(args: unknown[]) {
+  while (args.length && args[args.length - 1] == null) args.pop();
+  let arr: [options: Record<PropertyKey, any>, cb: Function | null] | undefined;
 
   if (args.length === 0) {
     arr = [{}, null];

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -669,7 +669,7 @@ const Socket = (function (InternalSocket) {
 
       if (
         // TLSSocket already created a socket and is forwarding it here. This is a private API.
-        !(options.socket && $isObject(options.socket) && options.socket instanceof Socket) &&
+        !(options.socket && $isObject(options.socket) && options.socket instanceof Duplex) &&
         // public api for net.Socket.connect
         options.port === undefined &&
         options.path == null

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -22,7 +22,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 const { Duplex } = require("node:stream");
 const EventEmitter = require("node:events");
-const { SocketAddress, addServerName, upgradeDuplexToTLS, isNamedPipeSocket } = require("internal/net");
+const {
+  SocketAddress,
+  addServerName,
+  upgradeDuplexToTLS,
+  isNamedPipeSocket,
+  normalizedArgsSymbol,
+} = require("internal/net");
 const { ExceptionWithHostPort } = require("internal/shared");
 import type { SocketListener } from "bun";
 import type { ServerOpts, Server as ServerType } from "node:net";
@@ -654,8 +660,20 @@ const Socket = (function (InternalSocket) {
     }
 
     public connect(...args) {
-      const [options, connectListener] = normalizeArgs(args);
-      if (options.port === undefined && options.path == null) {
+      const [options, connectListener] =
+        $isArray(args[0]) && args[0][normalizedArgsSymbol]
+          ? // args have already been normalized.
+            // Normalized array is passed as the first and only argument.
+            ($assert(args[0].length == 2 && typeof args[0][0] === "object"), args[0])
+          : normalizeArgs(args);
+
+      if (
+        // TLSSocket already created a socket and is forwarding it here. This is a private API.
+        !(options.socket && $isObject(options.socket) && options.socket instanceof Socket) &&
+        // public api for net.Socket.connect
+        options.port === undefined &&
+        options.path == null
+      ) {
         throw $ERR_MISSING_ARGS(["options", "port", "path"]);
       }
       let connection = this.#socket;
@@ -1610,12 +1628,13 @@ function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
 }
 
-function normalizeArgs(args: unknown[]) {
+function normalizeArgs(args: unknown[]): [options: Record<PropertyKey, any>, cb: Function | null] {
   while (args.length && args[args.length - 1] == null) args.pop();
-  let arr: [options: Record<PropertyKey, any>, cb: Function | null] | undefined;
+  let arr;
 
   if (args.length === 0) {
     arr = [{}, null];
+    arr[normalizedArgsSymbol as symbol] = true;
     return arr;
   }
 
@@ -1635,6 +1654,7 @@ function normalizeArgs(args: unknown[]) {
   const cb = args[args.length - 1];
   if (typeof cb !== "function") arr = [options, null];
   else arr = [options, cb];
+  arr[normalizedArgsSymbol as symbol] = true;
 
   return arr;
 }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -667,15 +667,6 @@ const Socket = (function (InternalSocket) {
             ($assert(args[0].length == 2 && typeof args[0][0] === "object"), args[0])
           : normalizeArgs(args);
 
-      if (
-        // TLSSocket already created a socket and is forwarding it here. This is a private API.
-        !(options.socket && $isObject(options.socket) && options.socket instanceof Duplex) &&
-        // public api for net.Socket.connect
-        options.port === undefined &&
-        options.path == null
-      ) {
-        throw $ERR_MISSING_ARGS(["options", "port", "path"]);
-      }
       let connection = this.#socket;
 
       let upgradeDuplex = false;
@@ -739,6 +730,16 @@ const Socket = (function (InternalSocket) {
 
       if (fd) {
         return this;
+      }
+
+      if (
+        // TLSSocket already created a socket and is forwarding it here. This is a private API.
+        !(socket && $isObject(socket) && socket instanceof Duplex) &&
+        // public api for net.Socket.connect
+        port === undefined &&
+        path == null
+      ) {
+        throw $ERR_MISSING_ARGS(["options", "port", "path"]);
       }
 
       this.remotePort = port;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -648,8 +648,7 @@ const DEFAULT_ECDH_CURVE = "auto",
 
 function normalizeConnectArgs(listArgs) {
   const args = net._normalizeArgs(listArgs);
-  const options = args[0];
-  const cb = args[1];
+  $assert($isObject(args[0]));
 
   // If args[0] was options, then normalize dealt with it.
   // If args[0] is port, or args[0], args[1] is host, port, we need to
@@ -657,27 +656,25 @@ function normalizeConnectArgs(listArgs) {
   // the host/port/path args that it knows about, not the tls options.
   // This means that options.host overrides a host arg.
   if (listArgs[1] !== null && typeof listArgs[1] === "object") {
-    ObjectAssign(options, listArgs[1]);
+    ObjectAssign(args[0], listArgs[1]);
   } else if (listArgs[2] !== null && typeof listArgs[2] === "object") {
-    ObjectAssign(options, listArgs[2]);
+    ObjectAssign(args[0], listArgs[2]);
   }
 
-  return cb ? [options, cb] : [options];
+  return args;
 }
 
 // tls.connect(options[, callback])
 // tls.connect(path[, options][, callback])
 // tls.connect(port[, host][, options][, callback])
 function connect(...args) {
-  if (typeof args[0] !== "object") {
-    return new TLSSocket().connect(...args);
-  }
-  let [options, callback] = normalizeConnectArgs(args);
+  let normal = normalizeConnectArgs(args);
+  const options = normal[0];
   const { ALPNProtocols } = options;
   if (ALPNProtocols) {
     convertALPNProtocols(ALPNProtocols, options);
   }
-  return new TLSSocket(options).connect(options, callback);
+  return new TLSSocket(options).connect(normal);
 }
 
 function getCiphers() {

--- a/test/js/node/test/parallel/test-net-connect-no-arg.js
+++ b/test/js/node/test/parallel/test-net-connect-no-arg.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const net = require('net');
+
+// Tests that net.connect() called without arguments throws ERR_MISSING_ARGS.
+const message = 'The "options", "port", or "path" argument must be specified';
+assert.throws(() => {
+  net.connect();
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message,
+});
+
+assert.throws(() => {
+  new net.Socket().connect();
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message,
+});
+
+assert.throws(() => {
+  net.connect({});
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message,
+});
+
+assert.throws(() => {
+  new net.Socket().connect({});
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message,
+});


### PR DESCRIPTION
### What does this PR do?
Extracted from #17907.
- Fixes an infinite loop in `normalizeArgs` when `net.Socket.prototype.connect` is called with only null/undefined arguments
- Gets `parallel/test-net-connect-no-arg.js` passing

### How did you verify your code works?
There is a test
