### PR TITLE
node:http2: add throw for ERR_HTTP2_UNSUPPORTED_PROTOCOL

### DIFF
--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -1554,6 +1554,14 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_BUFFER_OUT_OF_BOUNDS, "Attempt to access memory outside buffer bounds"_s));
     }
 
+    case Bun::ErrorCode::ERR_HTTP2_UNSUPPORTED_PROTOCOL: {
+        auto arg0 = callFrame->argument(1);
+        auto str0 = arg0.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto message = makeString("protocol \""_s, str0, "\" is unsupported."_s);
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_UNSUPPORTED_PROTOCOL, message));
+    }
+
     case ErrorCode::ERR_IPC_DISCONNECTED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_IPC_DISCONNECTED, "IPC channel is already disconnected"_s));
     case ErrorCode::ERR_SERVER_NOT_RUNNING:

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -88,6 +88,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_CHAR", TypeError],
   ["MODULE_NOT_FOUND", Error],
   ["ERR_SERVER_ALREADY_LISTEN", Error],
+  ["ERR_HTTP2_UNSUPPORTED_PROTOCOL", Error],
 
   // Bun-specific
   ["ERR_FORMDATA_PARSE_ERROR", TypeError],

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -606,6 +606,7 @@ declare function $ERR_METHOD_NOT_IMPLEMENTED(method: string): Error;
 declare function $ERR_STREAM_ALREADY_FINISHED(method: string): Error;
 declare function $ERR_MISSING_ARGS(a1: string, a2?: string): TypeError;
 declare function $ERR_INVALID_RETURN_VALUE(expected_type: string, name: string, actual_value: any): TypeError;
+declare function $ERR_HTTP2_UNSUPPORTED_PROTOCOL(protocol: string): Error;
 
 declare function $ERR_IPC_DISCONNECTED(): Error;
 declare function $ERR_SERVER_NOT_RUNNING(): Error;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2155,7 +2155,10 @@ function connectWithProtocol(protocol: string, options: Http2ConnectOptions | st
   if (protocol === "http:") {
     return net.connect(options, listener);
   }
-  return tls.connect(options, listener);
+  if (protocol === "https:") {
+    return tls.connect(options, listener);
+  }
+  throw $ERR_HTTP2_UNSUPPORTED_PROTOCOL(protocol);
 }
 
 function emitConnectNT(self, socket) {


### PR DESCRIPTION
this is progress toward `test-http2-connect.js` but i didnt add it here since there were other issues and i noticed this while inspecting other code