### PR TITLE
Fix 14585 — unminified identifier collisions

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -15785,6 +15785,7 @@ fn NewParser_(
                             .binding = p.b(B.Identifier{ .ref = ref }, local.loc),
                         };
                         try partStmts.append(p.s(S.Local{ .decls = G.Decl.List.init(decls) }, local.loc));
+                        try p.declared_symbols.append(p.allocator, .{ .ref = ref, .is_top_level = true });
                     }
                 }
                 p.relocated_top_level_vars.clearRetainingCapacity();

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2263,6 +2263,37 @@ describe("bundler", () => {
       stdout: "success",
     },
   });
+  // https://github.com/oven-sh/bun/issues/14585
+  itBundled("identifiers/SameNameDifferentModulesWithMinifyIdentifiersDisabled", {
+    files: {
+      "/foo.js": `
+        {
+            var d = 0;
+        }
+
+        export const foo = () => {}
+      `,
+      "/bar.js": `
+        // bar.js - The collision happens with this function declaration
+        function d() {}
+        export function bar() {d.length;}
+      `,
+      "/index.js": `
+        import { foo } from "./foo.js";
+        import { bar } from "./bar.js";
+
+        // Execute in order
+        foo();
+        bar();
+      `,
+    },
+    entryPoints: ["/index.js"],
+    outfile: "/out.js",
+    minifyIdentifiers: false,
+    run: {
+      stdout: "",
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/oven-sh/bun/issues/14585

This fixes a bundling bug in which the parsing step fails to hoist block-scoped vars, which can result in identifier collisions. 

### Implementation
I did a fair amount of debugging in `bundler_v2.zig` and `renamer.zig` to understand the issue well enough to identify the issue being in the parsing step. Namely, the discovery that at identifier rename time, `d` was not a [top-level symbol](https://github.com/oven-sh/bun/blob/main/src/bundler/bundle_v2.zig#L10159) in any of `foo.js`'s chunks. It was instead in a child scope. Thus, the performing renaming on `bar.js` wasn't detecting that the identifier `d` was already taken by the block-scoped var in `foo.js`.

That said, I spent much less time stepping through the `js_parser.zig` stack frames and have a very limited understanding of it. The implementation may be less than ideal for all I know.

### How did you verify your code works?
- [X] I included a test for the new code, or existing tests cover it
- [X] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

I added the test @Jarred-Sumner [provided](https://github.com/oven-sh/bun/issues/14585#issuecomment-2683914329) based on my initial reproduction of the issue. I observed the test failing initially, and passing after the the change. Additionally, manually verifying the output looks as expected:
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/27a1aae5-317f-46c8-a395-e81e0e8e6ce2" />


#### Zig change PR template checkboxes
I don't know if these apply or how to do/answer them.
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [X] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
