### PR TITLE
fix: dont run all nested beforeAll hooks on test start 

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1048,12 +1048,12 @@ pub const DescribeScope = struct {
         return null;
     }
 
-    pub fn runBeforeAllIfNeeded(
+    pub fn runBeforeAll(
         this: *DescribeScope,
         globalObject: *JSGlobalObject,
     ) ?JSValue {
         if (this.parent) |p| {
-            if (p.runBeforeAllIfNeeded(globalObject)) |err| {
+            if (p.runBeforeAll(globalObject)) |err| {
                 return err;
             }
         }
@@ -1387,7 +1387,7 @@ pub const TestRunnerTask = struct {
         jsc_vm.onUnhandledRejectionCtx = this;
         jsc_vm.onUnhandledRejection = onUnhandledRejection;
 
-        if (this.describe.runBeforeAllIfNeeded(globalThis)) |err| {
+        if (this.describe.runBeforeAll(globalThis)) |err| {
             _ = jsc_vm.uncaughtException(globalThis, err, true);
             Jest.runner.?.reportFailure(test_id, this.source_file_path, test_.label, 0, 0, describe);
             return false;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -814,7 +814,6 @@ pub const DescribeScope = struct {
     done: bool = false,
     skip_count: u32 = 0,
     tag: Tag = .pass,
-    needs_before_all: bool = true,
 
     fn isWithinOnlyScope(this: *const DescribeScope) bool {
         if (this.tag == .only) return true;

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1153,15 +1153,6 @@ pub const DescribeScope = struct {
         var i: TestRunner.Test.ID = 0;
 
         if (this.shouldEvaluateScope()) {
-            if (this.runCallback(globalObject, .beforeAll)) |err| {
-                _ = globalObject.bunVM().uncaughtException(globalObject, err, true);
-                while (i < end) {
-                    Jest.runner.?.reportFailure(i + this.test_id_start, source.path.text, tests[i].label, 0, 0, this);
-                    i += 1;
-                }
-                this.deinit(globalObject);
-                return;
-            }
             if (end == 0) {
                 var runner = allocator.create(TestRunnerTask) catch unreachable;
                 runner.* = .{

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1039,28 +1039,8 @@ pub const DescribeScope = struct {
             return err;
         }
 
-        if (comptime hook == .beforeEach) {
+        if (comptime hook == .beforeAll or hook == .beforeEach) {
             if (this.runBeforeCallbacks(globalObject, hook)) |err| {
-                return err;
-            }
-        }
-
-        return null;
-    }
-
-    pub fn runBeforeAll(
-        this: *DescribeScope,
-        globalObject: *JSGlobalObject,
-    ) ?JSValue {
-        if (this.parent) |p| {
-            if (p.runBeforeAll(globalObject)) |err| {
-                return err;
-            }
-        }
-
-        if (this.needs_before_all) {
-            this.needs_before_all = false;
-            if (this.execCallback(globalObject, .beforeAll)) |err| {
                 return err;
             }
         }
@@ -1387,7 +1367,7 @@ pub const TestRunnerTask = struct {
         jsc_vm.onUnhandledRejectionCtx = this;
         jsc_vm.onUnhandledRejection = onUnhandledRejection;
 
-        if (this.describe.runBeforeAll(globalThis)) |err| {
+        if (this.describe.runCallback(globalThis, .beforeAll)) |err| {
             _ = jsc_vm.uncaughtException(globalThis, err, true);
             Jest.runner.?.reportFailure(test_id, this.source_file_path, test_.label, 0, 0, describe);
             return false;

--- a/test/js/bun/test/jest-hooks.test.ts
+++ b/test/js/bun/test/jest-hooks.test.ts
@@ -20,7 +20,7 @@ describe("describe scope", () => {
     afterEach(() => hooks_run.push("nested describe afterEach"));
 
     it("should run after nested beforeAll/beforeEach in the correct order", () => {
-      // First test
+      // Entries from before first test
       expect(hooks_run).toEqual([
         "global beforeAll",
         "describe beforeAll",
@@ -33,6 +33,35 @@ describe("describe scope", () => {
 
     it("should run after nested afterEach/afterAll in the correct order", () => {
       expect(hooks_run).toEqual([
+        // Entries from before first test
+        "global beforeAll",
+        "describe beforeAll",
+        "nested describe beforeAll",
+        "global beforeEach",
+        "describe beforeEach",
+        "nested describe beforeEach",
+
+        // Entries from after first test
+        "nested describe afterEach",
+        "describe afterEach",
+        "global afterEach",
+
+        // Entries from before second test
+        "global beforeEach",
+        "describe beforeEach",
+        "nested describe beforeEach",
+      ]);
+    });
+  });
+
+  describe("nested describe scope 2", () => {
+    beforeAll(() => hooks_run.push("nested describe 2 beforeAll"));
+    beforeEach(() => hooks_run.push("nested describe 2 beforeEach"));
+    afterAll(() => hooks_run.push("nested describe 2 afterAll"));
+    afterEach(() => hooks_run.push("nested describe 2 afterEach"));
+
+    it("should run after beforeAll/beforeEach in the correct order", () => {
+      expect(hooks_run).toEqual([
         // Entries from first test
         "global beforeAll",
         "describe beforeAll",
@@ -41,77 +70,29 @@ describe("describe scope", () => {
         "describe beforeEach",
         "nested describe beforeEach",
 
-        // New entries
+        // Entries from after first test
         "nested describe afterEach",
         "describe afterEach",
         "global afterEach",
+
+        // Entries from before second test
         "global beforeEach",
         "describe beforeEach",
         "nested describe beforeEach",
+
+        // Entries from after second test
+        "nested describe afterEach",
+        "describe afterEach",
+        "global afterEach",
+        "nested describe afterAll",
+
+        // Entries from before third test
+        "nested describe 2 beforeAll",
+        "global beforeEach",
+        "describe beforeEach",
+        "nested describe 2 beforeEach",
       ]);
     });
-  });
-
-  it("should run after beforeAll/beforeEach in the correct order", () => {
-    expect(hooks_run).toEqual([
-      // Entries from first test
-      "global beforeAll",
-      "describe beforeAll",
-      "nested describe beforeAll",
-      "global beforeEach",
-      "describe beforeEach",
-      "nested describe beforeEach",
-
-      // Entries from second test
-      "nested describe afterEach",
-      "describe afterEach",
-      "global afterEach",
-      "global beforeEach",
-      "describe beforeEach",
-      "nested describe beforeEach",
-
-      // New entries
-      "nested describe afterEach",
-      "describe afterEach",
-      "global afterEach",
-      "nested describe afterAll",
-      "global beforeEach",
-      "describe beforeEach",
-    ]);
-  });
-
-  it("should run after afterEach/afterAll in the correct order", () => {
-    expect(hooks_run).toEqual([
-      // Entries from first test
-      "global beforeAll",
-      "describe beforeAll",
-      "nested describe beforeAll",
-      "global beforeEach",
-      "describe beforeEach",
-      "nested describe beforeEach",
-
-      // Entries from second test
-      "nested describe afterEach",
-      "describe afterEach",
-      "global afterEach",
-      "global beforeEach",
-      "describe beforeEach",
-      "nested describe beforeEach",
-
-      // Entries from third test
-      "nested describe afterEach",
-      "describe afterEach",
-      "global afterEach",
-      "nested describe afterAll",
-      "global beforeEach",
-      "describe beforeEach",
-
-      // New entries
-      "describe afterEach",
-      "global afterEach",
-      "global beforeEach",
-      "describe beforeEach",
-    ]);
   });
 });
 

--- a/test/js/bun/test/jest-hooks.test.ts
+++ b/test/js/bun/test/jest-hooks.test.ts
@@ -248,4 +248,37 @@ describe("test jest hooks in bun-test", () => {
       expect(afterEachCalled).toEqual(1);
     });
   });
+
+  describe("nested beforeAll blocks", () => {
+    let runHistory: string[] = [];
+
+    beforeAll(() => {
+      runHistory.push("top-level beforeAll");
+    });
+
+    it("should run the top-level beforeAll once for the first test", () => {
+      expect(runHistory).toEqual(["top-level beforeAll"]);
+    });
+
+    describe("nested scope level 1", () => {
+      beforeAll(() => {
+        runHistory.push("nested scope 1 beforeAll");
+      });
+
+      it("should have called both top-level and nested-level-1 beforeAll only once apiece", () => {
+        // Because we cleared runHistory above, we should see the calls fresh here
+        expect(runHistory).toEqual(["top-level beforeAll", "nested scope 1 beforeAll"]);
+      });
+
+      describe("nested scope level 2", () => {
+        beforeAll(() => {
+          runHistory.push("nested scope 2 beforeAll");
+        });
+
+        it("should have called top-level, level-1, and level-2 beforeAll only once each", () => {
+          expect(runHistory).toEqual(["top-level beforeAll", "nested scope 1 beforeAll", "nested scope 2 beforeAll"]);
+        });
+      });
+    });
+  });
 });

--- a/test/js/bun/test/jest-hooks.test.ts
+++ b/test/js/bun/test/jest-hooks.test.ts
@@ -13,16 +13,100 @@ describe("describe scope", () => {
   afterAll(() => hooks_run.push("describe afterAll"));
   afterEach(() => hooks_run.push("describe afterEach"));
 
+  describe("nested describe scope", () => {
+    beforeAll(() => hooks_run.push("nested describe beforeAll"));
+    beforeEach(() => hooks_run.push("nested describe beforeEach"));
+    afterAll(() => hooks_run.push("nested describe afterAll"));
+    afterEach(() => hooks_run.push("nested describe afterEach"));
+
+    it("should run after nested beforeAll/beforeEach in the correct order", () => {
+      // First test
+      expect(hooks_run).toEqual([
+        "global beforeAll",
+        "describe beforeAll",
+        "nested describe beforeAll",
+        "global beforeEach",
+        "describe beforeEach",
+        "nested describe beforeEach",
+      ]);
+    });
+
+    it("should run after nested afterEach/afterAll in the correct order", () => {
+      expect(hooks_run).toEqual([
+        // Entries from first test
+        "global beforeAll",
+        "describe beforeAll",
+        "nested describe beforeAll",
+        "global beforeEach",
+        "describe beforeEach",
+        "nested describe beforeEach",
+
+        // New entries
+        "nested describe afterEach",
+        "describe afterEach",
+        "global afterEach",
+        "global beforeEach",
+        "describe beforeEach",
+        "nested describe beforeEach",
+      ]);
+    });
+  });
+
   it("should run after beforeAll/beforeEach in the correct order", () => {
-    expect(hooks_run).toEqual(["global beforeAll", "describe beforeAll", "global beforeEach", "describe beforeEach"]);
+    expect(hooks_run).toEqual([
+      // Entries from first test
+      "global beforeAll",
+      "describe beforeAll",
+      "nested describe beforeAll",
+      "global beforeEach",
+      "describe beforeEach",
+      "nested describe beforeEach",
+
+      // Entries from second test
+      "nested describe afterEach",
+      "describe afterEach",
+      "global afterEach",
+      "global beforeEach",
+      "describe beforeEach",
+      "nested describe beforeEach",
+
+      // New entries
+      "nested describe afterEach",
+      "describe afterEach",
+      "global afterEach",
+      "nested describe afterAll",
+      "global beforeEach",
+      "describe beforeEach",
+    ]);
   });
 
   it("should run after afterEach/afterAll in the correct order", () => {
     expect(hooks_run).toEqual([
+      // Entries from first test
       "global beforeAll",
       "describe beforeAll",
+      "nested describe beforeAll",
       "global beforeEach",
       "describe beforeEach",
+      "nested describe beforeEach",
+
+      // Entries from second test
+      "nested describe afterEach",
+      "describe afterEach",
+      "global afterEach",
+      "global beforeEach",
+      "describe beforeEach",
+      "nested describe beforeEach",
+
+      // Entries from third test
+      "nested describe afterEach",
+      "describe afterEach",
+      "global afterEach",
+      "nested describe afterAll",
+      "global beforeEach",
+      "describe beforeEach",
+
+      // New entries
       "describe afterEach",
       "global afterEach",
       "global beforeEach",
@@ -246,39 +330,6 @@ describe("test jest hooks in bun-test", () => {
     it("should have called afterEach for previous test", () => {
       expect(beforeEachCalled).toEqual(2); // Called once just before this test
       expect(afterEachCalled).toEqual(1);
-    });
-  });
-
-  describe("nested beforeAll blocks", () => {
-    let runHistory: string[] = [];
-
-    beforeAll(() => {
-      runHistory.push("top-level beforeAll");
-    });
-
-    it("should run the top-level beforeAll once for the first test", () => {
-      expect(runHistory).toEqual(["top-level beforeAll"]);
-    });
-
-    describe("nested scope level 1", () => {
-      beforeAll(() => {
-        runHistory.push("nested scope 1 beforeAll");
-      });
-
-      it("should have called both top-level and nested-level-1 beforeAll only once apiece", () => {
-        // Because we cleared runHistory above, we should see the calls fresh here
-        expect(runHistory).toEqual(["top-level beforeAll", "nested scope 1 beforeAll"]);
-      });
-
-      describe("nested scope level 2", () => {
-        beforeAll(() => {
-          runHistory.push("nested scope 2 beforeAll");
-        });
-
-        it("should have called top-level, level-1, and level-2 beforeAll only once each", () => {
-          expect(runHistory).toEqual(["top-level beforeAll", "nested scope 1 beforeAll", "nested scope 2 beforeAll"]);
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->


This fixes a bug in the bun test runner related to `beforeAll` timing execution. Previously, `beforeAll` blocks inside nested `describe` blocks would execute at the beginning of the entire test file, rather than immediately before their `describe` block began. 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

Example test file:

```typescript
import { afterAll, beforeAll, describe, expect, it } from "bun:test";

beforeAll(() => console.log("beforeAll top level"));
afterAll(() => console.log("afterAll top level"));
describe("describe root", () => {
  beforeAll(() => console.log("beforeAll describe root"));
  afterAll(() => console.log("afterAll describe root"));

  describe("describe 1", () => {
    beforeAll(() => console.log("beforeAll describe 1"));
    afterAll(() => console.log("afterAll describe 1"));
    it("test 1", () => {
      console.log("started test 1");
      expect(true).toBe(true);
    });
  });

  describe("describe 2", () => {
    beforeAll(() => console.log("beforeAll describe 2"));
    afterAll(() => console.log("afterAll describe 2"));

    it("test 2", () => {
      console.log("started test 2");
      expect(true).toBe(true);
    });
  });
});
```

Before fix:

```bash
beforeAll top level
beforeAll describe root
beforeAll describe 1
beforeAll describe 2
started test 1
✓ describe root > describe 1 > test 1 [0.06ms]
afterAll describe 1
started test 2
✓ describe root > describe 2 > test 2 [0.01ms]
afterAll describe 2
afterAll describe root
afterAll top level
```

After fix:

```bash
beforeAll top level
beforeAll describe root
beforeAll describe 1
started test 1
✓ describe root > describe 1 > test 1 [0.03ms]
afterAll describe 1
beforeAll describe 2
started test 2
✓ describe root > describe 2 > test 2 [0.01ms]
afterAll describe 2
afterAll describe root
afterAll top level
```

### How did you verify your code works?

I updated the tests in `jest-hooks.test.ts` to validate this order of operations

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->



- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
