### PR TITLE
Faster new TextDecoder()

### DIFF
--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -1571,6 +1571,10 @@ pub const JSValue = enum(i64) {
         @"error",
         default,
         encoding,
+        fatal,
+        ignoreBOM,
+        type,
+        signal,
 
         pub fn has(property: []const u8) bool {
             return bun.ComptimeEnumMap(BuiltinName).has(property);

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5390,9 +5390,13 @@ enum class BuiltinNamesMap : uint8_t {
     error,
     defaultKeyword,
     encoding,
+    fatal,
+    ignoreBOM,
+    type,
+    signal,
 };
 
-static inline const JSC::Identifier builtinNameMap(JSC::VM& vm, unsigned char name)
+static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char name)
 {
 
     auto clientData = WebCore::clientData(vm);
@@ -5425,7 +5429,7 @@ static inline const JSC::Identifier builtinNameMap(JSC::VM& vm, unsigned char na
         return clientData->builtinNames().redirectPublicName();
     }
     case BuiltinNamesMap::inspectCustom: {
-        return Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.util.inspect.custom"_s));
+        return clientData->builtinNames().inspectCustomPublicName();
     }
     case BuiltinNamesMap::highWaterMark: {
         return clientData->builtinNames().highWaterMarkPublicName();
@@ -5454,9 +5458,21 @@ static inline const JSC::Identifier builtinNameMap(JSC::VM& vm, unsigned char na
     case BuiltinNamesMap::encoding: {
         return clientData->builtinNames().encodingPublicName();
     }
+    case BuiltinNamesMap::fatal: {
+        return clientData->builtinNames().fatalPublicName();
+    }
+    case BuiltinNamesMap::ignoreBOM: {
+        return clientData->builtinNames().ignoreBOMPublicName();
+    }
+    case BuiltinNamesMap::type: {
+        return vm.propertyNames->type;
+    }
+    case BuiltinNamesMap::signal: {
+        return clientData->builtinNames().signalPublicName();
+    }
     default: {
         ASSERT_NOT_REACHED();
-        return Identifier();
+        __builtin_unreachable();
     }
     }
 }
@@ -5478,8 +5494,8 @@ JSC__JSValue JSC__JSValue__fastGet(JSC__JSValue JSValue0, JSC__JSGlobalObject* g
     JSC::JSObject* object = value.getObject();
     ASSERT_WITH_MESSAGE(object, "fastGet() called on non-object. Check that the JSValue is an object before calling fastGet().");
     auto& vm = JSC::getVM(globalObject);
-    const auto property = JSC::PropertyName(builtinNameMap(vm, arg2));
 
+    const auto property = JSC::PropertyName(builtinNameMap(vm, arg2));
     return JSC::JSValue::encode(Bun::getIfPropertyExistsPrototypePollutionMitigationUnsafe(vm, globalObject, object, property));
 }
 
@@ -5490,6 +5506,7 @@ extern "C" JSC__JSValue JSC__JSValue__fastGetOwn(JSC__JSValue JSValue0, JSC__JSG
     PropertySlot slot = PropertySlot(value, PropertySlot::InternalMethodType::GetOwnProperty);
     const Identifier name = builtinNameMap(globalObject->vm(), arg2);
     auto* object = value.getObject();
+
     if (object->getOwnPropertySlot(object, globalObject, name, slot)) {
         return JSValue::encode(slot.getValue(globalObject, name));
     }

--- a/src/bun.js/bindings/webcore/JSTextEncoder.cpp
+++ b/src/bun.js/bindings/webcore/JSTextEncoder.cpp
@@ -387,7 +387,7 @@ static inline JSC::EncodedJSValue jsTextEncoderPrototypeFunction_encodeBody(JSC:
     JSC::EncodedJSValue res;
     StringView str;
     if (input->is8Bit()) {
-        if (input->isRope()) {
+        if (input->isNonSubstringRope()) {
             GCDeferralContext gcDeferralContext(vm);
             auto encodedValue = TextEncoder__encodeRopeString(lexicalGlobalObject, input);
             if (!JSC::JSValue::decode(encodedValue).isUndefined()) {
@@ -428,7 +428,9 @@ static inline JSC::EncodedJSValue jsTextEncoderPrototypeFunction_encodeIntoBody(
     if (UNLIKELY(callFrame->argumentCount() < 2))
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto source = argument0.value().toWTFString(lexicalGlobalObject);
+    auto* str = argument0.value().toString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    auto source = str->view(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto* destination = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(argument1.value());
@@ -438,11 +440,11 @@ static inline JSC::EncodedJSValue jsTextEncoderPrototypeFunction_encodeIntoBody(
     }
 
     size_t res = 0;
-    if (!source.is8Bit()) {
-        const auto span = source.span16();
+    if (!source->is8Bit()) {
+        const auto span = source->span16();
         res = TextEncoder__encodeInto16(span.data(), span.size(), destination->vector(), destination->byteLength());
     } else {
-        const auto span = source.span8();
+        const auto span = source->span8();
         res = TextEncoder__encodeInto8(span.data(), span.size(), destination->vector(), destination->byteLength());
     }
 

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -20,10 +20,27 @@ namespace WebCore {
 
 using namespace JSC;
 
+// Keep this list sorted.
 #define BUN_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(macro) \
+    macro(AbortSignal) \
+    macro(Buffer) \
+    macro(Bun) \
+    macro(Loader) \
+    macro(ReadableByteStreamController) \
+    macro(ReadableStream) \
+    macro(ReadableStreamBYOBReader) \
+    macro(ReadableStreamBYOBRequest) \
+    macro(ReadableStreamDefaultController) \
+    macro(ReadableStreamDefaultReader) \
+    macro(SQL) \
+    macro(TextEncoderStreamEncoder) \
+    macro(TransformStream) \
+    macro(TransformStreamDefaultController) \
+    macro(WritableStream) \
+    macro(WritableStreamDefaultController) \
+    macro(WritableStreamDefaultWriter) \
     macro(_events) \
     macro(abortAlgorithm) \
-    macro(AbortSignal) \
     macro(abortSteps) \
     macro(addAbortAlgorithmToSignal) \
     macro(addEventListener) \
@@ -31,13 +48,13 @@ using namespace JSC;
     macro(argv) \
     macro(assignToStream) \
     macro(associatedReadableByteStreamController) \
+    macro(atimeMs) \
     macro(autoAllocateChunkSize) \
     macro(backpressure) \
     macro(backpressureChangePromise) \
     macro(basename) \
+    macro(birthtimeMs) \
     macro(body) \
-    macro(Buffer) \
-    macro(Bun) \
     macro(bunNativePtr) \
     macro(bunNativeType) \
     macro(byobRequest) \
@@ -48,11 +65,11 @@ using namespace JSC;
     macro(cloneArrayBuffer) \
     macro(close) \
     macro(closeAlgorithm) \
+    macro(closeRequest) \
+    macro(closeRequested) \
     macro(closed) \
     macro(closedPromise) \
     macro(closedPromiseCapability) \
-    macro(closeRequest) \
-    macro(closeRequested) \
     macro(code) \
     macro(connect) \
     macro(controlledReadableStream) \
@@ -67,6 +84,7 @@ using namespace JSC;
     macro(createUninitializedArrayBuffer) \
     macro(createUsedReadableStream) \
     macro(createWritableStreamFromInternal) \
+    macro(ctimeMs) \
     macro(cwd) \
     macro(data) \
     macro(dataView) \
@@ -90,6 +108,7 @@ using namespace JSC;
     macro(exports) \
     macro(extname) \
     macro(failureKind) \
+    macro(fastPath) \
     macro(fatal) \
     macro(fd) \
     macro(fetch) \
@@ -115,8 +134,8 @@ using namespace JSC;
     macro(importer) \
     macro(inFlightCloseRequest) \
     macro(inFlightWriteRequest) \
-    macro(initializeWith) \
     macro(inherits) \
+    macro(initializeWith) \
     macro(internalModuleRegistry) \
     macro(internalRequire) \
     macro(internalStream) \
@@ -132,7 +151,6 @@ using namespace JSC;
     macro(lazyStreamPrototypeMap) \
     macro(lineText) \
     macro(loadCJS2ESM) \
-    macro(Loader) \
     macro(localStreams) \
     macro(main) \
     macro(makeAbortError) \
@@ -141,6 +159,10 @@ using namespace JSC;
     macro(makeGetterTypeError) \
     macro(method) \
     macro(mockedFunction) \
+    macro(mode) \
+    macro(mtimeMs) \
+    macro(napiDlopenHandle) \
+    macro(napiWrappedContents) \
     macro(nextTick) \
     macro(normalize) \
     macro(on) \
@@ -176,18 +198,12 @@ using namespace JSC;
     macro(put) \
     macro(queue) \
     macro(read) \
-    macro(readable) \
-    macro(ReadableByteStreamController) \
-    macro(ReadableStream) \
-    macro(ReadableStreamBYOBReader) \
-    macro(ReadableStreamBYOBRequest) \
-    macro(readableStreamController) \
-    macro(ReadableStreamDefaultController) \
-    macro(ReadableStreamDefaultReader) \
-    macro(readableStreamToArray) \
-    macro(reader) \
     macro(readIntoRequests) \
     macro(readRequests) \
+    macro(readable) \
+    macro(readableStreamController) \
+    macro(readableStreamToArray) \
+    macro(reader) \
     macro(readyPromise) \
     macro(readyPromiseCapability) \
     macro(redirect) \
@@ -206,6 +222,7 @@ using namespace JSC;
     macro(setBody) \
     macro(setStatus) \
     macro(setup) \
+    macro(signal) \
     macro(sink) \
     macro(size) \
     macro(start) \
@@ -228,14 +245,11 @@ using namespace JSC;
     macro(textDecoderStreamDecoder) \
     macro(textDecoderStreamTransform) \
     macro(textEncoderStreamEncoder) \
-    macro(TextEncoderStreamEncoder) \
     macro(textEncoderStreamTransform) \
     macro(toClass) \
     macro(toNamespacedPath) \
     macro(trace) \
     macro(transformAlgorithm) \
-    macro(TransformStream) \
-    macro(TransformStreamDefaultController) \
     macro(uncork) \
     macro(underlyingByteSource) \
     macro(underlyingSink) \
@@ -249,24 +263,12 @@ using namespace JSC;
     macro(view) \
     macro(warning) \
     macro(writable) \
-    macro(WritableStream) \
-    macro(WritableStreamDefaultController) \
-    macro(WritableStreamDefaultWriter) \
     macro(write) \
     macro(writeAlgorithm) \
-    macro(writer) \
     macro(writeRequests) \
+    macro(writer) \
     macro(writing) \
     macro(written) \
-    macro(napiDlopenHandle) \
-    macro(napiWrappedContents) \
-    macro(fastPath) \
-    macro(SQL) \
-    macro(atimeMs) \
-    macro(mtimeMs) \
-    macro(ctimeMs) \
-    macro(birthtimeMs) \
-    macro(mode) \
     BUN_ADDITIONAL_BUILTIN_NAMES(macro)
 // --- END of BUN_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME ---
 
@@ -288,9 +290,16 @@ public:
     BUN_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(DECLARE_BUILTIN_IDENTIFIER_ACCESSOR)
 
     const JSC::Identifier& resolvePublicName() const { return m_vm.propertyNames->resolve;}
+    const JSC::Identifier& inspectCustomPublicName() {
+        if (UNLIKELY(m_inspectCustomPublicName.isEmpty())) {
+            m_inspectCustomPublicName = Identifier::fromUid(m_vm.symbolRegistry().symbolForKey("nodejs.util.inspect.custom"_s));
+        }
+        return m_inspectCustomPublicName;
+    }
 
 private:
     JSC::VM& m_vm;
+    JSC::Identifier m_inspectCustomPublicName {};
     BUN_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(DECLARE_BUILTIN_NAMES)
 };
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
