### PR TITLE
Make `TimeoutObject` 8 bytes smaller

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2610,7 +2610,7 @@ pub const Formatter = struct {
                     return try this.printAs(.Undefined, Writer, writer_, .undefined, .Cell, enable_ansi_colors);
                 } else if (value.as(JSC.API.Bun.Timer.TimeoutObject)) |timer| {
                     this.addForNewLine("Timeout(# ) ".len + bun.fmt.fastDigitCount(@as(u64, @intCast(@max(timer.internals.id, 0)))));
-                    if (timer.internals.kind == .setInterval) {
+                    if (timer.internals.flags.kind == .setInterval) {
                         this.addForNewLine("repeats ".len + bun.fmt.fastDigitCount(@as(u64, @intCast(@max(timer.internals.id, 0)))));
                         writer.print(comptime Output.prettyFmt("<r><blue>Timeout<r> <d>(#<yellow>{d}<r><d>, repeats)<r>", enable_ansi_colors), .{
                             timer.internals.id,

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -39,7 +39,7 @@ pub const All = struct {
     warned_not_number: bool = false,
     /// Incremented when timers are scheduled or rescheduled. See doc comment on
     /// TimerObjectInternals.epoch.
-    epoch: u32 = 0,
+    epoch: u25 = 0,
 
     // We split up the map here to avoid storing an extra "repeat" boolean
     maps: struct {
@@ -99,7 +99,7 @@ pub const All = struct {
         timer.next = time.*;
         if (timer.jsTimerInternals()) |internals| {
             this.epoch +%= 1;
-            internals.epoch = this.epoch;
+            internals.flags.epoch = this.epoch;
         }
 
         this.timers.insert(timer);
@@ -287,7 +287,7 @@ pub const All = struct {
             Debugger.didScheduleAsyncCall(
                 globalThis,
                 .DOMTimer,
-                ID.asyncID(.{ .id = id, .kind = kind }),
+                ID.asyncID(.{ .id = id, .kind = kind.big() }),
                 kind != .setInterval, // single_shot
             );
         }
@@ -709,32 +709,37 @@ pub const ImmediateObject = struct {
 const TimerObjectInternals = struct {
     /// Identifier for this timer that is exposed to JavaScript (by `+timer`)
     id: i32 = -1,
-    /// Whenever a timer is inserted into the heap (which happen on creation or refresh), the global
-    /// epoch is incremented and the new epoch is set on the timer. For timers created by
-    /// JavaScript, the epoch is used to break ties between timers scheduled for the same
-    /// millisecond. This ensures that if you set two timers for the same amount of time, and
-    /// refresh the first one, the first one will fire last. This mimics Node.js's behavior where
-    /// the refreshed timer will be inserted at the end of a list, which makes it fire later.
-    epoch: u32,
-    kind: Kind = .setTimeout,
     interval: u31 = 0,
-    // we do not allow the timer to be refreshed after we call clearInterval/clearTimeout
-    has_cleared_timer: bool = false,
-    is_keeping_event_loop_alive: bool = false,
-
-    // if they never access the timer by integer, don't create a hashmap entry.
-    has_accessed_primitive: bool = false,
-
     strong_this: JSC.Strong = .empty,
+    flags: Flags = .{},
 
-    has_js_ref: bool = true,
+    const Flags = packed struct(u32) {
+        /// Whenever a timer is inserted into the heap (which happen on creation or refresh), the global
+        /// epoch is incremented and the new epoch is set on the timer. For timers created by
+        /// JavaScript, the epoch is used to break ties between timers scheduled for the same
+        /// millisecond. This ensures that if you set two timers for the same amount of time, and
+        /// refresh the first one, the first one will fire last. This mimics Node.js's behavior where
+        /// the refreshed timer will be inserted at the end of a list, which makes it fire later.
+        epoch: u25 = 0,
 
-    /// Set to `true` only during execution of the JavaScript function so that `_destroyed` can be
-    /// false during the callback, even though the `state` will be `FIRED`.
-    in_callback: bool = false,
+        kind: Kind = .setTimeout,
+
+        // we do not allow the timer to be refreshed after we call clearInterval/clearTimeout
+        has_cleared_timer: bool = false,
+        is_keeping_event_loop_alive: bool = false,
+
+        // if they never access the timer by integer, don't create a hashmap entry.
+        has_accessed_primitive: bool = false,
+
+        has_js_ref: bool = true,
+
+        /// Set to `true` only during execution of the JavaScript function so that `_destroyed` can be
+        /// false during the callback, even though the `state` will be `FIRED`.
+        in_callback: bool = false,
+    };
 
     fn eventLoopTimer(this: *TimerObjectInternals) *EventLoopTimer {
-        switch (this.kind) {
+        switch (this.flags.kind) {
             .setImmediate => {
                 const parent: *ImmediateObject = @fieldParentPtr("internals", this);
                 assert(parent.event_loop_timer.tag == .ImmediateObject);
@@ -749,14 +754,14 @@ const TimerObjectInternals = struct {
     }
 
     fn ref(this: *TimerObjectInternals) void {
-        switch (this.kind) {
+        switch (this.flags.kind) {
             .setImmediate => @as(*ImmediateObject, @fieldParentPtr("internals", this)).ref(),
             .setTimeout, .setInterval => @as(*TimeoutObject, @fieldParentPtr("internals", this)).ref(),
         }
     }
 
     fn deref(this: *TimerObjectInternals) void {
-        switch (this.kind) {
+        switch (this.flags.kind) {
             .setImmediate => @as(*ImmediateObject, @fieldParentPtr("internals", this)).deref(),
             .setTimeout, .setInterval => @as(*TimeoutObject, @fieldParentPtr("internals", this)).deref(),
         }
@@ -765,10 +770,10 @@ const TimerObjectInternals = struct {
     extern "c" fn Bun__JSTimeout__call(encodedTimeoutValue: JSValue, globalObject: *JSC.JSGlobalObject) void;
 
     pub fn runImmediateTask(this: *TimerObjectInternals, vm: *VirtualMachine) void {
-        if (this.has_cleared_timer or
+        if (this.flags.has_cleared_timer or
             // unref'd setImmediate callbacks should only run if there are things keeping the event
             // loop alive other than setImmediates
-            (!this.is_keeping_event_loop_alive and !vm.isEventLoopAliveExcludingImmediates()))
+            (!this.flags.is_keeping_event_loop_alive and !vm.isEventLoopAliveExcludingImmediates()))
         {
             this.deref();
             return;
@@ -800,13 +805,13 @@ const TimerObjectInternals = struct {
     }
 
     pub fn asyncID(this: *const TimerObjectInternals) u64 {
-        return ID.asyncID(.{ .id = this.id, .kind = this.kind });
+        return ID.asyncID(.{ .id = this.id, .kind = this.flags.kind.big() });
     }
 
     pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *JSC.VirtualMachine) EventLoopTimer.Arm {
         const id = this.id;
-        const kind = this.kind;
-        const has_been_cleared = this.eventLoopTimer().state == .CANCELLED or this.has_cleared_timer or vm.scriptExecutionStatus() != .running;
+        const kind = this.flags.kind.big();
+        const has_been_cleared = this.eventLoopTimer().state == .CANCELLED or this.flags.has_cleared_timer or vm.scriptExecutionStatus() != .running;
 
         this.eventLoopTimer().state = .FIRED;
 
@@ -817,7 +822,7 @@ const TimerObjectInternals = struct {
                 Debugger.didCancelAsyncCall(globalThis, .DOMTimer, ID.asyncID(.{ .id = id, .kind = kind }));
             }
 
-            this.has_cleared_timer = true;
+            this.flags.has_cleared_timer = true;
             this.strong_this.deinit();
             this.deref();
 
@@ -851,7 +856,7 @@ const TimerObjectInternals = struct {
                         // If we didn't clear the setInterval, reschedule it starting from
                         vm.timer.update(this.eventLoopTimer(), &time_before_call);
 
-                        if (this.has_js_ref) {
+                        if (this.flags.has_js_ref) {
                             this.setEnableKeepingEventLoopAlive(vm, true);
                         }
 
@@ -896,8 +901,8 @@ const TimerObjectInternals = struct {
         }
 
         // Bun__JSTimeout__call handles exceptions.
-        this.in_callback = true;
-        defer this.in_callback = false;
+        this.flags.in_callback = true;
+        defer this.flags.in_callback = false;
         Bun__JSTimeout__call(this_object, globalThis);
     }
 
@@ -911,11 +916,11 @@ const TimerObjectInternals = struct {
         callback: JSValue,
         arguments: JSValue,
     ) void {
+        const vm = globalThis.bunVM();
         this.* = .{
             .id = id,
-            .kind = kind,
+            .flags = .{ .kind = kind, .epoch = vm.timer.epoch },
             .interval = interval,
-            .epoch = globalThis.bunVM().timer.epoch,
         };
 
         if (kind == .setImmediate) {
@@ -923,8 +928,8 @@ const TimerObjectInternals = struct {
                 ImmediateObject.argumentsSetCached(timer_js, globalThis, arguments);
             ImmediateObject.callbackSetCached(timer_js, globalThis, callback);
             const parent: *ImmediateObject = @fieldParentPtr("internals", this);
-            globalThis.bunVM().enqueueImmediateTask(JSC.Task.init(parent));
-            this.setEnableKeepingEventLoopAlive(globalThis.bunVM(), true);
+            vm.enqueueImmediateTask(JSC.Task.init(parent));
+            this.setEnableKeepingEventLoopAlive(vm, true);
             // ref'd by event loop
             parent.ref();
         } else {
@@ -932,7 +937,7 @@ const TimerObjectInternals = struct {
                 TimeoutObject.argumentsSetCached(timer_js, globalThis, arguments);
             TimeoutObject.callbackSetCached(timer_js, globalThis, callback);
             // this increments the refcount
-            this.reschedule(globalThis.bunVM());
+            this.reschedule(vm);
         }
 
         this.strong_this.set(globalThis, timer_js);
@@ -942,8 +947,8 @@ const TimerObjectInternals = struct {
         const this_value = callframe.this();
         this_value.ensureStillAlive();
 
-        const did_have_js_ref = this.has_js_ref;
-        this.has_js_ref = true;
+        const did_have_js_ref = this.flags.has_js_ref;
+        this.flags.has_js_ref = true;
 
         if (!did_have_js_ref) {
             this.setEnableKeepingEventLoopAlive(JSC.VirtualMachine.get(), true);
@@ -957,10 +962,10 @@ const TimerObjectInternals = struct {
         // Immediates do not have a refresh function, and our binding generator should not let this
         // function be reached even if you override the `this` value calling a Timeout object's
         // `refresh` method
-        assert(this.kind != .setImmediate);
+        assert(this.flags.kind != .setImmediate);
 
         // setImmediate does not support refreshing and we do not support refreshing after cleanup
-        if (this.id == -1 or this.kind == .setImmediate or this.has_cleared_timer) {
+        if (this.id == -1 or this.flags.kind == .setImmediate or this.flags.has_cleared_timer) {
             return this_value;
         }
 
@@ -974,8 +979,8 @@ const TimerObjectInternals = struct {
         const this_value = callframe.this();
         this_value.ensureStillAlive();
 
-        const did_have_js_ref = this.has_js_ref;
-        this.has_js_ref = false;
+        const did_have_js_ref = this.flags.has_js_ref;
+        this.flags.has_js_ref = false;
 
         if (did_have_js_ref) {
             this.setEnableKeepingEventLoopAlive(JSC.VirtualMachine.get(), false);
@@ -986,9 +991,9 @@ const TimerObjectInternals = struct {
 
     pub fn cancel(this: *TimerObjectInternals, vm: *VirtualMachine) void {
         this.setEnableKeepingEventLoopAlive(vm, false);
-        this.has_cleared_timer = true;
+        this.flags.has_cleared_timer = true;
 
-        if (this.kind == .setImmediate) return;
+        if (this.flags.kind == .setImmediate) return;
 
         const was_active = this.eventLoopTimer().state == .ACTIVE;
 
@@ -1002,7 +1007,7 @@ const TimerObjectInternals = struct {
     }
 
     pub fn reschedule(this: *TimerObjectInternals, vm: *VirtualMachine) void {
-        if (this.kind == .setImmediate) return;
+        if (this.flags.kind == .setImmediate) return;
 
         const now = timespec.msFromNow(this.interval);
         const was_active = this.eventLoopTimer().state == .ACTIVE;
@@ -1013,19 +1018,19 @@ const TimerObjectInternals = struct {
         }
 
         vm.timer.update(this.eventLoopTimer(), &now);
-        this.has_cleared_timer = false;
+        this.flags.has_cleared_timer = false;
 
-        if (this.has_js_ref) {
+        if (this.flags.has_js_ref) {
             this.setEnableKeepingEventLoopAlive(vm, true);
         }
     }
 
     fn setEnableKeepingEventLoopAlive(this: *TimerObjectInternals, vm: *VirtualMachine, enable: bool) void {
-        if (this.is_keeping_event_loop_alive == enable) {
+        if (this.flags.is_keeping_event_loop_alive == enable) {
             return;
         }
-        this.is_keeping_event_loop_alive = enable;
-        switch (this.kind) {
+        this.flags.is_keeping_event_loop_alive = enable;
+        switch (this.flags.kind) {
             .setTimeout, .setInterval => vm.timer.incrementTimerRef(if (enable) 1 else -1),
             // If setImmediate calls ref the event loop, then when the only pending tasks are
             // immediate callbacks we will still try to check for I/O activity, when really we only
@@ -1035,24 +1040,24 @@ const TimerObjectInternals = struct {
     }
 
     pub fn hasRef(this: *TimerObjectInternals, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
-        return JSValue.jsBoolean(this.is_keeping_event_loop_alive);
+        return JSValue.jsBoolean(this.flags.is_keeping_event_loop_alive);
     }
 
     pub fn toPrimitive(this: *TimerObjectInternals, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
-        if (!this.has_accessed_primitive) {
-            this.has_accessed_primitive = true;
+        if (!this.flags.has_accessed_primitive) {
+            this.flags.has_accessed_primitive = true;
             const vm = VirtualMachine.get();
-            vm.timer.maps.get(this.kind).put(bun.default_allocator, this.id, this.eventLoopTimer()) catch bun.outOfMemory();
+            vm.timer.maps.get(this.flags.kind).put(bun.default_allocator, this.id, this.eventLoopTimer()) catch bun.outOfMemory();
         }
         return JSValue.jsNumber(this.id);
     }
 
     /// This is the getter for `_destroyed` on JS Timeout and Immediate objects
     pub fn getDestroyed(this: *TimerObjectInternals) bool {
-        if (this.has_cleared_timer) {
+        if (this.flags.has_cleared_timer) {
             return true;
         }
-        if (this.in_callback) {
+        if (this.flags.in_callback) {
             return false;
         }
         return switch (this.eventLoopTimer().state) {
@@ -1069,13 +1074,14 @@ const TimerObjectInternals = struct {
     pub fn deinit(this: *TimerObjectInternals) void {
         this.strong_this.deinit();
         const vm = VirtualMachine.get();
+        const kind = this.flags.kind;
 
         if (this.eventLoopTimer().state == .ACTIVE) {
             vm.timer.remove(this.eventLoopTimer());
         }
 
-        if (this.has_accessed_primitive) {
-            const map = vm.timer.maps.get(this.kind);
+        if (this.flags.has_accessed_primitive) {
+            const map = vm.timer.maps.get(kind);
             if (map.orderedRemove(this.id)) {
                 // If this array gets large, let's shrink it down
                 // Array keys are i32
@@ -1091,24 +1097,34 @@ const TimerObjectInternals = struct {
         }
 
         this.setEnableKeepingEventLoopAlive(vm, false);
-        switch (this.kind) {
+        switch (kind) {
             .setImmediate => @as(*ImmediateObject, @fieldParentPtr("internals", this)).destroy(),
             .setTimeout, .setInterval => @as(*TimeoutObject, @fieldParentPtr("internals", this)).destroy(),
         }
     }
 };
 
-pub const Kind = enum(u32) {
-    setTimeout,
-    setInterval,
-    setImmediate,
+pub const Kind = enum(u2) {
+    setTimeout = 0,
+    setInterval = 1,
+    setImmediate = 2,
+
+    pub fn big(this: Kind) Big {
+        return @enumFromInt(@intFromEnum(this));
+    }
+
+    pub const Big = enum(u32) {
+        setTimeout = 0,
+        setInterval = 1,
+        setImmediate = 2,
+    };
 };
 
 // this is sized to be the same as one pointer
 pub const ID = extern struct {
     id: i32,
 
-    kind: Kind = Kind.setTimeout,
+    kind: Kind.Big = .setTimeout,
 
     pub inline fn asyncID(this: ID) u64 {
         return @bitCast(this);
@@ -1146,11 +1162,13 @@ pub const EventLoopTimer = struct {
         if (order == .eq) {
             if (maybe_a_internals) |a_internals| {
                 if (maybe_b_internals) |b_internals| {
-                    // try to still maintain the order if epoch overflowed
-                    // if the difference is greater than half u32 range, it more likely got that way
-                    // because b has overflowed and a hasn't than because b is really so much newer
-                    // than a
-                    return b_internals.epoch -% a_internals.epoch < std.math.maxInt(u32) / 2;
+                    // We use a u25 internally to conserve memory, but we
+                    // generally want to avoid all integer operations involving
+                    // non^2 integers.
+                    const b_epoch: u32 = b_internals.flags.epoch;
+                    const a_epoch: u32 = a_internals.flags.epoch;
+
+                    return b_epoch -% a_epoch < std.math.maxInt(u25) / 2;
                 }
             }
         }

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1277,7 +1277,7 @@ pub const JestPrettyFormat = struct {
                         );
                     } else if (value.as(JSC.API.Bun.Timer.TimeoutObject)) |timer| {
                         this.addForNewLine("Timeout(# ) ".len + bun.fmt.fastDigitCount(@as(u64, @intCast(@max(timer.internals.id, 0)))));
-                        if (timer.internals.kind == .setInterval) {
+                        if (timer.internals.flags.kind == .setInterval) {
                             this.addForNewLine("repeats ".len + bun.fmt.fastDigitCount(@as(u64, @intCast(@max(timer.internals.id, 0)))));
                             writer.print(comptime Output.prettyFmt("<r><blue>Timeout<r> <d>(#<yellow>{d}<r><d>, repeats)<r>", enable_ansi_colors), .{
                                 timer.internals.id,


### PR DESCRIPTION
### What does this PR do?

Make TimeoutObject 8 bytes smaller by making the flags a packed struct and making epoch a `u25` instead of a `u32`

```zig
src/bun.js/api/Timer.zig:557:9: error: TimeoutObject is size: 88
@compileError(std.fmt.comptimePrint("TimeoutObject is size: {d}", .{@sizeOf(TimeoutObject)}));

src/bun.js/api/Timer.zig:557:9: error: TimeoutObject is size: 80
@compileError(std.fmt.comptimePrint("TimeoutObject is size: {d}", .{@sizeOf(TimeoutObject)}));
```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
