### PR TITLE
[untested] install fish completions based on pkg-config framework

### DIFF
--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -252,6 +252,36 @@ pub const InstallCompletionsCommand = struct {
 
             switch (shell) {
                 .fish => {
+                    // First try using pkg-config to find the vendor directory
+                    outer: {
+                        var result = std.ChildProcess.exec(.{
+                            .allocator = allocator,
+                            .argv = &[_][]const u8{ "pkg-config", "--variable=completionsdir", "fish" },
+                        }) catch break :outer;
+                        defer {
+                            allocator.free(result.stdout);
+                            allocator.free(result.stderr);
+                        }
+
+                        // Check if command was successful
+                        if (result.term.Exited == 0 and result.stdout.len > 0) {
+                            // Trim whitespace/newlines from the result
+                            const trimmed = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
+                            if (trimmed.len > 0) {
+                                completions_dir = trimmed;
+                                break :found std.fs.openDirAbsolute(trimmed, .{}) catch break :outer;
+                            }
+                        }
+                    }
+
+                    // Check the standard vendor completions directory
+                    outer: {
+                        completions_dir = "/usr/share/fish/vendor_completions.d";
+                        break :found std.fs.openDirAbsolute("/usr/share/fish/vendor_completions.d", .{}) catch break :outer;
+                    }
+
+                    // Fall back to user directories if vendor directories are not available
+
                     if (bun.getenvZ("XDG_CONFIG_HOME")) |config_dir| {
                         outer: {
                             var paths = [_]string{ config_dir, "./fish/completions" };


### PR DESCRIPTION
(presumably) fixes #17855

### What does this PR do?

This PR adds an attempt to determine the right directory for installing completions files based on `pkg-config`. 

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I didn't test this code. I tried following `CONTRIBUTING.md` but couldn't get the build to work despite installing the mentioned dependencies. I'm sharing it so I didn't get into this for nothing 😅 hopefully it helps someone else to fix this issue. 