### PR TITLE
Add `destroy` and destructors to `Hmac`, `Verify`, `Sign`, and `Hash`

### DIFF
--- a/src/bun.js/bindings/node/crypto/JSHash.cpp
+++ b/src/bun.js/bindings/node/crypto/JSHash.cpp
@@ -21,12 +21,17 @@ static const HashTableValue JSHashPrototypeTableValues[] = {
 };
 
 const ClassInfo JSHash::s_info = { "Hash"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHash) };
-const ClassInfo JSHashPrototype::s_info = { "HashPrototype"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHashPrototype) };
-const ClassInfo JSHashConstructor::s_info = { "HashConstructor"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHashConstructor) };
+const ClassInfo JSHashPrototype::s_info = { "Hash"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHashPrototype) };
+const ClassInfo JSHashConstructor::s_info = { "Hash"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHashConstructor) };
 
 JSHash::JSHash(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure)
 {
+}
+
+void JSHash::destroy(JSC::JSCell* cell)
+{
+    static_cast<JSHash*>(cell)->~JSHash();
 }
 
 JSHash::~JSHash()

--- a/src/bun.js/bindings/node/crypto/JSHash.h
+++ b/src/bun.js/bindings/node/crypto/JSHash.h
@@ -34,6 +34,8 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
+    static void destroy(JSC::JSCell* cell);
+
     JSHash(JSC::VM& vm, JSC::Structure* structure);
     ~JSHash();
 

--- a/src/bun.js/bindings/node/crypto/JSHmac.cpp
+++ b/src/bun.js/bindings/node/crypto/JSHmac.cpp
@@ -21,12 +21,17 @@ static const HashTableValue JSHmacPrototypeTableValues[] = {
 };
 
 const ClassInfo JSHmac::s_info = { "Hmac"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHmac) };
-const ClassInfo JSHmacPrototype::s_info = { "HmacPrototype"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHmacPrototype) };
-const ClassInfo JSHmacConstructor::s_info = { "HmacConstructor"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHmacConstructor) };
+const ClassInfo JSHmacPrototype::s_info = { "Hmac"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHmacPrototype) };
+const ClassInfo JSHmacConstructor::s_info = { "Hmac"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSHmacConstructor) };
 
 JSHmac::JSHmac(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure)
 {
+}
+
+void JSHmac::destroy(JSC::JSCell* cell)
+{
+    static_cast<JSHmac*>(cell)->~JSHmac();
 }
 
 JSHmac::~JSHmac()

--- a/src/bun.js/bindings/node/crypto/JSHmac.h
+++ b/src/bun.js/bindings/node/crypto/JSHmac.h
@@ -23,6 +23,7 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static JSHmac* create(JSC::VM& vm, JSC::Structure* structure);
+    static void destroy(JSC::JSCell* cell);
 
     DECLARE_INFO;
 

--- a/src/bun.js/bindings/node/crypto/JSSign.cpp
+++ b/src/bun.js/bindings/node/crypto/JSSign.cpp
@@ -44,6 +44,17 @@ static const JSC::HashTableValue JSSignPrototypeTableValues[] = {
 
 // JSSign implementation
 const JSC::ClassInfo JSSign::s_info = { "Sign"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSign) };
+const JSC::ClassInfo JSSignPrototype::s_info = { "Sign"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSignPrototype) };
+const JSC::ClassInfo JSSignConstructor::s_info = { "Sign"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSignConstructor) };
+
+void JSSign::destroy(JSC::JSCell* cell)
+{
+    static_cast<JSSign*>(cell)->~JSSign();
+}
+
+JSSign::~JSSign()
+{
+}
 
 JSSign::JSSign(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure)
@@ -81,7 +92,6 @@ JSC::GCClient::IsoSubspace* JSSign::subspaceFor(JSC::VM& vm)
 }
 
 // JSSignPrototype implementation
-const JSC::ClassInfo JSSignPrototype::s_info = { "Sign"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSignPrototype) };
 
 JSSignPrototype::JSSignPrototype(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure)
@@ -110,7 +120,6 @@ JSC::Structure* JSSignPrototype::createStructure(JSC::VM& vm, JSC::JSGlobalObjec
 }
 
 // JSSignConstructor implementation
-const JSC::ClassInfo JSSignConstructor::s_info = { "Sign"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSignConstructor) };
 
 JSSignConstructor::JSSignConstructor(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure, callSign, constructSign)

--- a/src/bun.js/bindings/node/crypto/JSSign.h
+++ b/src/bun.js/bindings/node/crypto/JSSign.h
@@ -24,6 +24,9 @@ public:
     static JSSign* create(JSC::VM& vm, JSC::Structure* structure);
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
 
+    static void destroy(JSC::JSCell* cell);
+    ~JSSign();
+
     template<typename CellType, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm);
 

--- a/src/bun.js/bindings/node/crypto/JSVerify.cpp
+++ b/src/bun.js/bindings/node/crypto/JSVerify.cpp
@@ -52,6 +52,17 @@ static const JSC::HashTableValue JSVerifyPrototypeTableValues[] = {
 
 // JSVerify implementation
 const JSC::ClassInfo JSVerify::s_info = { "Verify"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSVerify) };
+const JSC::ClassInfo JSVerifyPrototype::s_info = { "Verify"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSVerifyPrototype) };
+const JSC::ClassInfo JSVerifyConstructor::s_info = { "Verify"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSVerifyConstructor) };
+
+void JSVerify::destroy(JSC::JSCell* cell)
+{
+    static_cast<JSVerify*>(cell)->~JSVerify();
+}
+
+JSVerify::~JSVerify()
+{
+}
 
 JSVerify::JSVerify(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure)
@@ -89,7 +100,6 @@ JSC::GCClient::IsoSubspace* JSVerify::subspaceFor(JSC::VM& vm)
 }
 
 // JSVerifyPrototype implementation
-const JSC::ClassInfo JSVerifyPrototype::s_info = { "Verify"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSVerifyPrototype) };
 
 JSVerifyPrototype::JSVerifyPrototype(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure)
@@ -116,7 +126,6 @@ JSC::Structure* JSVerifyPrototype::createStructure(JSC::VM& vm, JSC::JSGlobalObj
 }
 
 // JSVerifyConstructor implementation
-const JSC::ClassInfo JSVerifyConstructor::s_info = { "Verify"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSVerifyConstructor) };
 
 JSVerifyConstructor::JSVerifyConstructor(JSC::VM& vm, JSC::Structure* structure)
     : Base(vm, structure, callVerify, constructVerify)

--- a/src/bun.js/bindings/node/crypto/JSVerify.h
+++ b/src/bun.js/bindings/node/crypto/JSVerify.h
@@ -22,6 +22,8 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static JSVerify* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSGlobalObject* globalObject);
+    static void destroy(JSC::JSCell* cell);
+    ~JSVerify();
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
 
     template<typename CellType, JSC::SubspaceAccess mode>


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
