### PR TITLE
25% smaller sourcemaps (for runtime)

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -548,7 +548,7 @@ pub const RuntimeTranspilerStore = struct {
             }
 
             if (cache.entry) |*entry| {
-                vm.source_mappings.putMappings(parse_result.source, .{
+                vm.source_mappings.putMappings(&parse_result.source, .{
                     .list = .{ .items = @constCast(entry.sourcemap), .capacity = entry.sourcemap.len },
                     .allocator = bun.default_allocator,
                 }) catch {};
@@ -1787,7 +1787,7 @@ pub const ModuleLoader = struct {
                 }
 
                 if (cache.entry) |*entry| {
-                    jsc_vm.source_mappings.putMappings(parse_result.source, .{
+                    jsc_vm.source_mappings.putMappings(&parse_result.source, .{
                         .list = .{ .items = @constCast(entry.sourcemap), .capacity = entry.sourcemap.len },
                         .allocator = bun.default_allocator,
                     }) catch {};

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -1226,7 +1226,7 @@ pub const Chunk = struct {
 
     pub fn printSourceMapContents(
         chunk: Chunk,
-        source: Logger.Source,
+        source: *const Logger.Source,
         mutable: MutableString,
         include_sources_contents: bool,
         comptime ascii_only: bool,
@@ -1243,7 +1243,7 @@ pub const Chunk = struct {
 
     pub fn printSourceMapContentsAtOffset(
         chunk: Chunk,
-        source: Logger.Source,
+        source: *const Logger.Source,
         mutable: MutableString,
         include_sources_contents: bool,
         offset: usize,

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -910,6 +910,12 @@ pub const Transpiler = struct {
                         .print_dce_annotations = transpiler.options.emit_dce_annotations,
                         .hmr_ref = ast.wrapper_ref,
                         .mangled_props = null,
+
+                        .source_map_cover_lines_without_mappings = if (is_bun)
+                            // If the sourcemaps are strictly for internal usage, we can disable this
+                            transpiler.options.debugger or transpiler.options.code_coverage or transpiler.options.dead_code_elimination == false
+                        else
+                            true,
                     },
                     enable_source_map,
                 ),


### PR DESCRIPTION
### What does this PR do?

Ordinarily, we emit sourcemaps for lines with no mappings so that popular npm packages like `source-map` work as expected. We don't need this feature when source mapping internally, so this is unnecessary at runtime when sourcemaps aren't sent anywhere (when the debugger is not connected and cautiously, when code coverage is not enabled). 

Two datapoints:

TypeScript's CLI (_tsc.js):
| commit |  source map size|
|--------|-----------------|
| main  |  3.18 MB  |
| this branch  |  2.49 MB  |

test/harness.ts:
| commit |  source map size|
|--------|-----------------|
| main  | 29.30 KB  |
| this branch  |  22.1 KB  |

### How did you verify your code works?

Ran our existing tests