### PR TITLE
18% smaller runtime sourcemaps

### DIFF
--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -646,6 +646,7 @@ pub const RuntimeTranspilerStore = struct {
                     &printer,
                     .esm_ascii,
                     mapper.get(),
+                    vm.canUseNonstandardSourceMaps(),
                 ) catch |err| {
                     this.parse_error = err;
                     return;
@@ -1409,6 +1410,7 @@ pub const ModuleLoader = struct {
                     &printer,
                     .esm_ascii,
                     mapper.get(),
+                    jsc_vm.canUseNonstandardSourceMaps(),
                 );
             }
 
@@ -1891,6 +1893,7 @@ pub const ModuleLoader = struct {
                         &printer,
                         .esm_ascii,
                         mapper.get(),
+                        jsc_vm.canUseNonstandardSourceMaps(),
                     );
                 };
 

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -454,6 +454,8 @@ pub const Options = struct {
     source_map_allocator: ?std.mem.Allocator = null,
     source_map_handler: ?SourceMapHandler = null,
     source_map_builder: ?*bun.sourcemap.Chunk.Builder = null,
+    source_map_is_internal: bool = false,
+
     css_import_behavior: Api.CssInJsBehavior = Api.CssInJsBehavior.facade,
     target: options.Target = .browser,
 
@@ -5847,6 +5849,7 @@ pub fn getSourceMapBuilder(
         .source_map = .init(
             opts.source_map_allocator orelse opts.allocator,
             is_bun_platform and generate_source_map == .lazy,
+            opts.source_map_is_internal and is_bun_platform and generate_source_map == .lazy,
         ),
         .cover_lines_without_mappings = true,
         .approximate_input_line_count = tree.approximate_newline_count,

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -821,6 +821,7 @@ pub const Transpiler = struct {
         comptime enable_source_map: bool,
         source_map_context: ?js_printer.SourceMapHandler,
         runtime_transpiler_cache: ?*bun.JSC.RuntimeTranspilerCache,
+        source_map_is_internal: bool,
     ) !usize {
         const tracer = bun.tracy.traceNamed(@src(), if (enable_source_map) "JSPrinter.printWithSourceMap" else "JSPrinter.print");
         defer tracer.end();
@@ -848,6 +849,7 @@ pub const Transpiler = struct {
                     .runtime_transpiler_cache = runtime_transpiler_cache,
                     .print_dce_annotations = transpiler.options.emit_dce_annotations,
                     .hmr_ref = ast.wrapper_ref,
+                    .source_map_is_internal = source_map_is_internal,
                 },
                 enable_source_map,
             ),
@@ -874,6 +876,7 @@ pub const Transpiler = struct {
                     .print_dce_annotations = transpiler.options.emit_dce_annotations,
                     .hmr_ref = ast.wrapper_ref,
                     .mangled_props = null,
+                    .source_map_is_internal = source_map_is_internal,
                 },
                 enable_source_map,
             ),
@@ -910,6 +913,7 @@ pub const Transpiler = struct {
                         .print_dce_annotations = transpiler.options.emit_dce_annotations,
                         .hmr_ref = ast.wrapper_ref,
                         .mangled_props = null,
+                        .source_map_is_internal = source_map_is_internal,
                     },
                     enable_source_map,
                 ),
@@ -934,6 +938,7 @@ pub const Transpiler = struct {
             false,
             null,
             null,
+            false,
         );
     }
 
@@ -944,6 +949,7 @@ pub const Transpiler = struct {
         writer: Writer,
         comptime format: js_printer.Format,
         handler: js_printer.SourceMapHandler,
+        source_map_is_internal: bool,
     ) !usize {
         if (bun.getRuntimeFeatureFlag("BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS")) {
             return transpiler.printWithSourceMapMaybe(
@@ -955,6 +961,7 @@ pub const Transpiler = struct {
                 false,
                 handler,
                 result.runtime_transpiler_cache,
+                source_map_is_internal,
             );
         }
         return transpiler.printWithSourceMapMaybe(
@@ -966,6 +973,7 @@ pub const Transpiler = struct {
             true,
             handler,
             result.runtime_transpiler_cache,
+            source_map_is_internal,
         );
     }
 


### PR DESCRIPTION
### What does this PR do?

When we know all the sourcemaps have the same source index, we can skip
including the source index in each mapping entry. 

For _tsc.js, this is a 18% reduction:
| Version | Size |
|--------|-------|
| Standard | 2.97 MB |
| this PR | 2.42 MB |

This optimization is only enabled at runtime when we're confident that the sourcemaps are internal to the runtime (no debugger, no code coverage). Out of caution, this also disabled when DCE is disabled.

The sourcemap format normally requires 4-5 VLQ-encoded values per mapping:
1. Generated column
2. Source index
3. Original line
4. Original column
5. Name index (optional)

With this optimization, we only include 3 values:
1. Generated column
2. Original line (interpreted as source index in standard parsers)
3. Original column (interpreted as original line in standard parsers)

| Version | Mappings |
|---------|----------|
| Standard | `"AAAA,CAAC,IAAI,IAAI"` |
| This PR | `"AAA,CAC,IAI"` |



### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
