### PR TITLE
fix(bun-plugin-svelte): Split compiler options

### DIFF
--- a/packages/bun-plugin-svelte/src/options.spec.ts
+++ b/packages/bun-plugin-svelte/src/options.spec.ts
@@ -1,20 +1,19 @@
 import { describe, beforeAll, it, expect } from "bun:test";
 import type { BuildConfig } from "bun";
-import type { CompileOptions } from "svelte/compiler";
 
-import { getBaseCompileOptions, type SvelteOptions } from "./options";
+import { getBaseCompileOptions, type BaseCompileOptions, type SvelteOptions } from "./options";
 
 describe("getBaseCompileOptions", () => {
   describe("when no options are provided", () => {
     const pluginOptions: SvelteOptions = {};
-    let fullDefault: Readonly<CompileOptions>;
+    let fullDefault: Readonly<BaseCompileOptions>;
 
     beforeAll(() => {
       fullDefault = Object.freeze(getBaseCompileOptions(pluginOptions, {}));
     });
 
     it("when minification is disabled, whitespace and comments are preserved", () => {
-      expect(getBaseCompileOptions(pluginOptions, { minify: false })).toEqual(
+      expect(getBaseCompileOptions(pluginOptions, { minify: false }).component).toEqual(
         expect.objectContaining({
           preserveWhitespace: true,
           preserveComments: true,
@@ -23,19 +22,19 @@ describe("getBaseCompileOptions", () => {
     });
 
     it("defaults to production mode", () => {
-      expect(fullDefault.dev).toBeFalse();
+      expect(fullDefault.common.dev).toBeFalse();
     });
   });
 
   it.each([{}, { side: "server" }, { side: "client" }, { side: undefined }] as Partial<BuildConfig>[])(
     "when present, forceSide takes precedence over config (%o)",
     buildConfig => {
-      expect(getBaseCompileOptions({ forceSide: "client" }, buildConfig)).toEqual(
+      expect(getBaseCompileOptions({ forceSide: "client" }, buildConfig).common).toEqual(
         expect.objectContaining({
           generate: "client",
         }),
       );
-      expect(getBaseCompileOptions({ forceSide: "server" }, buildConfig)).toEqual(
+      expect(getBaseCompileOptions({ forceSide: "server" }, buildConfig).common).toEqual(
         expect.objectContaining({
           generate: "server",
         }),

--- a/packages/bun-plugin-svelte/src/options.ts
+++ b/packages/bun-plugin-svelte/src/options.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import type { BuildConfig } from "bun";
-import type { CompileOptions } from "svelte/compiler";
+import type { CompileOptions, ModuleCompileOptions } from "svelte/compiler";
 
 export interface SvelteOptions {
   /**
@@ -20,6 +20,11 @@ export interface SvelteOptions {
    * Defaults to `true` when run via Bun's dev server, `false` otherwise.
    */
   development?: boolean;
+}
+
+export type BaseCompileOptions = {
+  common: ModuleCompileOptions,
+  component: CompileOptions,
 }
 
 /**
@@ -43,7 +48,7 @@ export function validateOptions(options: unknown): asserts options is SvelteOpti
 /**
  * @internal
  */
-export function getBaseCompileOptions(pluginOptions: SvelteOptions, config: Partial<BuildConfig>): CompileOptions {
+export function getBaseCompileOptions(pluginOptions: SvelteOptions, config: Partial<BuildConfig>): BaseCompileOptions {
   let { forceSide, development = false } = pluginOptions;
   const { minify = false, target } = config;
 
@@ -75,15 +80,19 @@ export function getBaseCompileOptions(pluginOptions: SvelteOptions, config: Part
   }
 
   return {
-    css: "external",
-    generate: forceSide,
-    preserveWhitespace: !minifyWhitespace,
-    preserveComments: !shouldMinify,
-    dev: development,
-    cssHash({ css }) {
-      // same prime number seed used by svelte/compiler.
-      // TODO: ensure this provides enough entropy
-      return `svelte-${hash(css)}`;
+    common: {
+      generate: forceSide,
+      dev: development,
+    },
+    component: {
+      css: "external",
+      preserveWhitespace: !minifyWhitespace,
+      preserveComments: !shouldMinify,
+      cssHash({ css }) {
+        // same prime number seed used by svelte/compiler.
+        // TODO: ensure this provides enough entropy
+        return `svelte-${hash(css)}`;
+      },
     },
   };
 }

--- a/test/integration/svelte/fixtures/app/App.svelte
+++ b/test/integration/svelte/fixtures/app/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import "./Module.svelte.ts";
   let count: number = 0;
 </script>
 

--- a/test/integration/svelte/fixtures/app/Module.svelte.ts
+++ b/test/integration/svelte/fixtures/app/Module.svelte.ts
@@ -1,0 +1,1 @@
+export default {}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I added tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

### Additional information
Previous error on my svelte project
```js
error: Unrecognised compiler option css
https://svelte.dev/e/options_unrecognised
    at [redacted]\src\components\grid-view\DataProvider.svelte.js:0
error: Unrecognised compiler option css
https://svelte.dev/e/options_unrecognised
    at [redacted]\src\components\grid-view\DataProvider.svelte.js:0

```
Ref: https://github.com/sveltejs/svelte/blob/main/packages/svelte/src/compiler/validate-options.js