### PR TITLE
fix(bun-plugin-svelte): fix svelte module imports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1132,6 +1132,17 @@
       "postRunCommands": ["command source '${workspaceFolder}/misctools/lldb/lldb_commands'"],
     },
     {
+      "type": "bun",
+      "name": "[JS] bun test [file]",
+      "runtime": "${workspaceFolder}/build/debug/bun-debug",
+      "runtimeArgs": ["test", "${file}"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "BUN_DEBUG_QUIET_LOGS": "1",
+        "BUN_GARBAGE_COLLECTOR_LEVEL": "2",
+      },
+    },
+    {
       "type": "midas-rr",
       "request": "attach",
       "name": "rr",

--- a/packages/bun-plugin-svelte/README.md
+++ b/packages/bun-plugin-svelte/README.md
@@ -86,7 +86,9 @@ Bun.build({
 This will be added in the near future.
 
 ## Not Yet Supported
+
 Support for these features will be added in the near future
+
 - Server-side imports/rendering
 - Source maps
 - CSS extensions (e.g. tailwind) in `<style>` blocks

--- a/packages/bun-plugin-svelte/README.md
+++ b/packages/bun-plugin-svelte/README.md
@@ -84,3 +84,11 @@ Bun.build({
 
 `bun-plugin-svelte` does not yet support server-side imports (e.g. for SSR).
 This will be added in the near future.
+
+## Not Yet Supported
+Support for these features will be added in the near future
+- Server-side imports/rendering
+- Source maps
+- CSS extensions (e.g. tailwind) in `<style>` blocks
+- TypeScript-specific features (e.g. enums and namespaces). If you're using
+  TypeScript 5.8, consider enabling [`--erasableSyntaxOnly`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option)

--- a/packages/bun-plugin-svelte/package.json
+++ b/packages/bun-plugin-svelte/package.json
@@ -1,6 +1,14 @@
 {
   "name": "bun-plugin-svelte",
   "version": "0.0.1",
+  "description": "Official Svelte plugin for Bun",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oven-sh/bun",
+    "directory": "packages/bun-plugin-svelte"
+  },
+  "homepage": "https://bun.sh",
+  "license": "MIT",
   "type": "module",
   "module": "src/index.ts",
   "index": "src/index.ts",
@@ -17,7 +25,6 @@
     "svelte": "^5.20.4"
   },
   "peerDependencies": {
-    "typescript": "^5",
     "svelte": "^5"
   },
   "files": [

--- a/packages/bun-plugin-svelte/src/index.ts
+++ b/packages/bun-plugin-svelte/src/index.ts
@@ -38,6 +38,7 @@ function SveltePlugin(options: SvelteOptions = kEmptyObject as SvelteOptions): B
 
       const ts = new Bun.Transpiler({
         loader: "ts",
+        target: config.target,
       });
 
       builder

--- a/packages/bun-plugin-svelte/src/index.ts
+++ b/packages/bun-plugin-svelte/src/index.ts
@@ -1,6 +1,6 @@
 import type { BunPlugin, BuildConfig, OnLoadResult } from "bun";
 import { basename } from "node:path";
-import { compile, compileModule, type CompileResult, type ModuleCompileOptions } from "svelte/compiler";
+import { compile, compileModule } from "svelte/compiler";
 import {
   getBaseCompileOptions,
   validateOptions,

--- a/packages/bun-plugin-svelte/src/options.ts
+++ b/packages/bun-plugin-svelte/src/options.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { plugin, type BuildConfig } from "bun";
+import { type BuildConfig } from "bun";
 import type { CompileOptions, ModuleCompileOptions } from "svelte/compiler";
 
 export interface SvelteOptions {
@@ -44,8 +44,8 @@ export function validateOptions(options: unknown): asserts options is SvelteOpti
  * @internal
  */
 export function getBaseCompileOptions(pluginOptions: SvelteOptions, config: Partial<BuildConfig>): CompileOptions {
-  let { forceSide, development = false } = pluginOptions;
-  const { minify = false, target } = config;
+  let { development = false } = pluginOptions;
+  const { minify = false } = config;
 
   const shouldMinify = Boolean(minify);
   const {

--- a/packages/bun-plugin-svelte/test/fixtures/todo-cjs.svelte.ts
+++ b/packages/bun-plugin-svelte/test/fixtures/todo-cjs.svelte.ts
@@ -1,0 +1,15 @@
+class Todo {
+  title: string | undefined = $state();
+  done: boolean = $state(false);
+  createdAt: Date = $state(new Date());
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+  public toggle(): void {
+    this.done = !this.done;
+  }
+}
+
+module.exports = Todo;

--- a/packages/bun-plugin-svelte/test/fixtures/todo.svelte.ts
+++ b/packages/bun-plugin-svelte/test/fixtures/todo.svelte.ts
@@ -1,0 +1,13 @@
+export class Todo {
+  title: string = $state();
+  done: boolean = $state(false);
+  createdAt: Date = $state(new Date());
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+  public toggle(): void {
+    this.done = !this.done;
+  }
+}

--- a/packages/bun-plugin-svelte/test/fixtures/todo.svelte.ts
+++ b/packages/bun-plugin-svelte/test/fixtures/todo.svelte.ts
@@ -1,5 +1,5 @@
 export class Todo {
-  title: string = $state();
+  title: string | undefined = $state();
   done: boolean = $state(false);
   createdAt: Date = $state(new Date());
 

--- a/packages/bun-plugin-svelte/test/fixtures/with-cjs.svelte
+++ b/packages/bun-plugin-svelte/test/fixtures/with-cjs.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  const Todo = require("./todo-cjs.svelte.ts");
+
+  let name = "World";
+  let todo: Todo = $state(new Todo("Hello World!"));
+</script>
+
+<main class="app">
+  <h1>Hello {todo.title}!</h1>
+  <!-- clicking calls toggle -->
+  <input type="checkbox" bind:checked={todo.done} />
+  <button onclick={todo.toggle}>Toggle</button>
+</main>
+
+<style>
+  h1 {
+    color: #ff3e00;
+    text-align: center;
+    font-size: 2em;
+    font-weight: 100;
+  }
+  .app {
+    box-sizing: border-box;
+  }
+</style>

--- a/packages/bun-plugin-svelte/test/fixtures/with-modules.svelte
+++ b/packages/bun-plugin-svelte/test/fixtures/with-modules.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { Todo } from "./todo.svelte";
+
+  let name = "World";
+  let todo: Todo = $state(new Todo("Hello World!"));
+</script>
+
+<main class="app">
+  <h1>Hello {todo.title}!</h1>
+  <!-- clicking calls toggle -->
+  <input type="checkbox" bind:checked={todo.done} />
+  <button onclick={todo.toggle}>Toggle</button>
+</main>
+
+<style>
+  h1 {
+    color: #ff3e00;
+    text-align: center;
+    font-size: 2em;
+    font-weight: 100;
+  }
+  .app {
+    box-sizing: border-box;
+  }
+</style>

--- a/packages/bun-plugin-svelte/test/index.test.ts
+++ b/packages/bun-plugin-svelte/test/index.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import { render } from "svelte/server";
 import { SveltePlugin } from "../src";
+import type { BuildOutput } from "bun";
 
 const fixturePath = (...segs: string[]) => path.join(import.meta.dirname, "fixtures", ...segs);
 
@@ -30,6 +31,22 @@ it("hello world component", async () => {
     plugins: [SveltePlugin()],
   });
   expect(res.success).toBeTrue();
+});
+
+describe("when importing `.svelte.ts` files", () => {
+  let res: BuildOutput;
+
+  beforeAll(async () => {
+    res = await Bun.build({
+      entrypoints: [fixturePath("with-modules.svelte")],
+      outdir,
+      plugins: [SveltePlugin()],
+    });
+  });
+
+  it.only("builds successfully", () => {
+    expect(res.success).toBeTrue();
+  });
 });
 
 describe("Bun.build", () => {

--- a/packages/bun-plugin-svelte/test/index.test.ts
+++ b/packages/bun-plugin-svelte/test/index.test.ts
@@ -44,7 +44,7 @@ describe("when importing `.svelte.ts` files", () => {
     });
   });
 
-  it.only("builds successfully", () => {
+  it("builds successfully", () => {
     expect(res.success).toBeTrue();
   });
 });

--- a/packages/bun-plugin-svelte/test/index.test.ts
+++ b/packages/bun-plugin-svelte/test/index.test.ts
@@ -33,7 +33,7 @@ it("hello world component", async () => {
   expect(res.success).toBeTrue();
 });
 
-describe("when importing `.svelte.ts` files", () => {
+describe("when importing `.svelte.ts` files with ESM", () => {
   let res: BuildOutput;
 
   beforeAll(async () => {
@@ -46,6 +46,30 @@ describe("when importing `.svelte.ts` files", () => {
 
   it("builds successfully", () => {
     expect(res.success).toBeTrue();
+  });
+});
+
+describe("when importing `.svelte.ts` files with CJS", () => {
+  let res: BuildOutput;
+
+  beforeAll(async () => {
+    res = await Bun.build({
+      entrypoints: [fixturePath("with-cjs.svelte")],
+      outdir,
+      plugins: [SveltePlugin()],
+    });
+  });
+
+  it("builds successfully", () => {
+    expect(res.success).toBeTrue();
+  });
+
+  it("does not double-wrap the module with function(module, exports, __filename, __dirname)", async () => {
+    const ts = res.outputs.find(output => output.loader === "ts");
+    expect(ts).toBeDefined();
+    const code = await ts!.text();
+    expect(code).toContain("require_todo_cjs_svelte");
+    expect(code).toContain("var require_todo_cjs_svelte = __commonJS((exports, module) => {\n");
   });
 });
 


### PR DESCRIPTION
### What does this PR do?
- use separate options when compiling svelte modules vs svelte components, fixing a bug where "unknown option 'css'" was being thrown
- Transpile `*.svelte.ts` modules with `Bun.Transpiler` before calling `compileModule`. Svelte strips type annotations when compiling svelte components but not modules, so we need to do it ourselves.
- Add more details to `package.json`
- Update `README.md` to include current limitations and not-yet-implemented features

### How did you verify your code works?
I've added a test
