### PR TITLE
UDP: reset cached address and remoteAddress properties

### DIFF
--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -943,7 +943,9 @@ pub const UDPSocket = struct {
         this.connect_info = .{
             .port = port,
         };
-        // TODO reset cached remoteAddress property
+
+        UDPSocket.addressSetCached(callFrame.this(), globalThis, .zero);
+        UDPSocket.remoteAddressSetCached(callFrame.this(), globalThis, .zero);
 
         return .undefined;
     }

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -71,6 +71,17 @@ describe("createSocket()", () => {
     socket.bind(0, localhost);
   });
 
+  test("address before/after connecting", done => {
+    const socket = createSocket("udp4");
+    socket.bind(() => {
+      expect(socket.address().address).toBe("0.0.0.0");
+      socket.connect(60865, "127.0.0.1", () => {
+        expect(socket.address().address).toBe("127.0.0.1");
+        socket.close(done);
+      });
+    });
+  });
+
   const validateRecv = (server, data, rinfo, bytes) => {
     using _ = disableAggressiveGCScope();
     try {

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -73,9 +73,9 @@ describe("createSocket()", () => {
 
   test("address before/after connecting", done => {
     const socket = createSocket("udp4");
-    socket.bind(() => {
+    socket.bind(0, () => {
       expect(socket.address().address).toBe("0.0.0.0");
-      socket.connect(60865, "127.0.0.1", () => {
+      socket.connect(socket.address().port, "127.0.0.1", () => {
         expect(socket.address().address).toBe("127.0.0.1");
         socket.close(done);
       });


### PR DESCRIPTION
### What does this PR do?

Resets the `address` and `remoteAddress` properties of Bun.udpSocket after connecting.
This also affects `node:dgram`. Fixes #15512.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code (modified `test/js/bun/udp/dgram.test.ts`)
- [x] I ran my tests locally and they pass