### PR TITLE
fix assertion in `JSBuffer.cpp`

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1791,24 +1791,26 @@ JSC::EncodedJSValue jsBufferToString(JSC::VM& vm, JSC::JSGlobalObject* lexicalGl
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (UNLIKELY(!castedThis->byteLength())) {
+    auto byteLength = castedThis->byteLength();
+
+    if (UNLIKELY(!byteLength)) {
         RELEASE_AND_RETURN(scope, JSValue::encode(jsEmptyString(vm)));
     }
 
-    ASSERT(offset < castedThis->byteLength());
-    ASSERT(length <= castedThis->byteLength());
-    ASSERT(offset + length <= castedThis->byteLength());
+    ASSERT(offset <= byteLength);
+    ASSERT(length <= byteLength);
+    ASSERT(offset + length <= byteLength);
 
-    if (offset >= castedThis->byteLength()) {
-        offset = castedThis->byteLength();
+    if (offset >= byteLength) {
+        offset = byteLength;
     }
 
-    if (length > castedThis->byteLength()) {
-        length = castedThis->byteLength();
+    if (length > byteLength) {
+        length = byteLength;
     }
 
-    if (offset + length > castedThis->byteLength()) {
-        length = castedThis->byteLength() - offset;
+    if (offset + length > byteLength) {
+        length = byteLength - offset;
     }
 
     return jsBufferToStringFromBytes(lexicalGlobalObject, scope, castedThis->span().subspan(offset, length), encoding);


### PR DESCRIPTION
### What does this PR do?
This assertion was invalid. `offset` is allowed to be equal to byte length, result will be empty.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually running `third_party/grpc-js/test-server-errors.test.ts`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
