### PR TITLE
codegen: fix node error builtin types return type

### DIFF
--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -470,7 +470,7 @@ writeIfNotChanged(
  * @param msg The error message
  * @param args Additional arguments
  */
-declare function $${code}(msg: string, ...args: any[]): ${name};
+declare function $${code}(msg: string, ...args: any[]): ${name ?? constructor.name};
 `;
 
       for (const con of other_constructors) {


### PR DESCRIPTION
before

```ts
declare function $ERR_TLS_CERT_ALTNAME_INVALID(msg: string, ...args: any[]): undefined;
```

after

```ts
declare function $ERR_TLS_CERT_ALTNAME_INVALID(msg: string, ...args: any[]): Error;
```
