### PR TITLE
CI: fix canary uploading for x64 macos

### DIFF
--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -201,6 +201,8 @@ function create_release() {
   local artifacts=(
     bun-darwin-aarch64.zip
     bun-darwin-aarch64-profile.zip
+    bun-darwin-x64.zip
+    bun-darwin-x64-profile.zip
     bun-linux-aarch64.zip
     bun-linux-aarch64-profile.zip
     bun-linux-x64.zip


### PR DESCRIPTION
Upload script was missing the x64 iterations of darwin

In [full release](https://github.com/oven-sh/bun/releases/tag/bun-v1.2.5) there is `bun-darwin-x64-baseline.zip` - but doesn't look like canary CI generates them