### PR TITLE
 Fix express responses dying early

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -39,7 +39,7 @@ const runSymbol = Symbol("run");
 const deferredSymbol = Symbol("deferred");
 const eofInProgress = Symbol("eofInProgress");
 const fakeSocketSymbol = Symbol("fakeSocket");
-const finishedSymbol = "finished";
+const finishedSymbol = Symbol("finished");
 const firstWriteSymbol = Symbol("firstWrite");
 const headersSymbol = Symbol("headers");
 const isTlsSymbol = Symbol("is_tls");
@@ -1850,6 +1850,7 @@ function ServerResponse(req, options) {
   this._sent100 = false;
   this[headerStateSymbol] = NodeHTTPHeaderState.none;
   this[kPendingCallbacks] = [];
+  this[finishedSymbol] = false;
 
   // this is matching node's behaviour
   // https://github.com/nodejs/node/blob/cf8c6994e0f764af02da4fa70bc5962142181bf3/lib/_http_server.js#L192
@@ -1884,6 +1885,13 @@ const ServerResponsePrototype = {
   },
   set headersSent(value) {
     this[headerStateSymbol] = value ? NodeHTTPHeaderState.sent : NodeHTTPHeaderState.none;
+  },
+
+  get finished() {
+    return this[finishedSymbol];
+  },
+  set finished(value) {
+    this[finishedSymbol] = value;
   },
 
   // This end method is actually on the OutgoingMessage prototype in Node.js
@@ -1936,7 +1944,7 @@ const ServerResponsePrototype = {
         req._dump();
       }
       this.detachSocket(socket);
-      this[finishedSymbol] = this.finished = true;
+      this.finished = true;
 
       this.emit("prefinish");
       this._callPendingCallbacks();


### PR DESCRIPTION
### What does this PR do?

Fixes ServerResponse.finished not being initialized to false on construction. This (sometimes) caused Express responses to never complete. (Fixed version of #18078)

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

In addition to running the node:http tests, I ran this reproduction provided on Discord by @Lillious and spammed refresh with cache disabled on a simple index.html page that includes an image:

```js
import express from "express";
import path from "path";
import http from "http";
const port = process.env.WEB_PORT || 8081;

const webserver = express();
webserver.use(express.json());
webserver.use(express.urlencoded({ extended: true }));
webserver.disable("x-powered-by");

webserver.use(express.static(path.join(import.meta.dir, "www")));

const server = http.createServer(webserver);

server.listen(port, () => {
  console.log(`Webserver is running on port ${port}`);
});

server.on("error", (error) => {
  console.error(error);
});
```

Before this fix, it would sometimes fail to load the image or the page itself. Now it always succeeds.
