### PR TITLE
remove a memory leak in bun.String.concat/createFromConcat

### DIFF
--- a/src/bun.js/api/bun/socket/SocketAddress.zig
+++ b/src/bun.js/api/bun/socket/SocketAddress.zig
@@ -131,6 +131,7 @@ pub fn parse(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError
         if (!input_arg.isString()) return global.throwInvalidArgumentTypeValue("input", "string", input_arg);
         break :blk try bun.String.fromJS2(input_arg, global);
     };
+    defer input.deref();
 
     const prefix = "http://";
     const url_str = switch (input.is8Bit()) {


### PR DESCRIPTION
the function `bun.String.createFromConcat` and `bun.String.concat` have a memory leak, and make too many allocations. since there is exactly one usage of this function, the easiest solution is to just delete it.