### PR TITLE
Better edge case handling in napi_value<->String conversion

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -203,10 +203,10 @@ std::optional<double> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexica
 
         if (view->is8Bit()) {
             const auto span = view->span8();
-            return Bun__encoding__byteLengthLatin1(span.data(), span.size(), static_cast<uint8_t>(encoding));
+            return Bun__encoding__byteLengthLatin1AsUTF8(span.data(), span.size());
         } else {
             const auto span = view->span16();
-            return Bun__encoding__byteLengthUTF16(span.data(), span.size(), static_cast<uint8_t>(encoding));
+            return Bun__encoding__byteLengthUTF16AsUTF8(span.data(), span.size());
         }
     }
     default: {

--- a/src/bun.js/bindings/ZigString.zig
+++ b/src/bun.js/bindings/ZigString.zig
@@ -252,7 +252,7 @@ pub const ZigString = extern struct {
         }
 
         if (this.is16Bit()) {
-            return JSC.WebCore.Encoder.byteLengthU16(this.utf16SliceAligned().ptr, this.utf16Slice().len, .utf8);
+            return strings.elementLengthUTF16IntoUTF8([]const u16, this.utf16SliceAligned());
         }
 
         return JSC.WebCore.Encoder.byteLengthU8(this.slice().ptr, this.slice().len, .utf8);

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -384,8 +384,8 @@ extern "C" void ZigString__free_global(const unsigned char* ptr, size_t len);
 extern "C" size_t Bun__encoding__writeLatin1(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 extern "C" size_t Bun__encoding__writeUTF16(const UChar* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 
-extern "C" size_t Bun__encoding__byteLengthLatin1(const unsigned char* ptr, size_t len, Encoding encoding);
-extern "C" size_t Bun__encoding__byteLengthUTF16(const UChar* ptr, size_t len, Encoding encoding);
+extern "C" size_t Bun__encoding__byteLengthLatin1AsUTF8(const unsigned char* ptr, size_t len);
+extern "C" size_t Bun__encoding__byteLengthUTF16AsUTF8(const UChar* ptr, size_t len);
 
 extern "C" int64_t Bun__encoding__constructFromLatin1(void*, const unsigned char* ptr, size_t len, Encoding encoding);
 extern "C" int64_t Bun__encoding__constructFromUTF16(void*, const UChar* ptr, size_t len, Encoding encoding);

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2207,7 +2207,7 @@ napi_status napi_get_value_string_any_encoding(napi_env env, napi_value napiValu
         if constexpr (EncodeTo == NapiStringEncoding::utf16le) {
             // pass subslice to work around Bun__encoding__writeLatin1 asserting that the output has room
             written = Bun__encoding__writeLatin1(view.span8().data(),
-                std::min(static_cast<unsigned long>(view.span8().size()), bufsize),
+                std::min(static_cast<size_t>(view.span8().size()), bufsize),
                 writable_byte_slice.data(),
                 writable_byte_slice.size(),
                 static_cast<uint8_t>(EncodeTo));

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2134,8 +2134,25 @@ extern "C" napi_status napi_get_value_int64(napi_env env, napi_value value, int6
     NAPI_RETURN_SUCCESS(env);
 }
 
-template<typename BufferElement, WebCore::BufferEncodingType EncodeTo>
-napi_status napi_get_value_string_any_encoding(napi_env env, napi_value napiValue, BufferElement* buf, size_t bufsize, size_t* writtenPtr)
+// must match src/bun.js/node/types.zig#Encoding, which matches WebCore::BufferEncodingType
+enum class NapiStringEncoding : uint8_t {
+    utf8 = static_cast<uint8_t>(WebCore::BufferEncodingType::utf8),
+    utf16le = static_cast<uint8_t>(WebCore::BufferEncodingType::utf16le),
+    latin1 = static_cast<uint8_t>(WebCore::BufferEncodingType::latin1),
+};
+
+template<NapiStringEncoding...>
+struct BufferElement {
+    using Type = char;
+};
+
+template<>
+struct BufferElement<NapiStringEncoding::utf16le> {
+    using Type = char16_t;
+};
+
+template<NapiStringEncoding EncodeTo>
+napi_status napi_get_value_string_any_encoding(napi_env env, napi_value napiValue, typename BufferElement<EncodeTo>::Type* buf, size_t bufsize, size_t* writtenPtr)
 {
     NAPI_CHECK_ARG(env, napiValue);
     JSValue jsValue = toJS(napiValue);
@@ -2148,10 +2165,22 @@ napi_status napi_get_value_string_any_encoding(napi_env env, napi_value napiValu
     if (buf == nullptr) {
         // they just want to know the length
         NAPI_CHECK_ARG(env, writtenPtr);
-        if (view.is8Bit()) {
-            *writtenPtr = Bun__encoding__byteLengthLatin1(view.span8().data(), length, static_cast<uint8_t>(EncodeTo));
-        } else {
-            *writtenPtr = Bun__encoding__byteLengthUTF16(view.span16().data(), length, static_cast<uint8_t>(EncodeTo));
+        switch (EncodeTo) {
+        case NapiStringEncoding::utf8:
+            if (view.is8Bit()) {
+                *writtenPtr = Bun__encoding__byteLengthLatin1AsUTF8(view.span8().data(), length);
+            } else {
+                *writtenPtr = Bun__encoding__byteLengthUTF16AsUTF8(view.span16().data(), length);
+            }
+            break;
+        case NapiStringEncoding::utf16le:
+            [[fallthrough]];
+        case NapiStringEncoding::latin1:
+            // if the string's encoding is the same as the destination encoding, this is trivially correct
+            // if we are converting UTF-16 to Latin-1, then we do so by truncating each code unit, so the length is the same
+            // if we are converting Latin-1 to UTF-16, then we do so by extending each code unit, so the length is also the same
+            *writtenPtr = length;
+            break;
         }
         return napi_set_last_error(env, napi_ok);
     }
@@ -2168,10 +2197,30 @@ napi_status napi_get_value_string_any_encoding(napi_env env, napi_value napiValu
     }
 
     size_t written;
+    std::span<unsigned char> writable_byte_slice(reinterpret_cast<unsigned char*>(buf),
+        EncodeTo == NapiStringEncoding::utf16le
+            // don't write encoded text to the last element of the destination buffer
+            // since we need to put a null terminator there
+            ? 2 * (bufsize - 1)
+            : bufsize - 1);
     if (view.is8Bit()) {
-        written = Bun__encoding__writeLatin1(view.span8().data(), view.length(), reinterpret_cast<unsigned char*>(buf), bufsize - 1, static_cast<uint8_t>(EncodeTo));
+        if constexpr (EncodeTo == NapiStringEncoding::utf16le) {
+            // pass subslice to work around Bun__encoding__writeLatin1 asserting that the output has room
+            written = Bun__encoding__writeLatin1(view.span8().data(),
+                std::min(static_cast<unsigned long>(view.span8().size()), bufsize),
+                writable_byte_slice.data(),
+                writable_byte_slice.size(),
+                static_cast<uint8_t>(EncodeTo));
+        } else {
+            written = Bun__encoding__writeLatin1(view.span8().data(), view.length(), writable_byte_slice.data(), writable_byte_slice.size(), static_cast<uint8_t>(EncodeTo));
+        }
     } else {
-        written = Bun__encoding__writeUTF16(view.span16().data(), view.length(), reinterpret_cast<unsigned char*>(buf), bufsize - 1, static_cast<uint8_t>(EncodeTo));
+        written = Bun__encoding__writeUTF16(view.span16().data(), view.length(), writable_byte_slice.data(), writable_byte_slice.size(), static_cast<uint8_t>(EncodeTo));
+    }
+
+    // convert bytes to code units
+    if constexpr (EncodeTo == NapiStringEncoding::utf16le) {
+        written /= 2;
     }
 
     if (writtenPtr != nullptr) {
@@ -2193,7 +2242,7 @@ extern "C" napi_status napi_get_value_string_utf8(napi_env env,
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     // this function does set_last_error
-    return napi_get_value_string_any_encoding<char, WebCore::BufferEncodingType::utf8>(env, napiValue, buf, bufsize, writtenPtr);
+    return napi_get_value_string_any_encoding<NapiStringEncoding::utf8>(env, napiValue, buf, bufsize, writtenPtr);
 }
 
 extern "C" napi_status napi_get_value_string_latin1(napi_env env, napi_value napiValue, char* buf, size_t bufsize, size_t* writtenPtr)
@@ -2201,7 +2250,7 @@ extern "C" napi_status napi_get_value_string_latin1(napi_env env, napi_value nap
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     // this function does set_last_error
-    return napi_get_value_string_any_encoding<char, WebCore::BufferEncodingType::latin1>(env, napiValue, buf, bufsize, writtenPtr);
+    return napi_get_value_string_any_encoding<NapiStringEncoding::latin1>(env, napiValue, buf, bufsize, writtenPtr);
 }
 
 extern "C" napi_status napi_get_value_string_utf16(napi_env env, napi_value napiValue, char16_t* buf, size_t bufsize, size_t* writtenPtr)
@@ -2209,7 +2258,7 @@ extern "C" napi_status napi_get_value_string_utf16(napi_env env, napi_value napi
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     // this function does set_last_error
-    return napi_get_value_string_any_encoding<char16_t, WebCore::BufferEncodingType::latin1>(env, napiValue, buf, bufsize, writtenPtr);
+    return napi_get_value_string_any_encoding<NapiStringEncoding::utf16le>(env, napiValue, buf, bufsize, writtenPtr);
 }
 
 extern "C" napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result)

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -961,31 +961,13 @@ pub const Encoder = struct {
             else => unreachable,
         } catch 0;
     }
-    export fn Bun__encoding__byteLengthLatin1(input: [*]const u8, len: usize, encoding: u8) usize {
-        return switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
-            .utf8 => byteLengthU8(input, len, .utf8),
-            .latin1 => byteLengthU8(input, len, .ascii),
-            .ascii => byteLengthU8(input, len, .ascii),
-            .ucs2 => byteLengthU8(input, len, .utf16le),
-            .utf16le => byteLengthU8(input, len, .utf16le),
-            .base64 => byteLengthU8(input, len, .base64),
-            .base64url => byteLengthU8(input, len, .base64url),
-            .hex => byteLengthU8(input, len, .hex),
-            else => unreachable,
-        };
+    // TODO(@190n) handle unpaired surrogates
+    export fn Bun__encoding__byteLengthLatin1AsUTF8(input: [*]const u8, len: usize) usize {
+        return byteLengthU8(input, len, .utf8);
     }
-    export fn Bun__encoding__byteLengthUTF16(input: [*]const u16, len: usize, encoding: u8) usize {
-        return switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
-            .utf8 => byteLengthU16(input, len, .utf8),
-            .latin1 => byteLengthU16(input, len, .ascii),
-            .ascii => byteLengthU16(input, len, .ascii),
-            .ucs2 => byteLengthU16(input, len, .utf16le),
-            .utf16le => byteLengthU16(input, len, .utf16le),
-            .base64 => byteLengthU16(input, len, .base64),
-            .base64url => byteLengthU16(input, len, .base64url),
-            .hex => byteLengthU16(input, len, .hex),
-            else => unreachable,
-        };
+    // TODO(@190n) handle unpaired surrogates
+    export fn Bun__encoding__byteLengthUTF16AsUTF8(input: [*]const u16, len: usize) usize {
+        return byteLengthU16(input, len, .utf8);
     }
     export fn Bun__encoding__constructFromLatin1(globalObject: *JSGlobalObject, input: [*]const u8, len: usize, encoding: u8) JSValue {
         const slice = switch (@as(JSC.Node.Encoding, @enumFromInt(encoding))) {
@@ -1472,8 +1454,8 @@ pub const Encoder = struct {
         _ = Bun__encoding__writeLatin1;
         _ = Bun__encoding__writeUTF16;
 
-        _ = Bun__encoding__byteLengthLatin1;
-        _ = Bun__encoding__byteLengthUTF16;
+        _ = Bun__encoding__byteLengthLatin1AsUTF8;
+        _ = Bun__encoding__byteLengthUTF16AsUTF8;
 
         _ = Bun__encoding__toString;
         _ = Bun__encoding__toStringUTF8;

--- a/src/napi/js_native_api.h
+++ b/src/napi/js_native_api.h
@@ -238,8 +238,6 @@ NAPI_EXTERN napi_status napi_unwrap(napi_env env, napi_value js_object,
                                     void **result);
 NAPI_EXTERN napi_status napi_remove_wrap(napi_env env, napi_value js_object,
                                          void **result);
-NAPI_EXTERN napi_status napi_create_object(napi_env env, 
-                                             napi_value *result);
 NAPI_EXTERN napi_status napi_create_external(napi_env env, void *data,
                                              napi_finalize finalize_cb,
                                              void *finalize_hint,
@@ -454,6 +452,32 @@ napi_check_object_type_tag(napi_env env, napi_value value,
 NAPI_EXTERN napi_status napi_object_freeze(napi_env env, napi_value object);
 NAPI_EXTERN napi_status napi_object_seal(napi_env env, napi_value object);
 #endif // NAPI_VERSION >= 8
+
+#if NAPI_VERSION >= 10
+NAPI_EXTERN napi_status node_api_create_external_string_latin1(
+    napi_env env,
+    char* str,
+    size_t length,
+    napi_finalize finalize_callback,
+    void* finalize_hint,
+    napi_value* result,
+    bool* copied);
+NAPI_EXTERN napi_status
+node_api_create_external_string_utf16(napi_env env,
+                                      char16_t* str,
+                                      size_t length,
+                                      napi_finalize finalize_callback,
+                                      void* finalize_hint,
+                                      napi_value* result,
+                                      bool* copied);
+
+NAPI_EXTERN napi_status node_api_create_property_key_latin1(
+    napi_env env, const char* str, size_t length, napi_value* result);
+NAPI_EXTERN napi_status node_api_create_property_key_utf8(
+    napi_env env, const char* str, size_t length, napi_value* result);
+NAPI_EXTERN napi_status node_api_create_property_key_utf16(
+    napi_env env, const char16_t* str, size_t length, napi_value* result);
+#endif // NAPI_VERSION >= 10
 
 EXTERN_C_END
 

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -383,7 +383,7 @@ pub export fn napi_create_string_latin1(env_: napi_env, str: ?[*]const u8, lengt
         if (str) |ptr| {
             if (NAPI_AUTO_LENGTH == length) {
                 break :brk bun.sliceTo(@as([*:0]const u8, @ptrCast(ptr)), 0);
-            } else if (length > std.math.maxInt(u32)) {
+            } else if (length > std.math.maxInt(i32)) {
                 return env.invalidArg();
             } else {
                 break :brk ptr[0..length];
@@ -424,7 +424,7 @@ pub export fn napi_create_string_utf8(env_: napi_env, str: ?[*]const u8, length:
         if (str) |ptr| {
             if (NAPI_AUTO_LENGTH == length) {
                 break :brk bun.sliceTo(@as([*:0]const u8, @ptrCast(str)), 0);
-            } else if (length > std.math.maxInt(u32)) {
+            } else if (length > std.math.maxInt(i32)) {
                 return env.invalidArg();
             } else {
                 break :brk ptr[0..length];
@@ -460,7 +460,7 @@ pub export fn napi_create_string_utf16(env_: napi_env, str: ?[*]const char16_t, 
         if (str) |ptr| {
             if (NAPI_AUTO_LENGTH == length) {
                 break :brk bun.sliceTo(@as([*:0]const u16, @ptrCast(str)), 0);
-            } else if (length > std.math.maxInt(u32)) {
+            } else if (length > std.math.maxInt(i32)) {
                 return env.invalidArg();
             } else {
                 break :brk ptr[0..length];

--- a/src/string/WTFStringImpl.zig
+++ b/src/string/WTFStringImpl.zig
@@ -208,7 +208,7 @@ pub const WTFStringImplStruct = extern struct {
             return if (input.len > 0) JSC.WebCore.Encoder.byteLengthU8(input.ptr, input.len, .utf8) else 0;
         } else {
             const input = this.utf16Slice();
-            return if (input.len > 0) JSC.WebCore.Encoder.byteLengthU16(input.ptr, input.len, .utf8) else 0;
+            return if (input.len > 0) bun.strings.elementLengthUTF16IntoUTF8([]const u16, input) else 0;
         }
     }
 

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -11,7 +11,7 @@
                 },
             },
             # leak tests are unused as of #14501
-            "sources": ["main.cpp", "async_tests.cpp", "class_test.cpp", "conversion_tests.cpp", "js_test_helpers.cpp", "standalone_tests.cpp", "wrap_tests.cpp"],
+            "sources": ["main.cpp", "async_tests.cpp", "class_test.cpp", "conversion_tests.cpp", "js_test_helpers.cpp", "standalone_tests.cpp", "wrap_tests.cpp", "get_string_tests.cpp"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
             "libraries": [],
             "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],

--- a/test/napi/napi-app/get_string_tests.cpp
+++ b/test/napi/napi-app/get_string_tests.cpp
@@ -1,0 +1,79 @@
+#include "conversion_tests.h"
+
+#include "utils.h"
+#include <array>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <type_traits>
+
+namespace napitests {
+
+template <typename Element,
+          napi_status (*get_value_string_fn)(napi_env, napi_value, Element *,
+                                             size_t, size_t *)>
+static napi_value
+test_get_value_string_any_encoding(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  static constexpr size_t BUFSIZE = 32;
+  std::array<Element, BUFSIZE> buf;
+  napi_value string = info[0];
+
+  size_t full_length;
+  NODE_API_CALL(env,
+                get_value_string_fn(env, string, nullptr, 0, &full_length));
+  printf("full encoded size = %zu\n", full_length);
+
+  // try to write into every subslice of the buffer
+  for (size_t len = 0; len < BUFSIZE; len++) {
+    // initialize so we can tell which parts of the buffer were overwritten and
+    // which were not
+    buf.fill(std::is_same_v<Element, char> ? 0xaa : 0xaaaa);
+
+    size_t written = SIZE_MAX;
+    NODE_API_CALL(env,
+                  get_value_string_fn(env, string, buf.data(), len, &written));
+    printf("tried to fill %zu/%zu units of buffer, got %zu (+ terminator)\n",
+           len, BUFSIZE, written);
+    printf("[");
+    for (const auto &elem : buf) {
+      size_t i = &elem - buf.data();
+      if (i == written) {
+        printf("|");
+      }
+      if (i == len) {
+        printf("]");
+      }
+
+      if constexpr (std::is_same_v<Element, char>) {
+        printf("%02x", reinterpret_cast<const uint8_t &>(elem));
+      } else {
+        printf("%04x", reinterpret_cast<const uint16_t &>(elem));
+      }
+    }
+    printf("\n");
+    if (written == full_length) {
+      // at this point we are encoding the whole string, so no need to keep
+      // trying larger buffers
+      return env.Undefined();
+    }
+  }
+
+  return env.Undefined();
+}
+
+void register_get_string_tests(Napi::Env env, Napi::Object exports) {
+  exports.Set(
+      "test_get_value_string_latin1",
+      Napi::Function::New(env, test_get_value_string_any_encoding<
+                                   char, napi_get_value_string_latin1>));
+  exports.Set("test_get_value_string_utf8",
+              Napi::Function::New(env, test_get_value_string_any_encoding<
+                                           char, napi_get_value_string_utf8>));
+  exports.Set(
+      "test_get_value_string_utf16",
+      Napi::Function::New(env, test_get_value_string_any_encoding<
+                                   char16_t, napi_get_value_string_utf16>));
+}
+
+} // namespace napitests

--- a/test/napi/napi-app/get_string_tests.h
+++ b/test/napi/napi-app/get_string_tests.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Exposes functions to JavaScript to test the `napi_get_value_string_*` methods
+
+#include "napi_with_version.h"
+
+namespace napitests {
+
+void register_get_string_tests(Napi::Env env, Napi::Object exports);
+
+} // namespace napitests

--- a/test/napi/napi-app/main.cpp
+++ b/test/napi/napi-app/main.cpp
@@ -3,6 +3,7 @@
 #include "async_tests.h"
 #include "class_test.h"
 #include "conversion_tests.h"
+#include "get_string_tests.h"
 #include "js_test_helpers.h"
 #include "standalone_tests.h"
 #include "wrap_tests.h"
@@ -35,6 +36,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports1) {
   register_js_test_helpers(env, exports);
   register_wrap_tests(env, exports);
   register_conversion_tests(env, exports);
+  register_get_string_tests(env, exports);
 
   return exports;
 }

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -178,6 +178,12 @@ describe("napi", () => {
     });
   });
 
+  describe("napi_get_value_string_*", () => {
+    it("behaves like node on edge cases", () => {
+      checkSameOutput("test_get_value_string", []);
+    });
+  });
+
   it("#1288", async () => {
     const result = checkSameOutput("self", []);
     expect(result).toBe("hello world!");

--- a/test/napi/node-napi-tests/test/js-native-api/test_string/test.js
+++ b/test/napi/node-napi-tests/test/js-native-api/test_string/test.js
@@ -39,8 +39,9 @@ const unicodeCases = [
 function testLatin1Cases(str) {
   assert.strictEqual(test_string.TestLatin1(str), str);
   assert.strictEqual(test_string.TestLatin1AutoLength(str), str);
-  assert.strictEqual(test_string.TestLatin1External(str), str);
-  assert.strictEqual(test_string.TestLatin1ExternalAutoLength(str), str);
+  // BUN: skip these tests until we support making empty external strings
+  if (str.length > 0) assert.strictEqual(test_string.TestLatin1External(str), str);
+  if (str.length > 0) assert.strictEqual(test_string.TestLatin1ExternalAutoLength(str), str);
   assert.strictEqual(test_string.TestPropertyKeyLatin1(str), str);
   assert.strictEqual(test_string.TestPropertyKeyLatin1AutoLength(str), str);
   assert.strictEqual(test_string.Latin1Length(str), str.length);
@@ -55,8 +56,9 @@ function testUnicodeCases(str, utf8Length, utf8InsufficientIdx) {
   assert.strictEqual(test_string.TestUtf16(str), str);
   assert.strictEqual(test_string.TestUtf8AutoLength(str), str);
   assert.strictEqual(test_string.TestUtf16AutoLength(str), str);
-  assert.strictEqual(test_string.TestUtf16External(str), str);
-  assert.strictEqual(test_string.TestUtf16ExternalAutoLength(str), str);
+  // BUN: skip these tests until we support making empty external strings
+  if (str.length > 0) assert.strictEqual(test_string.TestUtf16External(str), str);
+  if (str.length > 0) assert.strictEqual(test_string.TestUtf16ExternalAutoLength(str), str);
   assert.strictEqual(test_string.TestPropertyKeyUtf8(str), str);
   assert.strictEqual(test_string.TestPropertyKeyUtf8AutoLength(str), str);
   assert.strictEqual(test_string.TestPropertyKeyUtf16(str), str);

--- a/test/napi/node-napi.test.ts
+++ b/test/napi/node-napi.test.ts
@@ -12,8 +12,9 @@ const nodeApiTests = Array.from(new Glob("**/*.js").scanSync(nodeApiRoot));
 
 // These js-native-api tests are known to fail and will be fixed in later PRs
 let failingJsNativeApiTests = [
-  // Fails because Bun doesn't support creating empty external strings
-  "test_string/test.js",
+  // We skip certain parts of test_string/test.js because we don't support creating empty external
+  // strings. We don't skip the entire thing because the other tests are useful to check.
+  // "test_string/test.js",
 ];
 
 // These are the tests from node-api that failed as of commit 83f536f4d, except for those that


### PR DESCRIPTION
### What does this PR do?

Fixes several bugs in `napi_get_value_string_*` and `napi_create_string_*` exposed by exhaustive testing.

`napi_get_value_string_*` still doesn't handle unpaired surrogates correctly, but this is still strictly better than status quo.

Fixes #18069
Fixes #18079

### How did you verify your code works?

Added new tests and ran the existing tests (ours and Node's)
