### PR TITLE
Fix #18064

### DIFF
--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -7145,13 +7145,19 @@ const Notation = struct {
 ///
 /// Returns null if value was an infinite number
 pub fn dtoa_short(buf: *[129]u8, value: f32, comptime precision: u8) !struct { []u8, ?Notation } {
-    // We must pass finite numbers to dtoa_short_impl
+    // We can't give Infinity/-Infinity to dtoa_short_impl so
+    // we'l handle them here.
+    //
+    // We need to print a valid finite number otherwise browsers like Safari will
+    // render certain things wrong (see https://github.com/oven-sh/bun/issues/18064)
+    //
+    // We'll use 3.40282e38 which is the largest finite number in 32-bit IEEE754 floating point
     if (std.math.isPositiveInf(value)) {
-        buf[0.."1e999".len].* = "1e999".*;
-        return .{ buf[0.."1e999".len], null };
+        buf[0.."3.40282e38".len].* = "3.40282e38".*;
+        return .{ buf[0.."3.40282e38".len], null };
     } else if (std.math.isNegativeInf(value)) {
-        buf[0.."-1e999".len].* = "-1e999".*;
-        return .{ buf[0.."-1e999".len], null };
+        buf[0.."-3.40282e38".len].* = "-3.40282e38".*;
+        return .{ buf[0.."-3.40282e38".len], null };
     }
     // We shouldn't receive NaN here.
     // NaN is not a valid CSS token and any inlined calculations from `calc()` we ensure

--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -7151,7 +7151,7 @@ pub fn dtoa_short(buf: *[129]u8, value: f32, comptime precision: u8) !struct { [
     // We need to print a valid finite number otherwise browsers like Safari will
     // render certain things wrong (see https://github.com/oven-sh/bun/issues/18064)
     //
-    // We'll use 3.40282e38 which is the largest finite number in 32-bit IEEE754 floating point
+    // We'll use 3.40282e38 which is approximately the largest finite number in 32-bit IEEE754 floating point
     if (std.math.isPositiveInf(value)) {
         buf[0.."3.40282e38".len].* = "3.40282e38".*;
         return .{ buf[0.."3.40282e38".len], null };

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -85,13 +85,14 @@ describe("css tests", () => {
   });
 
   test("calc edge case", () => {
+    // https://github.com/oven-sh/bun/issues/18064
     minify_test(
-      // Problem: the value is being printed as Infinity in our restrict_prec thing but the internal thing actually wants it as 3.40282e38px
       `.rounded-full {
   border-radius: calc(infinity * 1px);
   width: calc(infinity * -1px);
+  height: infinity;
 }`,
-      indoc`.rounded-full{border-radius:1e999px;width:-1e999px}`,
+      indoc`.rounded-full{height:infinity;border-radius:3.40282e38px;width:-3.40282e38px}`,
     );
   });
   describe("border_spacing", () => {


### PR DESCRIPTION
Fixes #18064 

Can't give safari a value which evaluates to infinity otherwise it will not render things correctly so use 3.40282e38 which is approximately the largest finite value in IEEE754 32 bit float