### PR TITLE
Fix #18131 (global catch-all route does not work with callback handler)

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -9205,7 +9205,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             // - DevServer
             // - HTML Bundle
             var needs_plugins = dev_server != null;
-            var has_html_catch_all = false;
 
             if (this.config.user_routes_to_build.items.len > 0) {
                 var user_routes_to_build = this.config.user_routes_to_build.moveToUnmanaged();
@@ -9310,9 +9309,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                         },
                         .framework_router => {},
                     }
-                    if (!has_html_catch_all and strings.eqlComptime(entry.path, "/*")) {
-                        has_html_catch_all = true;
-                    }
                 }
             }
 
@@ -9324,6 +9320,12 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                     this.plugins = ServePlugins.init(serve_plugins);
                 }
             };
+
+            const @"has /*" = for (this.config.static_routes.items) |route| {
+                if (strings.eqlComptime(route.path, "/*")) break true;
+            } else for (this.user_routes.items) |route| {
+                if (strings.eqlComptime(route.route.path, "/*")) break true;
+            } else false;
 
             // Setup user websocket fallback route aka fetch function if fetch is not provided will respond with 403.
             if (!has_any_ws) {
@@ -9339,7 +9341,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (this.config.onNodeHTTPRequest != .zero) {
                 app.any("/*", *ThisServer, this, onNodeHTTPRequest);
                 NodeHTTP_assignOnCloseFunction(@intFromBool(ssl_enabled), app);
-            } else if (this.config.onRequest != .zero and !has_html_catch_all) {
+            } else if (this.config.onRequest != .zero and !@"has /*") {
                 app.any("/*", *ThisServer, this, onRequest);
             }
 
@@ -9357,23 +9359,16 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 has_dev_catch_all = dev.setRoutes(this) catch bun.outOfMemory();
             }
 
-            const @"has /*" = brk: {
-                for (this.config.static_routes.items) |route| {
-                    if (strings.eqlComptime(route.path, "/*")) {
-                        break :brk true;
-                    }
-                }
-
-                break :brk false;
-            };
-
             // "/*" routes are added backwards, so if they have a static route, it will never be matched
             // so we need to check for that first
             if (!has_dev_catch_all and !@"has /*" and this.config.onNodeHTTPRequest != .zero) {
+                std.log.info("setting /* <0>", .{});
                 app.any("/*", *ThisServer, this, onNodeHTTPRequest);
             } else if (!has_dev_catch_all and !@"has /*" and this.config.onRequest != .zero) {
+                std.log.info("setting /* <1>", .{});
                 app.any("/*", *ThisServer, this, onRequest);
             } else if (!has_dev_catch_all and this.config.onNodeHTTPRequest != .zero) {
+                std.log.info("setting /* <2>", .{});
                 app.post("/*", *ThisServer, this, onNodeHTTPRequest);
                 app.put("/*", *ThisServer, this, onNodeHTTPRequest);
                 app.patch("/*", *ThisServer, this, onNodeHTTPRequest);
@@ -9382,11 +9377,14 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 app.trace("/*", *ThisServer, this, onNodeHTTPRequest);
                 app.connect("/*", *ThisServer, this, onNodeHTTPRequest);
             } else if (!has_dev_catch_all and this.config.onRequest != .zero) {
+                std.log.info("setting /* <3>", .{});
                 // "/*" routes are added backwards, so if they have a static route,
                 // it will never be matched so we need to check for that first
-                if (!has_html_catch_all) {
+                if (!@"has /*") {
+                    std.log.info("setting /* <4>", .{});
                     app.any("/*", *ThisServer, this, onRequest);
                 } else {
+                    std.log.info("setting /* <5>", .{});
                     // The HTML catch-all receives GET, HEAD.
                     app.post("/*", *ThisServer, this, onRequest);
                     app.put("/*", *ThisServer, this, onRequest);
@@ -9396,9 +9394,11 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                     app.trace("/*", *ThisServer, this, onRequest);
                     app.connect("/*", *ThisServer, this, onRequest);
                 }
-            } else if (!has_dev_catch_all and this.config.onRequest == .zero and !has_html_catch_all) {
+            } else if (!has_dev_catch_all and this.config.onRequest == .zero and !@"has /*") {
+                std.log.info("setting /* <6>", .{});
                 app.any("/*", *ThisServer, this, on404);
             } else if (!has_dev_catch_all and this.config.onRequest == .zero) {
+                std.log.info("setting /* <7>", .{});
                 app.post("/*", *ThisServer, this, on404);
                 app.put("/*", *ThisServer, this, on404);
                 app.patch("/*", *ThisServer, this, on404);
@@ -9406,6 +9406,8 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 app.options("/*", *ThisServer, this, on404);
                 app.trace("/*", *ThisServer, this, on404);
                 app.connect("/*", *ThisServer, this, on404);
+            } else {
+                std.log.info("setting /* <8>", .{});
             }
 
             return route_list_value;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -9362,13 +9362,10 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             // "/*" routes are added backwards, so if they have a static route, it will never be matched
             // so we need to check for that first
             if (!has_dev_catch_all and !@"has /*" and this.config.onNodeHTTPRequest != .zero) {
-                std.log.info("setting /* <0>", .{});
                 app.any("/*", *ThisServer, this, onNodeHTTPRequest);
             } else if (!has_dev_catch_all and !@"has /*" and this.config.onRequest != .zero) {
-                std.log.info("setting /* <1>", .{});
                 app.any("/*", *ThisServer, this, onRequest);
             } else if (!has_dev_catch_all and this.config.onNodeHTTPRequest != .zero) {
-                std.log.info("setting /* <2>", .{});
                 app.post("/*", *ThisServer, this, onNodeHTTPRequest);
                 app.put("/*", *ThisServer, this, onNodeHTTPRequest);
                 app.patch("/*", *ThisServer, this, onNodeHTTPRequest);
@@ -9377,14 +9374,11 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 app.trace("/*", *ThisServer, this, onNodeHTTPRequest);
                 app.connect("/*", *ThisServer, this, onNodeHTTPRequest);
             } else if (!has_dev_catch_all and this.config.onRequest != .zero) {
-                std.log.info("setting /* <3>", .{});
                 // "/*" routes are added backwards, so if they have a static route,
                 // it will never be matched so we need to check for that first
                 if (!@"has /*") {
-                    std.log.info("setting /* <4>", .{});
                     app.any("/*", *ThisServer, this, onRequest);
                 } else {
-                    std.log.info("setting /* <5>", .{});
                     // The HTML catch-all receives GET, HEAD.
                     app.post("/*", *ThisServer, this, onRequest);
                     app.put("/*", *ThisServer, this, onRequest);
@@ -9395,10 +9389,8 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                     app.connect("/*", *ThisServer, this, onRequest);
                 }
             } else if (!has_dev_catch_all and this.config.onRequest == .zero and !@"has /*") {
-                std.log.info("setting /* <6>", .{});
                 app.any("/*", *ThisServer, this, on404);
             } else if (!has_dev_catch_all and this.config.onRequest == .zero) {
-                std.log.info("setting /* <7>", .{});
                 app.post("/*", *ThisServer, this, on404);
                 app.put("/*", *ThisServer, this, on404);
                 app.patch("/*", *ThisServer, this, on404);
@@ -9406,8 +9398,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 app.options("/*", *ThisServer, this, on404);
                 app.trace("/*", *ThisServer, this, on404);
                 app.connect("/*", *ThisServer, this, on404);
-            } else {
-                std.log.info("setting /* <8>", .{});
             }
 
             return route_list_value;

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -193,7 +193,7 @@ describe("route precedence", () => {
     expect(await res.text()).toBe("api catchall");
   });
 
-  it.todo("matches root wildcard as last resort", async () => {
+  it("matches root wildcard as last resort", async () => {
     const res = await fetch(`${server.url}unknown`);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("root catchall");


### PR DESCRIPTION
### What does this PR do?

Fixes #18131

There are still be other issues related to global catch-all handlers. eg: `bun init` react, putting the app on `/app` the catch-all handler is never called. Maybe `/*` could be equivalent to `fetch(req)` because that still works with devserver.