### PR TITLE
Fix type error for Uint8Array.fromBase64

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1788,6 +1788,12 @@ declare global {
      * @param base64 The base64 encoded string to convert to a Uint8Array
      * @returns A new Uint8Array containing the decoded data
      */
-    fromBase64(base64: string): Uint8Array;
+    fromBase64(
+      base64: string,
+      options?: {
+        alphabet?: "base64" | "base64url";
+        lastChunkHandling?: "loose" | "strict" | "stop-before-partial"
+      }
+    ): Uint8Array;
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds option type for [`Uint8Array.fromBase64`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64).

### How did you verify your code works?

the `fromBase64` constructor option already works, we just missed the type definition.

```ts
const base64 = "Pn5+fg";
const base64url = "Pn5-fg";

console.log(Uint8Array.fromBase64(base64));

console.log(Uint8Array.fromBase64(base64, { lastChunkHandling: "loose", }));

console.log(Uint8Array.fromBase64(base64, { lastChunkHandling: "stop-before-partial", }));

console.log(Uint8Array.fromBase64(base64url, { alphabet: "base64url", }));

try {
  Uint8Array.fromBase64(base64, { lastChunkHandling: "strict", });
} catch (e) {
  console.log("error decoding base64 with strict");
}

try {
  Uint8Array.fromBase64(base64, { alphabet: "base64url", });
} catch (e) {
  console.log("error decoding base64 as base64url");
}

try {
  Uint8Array.fromBase64(base64url);
} catch (e) {
  console.log("error decoding base64url as base64");
}
```
Running above code on Bun 1.2.2 will print:
```
Uint8Array(4) [ 62, 126, 126, 126 ]
Uint8Array(4) [ 62, 126, 126, 126 ]
Uint8Array(3) [ 62, 126, 126 ]
Uint8Array(4) [ 62, 126, 126, 126 ]
error decoding base64 with strict
error decoding base64 as base64url
error decoding base64url as base64
```