### PR TITLE
fix: removal of trailing slash in s3 presign

### DIFF
--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -539,7 +539,7 @@ pub const S3Credentials = struct {
             }
         }
         if (strings.endsWith(path, "/")) {
-            path = path[0..path.len];
+            path = path[0 .. path.len - 1];
         } else if (strings.endsWith(path, "\\")) {
             path = path[0 .. path.len - 1];
         }


### PR DESCRIPTION
### What does this PR do?

I _think_ this is a bug because that line doesn't make any sense otherwise. Also, \ and / are treated equally in the rest of the code, except here.

If this line is intended (for example, to mark that the path should be left as-is in that case), there should be a comment stating that this is intentional.

### How did you verify your code works?
I didn't.

Probably @cirospaciari could have a quick look and tell if this is intended behaviour or not. Feel free to close this PR without any comment if this line is intended.