### PR TITLE
Fix `setTimeout(() => {})` from emitting a warning

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -366,8 +366,8 @@ pub const All = struct {
         // We don't deal with nesting levels directly
         // but we do set the minimum timeout to be 1ms for repeating timers
         // TODO: this is wrong as it clears exceptions (e.g `setTimeout(()=>{}, { [Symbol.toPrimitive]() { throw 'oops'; } })`)
-        const countdown_double = countdown.coerceToDouble(globalThis);
 
+        const countdown_double = countdown.coerceToDouble(globalThis);
         const countdown_int: u31 = switch (overflow_behavior) {
             .clamp => std.math.lossyCast(u31, countdown_double),
             .one_ms => if (!(countdown_double >= 1 and countdown_double <= std.math.maxInt(u31))) one: {
@@ -376,7 +376,7 @@ pub const All = struct {
                 } else if (countdown_double < 0 and !this.warned_negative_number) {
                     this.warned_negative_number = true;
                     warnInvalidCountdown(globalThis, countdown_double, .TimeoutNegativeWarning);
-                } else if (std.math.isNan(countdown_double) and !this.warned_not_number) {
+                } else if (!countdown.isUndefined() and countdown.isNumber() and std.math.isNan(countdown_double) and !this.warned_not_number) {
                     this.warned_not_number = true;
                     warnInvalidCountdown(globalThis, countdown_double, .TimeoutNaNWarning);
                 }

--- a/test/regression/issue/18159/18159.test.ts
+++ b/test/regression/issue/18159/18159.test.ts
@@ -1,0 +1,59 @@
+// Regression test for https://github.com/oven-sh/bun/issues/18159
+// When setTimeout is called without a delay argument, it should not emit a TimeoutNaNWarning
+
+import { test, expect } from "bun:test";
+
+test("setTimeout() without delay should not emit TimeoutNaNWarning", done => {
+  process.on("warning", warning => {
+    try {
+      expect(warning).toBeInstanceOf(Error);
+      expect(warning).not.toHaveProperty("name", "TimeoutNaNWarning");
+      expect(warning).toHaveProperty("message", "Another warning!");
+    } catch (error) {
+      done(error);
+      return;
+    }
+    done();
+  });
+
+  expect(() => setTimeout(() => {})).not.toThrow();
+
+  // Instead of waiting N seconds to see if the warning is emitted,
+  // emit another warning to test that the warning handler is working.
+  process.emitWarning("Another warning!");
+});
+
+test("setTimeout() with number delay should not emit TimeoutNaNWarning", done => {
+  process.on("warning", warning => {
+    try {
+      expect(warning).toBeInstanceOf(Error);
+      expect(warning).not.toHaveProperty("name", "TimeoutNaNWarning");
+      expect(warning).toHaveProperty("message", "Another warning!");
+    } catch (error) {
+      done(error);
+      return;
+    }
+    done();
+  });
+
+  expect(() => setTimeout(() => {}, 0)).not.toThrow();
+
+  // Instead of waiting N seconds to see if the warning is emitted,
+  // emit another warning to test that the warning handler is working.
+  process.emitWarning("Another warning!");
+});
+
+test("setTimeout() with NaN delay should emit TimeoutNaNWarning", done => {
+  process.on("warning", warning => {
+    try {
+      expect(warning).toBeInstanceOf(Error);
+      expect(warning).toHaveProperty("name", "TimeoutNaNWarning");
+    } catch (error) {
+      done(error);
+      return;
+    }
+    done();
+  });
+
+  expect(() => setTimeout(() => {}, NaN)).not.toThrow();
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #18159 

```js
setTimeout(() => {});
// previously: would emit TimeoutNaNWarning warning
// now: does not emit a warning
```

### How did you verify your code works?

Added a regression test.