### PR TITLE
Fix `fs.rm()` not deleting empty directory when recursive is false

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5685,8 +5685,7 @@ pub const NodeFS = struct {
             bun.handleErrorReturnTrace(err1, @errorReturnTrace());
             // empircally, it seems to return AccessDenied when the
             // file is actually a directory on macOS.
-            if (args.recursive and
-                (err1 == error.IsDir or err1 == error.NotDir or err1 == error.AccessDenied))
+            if (err1 == error.IsDir or err1 == error.NotDir or err1 == error.AccessDenied)
             {
                 std.posix.rmdirZ(dest) catch |err2| {
                     bun.handleErrorReturnTrace(err2, @errorReturnTrace());

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5685,8 +5685,7 @@ pub const NodeFS = struct {
             bun.handleErrorReturnTrace(err1, @errorReturnTrace());
             // empircally, it seems to return AccessDenied when the
             // file is actually a directory on macOS.
-            if (err1 == error.IsDir or err1 == error.NotDir or err1 == error.AccessDenied)
-            {
+            if (err1 == error.IsDir or err1 == error.NotDir or err1 == error.AccessDenied) {
                 std.posix.rmdirZ(dest) catch |err2| {
                     bun.handleErrorReturnTrace(err2, @errorReturnTrace());
                     const code: E = switch (err2) {

--- a/test/regression/issue/09419.test.ts
+++ b/test/regression/issue/09419.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "bun:test";
+import { existsSync, rmSync, rmdirSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdirSync } from "harness";
+
+describe("rm() with empty directories", () => {
+  test("rmSync(): recursive false should remove empty directory", () => {
+    const dir = tmpdirSync("rmSync-false");
+    rmSync(dir, { recursive: false });
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("rm(): recursive false should remove empty directory", async () => {
+    const dir = tmpdirSync("rm-false");
+    await rm(dir, { recursive: false });
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("rmSync(): recursive true should remove empty directory", () => {
+    const dir = tmpdirSync("rmSync-true");
+    rmSync(dir, { recursive: true });
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("rmdirSync(): should remove empty directory", () => {
+    const dir = tmpdirSync("rmdir");
+    rmdirSync(dir);
+    expect(existsSync(dir)).toBe(false);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #9419 

### How did you verify your code works?

Regression tests