### PR TITLE
fix: store correct `namespace` in `Fs.Path`

### DIFF
--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -46,7 +46,7 @@ fn createImportRecord(this: *HTMLScanner, input_path: []const u8, kind: ImportKi
     } else input_path;
 
     const record = ImportRecord{
-        .path = fs.Path.init(try this.allocator.dupeZ(u8, path_to_use)),
+        .path = fs.Path.initFile(try this.allocator.dupeZ(u8, path_to_use)),
         .kind = kind,
         .range = logger.Range.None,
     };

--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -158,7 +158,7 @@ pub fn initPending(loader: Loader, pending: resolver.Result) OutputFile {
 pub fn initFile(file: std.fs.File, pathname: string, size: usize) OutputFile {
     return .{
         .loader = .file,
-        .src_path = Fs.Path.init(pathname),
+        .src_path = Fs.Path.initFile(pathname),
         .size = size,
         .value = .{ .copy = FileOperation.fromFile(file.handle, pathname) },
     };
@@ -203,7 +203,7 @@ pub fn init(options: Options) OutputFile {
     return .{
         .loader = options.loader,
         .input_loader = options.input_loader,
-        .src_path = Fs.Path.init(options.input_path),
+        .src_path = Fs.Path.initFile(options.input_path),
         .dest_path = options.output_path,
         .size = options.size orelse switch (options.data) {
             .buffer => |buf| buf.data.len,

--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -157,7 +157,7 @@ pub const ResolveMessage = struct {
         resolve_error.* = ResolveMessage{
             .msg = msg.clone(allocator) catch unreachable,
             .allocator = allocator,
-            .referrer = Fs.Path.init(referrer),
+            .referrer = Fs.Path.initFile(referrer),
         };
         return resolve_error.toJS(globalThis);
     }

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -246,7 +246,7 @@ pub const RuntimeTranspilerStore = struct {
         loader: bun.options.Loader,
     ) *anyopaque {
         var job: *TranspilerJob = this.store.get();
-        const owned_path = Fs.Path.init(bun.default_allocator.dupe(u8, path.text) catch unreachable);
+        const owned_path = Fs.Path.initFile(bun.default_allocator.dupe(u8, path.text) catch unreachable);
         const promise = JSC.JSInternalPromise.create(globalObject);
         job.* = TranspilerJob{
             .non_threadsafe_input_specifier = input_specifier,
@@ -617,7 +617,7 @@ pub const RuntimeTranspilerStore = struct {
                 }
 
                 if (strings.hasPrefixComptime(import_record.path.text, "bun:")) {
-                    import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
+                    import_record.path = Fs.Path.initFile(import_record.path.text["bun:".len..]);
                     import_record.path.namespace = "bun";
                     import_record.is_external_without_side_effects = true;
 
@@ -1071,7 +1071,7 @@ pub const ModuleLoader = struct {
             opts.promise_ptr.?.* = this_promise.asInternalPromise().?;
             const referrer = buf.append(opts.referrer);
             const specifier = buf.append(opts.specifier);
-            const path = Fs.Path.init(buf.append(opts.path.text));
+            const path = Fs.Path.initFile(buf.append(opts.path.text));
 
             return AsyncModule{
                 .parse_result = opts.parse_result,
@@ -2554,7 +2554,7 @@ pub const ModuleLoader = struct {
 
         var virtual_source = logger.Source.initPathString(specifier, source_code_slice.slice());
         var log = logger.Log.init(jsc_vm.allocator);
-        const path = Fs.Path.init(specifier);
+        const path = Fs.Path.initFile(specifier);
 
         const loader = if (loader_ != ._none)
             options.Loader.fromAPI(loader_)

--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -4752,10 +4752,10 @@ pub const Blob = struct {
 
     pub fn getLoader(blob: *const Blob, jsc_vm: *VirtualMachine) ?bun.options.Loader {
         if (blob.getFileName()) |filename| {
-            const current_path = bun.fs.Path.init(filename);
+            const current_path = bun.fs.Path.initWithNamespace(filename, "blob");
             return current_path.loader(&jsc_vm.transpiler.options.loaders) orelse .tsx;
         } else if (blob.getMimeTypeOrContentType()) |mime_type| {
-            return .fromMimeType(mime_type);
+            return bun.options.Loader.fromMimeType(mime_type);
         } else {
             // Be maximally permissive.
             return .tsx;

--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -1408,7 +1408,7 @@ pub const BundlerAtRuleParser = struct {
             const import_record_index = this.import_records.len;
             import_rule.import_record_idx = import_record_index;
             this.import_records.push(this.allocator, ImportRecord{
-                .path = bun.fs.Path.init(import_rule.url),
+                .path = bun.fs.Path.initFile(import_rule.url),
                 .kind = if (import_rule.supports != null) .at_conditional else .at,
                 .range = bun.logger.Range{
                     .loc = bun.logger.Loc{ .start = @intCast(start_position) },
@@ -3420,7 +3420,7 @@ pub fn StyleSheet(comptime AtRule: type) type {
                                     const import_record_idx = new_import_records.len;
                                     import_rule.import_record_idx = import_record_idx;
                                     new_import_records.push(allocator, ImportRecord{
-                                        .path = bun.fs.Path.init(import_rule.url),
+                                        .path = bun.fs.Path.initFile(import_rule.url),
                                         .kind = if (import_rule.supports != null) .at_conditional else .at,
                                         .range = bun.logger.Range.None,
                                     }) catch bun.outOfMemory();
@@ -3850,7 +3850,7 @@ pub const Parser = struct {
         if (this.import_records) |import_records| {
             const idx = import_records.len;
             import_records.push(this.allocator(), ImportRecord{
-                .path = bun.fs.Path.init(url),
+                .path = bun.fs.Path.initFile(url),
                 .kind = kind,
                 .range = bun.logger.Range{
                     .loc = bun.logger.Loc{ .start = @intCast(start_position) },

--- a/src/css_scanner.zig
+++ b/src/css_scanner.zig
@@ -1257,7 +1257,7 @@ pub fn NewBundler(
             const entry = try this.fs_reader.readFile(this.fs, url, 0, true, input_fd);
             return logger.Source.initFile(
                 .{
-                    .path = Fs.Path.init(url),
+                    .path = Fs.Path.initFile(url),
                     .contents = entry.contents,
                 },
                 this.allocator,

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -5216,7 +5216,7 @@ fn NewParser_(
 
                     str.resolveRopeIfNeeded(p.allocator);
                     const pathname = str.string(p.allocator) catch unreachable;
-                    const path = fs.Path.init(pathname);
+                    const path = fs.Path.initFile(pathname);
 
                     const handles_import_errors = p.fn_or_arrow_data_visit.try_body_count != 0;
 
@@ -13021,7 +13021,7 @@ fn NewParser_(
         }
 
         pub fn addImportRecordByRange(p: *P, kind: ImportKind, range: logger.Range, name: string) u32 {
-            return p.addImportRecordByRangeAndPath(kind, range, fs.Path.init(name));
+            return p.addImportRecordByRangeAndPath(kind, range, fs.Path.initFile(name));
         }
 
         pub fn addImportRecordByRangeAndPath(p: *P, kind: ImportKind, range: logger.Range, path: fs.Path) u32 {

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1422,7 +1422,7 @@ pub const Source = struct {
     };
 
     pub fn initEmptyFile(filepath: string) Source {
-        const path = fs.Path.init(filepath);
+        const path = fs.Path.initFile(filepath);
         return Source{ .path = path, .contents = "" };
     }
 
@@ -1447,7 +1447,7 @@ pub const Source = struct {
     }
 
     pub fn initPathString(pathString: string, contents: string) Source {
-        const path = fs.Path.init(pathString);
+        const path = fs.Path.initFile(pathString);
         return Source{ .path = path, .contents = contents };
     }
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -982,7 +982,7 @@ pub fn getLoaderAndVirtualSource(
         jsc_vm,
         specifier_str,
     );
-    var path = Fs.Path.init(normalized_file_path_from_specifier);
+    var path = Fs.Path.initFile(normalized_file_path_from_specifier);
 
     var loader: ?Loader = path.loader(&jsc_vm.transpiler.options.loaders);
     var virtual_source: ?*logger.Source = null;
@@ -1006,7 +1006,7 @@ pub fn getLoaderAndVirtualSource(
             // "file:" loader makes no sense for blobs
             // so let's default to tsx.
             if (blob.getFileName()) |filename| {
-                const current_path = Fs.Path.init(filename);
+                const current_path = Fs.Path.initFile(filename);
 
                 // Only treat it as a file if is a Bun.file()
                 if (blob.needsToReadFile()) {
@@ -2043,7 +2043,7 @@ pub const TransformOptions = struct {
         assert(entryPointName.len > 0);
 
         const entryPoint = Fs.File{
-            .path = Fs.Path.init(entryPointName),
+            .path = Fs.Path.initFile(entryPointName),
             .contents = code,
         };
 

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -604,7 +604,7 @@ pub const PackageJSON = struct {
             null,
         ) catch |err| {
             if (err != error.IsDir) {
-                r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "Cannot read file \"{s}\": {s}", .{ r.prettyPath(fs.Path.init(input_path)), @errorName(err) }) catch unreachable;
+                r.log.addErrorFmt(null, logger.Loc.Empty, allocator, "Cannot read file \"{s}\": {s}", .{ r.prettyPath(fs.Path.initFile(input_path)), @errorName(err) }) catch unreachable;
             }
 
             return null;
@@ -615,7 +615,7 @@ pub const PackageJSON = struct {
             debug.addNoteFmt("The file \"{s}\" exists", .{package_json_path});
         }
 
-        const key_path = fs.Path.init(package_json_path);
+        const key_path = fs.Path.initFile(package_json_path);
 
         var json_source = logger.Source.initPathString(key_path.text, entry.contents);
         json_source.path.pretty = r.prettyPath(json_source.path);

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -719,7 +719,9 @@ pub const Resolver = struct {
                     .success = Result{
                         .import_kind = kind,
                         .path_pair = PathPair{
-                            .primary = Path.init(import_path),
+                            // NOTE: not actually a "file" but we want this to
+                            // follow the same code path as files.
+                            .primary = Path.initFile(import_path),
                         },
                         .is_external = true,
                         .module_type = .cjs,
@@ -808,7 +810,7 @@ pub const Resolver = struct {
                             .success = Result{
                                 .import_kind = kind,
                                 .path_pair = PathPair{
-                                    .primary = Path.init(import_path),
+                                    .primary = Path.initFile(import_path),
                                 },
                                 .is_standalone_module = true,
                                 .module_type = .esm,
@@ -828,7 +830,7 @@ pub const Resolver = struct {
                                 .success = Result{
                                     .import_kind = kind,
                                     .path_pair = PathPair{
-                                        .primary = Path.init(file.name),
+                                        .primary = Path.initFile(file.name),
                                     },
                                     .is_standalone_module = true,
                                     .module_type = .esm,
@@ -1171,7 +1173,7 @@ pub const Resolver = struct {
 
                 return .{
                     .success = Result{
-                        .path_pair = .{ .primary = Path.init(import_path) },
+                        .path_pair = .{ .primary = Path.initFile(import_path) },
                         .is_external = true,
                     },
                 };
@@ -1216,7 +1218,7 @@ pub const Resolver = struct {
 
                 return .{
                     .success = Result{
-                        .path_pair = .{ .primary = Path.init(r.fs.dirname_store.append(@TypeOf(abs_path), abs_path) catch unreachable) },
+                        .path_pair = .{ .primary = Path.initFile(r.fs.dirname_store.append(@TypeOf(abs_path), abs_path) catch unreachable) },
                         .is_external = true,
                     },
                 };
@@ -1235,7 +1237,7 @@ pub const Resolver = struct {
 
                             // Is the path disabled?
                             if (remap.len == 0) {
-                                var _path = Path.init(r.fs.dirname_store.append(string, abs_path) catch unreachable);
+                                var _path = Path.initFile(r.fs.dirname_store.append(string, abs_path) catch unreachable);
                                 _path.is_disabled = true;
                                 return .{
                                     .success = Result{
@@ -1350,7 +1352,7 @@ pub const Resolver = struct {
                         }
                         return .{
                             .success = Result{
-                                .path_pair = .{ .primary = Path.init(query) },
+                                .path_pair = .{ .primary = Path.initFile(query) },
                                 .is_external = true,
                             },
                         };
@@ -1433,7 +1435,7 @@ pub const Resolver = struct {
                                         // "browser": {"module": false}
                                         // the module doesn't exist and it's disabled
                                         // so we should just not try to load it
-                                        var primary = Path.init(import_path);
+                                        var primary = Path.initFile(import_path);
                                         primary.is_disabled = true;
                                         return .{
                                             .success = Result{
@@ -2010,7 +2012,7 @@ pub const Resolver = struct {
                     if (err == error.FileNotFound) {
                         switch (manager.getPreinstallState(resolved_package_id)) {
                             .done => {
-                                var path = Fs.Path.init(import_path);
+                                var path = Fs.Path.initFile(import_path);
                                 path.is_disabled = true;
                                 // this might mean the package is disabled
                                 return .{
@@ -2538,7 +2540,7 @@ pub const Resolver = struct {
         // The file name needs to be persistent because it can have errors
         // and if those errors need to print the filename
         // then it will be undefined memory if we parse another tsconfig.json late
-        const key_path = Fs.Path.init(r.fs.dirname_store.append(string, file) catch unreachable);
+        const key_path = Fs.Path.initFile(r.fs.dirname_store.append(string, file) catch unreachable);
 
         const source = logger.Source.initPathString(key_path.text, entry.contents);
         const file_dir = source.path.sourceDir();
@@ -2830,7 +2832,7 @@ pub const Resolver = struct {
                         r.dir_cache.markNotFound(queue_top.result);
                         rfs.entries.markNotFound(cached_dir_entry_result);
                         if (comptime enable_logging) {
-                            const pretty = r.prettyPath(Path.init(queue_top.unsafe_path));
+                            const pretty = r.prettyPath(Path.initFile(queue_top.unsafe_path));
 
                             r.log.addErrorFmt(
                                 null,
@@ -3133,7 +3135,7 @@ pub const Resolver = struct {
                 if (JSC.HardcodedModule.Aliases.has(esm_resolution.path, r.opts.target)) {
                     return .{
                         .success = .{
-                            .path_pair = .{ .primary = bun.fs.Path.init(esm_resolution.path) },
+                            .path_pair = .{ .primary = bun.fs.Path.initFile(esm_resolution.path) },
                             .is_external = true,
                         },
                     };
@@ -3346,7 +3348,7 @@ pub const Resolver = struct {
                         if (remap.len == 0) {
                             const paths = [_]string{ path, field_rel_path };
                             const new_path = r.fs.absAlloc(r.allocator, &paths) catch unreachable;
-                            var _path = Path.init(new_path);
+                            var _path = Path.initFile(new_path);
                             _path.is_disabled = true;
                             return MatchResult{
                                 .path_pair = PathPair{
@@ -3368,14 +3370,14 @@ pub const Resolver = struct {
         if (r.loadAsFile(field_abs_path, extension_order)) |result| {
             if (dir_info.package_json) |package_json| {
                 return MatchResult{
-                    .path_pair = PathPair{ .primary = Fs.Path.init(result.path) },
+                    .path_pair = PathPair{ .primary = Fs.Path.initFile(result.path) },
                     .package_json = package_json,
                     .dirname_fd = result.dirname_fd,
                 };
             }
 
             return MatchResult{
-                .path_pair = PathPair{ .primary = Fs.Path.init(result.path) },
+                .path_pair = PathPair{ .primary = Fs.Path.initFile(result.path) },
                 .dirname_fd = result.dirname_fd,
                 .diff_case = result.diff_case,
             };
@@ -3496,7 +3498,7 @@ pub const Resolver = struct {
 
                         if (dir_info.package_json) |package_json| {
                             return MatchResult{
-                                .path_pair = .{ .primary = Path.init(out_buf) },
+                                .path_pair = .{ .primary = Path.initFile(out_buf) },
                                 .diff_case = lookup.diff_case,
                                 .package_json = package_json,
                                 .dirname_fd = dir_info.getFileDescriptor(),
@@ -3504,7 +3506,7 @@ pub const Resolver = struct {
                         }
 
                         return MatchResult{
-                            .path_pair = .{ .primary = Path.init(out_buf) },
+                            .path_pair = .{ .primary = Path.initFile(out_buf) },
                             .diff_case = lookup.diff_case,
 
                             .dirname_fd = dir_info.getFileDescriptor(),
@@ -3547,7 +3549,7 @@ pub const Resolver = struct {
                         if (remap.len == 0) {
                             const paths = [_]string{ path, field_rel_path };
                             const new_path = r.fs.absBuf(&paths, bufs(.remap_path));
-                            var _path = Path.init(new_path);
+                            var _path = Path.initFile(new_path);
                             _path.is_disabled = true;
                             return MatchResult{
                                 .path_pair = PathPair{
@@ -3562,7 +3564,7 @@ pub const Resolver = struct {
 
                         // Is this a file
                         if (r.loadAsFile(remapped_abs, extension_order)) |file_result| {
-                            return MatchResult{ .dirname_fd = file_result.dirname_fd, .path_pair = .{ .primary = Path.init(file_result.path) }, .diff_case = file_result.diff_case };
+                            return MatchResult{ .dirname_fd = file_result.dirname_fd, .path_pair = .{ .primary = Path.initFile(file_result.path) }, .diff_case = file_result.diff_case };
                         }
 
                         // Is it a directory with an index?
@@ -3594,7 +3596,7 @@ pub const Resolver = struct {
                     if ((r.dirInfoCached(file.path[0 .. node_modules_folder_offset + package_name_length]) catch null)) |package_dir_info| {
                         if (package_dir_info.package_json) |package_json| {
                             return MatchResult{
-                                .path_pair = .{ .primary = Path.init(file.path) },
+                                .path_pair = .{ .primary = Path.initFile(file.path) },
                                 .diff_case = file.diff_case,
                                 .dirname_fd = file.dirname_fd,
                                 .package_json = package_json,
@@ -3610,7 +3612,7 @@ pub const Resolver = struct {
             }
 
             return MatchResult{
-                .path_pair = .{ .primary = Path.init(file.path) },
+                .path_pair = .{ .primary = Path.initFile(file.path) },
                 .diff_case = file.diff_case,
                 .dirname_fd = file.dirname_fd,
                 .file_fd = file.file_fd,
@@ -3771,7 +3773,7 @@ pub const Resolver = struct {
                     r.allocator,
                     "Cannot read directory \"{s}\": {s}",
                     .{
-                        r.prettyPath(Path.init(dir_path)),
+                        r.prettyPath(Path.initFile(dir_path)),
                         @errorName(dir_entry.err.original_err),
                     },
                 ) catch {};
@@ -4135,7 +4137,7 @@ pub const Resolver = struct {
                     tsconfigpath,
                     if (FeatureFlags.store_file_descriptors) fd else .zero,
                 ) catch |err| brk: {
-                    const pretty = r.prettyPath(Path.init(tsconfigpath));
+                    const pretty = r.prettyPath(Path.initFile(tsconfigpath));
 
                     if (err == error.ENOENT or err == error.FileNotFound) {
                         r.log.addErrorFmt(null, logger.Loc.Empty, r.allocator, "Cannot find tsconfig file {}", .{bun.fmt.QuotedFormatter{ .text = pretty }}) catch {};

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -4461,7 +4461,7 @@ pub fn indexOfCharUsize(slice: []const u8, char: u8) ?usize {
     if (slice.len == 0)
         return null;
 
-    if (comptime !Environment.isNative) {
+    if (@inComptime() or comptime !Environment.isNative) {
         return std.mem.indexOfScalar(u8, slice, char);
     }
 


### PR DESCRIPTION
### What does this PR do?
Pulls out fixes to `Fs.Path` made in #18086.
- `Path.init` now attempts to resolve the correct `namespace` of a path, url, etc.
- `Path.initFile` has the same behavior that `Path.init` used to. Most calls to `Path.init` have been replaced with this.
- Calls to `Path.init` where the correct namespaces is already known have been replaced with `Path.initWithNamespace`

### How did you verify your code works?
Existing tests cover `Path` behavior. I also added debug assertions in key locations and ran tests locally; nothing panicked.