### PR TITLE
Extend bun sql to insert/update TEXT[] values

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2058,6 +2058,9 @@ declare module "bun" {
    */
   type SQLSavepointContextCallback = (sql: SavepointSQL) => Promise<any> | Array<SQLQuery>;
 
+  type SQLAllowedArrayType = string | number | boolean | null;
+  type SQLAllowedArrayValue = SQLAllowedArrayType | SQLAllowedArrayValue[];
+
   /**
    * Main SQL client interface providing connection and transaction management
    */
@@ -2088,7 +2091,12 @@ declare module "bun" {
      * @example
      * const result = await sql`insert into users ${sql(users)} RETURNING *`;
      */
-    (obj: any): SQLQuery;
+    <T extends Record<string, any>>(obj: {
+      // Maps over object keys (K) and checks if the value is an array.
+      // If it is an array, ensures it only contains allowed SQL values (strings, numbers, booleans, null, or nested arrays of these).
+      // If not an array, keeps the original type.
+      [K in keyof T]: T[K] extends any[] ? SQLAllowedArrayValue[] : T[K];
+    }): SQLQuery;
     /** Commits a distributed transaction also know as prepared transaction in postgres or XA transaction in MySQL
      * @example
      * await sql.commitDistributed("my_distributed_transaction");

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -918,7 +918,8 @@ fn writeArrayItem(
             try writer.write("\"");
         }
 
-        // Allocation happens only when the value is finite or the value is between -100 and 100
+        // Allocation happens only when the value is finite and
+        // the value is outside the range -100 and 100 or when the value has a floating point
         if (std.math.isFinite(num_value) and
             (num_value > 100 or num_value < -100 or
             num_value != @trunc(num_value)))

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -903,7 +903,7 @@ fn writeArrayItem(
         const slice = str.toUTF8WithoutRef(bun.default_allocator);
         defer slice.deinit();
         try writer.write(slice.slice());
-    } else if (item.isUndefinedOrNull()) {
+    } else if (item.isNull()) {
         try writer.write("NULL");
     } else if (item.isNumber()) {
         const num_value = item.asNumber();
@@ -948,6 +948,13 @@ fn writeArrayItem(
         if (should_quote) {
             try writer.write("\"");
         }
+    } else {
+        // Doesn't show exactly where the error happened ?
+        return globalObject.throwValue(postgresErrorToJS(
+            globalObject,
+            "Array items must be string, number, boolean, null, or array",
+            error.UnsupportedArrayFormat,
+        ));
     }
 }
 

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -3,6 +3,7 @@ const JSC = bun.JSC;
 const String = bun.String;
 const uws = bun.uws;
 const std = @import("std");
+const js_ast = @import("../js_ast.zig");
 pub const debug = bun.Output.scoped(.Postgres, false);
 pub const int4 = u32;
 pub const PostgresInt32 = int4;
@@ -889,6 +890,67 @@ pub const PostgresSQLQuery = struct {
     }
 };
 
+fn writeArrayItem(
+    item: JSValue,
+    globalObject: *JSC.JSGlobalObject,
+    should_quote: bool,
+    comptime Context: type,
+    writer: protocol.NewWriter(Context),
+) !void {
+    if (item.isString()) {
+        var str = String.fromJS2(item, globalObject) catch return error.OutOfMemory;
+        defer str.deref();
+        const slice = str.toUTF8WithoutRef(bun.default_allocator);
+        defer slice.deinit();
+        try writer.write(slice.slice());
+    } else if (item.isUndefinedOrNull()) {
+        try writer.write("NULL");
+    } else if (item.isNumber()) {
+        const num_value = item.asNumber();
+
+        if (should_quote) {
+            try writer.write("\"");
+        }
+        // Always valid ?
+        const str = js_ast.E.Number.toStringFromF64(num_value, bun.default_allocator).?;
+        try writer.write(str);
+        if (should_quote) {
+            try writer.write("\"");
+        }
+
+        // Allocation happens only when the value is finite or the value is between -100 and 100
+        if (std.math.isFinite(num_value) and
+            (num_value > 100 or num_value < -100 or
+            num_value != @trunc(num_value)))
+        {
+            bun.default_allocator.free(str);
+        }
+    } else if (item.isBoolean()) {
+        try writer.write(if (item.toBoolean()) "true" else "false");
+    } else if (item.isArray()) {
+        var inner_arr_iter = item.arrayIterator(globalObject);
+
+        if (should_quote) {
+            try writer.write("\"");
+        }
+        while (inner_arr_iter.next()) |inner_item| {
+            try writeArrayItem(
+                inner_item,
+                globalObject,
+                false,
+                Context,
+                writer,
+            );
+            if (inner_arr_iter.i < inner_arr_iter.len) {
+                try writer.write(",");
+            }
+        }
+        if (should_quote) {
+            try writer.write("\"");
+        }
+    }
+}
+
 pub const PostgresRequest = struct {
     pub fn writeBind(
         name: []const u8,
@@ -995,15 +1057,13 @@ pub const PostgresRequest = struct {
                     try writer.write("{");
                     var arr_iter = value.arrayIterator(globalObject);
                     while (arr_iter.next()) |item| {
-                        if (item.isEmptyOrUndefinedOrNull()) {
-                            try writer.write("NULL");
-                        } else {
-                            var str = String.fromJS2(item, globalObject) catch return error.OutOfMemory;
-                            defer str.deref();
-                            const slice = str.toUTF8WithoutRef(bun.default_allocator);
-                            defer slice.deinit();
-                            try writer.write(slice.slice());
-                        }
+                        try writeArrayItem(
+                            item,
+                            globalObject,
+                            true,
+                            Context,
+                            writer,
+                        );
                         if (arr_iter.i < arr_iter.len) {
                             try writer.write(",");
                         }

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -995,11 +995,15 @@ pub const PostgresRequest = struct {
                     try writer.write("{");
                     var arr_iter = value.arrayIterator(globalObject);
                     while (arr_iter.next()) |item| {
-                        var str = String.fromJS2(item, globalObject) catch return error.OutOfMemory;
-                        defer str.deref();
-                        const slice = str.toUTF8WithoutRef(bun.default_allocator);
-                        defer slice.deinit();
-                        try writer.write(slice.slice());
+                        if (item.isEmptyOrUndefinedOrNull()) {
+                            try writer.write("NULL");
+                        } else {
+                            var str = String.fromJS2(item, globalObject) catch return error.OutOfMemory;
+                            defer str.deref();
+                            const slice = str.toUTF8WithoutRef(bun.default_allocator);
+                            defer slice.deinit();
+                            try writer.write(slice.slice());
+                        }
                         if (arr_iter.i < arr_iter.len) {
                             try writer.write(",");
                         }

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -626,7 +626,6 @@ if (isDockerEnabled()) {
       // Insert
       const result = await sql`INSERT INTO test ${sql(item)} returning *`;
 
-      // Retrieve and verify
       expect(result[0]).toEqual(item);
     } finally {
       await sql`DROP TABLE test`;
@@ -655,10 +654,8 @@ if (isDockerEnabled()) {
 
       // Update
       const update = { arr: ["c", "d"] };
-      await sql`UPDATE test SET ${sql(update)} WHERE id = ${item.id}`;
+      const result = await sql`UPDATE test SET ${sql(update)} WHERE id = ${item.id} returning *`;
 
-      // Retrieve and verify
-      const result = await sql`SELECT * FROM test WHERE id = ${item.id}`;
       expect(result[0]).toEqual({ ...item, ...update });
     } finally {
       await sql`DROP TABLE test`;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -606,6 +606,66 @@ if (isDockerEnabled()) {
     }
   });
 
+  test("#17798: it should handle inserting values of type text[] using array of values", async () => {
+    try {
+      await sql`
+    CREATE TEMPORARY TABLE test (
+      id INTEGER PRIMARY KEY,
+      name TEXT,
+      arr TEXT[]
+    )
+  `;
+
+      // Test data
+      const item = {
+        id: 1,
+        name: "test",
+        arr: ["a", "b"],
+      };
+
+      // Insert
+      await sql`INSERT INTO test ${sql(item)}`;
+
+      // Retrieve and verify
+      const result = await sql`SELECT * FROM test WHERE id = ${item.id}`;
+      expect(result[0]).toEqual(item);
+    } finally {
+      await sql`DROP TABLE test`;
+    }
+  });
+
+  test("#17798: it should handle updating values of type text[] using array of values", async () => {
+    try {
+      await sql`
+    CREATE TEMPORARY TABLE test (
+      id INTEGER PRIMARY KEY,
+      name TEXT,
+      arr TEXT[]
+    )
+  `;
+
+      // Test data
+      const item = {
+        id: 1,
+        name: "test",
+        arr: ["a", "b"],
+      };
+
+      // Insert
+      await sql`INSERT INTO test ${sql(item)}`;
+
+      // Update
+      const update = { arr: ["c", "d"] };
+      await sql`UPDATE test SET ${sql(update)} WHERE id = ${item.id}`;
+
+      // Retrieve and verify
+      const result = await sql`SELECT * FROM test WHERE id = ${item.id}`;
+      expect(result[0]).toEqual({ ...item, ...update });
+    } finally {
+      await sql`DROP TABLE test`;
+    }
+  });
+
   test("Transaction throws on uncaught savepoint", async () => {
     await sql`create table test (a int)`;
     try {


### PR DESCRIPTION
### What does this PR do?

Fixes: #17798

code snippet:
```ts
import {sql} from "bun";
import crypto from "crypto"

async function createTable() {
	await sql`
CREATE TABLE IF NOT EXISTS foo(
id INTEGER PRIMARY KEY,
name TEXT,
arr TEXT[]
)`;
}

async function main() {
	await createTable();
	const id = crypto.randomInt(1, 1000);
	const item = { id, name: "test" , arr: ['a', 'b'] };

	await sql`insert into foo${sql(item)}`;
	const value = await sql`select * from foo where id = ${id}`;
	console.log(value);

	const update = { name: "test2" , arr: ['c', null]}
	const newValue = await sql`update foo set ${sql(update)} where id = ${id} returning *`;
	console.log(newValue);
}

main();
```

Before (bun 1.2.5):
![image](https://github.com/user-attachments/assets/47c6379c-868c-4a42-a4b3-255eed873b5d)

After:
![image](https://github.com/user-attachments/assets/c535a243-ab98-4083-a3ee-2e49d27b3b3b)

With the updated type passed to `sql`:
code snippet:
```ts
  // undefined values are not allowed, same goes for objects inside an array
  const update = { name: "test", arr: ["a", "another", undefined, [1,2,3, [null]]] };
  const sqlNewValue = await sql`
        update foo 
        set ${sql(update)}
        where id = ${id} 
        returning *`;
```
Diagnostics:
```ts
1. No overload matches this call.
     Overload 1 of 2, '(strings: string | TemplateStringsArray, ...values: any[]): SQLQuery', gave the following error.
       Argument of type '{ name: string; arr: (string | (number | null[])[] | undefined)[]; }' is not assignable to parameter of type 'string | TemplateStringsArray'.
     Overload 2 of 2, '(obj: { name: string; arr: SQLAllowedArrayValue[]; }): SQLQuery', gave the following error.
       Argument of type '{ name: string; arr: (string | (number | null[])[] | undefined)[]; }' is not assignable to parameter of type '{ name: string; arr: SQLAllowedArrayValue[]; }'.
         Types of property 'arr' are incompatible.
           Type '(string | (number | null[])[] | undefined)[]' is not assignable to type 'SQLAllowedArrayValue[]'.
             Type 'string | (number | null[])[] | undefined' is not assignable to type 'SQLAllowedArrayValue'.
               Type 'undefined' is not assignable to type 'SQLAllowedArrayValue'. [2769]
```
