### PR TITLE
fix(ShadowRealm): give global objects a unique execution context id

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1149,7 +1149,10 @@ using namespace WebCore;
 static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
-    Zig::GlobalObject* shadow = Zig::GlobalObject::create(vm, Zig::GlobalObject::createStructure(vm));
+    Zig::GlobalObject* shadow = Zig::GlobalObject::create(
+        vm,
+        Zig::GlobalObject::createStructure(vm),
+        ScriptExecutionContext::generateIdentifier());
     shadow->setConsole(shadow);
 
     return shadow;

--- a/test/js/node/test/.gitignore
+++ b/test/js/node/test/.gitignore
@@ -7,4 +7,5 @@ fixtures/snapshot
 fixtures/repl*
 .tmp.*
 *shadow-realm*
+!test-shadow-realm.js
 **/fails.txt

--- a/test/js/node/test/parallel/test-shadow-realm.js
+++ b/test/js/node/test/parallel/test-shadow-realm.js
@@ -1,0 +1,12 @@
+// Flags: --experimental-shadow-realm
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Validates we can construct ShadowRealm successfully.
+const shadowRealm = new ShadowRealm();
+
+const getter = shadowRealm.evaluate('globalThis.realmValue = "inner"; () => globalThis.realmValue;');
+assert.strictEqual(getter(), 'inner');
+assert.strictEqual('realmValue' in globalThis, false);


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in `ShadowRealm`'s constructor where new realms were re-using the main thread's `ScriptExecutionIdentifier` when creating their own global object.

### How did you verify your code works?
Tests pass
