### PR TITLE
test: install detect-libc

### DIFF
--- a/test/bun.lock
+++ b/test/bun.lock
@@ -27,6 +27,7 @@
         "bun-plugin-yaml": "0.0.1",
         "comlink": "4.4.1",
         "commander": "12.1.0",
+        "detect-libc": "^2.0.3",
         "devalue": "5.1.1",
         "duckdb": "1.1.3",
         "es-module-lexer": "1.3.0",
@@ -870,8 +871,9 @@
 
     "bun-plugin-svelte": ["bun-plugin-svelte@file:../packages/bun-plugin-svelte", { "dependencies": { "svelte": "^5.20.4", "svelte-hmr": "^0.16.0" }, "devDependencies": { "bun-types": "canary" }, "peerDependencies": { "typescript": "^5" } }],
 
-    "bun-types": ["bun-types@1.2.4-canary.20250226T140704", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-P8b2CGLtbvi/kQ4dPHBhU5qkguIjHMYCjNqjWDTKSnodWDTbcv9reBdktZJ7m5SF4m15JLthfFq2PtwKpA9a+w=="],
     "bun-plugin-yaml": ["bun-plugin-yaml@0.0.1", "", { "dependencies": { "js-yaml": "^4.1.0" } }, "sha512-dAqe0eJu+SGtrwp75hrtDHWRnmMUdBJK365PPeM0skwFqWu6FYouVzaluG2FVVgs0NsKd+sXiWyGqvs0cilrkA=="],
+
+    "bun-types": ["bun-types@1.2.4-canary.20250226T140704", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-P8b2CGLtbvi/kQ4dPHBhU5qkguIjHMYCjNqjWDTKSnodWDTbcv9reBdktZJ7m5SF4m15JLthfFq2PtwKpA9a+w=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 

--- a/test/package.json
+++ b/test/package.json
@@ -32,6 +32,7 @@
     "bun-plugin-yaml": "0.0.1",
     "comlink": "4.4.1",
     "commander": "12.1.0",
+    "detect-libc": "^2.0.3",
     "devalue": "5.1.1",
     "duckdb": "1.1.3",
     "es-module-lexer": "1.3.0",

--- a/test/package.json
+++ b/test/package.json
@@ -32,7 +32,7 @@
     "bun-plugin-yaml": "0.0.1",
     "comlink": "4.4.1",
     "commander": "12.1.0",
-    "detect-libc": "^2.0.3",
+    "detect-libc": "2.0.3",
     "devalue": "5.1.1",
     "duckdb": "1.1.3",
     "es-module-lexer": "1.3.0",


### PR DESCRIPTION
fixes contributors running tests, and future proofs bun upgrade on infrastructure 
bun used to provide its own version of `'detect-libc'` but this was removed in https://github.com/oven-sh/bun/pull/18138
issue is not caught in CI since we use a stable version of bun to install dependencies and this change is only in canary
