### PR TITLE
fix(crypto) Fix ED25519 from private

### DIFF
--- a/src/bun.js/bindings/KeyObject.cpp
+++ b/src/bun.js/bindings/KeyObject.cpp
@@ -780,7 +780,29 @@ static JSC::EncodedJSValue KeyObject__createECFromPrivate(JSC::JSGlobalObject* g
     return JSC::JSValue::encode(JSCryptoKey::create(structure, zigGlobalObject, WTFMove(impl)));
 }
 
-static JSC::EncodedJSValue KeyObject__createOKPFromPrivate(JSC::JSGlobalObject* globalObject, const WebCore::CryptoKeyOKP::KeyMaterial keyData, CryptoKeyOKP::NamedCurve namedCurve, WebCore::CryptoAlgorithmIdentifier alg)
+static JSC::EncodedJSValue KeyObject__createOKPEd25519FromPublicKey(JSC::JSGlobalObject* globalObject, Vector<uint8_t>& keyData)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (keyData.size() != ED25519_PUBLIC_KEY_LEN) {
+        throwException(globalObject, scope, createTypeError(globalObject, "Invalid Ed25519 key material"_s));
+        return {};
+    }
+
+    auto result = CryptoKeyOKP::create(CryptoAlgorithmIdentifier::Ed25519, CryptoKeyOKP::NamedCurve::Ed25519, CryptoKeyType::Public, WTFMove(keyData), true, CryptoKeyUsageVerify);
+    if (UNLIKELY(result == nullptr)) {
+        JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Failed to create a public key from private"_s);
+        return {};
+    }
+    auto impl = result.releaseNonNull();
+
+    Zig::GlobalObject* zigGlobalObject = reinterpret_cast<Zig::GlobalObject*>(globalObject);
+    auto* structure = zigGlobalObject->JSCryptoKeyStructure();
+
+    return JSC::JSValue::encode(JSCryptoKey::create(structure, zigGlobalObject, WTFMove(impl)));
+}
+static JSC::EncodedJSValue KeyObject__createOKPFromKeyMaterial(JSC::JSGlobalObject* globalObject, const WebCore::CryptoKeyOKP::KeyMaterial keyData, CryptoKeyOKP::NamedCurve namedCurve, WebCore::CryptoAlgorithmIdentifier alg)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -788,6 +810,10 @@ static JSC::EncodedJSValue KeyObject__createOKPFromPrivate(JSC::JSGlobalObject* 
     Vector<unsigned char> public_key(ED25519_PUBLIC_KEY_LEN);
 
     if (namedCurve == CryptoKeyOKP::NamedCurve::Ed25519) {
+        if (keyData.size() != ED25519_PRIVATE_KEY_LEN + ED25519_PUBLIC_KEY_LEN) {
+            throwException(globalObject, scope, createTypeError(globalObject, "Invalid Ed25519 key material"_s));
+            return {};
+        }
         memcpy(public_key.data(), keyData.data() + ED25519_PRIVATE_KEY_LEN, ED25519_PUBLIC_KEY_LEN);
     } else {
         X25519_public_from_private(public_key.data(), keyData.data());
@@ -842,7 +868,19 @@ static JSC::EncodedJSValue KeyObject__createPublicFromPrivate(JSC::JSGlobalObjec
         }
         EC_KEY_free(ec_key);
         return KeyObject__createECFromPrivate(globalObject, pkey, curve, CryptoAlgorithmIdentifier::ECDSA);
-    } else if (pKeyID == EVP_PKEY_ED25519 || pKeyID == EVP_PKEY_X25519) {
+    } else if (pKeyID == EVP_PKEY_ED25519) {
+        size_t out_len = 0;
+        if (!EVP_PKEY_get_raw_public_key(pkey, nullptr, &out_len)) {
+            throwException(globalObject, scope, createTypeError(globalObject, "Invalid private key"_s));
+            return {};
+        }
+        Vector<uint8_t> out(out_len);
+        if (!EVP_PKEY_get_raw_public_key(pkey, out.data(), &out_len) || out_len != out.size()) {
+            throwException(globalObject, scope, createTypeError(globalObject, "Invalid private key"_s));
+            return {};
+        }
+        return KeyObject__createOKPEd25519FromPublicKey(globalObject, out);
+    } else if (pKeyID == EVP_PKEY_X25519) {
         size_t out_len = 0;
         if (!EVP_PKEY_get_raw_private_key(pkey, nullptr, &out_len)) {
             throwException(globalObject, scope, createTypeError(globalObject, "Invalid private key"_s));
@@ -853,7 +891,7 @@ static JSC::EncodedJSValue KeyObject__createPublicFromPrivate(JSC::JSGlobalObjec
             throwException(globalObject, scope, createTypeError(globalObject, "Invalid private key"_s));
             return {};
         }
-        return KeyObject__createOKPFromPrivate(globalObject, out, pKeyID == EVP_PKEY_ED25519 ? CryptoKeyOKP::NamedCurve::Ed25519 : CryptoKeyOKP::NamedCurve::X25519, CryptoAlgorithmIdentifier::Ed25519);
+        return KeyObject__createOKPFromKeyMaterial(globalObject, out, CryptoKeyOKP::NamedCurve::X25519, CryptoAlgorithmIdentifier::X25519);
     } else {
         throwException(globalObject, scope, createTypeError(globalObject, "Invalid private key type"_s));
         return {};
@@ -907,7 +945,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__createPublicKey, (JSC::JSGlobalObject * glob
         }
         case CryptoKeyClass::OKP: {
             auto& impl = downcast<WebCore::CryptoKeyOKP>(wrapped);
-            return KeyObject__createOKPFromPrivate(globalObject, impl.exportKey(), impl.namedCurve(), wrapped.algorithmIdentifier());
+            return KeyObject__createOKPFromKeyMaterial(globalObject, impl.exportKey(), impl.namedCurve(), wrapped.algorithmIdentifier());
         }
         default: {
             JSC::throwTypeError(globalObject, scope, "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Invalid key object type, expected private"_s);
@@ -985,7 +1023,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__createPublicKey, (JSC::JSGlobalObject * glob
                     }
                     auto impl = result.releaseNonNull();
                     if (impl->type() == CryptoKeyType::Private) {
-                        return KeyObject__createOKPFromPrivate(globalObject, impl.get().exportKey(), CryptoKeyOKP::NamedCurve::Ed25519, CryptoAlgorithmIdentifier::Ed25519);
+                        return KeyObject__createOKPFromKeyMaterial(globalObject, impl.get().exportKey(), CryptoKeyOKP::NamedCurve::Ed25519, CryptoAlgorithmIdentifier::Ed25519);
                     }
                     return JSC::JSValue::encode(JSCryptoKey::create(structure, zigGlobalObject, WTFMove(impl)));
                 } else if (jwk.crv == "X25519"_s) {
@@ -996,7 +1034,7 @@ JSC_DEFINE_HOST_FUNCTION(KeyObject__createPublicKey, (JSC::JSGlobalObject * glob
                     }
                     auto impl = result.releaseNonNull();
                     if (impl->type() == CryptoKeyType::Private) {
-                        return KeyObject__createOKPFromPrivate(globalObject, impl.get().exportKey(), CryptoKeyOKP::NamedCurve::X25519, CryptoAlgorithmIdentifier::Ed25519);
+                        return KeyObject__createOKPFromKeyMaterial(globalObject, impl.get().exportKey(), CryptoKeyOKP::NamedCurve::X25519, CryptoAlgorithmIdentifier::Ed25519);
                     }
                     return JSC::JSValue::encode(JSCryptoKey::create(structure, zigGlobalObject, WTFMove(impl)));
                 } else {


### PR DESCRIPTION
### What does this PR do?
This code has a memory error that reads out bounds from the private key to get the public key, this only worked before because the memory is stored in the right place. Thanks @DonIsaac for finding it.
Function was renamed to a better name.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Manually run `test/js/node/crypto/crypto.key-objects.test.ts` with ASAN 

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
