### PR TITLE
fix(sql) fix query parameters options

### DIFF
--- a/src/sql/postgres/postgres_protocol.zig
+++ b/src/sql/postgres/postgres_protocol.zig
@@ -1330,8 +1330,7 @@ pub const StartupMessage = struct {
         const user = this.user.slice();
         const database = this.database.slice();
         const options = this.options.slice();
-
-        const count: usize = @sizeOf((int4)) + @sizeOf((int4)) + zFieldCount("user", user) + zFieldCount("database", database) + zFieldCount("client_encoding", "UTF8") + zFieldCount("", options) + 1;
+        const count: usize = @sizeOf((int4)) + @sizeOf((int4)) + zFieldCount("user", user) + zFieldCount("database", database) + zFieldCount("client_encoding", "UTF8") + options.len + 1;
 
         const header = toBytes(Int32(@as(u32, @truncate(count))));
         try writer.write(&header);
@@ -1349,13 +1348,11 @@ pub const StartupMessage = struct {
         } else {
             try writer.string(database);
         }
-
         try writer.string("client_encoding");
         try writer.string("UTF8");
-
-        if (options.len > 0)
-            try writer.string(options);
-
+        if (options.len > 0) {
+            try writer.write(options);
+        }
         try writer.write(&[_]u8{0});
     }
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -11120,4 +11120,19 @@ CREATE TABLE ${table_name} (
       expect(() => sql`DELETE FROM ${sql(random_name)} ${sql(users, "id")}`.execute()).toThrow(SyntaxError);
     });
   });
+
+  describe("connection options", () => {
+    test("connection", async () => {
+      await using sql = postgres({ ...options, max: 1, connection: { search_path: "information_schema" } });
+      const [item] = await sql`SELECT COUNT(*)::INT FROM columns LIMIT 1`.values();
+      expect(item[0]).toBeGreaterThan(0);
+    });
+    test("query string", async () => {
+      await using sql = postgres(process.env.DATABASE_URL + "?search_path=information_schema", {
+        max: 1,
+      });
+      const [item] = await sql`SELECT COUNT(*)::INT FROM columns LIMIT 1`.values();
+      expect(item[0]).toBeGreaterThan(0);
+    });
+  });
 }


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/18061

Should be able to change the schema using options in https://www.postgresql.org/docs/current/runtime-config-client.html

```ts
{
  await using db = new SQL("postgres://cirospaciari:postgres@localhost:5432/bun?search_path=information_schema", {
    max: 1,
  });

  const res = await db`SELECT COUNT(*)::INT FROM columns LIMIT 1`.values();
  console.log(res);
}
{
  await using db = new SQL("postgres://cirospaciari:postgres@localhost:5432/bun", {
    connection: {
      search_path: "information_schema",
    },
    max: 1,
  });

  const res = await db`SELECT COUNT(*)::INT FROM columns LIMIT 1`.values();
  console.log(res);
}
```


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
