### PR TITLE
fix(serve): make error messages for invalid fetch() clearer

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1684,7 +1684,7 @@ pub const ServerConfig = struct {
                     } else {
                         const ty = try global.determineSpecificType(onRequest_);
                         defer ty.deref();
-                        return global.throwInvalidArgumentType("Expected 'fetch()' to be a function, got {s}", .{ty});
+                        return global.throwInvalidArguments("Expected 'fetch()' to be a function, got {s}", .{ty});
                     }
                 }
                 const onRequest = onRequest_.withAsyncContextIfNeeded(global);


### PR DESCRIPTION
### What does this PR do?
Makes errors thrown when `Bun.serve` is passed an invalid `fetch()` argument clearer. Partially addresses #18255.

It looks like this issue is causing problems within SST; I don't see a fetch() function being passed to Bun.serve. 

### How did you verify your code works?
