### PR TITLE
Update docker images from debian:bullseye to debian:bookworm

### DIFF
--- a/dockerhub/debian-slim/Dockerfile
+++ b/dockerhub/debian-slim/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update -qq \
     && which bun \
     && bun --version
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful

--- a/dockerhub/debian/Dockerfile
+++ b/dockerhub/debian/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update -qq \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 COPY docker-entrypoint.sh /usr/local/bin
 COPY --from=build /usr/local/bin/bun /usr/local/bin/bun


### PR DESCRIPTION
### What does this PR do?

- Update Bun docker image from `debian:bullseye` to `debian:bookworm`

Based on the @Jarred-Sumner 's comment here https://github.com/oven-sh/bun/issues/9240#issuecomment-2464452704

It also seems like Jarred updated these files prev ( https://github.com/oven-sh/bun/commit/5c8da4436c8e99a0f23ee27f5b55d8c9b0513303 ) but only on the first stages, not final.