### PR TITLE
Fix `node:url` test

### DIFF
--- a/src/bun.js/bindings/webcore/JSDOMURL.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMURL.cpp
@@ -68,6 +68,7 @@ static JSC_DECLARE_HOST_FUNCTION(jsDOMURLPrototypeFunction_toJSON);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_createObjectURL);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLConstructorFunction_revokeObjectURL);
 static JSC_DECLARE_HOST_FUNCTION(jsDOMURLPrototypeFunction_toString);
+static JSC_DECLARE_HOST_FUNCTION(jsDOMURLPrototypeFunction_inspectCustom);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__createObjectURL);
 BUN_DECLARE_HOST_FUNCTION(Bun__revokeObjectURL);
@@ -234,6 +235,13 @@ void JSDOMURLPrototype::finishCreation(VM& vm)
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSDOMURL::info(), JSDOMURLPrototypeTableValues, *this);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    auto& builtinNames = WebCore::builtinNames(vm);
+    const auto& inspectCustomPublicName = builtinNames.inspectCustomPublicName();
+
+    auto* fn = JSC::JSFunction::create(vm, globalObject(), 0, "[nodejs.util.inspect.custom]"_s, jsDOMURLPrototypeFunction_inspectCustom, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic);
+
+    this->putDirect(vm, inspectCustomPublicName, fn, JSC::PropertyAttribute::DontEnum | 0);
 }
 
 const ClassInfo JSDOMURL::s_info = { "URL"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMURL) };
@@ -770,6 +778,21 @@ static inline JSC::EncodedJSValue jsDOMURLPrototypeFunction_toStringBody(JSC::JS
 JSC_DEFINE_HOST_FUNCTION(jsDOMURLPrototypeFunction_toString, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     return IDLOperation<JSDOMURL>::call<jsDOMURLPrototypeFunction_toStringBody>(*lexicalGlobalObject, *callFrame, "toString");
+}
+
+static inline JSC::EncodedJSValue jsDOMURLPrototypeFunction_inspectCustomBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMURL>::ClassParameter castedThis)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
+    auto& impl = castedThis->wrapped();
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUSVString>(*lexicalGlobalObject, throwScope, impl.href())));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsDOMURLPrototypeFunction_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSDOMURL>::call<jsDOMURLPrototypeFunction_inspectCustomBody>(*lexicalGlobalObject, *callFrame, "[nodejs.util.inspect.custom]");
 }
 
 JSC::GCClient::IsoSubspace* JSDOMURL::subspaceForImpl(JSC::VM& vm)

--- a/src/bun.js/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/bun.js/bindings/webcore/JSURLSearchParams.cpp
@@ -194,6 +194,13 @@ void JSURLSearchParamsPrototype::finishCreation(VM& vm)
     reifyStaticProperties(vm, JSURLSearchParams::info(), JSURLSearchParamsPrototypeTableValues, *this);
     putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    auto& builtinNames = WebCore::builtinNames(vm);
+    const auto& inspectCustomPublicName = builtinNames.inspectCustomPublicName();
+
+    auto* fn = JSC::JSFunction::create(vm, globalObject(), 0, "[nodejs.util.inspect.custom]"_s, jsURLSearchParamsPrototypeFunction_toString, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic);
+
+    this->putDirect(vm, inspectCustomPublicName, fn, JSC::PropertyAttribute::DontEnum | 0);
 }
 
 const ClassInfo JSURLSearchParams::s_info = { "URLSearchParams"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSURLSearchParams) };

--- a/test/js/node/test/parallel/test-whatwg-url-properties.js
+++ b/test/js/node/test/parallel/test-whatwg-url-properties.js
@@ -1,0 +1,143 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { URL, URLSearchParams, format } = require('url');
+
+[
+  { name: 'toString' },
+  { name: 'toJSON' },
+  { name: Symbol.for('nodejs.util.inspect.custom') },
+].forEach(({ name }) => {
+  testMethod(URL.prototype, name);
+});
+
+[
+  'http://www.google.com',
+  'https://www.domain.com:443',
+  'file:///Users/yagiz/Developer/node',
+].forEach((url) => {
+  const u = new URL(url);
+  assert.strictEqual(JSON.stringify(u), `"${u.href}"`);
+  assert.strictEqual(u.toString(), u.href);
+  assert.strictEqual(format(u), u.href);
+});
+
+[
+  { name: 'href' },
+  { name: 'protocol' },
+  { name: 'username' },
+  { name: 'password' },
+  { name: 'host' },
+  { name: 'hostname' },
+  { name: 'port' },
+  { name: 'pathname' },
+  { name: 'search' },
+  { name: 'hash' },
+  { name: 'origin', readonly: true },
+  { name: 'searchParams', readonly: true },
+].forEach(({ name, readonly = false }) => {
+  testAccessor(URL.prototype, name, readonly);
+});
+
+[
+  { name: 'createObjectURL' },
+  { name: 'revokeObjectURL' },
+].forEach(({ name }) => {
+  testStaticAccessor(URL, name);
+});
+
+[
+  { name: 'append' },
+  { name: 'delete' },
+  { name: 'get' },
+  { name: 'getAll' },
+  { name: 'has' },
+  { name: 'set' },
+  { name: 'sort' },
+  { name: 'entries' },
+  { name: 'forEach' },
+  { name: 'keys' },
+  { name: 'values' },
+  { name: 'toString' },
+  { name: Symbol.iterator, methodName: 'entries' },
+  { name: Symbol.for('nodejs.util.inspect.custom') },
+].forEach(({ name, methodName }) => {
+  testMethod(URLSearchParams.prototype, name, methodName);
+});
+
+{
+  const params = new URLSearchParams();
+  params.append('a', 'b');
+  params.append('a', 'c');
+  params.append('b', 'c');
+  assert.strictEqual(params.size, 3);
+}
+
+{
+  const u = new URL('https://abc.com/?q=old');
+  const s = u.searchParams;
+  u.href = 'http://abc.com/?q=new';
+  assert.strictEqual(s.get('q'), 'new');
+}
+
+function stringifyName(name) {
+  if (typeof name === 'symbol') {
+    const { description } = name;
+    if (description === undefined) {
+      return '';
+    }
+    return `[${description}]`;
+  }
+
+  return name;
+}
+
+function testMethod(target, name, methodName = stringifyName(name)) {
+  const desc = Object.getOwnPropertyDescriptor(target, name);
+  console.log(name, methodName);
+  assert.notStrictEqual(desc, undefined);
+  assert.strictEqual(desc.enumerable, typeof name === 'string');
+
+  const { value } = desc;
+  assert.strictEqual(typeof value, 'function');
+  assert.strictEqual(value.name, methodName);
+  assert.strictEqual(
+    Object.hasOwn(value, 'prototype'),
+    false,
+  );
+}
+
+function testAccessor(target, name, readonly = false) {
+  const desc = Object.getOwnPropertyDescriptor(target, name);
+  assert.notStrictEqual(desc, undefined);
+  assert.strictEqual(desc.enumerable, typeof name === 'string');
+
+  const methodName = stringifyName(name);
+  const { get, set } = desc;
+  assert.strictEqual(typeof get, 'function');
+  assert.strictEqual(get.name, `get ${methodName}`);
+  assert.strictEqual(
+    Object.hasOwn(get, 'prototype'),
+    false,
+  );
+
+  if (readonly) {
+    assert.strictEqual(set, undefined);
+  } else {
+    assert.strictEqual(typeof set, 'function');
+    assert.strictEqual(set.name, `set ${methodName}`);
+    assert.strictEqual(
+      Object.hasOwn(set, 'prototype'),
+      false,
+    );
+  }
+}
+
+function testStaticAccessor(target, name) {
+  const desc = Object.getOwnPropertyDescriptor(target, name);
+  assert.notStrictEqual(desc, undefined);
+
+  assert.strictEqual(desc.configurable, true);
+  assert.strictEqual(desc.enumerable, true);
+  assert.strictEqual(desc.writable, true);
+}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
