### PR TITLE
fix(uws): make `Socket` bindings safer

### DIFF
--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -513,9 +513,14 @@ void us_socket_nodelay(struct us_socket_t *s, int enabled) {
     }
 }
 
+/// Returns 0 on success. Returned error values depend on the platform.
+/// - on posix, returns `errno`
+/// - on windows, when libuv is used, returns a UV err code
+/// - on windows, LIBUS_USE_LIBUV is set, returns `WSAGetLastError()`
+/// - on windows, otherwise returns result of `WSAGetLastError`
 int us_socket_keepalive(us_socket_r s, int enabled, unsigned int delay){
     if (!us_socket_is_shut_down(0, s)) {
-        bsd_socket_keepalive(us_poll_fd((struct us_poll_t *) s), enabled, delay);
+        return bsd_socket_keepalive(us_poll_fd((struct us_poll_t *) s), enabled, delay);
     }
     return 0;
 }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -2110,7 +2110,7 @@ fn NewSocket(comptime ssl: bool) type {
             var buf: [64]u8 = [_]u8{0} ** 64;
             var text_buf: [512]u8 = undefined;
 
-            const address_bytes: []const u8 = this.socket.remoteAddress(&buf);
+            const address_bytes: []const u8 = this.socket.remoteAddress(&buf) orelse return JSValue.jsUndefined();
             const address: std.net.Address = switch (address_bytes.len) {
                 4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
                 16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1660,7 +1660,7 @@ fn NewSocket(comptime ssl: bool) type {
             }
         }
 
-        pub fn closeAndDetach(this: *This, code: uws.CloseCode) void {
+        pub fn closeAndDetach(this: *This, code: uws.Socket.CloseCode) void {
             const socket = this.socket;
             this.buffered_data_for_node_net.deinitWithAllocator(bun.default_allocator);
 
@@ -2108,12 +2108,10 @@ fn NewSocket(comptime ssl: bool) type {
             }
 
             var buf: [64]u8 = [_]u8{0} ** 64;
-            var length: i32 = 64;
             var text_buf: [512]u8 = undefined;
 
-            this.socket.remoteAddress(&buf, &length);
-            const address_bytes = buf[0..@as(usize, @intCast(length))];
-            const address: std.net.Address = switch (length) {
+            const address_bytes: []const u8 = this.socket.remoteAddress(&buf);
+            const address: std.net.Address = switch (address_bytes.len) {
                 4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
                 16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),
                 else => return JSValue.jsUndefined(),
@@ -2250,7 +2248,7 @@ fn NewSocket(comptime ssl: bool) type {
                 if (comptime !ssl and Environment.isPosix) {
                     // fast-ish path: use writev() to avoid cloning to another buffer.
                     if (this.socket.socket == .connected and buffer.slice().len > 0) {
-                        const rc = this.socket.socket.connected.write2(this.buffered_data_for_node_net.slice(), buffer.slice());
+                        const rc = this.socket.socket.connected.write2(ssl, this.buffered_data_for_node_net.slice(), buffer.slice());
                         const written: usize = @intCast(@max(rc, 0));
                         const leftover = total_to_write -| written;
                         if (leftover == 0) {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -8237,9 +8237,11 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (this.cached_hostname.isEmpty()) {
                 if (this.listener) |listener| {
                     var buf: [1024]u8 = [_]u8{0} ** 1024;
-                    const addr: []const u8 = listener.socket().remoteAddress(&buf);
-                    if (addr.len > 0) {
-                        this.cached_hostname = bun.String.createUTF8(addr);
+
+                    if (listener.socket().remoteAddress(buf[0..1024])) |addr| {
+                        if (addr.len > 0) {
+                            this.cached_hostname = bun.String.createUTF8(addr);
+                        }
                     }
                 }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -8237,10 +8237,9 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             if (this.cached_hostname.isEmpty()) {
                 if (this.listener) |listener| {
                     var buf: [1024]u8 = [_]u8{0} ** 1024;
-                    var len: i32 = 1024;
-                    listener.socket().remoteAddress(&buf, &len);
-                    if (len > 0) {
-                        this.cached_hostname = bun.String.createUTF8(buf[0..@as(usize, @intCast(len))]);
+                    const addr: []const u8 = listener.socket().remoteAddress(&buf);
+                    if (addr.len > 0) {
+                        this.cached_hostname = bun.String.createUTF8(addr);
                     }
                 }
 

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1678,7 +1678,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         pub fn localAddress(this: ThisSocket, buf: []u8) ?[]const u8 {
             return switch (this.socket) {
                 .connected => |sock| sock.localAddress(is_ssl, buf) catch |e| {
-                    bun.Output.panic("Failed to get socket's remote address: {s}", .{@errorName(e)});
+                    bun.Output.panic("Failed to get socket's local address: {s}", .{@errorName(e)});
                 },
                 .pipe, .upgradedDuplex, .connecting, .detached => null,
             };

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1660,10 +1660,12 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                 .pipe, .upgradedDuplex, .connecting, .detached => 0,
             };
         }
-        pub fn remoteAddress(this: ThisSocket, buf: [*]u8) []const u8 {
+
+        /// `buf` cannot be longer than 2^31 bytes long.
+        pub fn remoteAddress(this: ThisSocket, buf: []u8) ?[]const u8 {
             return switch (this.socket) {
                 .connected => |sock| sock.remoteAddress(is_ssl, buf) catch unreachable, // fixme
-                .pipe, .upgradedDuplex, .connecting, .detached => &[_]u8{},
+                .pipe, .upgradedDuplex, .connecting, .detached => null,
             };
         }
 

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -27,12 +27,12 @@ pub const Socket = opaque {
     }
 
     pub fn pause(this: *Socket, ssl: bool) void {
-        debug("us_socket_pause({d})", .{ @intFromPtr(this) });
+        debug("us_socket_pause({d})", .{@intFromPtr(this)});
         us_socket_pause(@intFromBool(ssl), this);
     }
 
     pub fn @"resume"(this: *Socket, ssl: bool) void {
-        debug("us_socket_resume({d})", .{ @intFromPtr(this) });
+        debug("us_socket_resume({d})", .{@intFromPtr(this)});
         us_socket_resume(@intFromBool(ssl), this);
     }
 
@@ -42,7 +42,7 @@ pub const Socket = opaque {
     }
 
     pub fn shutdown(this: *Socket, ssl: bool) void {
-        debug("us_socket_shutdown({d})", .{ @intFromPtr(this) });
+        debug("us_socket_shutdown({d})", .{@intFromPtr(this)});
         us_socket_shutdown(@intFromBool(ssl), this);
     }
 
@@ -63,7 +63,7 @@ pub const Socket = opaque {
     }
 
     /// Returned slice is a view into `buf`. On error, `errno` should be set
-    pub fn localAddress(this: *Socket, ssl: bool, buf: []u8) error {LocalAddress}![]const u8 {
+    pub fn localAddress(this: *Socket, ssl: bool, buf: []u8) error{LocalAddress}![]const u8 {
         var length: i32 = @intCast(buf.len); // todo: check us_socket_local_address reads length
         us_socket_local_address(@intFromBool(ssl), this, buf.ptr, &length);
         if (length < 0) return error.LocalAddress;
@@ -71,7 +71,7 @@ pub const Socket = opaque {
     }
 
     /// Returned slice is a view into `buf`. On error, `errno` should be set
-    pub fn remoteAddress(this: *Socket, ssl: bool, buf: [*]u8) error {RemoteAddress}![]const u8 {
+    pub fn remoteAddress(this: *Socket, ssl: bool, buf: [*]u8) error{RemoteAddress}![]const u8 {
         var length: i32 = 0;
         us_socket_remote_address(@intFromBool(ssl), this, buf, &length);
         if (length < 0) return error.RemoteAddress;
@@ -86,7 +86,7 @@ pub const Socket = opaque {
         us_socket_long_timeout(@intFromBool(ssl), this, @intCast(minutes));
     }
 
-    pub fn setNodelay(this: *Socket,  enabled: bool) void {
+    pub fn setNodelay(this: *Socket, enabled: bool) void {
         us_socket_nodelay(this, @intFromBool(enabled));
     }
 
@@ -109,7 +109,7 @@ pub const Socket = opaque {
     }
 
     pub fn write(this: *Socket, ssl: bool, data: []const u8, msg_more: bool) i32 {
-        debug("us_socket_write({d}, {d})", .{  @intFromPtr(this), data.len });
+        debug("us_socket_write({d}, {d})", .{ @intFromPtr(this), data.len });
         return us_socket_write(@intFromBool(ssl), this, data.ptr, @intCast(data.len), @intFromBool(msg_more));
     }
 
@@ -120,7 +120,7 @@ pub const Socket = opaque {
     }
 
     pub fn rawWrite(this: *Socket, ssl: bool, data: []const u8, msg_more: bool) i32 {
-        debug("us_socket_raw_write({d}, {d})", .{ @intFromPtr(this), data.len  });
+        debug("us_socket_raw_write({d}, {d})", .{ @intFromPtr(this), data.len });
         return us_socket_raw_write(@intFromBool(ssl), this, data.ptr, @intCast(data.len), @intFromBool(msg_more));
     }
 

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -1,0 +1,165 @@
+const std = @import("std");
+const bun = @import("root").bun;
+const uws = @import("../uws.zig");
+
+const SocketContext = uws.SocketContext;
+
+const debug = bun.Output.scoped(.uws, false);
+const max_i32 = std.math.maxInt(i32);
+
+/// Zig bindings for `us_socket_t`
+pub const Socket = opaque {
+    pub const CloseCode = enum(i32) {
+        normal = 0,
+        failure = 1,
+    };
+
+    pub fn open(this: *Socket, comptime is_ssl: bool, is_client: bool, ip_addr: ?[]const u8) void {
+        debug("us_socket_open({d}, is_client: {})", .{ @intFromPtr(this), is_client });
+        const ssl = @intFromBool(is_ssl);
+
+        if (ip_addr) |ip| {
+            bun.assert(ip.len < max_i32);
+            _ = us_socket_open(ssl, this, @intFromBool(is_client), ip.ptr, @intCast(ip.len));
+        } else {
+            _ = us_socket_open(ssl, this, @intFromBool(is_client), null, 0);
+        }
+    }
+
+    pub fn pause(this: *Socket, ssl: bool) void {
+        debug("us_socket_pause({d})", .{ @intFromPtr(this) });
+        us_socket_pause(@intFromBool(ssl), this);
+    }
+
+    pub fn @"resume"(this: *Socket, ssl: bool) void {
+        debug("us_socket_resume({d})", .{ @intFromPtr(this) });
+        us_socket_resume(@intFromBool(ssl), this);
+    }
+
+    pub fn close(this: *Socket, ssl: bool, code: CloseCode) void {
+        debug("us_socket_close({d}, {s})", .{ @intFromPtr(this), @tagName(code) });
+        _ = us_socket_close(@intFromBool(ssl), this, code, null);
+    }
+
+    pub fn shutdown(this: *Socket, ssl: bool) void {
+        debug("us_socket_shutdown({d})", .{ @intFromPtr(this) });
+        us_socket_shutdown(@intFromBool(ssl), this);
+    }
+
+    pub fn shutdownRead(this: *Socket, ssl: bool) void {
+        us_socket_shutdown_read(@intFromBool(ssl), this);
+    }
+
+    pub fn isClosed(this: *Socket, ssl: bool) bool {
+        return us_socket_is_closed(@intFromBool(ssl), this) > 0;
+    }
+
+    pub fn isShutDown(this: *Socket, ssl: bool) bool {
+        return us_socket_is_shut_down(@intFromBool(ssl), this) > 0;
+    }
+
+    pub fn localPort(this: *Socket, ssl: bool) i32 {
+        return us_socket_local_port(@intFromBool(ssl), this);
+    }
+
+    /// Returned slice is a view into `buf`. On error, `errno` should be set
+    pub fn localAddress(this: *Socket, ssl: bool, buf: []u8) error {LocalAddress}![]const u8 {
+        var length: i32 = @intCast(buf.len); // todo: check us_socket_local_address reads length
+        us_socket_local_address(@intFromBool(ssl), this, buf.ptr, &length);
+        if (length < 0) return error.LocalAddress;
+        return buf[0..@intCast(length)];
+    }
+
+    /// Returned slice is a view into `buf`. On error, `errno` should be set
+    pub fn remoteAddress(this: *Socket, ssl: bool, buf: [*]u8) error {RemoteAddress}![]const u8 {
+        var length: i32 = 0;
+        us_socket_remote_address(@intFromBool(ssl), this, buf, &length);
+        if (length < 0) return error.RemoteAddress;
+        return buf[0..@intCast(length)];
+    }
+
+    pub fn setTimeout(this: *Socket, ssl: bool, seconds: u32) void {
+        us_socket_timeout(@intFromBool(ssl), this, @intCast(seconds));
+    }
+
+    pub fn setLongTimeout(this: *Socket, ssl: bool, minutes: u32) void {
+        us_socket_long_timeout(@intFromBool(ssl), this, @intCast(minutes));
+    }
+
+    pub fn setNodelay(this: *Socket,  enabled: bool) void {
+        us_socket_nodelay(this, @intFromBool(enabled));
+    }
+
+    pub fn setKeepalive(this: *Socket, enabled: bool, delay: u32) i32 {
+        return us_socket_keepalive(this, @intFromBool(enabled), @intCast(delay));
+    }
+
+    pub fn getNativeHandle(this: *Socket, ssl: bool) ?*anyopaque {
+        return us_socket_get_native_handle(@intFromBool(ssl), this);
+    }
+
+    pub fn ext(this: *Socket, ssl: bool) *anyopaque {
+        @setRuntimeSafety(true);
+        return us_socket_ext(@intFromBool(ssl), this).?;
+    }
+
+    pub fn context(this: *Socket, ssl: bool) *SocketContext {
+        @setRuntimeSafety(true);
+        return us_socket_context(@intFromBool(ssl), this).?;
+    }
+
+    pub fn write(this: *Socket, ssl: bool, data: []const u8, msg_more: bool) i32 {
+        debug("us_socket_write({d}, {d})", .{  @intFromPtr(this), data.len });
+        return us_socket_write(@intFromBool(ssl), this, data.ptr, @intCast(data.len), @intFromBool(msg_more));
+    }
+
+    pub fn write2(this: *Socket, ssl: bool, first: []const u8, second: []const u8) i32 {
+        const rc = us_socket_write2(@intFromBool(ssl), this, first.ptr, first.len, second.ptr, second.len);
+        debug("us_socket_write2({d}, {d}, {d}) = {d}", .{ @intFromPtr(this), first.len, second.len, rc });
+        return rc;
+    }
+
+    pub fn rawWrite(this: *Socket, ssl: bool, data: []const u8, msg_more: bool) i32 {
+        debug("us_socket_raw_write({d}, {d})", .{ @intFromPtr(this), data.len  });
+        return us_socket_raw_write(@intFromBool(ssl), this, data.ptr, @intCast(data.len), @intFromBool(msg_more));
+    }
+
+    pub fn flush(this: *Socket, ssl: bool) void {
+        us_socket_flush(@intFromBool(ssl), this);
+    }
+
+    pub fn sendFileNeedsMore(this: *Socket) void {
+        us_socket_sendfile_needs_more(this);
+    }
+
+    extern fn us_socket_get_native_handle(ssl: i32, s: ?*Socket) ?*anyopaque;
+
+    extern fn us_socket_local_port(ssl: i32, s: ?*Socket) i32;
+    extern fn us_socket_remote_address(ssl: i32, s: ?*Socket, buf: [*c]u8, length: [*c]i32) void;
+    extern fn us_socket_local_address(ssl: i32, s: ?*Socket, buf: [*c]u8, length: [*c]i32) void;
+    extern fn us_socket_timeout(ssl: i32, s: ?*Socket, seconds: c_uint) void;
+    extern fn us_socket_long_timeout(ssl: i32, s: ?*Socket, minutes: c_uint) void;
+    extern fn us_socket_nodelay(s: ?*Socket, enable: c_int) void;
+    extern fn us_socket_keepalive(s: ?*Socket, enable: c_int, delay: c_uint) c_int;
+
+    extern fn us_socket_ext(ssl: i32, s: ?*Socket) ?*anyopaque; // nullish to be safe
+    extern fn us_socket_context(ssl: i32, s: ?*Socket) ?*SocketContext;
+
+    extern fn us_socket_write(ssl: i32, s: ?*Socket, data: [*c]const u8, length: i32, msg_more: i32) i32;
+    extern "c" fn us_socket_write2(ssl: i32, *Socket, header: ?[*]const u8, len: usize, payload: ?[*]const u8, usize) i32;
+    extern fn us_socket_raw_write(ssl: i32, s: ?*Socket, data: [*c]const u8, length: i32, msg_more: i32) i32;
+    extern fn us_socket_flush(ssl: i32, s: ?*Socket) void;
+
+    // if a TLS socket calls this, it will start SSL instance and call open event will also do TLS handshake if required
+    // will have no effect if the socket is closed or is not TLS
+    extern fn us_socket_open(ssl: i32, s: ?*Socket, is_client: i32, ip: [*c]const u8, ip_length: i32) ?*Socket;
+    extern fn us_socket_pause(ssl: i32, s: ?*Socket) void;
+    extern fn us_socket_resume(ssl: i32, s: ?*Socket) void;
+    extern fn us_socket_close(ssl: i32, s: ?*Socket, code: CloseCode, reason: ?*anyopaque) ?*Socket;
+    extern fn us_socket_shutdown(ssl: i32, s: ?*Socket) void;
+    extern fn us_socket_is_closed(ssl: i32, s: ?*Socket) i32;
+    extern fn us_socket_shutdown_read(ssl: i32, s: ?*Socket) void;
+    extern fn us_socket_is_shut_down(ssl: i32, s: ?*Socket) i32;
+
+    extern fn us_socket_sendfile_needs_more(socket: *Socket) void;
+};

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -96,6 +96,8 @@ pub const Socket = opaque {
         us_socket_nodelay(this, @intFromBool(enabled));
     }
 
+    /// Returns error code. `0` on success. error codes depend on platform an
+    /// configured event loop.
     pub fn setKeepalive(this: *Socket, enabled: bool, delay: u32) i32 {
         return us_socket_keepalive(this, @intFromBool(enabled), @intCast(delay));
     }

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -64,17 +64,23 @@ pub const Socket = opaque {
 
     /// Returned slice is a view into `buf`. On error, `errno` should be set
     pub fn localAddress(this: *Socket, ssl: bool, buf: []u8) error{LocalAddress}![]const u8 {
-        var length: i32 = @intCast(buf.len); // todo: check us_socket_local_address reads length
+        var length: i32 = @intCast(buf.len);
+
         us_socket_local_address(@intFromBool(ssl), this, buf.ptr, &length);
         if (length < 0) return error.LocalAddress;
+        bun.unsafeAssert(buf.len >= length);
+
         return buf[0..@intCast(length)];
     }
 
     /// Returned slice is a view into `buf`. On error, `errno` should be set
-    pub fn remoteAddress(this: *Socket, ssl: bool, buf: [*]u8) error{RemoteAddress}![]const u8 {
-        var length: i32 = 0;
-        us_socket_remote_address(@intFromBool(ssl), this, buf, &length);
+    pub fn remoteAddress(this: *Socket, ssl: bool, buf: []u8) error{RemoteAddress}![]const u8 {
+        var length: i32 = @intCast(buf.len);
+
+        us_socket_remote_address(@intFromBool(ssl), this, buf.ptr, &length);
         if (length < 0) return error.RemoteAddress;
+        bun.unsafeAssert(buf.len >= length);
+
         return buf[0..@intCast(length)];
     }
 


### PR DESCRIPTION
### What does this PR do?
Unconditionally enable runtime safety checks when making FFI calls for/with `us_socket_t`. I'm seeing crashes around this part of the code and this will help us find bugs.

This is part of the `node:http` compatability/stabaility effort.

### How did you verify your code works?
Existing test cases should cover these changes.
