### PR TITLE
Fix `connection` event being emitted multiple times per socket in `node:http`

### DIFF
--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -887,7 +887,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
         auto* thisSocket = jsCast<JSNodeHTTPServerSocket*>(currentSocketDataPtr);
         thisSocket->currentResponseObject.set(vm, thisSocket, nodeHTTPResponseObject);
         args.append(thisSocket);
-        args.append(jsBoolean(true));
+        args.append(jsBoolean(false));
         if (thisSocket->m_duplex) {
             args.append(thisSocket->m_duplex.get());
         } else {
@@ -905,7 +905,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
         response->getHttpResponseData()->socketData = socket;
 
         args.append(socket);
-        args.append(jsBoolean(false));
+        args.append(jsBoolean(true));
         args.append(jsUndefined());
     }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where `node:http` servers would emit `connection` events multiple times for the same socket. This would cause Vite to accumulate excess `close` listeners on sockets.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

I ran an example Vite app (`/examples/web` in [sroussey/ellmers](https://github.com/sroussey/ellmers)) and spammed refresh in Firefox while checking for warnings about too many `close` listeners. I also ran the `node:http` tests.