### PR TITLE
Handle package.json scripts with colons in values for completions in bash

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -48,7 +48,7 @@ _read_scripts_in_package_json() {
         scripts="${scripts//@(\"|\')/}";
         readarray -td, scripts <<<"${scripts}";
         for completion in "${scripts[@]}"; do
-            package_json_compreply+=( "${completion%:*}" );
+            package_json_compreply+=( "${completion%\":*}" );
         done
         COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
     }


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where completions did not work with `package.json` scripts that contain colons (`:`) in their script values. These scenarios often occur when complex scripts or nested tasks are defined, and this fix ensures that completions function correctly even in such cases.

- [x] Code changes

### How did you verify your code works?
  I tested the fix with various `package.json` scripts containing colons in their values to ensure that completions now work as expected.  
  
  Example script that now works successfully:
  "build:extensions": "turbo run build:extensions"
