### PR TITLE
Implemented Uint8Array.prototype.toHex()

### DIFF
--- a/packages/bun-polyfills/src/global/index.ts
+++ b/packages/bun-polyfills/src/global/index.ts
@@ -44,6 +44,9 @@ Reflect.set(
     }
 );
 
+//? Polyfill because this isn't implemented.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toHex
+
 Uint8Array.prototype.toHex = function (): string {
     return Array.from(this)
         .map(byte => byte.toString(16).padStart(2, '0')) // Convert each byte to hex and pad with zeros

--- a/packages/bun-polyfills/src/global/index.ts
+++ b/packages/bun-polyfills/src/global/index.ts
@@ -43,3 +43,9 @@ Reflect.set(
         });
     }
 );
+
+Uint8Array.prototype.toHex = function (): string {
+    return Array.from(this)
+        .map(byte => byte.toString(16).padStart(2, '0')) // Convert each byte to hex and pad with zeros
+        .join('');
+};

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1775,6 +1775,12 @@ declare global {
     toBase64(options?: { alphabet?: "base64" | "base64url"; omitPadding?: boolean }): string;
 
     /**
+     * Convert the Uint8Array to hex
+     * @returns The string with hex representation of the Uint8Array
+     */
+    toHex(): string;
+
+    /**
      * Set the contents of the Uint8Array from a base64 encoded string
      * @param base64 The base64 encoded string to decode into the array
      * @param offset Optional starting index to begin setting the decoded bytes (default: 0)

--- a/packages/bun-types/test/globals.test.ts
+++ b/packages/bun-types/test/globals.test.ts
@@ -307,3 +307,9 @@ clearInterval(1);
 clearTimeout(1);
 setImmediate(() => {});
 clearImmediate(1);
+
+{
+  const uint8array = new Uint8Array([202, 254, 208, 13]);
+  const arrHex = uint8array.toHex();
+  expectType<string>(arrHex);
+}


### PR DESCRIPTION
### Adds .toHex() method to Uint8Array

Implements `Uint8Array.prototype.toHex()` for Bun.
Added the definition as a polyfill and changed the type definition of `Uint8Array` to include the new function.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### Tested it

I wrote automated tests

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

- [x] I added TypeScript types for the new methods, getters, or setters
