### PR TITLE
Add precompiled header

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -747,14 +747,16 @@ set_target_properties(${bun} PROPERTIES
   VISIBILITY_INLINES_HIDDEN YES
 )
 
-# Enable precompiled headers
-# Only enable in these scenarios:
-# 1. NOT in CI, OR
-# 2. In CI AND BUN_CPP_ONLY is enabled
-if(NOT CI OR (CI AND BUN_CPP_ONLY))
-  target_precompile_headers(${bun} PRIVATE
-    "$<$<COMPILE_LANGUAGE:CXX>:${CWD}/src/bun.js/bindings/root.h>"
-  )
+if (NOT WIN32)
+  # Enable precompiled headers
+  # Only enable in these scenarios:
+  # 1. NOT in CI, OR
+  # 2. In CI AND BUN_CPP_ONLY is enabled
+  if(NOT CI OR (CI AND BUN_CPP_ONLY))
+    target_precompile_headers(${bun} PRIVATE
+      "$<$<COMPILE_LANGUAGE:CXX>:${CWD}/src/bun.js/bindings/root.h>"
+    )
+  endif()
 endif()
 
 # --- C/C++ Includes ---

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -906,6 +906,10 @@ if(NOT WIN32)
       -Werror
     )
   endif()
+else()
+  target_compile_options(${bun} PUBLIC
+    -Wno-nullability-completeness
+  )
 endif()
 
 # --- Linker options ---

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -748,9 +748,14 @@ set_target_properties(${bun} PROPERTIES
 )
 
 # Enable precompiled headers
-target_precompile_headers(${bun} PRIVATE
-  "$<$<COMPILE_LANGUAGE:CXX>:${CWD}/src/bun.js/bindings/root.h>"
-)
+# Only enable in these scenarios:
+# 1. NOT in CI, OR
+# 2. In CI AND BUN_CPP_ONLY is enabled
+if(NOT CI OR (CI AND BUN_CPP_ONLY))
+  target_precompile_headers(${bun} PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:${CWD}/src/bun.js/bindings/root.h>"
+  )
+endif()
 
 # --- C/C++ Includes ---
 

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -747,6 +747,11 @@ set_target_properties(${bun} PROPERTIES
   VISIBILITY_INLINES_HIDDEN YES
 )
 
+# Enable precompiled headers
+target_precompile_headers(${bun} PRIVATE
+  "$<$<COMPILE_LANGUAGE:CXX>:${CWD}/src/bun.js/bindings/root.h>"
+)
+
 # --- C/C++ Includes ---
 
 if(WIN32)

--- a/src/bun.js/bindings/ExceptionOr.h
+++ b/src/bun.js/bindings/ExceptionOr.h
@@ -87,9 +87,6 @@ public:
 
 private:
     Expected<void, Exception> m_value;
-#if ASSERT_ENABLED
-    bool m_wasReleased { false };
-#endif
 };
 
 ExceptionOr<void> isolatedCopy(ExceptionOr<void>&&);

--- a/src/bun.js/bindings/root.h
+++ b/src/bun.js/bindings/root.h
@@ -76,6 +76,8 @@
 #include <wtf/text/MakeString.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/HandleSet.h>
+#include <wtf/Ref.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 #define ENABLE_WEB_CRYPTO 1
 #define USE_OPENSSL 1

--- a/src/bun.js/bindings/v8/V8FunctionTemplate.h
+++ b/src/bun.js/bindings/v8/V8FunctionTemplate.h
@@ -34,8 +34,8 @@ enum class SideEffectType {
 // (v8-fast-api-calls.h is not in the headers distribution)
 class CFunction {
 private:
-    const void* address;
-    const void* type_info;
+    [[maybe_unused]] const void* address;
+    [[maybe_unused]] const void* type_info;
 };
 
 class FunctionTemplate : public Template {

--- a/src/bun.js/bindings/webcore/EventContext.h
+++ b/src/bun.js/bindings/webcore/EventContext.h
@@ -98,9 +98,9 @@ private:
     RefPtr<TouchList> m_targetTouches;
     RefPtr<TouchList> m_changedTouches;
 #endif
-    int m_closedShadowDepth { 0 };
-    bool m_currentTargetIsInShadowTree { false };
-    bool m_contextNodeIsFormElement { false };
+    [[maybe_unused]] int m_closedShadowDepth { 0 };
+    [[maybe_unused]] bool m_currentTargetIsInShadowTree { false };
+    [[maybe_unused]] bool m_contextNodeIsFormElement { false };
     Type m_type { Type::Normal };
 };
 

--- a/src/bun.js/bindings/webcore/EventNames.h
+++ b/src/bun.js/bindings/webcore/EventNames.h
@@ -81,7 +81,7 @@ private:
     EventNames(); // Private to prevent accidental call to EventNames() instead of eventNames().
     // friend class ThreadGlobalData; // Allow ThreadGlobalData to create the per-thread EventNames object.
 
-    int dummy; // Needed to make initialization macro work.
+    [[maybe_unused]] int dummy; // Needed to make initialization macro work.
 };
 
 const EventNames& eventNames();

--- a/src/bun.js/bindings/webcore/Worker.h
+++ b/src/bun.js/bindings/webcore/Worker.h
@@ -137,7 +137,6 @@ private:
     Deque<RefPtr<Event>> m_pendingEvents;
     Lock m_pendingTasksMutex;
     Deque<Function<void(ScriptExecutionContext&)>> m_pendingTasks;
-    bool m_didStartWorkerGlobalScope { false };
     // Tracks OnlineFlag and ClosingFlag
     std::atomic<uint8_t> m_onlineClosingFlags { 0 };
     // Tracks TerminateRequestedFlag and TerminatedFlag

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -595,7 +595,7 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
         void exportNames();
 
     private:
-        JSC::VM& m_vm;
+        [[maybe_unused]] JSC::VM& m_vm;
 
         WEBCORE_FOREACH_${basename.toUpperCase()}_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_NAMES)
 

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -638,7 +638,7 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
         template<typename Visitor> void visit(Visitor&);
 
     public:
-        JSC::VM& m_vm;
+        [[maybe_unused]] JSC::VM& m_vm;
 
     #define DECLARE_BUILTIN_SOURCE_MEMBERS(functionName) \\
         JSC::WriteBarrier<JSC::JSFunction> m_##functionName##Function;
@@ -682,7 +682,7 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
 
   bundledHeader += `
     private:
-        JSC::VM& m_vm;
+        [[maybe_unused]] JSC::VM& m_vm;
     `;
 
   for (const { basename } of files) {
@@ -708,7 +708,7 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
 
   bundledHeader += `
     private:
-        JSC::VM& m_vm;
+        [[maybe_unused]] JSC::VM& m_vm;
     `;
 
   for (const { basename, internal } of files) {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
