### PR TITLE
Remove debug assertion failure for missing error code in switch case

### DIFF
--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -2035,10 +2035,6 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
     }
     }
 
-#if BUN_DEBUG
-    ASSERT(false, "Improper use of @makeError! Add error function to ErrorCode.cpp and builtins.d.ts");
-#endif
-
     auto&& message = callFrame->argument(1).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 


### PR DESCRIPTION
### What does this PR do?

There's a bunch of errors used in JS that are not defined in ErrorCode.cpp, and it crashes fuzzy-wuzzy on debug builds