### PR TITLE
Fix bun --inspect-brk hanging

### DIFF
--- a/src/bun.js/bindings/BunDebugger.cpp
+++ b/src/bun.js/bindings/BunDebugger.cpp
@@ -52,7 +52,7 @@ public:
     void pauseWaitingForAutomaticInspection() override
     {
     }
-    void unpauseForInitializedInspector()
+    void unpauseForResolvedAutomaticInspection() override
     {
         if (waitingForConnection) {
             waitingForConnection = false;


### PR DESCRIPTION
### What does this PR do?

Restore WebKit's ability to notify us that the debugger has connected. Without this, with `bun --inspect-brk` the debugger would just open to a blank screen and never pull up the source code:

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/28ff6c7f-1a09-47ea-bdea-3942bab5d4d2" />

They changed this function in https://commits.webkit.org/292318@main. We incorrectly adapted to the new name in #18317.

### How did you verify your code works?

`bun-debug --inspect-brk` on a small file now works just like the stable version of Bun.