### PR TITLE
fix: test-http-header-obstext.js

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -1761,7 +1761,8 @@ void WebCore__FetchHeaders__copyTo(WebCore__FetchHeaders* headers, StringPointer
                 *values = { i, value.length() };
                 i += value.length();
             } else {
-                ASSERT_WITH_MESSAGE(value.containsOnlyASCII(), "Header value must be ASCII. This should already be validated before calling this function.");
+                // HTTP headers can contain non-ASCII characters according to RFC 7230
+                // Non-ASCII content should be properly encoded
                 WTF::CString valueCString = value.utf8();
                 memcpy(&buf[i], valueCString.data(), valueCString.length());
                 *values = { i, static_cast<uint32_t>(valueCString.length()) };

--- a/test/js/node/test/parallel/test-http-header-obstext.js
+++ b/test/js/node/test/parallel/test-http-header-obstext.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that the http-parser can handle UTF-8 characters
+// in the http header.
+
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.end('ok');
+}));
+server.listen(0, () => {
+  http.get({
+    port: server.address().port,
+    headers: { 'Test': 'Düsseldorf' }
+  }, common.mustCall((res) => {
+    assert.strictEqual(res.statusCode, 200);
+    server.close();
+  }));
+});


### PR DESCRIPTION
This PR fixes the test-http-header-obstext.js test to improve node:http compatibility.