### PR TITLE
fix: test-http-outgoing-settimeout.js

### DIFF
--- a/test/js/node/test/parallel/test-http-outgoing-settimeout.js
+++ b/test/js/node/test/parallel/test-http-outgoing-settimeout.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { OutgoingMessage } = require('http');
+
+{
+  // Tests for settimeout method with socket
+  const expectedMsecs = 42;
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.socket = {
+    setTimeout: common.mustCall((msecs) => {
+      assert.strictEqual(msecs, expectedMsecs);
+    })
+  };
+  outgoingMessage.setTimeout(expectedMsecs);
+}
+
+{
+  // Tests for settimeout method without socket
+  const expectedMsecs = 23;
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setTimeout(expectedMsecs);
+
+  outgoingMessage.emit('socket', {
+    setTimeout: common.mustCall((msecs) => {
+      assert.strictEqual(msecs, expectedMsecs);
+    })
+  });
+}


### PR DESCRIPTION
This PR fixes the test-http-outgoing-settimeout.js test to improve node:http compatibility.