### PR TITLE
fix: test-http-agent-getname.js

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -553,7 +553,7 @@ Agent.prototype.createConnection = function () {
 };
 
 Agent.prototype.getName = function (options = kEmptyObject) {
-  let name = `http:${options.host || "localhost"}:`;
+  let name = `${options.host || "localhost"}:`;
   if (options.port) name += options.port;
   name += ":";
   if (options.localAddress) name += options.localAddress;

--- a/test/js/node/test/parallel/test-http-agent-getname.js
+++ b/test/js/node/test/parallel/test-http-agent-getname.js
@@ -1,0 +1,55 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const tmpdir = require('../common/tmpdir');
+
+const agent = new http.Agent();
+
+// Default to localhost
+assert.strictEqual(
+  agent.getName({
+    port: 80,
+    localAddress: '192.168.1.1'
+  }),
+  'localhost:80:192.168.1.1'
+);
+
+// empty argument
+assert.strictEqual(
+  agent.getName(),
+  'localhost::'
+);
+
+// empty options
+assert.strictEqual(
+  agent.getName({}),
+  'localhost::'
+);
+
+// pass all arguments
+assert.strictEqual(
+  agent.getName({
+    host: '0.0.0.0',
+    port: 80,
+    localAddress: '192.168.1.1'
+  }),
+  '0.0.0.0:80:192.168.1.1'
+);
+
+// unix socket
+const socketPath = tmpdir.resolve('foo', 'bar');
+assert.strictEqual(
+  agent.getName({
+    socketPath
+  }),
+  `localhost:::${socketPath}`
+);
+
+for (const family of [0, null, undefined, 'bogus'])
+  assert.strictEqual(agent.getName({ family }), 'localhost::');
+
+for (const family of [4, 6])
+  assert.strictEqual(agent.getName({ family }), `localhost:::${family}`);


### PR DESCRIPTION
This PR fixes the test-http-agent-getname.js test to improve node:http compatibility.