### PR TITLE
fix: test-http-outgoing-internal-headernames-setter.js

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1598,6 +1598,23 @@ const OutgoingMessagePrototype = {
   usesChunkedEncodingByDefault: true,
   _closed: false,
 
+  get _headerNames() {
+    process.emitWarning("OutgoingMessage.prototype._headerNames is deprecated", "DeprecationWarning", "DEP0066");
+
+    const headers = this[headersSymbol];
+    if (!headers) return null;
+
+    const out = Object.create(null);
+    for (const key of headers.keys()) {
+      out[key.toLowerCase()] = key;
+    }
+    return out;
+  },
+
+  set _headerNames(val) {
+    process.emitWarning("OutgoingMessage.prototype._headerNames is deprecated", "DeprecationWarning", "DEP0066");
+  },
+
   appendHeader(name, value) {
     var headers = (this[headersSymbol] ??= new Headers());
     headers.append(name, value);

--- a/test/js/node/test/parallel/test-http-outgoing-internal-headernames-setter.js
+++ b/test/js/node/test/parallel/test-http-outgoing-internal-headernames-setter.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+
+const { OutgoingMessage } = require('http');
+
+const warn = 'OutgoingMessage.prototype._headerNames is deprecated';
+common.expectWarning('DeprecationWarning', warn, 'DEP0066');
+
+{
+  // Tests for _headerNames set method
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage._headerNames = {
+    'x-flow-id': '61bba6c5-28a3-4eab-9241-2ecaa6b6a1fd'
+  };
+}


### PR DESCRIPTION
This PR fixes the test-http-outgoing-internal-headernames-setter.js test to improve node:http compatibility.