### PR TITLE
fix: test-http-client-request-options.js

### DIFF
--- a/src/js/internal/url.ts
+++ b/src/js/internal/url.ts
@@ -15,6 +15,9 @@ function urlToHttpOptions(url) {
   if (url.username || url.password) {
     options.auth = `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`;
   }
+  if ("headers" in url) {
+    options.headers = url.headers;
+  }
   return options;
 }
 

--- a/test/js/node/test/parallel/test-http-client-request-options.js
+++ b/test/js/node/test/parallel/test-http-client-request-options.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const headers = { foo: 'Bar' };
+const server = http.createServer(common.mustCall((req, res) => {
+  assert.strictEqual(req.url, '/ping?q=term');
+  assert.strictEqual(req.headers?.foo, headers.foo);
+  req.resume();
+  req.on('end', () => {
+    res.writeHead(200);
+    res.end('pong');
+  });
+}));
+
+server.listen(0, common.localhostIPv4, () => {
+  const { address, port } = server.address();
+  const url = new URL(`http://${address}:${port}/ping?q=term`);
+  url.headers = headers;
+  const clientReq = http.request(url);
+  clientReq.on('close', common.mustCall(() => {
+    server.close();
+  }));
+  clientReq.end();
+});


### PR DESCRIPTION
This PR fixes the test-http-client-request-options.js test to improve node:http compatibility.