### PR TITLE
fix: test-set-incoming-message-header.js

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -61,6 +61,7 @@ const kInternalSocketData = Symbol.for("::bunternal::");
 const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
+const kTrailers = Symbol("kTrailers");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
@@ -1232,6 +1233,7 @@ function IncomingMessage(req, defaultIncomingOpts) {
   this._dumped = false;
   this.complete = false;
   this._closed = false;
+  this[kTrailers] = null;
 
   // (url, method, headers, rawHeaders, handle, hasBody)
   if (req === kHandle) {
@@ -1496,10 +1498,34 @@ const IncomingMessagePrototype = {
     // noop
   },
   get trailers() {
-    return kEmptyObject;
+    if (!this[kTrailers]) {
+      this[kTrailers] = Object.create(null);
+    }
+    return this[kTrailers];
   },
   set trailers(value) {
-    // noop
+    this[kTrailers] = value;
+  },
+  _addHeaderLines(headers, n) {
+    if (headers?.length) {
+      let dest;
+      if (this.complete) {
+        dest = this.trailers;
+      } else {
+        dest = this.headers;
+      }
+
+      if (dest) {
+        for (let i = 0; i < n; i += 2) {
+          this._addHeaderLine(headers[i], headers[i + 1], dest);
+        }
+      }
+    }
+  },
+  _addHeaderLine(field, value, dest) {
+    if (dest[field] === undefined) {
+      dest[field] = value;
+    }
   },
   setTimeout(msecs, callback) {
     this.take;

--- a/test/js/node/test/parallel/test-set-incoming-message-header.js
+++ b/test/js/node/test/parallel/test-set-incoming-message-header.js
@@ -1,0 +1,27 @@
+'use strict';
+
+require('../common');
+const { IncomingMessage } = require('http');
+const assert = require('assert');
+
+// Headers setter function set a header correctly
+{
+  const im = new IncomingMessage();
+  im.headers = { key: 'value' };
+  assert.deepStrictEqual(im.headers, { key: 'value' });
+}
+
+// Trailers setter function set a header correctly
+{
+  const im = new IncomingMessage();
+  im.trailers = { key: 'value' };
+  assert.deepStrictEqual(im.trailers, { key: 'value' });
+}
+
+// _addHeaderLines function set a header correctly
+{
+  const im = new IncomingMessage();
+  im.headers = { key1: 'value1' };
+  im._addHeaderLines(['key2', 'value2'], 2);
+  assert.deepStrictEqual(im.headers, { key1: 'value1', key2: 'value2' });
+}


### PR DESCRIPTION
This PR fixes the test-set-incoming-message-header.js test to improve node:http compatibility.