### PR TITLE
Fix not displaying 405

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -9429,6 +9429,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
 
                     switch (route.route.method) {
                         .any => {
+                            // TODO: Issue #18406 there's a problem upstream where this path isn't entered.
                             resp.writeStatus("501 Method Not Allowed");
                             resp.end("", false);
                             return;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -9421,7 +9421,6 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             const path = req.url();
             for (this.user_routes.items) |route| {
                 if (std.mem.eql(u8, route.route.path, path)) {
-                    std.debug.print("bazinga\n", .{});
                     if (comptime Environment.enable_logs)
                         httplog("{s} - {s} 405", .{ method, path });
                     resp.writeStatus("405 Method Not Allowed");

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -548,26 +548,29 @@ it("returns 405 when method is not implemented for a route", async () => {
     routes: {
       "/test": {
         GET: () => new Response("bun"),
+        HEAD: () => new Response("bun"),
       },
     },
   });
 
-  // Test that GET works
+  // Get should work
   expect(await fetch(new URL("/test", server.url)).then(res => res.text())).toBe("bun");
   
-  // Test that POST returns 405
+  // Post should 405
   const postResponse = await fetch(new URL("/test", server.url), {
     method: "POST",
   });
   expect(postResponse.status).toBe(405);
+  expect(postResponse.headers.get("Allow")).toBe("GET, HEAD");
   
-  // Test that PUT returns 405
+  // Put should also 405
   const putResponse = await fetch(new URL("/test", server.url), {
     method: "PUT",
   });
   expect(putResponse.status).toBe(405);
+  expect(putResponse.headers.get("Allow")).toBe("GET, HEAD");
 
-  // Test that non-existent path still returns 404
+  // Non-existent path still returns 404
   const notFoundResponse = await fetch(new URL("/nonexistent", server.url));
   expect(notFoundResponse.status).toBe(404);
 });

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -541,3 +541,33 @@ it("throws a validation error when routes object is undefined and fetch is not s
     Learn more at https://bun.sh/docs/api/http"
   `);
 });
+
+it("returns 405 when method is not implemented for a route", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    routes: {
+      "/test": {
+        GET: () => new Response("bun"),
+      },
+    },
+  });
+
+  // Test that GET works
+  expect(await fetch(new URL("/test", server.url)).then(res => res.text())).toBe("bun");
+  
+  // Test that POST returns 405
+  const postResponse = await fetch(new URL("/test", server.url), {
+    method: "POST",
+  });
+  expect(postResponse.status).toBe(405);
+  
+  // Test that PUT returns 405
+  const putResponse = await fetch(new URL("/test", server.url), {
+    method: "PUT",
+  });
+  expect(putResponse.status).toBe(405);
+
+  // Test that non-existent path still returns 404
+  const notFoundResponse = await fetch(new URL("/nonexistent", server.url));
+  expect(notFoundResponse.status).toBe(404);
+});


### PR DESCRIPTION
### What does this PR do?
- Adds checks to see when a request is unimplemented, if the route is unimplemented, or just the method is unsupported.
- Returns 405 correctly
- related to Issue #18197 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->
- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [X] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
