### PR TITLE
Fix `dns.resolve`

### DIFF
--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -2501,7 +2501,7 @@ pub const DNSResolver = struct {
             return globalThis.throwNotEnoughArguments("resolve", 3, arguments.len);
         }
 
-        const record_type: RecordType = if (arguments.len == 1)
+        const record_type: RecordType = if (arguments.len <= 1)
             RecordType.default
         else brk: {
             const record_type_value = arguments.ptr[1];
@@ -2518,7 +2518,7 @@ pub const DNSResolver = struct {
             }
 
             break :brk RecordType.map.getWithEql(record_type_str.getZigString(globalThis), JSC.ZigString.eqlComptime) orelse {
-                return globalThis.throwInvalidArgumentType("resolve", "record", "one of: A, AAAA, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT");
+                return globalThis.throwInvalidArgumentType("resolve", "record", "one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT");
             };
         };
 

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -395,7 +395,7 @@ var InternalResolver = class Resolver {
     validateResolve(hostname, callback);
 
     Resolver.#getResolver(this)
-      .resolve(hostname)
+      .resolve(hostname, rrtype)
       .then(
         results => {
           switch (rrtype?.toLowerCase()) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where `dns.resolve` doesn't pass its record type parameter to native code, resulting in A record lookups only.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

`test-http-autoselectfamily.js`