### PR TITLE
Add benchmark for `Cipheriv` and `Decipheriv`

### DIFF
--- a/bench/crypto/aes-gcm-throughput.mjs
+++ b/bench/crypto/aes-gcm-throughput.mjs
@@ -1,0 +1,44 @@
+import { bench, run } from "../runner.mjs";
+import crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+const keylen = { "aes-128-gcm": 16, "aes-192-gcm": 24, "aes-256-gcm": 32 };
+const sizes = [4 * 1024, 1024 * 1024];
+const ciphers = ["aes-128-gcm", "aes-192-gcm", "aes-256-gcm"];
+
+const messages = {};
+sizes.forEach(size => {
+  messages[size] = Buffer.alloc(size, "b");
+});
+
+const keys = {};
+ciphers.forEach(cipher => {
+  keys[cipher] = crypto.randomBytes(keylen[cipher]);
+});
+
+// Fixed IV and AAD
+const iv = crypto.randomBytes(12);
+const associate_data = Buffer.alloc(16, "z");
+
+for (const cipher of ciphers) {
+  for (const size of sizes) {
+    const message = messages[size];
+    const key = keys[cipher];
+
+    bench(`${cipher} ${size / 1024}KB`, () => {
+      const alice = crypto.createCipheriv(cipher, key, iv);
+      alice.setAAD(associate_data);
+      const enc = alice.update(message);
+      alice.final();
+      const tag = alice.getAuthTag();
+
+      const bob = crypto.createDecipheriv(cipher, key, iv);
+      bob.setAuthTag(tag);
+      bob.setAAD(associate_data);
+      bob.update(enc);
+      bob.final();
+    });
+  }
+}
+
+await run();


### PR DESCRIPTION
### What does this PR do?
Test originates from https://github.com/nodejs/node/blob/13a9d4c1609bfcf89c39f1ad864ed46a117961a0/benchmark/crypto/aes-gcm-throughput.js#L26
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
