### PR TITLE
fixed using option "unix" in Bun's fetch result in type error

### DIFF
--- a/packages/bun-types/fetch.d.ts
+++ b/packages/bun-types/fetch.d.ts
@@ -123,6 +123,11 @@ interface BunFetchRequestInit extends RequestInit {
    * Override the default TLS options
    */
   tls?: BunFetchRequestInitTLS;
+  
+  /**
+   * The unix socket to connect to
+   */
+  unix?: string;
 }
 
 var fetch: {


### PR DESCRIPTION
### What does this PR do?
fixes a type error when using the unix option in Bun's fetch function. 

Previously this code would result in an type error because the option "unix" is not defined in the types
```ts
const response = await fetch("http://localhost/info", {
    unix: "/var/run/path/to/unix.sock"
});
```
```
error TS2769: No overload matches this call.
  Overload 1 of 2, '(input: string | URL | Request, init?: RequestInit | undefined): Promise<Response>', gave the following error.
    Object literal may only specify known properties, and 'unix' does not exist in type 'RequestInit'.
  Overload 2 of 2, '(input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>', gave the following error.
    Object literal may only specify known properties, and 'unix' does not exist in type 'RequestInit'.
```

### How did you verify your code works?

I checked for type errors using the typescript compiler after i updated the type BunFetchRequestInit
