### PR TITLE
Update sql.md to  reduce confuse

### DIFF
--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -319,6 +319,9 @@ const db = new SQL({
     console.log("Connection closed");
   },
 });
+
+// how to use this manual connention
+const result = await db`SELECT 1`;
 ```
 
 ## Dynamic passwords


### PR DESCRIPTION
Add how to use manual connection compared to direct import `sql`, reduct confuse.

### What does this PR do?

This adds a new example  show how to use `db` after manual connection. Saw this Documentation make me very confuse, and https://github.com/oven-sh/bun/issues/15088 show some reason.