### PR TITLE
Fix CSS Modules when code splitting enabled

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -7115,7 +7115,7 @@ pub const LinkerContext = struct {
                 const visited_entry = v.visited.getOrPut(source_index) catch unreachable;
                 if (visited_entry.found_existing) return;
 
-                var is_file_in_chunk = if (comptime with_code_splitting)
+                var is_file_in_chunk = if ((comptime with_code_splitting) and v.c.graph.ast.items(.css)[source_index] == null)
                     // when code splitting, include the file in the chunk if ALL of the entry points overlap
                     v.entry_bits.eql(&v.c.graph.files.items(.entry_bits)[source_index])
                 else

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -7115,7 +7115,7 @@ pub const LinkerContext = struct {
                 const visited_entry = v.visited.getOrPut(source_index) catch unreachable;
                 if (visited_entry.found_existing) return;
 
-                var is_file_in_chunk = if ((comptime with_code_splitting) and v.c.graph.ast.items(.css)[source_index] == null)
+                var is_file_in_chunk = if (with_code_splitting and v.c.graph.ast.items(.css)[source_index] == null)
                     // when code splitting, include the file in the chunk if ALL of the entry points overlap
                     v.entry_bits.eql(&v.c.graph.files.items(.entry_bits)[source_index])
                 else

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -20,4 +20,83 @@ describe("css", () => {
       `);
     },
   });
+
+  itBundled("css-module/BundleTwoFilesWithoutCodeSplitting", {
+    files: {
+      "/foo-entry.js": `
+        import styles from './common.module.css'
+        console.log(styles)
+      `,
+      "/bar-entry.js": `
+        import styles from './common.module.css'
+        console.log(styles)
+      `,
+      "/common.module.css": `.baz { color: red }`,
+    },
+    entryPoints: ["/foo-entry.js", "/bar-entry.js"],
+    outdir: "/out",
+
+    onAfterBundle(api) {
+      api.expectFile("/out/foo-entry.js").toMatchInlineSnapshot(`
+        "// common.module.css
+        var common_module_default = {
+          baz: "baz_I7o34g"
+        };
+
+        // foo-entry.js
+        console.log(common_module_default);
+        "
+      `);
+      api.expectFile("/out/bar-entry.js").toMatchInlineSnapshot(`
+        "// common.module.css
+        var common_module_default = {
+          baz: "baz_I7o34g"
+        };
+
+        // bar-entry.js
+        console.log(common_module_default);
+        "
+      `);
+    },
+  });
+
+  itBundled("css-module/BundleTwoFilesWithCodeSplitting", {
+    files: {
+      "/foo-entry.js": `
+        import styles from './common.module.css'
+        console.log(styles)
+      `,
+      "/bar-entry.js": `
+        import styles from './common.module.css'
+        console.log(styles)
+      `,
+      "/common.module.css": `.baz { color: red }`,
+    },
+    entryPoints: ["/foo-entry.js", "/bar-entry.js"],
+    splitting: true,
+    outdir: "/out",
+
+    onAfterBundle(api) {
+      api.expectFile("/out/foo-entry.js").toMatchInlineSnapshot(`
+        "// common.module.css
+        var common_module_default = {
+          baz: "baz_I7o34g"
+        };
+
+        // foo-entry.js
+        console.log(common_module_default);
+        "
+      `);
+      api.expectFile("/out/bar-entry.js").toMatchInlineSnapshot(`
+        "// common.module.css
+        var common_module_default = {
+          baz: "baz_I7o34g"
+        };
+
+        // bar-entry.js
+        console.log(common_module_default);
+        "
+      `);
+    },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

This PR fixes missing CSS Modules class mapping (fixes https://github.com/oven-sh/bun/issues/18244).

This is probably not a permanent solution and in the future class mapping should be placed in a separate chunk. But now it's better than completely broken css modules. 

### How did you verify your code works?

I included a test for the new code.
