### PR TITLE
Skip flaky macOS x64 node-napi tests in CI

### DIFF
--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -15,7 +15,8 @@ describe("napi", () => {
       stdin: "inherit",
     });
     if (!install.success) {
-      throw new Error("build failed");
+      console.error("build failed, bailing out!");
+      process.exit(1);
     }
   });
 

--- a/test/napi/node-napi.test.ts
+++ b/test/napi/node-napi.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync, spawn, Glob } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isCI, isMusl } from "harness";
+import { bunEnv, bunExe, isCI, isIntelMacOS, isMusl } from "harness";
 import { join, dirname } from "path";
 import os from "node:os";
 
@@ -11,11 +11,17 @@ const jsNativeApiTests = Array.from(new Glob("**/*.js").scanSync(jsNativeApiRoot
 const nodeApiTests = Array.from(new Glob("**/*.js").scanSync(nodeApiRoot));
 
 // These js-native-api tests are known to fail and will be fixed in later PRs
-let failingJsNativeApiTests = [
+let failingJsNativeApiTests: string[] = [
   // We skip certain parts of test_string/test.js because we don't support creating empty external
   // strings. We don't skip the entire thing because the other tests are useful to check.
   // "test_string/test.js",
 ];
+
+if (isCI && isIntelMacOS) {
+  // TODO(@190n)
+  // these are flaky on Intel Mac
+  failingJsNativeApiTests.push("test_reference_by_node_api_version/test.js", "test_reference/test.js");
+}
 
 // These are the tests from node-api that failed as of commit 83f536f4d, except for those that
 // passed in Bun v1.1.34. It'll take some time to get all these to work, as we've been focusing more

--- a/test/napi/node-napi.test.ts
+++ b/test/napi/node-napi.test.ts
@@ -112,7 +112,7 @@ beforeAll(async () => {
   }
 
   const parallelism = Math.min(8, os.cpus().length, 1 /* TODO(@heimskr): remove */);
-  const jobs = [];
+  const jobs: Promise<void>[] = [];
   for (let i = 0; i < parallelism; i++) {
     jobs.push(worker());
   }

--- a/test/napi/node-napi.test.ts
+++ b/test/napi/node-napi.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync, spawn, Glob } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isCI, isIntelMacOS, isMusl } from "harness";
+import { bunEnv, bunExe, isBroken, isCI, isIntelMacOS, isMusl } from "harness";
 import { join, dirname } from "path";
 import os from "node:os";
 
@@ -17,7 +17,7 @@ let failingJsNativeApiTests: string[] = [
   // "test_string/test.js",
 ];
 
-if (isCI && isIntelMacOS) {
+if (isBroken && isIntelMacOS) {
   // TODO(@190n)
   // these are flaky on Intel Mac
   failingJsNativeApiTests.push("test_reference_by_node_api_version/test.js", "test_reference/test.js");

--- a/test/napi/node-napi.test.ts
+++ b/test/napi/node-napi.test.ts
@@ -100,7 +100,9 @@ beforeAll(async () => {
     await child.exited;
     if (child.exitCode !== 0) {
       const stderr = await new Response(child.stderr).text();
-      throw new Error(`node-gyp rebuild in ${dir} failed:\n${stderr}`);
+      console.error(`node-gyp rebuild in ${dir} failed:\n${stderr}`);
+      console.error("bailing out!");
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Skips these tests that have been failing.

Since I was in the Node-API tests anyway, I also made them exit immediately if the compile step fails, as that will produce a more useful error (currently you have to scroll up past a lot of errors where it fails to `require()` the module that didn't build)

### How did you verify your code works?

Will see if CI passes
