### PR TITLE
chore(bun-plugin-svelte): bump version to v0.0.6

### DIFF
--- a/packages/bun-plugin-svelte/package.json
+++ b/packages/bun-plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-plugin-svelte",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Official Svelte plugin for Bun",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What does this PR do?
Prepares for the release of `bun-plugin-svelte@0.0.6`
