### PR TITLE
Fix #18414

### DIFF
--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1092,11 +1092,11 @@ describe("Response", () => {
           "content-type": "potato",
           "x-hello": "world",
         },
-        status: 408,
+        status: 301,
       });
 
       expect(response.headers.get("x-hello")).toBe("world");
-      expect(response.status).toBe(408);
+      expect(response.status).toBe(301);
     });
   });
   describe("Response.redirect", () => {
@@ -1121,7 +1121,7 @@ describe("Response", () => {
           "x-hello": "world",
           Location: "https://wrong.com",
         },
-        status: 408,
+        status: 302,
       });
       expect(response.headers.get("x-hello")).toBe("world");
       expect(response.headers.get("Location")).toBe("https://example.com");

--- a/test/regression/issue/18414.test.js
+++ b/test/regression/issue/18414.test.js
@@ -1,0 +1,64 @@
+import { expect, test, describe } from "bun:test";
+
+describe("Response.redirect", () => {
+  test("should validate URL parameter type - number", () => {
+    expect(() => {
+      Response.redirect(420, "blaze it");
+    }).toThrow('The "url" argument must be of type string');
+  });
+
+  test("should validate URL parameter type - null", () => {
+    expect(() => {
+      Response.redirect(null);
+    }).toThrow('The "url" argument must be of type string');
+  });
+
+  test("should validate URL parameter type - undefined", () => {
+    expect(() => {
+      Response.redirect(undefined);
+    }).toThrow('The "url" argument must be of type string');
+  });
+
+  test("accepts arrays with toString", () => {
+    const response = Response.redirect(["not", "a", "url"]);
+    expect(response.headers.get("Location")).toBe("not,a,url");
+  });
+
+  test("rejects a plain object as URL", () => {
+    expect(() => {
+      Response.redirect({ not: "a url" });
+    }).toThrow('The "url" argument must be of type string');
+  });
+
+  test("accepts a string URL with default status code", () => {
+    const response = Response.redirect("https://example.com");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("https://example.com");
+  });
+
+  test("accepts a string URL with valid redirect status code", () => {
+    const response = Response.redirect("https://example.com", 301);
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("https://example.com");
+  });
+
+  test("accepts a URL object as first parameter", () => {
+    const url = new URL("https://example.com");
+    const response = Response.redirect(url, 301);
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("https://example.com/");
+  });
+
+  test("accepts objects with toString method as first parameter", () => {
+    const urlLike = { toString: () => "https://example.com" };
+    const response = Response.redirect(urlLike, 301);
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("https://example.com");
+  });
+
+  test("rejects an invalid redirect status code", () => {
+    expect(() => {
+      Response.redirect("https://example.com", 420);
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #18414

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
