### PR TITLE
Fix #18413

### DIFF
--- a/test/regression/issue/18413.test.ts
+++ b/test/regression/issue/18413.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "bun:test";
+import { serve } from "bun";
+import { createGzip } from "node:zlib";
+
+/**
+ * Regression test for issue #18413
+ * "Decompression error: ShortRead - empty chunked gzip response breaks fetch()"
+ *
+ * The issue was in Bun's zlib.zig implementation, which was incorrectly returning
+ * error.ShortRead when encountering empty gzip streams (when avail_in == 0).
+ *
+ * This test verifies that fetch() properly handles empty gzip responses with
+ * chunked transfer encoding.
+ */
+
+let server: ReturnType<typeof serve>;
+
+// Test for issue #18413: Empty chunked gzip response breaks fetch()
+test("empty chunked gzip response (simple case)", async () => {
+  server = serve({
+    async fetch(req) {
+      // Create a ReadableStream that will produce an empty response
+      const stream = new ReadableStream({
+        start(controller) {
+          // Just close the stream immediately without pushing any data
+          controller.close();
+        },
+      });
+
+      // Return a Response with Content-Encoding: gzip and Transfer-Encoding: chunked
+      // and an empty body
+      return new Response(stream, {
+        headers: {
+          "Content-Encoding": "gzip",
+          "Transfer-Encoding": "chunked",
+          "Content-Type": "text/plain",
+        },
+      });
+    },
+    port: 0, // Use random available port
+  });
+
+  try {
+    const url = `http://localhost:${server.port}`;
+
+    const response = await fetch(url);
+    expect(response.status).toBe(200);
+
+    // This is where it would fail with "Decompression error: ShortRead"
+    const text = await response.text();
+    expect(text).toBe(""); // We expect an empty string
+  } finally {
+    server.stop();
+  }
+});
+
+// Test with node's zlib to create a proper gzip empty stream
+test("empty chunked gzip response (using node:zlib)", async () => {
+  // This test uses a custom HTTP handler to ensure proper chunked encoding
+  const http = require("node:http");
+
+  // Create a server that responds with an empty gzipped chunked response
+  const nodeServer = http.createServer((req, res) => {
+    res.writeHead(200, {
+      "Content-Type": "text/plain",
+      "Content-Encoding": "gzip",
+      "Transfer-Encoding": "chunked",
+    });
+
+    // Create a gzip stream
+    const gzip = createGzip();
+    gzip.pipe(res);
+
+    // End without writing any data - should create a valid empty gzip stream
+    gzip.end();
+  });
+
+  // Start the server
+  await new Promise(resolve => {
+    nodeServer.listen(0, () => resolve());
+  });
+
+  const port = nodeServer.address().port;
+
+  try {
+    const url = `http://localhost:${port}`;
+
+    const response = await fetch(url);
+    expect(response.status).toBe(200);
+
+    // This is where it would fail with "Decompression error: ShortRead"
+    const text = await response.text();
+    expect(text).toBe(""); // We expect an empty string
+  } finally {
+    nodeServer.close();
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #18413

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
