### PR TITLE
Skip "text lockfile is hoisted" test on Windows CI

### DIFF
--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4596,7 +4596,7 @@ describe("hoisting", async () => {
     });
   });
 
-  test("text lockfile is hoisted", async () => {
+  test.todoIf(isFlaky && isWindows)("text lockfile is hoisted", async () => {
     // Each dependency depends on 'hoist-lockfile-shared'.
     // 1 - "*"
     // 2 - "^1.0.1"


### PR DESCRIPTION
### What does this PR do?

Skips a flaky test. I checked a few PRs and "text lockfile is hoisted" seems to be the only test in this file that is flaky on Windows.

### How did you verify your code works?