### PR TITLE
Rename non-refing Bun::toString overloads to Bun::toStringNonRef

### DIFF
--- a/src/bake/BakeGlobalObject.cpp
+++ b/src/bake/BakeGlobalObject.cpp
@@ -39,7 +39,7 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
             return promise;
         }
 
-        BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
+        BunString result = BakeProdResolve(global, Bun::toStringNonRef(refererString), Bun::toStringNonRef(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
         return JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
@@ -65,7 +65,7 @@ JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
         RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
 
         if (refererString.startsWith("bake:/"_s) || (refererString == "."_s && keyString.startsWith("bake:/"_s))) {
-            BunString result = BakeProdResolve(global, Bun::toString(referrer.getString(global)), Bun::toString(keyString));
+            BunString result = BakeProdResolve(global, Bun::toStringNonRef(referrer.getString(global)), Bun::toStringNonRef(keyString));
             RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
 
             return JSC::Identifier::fromString(vm, result.toWTFString(BunString::ZeroCopy));
@@ -109,7 +109,7 @@ JSC::JSInternalPromise* bakeModuleLoaderFetch(JSC::JSGlobalObject* globalObject,
 
     if (moduleKey.startsWith("bake:/"_s)) {
         if (LIKELY(global->m_perThreadData)) {
-            BunString source = BakeProdLoad(global->m_perThreadData, Bun::toString(moduleKey));
+            BunString source = BakeProdLoad(global->m_perThreadData, Bun::toStringNonRef(moduleKey));
             if (source.tag != BunStringTag::Dead) {
                 JSC::SourceOrigin origin = JSC::SourceOrigin(WTF::URL(moduleKey));
                 JSC::SourceCode sourceCode = JSC::SourceCode(Bake::SourceProvider::create(

--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -528,7 +528,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
         if (url.isValid() && url.protocolIsFile()) {
             auto fromString = url.fileSystemPath();
-            BunString from = Bun::toString(fromString);
+            BunString from = Bun::toStringNonRef(fromString);
             auto catchScope = DECLARE_CATCH_SCOPE(vm);
             auto result = JSValue::decode(Bun__resolveSyncWithSource(globalObject, JSValue::encode(specifierString), &from, true, false));
             if (catchScope.exception()) {

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -426,7 +426,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
 #define StandaloneModuleGraph__base_path "/$bunfs/"_s
 #endif
     if (filename.startsWith(StandaloneModuleGraph__base_path)) {
-        BunString bunStr = Bun::toString(filename);
+        BunString bunStr = Bun::toStringNonRef(filename);
         if (Bun__resolveEmbeddedNodeFile(globalObject->bunVM(), &bunStr)) {
             filename = bunStr.toWTFString(BunString::ZeroCopy);
         }
@@ -3459,7 +3459,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionLoadBuiltinModule, (JSGlobalObject * gl
 
     String idWtfStr = id.toWTFString(zigGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    BunString idStr = Bun::toString(idWtfStr);
+    BunString idStr = Bun::toStringNonRef(idWtfStr);
 
     JSValue fetchResult = Bun::resolveAndFetchBuiltinModule(zigGlobalObject, &idStr);
     if (fetchResult) {

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -224,13 +224,6 @@ BunString toStringRef(JSC::JSGlobalObject* globalObject, JSValue value)
     return { BunStringTag::WTFStringImpl, { .wtf = impl } };
 }
 
-BunString toStringNonRef(WTF::String& wtfString)
-{
-    if (wtfString.isEmpty())
-        return { BunStringTag::Empty };
-
-    return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
-}
 BunString toStringNonRef(const WTF::String& wtfString)
 {
     if (wtfString.isEmpty())
@@ -246,14 +239,6 @@ BunString toStringNonRef(WTF::StringImpl* wtfString)
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString } };
 }
 
-BunString toStringRef(WTF::String& wtfString)
-{
-    if (wtfString.isEmpty())
-        return { BunStringTag::Empty };
-
-    wtfString.impl()->ref();
-    return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
-}
 BunString toStringRef(const WTF::String& wtfString)
 {
     if (wtfString.isEmpty())

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -61,7 +61,7 @@ extern "C" void Bun__WTFStringImpl__ref(WTF::StringImpl* impl)
 extern "C" bool BunString__fromJS(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, BunString* bunString)
 {
     JSC::JSValue value = JSC::JSValue::decode(encodedValue);
-    *bunString = Bun::toString(globalObject, value);
+    *bunString = Bun::toStringNonRef(globalObject, value);
     return bunString->tag != BunStringTag::Dead;
 }
 
@@ -202,7 +202,7 @@ extern "C" void BunString__toThreadSafe(BunString* str)
     }
 }
 
-BunString toString(JSC::JSGlobalObject* globalObject, JSValue value)
+BunString toStringNonRef(JSC::JSGlobalObject* globalObject, JSValue value)
 {
     return fromJS(globalObject, value);
 }
@@ -224,21 +224,21 @@ BunString toStringRef(JSC::JSGlobalObject* globalObject, JSValue value)
     return { BunStringTag::WTFStringImpl, { .wtf = impl } };
 }
 
-BunString toString(WTF::String& wtfString)
+BunString toStringNonRef(WTF::String& wtfString)
 {
     if (wtfString.isEmpty())
         return { BunStringTag::Empty };
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
 }
-BunString toString(const WTF::String& wtfString)
+BunString toStringNonRef(const WTF::String& wtfString)
 {
     if (wtfString.isEmpty())
         return { BunStringTag::Empty };
 
     return { BunStringTag::WTFStringImpl, { .wtf = wtfString.impl() } };
 }
-BunString toString(WTF::StringImpl* wtfString)
+BunString toStringNonRef(WTF::StringImpl* wtfString)
 {
     if (wtfString->isEmpty())
         return { BunStringTag::Empty };
@@ -328,7 +328,7 @@ extern "C" BunString BunString__fromUTF8(const char* bytes, size_t length)
         return { .tag = BunStringTag::Dead };
     }
     auto impl = str.releaseImpl();
-    return Bun::toString(impl.leakRef());
+    return Bun::toStringNonRef(impl.leakRef());
 }
 
 extern "C" BunString BunString__fromLatin1(const char* bytes, size_t length)

--- a/src/bun.js/bindings/ImportMetaObject.cpp
+++ b/src/bun.js/bindings/ImportMetaObject.cpp
@@ -82,7 +82,7 @@ static JSC::EncodedJSValue functionRequireResolve(JSC::JSGlobalObject* globalObj
                 }
             }
 
-            BunString from = Bun::toString(fromStr);
+            BunString from = Bun::toStringNonRef(fromStr);
             auto result = Bun__resolveSyncWithSource(globalObject, JSC::JSValue::encode(moduleName), &from, false, true);
             RETURN_IF_EXCEPTION(scope, {});
 
@@ -319,7 +319,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                     args.append(moduleName);
                     args.append(parentModuleObject);
                     auto parentIdStr = parentID.toWTFString(globalObject);
-                    auto bunStr = Bun::toString(parentIdStr);
+                    auto bunStr = Bun::toStringNonRef(parentIdStr);
                     args.append(jsBoolean(Bun__isBunMain(lexicalGlobalObject, &bunStr)));
 
                     JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, overrideHandler, JSC::getCallData(overrideHandler), parentModuleObject, args);
@@ -442,8 +442,8 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
     }
 
     // Run it through the module resolver, errors at this point are actual errors.
-    auto a = Bun::toString(specifier);
-    auto b = Bun::toString(fromWTFString);
+    auto a = Bun::toStringNonRef(specifier);
+    auto b = Bun::toStringNonRef(fromWTFString);
     auto result = JSValue::decode(Bun__resolveSyncWithStrings(globalObject, &a, &b, true));
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/bun.js/bindings/InternalModuleRegistry.cpp
+++ b/src/bun.js/bindings/InternalModuleRegistry.cpp
@@ -22,9 +22,9 @@ static void maybeAddCodeCoverage(JSC::VM& vm, const JSC::SourceCode& code)
 {
 #if ASSERT_ENABLED
     bool isCodeCoverageEnabled = !!vm.controlFlowProfiler();
-    bool shouldGenerateCodeCoverage = isCodeCoverageEnabled && BunTest__shouldGenerateCodeCoverage(Bun::toString(code.provider()->sourceURL()));
+    bool shouldGenerateCodeCoverage = isCodeCoverageEnabled && BunTest__shouldGenerateCodeCoverage(Bun::toStringNonRef(code.provider()->sourceURL()));
     if (shouldGenerateCodeCoverage) {
-        ByteRangeMapping__generate(Bun::toString(code.provider()->sourceURL()), Bun::toString(code.provider()->source().toStringWithoutCopying()), code.provider()->asID());
+        ByteRangeMapping__generate(Bun::toStringNonRef(code.provider()->sourceURL()), Bun::toStringNonRef(code.provider()->source().toStringWithoutCopying()), code.provider()->asID());
     }
 #endif
 }

--- a/src/bun.js/bindings/JSCommonJSModule.cpp
+++ b/src/bun.js/bindings/JSCommonJSModule.cpp
@@ -1151,8 +1151,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
     // This is always a new JSCommonJSModule object; cast cannot fail.
     JSCommonJSModule* child = jsCast<JSCommonJSModule*>(callframe->uncheckedArgument(1));
 
-    BunString specifierStr = Bun::toString(specifier);
-    BunString referrerStr = Bun::toString(referrer);
+    BunString specifierStr = Bun::toStringNonRef(specifier);
+    BunString referrerStr = Bun::toStringNonRef(referrer);
     BunString typeAttributeStr = { BunStringTag::Dead };
     String typeAttribute = String();
 
@@ -1170,7 +1170,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
                 if (typeValue.isString()) {
                     typeAttribute = typeValue.toWTFString(globalObject);
                     RETURN_IF_EXCEPTION(throwScope, {});
-                    typeAttributeStr = Bun::toString(typeAttribute);
+                    typeAttributeStr = Bun::toStringNonRef(typeAttribute);
                 }
             }
             RETURN_IF_EXCEPTION(throwScope, {});
@@ -1217,7 +1217,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     WTF::String specifier = specifierValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
     ErrorableResolvedSource res;
-    BunString specifierStr = Bun::toString(specifier);
+    BunString specifierStr = Bun::toStringNonRef(specifier);
     if (auto result = fetchBuiltinModuleWithoutResolution(globalObject, &specifierStr, &res)) {
         if (res.success)
             return JSC::JSValue::encode(result);

--- a/src/bun.js/bindings/JSPropertyIterator.cpp
+++ b/src/bun.js/bindings/JSPropertyIterator.cpp
@@ -124,7 +124,7 @@ static EncodedJSValue getOwnProxyObject(JSPropertyIterator* iter, JSObject* obje
     JSValue result = slot.getValue(globalObject, prop);
     RETURN_IF_EXCEPTION(scope, {});
 
-    *propertyName = Bun::toString(prop.impl());
+    *propertyName = Bun::toStringNonRef(prop.impl());
     return JSValue::encode(result);
 }
 
@@ -148,7 +148,7 @@ extern "C" EncodedJSValue Bun__JSPropertyIterator__getNameAndValue(JSPropertyIte
     JSValue result = slot.getValue(globalObject, prop);
     RETURN_IF_EXCEPTION(scope, {});
 
-    *propertyName = Bun::toString(prop.impl());
+    *propertyName = Bun::toStringNonRef(prop.impl());
     return JSValue::encode(result);
 }
 
@@ -174,14 +174,14 @@ extern "C" EncodedJSValue Bun__JSPropertyIterator__getNameAndValueNonObservable(
     JSValue result = slot.getPureResult();
     RETURN_IF_EXCEPTION(scope, {});
 
-    *propertyName = Bun::toString(prop.impl());
+    *propertyName = Bun::toStringNonRef(prop.impl());
     return JSValue::encode(result);
 }
 
 extern "C" void Bun__JSPropertyIterator__getName(JSPropertyIterator* iter, BunString* propertyName, size_t i)
 {
     const auto& prop = iter->properties->propertyNameVector()[i];
-    *propertyName = Bun::toString(prop.impl());
+    *propertyName = Bun::toStringNonRef(prop.impl());
 }
 
 extern "C" void Bun__JSPropertyIterator__deinit(JSPropertyIterator* iter)

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -996,8 +996,8 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionOnLoadObjectResultResolve, (JSC::JSGlobalObje
     pendingModule->internalField(1).set(vm, pendingModule, JSC::jsUndefined());
     JSC::JSInternalPromise* promise = pendingModule->internalPromise();
 
-    BunString specifier = Bun::toString(globalObject, specifierString);
-    BunString referrer = Bun::toString(globalObject, referrerString);
+    BunString specifier = Bun::toStringNonRef(globalObject, specifierString);
+    BunString referrer = Bun::toStringNonRef(globalObject, referrerString);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     bool wasModuleMock = pendingModule->wasModuleMock;

--- a/src/bun.js/bindings/PathInlines.h
+++ b/src/bun.js/bindings/PathInlines.h
@@ -62,7 +62,7 @@ ALWAYS_INLINE WTF::String pathResolveWTFString(JSC::JSGlobalObject* globalToGetC
 {
     if (isAbsolutePath(input))
         return input;
-    BunString in = Bun::toString(input);
+    BunString in = Bun::toStringNonRef(input);
     BunString out = ResolvePath__joinAbsStringBufCurrentPlatformBunString(globalToGetCwdFrom, in);
     return out.transferToWTFString();
 }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1042,7 +1042,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFulfillModuleSync,
         return {};
     }
 
-    auto specifier = Bun::toString(moduleKey);
+    auto specifier = Bun::toStringNonRef(moduleKey);
     ErrorableResolvedSource res;
     res.success = false;
     res.result.err.code = 0;
@@ -4466,7 +4466,7 @@ JSC::JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
         return rejectedInternalPromise(globalObject, createTypeError(globalObject, "To load Node-API modules, use require() or process.dlopen instead of import."_s));
     }
 
-    auto moduleKeyBun = Bun::toString(moduleKey);
+    auto moduleKeyBun = Bun::toStringNonRef(moduleKey);
     auto sourceString = String("undefined"_s);
     auto typeAttributeString = String();
 
@@ -4486,8 +4486,8 @@ JSC::JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
         }
     }
 
-    auto source = Bun::toString(sourceString);
-    auto typeAttribute = Bun::toString(typeAttributeString);
+    auto source = Bun::toStringNonRef(sourceString);
+    auto typeAttribute = Bun::toStringNonRef(typeAttributeString);
     ErrorableResolvedSource res;
     res.success = false;
     res.result.err.code = 0;

--- a/src/bun.js/bindings/ZigSourceProvider.cpp
+++ b/src/bun.js/bindings/ZigSourceProvider.cpp
@@ -53,19 +53,19 @@ extern "C" int ByteRangeMapping__getSourceID(void* mappings, BunString sourceURL
 extern "C" void* ByteRangeMapping__find(BunString sourceURL);
 void* sourceMappingForSourceURL(const WTF::String& sourceURL)
 {
-    return ByteRangeMapping__find(Bun::toString(sourceURL));
+    return ByteRangeMapping__find(Bun::toStringNonRef(sourceURL));
 }
 
 extern "C" void ByteRangeMapping__generate(BunString sourceURL, BunString code, int sourceID);
 
 JSC::SourceID sourceIDForSourceURL(const WTF::String& sourceURL)
 {
-    void* mappings = ByteRangeMapping__find(Bun::toString(sourceURL));
+    void* mappings = ByteRangeMapping__find(Bun::toStringNonRef(sourceURL));
     if (!mappings) {
         return 0;
     }
 
-    return ByteRangeMapping__getSourceID(mappings, Bun::toString(sourceURL));
+    return ByteRangeMapping__getSourceID(mappings, Bun::toStringNonRef(sourceURL));
 }
 
 extern "C" bool BunTest__shouldGenerateCodeCoverage(BunString sourceURL);
@@ -130,7 +130,7 @@ Ref<SourceProvider> SourceProvider::create(
     auto provider = getProvider();
 
     if (shouldGenerateCodeCoverage) {
-        ByteRangeMapping__generate(Bun::toString(provider->sourceURL()), Bun::toString(provider->source().toStringWithoutCopying()), provider->asID());
+        ByteRangeMapping__generate(Bun::toStringNonRef(provider->sourceURL()), Bun::toStringNonRef(provider->source().toStringWithoutCopying()), provider->asID());
     }
 
     if (resolvedSource.already_bundled) {
@@ -148,7 +148,7 @@ StringView SourceProvider::source() const
 SourceProvider::~SourceProvider()
 {
     if (m_resolvedSource.already_bundled) {
-        BunString str = Bun::toString(sourceURL());
+        BunString str = Bun::toStringNonRef(sourceURL());
         Bun__removeSourceProviderSourceMap(m_globalObject->bunVM(), this, &str);
     }
 }

--- a/src/bun.js/bindings/blob.cpp
+++ b/src/bun.js/bindings/blob.cpp
@@ -8,7 +8,7 @@ namespace WebCore {
 
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebCore::Blob& impl)
 {
-    BunString filename = Bun::toString(impl.fileName());
+    BunString filename = Bun::toStringNonRef(impl.fileName());
     impl.m_impl = Blob__setAsFile(impl.impl(), &filename);
 
     return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
@@ -17,7 +17,7 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)
 {
     auto fileNameStr = impl->fileName();
-    BunString filename = Bun::toString(fileNameStr);
+    BunString filename = Bun::toStringNonRef(fileNameStr);
 
     JSC::EncodedJSValue encoded = Blob__create(lexicalGlobalObject, impl->impl());
     JSBlob* blob = jsCast<JSBlob*>(JSC::JSValue::decode(encoded));

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -299,14 +299,12 @@ BunString toString(const char* bytes, size_t length);
 // the same lifetime as the argument. Be very careful that the BunString is not used after the
 // WTF::String has gone out of scope.
 BunString toStringNonRef(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
-BunString toStringNonRef(WTF::String& wtfString);
 BunString toStringNonRef(const WTF::String& wtfString);
 BunString toStringNonRef(WTF::StringImpl* wtfString);
 
 // These functions increment the reference count on their argument. `deref` must be called later
 // on the return value to avoid a leak.
 BunString toStringRef(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
-BunString toStringRef(WTF::String& wtfString);
 BunString toStringRef(const WTF::String& wtfString);
 BunString toStringRef(WTF::StringImpl* wtfString);
 

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -293,12 +293,18 @@ extern "C" void BunString__toWTFString(BunString*);
 
 namespace Bun {
 JSC::JSString* toJS(JSC::JSGlobalObject*, BunString);
-BunString toString(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
 BunString toString(const char* bytes, size_t length);
-BunString toString(WTF::String& wtfString);
-BunString toString(const WTF::String& wtfString);
-BunString toString(WTF::StringImpl* wtfString);
 
+// These functions do not touch the reference count on their argument. The resulting BunString has
+// the same lifetime as the argument. Be very careful that the BunString is not used after the
+// WTF::String has gone out of scope.
+BunString toStringNonRef(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
+BunString toStringNonRef(WTF::String& wtfString);
+BunString toStringNonRef(const WTF::String& wtfString);
+BunString toStringNonRef(WTF::StringImpl* wtfString);
+
+// These functions increment the reference count on their argument. `deref` must be called later
+// on the return value to avoid a leak.
 BunString toStringRef(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
 BunString toStringRef(WTF::String& wtfString);
 BunString toStringRef(const WTF::String& wtfString);

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -157,9 +157,9 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
             return Exception { TypeError, makeString("Invalid file URL: \""_s, urlInit, '"') };
         }
     }
-    BunString urlStr = Bun::toString(url);
+    BunString urlStr = Bun::toStringNonRef(url);
     BunString errorMessage = BunStringEmpty;
-    BunString nameStr = Bun::toString(worker->m_options.name);
+    BunString nameStr = Bun::toStringNonRef(worker->m_options.name);
 
     bool miniMode = worker->m_options.bun.mini;
     bool unrefByDefault = worker->m_options.bun.unref;
@@ -178,7 +178,7 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
             str = urlObject.fileSystemPath();
         }
 
-        preloadModules.append(Bun::toString(str));
+        preloadModules.append(Bun::toStringNonRef(str));
     }
 
     void* impl = WebWorker__create(

--- a/src/bun.js/modules/BunJSCModule.h
+++ b/src/bun.js/modules/BunJSCModule.h
@@ -887,7 +887,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCodeCoverageForFile,
     }
 
     return ByteRangeMapping__findExecutedLines(
-        globalObject, Bun::toString(fileName), basicBlocks.data(),
+        globalObject, Bun::toStringNonRef(fileName), basicBlocks.data(),
         basicBlocks.size(), functionStartOffset, ignoreSourceMap);
 }
 

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -269,7 +269,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
 
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/modules/cjs/loader.js#L1603-L1620
     if (trailingSlash) {
-        BunString lhs = Bun::toString(val);
+        BunString lhs = Bun::toStringNonRef(val);
         BunString result;
         Bun__Node__Path_joinWTF(&lhs, "noop.js", sizeof("noop.js") - 1, &result);
         val = result.toWTFString();
@@ -516,7 +516,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPath, (JSGlobalObject * globalObject, JSC
 
     String request = request_value.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    BunString request_bun_str = Bun::toString(request);
+    BunString request_bun_str = Bun::toStringNonRef(request);
 
     JSArray* paths = paths_value.isCell() ? jsDynamicCast<JSArray*>(paths_value) : nullptr;
 

--- a/src/codegen/bindgen.ts
+++ b/src/codegen/bindgen.ts
@@ -480,7 +480,7 @@ function emitConvertValue(
         if (decl === "declare") {
           cpp.add(`${type.cppName()} `);
         }
-        cpp.line(`${storageLocation} = Bun::toString(${temp});`);
+        cpp.line(`${storageLocation} = Bun::toStringNonRef(${temp});`);
         break;
       }
       case "UTF8String": {
@@ -491,7 +491,7 @@ function emitConvertValue(
         if (decl === "declare") {
           cpp.add(`${type.cppName()} `);
         }
-        cpp.line(`${storageLocation} = Bun::toString(${temp});`);
+        cpp.line(`${storageLocation} = Bun::toStringNonRef(${temp});`);
         break;
       }
       case "dictionary": {
@@ -1485,7 +1485,7 @@ zigInternal.line("};");
 zigInternal.line();
 zigInternal.line("comptime {");
 zigInternal.line(`    if (bun.Environment.export_cpp_apis) {`);
-zigInternal.line("        for (@typeInfo(binding_internals).@\"struct\".decls) |decl| {");
+zigInternal.line('        for (@typeInfo(binding_internals).@"struct".decls) |decl| {');
 zigInternal.line("            _ = &@field(binding_internals, decl.name);");
 zigInternal.line("        }");
 zigInternal.line("    }");


### PR DESCRIPTION
### What does this PR do?

It's not clear enough that these functions do not cause their argument to be kept alive. The new name makes it clearer.

### How did you verify your code works?

CI.