### PR TITLE
fix(docs): failing typo CI pipeline

### DIFF
--- a/docs/api/cookie.md
+++ b/docs/api/cookie.md
@@ -111,7 +111,7 @@ cookies.set(cookie);
 
 #### `delete(options: CookieStoreDeleteOptions): void`
 
-Removes a cookie from the map. When applied to a Response, this adds a cookie with an empty string value and an expiry date in the past. A cookie will only delete succesfully on the browser if the domain and path is the same as it was when the cookie was created.
+Removes a cookie from the map. When applied to a Response, this adds a cookie with an empty string value and an expiry date in the past. A cookie will only delete successfully on the browser if the domain and path is the same as it was when the cookie was created.
 
 ```ts
 // Delete by name using default domain and path.


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in `cookies.md` causing our Typos CI pipeline to fail. 