### PR TITLE
more cookie mistakes

### DIFF
--- a/src/bun.js/bindings/CookieMap.cpp
+++ b/src/bun.js/bindings/CookieMap.cpp
@@ -272,7 +272,7 @@ std::optional<KeyValuePair<String, String>> CookieMap::Iterator::next()
 {
     while (m_index < m_target->m_modifiedCookies.size() + m_target->m_originalCookies.size()) {
         if (m_index >= m_target->m_modifiedCookies.size()) {
-            return m_target->m_originalCookies[m_index++];
+            return m_target->m_originalCookies[(m_index++) - m_target->m_modifiedCookies.size()];
         }
 
         auto result = m_target->m_modifiedCookies[m_index++];

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -280,3 +280,38 @@ describe("Cookie name field is immutable", () => {
     `);
   });
 });
+
+test("delete in a loop", () => {
+  const map = new Bun.CookieMap();
+  for (let i = 0; i < 1000; i++) {
+    map.set(`name${i}`, `value${i}`);
+  }
+  for (const key of map.keys()) {
+    map.delete(key);
+  }
+  // expect(map.size).toBe(0);
+  expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+});
+test("delete in a loop with predefined entries", () => {
+  const entries: [string, string][] = [];
+  for (let i = 0; i < 1000; i++) {
+    entries.push([`name${i}`, `value${i}`]);
+  }
+  const map = new Bun.CookieMap(entries);
+  for (const key of map.keys()) {
+    map.delete(key);
+  }
+  // expect(map.size).toBe(0);
+  expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+});
+test.only("basic iterator", () => {
+  const cookies = new Bun.CookieMap({ a: "b", c: "d" });
+  cookies.set("e", "f");
+  cookies.set("g", "h");
+  expect([...cookies.entries()].map(([key, value]) => `${key}=${value}`).join("\n")).toMatchInlineSnapshot(`
+    "e=f
+    g=h
+    c=d
+    a=b"
+  `);
+});

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -281,7 +281,7 @@ describe("Cookie name field is immutable", () => {
   });
 });
 
-test("iterator", () => {
+describe("iterator", () => {
   test("delete in a loop", () => {
     const map = new Bun.CookieMap();
     for (let i = 0; i < 1000; i++) {
@@ -302,8 +302,7 @@ test("iterator", () => {
     for (const key of map.keys()) {
       map.delete(key);
     }
-    // expect(map.size).toBe(0);
-    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+    expect(map.size).toBe(0);
   });
   test("delete in a loop with both", () => {
     const entries: [string, string][] = [];
@@ -320,7 +319,7 @@ test("iterator", () => {
     // expect(map.size).toBe(0);
     expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
   });
-  test.only("basic iterator", () => {
+  test("basic iterator", () => {
     const cookies = new Bun.CookieMap({ a: "b", c: "d" });
     cookies.set("e", "f");
     cookies.set("g", "h");

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -281,37 +281,54 @@ describe("Cookie name field is immutable", () => {
   });
 });
 
-test("delete in a loop", () => {
-  const map = new Bun.CookieMap();
-  for (let i = 0; i < 1000; i++) {
-    map.set(`name${i}`, `value${i}`);
-  }
-  for (const key of map.keys()) {
-    map.delete(key);
-  }
-  // expect(map.size).toBe(0);
-  expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
-});
-test("delete in a loop with predefined entries", () => {
-  const entries: [string, string][] = [];
-  for (let i = 0; i < 1000; i++) {
-    entries.push([`name${i}`, `value${i}`]);
-  }
-  const map = new Bun.CookieMap(entries);
-  for (const key of map.keys()) {
-    map.delete(key);
-  }
-  // expect(map.size).toBe(0);
-  expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
-});
-test.only("basic iterator", () => {
-  const cookies = new Bun.CookieMap({ a: "b", c: "d" });
-  cookies.set("e", "f");
-  cookies.set("g", "h");
-  expect([...cookies.entries()].map(([key, value]) => `${key}=${value}`).join("\n")).toMatchInlineSnapshot(`
+test("iterator", () => {
+  test("delete in a loop", () => {
+    const map = new Bun.CookieMap();
+    for (let i = 0; i < 1000; i++) {
+      map.set(`name${i}`, `value${i}`);
+    }
+    for (const key of map.keys()) {
+      map.delete(key);
+    }
+    // expect(map.size).toBe(0);
+    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+  });
+  test("delete in a loop with predefined entries", () => {
+    const entries: [string, string][] = [];
+    for (let i = 0; i < 1000; i++) {
+      entries.push([`name${i}`, `value${i}`]);
+    }
+    const map = new Bun.CookieMap(entries);
+    for (const key of map.keys()) {
+      map.delete(key);
+    }
+    // expect(map.size).toBe(0);
+    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+  });
+  test("delete in a loop with both", () => {
+    const entries: [string, string][] = [];
+    for (let i = 0; i < 500; i++) {
+      entries.push([`pre${i}`, `pre${i}`]);
+    }
+    const map = new Bun.CookieMap(entries);
+    for (let i = 0; i < 1000; i++) {
+      map.set(`post${i}`, `post${i}`);
+    }
+    for (const key of map.keys()) {
+      map.delete(key);
+    }
+    // expect(map.size).toBe(0);
+    expect(map.size).toBe(500); // FormData works this way, but not Set. maybe we should work like Set.
+  });
+  test.only("basic iterator", () => {
+    const cookies = new Bun.CookieMap({ a: "b", c: "d" });
+    cookies.set("e", "f");
+    cookies.set("g", "h");
+    expect([...cookies.entries()].map(([key, value]) => `${key}=${value}`).join("\n")).toMatchInlineSnapshot(`
     "e=f
     g=h
     c=d
     a=b"
   `);
+  });
 });


### PR DESCRIPTION
wrong number in the iterator -> asan crash.

for now, deleting cookies in an iterator works like FormData rather than Set. which means you can't do it, you need to `for(const key of [...map.keys()])`