### PR TITLE
fix(CSRF) remove undefined's and add more checks for bad tokens

### DIFF
--- a/src/csrf.zig
+++ b/src/csrf.zig
@@ -167,12 +167,6 @@ pub fn verify(options: VerifyOptions) bool {
 
     // Check if token has expired
     const current_time = @as(u64, @bitCast(std.time.milliTimestamp()));
-    if (current_time < timestamp and timestamp - current_time > 5 * 60 * 1000) {
-        // give some margin to check to a invalid token 5 minutes sounds plausable for server time difference
-        // we will still check expiry and the signature so should be fine
-        // this is meant to just short circuit the check for a bad token
-        return false;
-    }
     // Extract expires_in (last 8 bytes)
     const expires_in = std.mem.readInt(u64, decoded[24..32], .big);
     {

--- a/src/csrf.zig
+++ b/src/csrf.zig
@@ -78,7 +78,7 @@ pub fn generate(
     out_buffer: *[512]u8,
 ) ![]u8 {
     // Generate nonce from entropy
-    var nonce: [16]u8 = undefined;
+    var nonce: [16]u8 = .{0} ** 16;
     bun.csprng(&nonce);
 
     // Current timestamp in milliseconds
@@ -86,18 +86,18 @@ pub fn generate(
     const timestamp_u64: u64 = @bitCast(@as(i64, timestamp));
 
     // Write timestamp to out_buffer
-    var timestamp_bytes: [8]u8 = undefined;
+    var timestamp_bytes: [8]u8 = .{0} ** 8;
     std.mem.writeInt(u64, &timestamp_bytes, timestamp_u64, .big);
-    var expires_in_bytes: [8]u8 = undefined;
+    var expires_in_bytes: [8]u8 = .{0} ** 8;
     std.mem.writeInt(u64, &expires_in_bytes, options.expires_in_ms, .big);
     // Prepare payload for signing: timestamp|nonce
-    var payload_buf: [32]u8 = undefined; // 8 (timestamp) + 16 (nonce)
+    var payload_buf: [32]u8 = .{0} ** 32; // 8 (timestamp) + 16 (nonce)
     @memcpy(payload_buf[0..8], &timestamp_bytes);
     @memcpy(payload_buf[8..24], &nonce);
     @memcpy(payload_buf[24..32], &expires_in_bytes);
 
     // Sign the payload
-    var digest_buf: [boring.EVP_MAX_MD_SIZE]u8 = undefined;
+    var digest_buf: [boring.EVP_MAX_MD_SIZE]u8 = .{0} ** boring.EVP_MAX_MD_SIZE;
     const digest = hmac.generate(options.secret, &payload_buf, options.algorithm, &digest_buf) orelse
         return Error.TokenCreationFailed;
 
@@ -122,7 +122,7 @@ pub fn verify(options: VerifyOptions) bool {
     const encoding: TokenFormat = options.encoding;
 
     // Allocate output buffer for decoded data
-    var buf: [boring.EVP_MAX_MD_SIZE + 32]u8 = undefined;
+    var buf: [boring.EVP_MAX_MD_SIZE + 32]u8 = .{0} ** (boring.EVP_MAX_MD_SIZE + 32);
     var token = options.token;
     // check if ends with \0
     if (token.len > 0 and token[token.len - 1] == 0) {
@@ -158,17 +158,30 @@ pub fn verify(options: VerifyOptions) bool {
     if (decoded.len < 64) {
         return false;
     }
+    // We successfully decoded the token but it could be a bad token
+    // base64 and hex can have ambiguity so we need to check for weird cases and reject them
+    // it could also be a handcrafted token that is invalid
 
     // Extract timestamp (first 8 bytes)
     const timestamp = std.mem.readInt(u64, decoded[0..8], .big);
 
     // Check if token has expired
     const current_time = @as(u64, @bitCast(std.time.milliTimestamp()));
+    if (current_time < timestamp and timestamp - current_time > 5 * 60 * 1000) {
+        // give some margin to check to a invalid token 5 minutes sounds plausable for server time difference
+        // we will still check expiry and the signature so should be fine
+        // this is meant to just short circuit the check for a bad token
+        return false;
+    }
     // Extract expires_in (last 8 bytes)
     const expires_in = std.mem.readInt(u64, decoded[24..32], .big);
     {
         // respect the token's expiration time
         if (expires_in > 0) {
+            // handle overflow for invalid expiry, which means bad token
+            if (std.math.maxInt(u64) - timestamp < expires_in) {
+                return false;
+            }
             if (current_time > timestamp + expires_in) {
                 return false;
             }
@@ -178,6 +191,10 @@ pub fn verify(options: VerifyOptions) bool {
         // repect options.max_age_ms
         const expiry = options.max_age_ms;
         if (expiry > 0) {
+            // handle overflow for invalid expiry, which means bad token
+            if (std.math.maxInt(u64) - timestamp < expiry) {
+                return false;
+            }
             if (current_time > timestamp + expiry) {
                 return false;
             }
@@ -188,7 +205,7 @@ pub fn verify(options: VerifyOptions) bool {
     const received_signature = decoded[32..];
 
     // Verify the signature
-    var expected_signature: [boring.EVP_MAX_MD_SIZE]u8 = undefined;
+    var expected_signature: [boring.EVP_MAX_MD_SIZE]u8 = .{0} ** boring.EVP_MAX_MD_SIZE;
     const signature = hmac.generate(options.secret, payload, options.algorithm, &expected_signature) orelse
         return false;
 
@@ -269,7 +286,7 @@ pub fn csrf__generate_impl(globalObject: *JSC.JSGlobalObject, callframe: *JSC.Ca
     }
 
     // Buffer for token generation
-    var token_buffer: [512]u8 = undefined;
+    var token_buffer: [512]u8 = .{0} ** 512;
 
     // Generate the token
     const token_bytes = generate(.{

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -141,4 +141,16 @@ describe("Bun.CSRF", () => {
     // Empty secret for verification
     expect(() => CSRF.verify("some-token", { secret: "" })).toThrow();
   });
+
+  test("handle bad decoding", () => {
+    const ambigousSecret = "test-secret";
+
+    const token = CSRF.generate(ambigousSecret, {
+      encoding: "hex",
+      expiresIn: 60 * 60 * 1000,
+    });
+    // the default encoding is base64url with is the same decoding for base64
+    expect(CSRF.verify(token, { secret: ambigousSecret })).toBe(false);
+    expect(CSRF.verify(token, { secret: ambigousSecret, encoding: "hex" })).toBe(true);
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/18341
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Tests
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
