### PR TITLE
fix(install): resolution order and unused resolutions

### DIFF
--- a/src/install/bun.lock.zig
+++ b/src/install/bun.lock.zig
@@ -95,10 +95,6 @@ pub const Stringifier = struct {
         defer found_patched_dependencies.deinit(allocator);
         try found_patched_dependencies.ensureTotalCapacity(allocator, @truncate(lockfile.patched_dependencies.count()));
 
-        var found_overrides: std.AutoHashMapUnmanaged(u64, struct { String, Dependency.Version }) = .{};
-        defer found_overrides.deinit(allocator);
-        try found_overrides.ensureTotalCapacity(allocator, @truncate(lockfile.overrides.map.count()));
-
         var optional_peers_buf = std.ArrayList(String).init(allocator);
         defer optional_peers_buf.deinit();
 
@@ -279,12 +275,6 @@ pub const Stringifier = struct {
                             try found_trusted_dependencies.put(allocator, dep.name_hash, dep.name);
                         }
                     }
-
-                    if (lockfile.overrides.map.count() > 0) {
-                        if (lockfile.overrides.get(dep.name_hash)) |version| {
-                            try found_overrides.put(allocator, dep.name_hash, .{ dep.name, version });
-                        }
-                    }
                 }
             }
 
@@ -344,28 +334,43 @@ pub const Stringifier = struct {
                 );
             }
 
-            if (found_overrides.count() > 0) {
+            if (lockfile.overrides.map.count() > 0) {
+                var overrides_buf: std.ArrayListUnmanaged(Dependency) = try .initCapacity(allocator, lockfile.overrides.map.count());
+                defer overrides_buf.deinit(allocator);
+
+                try overrides_buf.appendSlice(allocator, lockfile.overrides.map.values());
+
+                const OverridesSortCtx = struct {
+                    buf: string,
+
+                    pub fn lessThan(this: *@This(), l_dep: Dependency, r_dep: Dependency) bool {
+                        return l_dep.name.order(&r_dep.name, this.buf, this.buf) == .lt;
+                    }
+                };
+
+                var sort_ctx: OverridesSortCtx = .{
+                    .buf = buf,
+                };
+
+                std.sort.pdq(Dependency, overrides_buf.items, &sort_ctx, OverridesSortCtx.lessThan);
+
+                // lockfile.overrides.sort(lockfile);
                 try writeIndent(writer, indent);
                 try writer.writeAll(
                     \\"overrides": {
                     \\
                 );
                 indent.* += 1;
-                var values_iter = found_overrides.valueIterator();
-                while (values_iter.next()) |value| {
-                    const name, const version = value.*;
+                for (lockfile.overrides.map.values()) |override_dep| {
                     try writeIndent(writer, indent);
                     try writer.print(
                         \\{}: {},
                         \\
-                    , .{ name.fmtJson(buf, .{}), version.literal.fmtJson(buf, .{}) });
+                    , .{ override_dep.name.fmtJson(buf, .{}), override_dep.version.literal.fmtJson(buf, .{}) });
                 }
 
                 try decIndent(writer, indent);
-                try writer.writeAll(
-                    \\},
-                    \\
-                );
+                try writer.writeAll("},\n");
             }
 
             var tree_deps_sort_buf: std.ArrayListUnmanaged(DependencyID) = .{};

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -3034,7 +3034,7 @@ pub const OverrideMap = struct {
             }
         };
 
-        var ctx: Ctx = .{
+        const ctx: Ctx = .{
             .buf = lockfile.buffers.string_bytes.items,
             .override_deps = this.map.values().ptr,
         };

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -7117,17 +7117,10 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     for (l.buffers.trees.items) |l_tree| {
         const rel_path, _ = Tree.relativePathAndDepth(l, l_tree.id, &path_buf, &depth_buf, .pkg_path);
         const tree_path = try allocator.dupe(u8, rel_path);
-        for (l_tree.dependencies.get(l_hoisted_deps), 0..) |l_dep_id, j| {
-            if (l_dep_id == invalid_dependency_id) {
-                std.debug.print("skipping invalid l dep_id: {d}\n", .{j});
-                continue;
-            }
+        for (l_tree.dependencies.get(l_hoisted_deps)) |l_dep_id| {
+            if (l_dep_id == invalid_dependency_id) continue;
             const l_pkg_id = l.buffers.resolutions.items[l_dep_id];
-            if (l_pkg_id == invalid_package_id or l_pkg_id >= cut_off_pkg_id) {
-                const l_dep = l.buffers.dependencies.items[l_dep_id];
-                std.debug.print("skipping l_dep: {s}, {}, {}\n", .{ l_dep.name.slice(l_string_buf), l_pkg_id == invalid_package_id, l_pkg_id >= cut_off_pkg_id });
-                continue;
-            }
+            if (l_pkg_id == invalid_package_id or l_pkg_id >= cut_off_pkg_id) continue;
             l_buf[i] = .{
                 .pkg_id = l_pkg_id,
                 .tree_path = tree_path,
@@ -7141,17 +7134,10 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     for (r.buffers.trees.items) |r_tree| {
         const rel_path, _ = Tree.relativePathAndDepth(r, r_tree.id, &path_buf, &depth_buf, .pkg_path);
         const tree_path = try allocator.dupe(u8, rel_path);
-        for (r_tree.dependencies.get(r_hoisted_deps), 0..) |r_dep_id, j| {
-            if (r_dep_id == invalid_dependency_id) {
-                std.debug.print("skipping invalid dep_id: {d}\n", .{j});
-                continue;
-            }
+        for (r_tree.dependencies.get(r_hoisted_deps)) |r_dep_id| {
+            if (r_dep_id == invalid_dependency_id) continue;
             const r_pkg_id = r.buffers.resolutions.items[r_dep_id];
-            if (r_pkg_id == invalid_package_id or r_pkg_id >= cut_off_pkg_id) {
-                const r_dep = r.buffers.dependencies.items[r_dep_id];
-                std.debug.print("skipping r_dep: {s}, {}, {}\n", .{ r_dep.name.slice(r_string_buf), r_pkg_id == invalid_package_id, r_pkg_id >= cut_off_pkg_id });
-                continue;
-            }
+            if (r_pkg_id == invalid_package_id or r_pkg_id >= cut_off_pkg_id) continue;
             r_buf[i] = .{
                 .pkg_id = r_pkg_id,
                 .tree_path = tree_path,

--- a/test/cli/install/__snapshots__/bun-lock.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-lock.test.ts.snap
@@ -284,6 +284,13 @@ exports[`should not deduplicate bundled packages with un-bundled packages 1`] = 
 ]
 `;
 
+exports[`should not deduplicate bundled packages with un-bundled packages 2`] = `
+[
+  "",
+  "Saved bun.lock (5 packages)",
+]
+`;
+
 exports[`should not change formatting unexpectedly 1`] = `
 [
   "preinstall",
@@ -405,9 +412,77 @@ exports[`should not change formatting unexpectedly 3`] = `
 ]
 `;
 
-exports[`should not deduplicate bundled packages with un-bundled packages 2`] = `
-[
-  "",
-  "Saved bun.lock (5 packages)",
-]
+exports[`should sort overrides before comparing 1`] = `
+"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pkg-with-overrides",
+      "dependencies": {
+        "one-dep": "1.0.0",
+        "uses-what-bin": "1.5.0",
+      },
+      "peerDependencies": {
+        "no-deps": "2.0.0",
+        "what-bin": "1.0.0",
+      },
+      "optionalPeers": [
+        "no-deps",
+        "what-bin",
+      ],
+    },
+  },
+  "overrides": {
+    "what-bin": "1.0.0",
+    "no-deps": "2.0.0",
+  },
+  "packages": {
+    "no-deps": ["no-deps@2.0.0", "http://localhost:1234/no-deps/-/no-deps-2.0.0.tgz", {}, "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g=="],
+
+    "one-dep": ["one-dep@1.0.0", "http://localhost:1234/one-dep/-/one-dep-1.0.0.tgz", { "dependencies": { "no-deps": "1.0.1" } }, "sha512-qG6lZjwM1vFmRCHwP+XpOKu6FkrBmwr20+54+qaHGdjZlw/wz8aJrhFqX4dZksqmBLZtj2mzL77Yf04WKs1+Kg=="],
+
+    "uses-what-bin": ["uses-what-bin@1.5.0", "http://localhost:1234/uses-what-bin/-/uses-what-bin-1.5.0.tgz", { "dependencies": { "what-bin": "1.5.0" } }, "sha512-EI+uMDESinRewWTFhsyzibkzFV+j5LmLM7T1jEpb2X82TmzhSQRzCBTBURflt5dGvNEIY7l563P9Su01Tpe++g=="],
+
+    "what-bin": ["what-bin@1.0.0", "http://localhost:1234/what-bin/-/what-bin-1.0.0.tgz", { "bin": { "what-bin": "what-bin.js" } }, "sha512-sa99On1k5aDqCvpni/TQ6rLzYprUWBlb8fNwWOzbjDlM24fRr7FKDOuaBO/Y9WEIcZuzoPkCW5EkBCpflj8REQ=="],
+  }
+}
+"
+`;
+
+exports[`should include unused resolutions in the lockfile 1`] = `
+"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pkg-with-unused-override",
+      "dependencies": {
+        "one-dep": "1.0.0",
+        "uses-what-bin": "1.5.0",
+      },
+      "peerDependencies": {
+        "no-deps": "2.0.0",
+        "what-bin": "1.0.0",
+      },
+      "optionalPeers": [
+        "no-deps",
+        "what-bin",
+      ],
+    },
+  },
+  "overrides": {
+    "what-bin": "1.0.0",
+    "no-deps": "2.0.0",
+    "jquery": "4.0.0",
+  },
+  "packages": {
+    "no-deps": ["no-deps@2.0.0", "http://localhost:1234/no-deps/-/no-deps-2.0.0.tgz", {}, "sha512-W3duJKZPcMIG5rA1io5cSK/bhW9rWFz+jFxZsKS/3suK4qHDkQNxUTEXee9/hTaAoDCeHWQqogukWYKzfr6X4g=="],
+
+    "one-dep": ["one-dep@1.0.0", "http://localhost:1234/one-dep/-/one-dep-1.0.0.tgz", { "dependencies": { "no-deps": "1.0.1" } }, "sha512-qG6lZjwM1vFmRCHwP+XpOKu6FkrBmwr20+54+qaHGdjZlw/wz8aJrhFqX4dZksqmBLZtj2mzL77Yf04WKs1+Kg=="],
+
+    "uses-what-bin": ["uses-what-bin@1.5.0", "http://localhost:1234/uses-what-bin/-/uses-what-bin-1.5.0.tgz", { "dependencies": { "what-bin": "1.5.0" } }, "sha512-EI+uMDESinRewWTFhsyzibkzFV+j5LmLM7T1jEpb2X82TmzhSQRzCBTBURflt5dGvNEIY7l563P9Su01Tpe++g=="],
+
+    "what-bin": ["what-bin@1.0.0", "http://localhost:1234/what-bin/-/what-bin-1.0.0.tgz", { "bin": { "what-bin": "what-bin.js" } }, "sha512-sa99On1k5aDqCvpni/TQ6rLzYprUWBlb8fNwWOzbjDlM24fRr7FKDOuaBO/Y9WEIcZuzoPkCW5EkBCpflj8REQ=="],
+  }
+}
+"
 `;

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -502,3 +502,98 @@ index d156130662798530e852e1afaec5b1c03d429cdc..b4ddf35975a952fdaed99f2b14236519
     lockfile,
   );
 });
+
+it("should sort overrides before comparing", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  const pkg = {
+    name: "pkg-with-overrides",
+    dependencies: {
+      "one-dep": "1.0.0",
+      "uses-what-bin": "1.5.0",
+    },
+    peerDependencies: {
+      "what-bin": "1.0.0",
+      "no-deps": "2.0.0",
+    },
+    peerDependenciesMeta: {
+      "what-bin": {
+        optional: true,
+      },
+      "no-deps": {
+        optional: true,
+      },
+    },
+    resolutions: {
+      "what-bin": "1.0.0",
+      "no-deps": "2.0.0",
+    },
+  };
+
+  await write(packageJson, JSON.stringify(pkg));
+
+  await runBunInstall(env, packageDir);
+
+  const lockfile = (await file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234");
+  expect(lockfile).toMatchSnapshot();
+  await runBunInstall(env, packageDir, { frozenLockfile: true });
+
+  // now swap "what-bin" and "no-deps" in resolutions
+  pkg.resolutions = {
+    "no-deps": "2.0.0",
+    "what-bin": "1.0.0",
+  };
+  await write(packageJson, JSON.stringify(pkg));
+
+  await runBunInstall(env, packageDir, { frozenLockfile: true });
+
+  // --frozen-lockfile was a success. lockfile will be the same as the first
+  const secondLockfile = (await file(join(packageDir, "bun.lock")).text()).replaceAll(
+    /localhost:\d+/g,
+    "localhost:1234",
+  );
+  expect(secondLockfile).toBe(lockfile);
+});
+
+it("should include unused resolutions in the lockfile", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  // we need to include unused resolutions in order to detect changes from package.json
+
+  const pkg = {
+    name: "pkg-with-unused-override",
+    dependencies: {
+      "one-dep": "1.0.0",
+      "uses-what-bin": "1.5.0",
+    },
+    peerDependencies: {
+      "what-bin": "1.0.0",
+      "no-deps": "2.0.0",
+    },
+    peerDependenciesMeta: {
+      "what-bin": {
+        optional: true,
+      },
+      "no-deps": {
+        optional: true,
+      },
+    },
+    resolutions: {
+      "what-bin": "1.0.0",
+      "no-deps": "2.0.0",
+
+      // unused resolution
+      "jquery": "4.0.0",
+    },
+  };
+
+  await write(packageJson, JSON.stringify(pkg));
+
+  await runBunInstall(env, packageDir);
+
+  const lockfile = (await file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234");
+  expect(lockfile).toMatchSnapshot();
+
+  // --frozen-lockfile works
+  await runBunInstall(env, packageDir, { frozenLockfile: true });
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1111,7 +1111,7 @@ export async function runBunInstall(
   if (!options?.allowWarnings) {
     expect(err).not.toContain("warn:");
   }
-  if ((options?.savesLockfile ?? true) && !production) {
+  if ((options?.savesLockfile ?? true) && !production && !options?.frozenLockfile) {
     expect(err).toContain("Saved lockfile");
   }
   let out = await new Response(stdout).text();


### PR DESCRIPTION
### What does this PR do?
Two changes:
- sort overrides before comparing
- even if the override is unused, add it to text lockfile

Fixes #16692
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added tests for out of order resolutions and missing resolution.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
