### PR TITLE
fix: Bun.write() with empty string creates a file

### DIFF
--- a/src/bun.js/webcore/blob.zig
+++ b/src/bun.js/webcore/blob.zig
@@ -47,11 +47,12 @@ const libuv = bun.windows.libuv;
 const S3 = bun.S3;
 const S3Credentials = S3.S3Credentials;
 const PathOrBlob = JSC.Node.PathOrBlob;
-const WriteFilePromise = @import("./blob/WriteFile.zig").WriteFilePromise;
-const WriteFileWaitFromLockedValueTask = @import("./blob/WriteFile.zig").WriteFileWaitFromLockedValueTask;
-const NewReadFileHandler = @import("./blob/ReadFile.zig").NewReadFileHandler;
+const PathLike = JSC.Node.PathLike;
+const WriteFilePromise = @import("blob/WriteFile.zig").WriteFilePromise;
+const WriteFileWaitFromLockedValueTask = @import("blob/WriteFile.zig").WriteFileWaitFromLockedValueTask;
+const NewReadFileHandler = @import("blob/ReadFile.zig").NewReadFileHandler;
 
-const S3File = @import("./S3File.zig");
+const S3File = @import("S3File.zig");
 
 pub const Blob = struct {
     const bloblog = Output.scoped(.Blob, false);
@@ -59,13 +60,13 @@ pub const Blob = struct {
     pub usingnamespace bun.New(@This());
     pub usingnamespace JSC.Codegen.JSBlob;
 
-    const rf = @import("./blob/ReadFile.zig");
+    const rf = @import("blob/ReadFile.zig");
     pub const ReadFile = rf.ReadFile;
     pub const ReadFileUV = rf.ReadFileUV;
     pub const ReadFileTask = rf.ReadFileTask;
     pub const ReadFileResultType = rf.ReadFileResultType;
 
-    const wf = @import("./blob/WriteFile.zig");
+    const wf = @import("blob/WriteFile.zig");
     pub const WriteFile = wf.WriteFile;
     pub const WriteFileWindows = wf.WriteFileWindows;
     pub const WriteFileTask = wf.WriteFileTask;
@@ -858,42 +859,100 @@ pub const Blob = struct {
         return .no;
     }
 
-    pub fn writeFileWithSourceDestination(
+    /// Write an empty string to a file by truncating it.
+    ///
+    /// This behavior matches what we do with the fast path.
+    ///
+    /// Returns an encoded `*JSPromise` that resolves if the file
+    /// - doesn't exist and is created
+    /// - exists and is truncated
+    fn writeFileWithEmptySourceToDestination(
         ctx: JSC.C.JSContextRef,
-        source_blob: *Blob,
         destination_blob: *Blob,
         options: WriteFileOptions,
     ) JSC.JSValue {
-        const destination_type = std.meta.activeTag(destination_blob.store.?.data);
+        // SAFETY: null-checked by caller
+        const destination_store = destination_blob.store.?;
+        defer destination_blob.detach();
 
-        // Writing an empty string to a file truncates it
-        // This matches the behavior we do with the fast path.
-        // This case only really happens on Windows.
-        if (source_blob.store == null) {
-            defer destination_blob.detach();
-            if (destination_type == .file) {
+        switch (destination_store.data) {
+            .file => |file| {
                 // TODO: make this async
-                // TODO: mkdirp()
-                var result = ctx.bunVM().nodeFS().truncate(.{
-                    .path = destination_blob.store.?.data.file.pathlike,
+                const node_fs = ctx.bunVM().nodeFS();
+                var result = node_fs.truncate(.{
+                    .path = file.pathlike,
                     .len = 0,
                     .flags = bun.O.CREAT,
                 }, .sync);
+
                 if (result == .err) {
-                    // it might return EPERM when the parent directory doesn't exist
-                    // #6336
-                    if (result.err.getErrno() == .PERM) {
-                        result.err.errno = @intCast(@intFromEnum(bun.C.E.NOENT));
+                    const errno = result.err.getErrno();
+                    var was_eperm = false;
+                    err: switch (errno) {
+                        // truncate might return EPERM when the parent directory doesn't exist
+                        // #6336
+                        .PERM => {
+                            was_eperm = true;
+                            result.err.errno = @intCast(@intFromEnum(bun.C.E.NOENT));
+                            continue :err .NOENT;
+                        },
+                        .NOENT => {
+                            if (options.mkdirp_if_not_exists == false) break :err;
+                            // NOTE: if .err is PERM, it ~should~ really is a
+                            // permissions issue
+                            const dirpath: []const u8 = switch (file.pathlike) {
+                                .path => |path| std.fs.path.dirname(path.slice()) orelse break :err,
+                                .fd => {
+                                    // NOTE: if this is an fd, it means the file
+                                    // exists, so we shouldn't try to mkdir it
+                                    // also means PERM is _actually_ a
+                                    // permissions issue
+                                    if (was_eperm) result.err.errno = @intCast(@intFromEnum(bun.C.E.PERM));
+                                    break :err;
+                                },
+                            };
+                            const mkdir_result = node_fs.mkdirRecursive(.{
+                                .path = .{ .string = bun.PathString.init(dirpath) },
+                                // TODO: Do we really want .mode to be 0o777?
+                                .recursive = true,
+                                .always_return_none = true,
+                            });
+                            if (mkdir_result == .err) {
+                                result.err = mkdir_result.err;
+                                break :err;
+                            }
+
+                            // SAFETY: we check if `file.pathlike` is an fd or
+                            // not above, returning if it is.
+                            var buf: bun.PathBuffer = undefined;
+                            // TODO: respect `options.mode`
+                            const mode: bun.Mode = JSC.Node.default_permission;
+                            while (true) {
+                                const open_res = bun.sys.open(file.pathlike.path.sliceZ(&buf), bun.O.CREAT | bun.O.TRUNC, mode);
+                                switch (open_res) {
+                                    // errors fall through and are handled below
+                                    .err => |err| {
+                                        if (err.getErrno() == .INTR) continue;
+                                        result.err = open_res.err;
+                                        break :err;
+                                    },
+                                    .result => |fd| {
+                                        _ = bun.sys.close(fd);
+                                        return JSC.JSPromise.resolvedPromiseValue(ctx, .jsNumber(0));
+                                    },
+                                }
+                            }
+                        },
+                        else => {},
                     }
 
-                    result.err = result.err.withPathLike(destination_blob.store.?.data.file.pathlike);
-
+                    result.err = result.err.withPathLike(file.pathlike);
                     return JSC.JSPromise.rejectedPromiseValue(ctx, result.toJS(ctx));
                 }
-            } else if (destination_type == .s3) {
+            },
+            .s3 => |*s3| {
 
                 // create empty file
-                const s3 = &destination_blob.store.?.data.s3;
                 var aws_options = s3.getCredentialsWithOptions(options.extra_options, ctx) catch |err| {
                     return JSC.JSPromise.rejectedPromiseValue(ctx, ctx.takeException(err));
                 };
@@ -926,7 +985,7 @@ pub const Blob = struct {
                 const promise_value = promise.value();
                 const proxy = ctx.bunVM().transpiler.env.getHttpProxy(true, null);
                 const proxy_url = if (proxy) |p| p.href else null;
-                destination_blob.store.?.ref();
+                destination_store.ref();
                 S3.upload(
                     &aws_options.credentials,
                     s3.path(),
@@ -938,17 +997,31 @@ pub const Blob = struct {
                     Wrapper.resolve,
                     Wrapper.new(.{
                         .promise = promise,
-                        .store = destination_blob.store.?,
+                        .store = destination_store,
                         .global = ctx,
                     }),
                 );
                 return promise_value;
-            }
-
-            return JSC.JSPromise.resolvedPromiseValue(ctx, JSC.JSValue.jsNumber(0));
+            },
+            // Writing to a buffer-backed blob should be a type error,
+            // making this unreachable. TODO: `{}` -> `unreachable`
+            .bytes => {},
         }
 
-        const source_type = std.meta.activeTag(source_blob.store.?.data);
+        return JSC.JSPromise.resolvedPromiseValue(ctx, JSC.JSValue.jsNumber(0));
+    }
+
+    pub fn writeFileWithSourceDestination(
+        ctx: JSC.C.JSContextRef,
+        source_blob: *Blob,
+        destination_blob: *Blob,
+        options: WriteFileOptions,
+    ) JSC.JSValue {
+        const destination_store = destination_blob.store orelse Output.panic("Destination blob is detached", .{});
+        const destination_type = std.meta.activeTag(destination_store.data);
+
+        const source_store = source_blob.store orelse return writeFileWithEmptySourceToDestination(ctx, destination_blob, options);
+        const source_type = std.meta.activeTag(source_store.data);
 
         if (destination_type == .file and source_type == .bytes) {
             var write_file_promise = bun.new(WriteFilePromise, .{
@@ -994,7 +1067,7 @@ pub const Blob = struct {
             if (comptime Environment.isWindows) {
                 return Store.CopyFileWindows.init(
                     destination_blob.store.?,
-                    source_blob.store.?,
+                    source_store,
                     ctx.bunVM().eventLoop(),
                     options.mkdirp_if_not_exists orelse true,
                     destination_blob.size,
@@ -1003,7 +1076,7 @@ pub const Blob = struct {
             var file_copier = Store.CopyFile.create(
                 bun.default_allocator,
                 destination_blob.store.?,
-                source_blob.store.?,
+                source_store,
 
                 destination_blob.offset,
                 destination_blob.size,
@@ -1013,7 +1086,7 @@ pub const Blob = struct {
             file_copier.schedule();
             return file_copier.promise.value();
         } else if (destination_type == .file and source_type == .s3) {
-            const s3 = &source_blob.store.?.data.s3;
+            const s3 = &source_store.data.s3;
             if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlob(
                 ctx,
                 source_blob,
@@ -1046,10 +1119,9 @@ pub const Blob = struct {
                 return JSC.JSPromise.rejectedPromiseValue(ctx, ctx.takeException(err));
             };
             defer aws_options.deinit();
-            const store = source_blob.store.?;
             const proxy = ctx.bunVM().transpiler.env.getHttpProxy(true, null);
             const proxy_url = if (proxy) |p| p.href else null;
-            switch (store.data) {
+            switch (source_store.data) {
                 .bytes => |bytes| {
                     if (bytes.len > S3.MultiPartUploadOptions.MAX_SINGLE_UPLOAD_SIZE) {
                         if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlob(
@@ -1095,7 +1167,7 @@ pub const Blob = struct {
                                 this.store.deref();
                             }
                         };
-                        store.ref();
+                        source_store.ref();
                         const promise = JSC.JSPromise.Strong.init(ctx);
                         const promise_value = promise.value();
 
@@ -1109,7 +1181,7 @@ pub const Blob = struct {
                             aws_options.storage_class,
                             Wrapper.resolve,
                             Wrapper.new(.{
-                                .store = store,
+                                .store = source_store,
                                 .promise = promise,
                                 .global = ctx,
                             }),

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1217,7 +1217,7 @@ interface BunHarnessTestMatchers {
   toBeBinaryType(expected: keyof typeof binaryTypes): void;
   toRun(optionalStdout?: string, expectedCode?: number): void;
   toThrowWithCode(cls: CallableFunction, code: string): void;
-  toThrowWithCodeAsync(cls: CallableFunction, code: string): void;
+  toThrowWithCodeAsync(cls: CallableFunction, code: string): Promise<void>;
 }
 
 declare module "bun:test" {

--- a/test/js/bun/bun-object/write.spec.ts
+++ b/test/js/bun/bun-object/write.spec.ts
@@ -1,0 +1,142 @@
+import { promises as fs, constants } from "node:fs";
+import path from "node:path";
+import { tmpdirSync } from "harness";
+
+// 0o644
+const default_mode = constants.S_IWUSR | constants.S_IRUSR | constants.S_IRGRP | constants.S_IROTH;
+
+describe("Bun.write()", () => {
+  it("Throws when no arguments are provided", async () => {
+    // @ts-expect-error
+    await expect(() => Bun.write()).toThrowWithCodeAsync(Error, "ERR_INVALID_ARG_TYPE");
+  });
+  it.each([undefined, null, /* 1, */ true, Symbol("foo"), {}])(
+    "Throws when `destination` is not a path or blob-y thing (%p)",
+    async (destination: any) => {
+      await expect(() => Bun.write(destination, "foo")).toThrowWithCodeAsync(Error, "ERR_INVALID_ARG_TYPE");
+    },
+  );
+
+  // FIXME
+  it.failing("Throws when `destination` is a number ", async () => {
+    // @ts-expect-error
+    await expect(() => Bun.write(1, "foo 1")).toThrowWithCodeAsync(Error, "ERR_INVALID_ARG_TYPE");
+    // @ts-expect-error
+    await expect(() => Bun.write(0, "foo 0")).toThrowWithCodeAsync(Error, "ERR_INVALID_ARG_TYPE");
+    // @ts-expect-error
+    await expect(() => Bun.write(-10, "foo -10")).toThrowWithCodeAsync(Error, "ERR_INVALID_ARG_TYPE");
+  });
+});
+
+describe("Bun.write() on file paths", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = tmpdirSync("bun-write");
+  });
+  afterAll(() => {
+    fs.rmdir(dir, { recursive: true });
+  });
+
+  describe("Given a path to a file in an existing directory", () => {
+    let filepath: string;
+
+    beforeEach(async () => {
+      filepath = path.join(dir, "test-file.txt");
+    });
+
+    afterEach(async () => {
+      await fs.unlink(filepath).catch(() => {});
+    });
+
+    describe("When the file does not exist", () => {
+      const content = "Hello, world!";
+
+      it("When content is not empty, creates the file and writes it", async () => {
+        const result = await Bun.write(filepath, content);
+        expect(result).toBe(content.length);
+        expect(await fs.readFile(filepath, "utf-8")).toBe(content);
+      });
+
+      it("When content is empty, creates the file with default permissions and writes it", async () => {
+        const result = await Bun.write(filepath, "");
+        expect(result).toBe(0);
+        expect(await fs.readFile(filepath, "utf-8")).toBe("");
+        const stats = await fs.stat(filepath);
+        expect(stats.mode & default_mode).toBe(default_mode);
+        expect(stats.mode & constants.S_IFDIR).toBe(0); // not a directory
+      });
+
+      it("When options.createPath is false, creates the file with default permissions and writes it", async () => {
+        const result = await Bun.write(filepath, content, { createPath: false });
+        expect(result).toBe(content.length);
+        expect(await fs.readFile(filepath, "utf-8")).toBe(content);
+        const stats = await fs.stat(filepath);
+        expect(stats.mode & default_mode).toBe(default_mode);
+        expect(stats.mode & constants.S_IFDIR).toBe(0); // not a directory
+      });
+    }); // </When the file does not exist>
+
+    describe("When the file exists and has content", () => {
+      beforeEach(async () => {
+        await fs.writeFile(filepath, "Hello, world!");
+      });
+
+      it.each(["", "Foo Bar"])("Writing '%s' overwrites the file", async content => {
+        const result = await Bun.write(filepath, content);
+        expect(result).toBe(content.length);
+        expect(await fs.readFile(filepath, "utf-8")).toBe(content);
+      });
+    }); // </When the file exists and has content>
+  }); // </Given a path to a file in an existing directory>
+
+  describe("Given a path to a file in a non-existent directory", () => {
+    let filepath: string;
+    const rootdir = path.join(dir, "foo");
+
+    beforeEach(async () => {
+      filepath = path.join(rootdir, "bar/baz", "test-file.txt");
+    });
+    afterEach(async () => {
+      await fs.rmdir(rootdir, { recursive: true }).catch(() => {});
+    });
+
+    describe("When no options are provided", () => {
+      describe("When a non-empty string is written", () => {
+        const content = "Hello, world!";
+        beforeEach(async () => {
+          await Bun.write(filepath, content);
+        });
+        it("Recursively creates the directory", async () => {
+          // FIXME: should be undefined, not null
+          expect(await fs.access(rootdir, constants.F_OK)).toBeFalsy();
+          expect(await fs.access(path.dirname(filepath), constants.F_OK)).toBeFalsy();
+        });
+
+        it("Creates a file with the provided content", async () => {
+          expect(await fs.readFile(filepath, "utf-8")).toBe(content);
+        });
+
+        it("Creates a file with default permissions", async () => {
+          const stats = await fs.stat(filepath);
+          expect(stats.mode & default_mode).toBe(default_mode);
+          expect(stats.mode & constants.S_IFDIR).toBe(0); // not a directory
+        });
+      }); // </When a non-empty string is written>
+
+      it("When an empty string is written, recursively creates the directory and writes the file", async () => {
+        const result = await Bun.write(filepath, "");
+        expect(result).toBe(0);
+        expect(await fs.readFile(filepath, "utf-8")).toBe("");
+      });
+    }); // </When no options are provided>
+
+    describe("When options.createPath is false", () => {
+      const options = { createPath: false };
+
+      it.each(["", "Hello, world!"])("When '%s' is written, throws ENOENT", async content => {
+        await expect(() => Bun.write(filepath, content, options)).toThrowWithCodeAsync(Error, "ENOENT");
+      });
+    }); // </When options.createPath is false>
+  });
+}); // </Bun.write() on files>


### PR DESCRIPTION
### What does this PR do?
Calling `Bun.write(path, "")` now recursively creates directories and creates an empty file. Closes #8396
Fixes https://github.com/oven-sh/bun/issues/12830

### How did you verify your code works?
I've added tests
