### PR TITLE
Fix a `node:http` UAF

### DIFF
--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -128,6 +128,7 @@ export default [
       pause: {
         fn: "doPause",
         length: 0,
+        passThis: true,
       },
       drainRequestBody: {
         fn: "drainRequestBody",
@@ -136,6 +137,7 @@ export default [
       dumpRequestBody: {
         fn: "dumpRequestBody",
         length: 0,
+        passThis: true,
       },
       resume: {
         fn: "doResume",
@@ -159,6 +161,7 @@ export default [
       ondata: {
         getter: "getOnData",
         setter: "setOnData",
+        this: true,
       },
       onabort: {
         getter: "getOnAbort",
@@ -178,6 +181,7 @@ export default [
       onwritable: {
         getter: "getOnWritable",
         setter: "setOnWritable",
+        this: true,
       },
     },
     klass: {},

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6536,7 +6536,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 }
                 // If we ended the response without attaching an ondata handler, we discard the body read stream
                 else if (http_result != .pending) {
-                    node_response.maybeStopReadingBody(vm);
+                    node_response.maybeStopReadingBody(vm, node_response.getThisValue());
                 }
             }
         }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6531,12 +6531,14 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             }
 
             if (node_http_response) |node_response| {
-                if (!node_response.request_has_completed and node_response.raw_response.state().isResponsePending()) {
-                    node_response.setOnAbortedHandler();
-                }
-                // If we ended the response without attaching an ondata handler, we discard the body read stream
-                else if (http_result != .pending) {
-                    node_response.maybeStopReadingBody(vm, node_response.getThisValue());
+                if (!node_response.upgraded) {
+                    if (!node_response.request_has_completed and node_response.raw_response.state().isResponsePending()) {
+                        node_response.setOnAbortedHandler();
+                    }
+                    // If we ended the response without attaching an ondata handler, we discard the body read stream
+                    else if (http_result != .pending) {
+                        node_response.maybeStopReadingBody(vm, node_response.getThisValue());
+                    }
                 }
             }
         }

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -932,9 +932,6 @@ fn clearOnDataCallback(this: *NodeHTTPResponse) void {
             this.raw_response.clearOnData();
         if (this.body_read_state != .done) {
             this.body_read_state = .done;
-            if (this.body_read_ref.has) {
-                this.deref();
-            }
         }
     }
 }

--- a/test/js/node/http/node-http-uaf-fixture-2.ts
+++ b/test/js/node/http/node-http-uaf-fixture-2.ts
@@ -1,0 +1,26 @@
+import http from "http";
+import { once } from "events";
+const server = http
+  .createServer((req, res) => {
+    res.writeHead(200, { Connection: "close" });
+    res.destroy();
+  })
+  .listen(0);
+await once(server, "listening");
+const url = `http://localhost:${server.address().port}`;
+console.log(`Server running at ${url}`);
+
+const body = new Blob([Buffer.allocUnsafe(1024 * 1024 * 10)]);
+
+for (let i = 0; i < 100; i++) {
+  await Promise.all(
+    [...Array(10)].map(() =>
+      fetch(url, {
+        method: "POST",
+        body,
+      }).then(r => r.blob()),
+    ),
+  );
+}
+
+server.close();

--- a/test/js/node/http/node-http-uaf-fixture-2.ts
+++ b/test/js/node/http/node-http-uaf-fixture-2.ts
@@ -18,7 +18,9 @@ for (let i = 0; i < 100; i++) {
       fetch(url, {
         method: "POST",
         body,
-      }).then(r => r.blob()),
+      })
+        .then(r => r.blob())
+        .catch(() => {}),
     ),
   );
 }

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -11,8 +11,8 @@ function uafTest(fixture, iterations = 2) {
       const { exited } = Bun.spawn({
         cmd: [bunExe(), join(import.meta.dir, fixture)],
         env: bunEnv,
-        stdout: "ignore",
-        stderr: "ignore",
+        stdout: "inherit",
+        stderr: "inherit",
         stdin: "ignore",
       });
       const exitCode = await exited;

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -2,17 +2,22 @@ import { test, expect } from "bun:test";
 import { join } from "path";
 import { bunExe, bunEnv } from "harness";
 
-test("should not crash on abort", async () => {
-  for (let i = 0; i < 2; i++) {
-    const { exited } = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "node-http-uaf-fixture.ts")],
-      env: bunEnv,
-      stdout: "ignore",
-      stderr: "ignore",
-      stdin: "ignore",
-    });
-    const exitCode = await exited;
-    expect(exitCode).not.toBeNull();
-    expect(exitCode).toBe(0);
-  }
-});
+uafTest("node-http-uaf-fixture.ts");
+uafTest("node-http-uaf-fixture-2.ts");
+
+function uafTest(fixture, iterations = 2) {
+  test(`should not crash on abort (${fixture})`, async () => {
+    for (let i = 0; i < iterations; i++) {
+      const { exited } = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, fixture)],
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "ignore",
+        stdin: "ignore",
+      });
+      const exitCode = await exited;
+      expect(exitCode).not.toBeNull();
+      expect(exitCode).toBe(0);
+    }
+  });
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a UAF in `node:http`.

- [ ] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

```js
import http from "http";
import { once } from "events";
const server = http
  .createServer((req, res) => {
    console.log(req.headers);
    res.writeHead(200, { Connection: "close" });
    res.destroy();
  })
  .listen(3004);
await once(server, "listening");
console.log(`Server running at http://localhost:3004`);
fetch("http://localhost:3004", {
  method: "POST",
  body: Buffer.allocUnsafe(1024 * 1024 * 10),
}).then((r) => r.bytes());
```
Previously used to crash with UAF; no longer does. I also ran `test/js/third_party/body-parser/express-memory-leak.test.ts` to ensure the changes didn't cause any leaks.
