### PR TITLE
2x faster headers.get, headers.delete, headers.has

### DIFF
--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -1379,6 +1379,8 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetHeader, (JSGlobalObject * globalObject, CallFr
 
         if (nameValue.isString()) {
             String name = nameValue.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+
             FetchHeaders* impl = &headers->wrapped();
 
             if (valueValue.isUndefined())

--- a/src/bun.js/bindings/webcore/FetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/FetchHeaders.cpp
@@ -207,22 +207,20 @@ ExceptionOr<void> FetchHeaders::append(const String& name, const String& value)
 // https://fetch.spec.whatwg.org/#dom-headers-delete
 ExceptionOr<void> FetchHeaders::remove(const StringView name)
 {
+    ASSERT_WITH_MESSAGE(m_guard == FetchHeaders::Guard::None, "We don't use guards in Bun");
+
+    HTTPHeaderName headerName;
+    if (findHTTPHeaderName(name, headerName)) {
+        ++m_updateCounter;
+        m_headers.remove(headerName);
+        return {};
+    }
+
     if (!isValidHTTPToken(name))
         return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
-    if (m_guard == FetchHeaders::Guard::Immutable)
-        return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
-    if (m_guard == FetchHeaders::Guard::Request && isForbiddenHeaderName(name))
-        return {};
-    if (m_guard == FetchHeaders::Guard::RequestNoCors && !isNoCORSSafelistedRequestHeaderName(name) && !isPriviledgedNoCORSRequestHeaderName(name))
-        return {};
-    if (m_guard == FetchHeaders::Guard::Response && isForbiddenResponseHeaderName(name))
-        return {};
 
     ++m_updateCounter;
-    m_headers.remove(name);
-
-    if (m_guard == FetchHeaders::Guard::RequestNoCors)
-        removePrivilegedNoCORSRequestHeaders(m_headers);
+    m_headers.removeUncommonHeader(name);
 
     return {};
 }
@@ -234,16 +232,23 @@ size_t FetchHeaders::memoryCost() const
 
 ExceptionOr<String> FetchHeaders::get(const StringView name) const
 {
-    if (!isValidHTTPToken(name))
-        return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
-    return m_headers.get(name);
+    auto result = m_headers.get(name);
+    if (result.isEmpty()) {
+        if (!isValidHTTPToken(name))
+            return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
+    }
+
+    return result;
 }
 
 ExceptionOr<bool> FetchHeaders::has(const StringView name) const
 {
-    if (!isValidHTTPToken(name))
-        return Exception { TypeError, makeString("Invalid header name: '"_s, name, '"') };
-    return m_headers.contains(name);
+    bool has = m_headers.contains(name);
+    if (!has) {
+        if (!isValidHTTPToken(name))
+            return Exception { TypeError, makeString("Invalid header name: '"_s, name, '"') };
+    }
+    return has;
 }
 
 ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& value)

--- a/src/bun.js/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/bun.js/bindings/webcore/HTTPHeaderMap.cpp
@@ -219,6 +219,16 @@ bool HTTPHeaderMap::remove(const StringView name)
     if (findHTTPHeaderName(name, headerName))
         return remove(headerName);
 
+    return removeUncommonHeader(name);
+}
+
+bool HTTPHeaderMap::removeUncommonHeader(const StringView name)
+{
+#if ASSERT_ENABLED
+    HTTPHeaderName headerName;
+    ASSERT(!findHTTPHeaderName(name, headerName));
+#endif
+
     return m_uncommonHeaders.removeFirstMatching([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });

--- a/src/bun.js/bindings/webcore/HTTPHeaderMap.h
+++ b/src/bun.js/bindings/webcore/HTTPHeaderMap.h
@@ -189,6 +189,7 @@ public:
     WEBCORE_EXPORT bool contains(const StringView) const;
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;
     WEBCORE_EXPORT bool remove(const StringView);
+    WEBCORE_EXPORT bool removeUncommonHeader(const StringView);
 
     WEBCORE_EXPORT String getIndex(HeaderIndex index) const;
     WEBCORE_EXPORT bool setIndex(HeaderIndex index, const String &value);


### PR DESCRIPTION
### What does this PR do?

This makes headers.get(name), headers.delete(name) and headers.has(name) 2x faster in the happy path case where the header is well-known.

```js
bun on  jarred/faster-headers [$!?] via 🍞 v1.2.6
❯ bun bench/snippets/headers.mjs
clk: ~3.95 GHz
cpu: Apple M3 Max
runtime: bun 1.2.6 (arm64-darwin)

benchmark                     avg (min … max) p75   p99    (min … top 1%)
--------------------------------------------- -------------------------------
Headers.get('Content-Type')     16.35 ns/iter  16.30 ns        █
                        (14.94 ns … 21.38 ns)  18.88 ns ▁▁▁▁▁▁▅█▁▁▁▂▁▁▁▁▁▁▁▁▁
Headers.get('content-type')     16.72 ns/iter  16.68 ns       █
                        (15.37 ns … 27.70 ns)  19.52 ns ▁▁▁▁▁▄█▃▁▁▂▁▁▁▁▁▁▁▁▁▁
Headers.has('Content-Type')     14.87 ns/iter  14.83 ns      █
                        (13.43 ns … 26.38 ns)  17.76 ns ▁▁▁▁▂█▇▄▁▂▁▂▁▁▁▁▂▂▁▁▁
Headers.delete('Content-Type')  15.65 ns/iter  16.62 ns      ▄       █
                        (13.36 ns … 21.68 ns)  18.55 ns ▁▁▁▁▇██▃▃▄▄▃▄█▁▁▂▁▁▁▁

bun on  jarred/faster-headers [$!?] via 🍞 v1.2.6 took 5s
❯ bun-1.2.5 bench/snippets/headers.mjs
clk: ~3.89 GHz
cpu: Apple M3 Max
runtime: bun 1.2.5 (arm64-darwin)

benchmark                     avg (min … max) p75   p99    (min … top 1%)
--------------------------------------------- -------------------------------
Headers.get('Content-Type')     31.21 ns/iter  32.08 ns  ▃   ▄█▃▄
                        (28.45 ns … 43.65 ns)  37.03 ns █████████▆▄▅▅▅▃▂▂▂▂▁▁
Headers.get('content-type')     32.31 ns/iter  34.28 ns ▅▆▅██▆▄▃▂▃▄
                        (28.43 ns … 52.90 ns)  41.34 ns ████████████▆▄▃▂▂▁▁▁▁
Headers.has('Content-Type')     29.83 ns/iter  30.83 ns  ▇▆█▇█▆▄▂
                        (26.94 ns … 48.91 ns)  37.10 ns ▄█████████▇▄▄▃▂▂▂▁▂▁▂
Headers.delete('Content-Type')  30.63 ns/iter  31.38 ns ▂     █
                        (28.46 ns … 39.66 ns)  35.64 ns █▃▂▁▁▁█▃▂▂▁▁▇▂▂▁▁▁▁▁▁

bun on  jarred/faster-headers [$!?] via 🍞 v1.2.6 took 5s
❯ node bench/snippets/headers.mjs
clk: ~3.84 GHz
cpu: Apple M3 Max
runtime: node 23.9.0 (arm64-darwin)

benchmark                     avg (min … max) p75   p99    (min … top 1%)
--------------------------------------------- -------------------------------
Headers.get('Content-Type')     70.32 ns/iter  72.76 ns ▄█
                       (67.84 ns … 133.53 ns)  81.30 ns ██▇▄▂▂▂▂█▃▂▁▁▁▁▁▁▁▁▁▁
Headers.get('content-type')     57.89 ns/iter  59.88 ns █
                        (55.78 ns … 86.66 ns)  69.94 ns █▆▃▂▂▂█▃▂▂▁▁▁▁▁▁▁▁▁▁▁
Headers.has('Content-Type')     69.71 ns/iter  70.31 ns ▅▃ █▂
                       (66.59 ns … 136.12 ns)  82.80 ns █████▅▄▄▂▃▃▂▁▁▁▁▁▁▁▁▁
Headers.delete('Content-Type')  67.44 ns/iter  70.07 ns █
                       (65.26 ns … 136.61 ns)  77.87 ns █▆▂▃▁▂▂▂▆▃▂▁▁▁▁▁▁▁▁▁▁

bun on  jarred/faster-headers [$!?] via 🍞 v1.2.6 took 5s
❯ deno run -A bench/snippets/headers.mjs
clk: ~3.66 GHz
cpu: Apple M3 Max
runtime: deno 2.2.5+e2f66d4 (aarch64-apple-darwin)

benchmark                     avg (min … max) p75   p99    (min … top 1%)
--------------------------------------------- -------------------------------
Headers.get('Content-Type')    166.46 ns/iter 172.51 ns    █
                      (148.61 ns … 300.16 ns) 212.32 ns ▂▂▁██▄▃▃▃▃▃▂▂▁▂▁▁▁▁▁▁
Headers.get('content-type')    173.40 ns/iter 182.42 ns ▃▂  ▃▄██▇▆▂
                      (148.34 ns … 285.05 ns) 223.04 ns ██▆█████████▆▄▃▂▂▂▂▁▁
Headers.has('Content-Type')     54.91 ns/iter  55.53 ns       █
                       (49.07 ns … 218.96 ns)  69.15 ns ▂▁█▆▃▂█▅▂▂▂▂▁▁▁▁▁▁▁▁▁
Headers.delete('Content-Type') 180.44 ns/iter 208.00 ns           █
                       (83.00 ns … 182.63 µs) 250.00 ns ▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▆▁▁▁▁▁
```

### How did you verify your code works?

Ran existing tests that seemed relevant. This should have no behavior difference.
