### PR TITLE
test: disable failing shadcn tests in CI

### DIFF
--- a/test/cli/create/create-jsx.test.ts
+++ b/test/cli/create/create-jsx.test.ts
@@ -297,7 +297,7 @@ for (const development of [true, false]) {
         }
       });
 
-      test.todoIf(isWindows)("build", async () => {
+      test.todoIf(isCI || isWindows)("build", async () => {
         {
           const process = Bun.spawn([bunExe(), "create", "./index.tsx"], {
             cwd: dir,


### PR DESCRIPTION
### What does this PR do?
Disables `shadcn/ui build` tests in CI.

There's a bug in `shadcn add` causing some of our CI pipelines to fail, blocking PRs. We should re-enable these when they've fixed their code.

### How did you verify your code works?
CI