### PR TITLE
refactor(uws): remove unused `uws_res_write_headers`

### DIFF
--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1593,33 +1593,6 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
                    { cb(ctx); });
   }
 
-  void uws_res_write_headers(int ssl, uws_res_r res, const StringPointer *names,
-                             const StringPointer *values, size_t count,
-                             const char *buf) nonnull_fn_decl;
-  void uws_res_write_headers(int ssl, uws_res_r res, const StringPointer *names,
-                             const StringPointer *values, size_t count,
-                             const char *buf)
-  {
-    if (ssl)
-    {
-      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      for (size_t i = 0; i < count; i++)
-      {
-        uwsRes->writeHeader(stringViewFromC(&buf[names[i].off], names[i].len),
-                            stringViewFromC(&buf[values[i].off], values[i].len));
-      }
-    }
-    else
-    {
-      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      for (size_t i = 0; i < count; i++)
-      {
-        uwsRes->writeHeader(stringViewFromC(&buf[names[i].off], names[i].len),
-                            stringViewFromC(&buf[values[i].off], values[i].len));
-      }
-    }
-  }
-
   void uws_res_uncork(int ssl, uws_res_r res)
   {
     if (ssl)

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -1,11 +1,6 @@
 const bun = @import("root").bun;
-const Api = bun.ApiSchema;
 const std = @import("std");
 const Environment = bun.Environment;
-pub const u_int8_t = u8;
-pub const u_int16_t = c_ushort;
-pub const u_int32_t = c_uint;
-pub const u_int64_t = c_ulonglong;
 pub const LIBUS_LISTEN_DEFAULT: i32 = 0;
 pub const LIBUS_LISTEN_EXCLUSIVE_PORT: i32 = 1;
 pub const LIBUS_SOCKET_ALLOW_HALF_OPEN: i32 = 2;
@@ -21,7 +16,7 @@ const uws = @This();
 const SSLWrapper = @import("../bun.js/api/bun/ssl_wrapper.zig").SSLWrapper;
 const TextEncoder = @import("../bun.js/webcore/encoding.zig").Encoder;
 const JSC = bun.JSC;
-const EventLoopTimer = @import("../bun.js//api//Timer.zig").EventLoopTimer;
+const EventLoopTimer = @import("../bun.js/api/Timer.zig").EventLoopTimer;
 const WriteResult = union(enum) {
     want_more: usize,
     backpressure: usize,
@@ -3797,66 +3792,6 @@ pub fn NewApp(comptime ssl: bool) type {
                 uws_res_cork(ssl_flag, res.downcast(), optional_data, Wrapper.handle);
             }
 
-            // pub fn onSocketWritable(
-            //     res: *Response,
-            //     comptime UserDataType: type,
-            //     comptime handler: fn (UserDataType, fd: i32) void,
-            //     optional_data: UserDataType,
-            // ) void {
-            //     const Wrapper = struct {
-            //         pub fn handle(user_data: ?*anyopaque, fd: i32) callconv(.C) void {
-            //             if (comptime UserDataType == void) {
-            //                 @call(bun.callmod_inline, handler, .{
-            //                     {},
-            //                     fd,
-            //                 });
-            //             } else {
-            //                 @call(bun.callmod_inline, handler, .{
-            //                     @ptrCast(
-            //                         UserDataType,
-            //                         @alignCast( user_data.?),
-            //                     ),
-            //                     fd,
-            //                 });
-            //             }
-            //         }
-            //     };
-
-            //     const OnWritable = struct {
-            //         pub fn handle(socket: *Socket) callconv(.C) ?*Socket {
-            //             if (comptime UserDataType == void) {
-            //                 @call(bun.callmod_inline, handler, .{
-            //                     {},
-            //                     fd,
-            //                 });
-            //             } else {
-            //                 @call(bun.callmod_inline, handler, .{
-            //                     @ptrCast(
-            //                         UserDataType,
-            //                         @alignCast( user_data.?),
-            //                     ),
-            //                     fd,
-            //                 });
-            //             }
-
-            //             return socket;
-            //         }
-            //     };
-
-            //     var socket_ctx = us_socket_context(ssl_flag, uws_res_get_native_handle(ssl_flag, res)).?;
-            //     var child = us_create_child_socket_context(ssl_flag, socket_ctx, 8);
-
-            // }
-
-            pub fn writeHeaders(
-                res: *Response,
-                names: []const Api.StringPointer,
-                values: []const Api.StringPointer,
-                buf: []const u8,
-            ) void {
-                uws_res_write_headers(ssl_flag, res.downcast(), names.ptr, values.ptr, values.len, buf.ptr);
-            }
-
             pub fn upgrade(
                 res: *Response,
                 comptime Data: type,
@@ -4069,7 +4004,6 @@ extern fn uws_res_upgrade(
     ws: ?*uws_socket_context_t,
 ) *Socket;
 extern fn uws_res_cork(i32, res: *uws_res, ctx: *anyopaque, corker: *const (fn (?*anyopaque) callconv(.C) void)) void;
-extern fn uws_res_write_headers(i32, res: *uws_res, names: [*]const Api.StringPointer, values: [*]const Api.StringPointer, count: usize, buf: [*]const u8) void;
 pub const LIBUS_RECV_BUFFER_LENGTH = 524288;
 pub const LIBUS_TIMEOUT_GRANULARITY = @as(i32, 4);
 pub const LIBUS_RECV_BUFFER_PADDING = @as(i32, 32);


### PR DESCRIPTION
### What does this PR do?
Removes `uws_res_write_headers` from `bun-usockets` and `uws.zig`. It's not used anywhere.

### How did you verify your code works?
If it builds, it works.
