### PR TITLE
Run mi_collect on thread idle

### DIFF
--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -702,6 +702,8 @@ pub const Thread = struct {
             Output.flush();
 
             self.drainIdleEvents();
+
+            bun.Mimalloc.mi_collect(false);
         }
     }
 


### PR DESCRIPTION
appears to increase memory usage & cause crashes, closing