### PR TITLE
Update bun serve type to accept partial options

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4500,12 +4500,12 @@ declare module "bun" {
    * ```
    */
   function serve<T, R extends { [K in keyof R]: RouterTypes.RouteValue<K & string> }>(
-    options: ServeFunctionOptions<T, R> & {
+    options: Partial<ServeFunctionOptions<T, R> & {
       /**
        * @deprecated Use `routes` instead in new code. This will continue to work for a while though.
        */
       static?: R;
-    },
+    }>,
   ): Server;
 
   /**


### PR DESCRIPTION
### What does this PR do?

I found that when I use Bun.serve() with partial options, (I left out the `websocket` property as I'm not using websockets in my hobby project) I get a ts(2345) error `bun.d.ts(3660, 5): 'websocket' is declared here.`. So, I assume that the options object should be a partial of what it currently is maybe this is thee way it is for a reason, just thought it's nicer to receive a PR than an bug report, but idk 😅

- [x ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)

### How did you verify your code works?

I updated the types package in my project with the same changes as I have in this PR and I didn't get any error for not including the `websockets` property, but I still got correct typing for it and the other properties if I added them. I'm not sure if you have tests for this kinda thing. I'm a first-time contributor for Bun and I'm not quite familiar with the project structure. 


### Related information 
So I had this issue in a hobby project of mine where my code looks something like this 

```
const server = Bun.serve({
  development: true,
  routes: {
    '/': new Response('Hello, world!'),
  },
});
```

And this is how my tsconfig.json looks
```
{
  "compilerOptions": {
    "target": "ES2022",
    "module": "ESNext",
    "moduleResolution": "node",
    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "forceConsistentCasingInFileNames": true,
    "noImplicitOverride": true,
    "noImplicitAny": true,
    "noFallthroughCasesInSwitch": true,
    "noImplicitReturns": true,
    "noErrorTruncation": true,
    "noUnusedLocals": true,
    "alwaysStrict": true
  },
  "include": ["**/*.ts"],
  "exclude": ["node_modules", "**/*.spec.ts"]
}
```