### PR TITLE
fix(node:http) http.request empty requests should not always be `transfer-encoding: chunked`

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -2753,8 +2753,10 @@ function ClientRequest(input, options, cb) {
         keepalive,
       };
       let keepOpen = false;
+      // no body and not finished
+      const isDuplex = customBody === undefined && !this.finished;
 
-      if (customBody === undefined) {
+      if (isDuplex) {
         fetchOptions.duplex = "half";
         keepOpen = true;
       }
@@ -2763,7 +2765,7 @@ function ClientRequest(input, options, cb) {
         const self = this;
         if (customBody !== undefined) {
           fetchOptions.body = customBody;
-        } else {
+        } else if (isDuplex) {
           fetchOptions.body = async function* () {
             while (self[kBodyChunks]?.length > 0) {
               yield self[kBodyChunks].shift();

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2317,3 +2317,57 @@ it("should handle data if not immediately handled", async () => {
     server.close();
   }
 });
+
+it("Empty requests should not be Transfer-Encoding: chunked", async () => {
+  const server = http.createServer((req, res) => {
+    res.end(JSON.stringify(req.headers));
+  });
+  await once(server.listen(0), "listening");
+  const url = `http://localhost:${server.address().port}`;
+  try {
+    for (let method of ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"]) {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      http
+        .request(
+          url,
+          {
+            method,
+          },
+          res => {
+            const body: Uint8Array[] = [];
+            res.on("data", chunk => {
+              body.push(chunk);
+            });
+            res.on("end", () => {
+              try {
+                resolve(JSON.parse(Buffer.concat(body).toString()));
+              } catch (e) {
+                reject(e);
+              }
+            });
+          },
+        )
+        .on("error", reject)
+        .end();
+
+      const headers = (await promise) as Record<string, string | undefined>;
+      expect(headers).toBeDefined();
+      expect(headers["transfer-encoding"]).toBeUndefined();
+      switch (method) {
+        case "GET":
+        case "DELETE":
+        case "OPTIONS":
+          // Content-Length will not be present for GET, DELETE, and OPTIONS
+          // aka DELETE in node.js will be undefined and in bun it will be 0
+          // this is not outside the spec but is different between node.js and bun
+          expect(headers["content-length"]).toBeOneOf(["0", undefined]);
+          break;
+        default:
+          expect(headers["content-length"]).toBeDefined();
+          break;
+      }
+    }
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
### What does this PR do?
Fix regression about Content-Length, behavior is not intended to match node.js (will be better than the status quo) but to be equal was before the http compatibility changes, test added to avoid regression, a followup will be open to make the behavior identical to node.js 
Fix: https://github.com/oven-sh/bun/issues/18640
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Added a test that pass in node and bun
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
