### PR TITLE
A import feature for wakeonlan

### DIFF
--- a/docs/api/udp.md
+++ b/docs/api/udp.md
@@ -15,6 +15,9 @@ const socket = await Bun.udpSocket({
   port: 41234
 })
 console.log(socket.port); // 41234
+
+A import feature for wakeonlan scene, you need set this
+socket.setBroadcast(true)
 ```
 
 ### Send a datagram


### PR DESCRIPTION
Bun.updSocket support setBroadcast(true) for wakeonlan, I think it's import for native support by bun, otherwise, has to use node:dragm,it's not good

### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
