### PR TITLE
Shrink js_ast.Symbol by 16 bytes

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3512,8 +3512,8 @@ pub fn assertWithLocation(value: bool, src: std.builtin.SourceLocation) callconv
 pub inline fn assert_eql(a: anytype, b: anytype) void {
     if (@inComptime()) {
         if (a != b) {
-            @compileLog(a);
-            @compileLog(b);
+            @compileLog("a: ", a);
+            @compileLog("b: ", b);
             @compileError("A != B");
         }
     }

--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -1697,15 +1697,15 @@ pub fn TopLevelRuleParser(comptime AtRuleParserT: type) type {
 
                             const layer: ?struct { value: ?LayerName } =
                                 if (input.tryParse(Parser.expectIdentMatching, .{"layer"}) == .result)
-                                .{ .value = null }
-                            else if (input.tryParse(Parser.expectFunctionMatching, .{"layer"}) == .result) brk: {
-                                break :brk .{
-                                    .value = switch (input.parseNestedBlock(LayerName, {}, voidWrap(LayerName, LayerName.parse))) {
-                                        .result => |v| v,
-                                        .err => |e| return .{ .err = e },
-                                    },
-                                };
-                            } else null;
+                                    .{ .value = null }
+                                else if (input.tryParse(Parser.expectFunctionMatching, .{"layer"}) == .result) brk: {
+                                    break :brk .{
+                                        .value = switch (input.parseNestedBlock(LayerName, {}, voidWrap(LayerName, LayerName.parse))) {
+                                            .result => |v| v,
+                                            .err => |e| return .{ .err = e },
+                                        },
+                                    };
+                                } else null;
 
                             const supports = if (input.tryParse(Parser.expectFunctionMatching, .{"supports"}) == .result) brk: {
                                 const Func = struct {
@@ -3831,7 +3831,9 @@ pub const Parser = struct {
                 .loc = loc,
             };
             extra.symbols.push(this.allocator(), bun.JSAst.Symbol{
-                .kind = .local_css,
+                .flags = .{
+                    .kind = .local_css,
+                },
                 .original_name = name,
             }) catch bun.outOfMemory();
         } else {
@@ -4710,11 +4712,12 @@ pub const nth = struct {
         if (bytes.len >= 3 and
             bun.strings.eqlCaseInsensitiveASCIIICheckLength(bytes[0..2], "n-") and
             brk: {
-            for (bytes[2..]) |b| {
-                if (b < '0' or b > '9') break :brk false;
-            }
-            break :brk true;
-        }) {
+                for (bytes[2..]) |b| {
+                    if (b < '0' or b > '9') break :brk false;
+                }
+                break :brk true;
+            })
+        {
             return parse_number_saturate(allocator, str[1..]); // Include the minus sign
         } else {
             return .{ .err = {} };

--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -230,8 +230,8 @@ pub const MinifyRenamer = struct {
         var ref = this.symbols.follow(_ref);
         var symbol = this.symbols.get(ref).?;
 
-        while (symbol.namespace_alias != null) {
-            const ref_ = this.symbols.follow(symbol.namespace_alias.?.namespace_ref);
+        while (symbol.namespaceAlias()) |alias| {
+            const ref_ = this.symbols.follow(alias.namespace_ref);
             if (ref_.eql(ref)) break;
             ref = ref_;
             symbol = this.symbols.get(ref_).?;
@@ -243,7 +243,7 @@ pub const MinifyRenamer = struct {
         if (symbol.nestedScopeSlot()) |i| {
             var slot = &this.slots.getPtr(ns).items[i];
             slot.count += count;
-            if (symbol.must_start_with_capital_letter_for_jsx) {
+            if (symbol.flags.must_start_with_capital_letter_for_jsx) {
                 slot.needs_capital_for_jsx = true;
             }
             return;
@@ -265,14 +265,14 @@ pub const MinifyRenamer = struct {
             if (existing.found_existing) {
                 var slot = &slots.items[existing.value_ptr.*];
                 slot.count += stable.count;
-                if (symbol.must_start_with_capital_letter_for_jsx) {
+                if (symbol.flags.must_start_with_capital_letter_for_jsx) {
                     slot.needs_capital_for_jsx = true;
                 }
             } else {
                 existing.value_ptr.* = slots.items.len;
                 try slots.append(SymbolSlot{
                     .count = stable.count,
-                    .needs_capital_for_jsx = symbol.must_start_with_capital_letter_for_jsx,
+                    .needs_capital_for_jsx = symbol.flags.must_start_with_capital_letter_for_jsx,
                 });
             }
         }
@@ -942,14 +942,14 @@ pub fn computeReservedNamesForScope(
     var member_iter = scope.members.valueIterator();
     while (member_iter.next()) |member| {
         const symbol = symbols.get(member.ref).?;
-        if (symbol.kind == .unbound or symbol.must_not_be_renamed) {
+        if (symbol.flags.kind == .unbound or symbol.flags.must_not_be_renamed) {
             names.put(allocator, symbol.original_name, 1) catch unreachable;
         }
     }
 
     for (scope.generated.slice()) |ref| {
         const symbol = symbols.get(ref).?;
-        if (symbol.kind == .unbound or symbol.must_not_be_renamed) {
+        if (symbol.flags.kind == .unbound or symbol.flags.must_not_be_renamed) {
             names.put(allocator, symbol.original_name, 1) catch unreachable;
         }
     }


### PR DESCRIPTION
### What does this PR do?

Shrink `js_ast.Symbol` from 88 bytes to 72 bytes by using a packed struct and using a boolean for an optional field instead of a `?`

### How did you verify your code works?

CI