### PR TITLE
fix(server) Fix empty stream response

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3262,7 +3262,11 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             // we use this memory address to disable signals being sent
             signal.clear();
             assert(signal.isDead());
-
+            // we need to render metadata before assignToStream because the stream can call res.end
+            // and this would auto write an 200 status
+            if (!this.flags.has_written_status) {
+                this.renderMetadata();
+            }
             // We are already corked!
             const assignment_result: JSValue = ResponseStream.JSSink.assignToStream(
                 globalThis,

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -34,9 +34,8 @@ for (let doClone of [true, false]) {
       },
       async url => {
         called = true;
-        expect(await fetch(url).then(res => res.text())).toContain(
-          "Welcome to Bun! To get started, return a Response object.",
-        );
+        // if we can flush it will be "hey" otherwise will be empty
+        expect(await fetch(url).then(res => res.text())).toBeOneOf(["hey", ""]);
       },
     );
 

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -4,6 +4,32 @@ import { afterAll, describe, expect, it, test } from "bun:test";
 
 const port = 0;
 
+test("Should receive the response body when direct stream is properly flushed", async () => {
+  var called = false;
+  await runInServer(
+    {
+      async fetch() {
+        var stream = new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            controller.write("hey");
+            await Bun.sleep(1);
+            await controller.end();
+          },
+        });
+
+        return new Response(stream);
+      },
+    },
+    async url => {
+      called = true;
+      expect(await fetch(url).then(res => res.text())).toBe("hey");
+    },
+  );
+
+  expect(called).toBe(true);
+});
+
 for (let doClone of [true, false]) {
   const BodyMixin = [
     Request.prototype.arrayBuffer,


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/15320

This fix responses when the stream is early closed without sending any data.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
