### PR TITLE
Fix updating dependency not cloning and re-building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-message(STATUS "Configuring Bun")
+mesage(STATUS "Configuring Bun")
 
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_SOURCE_DIR}/cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-mesage(STATUS "Configuring Bun")
+message(STATUS "Configuring Bun")
 
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_SOURCE_DIR}/cmake

--- a/cmake/Globals.cmake
+++ b/cmake/Globals.cmake
@@ -633,7 +633,7 @@ function(register_repository)
     set(GIT_PATH ${VENDOR_PATH}/${GIT_NAME})
   endif()
 
-  set(GIT_EFFECTIVE_OUTPUTS)
+  set(GIT_EFFECTIVE_OUTPUTS ${GIT_PATH}/.ref)
   foreach(output ${GIT_OUTPUTS})
     list(APPEND GIT_EFFECTIVE_OUTPUTS ${GIT_PATH}/${output})
   endforeach()
@@ -756,6 +756,7 @@ function(register_cmake_command)
     TARGET configure-${MAKE_TARGET}
     COMMAND ${CMAKE_COMMAND} ${MAKE_EFFECTIVE_ARGS}
     CWD ${MAKE_CWD}
+    SOURCES ${MAKE_CWD}/.ref
     OUTPUTS ${MAKE_BUILD_PATH}/CMakeCache.txt
   )
 
@@ -807,6 +808,7 @@ function(register_cmake_command)
     TARGETS configure-${MAKE_TARGET}
     COMMAND ${CMAKE_COMMAND} ${MAKE_BUILD_ARGS}
     CWD ${MAKE_CWD}
+    SOURCES ${MAKE_CWD}/.ref
     ARTIFACTS ${MAKE_ARTIFACTS}
   )
 

--- a/cmake/Globals.cmake
+++ b/cmake/Globals.cmake
@@ -751,12 +751,17 @@ function(register_cmake_command)
     list(APPEND MAKE_EFFECTIVE_ARGS --fresh)
   endif()
 
+  set(MAKE_SOURCES)
+  if(TARGET clone-${MAKE_TARGET})
+    list(APPEND MAKE_SOURCES ${MAKE_CWD}/.ref)
+  endif()
+
   register_command(
     COMMENT "Configuring ${MAKE_TARGET}"
     TARGET configure-${MAKE_TARGET}
     COMMAND ${CMAKE_COMMAND} ${MAKE_EFFECTIVE_ARGS}
     CWD ${MAKE_CWD}
-    SOURCES ${MAKE_CWD}/.ref
+    SOURCES ${MAKE_SOURCES}
     OUTPUTS ${MAKE_BUILD_PATH}/CMakeCache.txt
   )
 
@@ -808,7 +813,7 @@ function(register_cmake_command)
     TARGETS configure-${MAKE_TARGET}
     COMMAND ${CMAKE_COMMAND} ${MAKE_BUILD_ARGS}
     CWD ${MAKE_CWD}
-    SOURCES ${MAKE_CWD}/.ref
+    SOURCES ${MAKE_SOURCES}
     ARTIFACTS ${MAKE_ARTIFACTS}
   )
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,7 +3,14 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import { existsSync, readFileSync, mkdirSync, cpSync, chmodSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
-import { isCI, parseAnnotations, printEnvironment, reportAnnotationToBuildKite, startGroup } from "./utils.mjs";
+import {
+  formatAnnotationToHtml,
+  isCI,
+  parseAnnotations,
+  printEnvironment,
+  reportAnnotationToBuildKite,
+  startGroup,
+} from "./utils.mjs";
 
 // https://cmake.org/cmake/help/latest/manual/cmake.1.html#generate-a-project-buildsystem
 const generateFlags = [
@@ -263,10 +270,10 @@ async function spawn(command, args, options, label) {
   try {
     const { annotations } = parseAnnotations(stdoutBuffer);
     for (const annotation of annotations) {
-      const { filename, content } = annotation;
+      const content = formatAnnotationToHtml(annotation);
       reportAnnotationToBuildKite({
         priority: 10,
-        label: filename,
+        label: annotation.title || annotation.filename,
         content,
       });
     }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -277,6 +277,19 @@ async function spawn(command, args, options, label) {
         content,
       });
     }
+    if (!annotations.length) {
+      const content = formatAnnotationToHtml({
+        title: "build failed",
+        content: stdoutBuffer,
+        source: "build",
+        level: "error",
+      });
+      reportAnnotationToBuildKite({
+        priority: 10,
+        label: "build failed",
+        content,
+      });
+    }
   } catch (error) {
     console.error(`Failed to parse annotations:`, error);
   }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -267,6 +267,7 @@ async function spawn(command, args, options, label) {
     return;
   }
 
+  let annotated;
   try {
     const { annotations } = parseAnnotations(stdoutBuffer);
     for (const annotation of annotations) {
@@ -276,23 +277,25 @@ async function spawn(command, args, options, label) {
         label: annotation.title || annotation.filename,
         content,
       });
-    }
-    if (!annotations.length) {
-      const content = formatAnnotationToHtml({
-        filename: relative(process.cwd(), import.meta.filename),
-        title: "build failed",
-        content: stdoutBuffer,
-        source: "build",
-        level: "error",
-      });
-      reportAnnotationToBuildKite({
-        priority: 10,
-        label: "build failed",
-        content,
-      });
+      annotated = true;
     }
   } catch (error) {
     console.error(`Failed to parse annotations:`, error);
+  }
+
+  if (!annotated) {
+    const content = formatAnnotationToHtml({
+      filename: relative(process.cwd(), import.meta.filename),
+      title: "build failed",
+      content: stdoutBuffer,
+      source: "build",
+      level: "error",
+    });
+    reportAnnotationToBuildKite({
+      priority: 10,
+      label: "build failed",
+      content,
+    });
   }
 
   if (signalCode) {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,7 +2,7 @@
 
 import { spawn as nodeSpawn } from "node:child_process";
 import { existsSync, readFileSync, mkdirSync, cpSync, chmodSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import {
   formatAnnotationToHtml,
   isCI,
@@ -279,6 +279,7 @@ async function spawn(command, args, options, label) {
     }
     if (!annotations.length) {
       const content = formatAnnotationToHtml({
+        filename: relative(process.cwd(), import.meta.filename),
         title: "build failed",
         content: stdoutBuffer,
         source: "build",

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1334,7 +1334,9 @@ function formatTestToMarkdown(result, concise) {
     if (error) {
       markdown += ` - ${error}`;
     }
-    markdown += ` on ${platform}`;
+    if (platform) {
+      markdown += ` on ${platform}`;
+    }
 
     if (concise) {
       markdown += "</li>\n";


### PR DESCRIPTION
### What does this PR do?

* Fixed when we update a dependency, the CMake build directory will now properly be invalidated.
* Fixed that build errors do not register as an error annotation.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
