### PR TITLE
Call `node:http` request callback through AsyncContextFrame

### DIFF
--- a/src/bun.js/bindings/AsyncContextFrame.cpp
+++ b/src/bun.js/bindings/AsyncContextFrame.cpp
@@ -111,5 +111,13 @@ JSValue AsyncContextFrame::call(JSGlobalObject* global, JSValue functionObject, 
 
     ASYNCCONTEXTFRAME_CALL_IMPL(global, ProfilingReason::API, functionObject, JSC::getCallData(functionObject), thisValue, args, returnedException);
 }
+JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args)
+{
+    return call(global, functionObject, thisValue, args);
+}
+JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args, NakedPtr<Exception>& returnedException)
+{
+    return call(global, functionObject, thisValue, args, returnedException);
+}
 
 #undef ASYNCCONTEXTFRAME_CALL_IMPL

--- a/src/bun.js/bindings/AsyncContextFrame.cpp
+++ b/src/bun.js/bindings/AsyncContextFrame.cpp
@@ -113,11 +113,11 @@ JSValue AsyncContextFrame::call(JSGlobalObject* global, JSValue functionObject, 
 }
 JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args)
 {
-    return call(global, functionObject, thisValue, args);
+    return AsyncContextFrame::call(global, functionObject, thisValue, args);
 }
 JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args, NakedPtr<Exception>& returnedException)
 {
-    return call(global, functionObject, thisValue, args, returnedException);
+    return AsyncContextFrame::call(global, functionObject, thisValue, args, returnedException);
 }
 
 #undef ASYNCCONTEXTFRAME_CALL_IMPL

--- a/src/bun.js/bindings/AsyncContextFrame.h
+++ b/src/bun.js/bindings/AsyncContextFrame.h
@@ -25,6 +25,12 @@ public:
     static JSC::JSValue call(JSC::JSGlobalObject*, JSC::JSValue functionObject, JSC::JSValue thisValue, const JSC::ArgList&);
     static JSC::JSValue call(JSC::JSGlobalObject*, JSC::JSValue functionObject, JSC::JSValue thisValue, const JSC::ArgList&, NakedPtr<JSC::Exception>& returnedException);
 
+    // Alias of call.
+    static JSC::JSValue profiledCall(JSC::JSGlobalObject*, JSC::JSValue functionObject, JSC::JSValue thisValue, const JSC::ArgList&);
+
+    // Alias of call.
+    static JSC::JSValue profiledCall(JSC::JSGlobalObject*, JSC::JSValue functionObject, JSC::JSValue thisValue, const JSC::ArgList&, NakedPtr<JSC::Exception>& returnedException);
+
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -961,7 +961,6 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     bool hasBody = false;
     WebCore::JSNodeHTTPResponse* nodeHTTPResponseObject = jsCast<WebCore::JSNodeHTTPResponse*>(JSValue::decode(NodeHTTPResponse__createForJS(any_server, globalObject, &hasBody, request, isSSL, response, upgrade_ctx, nodeHttpResponsePtr)));
 
-    JSC::CallData callData = getCallData(callbackObject);
     args.append(nodeHTTPResponseObject);
     args.append(jsBoolean(hasBody));
 
@@ -994,7 +993,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     }
 
     WTF::NakedPtr<JSC::Exception> exception;
-    JSValue returnValue = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, callbackObject, callData, jsUndefined(), args, exception);
+    JSValue returnValue = AsyncContextFrame::call(globalObject, callbackObject, jsUndefined(), args, exception);
     if (exception) {
         auto* ptr = exception.get();
         exception.clear();

--- a/test/regression/issue/18595.test.ts
+++ b/test/regression/issue/18595.test.ts
@@ -1,0 +1,29 @@
+import { createServer } from "node:http";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { test, expect } from "bun:test";
+
+test("18595", () => {
+  const als = new AsyncLocalStorage();
+
+  const server = createServer((req, res) => {
+    const appStore = als.getStore();
+    als.run(appStore, async () => {
+      const out = `counter: ${++als.getStore().counter}`;
+      await new Promise(resolve => setTimeout(resolve, 10));
+      res.end(out);
+    });
+  });
+
+  const { promise, resolve } = Promise.withResolvers();
+
+  als.run({ counter: 0 }, () => {
+    server.listen(0, async () => {
+      const response = await fetch(`http://localhost:${server.address().port}`);
+      expect(await response.text()).toBe("counter: 1");
+      server.close();
+      resolve();
+    });
+  });
+
+  return promise;
+});


### PR DESCRIPTION
### What does this PR do?

Correctly handle async callbacks in `NodeHTTPServer__onRequest`. 

Fixes #18595
Fixes https://github.com/oven-sh/bun/issues/18497



### How did you verify your code works?

Ran the repro code provided in #18595 and added a regression test.