### PR TITLE
Implement `bun unlink {packageName}`

### DIFF
--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -11014,7 +11014,7 @@ pub const PackageManager = struct {
         buffer_writer.append_newline = preserve_trailing_newline_at_eof_for_package_json;
         var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
 
-        var written = JSPrinter.printJSON(
+        _ = JSPrinter.printJSON(
             @TypeOf(&package_json_writer),
             &package_json_writer,
             current_package_json.root,
@@ -11155,7 +11155,7 @@ pub const PackageManager = struct {
                 preserve_trailing_newline_at_eof_for_package_json;
             var package_json_writer_two = JSPrinter.BufferPrinter.init(buffer_writer_two);
 
-            written = JSPrinter.printJSON(
+            _ = JSPrinter.printJSON(
                 @TypeOf(&package_json_writer_two),
                 &package_json_writer_two,
                 new_package_json,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Saw that `bun unlink {packageName}` was unimplemented and gave it a shot. Fixes https://github.com/oven-sh/bun/issues/7852.
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [x] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

It seemed like `manager.updatePackageJSONAndInstallWithManager()` in `install.zig` mostly handles the case of unlinking. I accounted for three cases when writing this code:
- A new package is linked and unlinked
- An existing unlinked package is linked and unlinked
- A package linked with `--save` is unlinked with `--save`

The current summary is not that helpful, but I haven’t yet wrapped my head around how the lockfile diffing works. The tricky thing with unlink is that it typically won’t create package.json changes, so I’m unsure how to show the unlinked packages as removed.