### PR TITLE
build: do not include UBSan RT in `bun-zig.o`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -465,6 +465,7 @@ pub fn addBunObject(b: *Build, opts: *BunBuildOptions) *Compile {
         }
     }
     obj.bundle_compiler_rt = false;
+    obj.bundle_ubsan_rt = false;
     obj.root_module.omit_frame_pointer = false;
 
     // Link libc


### PR DESCRIPTION
### What does this PR do?
We include the Undefined Behavior (UBSan) runtime when linking with clang, so we don't need it twice.

### How did you verify your code works?
CI + build/run tests locally
