### PR TITLE
In HTTP thread, use `pushBatch` for scheduling instead of `push`

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -1508,11 +1508,23 @@ pub const HTTPThread = struct {
             return;
 
         {
-            var batch_ = batch;
-            while (batch_.pop()) |task| {
+
+            // Move the linked list from Batch into AsyncHTTP.next.
+            // This is kind of unnecessary work.
+            var next = batch.head;
+            const head: *AsyncHTTP = @fieldParentPtr("task", next.?);
+            var tail: *AsyncHTTP = head;
+            next = if (next.?.node.next) |node| @fieldParentPtr("node", node) else null;
+            while (next) |task| {
                 const http: *AsyncHTTP = @fieldParentPtr("task", task);
-                this.queued_tasks.push(http);
+                tail.next = http;
+                tail = http;
+                const node = task.node.next orelse break;
+                next = @fieldParentPtr("node", node);
             }
+
+            // Use pushBatch so we do fewer atomic operations.
+            this.queued_tasks.pushBatch(head, tail, batch.len);
         }
 
         if (this.has_awoken.load(.monotonic))

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -88,26 +88,7 @@ pub const Batch = struct {
     head: ?*Task = null,
     tail: ?*Task = null,
 
-    pub fn pop(this: *Batch) ?*Task {
-        const len = @atomicLoad(usize, &this.len, .monotonic);
-        if (len == 0) {
-            return null;
-        }
-        const task = this.head.?;
-        if (task.node.next) |node| {
-            this.head = @fieldParentPtr("node", node);
-        } else {
-            if (task != this.tail.?) unreachable;
-            this.tail = null;
-            this.head = null;
-        }
-
-        this.len -= 1;
-        if (len == 0) {
-            this.tail = null;
-        }
-        return task;
-    }
+    pub const pop = @compileError("Iterate through .head in a while loop");
 
     /// Create a batch from a single task.
     pub fn from(task: *Task) Batch {


### PR DESCRIPTION
### What does this PR do?

In HTTP thread, use `pushBatch` for scheduling instead of `push`

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
