### PR TITLE
change logic on path normalization, fixing `node:fs` on windows network shares

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -942,7 +942,7 @@ pub const PathLike = union(enum) {
             const s = this.slice();
             const b = bun.PathBufferPool.get();
             defer bun.PathBufferPool.put(b);
-            if (bun.strings.hasPrefixComptime(s, "/")) {
+            if (s.len > 0 and bun.path.isSepAny(s[0])) {
                 const resolve = path_handler.PosixToWinNormalizer.resolveCWDWithExternalBuf(buf, s) catch @panic("Error while resolving path.");
                 const normal = path_handler.normalizeBuf(resolve, b, .windows);
                 return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -782,12 +782,12 @@ pub fn normalizeStringGenericTZ(
     var dotdot: usize = 0;
     var path_begin: usize = 0;
 
-    const volLen, const indexOfThirdUNCSlash = if (isWindows and !options.allow_above_root)
+    const volLen, const indexOfThirdUNCSlash = if (isWindows)
         windowsVolumeNameLenT(T, path_)
     else
         .{ 0, 0 };
 
-    if (isWindows and !options.allow_above_root) {
+    if (isWindows) {
         if (volLen > 0) {
             if (options.add_nt_prefix) {
                 @memcpy(buf[buf_i .. buf_i + 4], strings.literal(T, "\\??\\"));
@@ -839,19 +839,6 @@ pub fn normalizeStringGenericTZ(
             buf_i += 1;
             dotdot = buf_i;
             path_begin = 1;
-        }
-    }
-    if (isWindows and options.allow_above_root) {
-        if (path_.len >= 2 and path_[1] == ':') {
-            if (options.add_nt_prefix) {
-                @memcpy(buf[buf_i .. buf_i + 4], &strings.literalBuf(T, "\\??\\"));
-                buf_i += 4;
-            }
-            buf[buf_i] = std.ascii.toUpper(@truncate(path_[0]));
-            buf[buf_i + 1] = ':';
-            buf_i += 2;
-            dotdot = buf_i;
-            path_begin = 2;
         }
     }
 


### PR DESCRIPTION
this path resolution function would previously convert `\\zenith\clover\hell.txt` into `\zenith\clover\hell.txt` causing it to fail. I dont think theres any reason for the logic in allow above root to only run in the allow above root case. that block deals with handling the root itself, which has to be done in both cases, but should only be done on windows.

Fixes #18514. I verified by using Bun to access my home network share (samba) and verify a set of `node:fs` methods work now. Will run CI to see how other regressions go, and work from there.