### PR TITLE
Improve documentation for bun-inspector-protocol package

### DIFF
--- a/packages/bun-inspector-protocol/.gitignore
+++ b/packages/bun-inspector-protocol/.gitignore
@@ -1,2 +1,3 @@
+index.js
 protocol/*.json
 protocol/v8

--- a/packages/bun-inspector-protocol/README.md
+++ b/packages/bun-inspector-protocol/README.md
@@ -1,1 +1,355 @@
 # bun-inspector-protocol
+
+`bun-inspector-protocol` is a TypeScript library that provides a comprehensive interface for interacting with the WebKit Inspector Protocol. This package makes it easy to build debugging tools, IDE integrations, and other developer tools that communicate with Bun's JavaScript runtime.
+
+You can use this library with Node.js or Bun.
+
+## Overview
+
+The WebKit Inspector Protocol is a JSON-based protocol similar to the Chrome DevTools Protocol. It allows external tools to interact with Bun's JavaScript runtime for debugging, profiling, and instrumentation purposes.
+
+## Features
+
+- 🌐 **WebSocket communication**: Connect to Bun's debugging endpoint via WebSockets
+- 🔌 **Socket communication**: Connect via Unix/TCP sockets for local debugging
+- 🔄 **Full API typing**: Complete TypeScript definitions for the protocol
+- 📊 **Object preview utilities**: Format runtime objects for display
+- 🔄 **Event-driven architecture**: Subscribe to specific debugging events
+- 🧩 **Promise-based API**: Clean, modern async interface
+
+## Installation
+
+```bash
+bun add bun-inspector-protocol
+# npm install bun-inspector-protocol
+# yarn add bun-inspector-protocol
+# pnpm add bun-inspector-protocol
+```
+
+## Basic Usage
+
+The first step is to spawn a Bun process with the inspector attached. There are a few different ways to do this.
+
+The `--inspect-wait` flag is the easiest way to spawn a Bun process with the inspector attached.
+
+```bash
+bun --inspect-wait my-script.ts
+```
+
+From there, it will start a WebSocket server defaulting to port 9229 and you will need to read the output from stdout to get the URL of the inspector:
+
+```bash
+bun --inspect-wait my-script.ts 2>&1 | grep -o '\sws://.*$'
+```
+
+From there, you can connect to the inspector using the `WebSocketInspector` class:
+
+```typescript
+import { WebSocketInspector } from "bun-inspector-protocol";
+
+// Create a new inspector client
+const inspector = new WebSocketInspector("ws://localhost:9229/ws");
+```
+
+### Connecting via WebSocket
+
+```typescript
+import { WebSocketInspector } from "bun-inspector-protocol";
+
+// Create a new inspector client
+const inspector = new WebSocketInspector("ws://localhost:9229/ws");
+
+// Listen for connection events
+inspector.on("Inspector.connected", () => {
+  console.log("Connected to debugger!");
+});
+
+inspector.on("Inspector.error", error => {
+  console.error("Inspector error:", error);
+});
+
+// Connect to the debugger
+await inspector.start();
+
+// Enable the Runtime domain
+await inspector.send("Runtime.enable");
+
+// Execute some code in the target context
+const result = await inspector.send("Runtime.evaluate", {
+  expression: "2 + 2",
+  returnByValue: true,
+});
+
+console.log("Evaluation result:", result.result.value); // 4
+
+// Close the connection
+inspector.close();
+```
+
+### Connecting via Socket (for Local Debugging)
+
+```typescript
+import { NodeSocketInspector } from "bun-inspector-protocol";
+import { Socket } from "node:net";
+
+// Create a socket connection
+const socket = new Socket();
+socket.connect("/path/to/debug/socket");
+
+// Create a new inspector client
+const inspector = new NodeSocketInspector(socket);
+
+// Set up event listeners and use the API as with WebSocketInspector
+inspector.on("Inspector.connected", () => {
+  console.log("Connected to debugger via socket!");
+});
+
+await inspector.start();
+// Use the same API as WebSocketInspector from here...
+```
+
+## Event Handling
+
+The inspector emits various events you can listen for:
+
+```typescript
+// Listen for specific protocol events
+inspector.on("Debugger.scriptParsed", params => {
+  console.log("Script parsed:", params.url);
+});
+
+// Listen for breakpoint hits
+inspector.on("Debugger.paused", params => {
+  console.log("Execution paused at:", params.callFrames[0].location);
+});
+
+// Listen for console messages
+inspector.on("Runtime.consoleAPICalled", params => {
+  console.log(
+    "Console message:",
+    params.args
+      .map(arg =>
+        // Use the included utility to format objects
+        remoteObjectToString(arg, true),
+      )
+      .join(" "),
+  );
+});
+```
+
+## Protocol Domains
+
+The Bun Inspector Protocol is organized into domains that group related functionality. Based on the JavaScriptCore protocol implementation, the following domains are available:
+
+### Console Domain
+
+- Console message capturing and monitoring
+- Support for different logging channels and levels (xml, javascript, network, etc.)
+- Methods: `enable`, `disable`, `clearMessages`, `setLoggingChannelLevel`, etc.
+- Events: `messageAdded`, `messageRepeatCountUpdated`, `messagesCleared`
+
+### Debugger Domain
+
+- Comprehensive debugging capabilities
+- Setting and managing breakpoints (conditional, URL-based, symbolic)
+- Execution control (pause, resume, step, etc.)
+- Stack frame inspection and manipulation
+- Methods: `enable`, `setBreakpoint`, `resume`, `stepInto`, `evaluateOnCallFrame`, etc.
+- Events: `scriptParsed`, `breakpointResolved`, `paused`, `resumed`
+
+### Heap Domain
+
+- Memory management and garbage collection monitoring
+- Heap snapshot creation and analysis
+- Memory leak detection with tracking
+- Methods: `enable`, `gc`, `snapshot`, `startTracking`, `stopTracking`
+- Events: `garbageCollected`, `trackingStart`, `trackingComplete`
+
+### Inspector Domain
+
+- Core inspector functionality
+- Methods: `enable`, `disable`, `initialized`
+- Events: `evaluateForTestInFrontend`, `inspect`
+
+### LifecycleReporter Domain
+
+- Process lifecycle management
+- Error reporting
+- Methods: `enable`, `preventExit`, `stopPreventingExit`
+- Events: `reload`, `error`
+
+### Runtime Domain
+
+- JavaScript runtime interaction
+- Expression evaluation
+- Object property inspection
+- Promise handling
+- Type profiling and control flow analysis
+- Methods: `evaluate`, `callFunctionOn`, `getProperties`, `awaitPromise`, etc.
+- Events: `executionContextCreated`
+
+### ScriptProfiler Domain
+
+- Script execution profiling
+- Performance tracking
+- Methods: `startTracking`, `stopTracking`
+- Events: `trackingStart`, `trackingUpdate`, `trackingComplete`
+
+### TestReporter Domain
+
+- Test execution monitoring
+- Test status reporting (pass, fail, timeout, skip, todo)
+- Methods: `enable`, `disable`
+- Events: `found`, `start`, `end`
+
+Each domain has its own set of commands, events, and data types. Refer to the TypeScript definitions in this package for complete API details.
+
+## Working with Remote Objects
+
+When evaluating expressions, you'll often receive remote object references. Use the `remoteObjectToString` utility to convert these to string representations:
+
+```typescript
+import { remoteObjectToString } from "bun-inspector-protocol";
+
+const result = await inspector.send("Runtime.evaluate", {
+  expression: "{ a: 1, b: { c: 'hello' } }",
+});
+
+console.log(remoteObjectToString(result.result, true));
+// Output: {a: 1, b: {c: "hello"}}
+```
+
+## Message Structure
+
+The protocol uses a simple JSON-based message format:
+
+### Requests
+
+```typescript
+interface Request<T> {
+  id: number; // Unique request identifier
+  method: string; // Domain.method name format
+  params: T; // Method-specific parameters
+}
+```
+
+### Responses
+
+```typescript
+interface Response<T> {
+  id: number; // Matching request identifier
+  result?: T; // Method-specific result (on success)
+  error?: {
+    // Error information (on failure)
+    code?: string;
+    message: string;
+  };
+}
+```
+
+### Events
+
+```typescript
+interface Event<T> {
+  method: string; // Domain.event name format
+  params: T; // Event-specific parameters
+}
+```
+
+### Setting Breakpoints
+
+```typescript
+// Set a breakpoint by URL
+const { breakpointId } = await inspector.send("Debugger.setBreakpointByUrl", {
+  lineNumber: 42,
+  url: "/app/foo.ts",
+  condition: "x > 5", // Optional condition
+});
+
+// Set a breakpoint with custom actions
+await inspector.send("Debugger.setBreakpoint", {
+  location: { scriptId: "123", lineNumber: 10 },
+  options: {
+    condition: "count > 5",
+    actions: [
+      { type: "log", data: "Breakpoint hit!" },
+      { type: "evaluate", data: "console.log('Custom breakpoint action')" },
+    ],
+    autoContinue: true,
+  },
+});
+
+// Remove a breakpoint
+await inspector.send("Debugger.removeBreakpoint", { breakpointId });
+```
+
+### Memory Profiling
+
+```typescript
+// Start heap tracking
+await inspector.send("Heap.enable");
+await inspector.send("Heap.startTracking");
+
+// Listen for GC events
+inspector.on("Heap.garbageCollected", ({ collection }) => {
+  console.log(
+    `GC completed: ${collection.type} (${collection.endTime - collection.startTime}ms)`,
+  );
+});
+
+// ... perform operations to analyze ...
+
+// Get heap snapshot
+const { snapshotData } = await inspector.send("Heap.stopTracking");
+// Process snapshotData to find memory leaks
+```
+
+### Script Profiling
+
+```typescript
+// Start script profiling with sampling
+await inspector.send("ScriptProfiler.startTracking", { includeSamples: true });
+
+// Listen for profiling updates
+inspector.on("ScriptProfiler.trackingUpdate", event => {
+  console.log("Profiling event:", event);
+});
+
+// Stop profiling to get complete data
+inspector.on("ScriptProfiler.trackingComplete", data => {
+  if (data.samples) {
+    // Process stack traces
+    console.log(`Collected ${data.samples.stackTraces.length} stack traces`);
+  }
+});
+
+await inspector.send("ScriptProfiler.stopTracking");
+```
+
+## Protocol Differences from WebKit
+
+The Bun Inspector Protocol is based on the WebKit Inspector Protocol with some modifications:
+Notable Bun-specific additions include:
+
+- `LifecycleReporter` domain for process lifecycle management
+- Enhanced `TestReporter` domain for test framework integration
+- Additional utilities for script and heap profiling
+
+## Building Tools with the Protocol
+
+This library is ideal for building:
+
+- IDE extensions and debuggers
+- Performance monitoring tools
+- Testing frameworks with runtime instrumentation
+- Hot module reloading systems
+- Custom REPL environments
+- Profiling and optimization tools
+
+## Full API Reference
+
+For complete API documentation, please refer to the TypeScript definitions included in this package. The definitions provide comprehensive information about all available commands, events, and their parameters.
+
+## License
+
+MIT

--- a/packages/bun-inspector-protocol/README.md
+++ b/packages/bun-inspector-protocol/README.md
@@ -139,7 +139,7 @@ inspector.on("Runtime.consoleAPICalled", params => {
 
 ## Protocol Domains
 
-The Bun Inspector Protocol is organized into domains that group related functionality. Based on the JavaScriptCore protocol implementation, the following domains are available:
+The WebKit Inspector Protocol is organized into domains that group related functionality. Based on the JavaScriptCore protocol implementation, the following domains are available:
 
 ### Console Domain
 
@@ -326,9 +326,8 @@ inspector.on("ScriptProfiler.trackingComplete", data => {
 await inspector.send("ScriptProfiler.stopTracking");
 ```
 
-## Protocol Differences from WebKit
+## Protocol Differences from Upstream WebKit
 
-The Bun Inspector Protocol is based on the WebKit Inspector Protocol with some modifications:
 Notable Bun-specific additions include:
 
 - `LifecycleReporter` domain for process lifecycle management

--- a/packages/bun-inspector-protocol/index.ts
+++ b/packages/bun-inspector-protocol/index.ts
@@ -1,4 +1,5 @@
-export type * from "./src/inspector/index.js";
-export * from "./src/inspector/websocket.js";
-export type * from "./src/protocol/index.js";
-export * from "./src/util/preview.js";
+export type * from "./src/inspector/index";
+export * from "./src/inspector/websocket";
+export * from "./src/inspector/node-socket";
+export type * from "./src/protocol/index";
+export * from "./src/util/preview";

--- a/packages/bun-inspector-protocol/package.json
+++ b/packages/bun-inspector-protocol/package.json
@@ -1,7 +1,19 @@
 {
   "name": "bun-inspector-protocol",
-  "version": "0.0.1",
+  "version": "0.0.2",
+  "scripts": {
+    "build": "bun build --target=node --outfile=index.js --minify-syntax ./index.ts --external=ws"
+  },
   "dependencies": {
     "ws": "^8.13.0"
-  }
+  },
+  "main": "./index.js",
+  "type": "module",
+  "files": [
+    "index.js",
+    "index.ts",
+    "src",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
