### PR TITLE
js: $isPromise* fixes

### DIFF
--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -169,7 +169,9 @@ export const function_replacements = [
   "$newZigFunction",
   "$cpp",
   "$newCppFunction",
-  "$isPromiseResolved",
+  "$isPromiseFulfilled",
+  "$isPromiseRejected",
+  "$isPromisePending",
   "$bindgenFn",
 ];
 const function_regexp = new RegExp(`__intrinsic__(${function_replacements.join("|").replaceAll("$", "")})`);
@@ -254,7 +256,7 @@ export function applyReplacements(src: string, length: number) {
       const id = registerNativeCall(kind, args[0], args[1], is_create_fn ? args[2] : undefined);
 
       return [slice.slice(0, match.index) + "__intrinsic__lazy(" + id + ")", inner.rest, true];
-    } else if (name === "isPromiseResolved") {
+    } else if (name === "isPromiseFulfilled") {
       const inner = sliceSourceCode(rest, true);
       let args;
       if (debug) {
@@ -262,6 +264,26 @@ export function applyReplacements(src: string, length: number) {
         args = `($assert(__intrinsic__isPromise(__intrinsic__lazy.temp=${inner.result.slice(0, -1)}))),(__intrinsic__getPromiseInternalField(__intrinsic__lazy.temp, __intrinsic__promiseFieldFlags) & __intrinsic__promiseStateMask) === (__intrinsic__lazy.temp = undefined, __intrinsic__promiseStateFulfilled))`;
       } else {
         args = `((__intrinsic__getPromiseInternalField(${inner.result.slice(0, -1)}), __intrinsic__promiseFieldFlags) & __intrinsic__promiseStateMask) === __intrinsic__promiseStateFulfilled)`;
+      }
+      return [slice.slice(0, match.index) + args, inner.rest, true];
+    } else if (name === "isPromiseRejected") {
+      const inner = sliceSourceCode(rest, true);
+      let args;
+      if (debug) {
+        // use a property on @lazy as a temporary holder for the expression. only in debug!
+        args = `($assert(__intrinsic__isPromise(__intrinsic__lazy.temp=${inner.result.slice(0, -1)}))),(__intrinsic__getPromiseInternalField(__intrinsic__lazy.temp, __intrinsic__promiseFieldFlags) & __intrinsic__promiseStateMask) === (__intrinsic__lazy.temp = undefined, __intrinsic__promiseStateRejected))`;
+      } else {
+        args = `((__intrinsic__getPromiseInternalField(${inner.result.slice(0, -1)}), __intrinsic__promiseFieldFlags) & __intrinsic__promiseStateMask) === __intrinsic__promiseStateRejected)`;
+      }
+      return [slice.slice(0, match.index) + args, inner.rest, true];
+    } else if (name === "isPromisePending") {
+      const inner = sliceSourceCode(rest, true);
+      let args;
+      if (debug) {
+        // use a property on @lazy as a temporary holder for the expression. only in debug!
+        args = `($assert(__intrinsic__isPromise(__intrinsic__lazy.temp=${inner.result.slice(0, -1)}))),(__intrinsic__getPromiseInternalField(__intrinsic__lazy.temp, __intrinsic__promiseFieldFlags) & __intrinsic__promiseStateMask) === (__intrinsic__lazy.temp = undefined, __intrinsic__promiseStatePending))`;
+      } else {
+        args = `((__intrinsic__getPromiseInternalField(${inner.result.slice(0, -1)}), __intrinsic__promiseFieldFlags) & __intrinsic__promiseStateMask) === __intrinsic__promiseStatePending)`;
       }
       return [slice.slice(0, match.index) + args, inner.rest, true];
     } else if (name === "bindgenFn") {

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -22,7 +22,11 @@ declare function $debug(...args: any[]): void;
 declare function $assert(check: any, ...message: any[]): asserts check;
 
 /** Asserts the input is a promise. Returns `true` if the promise is resolved */
-declare function $isPromiseResolved(promise: Promise<any>): boolean;
+declare function $isPromiseFulfilled(promise: Promise<any>): boolean;
+/** Asserts the input is a promise. Returns `true` if the promise is rejected */
+declare function $isPromiseRejected(promise: Promise<any>): boolean;
+/** Asserts the input is a promise. Returns `true` if the promise is pending */
+declare function $isPromisePending(promise: Promise<any>): boolean;
 
 declare const IS_BUN_DEVELOPMENT: boolean;
 
@@ -488,7 +492,7 @@ declare function $createCommonJSModule(
 ): JSCommonJSModule;
 declare function $evaluateCommonJSModule(
   moduleToEvaluate: JSCommonJSModule,
-  sourceModule: JSCommonJSModule
+  sourceModule: JSCommonJSModule,
 ): JSCommonJSModule[];
 
 declare function $overridableRequire(this: JSCommonJSModule, id: string): any;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1717,7 +1717,7 @@ export function readableStreamFromAsyncIterator(target, fn) {
             return;
           }
 
-          if ($isPromise(promise) && $isPromiseResolved(promise)) {
+          if ($isPromise(promise) && $isPromiseFulfilled(promise)) {
             clearImmediate(immediateTask);
             ({ value, done } = $getPromiseInternalField(promise, $promiseFieldReactionsOrResult));
             $assert(!$isPromise(value), "Expected a value, not a promise");

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -219,4 +219,4 @@ declare function $newZigFunction<T = (...args: any) => any>(
  * @param symbol - The name of the function to call.
  */
 declare function $bindgenFn<T = (...args: any) => any>(filename: string, symbol: string): T;
-// NOTE: $debug, $assert, and $isPromiseResolved omitted
+// NOTE: $debug, $assert, and $isPromiseFulfilled omitted


### PR DESCRIPTION
pulled out of an upcoming pr to refactor node:net
align $isPromiseResolved with proper name $isPromiseFulfilled
add $isPromiseRejected
add $isPromisePending
