### PR TITLE
fix(crypto): `Cipheriv` options without `authTagLength`

### DIFF
--- a/src/bun.js/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/bun.js/bindings/node/crypto/JSCipherConstructor.cpp
@@ -136,14 +136,16 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
         JSValue authTagLengthValue = optionsValue.get(globalObject, Identifier::fromString(vm, "authTagLength"_s));
         RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
-        double authTagLengthNumber = authTagLengthValue.toNumber(globalObject);
-        RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
+        if (!authTagLengthValue.isUndefinedOrNull()) {
+            double authTagLengthNumber = authTagLengthValue.toNumber(globalObject);
+            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
-        authTagLength = JSC::toInt32(authTagLengthNumber);
-        RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
+            authTagLength = JSC::toInt32(authTagLengthNumber);
+            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
-        if (authTagLengthNumber != authTagLength) {
-            return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.authTagLength"_s, authTagLengthValue);
+            if (authTagLengthNumber != authTagLength) {
+                return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.authTagLength"_s, authTagLengthValue);
+            }
         }
     }
 

--- a/src/bun.js/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/bun.js/bindings/node/crypto/JSCipherConstructor.cpp
@@ -137,15 +137,16 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
         RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
         if (!authTagLengthValue.isUndefinedOrNull()) {
-            double authTagLengthNumber = authTagLengthValue.toNumber(globalObject);
-            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
-
-            authTagLength = JSC::toInt32(authTagLengthNumber);
-            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
-
-            if (authTagLengthNumber != authTagLength) {
+            if (!authTagLengthValue.isUInt32()) {
                 return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.authTagLength"_s, authTagLengthValue);
             }
+
+            std::optional<int32_t> maybeAuthTagLength = authTagLengthValue.tryGetAsInt32();
+            if (!maybeAuthTagLength || *maybeAuthTagLength < 0) {
+                return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.authTagLength"_s, authTagLengthValue);
+            }
+
+            authTagLength = *maybeAuthTagLength;
         }
     }
 

--- a/src/bun.js/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/bun.js/bindings/node/crypto/JSCipherConstructor.cpp
@@ -137,10 +137,6 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
         RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
         if (!authTagLengthValue.isUndefinedOrNull()) {
-            if (!authTagLengthValue.isUInt32()) {
-                return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.authTagLength"_s, authTagLengthValue);
-            }
-
             std::optional<int32_t> maybeAuthTagLength = authTagLengthValue.tryGetAsInt32();
             if (!maybeAuthTagLength || *maybeAuthTagLength < 0) {
                 return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.authTagLength"_s, authTagLengthValue);

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -202,3 +202,11 @@ it("should encrypt & decrypt well-known values", () => {
     }
   });
 });
+
+it("should work with authTagLength missing from options", () => {
+  const cipher = createCipheriv("aes-128-gcm", randomBytes(16), randomBytes(16), {});
+  cipher.update("hi");
+  cipher.final();
+  const authTag = cipher.getAuthTag();
+  expect(authTag.length).toBe(16);
+});

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -210,3 +210,15 @@ it("should work with authTagLength missing from options", () => {
   const authTag = cipher.getAuthTag();
   expect(authTag.length).toBe(16);
 });
+
+it("should not accept negative authTagLength, or other coercable values", () => {
+  const lengths = [-2, true, new Number(12), {}];
+
+  for (const length of lengths) {
+    expect(() => {
+      createCipheriv("aes-128-gcm", randomBytes(16), randomBytes(16), {
+        authTagLength: length,
+      });
+    }).toThrow(`The property 'options.authTagLength' is invalid. Received `);
+  }
+});


### PR DESCRIPTION
### What does this PR do?
fixes #14991
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test. There are other tests for undefined `authTagLength`, but this bug was not caught because an empty options object was not tested.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
