### PR TITLE
node:net: fix Server.prototype.address()

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -540,11 +540,7 @@ pub const Listener = struct {
         return this.strong_data.get() orelse JSValue.jsUndefined();
     }
 
-    pub fn setData(
-        this: *Listener,
-        globalObject: *JSC.JSGlobalObject,
-        value: JSC.JSValue,
-    ) callconv(.C) bool {
+    pub fn setData(this: *Listener, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) callconv(.C) bool {
         log("setData()", .{});
         this.strong_data.set(globalObject, value);
         return true;
@@ -847,15 +843,11 @@ pub const Listener = struct {
         return this_value;
     }
 
-    pub fn onCreateTLS(
-        socket: uws.NewSocketHandler(true),
-    ) void {
+    pub fn onCreateTLS(socket: uws.NewSocketHandler(true)) void {
         onCreate(true, socket);
     }
 
-    pub fn onCreateTCP(
-        socket: uws.NewSocketHandler(false),
-    ) void {
+    pub fn onCreateTCP(socket: uws.NewSocketHandler(false)) void {
         onCreate(false, socket);
     }
 
@@ -1262,6 +1254,36 @@ pub const Listener = struct {
                 return promise_value;
             },
         }
+    }
+
+    pub fn getsockname(this: *Listener, globalThis: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSValue {
+        if (this.listener != .uws) {
+            return .jsUndefined();
+        }
+
+        const out = callFrame.argumentsAsArray(1)[0];
+        const socket = this.listener.uws;
+
+        var buf: [64]u8 = [_]u8{0} ** 64;
+        var text_buf: [512]u8 = undefined;
+        const address_bytes: []const u8 = socket.getLocalAddress(this.ssl, &buf) catch return .jsUndefined();
+        const address_zig: std.net.Address = switch (address_bytes.len) {
+            4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
+            16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),
+            else => return .jsUndefined(),
+        };
+        const family_js = switch (address_bytes.len) {
+            4 => bun.String.static("IPv4").toJS(globalThis),
+            16 => bun.String.static("IPv6").toJS(globalThis),
+            else => return .jsUndefined(),
+        };
+        const address_js = ZigString.init(bun.fmt.formatIp(address_zig, &text_buf) catch unreachable).toJS(globalThis);
+        const port_js: JSValue = .jsNumber(socket.getLocalPort(this.ssl));
+
+        out.put(globalThis, bun.String.static("family"), family_js);
+        out.put(globalThis, bun.String.static("address"), address_js);
+        out.put(globalThis, bun.String.static("port"), port_js);
+        return .jsUndefined();
     }
 };
 

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -281,6 +281,11 @@ export default [
         getter: "getData",
         setter: "setData",
       },
+
+      getsockname: {
+        fn: "getsockname",
+        length: 1,
+      },
     },
     finalize: true,
     construct: true,

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -3014,6 +3014,10 @@ pub const ListenSocket = opaque {
     pub fn close(this: *ListenSocket, ssl: bool) void {
         us_listen_socket_close(@intFromBool(ssl), this);
     }
+    pub fn getLocalAddress(this: *ListenSocket, ssl: bool, buf: []u8) ![]const u8 {
+        const self: *uws.Socket = @ptrCast(this);
+        return self.localAddress(ssl, buf);
+    }
     pub fn getLocalPort(this: *ListenSocket, ssl: bool) i32 {
         const self: *uws.Socket = @ptrCast(this);
         return self.localPort(ssl);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1310,25 +1310,10 @@ Server.prototype.address = function address() {
       return unix;
     }
 
-    //TODO: fix adress when host is passed
-    let address = server.hostname;
-    const type = isIP(address);
-    const port = server.port;
-    if (typeof port === "number") {
-      return {
-        port,
-        address,
-        family: type ? `IPv${type}` : undefined,
-      };
-    }
-    if (type) {
-      return {
-        address,
-        family: type ? `IPv${type}` : undefined,
-      };
-    }
-
-    return address;
+    const out = {};
+    const err = this._handle.getsockname(out);
+    if (err) throw new ErrnoException(err, "address");
+    return out;
   }
   return null;
 };


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/4341
Fixes https://github.com/oven-sh/bun/issues/7352

```js
const net = require("node:net");
const server = net
  .createServer(socket => {
    socket.end("goodbye\n");
  })
  .on("error", err => {
    throw err;
  });

server.listen(0, "localhost", () => {
  console.log("opened server on", server.address());
  server.close();
});

//

require("dns").lookup("localhost", console.log);

const server2 = require("net").createServer();
server2.listen(0, "localhost", () => {
  console.log(JSON.stringify(server2.address()));
  server2.close();
});
```

before

<img width="525" alt="image" src="https://github.com/user-attachments/assets/0a66ecb7-6bbc-489b-a9b0-c6884293abdc" />

after

<img width="525" alt="image" src="https://github.com/user-attachments/assets/6ae2767f-5a5b-4785-a580-aacca7337bed" />

