### PR TITLE
Fix maxbuf

### DIFF
--- a/src/bun.js/MaxBuf.zig
+++ b/src/bun.js/MaxBuf.zig
@@ -29,7 +29,7 @@ pub fn createForSubprocess(owner: *Subprocess, ptr: *?*MaxBuf, initial: ?i64) vo
     ptr.* = maxbuf;
 }
 fn disowned(this: *MaxBuf) bool {
-    return this.owned_by_subprocess != null and this.owned_by_reader == false;
+    return this.owned_by_subprocess == null and this.owned_by_reader == false;
 }
 fn destroy(this: *MaxBuf) void {
     bun.assert(this.disowned());

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -241,7 +241,6 @@ function execFile(file, args, options, callback) {
     windowsVerbatimArguments: options.windowsVerbatimArguments,
     shell: options.shell,
     signal: options.signal,
-    maxBuffer: options.maxBuffer,
   });
 
   let encoding;
@@ -1314,7 +1313,6 @@ class ChildProcess extends EventEmitter {
         argv0: spawnargs[0],
         windowsHide: !!options.windowsHide,
         windowsVerbatimArguments: !!options.windowsVerbatimArguments,
-        maxBuffer: options.maxBuffer,
       });
       this.pid = this.#handle.pid;
 


### PR DESCRIPTION
### What does this PR do?

It's not supposed to deinit when owned_by_subprocess isn't null. Also, it's no longer used for the non-sync case, so there's no reason to pass it to Bun.spawn().