### PR TITLE
Make shell more reliable

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -697,7 +697,7 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
             }
         }
 
-        pub fn runFromJSThreadMini(this: *ThisAsyncCpTask, _: *void) void {
+        pub fn runFromJSThreadMini(this: *ThisAsyncCpTask, _: *anyopaque) void {
             this.runFromJSThread();
         }
 

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -215,10 +215,8 @@ pub fn onShellCpTaskDone(this: *Cp, task: *ShellCpTask) void {
     log("task done: 0x{x} {d}", .{ @intFromPtr(task), this.state.exec.tasks_count });
     this.state.exec.tasks_count -= 1;
 
-    const err_ = &task.err;
-
     if (comptime bun.Environment.isWindows) {
-        if (err_) |err| {
+        if (task.err) |*err| {
             if (err.* == .sys and
                 err.sys.getErrno() == .BUSY and
                 (task.tgt_absolute != null and

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -253,8 +253,8 @@ pub fn printShellCpTask(this: *Cp, task: *ShellCpTask) void {
         .output = .{ .arrlist = output.moveToUnmanaged() },
         .state = .waiting_write_err,
     });
-    if (task.err) |*err| {
-        this.state.exec.err = err.take();
+    if (bun.take(&task.err)) |err| {
+        this.state.exec.err = err;
         const error_string = this.bltn().taskErrorToString(.cp, this.state.exec.err.?);
         output_task.start(error_string);
         return;

--- a/src/shell/builtin/ls.zig
+++ b/src/shell/builtin/ls.zig
@@ -112,7 +112,6 @@ pub fn onShellLsTaskDone(this: *Ls, task: *ShellLsTask) void {
     defer task.deinit(true);
     this.state.exec.tasks_done += 1;
     var output = task.takeOutput();
-    const err_ = task.err;
 
     // TODO: Reuse the *ShellLsTask allocation
     const output_task: *ShellLsOutputTask = bun.new(ShellLsOutputTask, .{
@@ -121,9 +120,10 @@ pub fn onShellLsTaskDone(this: *Ls, task: *ShellLsTask) void {
         .state = .waiting_write_err,
     });
 
-    if (err_) |err| {
-        this.state.exec.err = err;
-        const error_string = this.bltn().taskErrorToString(.ls, err);
+    if (task.err) |*err| {
+        this.state.exec.err = err.*;
+        task.err = null;
+        const error_string = this.bltn().taskErrorToString(.ls, this.state.exec.err.?);
         output_task.start(error_string);
         return;
     }

--- a/src/shell/builtin/touch.zig
+++ b/src/shell/builtin/touch.zig
@@ -191,7 +191,7 @@ pub const ShellTouchTask = struct {
     }
 
     pub fn deinit(this: *ShellTouchTask) void {
-        if (this.err) |e| {
+        if (this.err) |*e| {
             e.deref();
         }
         bun.default_allocator.destroy(this);

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -4262,8 +4262,9 @@ pub const Interpreter = struct {
         pub fn childDone(this: *Cmd, child: ChildPtr, exit_code: ExitCode) void {
             if (child.ptr.is(Assigns)) {
                 if (exit_code != 0) {
-                    const err = this.state.expanding_assigns.state.err;
+                    const err = this.state.expanding_assigns.state.err.take();
                     defer err.deinit(bun.default_allocator);
+
                     this.state.expanding_assigns.deinit();
                     this.writeFailingError("{}\n", .{err});
                     return;

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -4262,7 +4262,8 @@ pub const Interpreter = struct {
         pub fn childDone(this: *Cmd, child: ChildPtr, exit_code: ExitCode) void {
             if (child.ptr.is(Assigns)) {
                 if (exit_code != 0) {
-                    const err = this.state.expanding_assigns.state.err.take();
+                    const err = this.state.expanding_assigns.state.err;
+                    this.state.expanding_assigns.state.err = .{ .custom = "" };
                     defer err.deinit(bun.default_allocator);
 
                     this.state.expanding_assigns.deinit();

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -52,14 +52,6 @@ pub const ShellErr = union(enum) {
     invalid_arguments: struct { val: []const u8 = "" },
     todo: []const u8,
 
-    pub const empty = ShellErr{ .custom = "" };
-
-    pub fn take(this: *@This()) ShellErr {
-        const ret = this.*;
-        this.* = empty;
-        return ret;
-    }
-
     pub fn newSys(e: anytype) @This() {
         return .{
             .sys = switch (@TypeOf(e)) {

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -27,7 +27,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
   "alloc.ptr !=": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
   "== alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
   "!= alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
-  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 244, regex: true },
+  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 245, regex: true },
   "usingnamespace": { reason: "Zig deprecates this, and will not support it in incremental compilation.", limit: 492 },
 };
 const words_keys = [...Object.keys(words)];

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -187,7 +187,7 @@ export function createTestBuilder(path: string) {
 
     static tmpdir(): string {
       const tmp = os.tmpdir();
-      return fs.mkdtempSync(join(tmp, "test_builder"));
+      return fs.realpathSync(fs.mkdtempSync(join(tmp, "test_builder")));
     }
 
     setTempdir(tempdir: string): this {


### PR DESCRIPTION
### What does this PR do?

This fixes an assertion failure that can happen when the `cp` command finishes running

A crash in `seq`, `basename`, and `dirname` was fixed in the previous PR

### How did you verify your code works?

The cp tests no longer assertion failure