### PR TITLE
docs: add missing static methods of S3Client

### DIFF
--- a/docs/api/s3.md
+++ b/docs/api/s3.md
@@ -619,6 +619,48 @@ When the S3 Object Storage service returns an error (that is, not Bun), it will 
 
 The `S3Client` class provides several static methods for interacting with S3.
 
+### `S3Client.write` (static)
+
+To write data directly to a path in the bucket, you can use the `S3Client.write` static method.
+
+```ts
+import { S3Client } from "bun";
+
+const credentials = {
+  accessKeyId: "your-access-key",
+  secretAccessKey: "your-secret-key",
+  bucket: "my-bucket",
+  // endpoint: "https://s3.us-east-1.amazonaws.com",
+  // endpoint: "https://<account-id>.r2.cloudflarestorage.com", // Cloudflare R2
+};
+
+// Write string
+await S3Client.write("my-file.txt", "Hello World");
+
+// Write JSON with type
+await S3Client.write(
+  "data.json",
+  JSON.stringify({hello: "world"}),
+  {
+    ...credentials,
+    type: "application/json",
+  }
+);
+
+// Write from fetch
+const res = await fetch("https://example.com/data");
+await S3Client.write("data.bin", res, credentials);
+
+// Write with ACL
+await S3Client.write("public.html", html, {
+  ...credentials,
+  acl: "public-read",
+  type: "text/html"
+});
+```
+
+This is equivalent to calling `new S3Client(credentials).write("my-file.txt", "Hello World")`.
+
 ### `S3Client.presign` (static)
 
 To generate a presigned URL for an S3 file, you can use the `S3Client.presign` static method.
@@ -642,6 +684,45 @@ const url = S3Client.presign("my-file.txt", {
 
 This is equivalent to calling `new S3Client(credentials).presign("my-file.txt", { expiresIn: 3600 })`.
 
+### `S3Client.list` (static)
+
+To list some or all (up to 1,000) objects in a bucket, you can use the `S3Client.list` static method.
+
+```ts
+import { S3Client } from "bun";
+
+const credentials = {
+  accessKeyId: "your-access-key",
+  secretAccessKey: "your-secret-key",
+  bucket: "my-bucket",
+  // endpoint: "https://s3.us-east-1.amazonaws.com",
+  // endpoint: "https://<account-id>.r2.cloudflarestorage.com", // Cloudflare R2
+};
+
+// List (up to) 1000 objects in the bucket
+const allObjects = await S3Client.list(null, credentials);
+
+// List (up to) 500 objects under `uploads/` prefix, with owner field for each object
+const uploads = await S3Client.list({
+  prefix: 'uploads/',
+  maxKeys: 500,
+  fetchOwner: true,
+}, credentials);
+
+// Check if more results are available
+if (uploads.isTruncated) {
+  // List next batch of objects under `uploads/` prefix
+  const moreUploads = await S3Client.list({
+    prefix: 'uploads/',
+    maxKeys: 500,
+    startAfter: uploads.contents!.at(-1).key
+    fetchOwner: true,
+  }, credentials);
+}
+```
+
+This is equivalent to calling `new S3Client(credentials).list()`.
+
 ### `S3Client.exists` (static)
 
 To check if an S3 file exists, you can use the `S3Client.exists` static method.
@@ -654,6 +735,7 @@ const credentials = {
   secretAccessKey: "your-secret-key",
   bucket: "my-bucket",
   // endpoint: "https://s3.us-east-1.amazonaws.com",
+  // endpoint: "https://<account-id>.r2.cloudflarestorage.com", // Cloudflare R2
 };
 
 const exists = await S3Client.exists("my-file.txt", credentials);
@@ -670,6 +752,26 @@ const s3file = s3.file("my-file.txt", {
 const exists = await s3file.exists();
 ```
 
+### `S3Client.size` (static)
+
+To quickly check the size of S3 file without downloading it, you can use the `S3Client.size` static method.
+
+```ts
+import { S3Client } from "bun";
+
+const credentials = {
+  accessKeyId: "your-access-key",
+  secretAccessKey: "your-secret-key",
+  bucket: "my-bucket",
+  // endpoint: "https://s3.us-east-1.amazonaws.com",
+  // endpoint: "https://<account-id>.r2.cloudflarestorage.com", // Cloudflare R2
+};
+
+const bytes = await S3Client.size("my-file.txt", credentials);
+```
+
+This is equivalent to calling `new S3Client(credentials).size("my-file.txt")`.
+
 ### `S3Client.stat` (static)
 
 To get the size, etag, and other metadata of an S3 file, you can use the `S3Client.stat` static method.
@@ -682,6 +784,7 @@ const credentials = {
   secretAccessKey: "your-secret-key",
   bucket: "my-bucket",
   // endpoint: "https://s3.us-east-1.amazonaws.com",
+  // endpoint: "https://<account-id>.r2.cloudflarestorage.com", // Cloudflare R2
 };
 
 const stat = await S3Client.stat("my-file.txt", credentials);


### PR DESCRIPTION
### What does this PR do?

This adds missing documentation for `S3Client.write()`, `S3Client.list()`, and `S3Client.size()` static methods.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)

Related to #18819