### PR TITLE
`napi_async_work` fixes

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -423,7 +423,7 @@ pub export fn napi_create_string_utf8(env_: napi_env, str: ?[*]const u8, length:
     const slice: []const u8 = brk: {
         if (str) |ptr| {
             if (NAPI_AUTO_LENGTH == length) {
-                break :brk bun.sliceTo(@as([*:0]const u8, @ptrCast(str)), 0);
+                break :brk bun.sliceTo(@as([*:0]const u8, @ptrCast(ptr)), 0);
             } else if (length > std.math.maxInt(i32)) {
                 return env.invalidArg();
             } else {
@@ -459,7 +459,7 @@ pub export fn napi_create_string_utf16(env_: napi_env, str: ?[*]const char16_t, 
     const slice: []const u16 = brk: {
         if (str) |ptr| {
             if (NAPI_AUTO_LENGTH == length) {
-                break :brk bun.sliceTo(@as([*:0]const u16, @ptrCast(str)), 0);
+                break :brk bun.sliceTo(@as([*:0]const u16, @ptrCast(ptr)), 0);
             } else if (length > std.math.maxInt(i32)) {
                 return env.invalidArg();
             } else {
@@ -1045,18 +1045,17 @@ const WorkPoolTask = @import("../work_pool.zig").Task;
 pub const napi_async_work = struct {
     task: WorkPoolTask = .{ .callback = &runFromThreadPool },
     concurrent_task: JSC.ConcurrentTask = .{},
-    completion_task: ?*anyopaque = null,
     event_loop: *JSC.EventLoop,
     global: *JSC.JSGlobalObject,
     env: *NapiEnv,
-    execute: napi_async_execute_callback = null,
-    complete: napi_async_complete_callback = null,
+    execute: napi_async_execute_callback,
+    complete: ?napi_async_complete_callback,
     data: ?*anyopaque = null,
-    status: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
-    can_deinit: bool = false,
+    status: std.atomic.Value(Status) = .init(.pending),
     wait_for_deinit: bool = false,
     scheduled: bool = false,
     ref: Async.KeepAlive = .{},
+
     pub const Status = enum(u32) {
         pending = 0,
         started = 1,
@@ -1064,7 +1063,7 @@ pub const napi_async_work = struct {
         cancelled = 3,
     };
 
-    pub fn create(env: *NapiEnv, execute: napi_async_execute_callback, complete: napi_async_complete_callback, data: ?*anyopaque) !*napi_async_work {
+    pub fn new(env: *NapiEnv, execute: napi_async_execute_callback, complete: ?napi_async_complete_callback, data: ?*anyopaque) !*napi_async_work {
         const work = try bun.default_allocator.create(napi_async_work);
         const global = env.toJS();
         work.* = .{
@@ -1078,23 +1077,23 @@ pub const napi_async_work = struct {
         return work;
     }
 
+    pub fn destroy(this: *napi_async_work) void {
+        bun.default_allocator.destroy(this);
+    }
+
     pub fn runFromThreadPool(task: *WorkPoolTask) void {
         var this: *napi_async_work = @fieldParentPtr("task", task);
 
         this.run();
     }
     pub fn run(this: *napi_async_work) void {
-        if (this.status.cmpxchgStrong(@intFromEnum(Status.pending), @intFromEnum(Status.started), .seq_cst, .seq_cst)) |state| {
-            if (state == @intFromEnum(Status.cancelled)) {
-                if (this.wait_for_deinit) {
-                    // this might cause a segfault due to Task using a linked list!
-                    bun.default_allocator.destroy(this);
-                }
+        if (this.status.cmpxchgStrong(.pending, .started, .seq_cst, .seq_cst)) |state| {
+            if (state == .cancelled) {
+                return;
             }
-            return;
         }
-        this.execute.?(this.env, this.data);
-        this.status.store(@intFromEnum(Status.completed), .seq_cst);
+        this.execute(this.env, this.data);
+        this.status.store(.completed, .seq_cst);
 
         this.event_loop.enqueueTaskConcurrent(this.concurrent_task.from(this, .manual_deinit));
     }
@@ -1107,29 +1106,34 @@ pub const napi_async_work = struct {
     }
 
     pub fn cancel(this: *napi_async_work) bool {
-        this.ref.unref(this.global.bunVM());
-        return this.status.cmpxchgStrong(@intFromEnum(Status.cancelled), @intFromEnum(Status.pending), .seq_cst, .seq_cst) != null;
-    }
-
-    pub fn deinit(this: *napi_async_work) void {
-        this.ref.unref(this.global.bunVM());
-
-        if (this.can_deinit) {
-            bun.default_allocator.destroy(this);
-            return;
-        }
-        this.wait_for_deinit = true;
+        return this.status.cmpxchgStrong(.cancelled, .pending, .seq_cst, .seq_cst) != null;
     }
 
     fn runFromJSWithError(this: *napi_async_work) bun.JSError!void {
+
+        // likely `complete` will call `napi_delete_async_work`, so take a copy
+        // of `ref` beforehand
+        var ref = this.ref;
+        const vm = this.global.bunVM();
+        defer {
+            ref.unref(vm);
+        }
+
+        const complete = this.complete orelse {
+            return;
+        };
+
         const handle_scope = NapiHandleScope.open(this.env, false);
         defer if (handle_scope) |scope| scope.close(this.env);
-        this.complete.?(
+
+        const status: NapiStatus = if (this.status.load(.seq_cst) == .cancelled)
+            .cancelled
+        else
+            .ok;
+
+        complete(
             this.env,
-            @intFromEnum(if (this.status.load(.seq_cst) == @intFromEnum(Status.cancelled))
-                NapiStatus.cancelled
-            else
-                NapiStatus.ok),
+            @intFromEnum(status),
             this.data,
         );
         if (this.global.hasException()) {
@@ -1151,8 +1155,8 @@ pub const napi_threadsafe_function_release_mode = enum(c_uint) {
 pub const napi_tsfn_nonblocking = 0;
 pub const napi_tsfn_blocking = 1;
 pub const napi_threadsafe_function_call_mode = c_uint;
-pub const napi_async_execute_callback = ?*const fn (napi_env, ?*anyopaque) callconv(.C) void;
-pub const napi_async_complete_callback = ?*const fn (napi_env, napi_status, ?*anyopaque) callconv(.C) void;
+pub const napi_async_execute_callback = *const fn (napi_env, ?*anyopaque) callconv(.C) void;
+pub const napi_async_complete_callback = *const fn (napi_env, napi_status, ?*anyopaque) callconv(.C) void;
 pub const napi_threadsafe_function_call_js = *const fn (napi_env, napi_value, ?*anyopaque, ?*anyopaque) callconv(.C) void;
 pub const napi_node_version = extern struct {
     major: u32,
@@ -1275,8 +1279,8 @@ pub export fn napi_create_async_work(
     env_: napi_env,
     _: napi_value,
     _: [*:0]const u8,
-    execute: napi_async_execute_callback,
-    complete: napi_async_complete_callback,
+    execute_: ?napi_async_execute_callback,
+    complete: ?napi_async_complete_callback,
     data: ?*anyopaque,
     result_: ?**napi_async_work,
 ) napi_status {
@@ -1287,7 +1291,10 @@ pub export fn napi_create_async_work(
     const result = result_ orelse {
         return env.invalidArg();
     };
-    result.* = napi_async_work.create(env, execute, complete, data) catch {
+    const execute = execute_ orelse {
+        return env.invalidArg();
+    };
+    result.* = napi_async_work.new(env, execute, complete, data) catch {
         return env.genericFailure();
     };
     return env.ok();
@@ -1301,7 +1308,7 @@ pub export fn napi_delete_async_work(env_: napi_env, work_: ?*napi_async_work) n
         return env.invalidArg();
     };
     bun.assert(env.toJS() == work.global);
-    work.deinit();
+    work.destroy();
     return env.ok();
 }
 pub export fn napi_queue_async_work(env_: napi_env, work_: ?*napi_async_work) napi_status {

--- a/src/shell/Builtin.zig
+++ b/src/shell/Builtin.zig
@@ -301,7 +301,6 @@ pub fn init(
     cmd_local_env: *EnvMap,
     cwd: bun.FileDescriptor,
     io: *IO,
-    comptime in_cmd_subst: bool,
 ) CoroutineResult {
     const stdin: BuiltinIO.Input = switch (io.stdin) {
         .fd => |fd| .{ .fd = fd.refSelf() },
@@ -354,23 +353,7 @@ pub fn init(
         },
     }
 
-    if (node.redirect_file) |file| brk: {
-        if (comptime in_cmd_subst) {
-            if (node.redirect.stdin) {
-                stdin = .ignore;
-            }
-
-            if (node.redirect.stdout) {
-                stdout = .ignore;
-            }
-
-            if (node.redirect.stderr) {
-                stdout = .ignore;
-            }
-
-            break :brk;
-        }
-
+    if (node.redirect_file) |file| {
         switch (file) {
             .atom => {
                 if (cmd.redirection_file.items.len == 0) {

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -4377,7 +4377,6 @@ pub const Interpreter = struct {
                         &this.base.shell.cmd_local_env,
                         cwd,
                         &this.io,
-                        false,
                     );
                     if (coro_result == .yield) return;
 

--- a/test/napi/napi-app/async_tests.cpp
+++ b/test/napi/napi-app/async_tests.cpp
@@ -186,10 +186,123 @@ create_promise_with_threadsafe_function(const Napi::CallbackInfo &info) {
   return promise;
 }
 
+napi_value create_async_work_with_null_execute(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  int32_t *data = new int32_t;
+  *data = 0;
+
+  napi_status status;
+  napi_async_work work;
+  napi_value result;
+
+  status = napi_create_async_work(env, nullptr, nullptr, nullptr, nullptr, data,
+                                  &work);
+
+  // status must be napi_invalid_arg
+  if (status != napi_invalid_arg) {
+    napi_get_boolean(env, false, &result);
+    return result;
+  }
+
+  status = napi_get_boolean(env, true, &result);
+
+  return result;
+}
+
+void execute_for_null_complete(napi_env env, void *data) {
+  fprintf(stdout, "execute called!\n");
+}
+
+napi_value
+create_async_work_with_null_complete(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  int32_t *data = new int32_t;
+  *data = 0;
+
+  // napi_status status;
+  napi_async_work work;
+  napi_value result;
+
+  napi_value resource_name =
+      Napi::String::New(env, "napitests__create_async_work_with_null_complete");
+
+  napi_create_async_work(env, nullptr, resource_name,
+                         &execute_for_null_complete, nullptr, data, &work);
+
+  napi_queue_async_work(env, work);
+
+  napi_get_undefined(env, &result);
+
+  return result;
+}
+
+struct CancelData {
+  napi_ref callback;
+  napi_async_work work;
+};
+
+void execute_for_cancel(napi_env env, void *data) {
+  // nothing
+}
+
+void complete_for_cancel(napi_env env, napi_status status, void *data) {
+  CancelData *cancel_data = reinterpret_cast<CancelData *>(data);
+  napi_value callback;
+  napi_get_reference_value(env, cancel_data->callback, &callback);
+
+  napi_value global;
+  napi_get_global(env, &global);
+
+  // should be cancelled
+  bool result = status == napi_cancelled ? true : false;
+
+  napi_value argv[1];
+  napi_get_boolean(env, result, &argv[0]);
+
+  napi_call_function(env, global, callback, 1, argv, nullptr);
+
+  napi_delete_reference(env, cancel_data->callback);
+  napi_delete_async_work(env, cancel_data->work);
+}
+
+napi_value test_cancel_async_work(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  napi_ref callback;
+  napi_create_reference(env, info[0], 1, &callback);
+
+  napi_value resource_name =
+      Napi::String::New(env, "napitests__test_cancel_async_work");
+
+  napi_status status;
+  napi_value result;
+
+  struct CancelData *data = new CancelData;
+  data->callback = callback;
+
+  napi_create_async_work(env, nullptr, resource_name, &execute_for_cancel,
+                         &complete_for_cancel, data, &data->work);
+  napi_queue_async_work(env, data->work);
+
+  status = napi_cancel_async_work(env, data->work);
+  if (status != napi_ok) {
+    napi_get_boolean(env, false, &result);
+    return result;
+  }
+
+  napi_get_boolean(env, true, &result);
+  return result;
+}
+
 void register_async_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, create_promise);
   REGISTER_FUNCTION(env, exports, create_promise_with_napi_cpp);
   REGISTER_FUNCTION(env, exports, create_promise_with_threadsafe_function);
+  REGISTER_FUNCTION(env, exports, create_async_work_with_null_execute);
+  REGISTER_FUNCTION(env, exports, create_async_work_with_null_complete);
+  REGISTER_FUNCTION(env, exports, test_cancel_async_work);
 }
 
 } // namespace napitests

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -37,6 +37,34 @@ nativeTests.test_napi_handle_scope_finalizer = async () => {
   await gcUntil(() => nativeTests.was_finalize_called());
 };
 
+nativeTests.test_napi_async_work_execute_null_check = () => {
+  const res = nativeTests.create_async_work_with_null_execute();
+  if (res) {
+    console.log("success!");
+  } else {
+    console.log("failure!");
+  }
+};
+
+nativeTests.test_napi_async_work_complete_null_check = async () => {
+  nativeTests.create_async_work_with_null_complete();
+  await gcUntil(() => true);
+};
+
+nativeTests.test_napi_async_work_cancel = () => {
+  const res = nativeTests.test_cancel_async_work(result => {
+    if (result) {
+      console.log("success!");
+    } else {
+      console.log("failure!");
+    }
+  });
+
+  if (!res) {
+    console.log("failure!");
+  }
+};
+
 nativeTests.test_promise_with_threadsafe_function = async () => {
   await new Promise(resolve => setTimeout(resolve, 1));
   // create_promise_with_threadsafe_function returns a promise that calls our function from another

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -253,6 +253,22 @@ describe("napi", () => {
     });
   });
 
+  describe("napi_async_work", () => {
+    it("null checks execute callbacks", () => {
+      const output = checkSameOutput("test_napi_async_work_execute_null_check", []);
+      expect(output).toContain("success!");
+      expect(output).not.toContain("failure!");
+    });
+    it("null checks complete callbacks after scheduling", () => {
+      checkSameOutput("test_napi_async_work_complete_null_check", []);
+    });
+    it("works with cancelation", () => {
+      const output = checkSameOutput("test_napi_async_work_cancel", []);
+      expect(output).toContain("success!");
+      expect(output).not.toContain("failure!");
+    });
+  });
+
   describe("napi_threadsafe_function", () => {
     it("keeps the event loop alive without async_work", () => {
       const result = checkSameOutput("test_promise_with_threadsafe_function", []);


### PR DESCRIPTION
### What does this PR do?
Fixes four bugs:
- null check for `execute` callback (return `napi_invalid_arg` if null).
- null check `complete` callback after work is done (do nothing if null).
- fixes `napi_cancel_async_work`. Returns `napi_cancelled` through `complete`.
- does not free `napi_async_work` through any function other than `napi_delete_async_work`.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test for null `execute`, null `complete`, and receiving `napi_cancelled` after `napi_cancel_async_work`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
