### PR TITLE
Decrement `pendingRequests` counter when `Bun.serve` responds with HTTP 413

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6801,6 +6801,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
                 if (req_len > this.config.max_request_body_size) {
                     resp.writeStatus("413 Request Entity Too Large");
                     resp.endWithoutBody(true);
+                    this.pending_requests -= 1;
                     this.finalize();
                     return null;
                 }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1555,6 +1555,7 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
       body: "A".repeat(11),
     });
     expect(resp.status).toBe(413);
+    expect(server.pendingRequests).toBe(0);
   }
 });
 


### PR DESCRIPTION
### What does this PR do?

This change decrements the `Server#pendingRequests` counter when a request exceeds the `maxRequestBodySize` value passed to `Bun.serve()`.

- [x] Code changes

### How did you verify your code works?

Added an additional assertion to the existing HTTP 413 test, ensuring that `server.pendingRequests` returns to 0.

- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)