### PR TITLE
followup #18825

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1114,8 +1114,9 @@ pub const napi_async_work = struct {
         // likely `complete` will call `napi_delete_async_work`, so take a copy
         // of `ref` beforehand
         var ref = this.ref;
-        const global = this.global;
+        const env = this.env;
         defer {
+            const global = env.toJS();
             ref.unref(global.bunVM());
         }
 
@@ -1125,7 +1126,7 @@ pub const napi_async_work = struct {
         };
 
         const handle_scope = NapiHandleScope.open(this.env, false);
-        defer if (handle_scope) |scope| scope.close(this.env);
+        defer if (handle_scope) |scope| scope.close(env);
 
         const status: NapiStatus = if (this.status.load(.seq_cst) == .cancelled)
             .cancelled
@@ -1138,6 +1139,7 @@ pub const napi_async_work = struct {
             this.data,
         );
 
+        const global = env.toJS();
         if (global.hasException()) {
             return error.JSError;
         }

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1114,9 +1114,9 @@ pub const napi_async_work = struct {
         // likely `complete` will call `napi_delete_async_work`, so take a copy
         // of `ref` beforehand
         var ref = this.ref;
-        const vm = this.global.bunVM();
+        const global = this.global;
         defer {
-            ref.unref(vm);
+            ref.unref(global.bunVM());
         }
 
         // https://github.com/nodejs/node/blob/a2de5b9150da60c77144bb5333371eaca3fab936/src/node_api.cc#L1201
@@ -1137,7 +1137,8 @@ pub const napi_async_work = struct {
             @intFromEnum(status),
             this.data,
         );
-        if (this.global.hasException()) {
+
+        if (global.hasException()) {
             return error.JSError;
         }
     }

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1051,7 +1051,6 @@ pub const napi_async_work = struct {
     complete: ?napi_async_complete_callback,
     data: ?*anyopaque = null,
     status: std.atomic.Value(Status) = .init(.pending),
-    wait_for_deinit: bool = false,
     scheduled: bool = false,
     ref: Async.KeepAlive = .{},
 


### PR DESCRIPTION
### What does this PR do?
removes all uses of `napi_async_work` pointer after `complete` callback
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually tested `astro-post.test.js` with a debug build
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
