### PR TITLE
Introduce `--redis-preconnect` CLI flag

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -245,7 +245,8 @@ pub const Arguments = struct {
         clap.parseParam("--no-deprecation                  Suppress all reporting of the custom deprecation.") catch unreachable,
         clap.parseParam("--throw-deprecation               Determine whether or not deprecation warnings result in errors.") catch unreachable,
         clap.parseParam("--title <STR>                     Set the process title") catch unreachable,
-        clap.parseParam("--zero-fill-buffers               Boolean to force Buffer.allocUnsafe(size) to be zero-filled.") catch unreachable,
+        clap.parseParam("--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled.") catch unreachable,
+        clap.parseParam("--redis-preconnect                Preconnect to $REDIS_URL at startup") catch unreachable,
     };
 
     const auto_or_run_params = [_]ParamType{
@@ -704,6 +705,10 @@ pub const Arguments = struct {
 
             if (args.option("--origin")) |origin| {
                 opts.origin = origin;
+            }
+
+            if (args.flag("--redis-preconnect")) {
+                ctx.runtime_options.redis_preconnect = true;
             }
 
             if (args.option("--port")) |port_str| {
@@ -1529,6 +1534,7 @@ pub const Command = struct {
         smol: bool = false,
         debugger: Debugger = .{ .unspecified = {} },
         if_present: bool = false,
+        redis_preconnect: bool = false,
         eval: struct {
             script: []const u8 = "",
             eval_and_print: bool = false,

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -153,11 +153,9 @@ pub const JSValkeyClient = struct {
         return JSValue.jsNumber(len);
     }
 
-    pub fn jsConnect(this: *JSValkeyClient, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+    pub fn doConnect(this: *JSValkeyClient, globalObject: *JSC.JSGlobalObject, this_value: JSValue) bun.JSError!JSValue {
         this.ref();
         defer this.deref();
-
-        const this_value = callframe.this();
 
         // If already connected, resolve immediately
         if (this.client.status == .connected) {
@@ -207,6 +205,10 @@ pub const JSValkeyClient = struct {
         }
 
         return promise;
+    }
+
+    pub fn jsConnect(this: *JSValkeyClient, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+        return try this.doConnect(globalObject, callframe.this());
     }
 
     pub fn jsDisconnect(this: *JSValkeyClient, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {


### PR DESCRIPTION
### What does this PR do?

The `--redis-preconnect` CLI flag lets you automatically connect to Redis before your code starts to load, which can improve cold start performance.

### How did you verify your code works?

Internally, this is the equivalent of calling `Bun.redis.connect()` before the entry points load.
