### PR TITLE
experiment: destroy JSC::VM at exit when running tests in CI

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -692,6 +692,7 @@ async function spawnBun(execPath, { args, cwd, timeout, env, stdout, stderr }) {
     BUN_ENABLE_CRASH_REPORTING: "0", // change this to '1' if https://github.com/oven-sh/bun/issues/13012 is implemented
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
     SHELLOPTS: isWindows ? "igncr" : undefined, // ignore "\r" on Windows
     // Used in Node.js tests.
     TEST_TMPDIR: tmpdirPath,


### PR DESCRIPTION
### What does this PR do?

Tries running our tests with the `BUN_DESTRUCT_VM_ON_EXIT=1` flag from #18758. The expectation is a lot of them will fail; the goal here is really just to see the results from one run with this flag. Do not merge this!

### How did you verify your code works?
