### PR TITLE
Rename redis.disconnect to redis.close

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -103,7 +103,7 @@ declare module "bun" {
     /**
      * Disconnect from the Redis server
      */
-    disconnect(): void;
+    close(): void;
 
     /**
      * Send a raw command to the Redis server

--- a/src/bun.js/api/valkey.classes.ts
+++ b/src/bun.js/api/valkey.classes.ts
@@ -59,7 +59,7 @@ export default [
         fn: "jsConnect",
         length: 0,
       },
-      disconnect: {
+      close: {
         fn: "jsDisconnect",
         length: 0,
       },

--- a/test/js/valkey/integration/complex-operations.test.ts
+++ b/test/js/valkey/integration/complex-operations.test.ts
@@ -12,7 +12,7 @@ import { ConnectionType, createClient, ctx, isEnabled } from "../test-utils";
 describe.skipIf(!isEnabled)("Valkey: Complex Operations", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -30,7 +30,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
       } finally {
         // Cleanup
-        await client.disconnect();
+        await client.close();
       }
     });
 
@@ -110,7 +110,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       // Should still report disconnected
       expect(client.connected).toBe(false);
 
-      await client.disconnect();
+      await client.close();
     });
   });
 
@@ -136,7 +136,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
       }
 
-      await client.disconnect();
+      await client.close();
     });
 
     test("should reject commands when offline queue is disabled", async () => {
@@ -155,7 +155,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(error.message).toMatch(/connection closed|offline queue is disabled/i);
       }
 
-      await client.disconnect();
+      await client.close();
     });
 
     // Skip this test since it's hard to reliably wait for max retries in a test environment
@@ -183,7 +183,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       expect(onconnect).toHaveBeenCalled();
 
       // Explicitly disconnect to trigger onclose
-      client.disconnect();
+      client.close();
 
       // Wait a short time for disconnect callbacks to execute
       await delay(50);
@@ -220,7 +220,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       }
 
       // Disconnect to trigger close handler
-      await client.disconnect();
+      await client.close();
 
       // Wait a short time for the callbacks to execute
       await delay(50);
@@ -251,7 +251,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       await client.set("__test_key", "test-value");
 
       // Manually disconnect
-      client.disconnect();
+      client.close();
 
       // Try to send a command
       expect(client.connected).toBe(false);
@@ -273,15 +273,15 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       });
 
       // Disconnect immediately
-      await client.disconnect();
+      await client.close();
 
       expect(client.connected).toBe(false);
       expect(async () => {
         await client.get("any-key");
       }).toThrowErrorMatchingInlineSnapshot(`"Connection closed"`);
       // Multiple disconnects should not cause issues
-      await client.disconnect();
-      await client.disconnect();
+      await client.close();
+      await client.close();
     });
   });
 
@@ -297,7 +297,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         });
 
         // Immediately disconnect
-        promises.push(client.disconnect());
+        promises.push(client.close());
       }
 
       // All should resolve without errors
@@ -330,7 +330,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
 
       // Clean up
       for (const client of clients) {
-        await client.disconnect();
+        await client.close();
       }
     });
   });

--- a/test/js/valkey/reliability/error-handling.test.ts
+++ b/test/js/valkey/reliability/error-handling.test.ts
@@ -13,7 +13,7 @@ import { createClient, DEFAULT_REDIS_URL, ctx, ConnectionType, isEnabled } from 
 describe.skipIf(!isEnabled)("Valkey: Error Handling", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });
@@ -259,7 +259,7 @@ describe.skipIf(!isEnabled)("Valkey: Error Handling", () => {
       await client.set(key, "initial-value");
 
       // Disconnect explicitly
-      client.disconnect();
+      client.close();
 
       // This command should fail
       expect(async () => await client.get(key)).toThrowErrorMatchingInlineSnapshot(`"Connection has failed"`);

--- a/test/js/valkey/reliability/protocol-handling.test.ts
+++ b/test/js/valkey/reliability/protocol-handling.test.ts
@@ -11,7 +11,7 @@ import { ConnectionType, createClient, ctx, isEnabled, testKey } from "../test-u
 describe.skipIf(!isEnabled)("Valkey: Protocol Handling", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });
@@ -394,7 +394,7 @@ describe.skipIf(!isEnabled)("Valkey: Protocol Handling", () => {
         throw error;
       } finally {
         // Clean up clients
-        await Promise.all(clients.map(client => client.disconnect()));
+        await Promise.all(clients.map(client => client.close()));
       }
     });
   });

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -228,8 +228,8 @@ async function startContainer(): Promise<ContainerConfiguration> {
     const port = randomPort();
     const tlsPort = randomPort();
 
-    // Create container name with fixed name
-    const containerName = `valkey-unified-test-bun`;
+    // Create container name with unique identifier to avoid conflicts in CI
+    const containerName = `valkey-unified-test-bun-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 
     // Check if container exists and remove it
     try {
@@ -267,42 +267,82 @@ async function startContainer(): Promise<ContainerConfiguration> {
     // Start the unified container with TCP, TLS, and Unix socket
     console.log(`Starting Redis container ${containerName} on ports ${port}:6379 and ${tlsPort}:6380...`);
 
-    const startProcess = Bun.spawn({
-      cmd: [
-        dockerCLI,
-        "run",
-        "-d",
-        "--name",
-        containerName,
-        "-p",
-        `${port}:6379`,
-        "-p",
-        `${tlsPort}:6380`,
-        // TODO: unix domain socket has permission errors in CI.
-        // "-v",
-        // `${REDIS_TEMP_DIR}:/tmp`,
-        "--health-cmd",
-        "redis-cli ping || exit 1",
-        "--health-interval",
-        "2s",
-        "--health-timeout",
-        "1s",
-        "--health-retries",
-        "5",
-        "bun-valkey-unified-test",
-      ],
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    // Function to try starting container with port retries
+    async function tryStartContainer(attempt = 1, maxAttempts = 3) {
+      const currentPort = attempt === 1 ? port : randomPort();
+      const currentTlsPort = attempt === 1 ? tlsPort : randomPort();
+      
+      console.log(`Attempt ${attempt}: Using ports ${currentPort}:6379 and ${currentTlsPort}:6380...`);
+      
+      const startProcess = Bun.spawn({
+        cmd: [
+          dockerCLI,
+          "run",
+          "-d",
+          "--name",
+          containerName,
+          "-p",
+          `${currentPort}:6379`,
+          "-p",
+          `${currentTlsPort}:6380`,
+          // TODO: unix domain socket has permission errors in CI.
+          // "-v",
+          // `${REDIS_TEMP_DIR}:/tmp`,
+          "--health-cmd",
+          "redis-cli ping || exit 1",
+          "--health-interval",
+          "2s",
+          "--health-timeout",
+          "1s",
+          "--health-retries",
+          "5",
+          "bun-valkey-unified-test",
+        ],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const containerID = await new Response(startProcess.stdout).text();
-    const startError = await new Response(startProcess.stderr).text();
-    const startExitCode = await startProcess.exited;
+      const containerID = await new Response(startProcess.stdout).text();
+      const startError = await new Response(startProcess.stderr).text();
+      const startExitCode = await startProcess.exited;
 
-    if (startExitCode !== 0 || !containerID.trim()) {
+      if (startExitCode === 0 && containerID.trim()) {
+        // Update the ports if we used different ones on a retry
+        if (attempt > 1) {
+          REDIS_PORT = currentPort;
+          REDIS_TLS_PORT = currentTlsPort;
+          DEFAULT_REDIS_URL = `redis://${REDIS_HOST}:${REDIS_PORT}`;
+          TLS_REDIS_URL = `rediss://${REDIS_HOST}:${REDIS_TLS_PORT}`;
+          UNIX_REDIS_URL = `redis+unix://${REDIS_UNIX_SOCKET}`;
+          AUTH_REDIS_URL = `redis://testuser:test123@${REDIS_HOST}:${REDIS_PORT}`;
+          READONLY_REDIS_URL = `redis://readonly:readonly@${REDIS_HOST}:${REDIS_PORT}`;
+          WRITEONLY_REDIS_URL = `redis://writeonly:writeonly@${REDIS_HOST}:${REDIS_PORT}`;
+          
+          containerConfig = {
+            port: currentPort,
+            tlsPort: currentTlsPort,
+            containerName,
+            useUnixSocket: true,
+          };
+        }
+        return { containerID, success: true };
+      }
+      
+      // If the error is related to port already in use, try again with different ports
+      if (startError.includes("address already in use") && attempt < maxAttempts) {
+        console.log(`Port conflict detected. Retrying with different ports...`);
+        // Remove failed container if it was created
+        if (containerID.trim()) {
+          await Bun.spawn([dockerCLI, "rm", "-f", containerID.trim()]).exited;
+        }
+        return tryStartContainer(attempt + 1, maxAttempts);
+      }
+      
       console.error(`Failed to start container. Exit code: ${startExitCode}, Error: ${startError}`);
       throw new Error(`Failed to start Redis container: ${startError || "unknown error"}`);
     }
+    
+    const { containerID } = await tryStartContainer();
 
     console.log(`Container started with ID: ${containerID.trim()}`);
 

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -607,26 +607,26 @@ if (isEnabled)
       }
 
       // Disconnect all clients
-      await context.redis.disconnect();
+      await context.redis.close();
 
       if (context.redisTLS) {
-        await context.redisTLS.disconnect();
+        await context.redisTLS.close();
       }
 
       if (context.redisUnix) {
-        await context.redisUnix.disconnect();
+        await context.redisUnix.close();
       }
 
       if (context.redisAuth) {
-        await context.redisAuth.disconnect();
+        await context.redisAuth.close();
       }
 
       if (context.redisReadOnly) {
-        await context.redisReadOnly.disconnect();
+        await context.redisReadOnly.close();
       }
 
       if (context.redisWriteOnly) {
-        await context.redisWriteOnly.disconnect();
+        await context.redisWriteOnly.close();
       }
     } catch (err) {
       console.error("Error during test cleanup:", err);

--- a/test/js/valkey/unit/basic-operations.test.ts
+++ b/test/js/valkey/unit/basic-operations.test.ts
@@ -12,7 +12,7 @@ import { ctx, expectType, createClient, ConnectionType, isEnabled } from "../tes
 describe.skipIf(!isEnabled)("Valkey: Basic String Operations", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });

--- a/test/js/valkey/unit/hash-operations.test.ts
+++ b/test/js/valkey/unit/hash-operations.test.ts
@@ -176,7 +176,7 @@ describe.skipIf(!isEnabled)("Valkey: Hash Data Type Operations", () => {
       // Get all fields and values
       const result = await ctx.redis.send("HGETALL", [key]);
       expect(result).toBeDefined();
-      const res = ctx.redis.set("ok", "123", "GET");
+      const res = await ctx.redis.set("ok", "123", "GET");
 
       // When using RESP3, HGETALL returns a map/object
       if (typeof result === "object" && result !== null) {

--- a/test/js/valkey/unit/hash-operations.test.ts
+++ b/test/js/valkey/unit/hash-operations.test.ts
@@ -11,7 +11,9 @@ import { ConnectionType, createClient, ctx, expectType, isEnabled } from "../tes
 describe.skipIf(!isEnabled)("Valkey: Hash Data Type Operations", () => {
   beforeEach(async () => {
     if (ctx.redis?.connected) {
-      ctx.redis.close?.();
+      try {
+        ctx.redis.close();
+      } catch (e) {}
     }
     ctx.redis = createClient?.(ConnectionType.TCP);
   });

--- a/test/js/valkey/unit/hash-operations.test.ts
+++ b/test/js/valkey/unit/hash-operations.test.ts
@@ -11,7 +11,7 @@ import { ConnectionType, createClient, ctx, expectType, isEnabled } from "../tes
 describe.skipIf(!isEnabled)("Valkey: Hash Data Type Operations", () => {
   beforeEach(async () => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });
@@ -174,6 +174,7 @@ describe.skipIf(!isEnabled)("Valkey: Hash Data Type Operations", () => {
       // Get all fields and values
       const result = await ctx.redis.send("HGETALL", [key]);
       expect(result).toBeDefined();
+      const res = ctx.redis.set("ok", "123", "GET");
 
       // When using RESP3, HGETALL returns a map/object
       if (typeof result === "object" && result !== null) {

--- a/test/js/valkey/unit/hash-operations.test.ts
+++ b/test/js/valkey/unit/hash-operations.test.ts
@@ -13,7 +13,7 @@ describe.skipIf(!isEnabled)("Valkey: Hash Data Type Operations", () => {
     if (ctx.redis?.connected) {
       ctx.redis.close?.();
     }
-    ctx.redis = createClient(ConnectionType.TCP);
+    ctx.redis = createClient?.(ConnectionType.TCP);
   });
 
   describe("Basic Hash Commands", () => {

--- a/test/js/valkey/unit/list-operations.test.ts
+++ b/test/js/valkey/unit/list-operations.test.ts
@@ -12,7 +12,7 @@ import { isCI } from "harness";
 describe.skipIf(!isEnabled)("Valkey: List Data Type Operations", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });

--- a/test/js/valkey/unit/set-operations.test.ts
+++ b/test/js/valkey/unit/set-operations.test.ts
@@ -11,7 +11,7 @@ import { ctx, createClient, ConnectionType, expectType, isEnabled } from "../tes
 describe.skipIf(!isEnabled)("Valkey: Set Data Type Operations", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -6,7 +6,7 @@ import { expectType } from "./test-utils";
 describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
   beforeEach(() => {
     if (ctx.redis?.connected) {
-      ctx.redis.disconnect?.();
+      ctx.redis.close?.();
     }
     ctx.redis = createClient(ConnectionType.TCP);
   });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
