### PR TITLE
`Bun.SQL`:  `statement` and `columns` field for `SQLResultArray`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1725,21 +1725,21 @@ declare module "bun" {
    * Represents a SQL query that can be executed, with additional control methods
    * Extends Promise to allow for async/await usage
    */
-  interface SQLQuery extends Promise<SQLQueryResult> {
+  interface SQLQuery<T = any> extends Promise<SQLQueryResult<T>> {
     /** Indicates if the query is currently executing */
     active: boolean;
     /** Indicates if the query has been cancelled */
     cancelled: boolean;
     /** Cancels the executing query */
-    cancel(): SQLQuery;
+    cancel(): SQLQuery<T>;
     /** Execute as a simple query, no parameters are allowed but can execute multiple commands separated by semicolons */
-    simple(): SQLQuery;
+    simple(): SQLQuery<T>;
     /** Executes the query */
-    execute(): SQLQuery;
+    execute(): SQLQuery<T>;
     /** Returns the raw query result */
-    raw(): SQLQuery;
+    raw(): SQLQuery<T>;
     /** Returns only the values from the query result */
-    values(): SQLQuery;
+    values(): SQLQuery<T>;
   }
 
   /**
@@ -1769,7 +1769,7 @@ declare module "bun" {
   /**
    * A SQLQuery result
    */
-  interface SQLQueryResult extends Array<any> {
+  interface SQLQueryResult<T = any> extends Array<T> {
     /** Query of this result */
     query?: SQLQuery;
     /** Statement of this query */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1725,7 +1725,7 @@ declare module "bun" {
    * Represents a SQL query that can be executed, with additional control methods
    * Extends Promise to allow for async/await usage
    */
-  interface SQLQuery extends Promise<any> {
+  interface SQLQuery extends Promise<SQLQueryResult> {
     /** Indicates if the query is currently executing */
     active: boolean;
     /** Indicates if the query has been cancelled */
@@ -1739,7 +1739,47 @@ declare module "bun" {
     /** Returns the raw query result */
     raw(): SQLQuery;
     /** Returns only the values from the query result */
-    values(): SQLQuery;
+    values(): SQLQueryResult;
+  }
+
+  /**
+   * A SQLQuery statement summary
+   */
+  interface SQLQueryStatement {
+    /** Template SQL query */
+    string: string;
+    /** Columns associated with the SQL query */
+    columns: SQLQueryStatementColumn[];
+  }
+
+  /**
+   * A SQLQueryStatement column
+   */
+  interface SQLQueryStatementColumn {
+    /** Name/ID of column */
+    name: string;
+    /** Table ID of column (set to zero if no table associated) */
+    table: number;
+    /** Table column index of column (set to zero if no table associated) */
+    number: number;
+    /** Data Type OID of column */
+    type: number;
+  }
+
+  /**
+   * A SQLQuery result
+   */
+  interface SQLQueryResult extends Array<any> {
+    /** Query of this result */
+    query?: SQLQuery;
+    /** Statement of this query */
+    statement?: SQLQueryStatement;
+    /** Columns of this query */
+    columns?: SQLQueryStatementColumn[];
+    /** Number of rows in this query */
+    count?: number;
+    /** The command type ran */
+    commands?: string;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1759,11 +1759,11 @@ declare module "bun" {
     /** Name/ID of column */
     name: string;
     /** Table ID of column (set to zero if no table associated) */
-    table: number;
+    table?: number;
     /** Table column index of column (set to zero if no table associated) */
-    number: number;
+    number?: number;
     /** Data Type OID of column */
-    type: number;
+    type?: number;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1739,7 +1739,7 @@ declare module "bun" {
     /** Returns the raw query result */
     raw(): SQLQuery;
     /** Returns only the values from the query result */
-    values(): SQLQueryResult;
+    values(): SQLQuery;
   }
 
   /**

--- a/src/bun.js/api/postgres.classes.ts
+++ b/src/bun.js/api/postgres.classes.ts
@@ -76,8 +76,12 @@ export default [
         fn: "setPendingValue",
         length: 1,
       },
+      statement: {
+        getter: "getStatement",
+        this: true,
+      }
     },
-    values: ["pendingValue", "target", "columns", "binding"],
+    values: ["pendingValue", "target", "columns", "binding", "statement"],
     estimatedSize: true,
   }),
 ];

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -45,9 +45,18 @@ class SQLResultArray extends PublicArray {
     Object.defineProperties(this, {
       count: { value: null, writable: true },
       command: { value: null, writable: true },
-      columns: { value: null, writable: true },
+      query: { value: null, writable: true },
     });
   }
+
+  get statement() {
+    return this.query?.[_handle]?.statement;
+  }
+
+  get columns() {
+    return this.query?.[_handle]?.statement?.columns;
+  }
+
   static get [Symbol.species]() {
     return Array;
   }
@@ -612,7 +621,7 @@ class Query extends PublicPromise {
 Object.defineProperty(Query, Symbol.species, { value: PublicPromise });
 Object.defineProperty(Query, Symbol.toStringTag, { value: "Query" });
 init(
-  function onResolvePostgresQuery(query, columns, result, commandTag, count, queries, is_last) {
+  function onResolvePostgresQuery(query, result, commandTag, count, queries, is_last) {
     /// simple queries
     if (query[_flags] & SQLQueryFlags.simple) {
       // simple can have multiple results or a single result
@@ -640,7 +649,7 @@ init(
         result.command = cmds[commandTag];
       }
 
-      result.columns = columns;
+      result.query = query;
       result.count = count || 0;
       const last_result = query[_results];
 
@@ -667,7 +676,7 @@ init(
       result.command = cmds[commandTag];
     }
 
-    result.columns = columns;
+    result.query = query;
     result.count = count || 0;
     if (queries) {
       const queriesIndex = queries.indexOf(query);

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -45,6 +45,7 @@ class SQLResultArray extends PublicArray {
     Object.defineProperties(this, {
       count: { value: null, writable: true },
       command: { value: null, writable: true },
+      columns: { value: null, writable: true },
     });
   }
   static get [Symbol.species]() {
@@ -611,7 +612,7 @@ class Query extends PublicPromise {
 Object.defineProperty(Query, Symbol.species, { value: PublicPromise });
 Object.defineProperty(Query, Symbol.toStringTag, { value: "Query" });
 init(
-  function onResolvePostgresQuery(query, result, commandTag, count, queries, is_last) {
+  function onResolvePostgresQuery(query, columns, result, commandTag, count, queries, is_last) {
     /// simple queries
     if (query[_flags] & SQLQueryFlags.simple) {
       // simple can have multiple results or a single result
@@ -639,6 +640,7 @@ init(
         result.command = cmds[commandTag];
       }
 
+      result.columns = columns;
       result.count = count || 0;
       const last_result = query[_results];
 
@@ -665,6 +667,7 @@ init(
       result.command = cmds[commandTag];
     }
 
+    result.columns = columns;
     result.count = count || 0;
     if (queries) {
       const queriesIndex = queries.indexOf(query);

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -534,8 +534,22 @@ pub const PostgresSQLQuery = struct {
         const event_loop = vm.eventLoop();
         const tag = CommandTag.init(command_tag_str);
 
+        const columns = brk: {
+            const fields = &this.statement.?.fields;
+            const columns = JSValue.createEmptyArray(globalObject, fields.len);
+
+            var i: u32 = 0;
+            for (fields.*) |*field| {
+                columns.putIndex(globalObject, i, field.toJS(globalObject));
+                i += 1;
+            }
+
+            break :brk columns;
+        };
+
         event_loop.runCallback(function, globalObject, thisValue, &.{
             targetValue,
+            columns,
             consumePendingValue(thisValue, globalObject) orelse .undefined,
             tag.toJSTag(globalObject),
             tag.toJSNumber(),

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -628,7 +628,7 @@ pub const PostgresSQLQuery = struct {
 
             const obj = JSValue.createEmptyObject(globalObject, 2);
 
-            obj.put(globalObject, JSC.ZigString.static("string"), bun.String.init(this.query).toJS(globalObject));
+            obj.put(globalObject, JSC.ZigString.static("string"), this.query.toJS(globalObject));
 
             const columns = brk: {
                 const fields = &statement.fields;

--- a/src/sql/postgres/postgres_protocol.zig
+++ b/src/sql/postgres/postgres_protocol.zig
@@ -809,9 +809,9 @@ pub const ErrorResponse = struct {
         const error_code: JSC.Error =
             // https://www.postgresql.org/docs/8.1/errcodes-appendix.html
             if (code.eqlComptime("42601"))
-            JSC.Error.ERR_POSTGRES_SYNTAX_ERROR
-        else
-            JSC.Error.ERR_POSTGRES_SERVER_ERROR;
+                JSC.Error.ERR_POSTGRES_SYNTAX_ERROR
+            else
+                JSC.Error.ERR_POSTGRES_SERVER_ERROR;
         const err = error_code.fmt(globalObject, "{s}", .{b.allocatedSlice()[0..b.len]});
 
         inline for (possible_fields) |field| {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -2385,6 +2385,18 @@ if (isDockerEnabled()) {
     expect((await sql.unsafe("select 1 as x")).columns[0].name).toBe("x");
   });
 
+  test("Result has statement with query", async () => {
+    expect((await sql`select 1 as x`).statement.string).toBe("select 1 as x");
+  });
+
+  test("Result has statement with template query", async () => {
+    expect((await sql`select ${"TEST"} as x`).statement.string).toBe("select $1  as x");
+  });
+
+  test("Result has statement with columns", async () => {
+    expect((await sql`select 1 as x`).statement.columns[0].name).toBe("x");
+  });
+
   // t('forEach has result as second argument', async() => {
   //   let x
   //   await sql`select 1 as x`.forEach((_, result) => x = result)

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -2377,8 +2377,12 @@ if (isDockerEnabled()) {
   //   [true, (await sql`bad keyword`.catch(e => e)) instanceof sql.PostgresError]
   // )
 
-  test.todo("Result has columns spec", async () => {
+  test("Safe result has columns spec", async () => {
     expect((await sql`select 1 as x`).columns[0].name).toBe("x");
+  });
+
+  test("Unsafe result has columns spec", async () => {
+    expect((await sql.unsafe("select 1 as x")).columns[0].name).toBe("x");
   });
 
   // t('forEach has result as second argument', async() => {


### PR DESCRIPTION
### What does this PR do?

Improves: #18866

Exports a `columns` field on `SQLResultArray` providing additional context on columns returned by the query. This is mostly just binding PostgreSQL's  `RowDescription` that was already previously implemented.

This is meant to behave similarly to [postgres.js](https://github.com/porsager/postgres) `columns`. The main difference is our `type` uses the [internal OIDs](https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat) while postgresql.js uses [JDBC's OIDs](https://jdbc.postgresql.org/documentation/publicapi/constant-values.html). This would make ours more accurate but could impact DX that are used to the "less accurate" values.

Here is the result of a test query:

```js
const sql = Bun.SQL(connectionString);

// Using safe
console.log((await sql`select 1 as x, 2 as longer_name, 3 as sp3c141_n4m3`));

// Using unsafe
console.log((await sql.unsafe("select 1 as x, 2 as longer_name, 3 as sp3c141_n4m3")));
```

```
[
  {
    x: 1,
    longer_name: 2,
    sp3c141_n4m3: 3,
  }, count: 1, command: "SELECT", columns: [
    {
      name: "x",
      table: 0,
      number: 0,
      type: 23,
    }, {
      name: "longer_name",
      table: 0,
      number: 0,
      type: 23,
    }, {
      name: "sp3c141_n4m3",
      table: 0,
      number: 0,
      type: 23,
    }
  ]
]
```

- [?] Documentation or TypeScript types (might need some extra work?)
- [x] Code changes

### How did you verify your code works?

- [x] I wrote TypeScript tests and they pass locally (`bun-debug test test/js/sql/sql.test.ts`)
- [x] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed