### PR TITLE
fix(crypto) fix  `setAAD` undefined checks

### DIFF
--- a/src/bun.js/bindings/node/crypto/JSCipherPrototype.cpp
+++ b/src/bun.js/bindings/node/crypto/JSCipherPrototype.cpp
@@ -331,13 +331,12 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherSetAAD, (JSC::JSGlobalObject * globalObject, JS
         JSValue plaintextLengthValue = optionsValue.get(globalObject, Identifier::fromString(vm, "plaintextLength"_s));
         RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
         if (!plaintextLengthValue.isUndefinedOrNull()) {
-            double plaintextLengthNumber = plaintextLengthValue.toNumber(globalObject);
-            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
-
-            plaintextLength = JSC::toInt32(plaintextLengthNumber);
-            if (plaintextLengthNumber != plaintextLength) {
+            std::optional<int32_t> maybePlaintextLength = plaintextLengthValue.tryGetAsInt32();
+            if (!maybePlaintextLength || *maybePlaintextLength < 0) {
                 return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.plaintextLength"_s, plaintextLengthValue);
             }
+
+            plaintextLength = *maybePlaintextLength;
         }
     }
 

--- a/src/bun.js/bindings/node/crypto/JSCipherPrototype.cpp
+++ b/src/bun.js/bindings/node/crypto/JSCipherPrototype.cpp
@@ -323,18 +323,21 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherSetAAD, (JSC::JSGlobalObject * globalObject, JS
         encodingValue = optionsValue.get(globalObject, Identifier::fromString(vm, "encoding"_s));
         RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
-        V::validateString(scope, globalObject, encodingValue, "options.encoding"_s);
-        RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
+        if (!encodingValue.isUndefinedOrNull()) {
+            V::validateString(scope, globalObject, encodingValue, "options.encoding"_s);
+            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
+        }
 
         JSValue plaintextLengthValue = optionsValue.get(globalObject, Identifier::fromString(vm, "plaintextLength"_s));
         RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
+        if (!plaintextLengthValue.isUndefinedOrNull()) {
+            double plaintextLengthNumber = plaintextLengthValue.toNumber(globalObject);
+            RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
 
-        double plaintextLengthNumber = plaintextLengthValue.toNumber(globalObject);
-        RETURN_IF_EXCEPTION(scope, JSValue::encode({}));
-
-        plaintextLength = JSC::toInt32(plaintextLengthNumber);
-        if (plaintextLengthNumber != plaintextLength) {
-            return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.plaintextLength"_s, plaintextLengthValue);
+            plaintextLength = JSC::toInt32(plaintextLengthNumber);
+            if (plaintextLengthNumber != plaintextLength) {
+                return ERR::INVALID_ARG_VALUE(scope, globalObject, "options.plaintextLength"_s, plaintextLengthValue);
+            }
         }
     }
 

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -695,3 +695,20 @@ it("verifyError should not be on the prototype of DiffieHellman and DiffieHellma
   // DH_generate_parameters_ex
   expect(dhg.verifyError).toBe(8);
 });
+it("cipher.setAAD should not throw if encoding or plaintextLength is undefined #18700", () => {
+  const key = crypto.randomBytes(32);
+  const iv = crypto.randomBytes(16);
+  expect(() => {
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    cipher.setAAD("0123456789abcdef0123456789abcdef", {
+      encoding: undefined,
+    });
+  }).not.toThrow();
+
+  expect(() => {
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    cipher.setAAD("0123456789abcdef0123456789abcdef", {
+      plaintextLength: undefined,
+    });
+  }).not.toThrow();
+});


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/18700
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
