### PR TITLE
Unblock importing html files with non-html loader

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3250,7 +3250,7 @@ pub const BundleV2 = struct {
             }
 
             if (this.transpiler.options.dev_server) |dev_server| brk: {
-                if (path.loader(&this.transpiler.options.loaders) == .html) {
+                if (path.loader(&this.transpiler.options.loaders) == .html and (import_record.loader == null or import_record.loader.? == .html)) {
                     // This use case is currently not supported. This error
                     // blocks an assertion failure because the DevServer
                     // reserves the HTML file's spot in IncrementalGraph for the

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -95,6 +95,8 @@ export interface DevServerTest {
 
   /** Starting files */
   files?: FileObject;
+  /** Manually specify which html files to serve */
+  htmlFiles?: string[];
   /**
    * Framework to use. Consider `minimalFramework` if possible.
    * Provide this object or `files['bun.app.ts']` for a dynamic one.
@@ -1490,9 +1492,9 @@ function testImpl<T extends DevServerTest>(
 
     const mainDir = path.resolve(root, options.mainDir ?? ".");
     if (options.files) {
-      const htmlFiles = Object.keys(options.files)
-        .filter(file => file.endsWith(".html"))
-        .map(x => path.join(root, x));
+      const htmlFiles = (options.htmlFiles ?? Object.keys(options.files).filter(file => file.endsWith(".html"))).map(
+        x => path.join(root, x),
+      );
       await writeAll(root, options.files);
       if (options.files["bun.app.ts"] == undefined && htmlFiles.length === 0) {
         if (!options.framework) {

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -299,6 +299,24 @@ devTest("importing html file", {
     });
   },
 });
+devTest("importing html file with text loader (#18154)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import html from "./app.html" with { type: "text" };
+      console.log(html);
+    `,
+    "app.html": "<div>hello world</div>",
+  },
+  htmlFiles: ["index.html"],
+  async test(dev) {
+    await using c = await dev.client("/", {});
+    await c.expectMessage("<div>hello world</div>");
+  },
+});
 devTest("importing bun on the client", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
Fixes #18154

This isn't a great fix, probably in bundle_v2 'loader' should be initialized once rather than constantly determining the loader based on the file path
