### PR TITLE
fix(test): test.failing when tests use a done callback

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -426,8 +426,13 @@ declare module "bun:test" {
      *
      * @param label the label for the test
      * @param fn the test function
+     * @param options the test timeout or options
      */
-    failing(label: string, fn?: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void)): void;
+    failing(
+      label: string,
+      fn?: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
+      options?: number | TestOptions,
+    ): void;
     /**
      * Runs this test, if `condition` is true.
      *

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -633,22 +633,23 @@ pub const TestScope = struct {
 
         if (JSC.getFunctionData(function)) |data| {
             var task = bun.cast(*TestRunnerTask, data);
+            const current_test = task.describe.tests.items[task.describe.current_test_id];
+            const is_failing = current_test.tag == .fail;
+            const test_succeeded = args.len == 0 or args.ptr[0].isEmptyOrUndefinedOrNull();
+            const expect_count = expect.active_test_expectation_counter.actual;
 
             JSC.setFunctionData(function, null);
-            if (args.len > 0) {
-                const err = args.ptr[0];
-                if (err.isEmptyOrUndefinedOrNull()) {
-                    debug("done()", .{});
-                    task.handleResult(.{ .pass = expect.active_test_expectation_counter.actual }, .callback);
-                } else {
-                    debug("done(err)", .{});
-                    _ = globalThis.bunVM().uncaughtException(globalThis, err, true);
-                    task.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .callback);
-                }
-            } else {
-                debug("done()", .{});
-                task.handleResult(.{ .pass = expect.active_test_expectation_counter.actual }, .callback);
+            if (bun.Environment.enable_logs) {
+                if (test_succeeded) debug("done()", .{}) else debug("done(err)", .{});
             }
+
+            const test_result: Result = if (is_failing) blk: {
+                break :blk if (test_succeeded) .{ .fail_because_failing_test_passed = expect_count } else .{ .pass = expect_count };
+            } else blk: {
+                break :blk if (test_succeeded) .{ .pass = expect_count } else .{ .fail = expect_count };
+            };
+
+            task.handleResult(test_result, .callback);
         }
 
         return JSValue.jsUndefined();

--- a/test/js/bun/test/fixtures/failing-test-done-test-fails.fixture.ts
+++ b/test/js/bun/test/fixtures/failing-test-done-test-fails.fixture.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+
+test.failing("test.failing fails when done is called without an error", done => {
+  done();
+});
+
+test.failing("test.failing fails when all expectations are met and done is called without an error", done => {
+  expect(1).toBe(1);
+  done();
+});
+
+test.failing(
+  "test.failing fails when all expectations are met and done is called from a promise without an error",
+  async done => {
+    await Bun.sleep(5);
+    expect(1).toBe(1);
+    done();
+  },
+);

--- a/test/js/bun/test/fixtures/failing-test-done-test-succeeds.fixture.ts
+++ b/test/js/bun/test/fixtures/failing-test-done-test-succeeds.fixture.ts
@@ -1,0 +1,13 @@
+import { test } from "bun:test";
+
+test.failing("test.failing passes when an error is thrown", done => {
+  throw new Error("test error");
+  done();
+});
+
+test.failing("test.failing passes. when done() is called with an error", done => {
+  done(new Error("test error"));
+});
+
+// FIXME
+// test.failing("test.failing passes when done isn't called and the test times out", done => {}, { timeout: 500 });


### PR DESCRIPTION
### What does this PR do?
Fixes #18928

`test.failing` should pass when tests using `done()` pass it an error or throw.

I've also fixed the type definitions for `test.failing` so that it optionally takes `TestOptions` as the 3rd parameter.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
I've added test cases
