### PR TITLE
Fix m_terminationException assertion failure with spawnSync

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -28,7 +28,7 @@ pub const JSGlobalObject = opaque {
         return this.throwValue(err);
     }
 
-    pub const throwTerminationException = JSGlobalObject__throwTerminationException;
+    pub const requestTermination = JSGlobalObject__requestTermination;
     pub const clearTerminationException = JSGlobalObject__clearTerminationException;
 
     pub fn setTimeZone(this: *JSGlobalObject, timeZone: *const ZigString) bool {
@@ -728,7 +728,7 @@ pub const JSGlobalObject = opaque {
     extern fn JSGlobalObject__hasException(*JSGlobalObject) bool;
     extern fn JSGlobalObject__setTimeZone(this: *JSGlobalObject, timeZone: *const ZigString) bool;
     extern fn JSGlobalObject__tryTakeException(*JSGlobalObject) JSValue;
-    extern fn JSGlobalObject__throwTerminationException(this: *JSGlobalObject) void;
+    extern fn JSGlobalObject__requestTermination(this: *JSGlobalObject) void;
 
     extern fn Zig__GlobalObject__create(*anyopaque, i32, bool, bool, ?*anyopaque) *JSGlobalObject;
     pub fn create(

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2591,8 +2591,7 @@ extern "C" JSC__JSValue Bun__JSValue__call(JSContextRef ctx, JSC__JSValue object
     if (callData.type == JSC::CallData::Type::None)
         return JSC::JSValue::encode(JSC::JSValue());
 
-    NakedPtr<JSC::Exception> returnedException = nullptr;
-    auto result = JSC::profiledCall(globalObject, ProfilingReason::API, jsObject, callData, jsThisObject, argList, returnedException);
+    auto result = JSC::profiledCall(globalObject, ProfilingReason::API, jsObject, callData, jsThisObject, argList);
 
     if (asyncContextData) {
         asyncContextData->putInternalField(vm, 0, restoreAsyncContext);

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2559,6 +2559,7 @@ extern "C" JSC__JSValue Bun__JSValue__call(JSContextRef ctx, JSC__JSValue object
 {
     JSC::JSGlobalObject* globalObject = toJS(ctx);
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     ASSERT_WITH_MESSAGE(!vm.isCollectorBusyOnCurrentThread(), "Cannot call function inside a finalizer or while GC is running on same thread.");
 
@@ -2597,12 +2598,7 @@ extern "C" JSC__JSValue Bun__JSValue__call(JSContextRef ctx, JSC__JSValue object
         asyncContextData->putInternalField(vm, 0, restoreAsyncContext);
     }
 
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    if (returnedException.get()) {
-        scope.throwException(globalObject, returnedException.get());
-        return JSC::JSValue::encode({});
-    }
-
+    RETURN_IF_EXCEPTION(scope, {});
     return JSC::JSValue::encode(result);
 }
 

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1421,7 +1421,7 @@ pub const TestRunnerTask = struct {
         if (comptime Environment.allow_assert) assert(!this.reported);
         const elapsed = now.duration(&this.started_at).ms();
         this.ref.unref(this.globalThis.bunVM());
-        this.globalThis.throwTerminationException();
+        this.globalThis.requestTermination();
         this.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .{ .timeout = @intCast(@max(elapsed, 0)) });
     }
 

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -5,7 +5,7 @@ import path from "path";
 if (isFlaky && isLinux) {
   test.todo("processes get killed");
 } else {
-  test.each([true, false])("processes get killed", async sync => {
+  test.each([true, false])(`processes get killed (sync: %p)`, async sync => {
     const { exited, stdout, stderr } = Bun.spawn({
       cmd: [
         bunExe(),
@@ -20,7 +20,6 @@ if (isFlaky && isLinux) {
     const [out, err, exitCode] = await Promise.all([new Response(stdout).text(), new Response(stderr).text(), exited]);
     console.log(out);
     console.log(err);
-    // TODO: figure out how to handle terminatio nexception from spawn sync properly.
     expect(exitCode).not.toBe(0);
     expect(out).not.toContain("This should not be printed!");
     expect(err).toContain("killed 1 dangling process");

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -20,8 +20,12 @@ if (isFlaky && isLinux) {
     const [out, err, exitCode] = await Promise.all([new Response(stdout).text(), new Response(stderr).text(), exited]);
     console.log(out);
     console.log(err);
-    expect(exitCode).not.toBe(0);
+    // exit code should indicate failed tests, not abort or anything
+    expect(exitCode).toBe(1);
     expect(out).not.toContain("This should not be printed!");
     expect(err).toContain("killed 1 dangling process");
+    // both tests should have run with the expected result
+    expect(err).toContain("(fail) test timeout kills dangling processes");
+    expect(err).toContain("(pass) slow test after test timeout");
   });
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a debug-only assertion failure which occurred when tests with `spawnSync` timed out:

- Ensures that the termination exception singleton always exists, not just in workers (since we use it outside workers to stop tests that have timed out)
- Makes `JSGlobalObject__clearTerminationException` actually clear the termination exception (if it has been thrown), not just the request for termination
- Fixes an assertion failure exposed by those changes in `Bun__JSValue__call` trying to rethrow the termination exception (we can just let the throw scope handle this correctly for us)
- Makes `test/cli/test/test-timeout-behavior.test.ts` stricter (ensure the test runner exited with code 1 instead of aborting and ran both tests)

For context, as best I can tell the control flow for termination looks like:

- When you create the VM, if you want to use termination you call `ensureTerminationException()` (doing this for non-workers is the main change on this PR). This sets `m_terminationException` to a new `Exception` instance, and that will be the one used to indicate termination.
- To terminate, you can call `notifyNeedTermination()` from another thread (we should do this in the future for test timeouts so that a test blocking the event loop can still be stopped) or `setHasTerminationRequest()` on the same thread. These both set a flag which is checked later by JavaScript code and used to call `throwTerminationException()`, which just throws the exception stored in `m_terminationException`. This function also asserts that `m_terminationException` is non-null (i.e. that you have called `ensureTerminationException()`), which is what used to be failing.
- At this point the termination exception is mostly just propagated through native code by the normal exception handling mechanisms (except that it can't be caught by JS).

### How did you verify your code works?

These changes are covered by running `test/cli/test/test-timeout-behavior.test.ts` _in debug mode_ (which now passes). I'm not sure if it's possible to write a test for this that would fail in release.