### PR TITLE
Bump Zig again

### DIFF
--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -20,7 +20,7 @@ else()
   unsupported(CMAKE_SYSTEM_NAME)
 endif()
 
-set(ZIG_COMMIT "deab5c9e7526de0a47b449c5545c3a0f66ebc3c8")
+set(ZIG_COMMIT "a207204ee57a061f2fb96c7bae0c491b609e73a5")
 optionx(ZIG_TARGET STRING "The zig target to use" DEFAULT ${DEFAULT_ZIG_TARGET})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/src/allocators.zig
+++ b/src/allocators.zig
@@ -28,7 +28,7 @@ pub fn sliceRange(slice: []const u8, buffer: []const u8) ?[2]u32 {
         null;
 }
 
-pub const IndexType = packed struct {
+pub const IndexType = packed struct(u32) {
     index: u31,
     is_overflow: bool = false,
 };

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1389,7 +1389,7 @@ fn NewSocket(comptime ssl: bool) type {
                 total: usize = 0,
             },
         };
-        const Flags = packed struct {
+        const Flags = packed struct(u16) {
             is_active: bool = false,
             /// Prevent onClose from calling into JavaScript while we are finalizing
             finalizing: bool = false,
@@ -1400,6 +1400,7 @@ fn NewSocket(comptime ssl: bool) type {
             owned_protos: bool = true,
             is_paused: bool = false,
             allow_half_open: bool = false,
+            _: u7 = 0,
         };
 
         pub usingnamespace if (!ssl)

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -131,7 +131,7 @@ const Handlers = struct {
     is_server: bool = false,
     promise: JSC.Strong = .empty,
 
-    protection_count: bun.DebugOnly(u32) = bun.DebugOnlyDefault(0),
+    protection_count: bun.DebugOnly(u32) = if (Environment.isDebug) 0,
 
     pub fn markActive(this: *Handlers) void {
         Listener.log("markActive", .{});

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -275,7 +275,7 @@ const Handlers = struct {
             return;
         }
 
-        if (comptime Environment.allow_assert) {
+        if (comptime Environment.isDebug) {
             bun.assert(this.protection_count > 0);
             this.protection_count -= 1;
         }
@@ -291,7 +291,7 @@ const Handlers = struct {
     }
 
     pub fn protect(this: *Handlers) void {
-        if (comptime Environment.allow_assert) {
+        if (comptime Environment.isDebug) {
             this.protection_count += 1;
         }
         this.onOpen.protect();

--- a/src/bun.js/api/bun/ssl_wrapper.zig
+++ b/src/bun.js/api/bun/ssl_wrapper.zig
@@ -33,7 +33,7 @@ pub fn SSLWrapper(comptime T: type) type {
 
         flags: Flags = .{},
 
-        pub const Flags = packed struct {
+        pub const Flags = packed struct(u8) {
             handshake_state: HandshakeState = HandshakeState.HANDSHAKE_PENDING,
             received_ssl_shutdown: bool = false,
             sent_ssl_shutdown: bool = false,

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -46,12 +46,13 @@ stdout_maxbuf: ?*MaxBuf = null,
 stderr_maxbuf: ?*MaxBuf = null,
 exited_due_to_maxbuf: ?MaxBuf.Kind = null,
 
-pub const Flags = packed struct {
+pub const Flags = packed struct(u8) {
     is_sync: bool = false,
     killed: bool = false,
     has_stdin_destructor_called: bool = false,
     finalized: bool = false,
     deref_on_stdin_destroyed: bool = false,
+    _: u3 = 0,
 };
 
 pub const SignalCode = bun.SignalCode;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2413,7 +2413,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             }
 
             ctxLog("deinit<d> ({*})<r>", .{this});
-            if (comptime Environment.allow_assert)
+            if (comptime Environment.isDebug)
                 assert(this.flags.has_finalized);
 
             this.request_body_buf.clearAndFree(this.allocator);
@@ -2824,7 +2824,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             assert(this.server != null);
             const globalThis = this.server.?.globalThis;
 
-            if (comptime Environment.allow_assert) {
+            if (comptime Environment.isDebug) {
                 ctxLog("finalizeWithoutDeinit: has_finalized {any}", .{this.flags.has_finalized});
                 this.flags.has_finalized = true;
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1934,7 +1934,7 @@ pub const HTTPStatusText = struct {
 };
 
 fn NewFlags(comptime debug_mode: bool) type {
-    return packed struct {
+    return packed struct(u16) {
         has_marked_complete: bool = false,
         has_marked_pending: bool = false,
         has_abort_handler: bool = false,
@@ -1957,6 +1957,21 @@ fn NewFlags(comptime debug_mode: bool) type {
         has_finalized: bun.DebugOnly(bool) = bun.DebugOnlyDefault(false),
 
         is_error_promise_pending: bool = false,
+
+        _padding: PaddingInt = 0,
+
+        const PaddingInt = brk: {
+            var size: usize = 2;
+            if (Environment.isDebug) {
+                size -= 1;
+            }
+
+            if (debug_mode) {
+                size -= 1;
+            }
+
+            break :brk std.meta.Int(.unsigned, size);
+        };
     };
 }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1954,7 +1954,7 @@ fn NewFlags(comptime debug_mode: bool) type {
         has_written_status: bool = false,
         response_protected: bool = false,
         aborted: bool = false,
-        has_finalized: bun.DebugOnly(bool) = bun.DebugOnlyDefault(false),
+        has_finalized: bun.DebugOnly(bool) = if (Environment.isDebug) false,
 
         is_error_promise_pending: bool = false,
 

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5632,9 +5632,14 @@ pub const NodeFS = struct {
     }
 
     pub fn rm(this: *NodeFS, args: Arguments.Rm, _: Flavor) Maybe(Return.Rm) {
+        return this.rmAt(bun.toFD(std.fs.cwd().fd), args);
+    }
+
+    pub fn rmAt(this: *NodeFS, fd: bun.FileDescriptor, args: Arguments.Rm) Maybe(Return.Rm) {
+
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if (args.recursive) {
-            zigDeleteTree(std.fs.cwd(), args.path.slice(), .file) catch |err| {
+            zigDeleteTree(fd.asDir(), args.path.slice(), .file) catch |err| {
                 bun.handleErrorReturnTrace(err, @errorReturnTrace());
                 const errno: E = switch (@as(anyerror, err)) {
                     // error.InvalidHandle => .BADF,
@@ -6750,10 +6755,7 @@ pub fn zigDeleteTree(self: std.fs.Dir, sub_path: []const u8, kind_hint: std.fs.F
                             continue :process_stack;
                         } else |err| switch (err) {
                             error.FileNotFound => continue :process_stack,
-
-                            // Impossible because we do not pass any path separators.
-                            error.NotDir => unreachable,
-
+                            error.NotDir => if (Environment.isDebug) unreachable else return error.Unexpected,
                             error.IsDir => {
                                 treat_as_dir = true;
                                 continue :handle_entry;
@@ -6911,9 +6913,7 @@ fn zigDeleteTreeMinStackSizeWithKindHint(self: std.fs.Dir, sub_path: []const u8,
                             continue :dir_it;
                         } else |err| switch (err) {
                             error.FileNotFound => continue :dir_it,
-
-                            // Impossible because we do not pass any path separators.
-                            error.NotDir => unreachable,
+                            error.NotDir => if (Environment.isDebug) unreachable else return error.Unexpected,
 
                             error.IsDir => {
                                 treat_as_dir = true;

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5631,7 +5631,7 @@ pub const NodeFS = struct {
             Maybe(Return.Rmdir).success;
     }
 
-    pub fn rm(this: *NodeFS, args: Arguments.Rm) Maybe(Return.Rm) {
+    pub fn rm(this: *NodeFS, args: Arguments.Rm, _: Flavor) Maybe(Return.Rm) {
 
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if (args.recursive) {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5631,15 +5631,11 @@ pub const NodeFS = struct {
             Maybe(Return.Rmdir).success;
     }
 
-    pub fn rm(this: *NodeFS, args: Arguments.Rm, _: Flavor) Maybe(Return.Rm) {
-        return this.rmAt(bun.toFD(std.fs.cwd().fd), args);
-    }
-
-    pub fn rmAt(this: *NodeFS, fd: bun.FileDescriptor, args: Arguments.Rm) Maybe(Return.Rm) {
+    pub fn rm(this: *NodeFS, args: Arguments.Rm) Maybe(Return.Rm) {
 
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if (args.recursive) {
-            zigDeleteTree(fd.asDir(), args.path.slice(), .file) catch |err| {
+            zigDeleteTree(std.fs.cwd(), args.path.slice(), .file) catch |err| {
                 bun.handleErrorReturnTrace(err, @errorReturnTrace());
                 const errno: E = switch (@as(anyerror, err)) {
                     // error.InvalidHandle => .BADF,

--- a/src/bun.js/node/util/validators.zig
+++ b/src/bun.js/node/util/validators.zig
@@ -185,10 +185,11 @@ pub fn validateBoolean(globalThis: *JSGlobalObject, value: JSValue, comptime nam
     return value.asBoolean();
 }
 
-pub const ValidateObjectOptions = packed struct {
+pub const ValidateObjectOptions = packed struct(u8) {
     allow_nullable: bool = false,
     allow_array: bool = false,
     allow_function: bool = false,
+    _: u5 = 0,
 };
 
 pub fn validateObject(globalThis: *JSGlobalObject, value: JSValue, comptime name_fmt: string, name_args: anytype, comptime options: ValidateObjectOptions) bun.JSError!void {

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -80,7 +80,7 @@ pub const Expect = struct {
         return null;
     }
 
-    pub const Flags = packed struct {
+    pub const Flags = packed struct(u8) {
         // note: keep this struct in sync with C++ implementation (at bindings.cpp)
 
         promise: enum(u2) {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -449,15 +449,15 @@ pub const ByteList = BabyList(u8);
 pub const OffsetByteList = OffsetList(u8);
 
 pub fn DebugOnly(comptime Type: type) type {
-    if (comptime Environment.allow_assert) {
+    if (comptime Environment.isDebug) {
         return Type;
     }
 
     return void;
 }
 
-pub fn DebugOnlyDefault(comptime val: anytype) if (Environment.allow_assert) @TypeOf(val) else void {
-    if (comptime Environment.allow_assert) {
+pub fn DebugOnlyDefault(comptime val: anytype) if (Environment.isDebug) @TypeOf(val) else void {
+    if (comptime Environment.isDebug) {
         return val;
     }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1582,19 +1582,19 @@ comptime {
 pub fn DebugOnlyDisabler(comptime Type: type) type {
     return struct {
         const T = Type;
-        threadlocal var disable_create_in_debug: if (Environment.allow_assert) usize else u0 = 0;
+        threadlocal var disable_create_in_debug: if (Environment.isDebug) usize else u0 = 0;
         pub inline fn disable() void {
-            if (comptime !Environment.allow_assert) return;
+            if (comptime !Environment.isDebug) return;
             disable_create_in_debug += 1;
         }
 
         pub inline fn enable() void {
-            if (comptime !Environment.allow_assert) return;
+            if (comptime !Environment.isDebug) return;
             disable_create_in_debug -= 1;
         }
 
         pub inline fn assert() void {
-            if (comptime !Environment.allow_assert) return;
+            if (comptime !Environment.isDebug) return;
             if (disable_create_in_debug > 0) {
                 Output.panic(comptime "[" ++ @typeName(T) ++ "] called while disabled (did you forget to call enable?)", .{});
             }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -5663,7 +5663,7 @@ pub const JSMeta = struct {
 
     flags: Flags = .{},
 
-    pub const Flags = packed struct {
+    pub const Flags = packed struct(u8) {
         /// This is true if this file is affected by top-level await, either by having
         /// a top-level await inside this file or by having an import/export statement
         /// that transitively imports such a file. It is forbidden to call "require()"
@@ -16808,7 +16808,7 @@ pub const PartRange = struct {
     part_index_end: u32 = 0,
 };
 
-const StableRef = packed struct {
+const StableRef = packed struct(u96) {
     stable_source_index: Index.Int,
     ref: Ref,
 

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2171,7 +2171,7 @@ pub const PackCommand = struct {
         glob: CowString,
         flags: Flags,
 
-        const Flags = packed struct {
+        const Flags = packed struct(u8) {
             /// beginning or middle slash (leading slash was trimmed)
             rel_path: bool,
             // can only match directories (had an ending slash, also trimmed)
@@ -2180,6 +2180,8 @@ pub const PackCommand = struct {
             @"leading **/": bool,
             /// true if the pattern starts with `!`
             negated: bool,
+
+            _: u4 = 0,
         };
 
         pub fn fromUTF8(allocator: std.mem.Allocator, pattern: string) OOM!?Pattern {

--- a/src/copy_file.zig
+++ b/src/copy_file.zig
@@ -44,7 +44,7 @@ const InputType = if (Environment.isWindows) bun.OSPathSliceZ else posix.fd_t;
 ///
 /// on macOS and other platforms, sendfile() only works when one of the ends is a socket
 /// and in general on macOS, it doesn't seem to have much performance impact.
-const LinuxCopyFileState = packed struct {
+const LinuxCopyFileState = packed struct(u8) {
     /// This is the most important flag for reducing the system call count
     /// When copying files from one folder to another, if we see EXDEV once
     /// there's a very good chance we will see it for every file thereafter in that folder.
@@ -53,6 +53,7 @@ const LinuxCopyFileState = packed struct {
     has_ioctl_ficlone_failed: bool = false,
     has_copy_file_range_failed: bool = false,
     has_sendfile_failed: bool = false,
+    _: u4 = 0,
 };
 const EmptyCopyFileState = struct {};
 pub const CopyFileState = if (Environment.isLinux) LinuxCopyFileState else EmptyCopyFileState;

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -572,11 +572,12 @@ pub const WindowsNamedPipe = if (Environment.isWindows) struct {
     current_timeout: u32 = 0,
     flags: Flags = .{},
 
-    pub const Flags = packed struct {
+    pub const Flags = packed struct(u8) {
         disconnected: bool = true,
         is_closed: bool = false,
         is_client: bool = false,
         is_ssl: bool = false,
+        _: u4 = 0,
     };
     pub const Handlers = struct {
         ctx: *anyopaque,

--- a/src/dns.zig
+++ b/src/dns.zig
@@ -45,7 +45,7 @@ pub const GetAddrInfo = struct {
         return hasher.final();
     }
 
-    pub const Options = packed struct {
+    pub const Options = packed struct(u64) {
         family: Family = .unspecified,
         /// Leaving this unset leads to many duplicate addresses returned.
         /// Node hardcodes to `SOCK_STREAM`.
@@ -56,6 +56,7 @@ pub const GetAddrInfo = struct {
         protocol: Protocol = .unspecified,
         backend: Backend = Backend.default,
         flags: std.c.AI = .{},
+        _: u24 = 0,
 
         pub fn toLibC(this: Options) ?std.c.addrinfo {
             if (this.family == .unspecified and this.socktype == .unspecified and this.protocol == .unspecified and this.flags == std.c.AI{}) {

--- a/src/http.zig
+++ b/src/http.zig
@@ -1125,9 +1125,10 @@ pub const HTTPThread = struct {
     const WriteMessage = struct {
         data: []const u8,
         async_http_id: u32,
-        flags: packed struct {
+        flags: packed struct(u8) {
             is_tls: bool,
             ended: bool,
+            _: u6 = 0,
         },
     };
     const ShutdownMessage = struct {
@@ -2032,13 +2033,14 @@ pub const InternalState = struct {
     response_stage: HTTPStage = .pending,
     certificate_info: ?CertificateInfo = null,
 
-    pub const InternalStateFlags = packed struct {
+    pub const InternalStateFlags = packed struct(u8) {
         allow_keepalive: bool = true,
         received_last_chunk: bool = false,
         did_set_content_encoding: bool = false,
         is_redirect_pending: bool = false,
         is_libdeflate_fast_path_disabled: bool = false,
         resend_request_body_on_redirect: bool = false,
+        _padding: u2 = 0,
     };
 
     pub fn init(body: HTTPRequestBody, body_out_str: *MutableString) InternalState {
@@ -2221,7 +2223,7 @@ pub const HTTPVerboseLevel = enum {
     curl,
 };
 
-pub const Flags = packed struct {
+pub const Flags = packed struct(u16) {
     disable_timeout: bool = false,
     disable_keepalive: bool = false,
     disable_decompression: bool = false,
@@ -2233,6 +2235,7 @@ pub const Flags = packed struct {
     is_preconnect_only: bool = false,
     is_streaming_request_body: bool = false,
     defer_fail_until_connecting_is_complete: bool = false,
+    _padding: u5 = 0,
 };
 
 // TODO: reduce the size of this struct

--- a/src/http/websocket.zig
+++ b/src/http/websocket.zig
@@ -37,7 +37,7 @@ pub const Opcode = enum(u4) {
     }
 };
 
-pub const WebsocketHeader = packed struct {
+pub const WebsocketHeader = packed struct(u16) {
     len: u7,
     mask: bool,
     opcode: Opcode,

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7728,7 +7728,7 @@ pub const PackageManager = struct {
             }
         }
 
-        pub const Do = packed struct {
+        pub const Do = packed struct(u16) {
             save_lockfile: bool = true,
             load_lockfile: bool = true,
             install_packages: bool = true,
@@ -7741,9 +7741,10 @@ pub const PackageManager = struct {
             trust_dependencies_from_args: bool = false,
             update_to_latest: bool = false,
             analyze: bool = false,
+            _: u4 = 0,
         };
 
-        pub const Enable = packed struct {
+        pub const Enable = packed struct(u16) {
             manifest_cache: bool = true,
             manifest_cache_control: bool = true,
             cache: bool = true,
@@ -7758,6 +7759,7 @@ pub const PackageManager = struct {
 
             exact_versions: bool = false,
             only_missing: bool = false,
+            _: u7 = 0,
         };
     };
 

--- a/src/install/windows-shim/bun_shim_impl.zig
+++ b/src/install/windows-shim/bun_shim_impl.zig
@@ -620,7 +620,7 @@ fn launcher(comptime mode: LauncherMode, bun_ctx: anytype) mode.RetType() {
         true => spawn_command_line: {
             // When the shebang flag is set, we expect two u32s containing byte lengths of the bin and arg components
             // This is not needed for the other case because the other case does not have an args component.
-            const ShebangMetadataPacked = packed struct {
+            const ShebangMetadataPacked = packed struct(u64) {
                 bin_path_len_bytes: u32,
                 args_len_bytes: u32,
             };

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -83,7 +83,7 @@ const PosixBufferedReader = struct {
     count: usize = 0,
     maxbuf: ?*MaxBuf = null,
 
-    const Flags = packed struct {
+    const Flags = packed struct(u16) {
         is_done: bool = false,
         pollable: bool = false,
         nonblocking: bool = false,
@@ -93,6 +93,7 @@ const PosixBufferedReader = struct {
         close_handle: bool = true,
         memfd: bool = false,
         use_pread: bool = false,
+        _: u7 = 0,
     };
 
     pub fn init(comptime Type: type) PosixBufferedReader {
@@ -673,7 +674,7 @@ pub const WindowsBufferedReader = struct {
         return @sizeOf(@This()) + this._buffer.capacity;
     }
 
-    const Flags = packed struct {
+    const Flags = packed struct(u16) {
         is_done: bool = false,
         pollable: bool = false,
         nonblocking: bool = false,
@@ -684,6 +685,7 @@ pub const WindowsBufferedReader = struct {
         is_paused: bool = true,
         has_inflight_read: bool = false,
         use_pread: bool = false,
+        _: u7 = 0,
     };
 
     pub fn init(comptime Type: type) WindowsBufferedReader {

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -89,7 +89,7 @@ const SkipTypeParameterResult = enum {
     definitely_type_parameters,
 };
 
-const TypeParameterFlag = packed struct {
+const TypeParameterFlag = packed struct(u8) {
     /// TypeScript 4.7
     allow_in_out_variance_annotations: bool = false,
 
@@ -98,6 +98,8 @@ const TypeParameterFlag = packed struct {
 
     /// Allow "<>" without any type parameters
     allow_empty_type_parameters: bool = false,
+
+    _: u5 = 0,
 };
 
 const JSXImport = enum {
@@ -2436,11 +2438,12 @@ const AsyncPrefixExpression = enum(u2) {
     }
 };
 
-const IdentifierOpts = packed struct {
+const IdentifierOpts = packed struct(u8) {
     assign_target: js_ast.AssignTarget = js_ast.AssignTarget.none,
     is_delete_target: bool = false,
     was_originally_identifier: bool = false,
     is_call_target: bool = false,
+    _padding: u3 = 0,
 };
 
 fn statementCaresAboutScope(stmt: Stmt) bool {

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -394,7 +394,7 @@ pub const Data = struct {
     }
 };
 
-pub const BabyString = packed struct {
+pub const BabyString = packed struct(u32) {
     offset: u16,
     len: u16,
 

--- a/src/ptr/tagged_pointer.zig
+++ b/src/ptr/tagged_pointer.zig
@@ -10,7 +10,7 @@ const C = bun.C;
 
 const AddressableSize = u49;
 
-pub const TaggedPointer = packed struct {
+pub const TaggedPointer = packed struct(u64) {
     _ptr: AddressableSize,
     data: Tag,
 

--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -454,7 +454,7 @@ pub const StableSymbolCount = struct {
     }
 };
 
-const SlotAndCount = packed struct {
+const SlotAndCount = packed struct(u64) {
     slot: u32,
     count: u32,
 

--- a/src/router.zig
+++ b/src/router.zig
@@ -508,7 +508,7 @@ pub fn loadRoutes(
     this.loaded_routes = true;
 }
 
-pub const TinyPtr = packed struct {
+pub const TinyPtr = packed struct(u32) {
     offset: u16 = 0,
     len: u16 = 0,
 

--- a/src/shell/EnvStr.zig
+++ b/src/shell/EnvStr.zig
@@ -6,7 +6,7 @@
 /// don't want to incur the cost of heap allocating them and refcounting them
 ///
 /// So environment strings can be ref counted or borrowed slices
-pub const EnvStr = packed struct {
+pub const EnvStr = packed struct(u128) {
     ptr: u48,
     tag: Tag = .empty,
     len: usize = 0,

--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -11,7 +11,7 @@ const log = bun.Output.scoped(.BRACES, false);
 
 /// Using u16 because anymore tokens than that results in an unreasonably high
 /// amount of brace expansion (like around 32k variants to expand)
-const ExpansionVariant = packed struct {
+const ExpansionVariant = packed struct(u32) {
     start: u16 = 0,
     end: u16 = 0, // must be >= start
 };

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -615,7 +615,7 @@ pub const ShellCpTask = struct {
     }
 };
 
-const Opts = packed struct {
+const Opts = packed struct(u16) {
     /// -f
     ///
     /// If the destination file cannot be opened, remove it and create a
@@ -680,6 +680,8 @@ const Opts = packed struct {
     ///
     /// Do not overwrite an existing file.  (The -n option overrides any previous -f or -i options.)
     overwrite_existing_file: bool = true,
+
+    _padding: u7 = 0,
 
     const Parse = FlagParser(*@This());
 

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -3318,7 +3318,7 @@ const SrcAscii = struct {
     bytes: []const u8,
     i: usize,
 
-    const IndexValue = packed struct {
+    const IndexValue = packed struct(u8) {
         char: u7,
         escaped: bool = false,
     };
@@ -3350,7 +3350,7 @@ const SrcUnicode = struct {
     cursor: CodepointIterator.Cursor,
     next_cursor: CodepointIterator.Cursor,
 
-    const IndexValue = packed struct {
+    const IndexValue = packed struct(u32) {
         char: u29,
         width: u3 = 0,
     };

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -443,10 +443,11 @@ pub const ShellSubprocess = struct {
         }
     };
 
-    pub const Flags = packed struct(u3) {
+    pub const Flags = packed struct(u8) {
         is_sync: bool = false,
         killed: bool = false,
         waiting_for_onexit: bool = false,
+        _: u5 = 0,
     };
     pub const SignalCode = bun.SignalCode;
 

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -253,7 +253,7 @@ pub const PostgresSQLContext = struct {
         @export(&js_init, .{ .name = "PostgresSQLContext__init" });
     }
 };
-pub const PostgresSQLQueryResultMode = enum(u8) {
+pub const PostgresSQLQueryResultMode = enum(u2) {
     objects = 0,
     values = 1,
     raw = 2,
@@ -272,12 +272,13 @@ pub const PostgresSQLQuery = struct {
 
     ref_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(1),
 
-    flags: packed struct {
+    flags: packed struct(u8) {
         is_done: bool = false,
         binary: bool = false,
         bigint: bool = false,
         simple: bool = false,
         result_mode: PostgresSQLQueryResultMode = .objects,
+        _padding: u2 = 0,
     } = .{},
 
     pub usingnamespace JSC.Codegen.JSPostgresSQLQuery;

--- a/src/string.zig
+++ b/src/string.zig
@@ -1118,10 +1118,10 @@ pub const SliceWithUnderlyingString = struct {
     utf8: ZigString.Slice = ZigString.Slice.empty,
     underlying: String = String.dead,
 
-    did_report_extra_memory_debug: bun.DebugOnly(bool) = if (bun.Environment.allow_assert) false,
+    did_report_extra_memory_debug: bun.DebugOnly(bool) = if (bun.Environment.isDebug) false,
 
     pub inline fn reportExtraMemory(this: *SliceWithUnderlyingString, vm: *JSC.VM) void {
-        if (comptime bun.Environment.allow_assert) {
+        if (comptime bun.Environment.isDebug) {
             bun.assert(!this.did_report_extra_memory_debug);
             this.did_report_extra_memory_debug = true;
         }

--- a/src/string/PathString.zig
+++ b/src/string/PathString.zig
@@ -1,14 +1,18 @@
 const std = @import("std");
 const bun = @import("root").bun;
+const PathIntLen = std.math.IntFittingRange(0, bun.MAX_PATH_BYTES);
+const use_small_path_string_ = @bitSizeOf(usize) - @bitSizeOf(PathIntLen) >= 53;
+
+const PathStringBackingIntType = if (use_small_path_string_) u64 else u128;
 
 // macOS sets file path limit to 1024
 // Since a pointer on x64 is 64 bits and only 46 bits are used
 // We can safely store the entire path slice in a single u64.
-pub const PathString = packed struct {
-    const PathIntLen = std.math.IntFittingRange(0, bun.MAX_PATH_BYTES);
-    pub const use_small_path_string = @bitSizeOf(usize) - @bitSizeOf(PathIntLen) >= 53;
-    pub const PathInt = if (use_small_path_string) PathIntLen else usize;
-    pub const PointerIntType = if (use_small_path_string) u53 else usize;
+pub const PathString = packed struct(PathStringBackingIntType) {
+    pub const PathInt = if (use_small_path_string_) PathIntLen else usize;
+    pub const PointerIntType = if (use_small_path_string_) u53 else usize;
+    pub const use_small_path_string = use_small_path_string_;
+
     ptr: PointerIntType = 0,
     len: PathInt = 0,
 

--- a/src/string/SmolStr.zig
+++ b/src/string/SmolStr.zig
@@ -4,7 +4,7 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 
 /// This is a string type that stores up to 15 bytes inline on the stack, and heap allocates if it is longer
-pub const SmolStr = packed struct {
+pub const SmolStr = packed struct(u128) {
     __len: u32,
     cap: u32,
     __ptr: [*]u8,
@@ -16,7 +16,7 @@ pub const SmolStr = packed struct {
         try writer.write(self.slice());
     }
 
-    pub const Inlined = packed struct {
+    pub const Inlined = packed struct(u128) {
         data: u120,
         __len: u7,
         _tag: u1,

--- a/src/string_immutable.zig
+++ b/src/string_immutable.zig
@@ -629,7 +629,7 @@ pub const StringOrTinyString = struct {
     const Buffer = [Max]u8;
 
     remainder_buf: Buffer = undefined,
-    meta: packed struct {
+    meta: packed struct(u8) {
         remainder_len: u7 = 0,
         is_tiny_string: u1 = 0,
     } = .{},
@@ -5220,7 +5220,7 @@ pub const PackedCodepointIterator = struct {
 
     pub const ZeroValue = zeroValue;
 
-    pub const Cursor = packed struct {
+    pub const Cursor = packed struct(u64) {
         i: u32 = 0,
         c: u29 = zeroValue,
         width: u3 = 0,

--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -5,7 +5,7 @@
 pub const ValkeyContext = @import("ValkeyContext.zig");
 
 /// Connection flags to track Valkey client state
-pub const ConnectionFlags = packed struct {
+pub const ConnectionFlags = packed struct(u8) {
     is_authenticated: bool = false,
     is_manually_closed: bool = false,
     enable_offline_queue: bool = true,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
