### PR TITLE
Declare properties of WebSocket interface, + generators in Bun.BodyInit

### DIFF
--- a/packages/bun-types/fetch.d.ts
+++ b/packages/bun-types/fetch.d.ts
@@ -10,7 +10,12 @@
 
 declare module "bun" {
   type HeadersInit = string[][] | Record<string, string | ReadonlyArray<string>> | Headers;
-  type BodyInit = ReadableStream | Bun.XMLHttpRequestBodyInit | URLSearchParams | AsyncGenerator<Uint8Array>;
+  type BodyInit =
+    | ReadableStream
+    | Bun.XMLHttpRequestBodyInit
+    | URLSearchParams
+    | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+    | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>);
 
   namespace __internal {
     type LibOrFallbackHeaders = LibDomIsLoaded extends true ? {} : import("undici-types").Headers;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -12,6 +12,8 @@ declare module "bun" {
     type NodeCryptoWebcryptoSubtleCrypto = import("crypto").webcrypto.SubtleCrypto;
     type NodeCryptoWebcryptoCryptoKey = import("crypto").webcrypto.CryptoKey;
 
+    type LibEmptyOrWSWebSocket = LibDomIsLoaded extends true ? {} : import("ws").WebSocket;
+
     type LibEmptyOrNodeUtilTextEncoder = LibDomIsLoaded extends true ? {} : import("node:util").TextEncoder;
 
     type LibEmptyOrNodeUtilTextDecoder = LibDomIsLoaded extends true ? {} : import("node:util").TextDecoder;
@@ -66,6 +68,7 @@ declare var Worker: Bun.__internal.UseLibDomIfAvailable<
   }
 >;
 
+interface WebSocket extends Bun.__internal.LibEmptyOrWSWebSocket {}
 /**
  * A WebSocket client implementation
  *

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -102,15 +102,24 @@ describe("@types/bun integration test", () => {
     `;
 
     const importantLines = [
+      "globals.ts",
       "error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
+
+      "index.ts",
       "error TS2345: Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.",
+
+      "streams.ts",
       "error TS2769: No overload matches this call.",
-      "Overload 1 of 3, '(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number", // This line ends early because we've seen TypeScript emit differing messages in different environments
       "ReadableStream<Uint8Array<ArrayBufferLike>>', gave the following error.",
+      "Overload 1 of 3, '(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number", // This line truncates because we've seen TypeScript emit differing messages in different environments
       `Type '"direct"' is not assignable to type '"bytes"'`,
       "error TS2345: Argument of type '{ headers: { \"x-bun\": string; }; }' is not assignable to parameter of type 'number'.",
       "error TS2339: Property 'write' does not exist on type 'ReadableByteStreamController'.",
+
+      "websocket.ts",
       "error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
+
+      "worker.ts",
       "error TS2339: Property 'ref' does not exist on type 'Worker'.",
       "error TS2339: Property 'unref' does not exist on type 'Worker'.",
       "error TS2339: Property 'threadId' does not exist on type 'Worker'.",

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -105,6 +105,11 @@ describe("@types/bun integration test", () => {
       "globals.ts",
       "error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
 
+      "http.ts",
+      `error TS2345: Argument of type '() => AsyncGenerator<Uint8Array<ArrayBuffer> | "hey", void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.`,
+      `error TS2345: Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer> | "it works!", void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'`,
+      `Type 'AsyncGenerator<Uint8Array<ArrayBuffer> | "it works!", void, unknown>' is missing the following properties from type 'ReadableStream<any>'`,
+
       "index.ts",
       "error TS2345: Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.",
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -102,14 +102,15 @@ describe("@types/bun integration test", () => {
     `;
 
     const importantLines = [
-      `error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.`,
-      `error TS2345: Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.`,
+      "error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
+      "error TS2345: Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.",
       "error TS2769: No overload matches this call.",
       "Overload 1 of 3, '(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number", // This line ends early because we've seen TypeScript emit differing messages in different environments
       "ReadableStream<Uint8Array<ArrayBufferLike>>', gave the following error.",
       `Type '"direct"' is not assignable to type '"bytes"'`,
       "error TS2345: Argument of type '{ headers: { \"x-bun\": string; }; }' is not assignable to parameter of type 'number'.",
       "error TS2339: Property 'write' does not exist on type 'ReadableByteStreamController'.",
+      "error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
       "error TS2339: Property 'ref' does not exist on type 'Worker'.",
       "error TS2339: Property 'unref' does not exist on type 'Worker'.",
       "error TS2339: Property 'threadId' does not exist on type 'Worker'.",

--- a/test/integration/bun-types/fixture/http.ts
+++ b/test/integration/bun-types/fixture/http.ts
@@ -39,3 +39,19 @@ fetch("https://example.com", {
   },
   proxy: "cool",
 });
+
+const a = new Response(async function* () {
+  yield new Uint8Array([50, 60, 70]);
+  yield "hey";
+  await Bun.sleep(500);
+});
+
+const b_generator = async function* () {
+  await Bun.sleep(500);
+  yield new Uint8Array([1, 2, 3]);
+  yield "it works!";
+};
+
+const b = new Response(b_generator());
+
+for (const r of await Promise.all([a.text(), b.text()])) console.log(r);

--- a/test/integration/bun-types/fixture/websocket.ts
+++ b/test/integration/bun-types/fixture/websocket.ts
@@ -1,0 +1,15 @@
+export class TestWebSocketClient {
+  #ws: WebSocket;
+
+  constructor() {
+    this.#ws = new WebSocket("wss://dev.local", {
+      headers: {
+        cookie: "test=test",
+      },
+    });
+  }
+
+  close() {
+    if (this.#ws != null) this.#ws.close();
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Fixes #18949, I tested it works with a new test case that checks for passing headers as well as `.close()` existing (so properties and methods on the interface exist)

Also fixes #18946 by allowing string, ArrayBuffer and ArrayBufferView generators in Bun.BodyInit
