### PR TITLE
docs(redis): replace client.disconnect() with client.close()

### DIFF
--- a/docs/api/redis.md
+++ b/docs/api/redis.md
@@ -96,7 +96,7 @@ await client.connect();
 await client.set("key", "value");
 
 // Disconnect when done
-client.disconnect();
+client.close();
 ```
 
 ## Basic Operations
@@ -241,7 +241,7 @@ client.onclose = error => {
 
 // Manually connect/disconnect
 await client.connect();
-client.disconnect();
+client.close();
 ```
 
 ### Connection Status and Monitoring


### PR DESCRIPTION
### What does this PR do?

This PR replace `client.disconnect()` with `client.close()` in Redis client documentation as `client.disconnect()` doesn't exist :

```
TypeError: client.disconnect is not a function. (In 'client.disconnect()', 'client.disconnect' is undefined)
```
- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
