### PR TITLE
fix: `BufferWriter` never returns an error

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -179,10 +179,7 @@ pub const TransformTask = struct {
             return;
         }
 
-        var buffer_writer = JSPrinter.BufferWriter.init(allocator) catch |err| {
-            this.err = err;
-            return;
-        };
+        var buffer_writer = JSPrinter.BufferWriter.init(allocator);
         buffer_writer.buffer.list.ensureTotalCapacity(allocator, 512) catch unreachable;
         buffer_writer.reset();
 
@@ -1035,9 +1032,7 @@ pub fn transformSync(
     }
 
     var buffer_writer = this.buffer_writer orelse brk: {
-        var writer = JSPrinter.BufferWriter.init(arena.backingAllocator()) catch {
-            return globalThis.throw("Failed to create BufferWriter", .{});
-        };
+        var writer = JSPrinter.BufferWriter.init(arena.backingAllocator());
 
         writer.buffer.growIfNeeded(code.len) catch unreachable;
         writer.buffer.list.expandToCapacity();

--- a/src/bun.js/api/TOMLObject.zig
+++ b/src/bun.js/api/TOMLObject.zig
@@ -35,9 +35,7 @@ pub fn parse(
     };
 
     // for now...
-    const buffer_writer = js_printer.BufferWriter.init(allocator) catch {
-        return globalThis.throwValue(log.toJS(globalThis, default_allocator, "Failed to print toml"));
-    };
+    const buffer_writer = js_printer.BufferWriter.init(allocator);
     var writer = js_printer.BufferPrinter.init(buffer_writer);
     _ = js_printer.printJSON(
         *js_printer.BufferPrinter,

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -6404,7 +6404,7 @@ pub fn NewServer(comptime NamespaceType: type, comptime ssl_enabled_: bool, comp
             var stack_fallback = std.heap.stackFallback(8192, this.allocator);
             const allocator = stack_fallback.get();
 
-            const buffer_writer = js_printer.BufferWriter.init(allocator) catch unreachable;
+            const buffer_writer = js_printer.BufferWriter.init(allocator);
             var writer = js_printer.BufferPrinter.init(buffer_writer);
             defer writer.ctx.buffer.deinit();
             var source = logger.Source.initEmptyFile("info.json");

--- a/src/bun.js/javascript.zig
+++ b/src/bun.js/javascript.zig
@@ -1161,7 +1161,7 @@ pub const VirtualMachine = struct {
     fn ensureSourceCodePrinter(this: *VirtualMachine) void {
         if (source_code_printer == null) {
             const allocator = if (bun.heap_breakdown.enabled) bun.heap_breakdown.namedAllocator("SourceCode") else this.allocator;
-            const writer = try js_printer.BufferWriter.init(allocator);
+            const writer = js_printer.BufferWriter.init(allocator);
             source_code_printer = allocator.create(js_printer.BufferPrinter) catch unreachable;
             source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
             source_code_printer.?.ctx.append_null_byte = false;

--- a/src/bun.js/module_loader.zig
+++ b/src/bun.js/module_loader.zig
@@ -628,7 +628,7 @@ pub const RuntimeTranspilerStore = struct {
             }
 
             if (source_code_printer == null) {
-                const writer = try js_printer.BufferWriter.init(bun.default_allocator);
+                const writer = js_printer.BufferWriter.init(bun.default_allocator);
                 source_code_printer = bun.default_allocator.create(js_printer.BufferPrinter) catch unreachable;
                 source_code_printer.?.* = js_printer.BufferPrinter.init(writer);
                 source_code_printer.?.ctx.append_null_byte = false;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -10795,7 +10795,7 @@ pub const LinkerContext = struct {
         defer trace.end();
 
         var arena = &worker.temporary_arena;
-        var buffer_writer = js_printer.BufferWriter.init(worker.allocator) catch unreachable;
+        var buffer_writer = js_printer.BufferWriter.init(worker.allocator);
         defer _ = arena.reset(.retain_capacity);
 
         const css_import = chunk.content.css.imports_in_chunk_in_order.at(imports_in_chunk_index);
@@ -10958,7 +10958,7 @@ pub const LinkerContext = struct {
             default_allocator;
 
         var arena = &worker.temporary_arena;
-        var buffer_writer = js_printer.BufferWriter.init(allocator) catch bun.outOfMemory();
+        var buffer_writer = js_printer.BufferWriter.init(allocator);
         defer _ = arena.reset(.retain_capacity);
         worker.stmt_list.reset();
 

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1431,7 +1431,7 @@ pub const CreateCommand = struct {
 
                 const file = package_json_file.?;
 
-                var buffer_writer = try JSPrinter.BufferWriter.init(bun.default_allocator);
+                var buffer_writer = JSPrinter.BufferWriter.init(bun.default_allocator);
                 buffer_writer.append_newline = true;
                 var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -759,7 +759,7 @@ pub const InitCommand = struct {
         write_package_json: {
             var file = package_json_file orelse try std.fs.cwd().createFileZ("package.json", .{});
             defer file.close();
-            var buffer_writer = try JSPrinter.BufferWriter.init(bun.default_allocator);
+            var buffer_writer = JSPrinter.BufferWriter.init(bun.default_allocator);
             buffer_writer.append_newline = true;
             var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
 

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2135,7 +2135,7 @@ pub const PackCommand = struct {
         }
 
         const has_trailing_newline = json.source.contents.len > 0 and json.source.contents[json.source.contents.len - 1] == '\n';
-        var buffer_writer = try js_printer.BufferWriter.init(allocator);
+        var buffer_writer = js_printer.BufferWriter.init(allocator);
         try buffer_writer.buffer.list.ensureTotalCapacity(allocator, json.source.contents.len + 1);
         buffer_writer.append_newline = has_trailing_newline;
         var package_json_writer = js_printer.BufferPrinter.init(buffer_writer);

--- a/src/cli/pm_trusted_command.zig
+++ b/src/cli/pm_trusted_command.zig
@@ -416,7 +416,7 @@ pub const TrustCommand = struct {
 
         pm.lockfile.saveToDisk(&load_lockfile, &pm.options);
 
-        var buffer_writer = try bun.js_printer.BufferWriter.init(ctx.allocator);
+        var buffer_writer = bun.js_printer.BufferWriter.init(ctx.allocator);
         try buffer_writer.buffer.list.ensureTotalCapacity(ctx.allocator, package_json_contents.len + 1);
         buffer_writer.append_newline = package_json_contents.len > 0 and package_json_contents[package_json_contents.len - 1] == '\n';
         var package_json_writer = bun.js_printer.BufferPrinter.init(buffer_writer);

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -961,7 +961,7 @@ pub const PublishCommand = struct {
             );
         }
 
-        const buffer_writer = try bun.js_printer.BufferWriter.init(allocator);
+        const buffer_writer = bun.js_printer.BufferWriter.init(allocator);
         var writer = bun.js_printer.BufferPrinter.init(buffer_writer);
 
         const written = bun.js_printer.printJSON(

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -11012,7 +11012,7 @@ pub const PackageManager = struct {
             manager.update_requests = cloned;
         }
 
-        var buffer_writer = try JSPrinter.BufferWriter.init(manager.allocator);
+        var buffer_writer = JSPrinter.BufferWriter.init(manager.allocator);
         try buffer_writer.buffer.list.ensureTotalCapacity(manager.allocator, current_package_json.source.contents.len + 1);
         buffer_writer.append_newline = preserve_trailing_newline_at_eof_for_package_json;
         var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
@@ -11089,7 +11089,7 @@ pub const PackageManager = struct {
                     stuff.patch_key,
                     stuff.patchfile_path,
                 );
-                var buffer_writer2 = try JSPrinter.BufferWriter.init(manager.allocator);
+                var buffer_writer2 = JSPrinter.BufferWriter.init(manager.allocator);
                 try buffer_writer2.buffer.list.ensureTotalCapacity(manager.allocator, root_package_json.source.contents.len + 1);
                 buffer_writer2.append_newline = preserve_trailing_newline_at_eof_for_package_json;
                 var package_json_writer2 = JSPrinter.BufferPrinter.init(buffer_writer2);
@@ -11152,7 +11152,7 @@ pub const PackageManager = struct {
                     },
                 );
             }
-            var buffer_writer_two = try JSPrinter.BufferWriter.init(manager.allocator);
+            var buffer_writer_two = JSPrinter.BufferWriter.init(manager.allocator);
             try buffer_writer_two.buffer.list.ensureTotalCapacity(manager.allocator, source.contents.len + 1);
             buffer_writer_two.append_newline =
                 preserve_trailing_newline_at_eof_for_package_json;

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -5560,12 +5560,9 @@ pub const BufferWriter = struct {
         return this.buffer.list.items;
     }
 
-    pub fn init(allocator: std.mem.Allocator) !BufferWriter {
+    pub fn init(allocator: std.mem.Allocator) BufferWriter {
         return BufferWriter{
-            .buffer = MutableString.init(
-                allocator,
-                0,
-            ) catch unreachable,
+            .buffer = MutableString.initEmpty(allocator),
         };
     }
 
@@ -5939,7 +5936,7 @@ pub fn print(
     const trace = bun.perf.trace("JSPrinter.print");
     defer trace.end();
 
-    const buffer_writer = BufferWriter.init(allocator) catch |err| return .{ .err = err };
+    const buffer_writer = BufferWriter.init(allocator);
     var buffer_printer = BufferPrinter.init(buffer_writer);
 
     return printWithWriter(

--- a/src/json_parser.zig
+++ b/src/json_parser.zig
@@ -1036,7 +1036,7 @@ fn expectPrintedJSON(_contents: string, expected: string) !void {
         Output.panic("--FAIL--\nExpr {s}\nLog: {s}\n--FAIL--", .{ expr, log.msgs.items[0].data.text });
     }
 
-    const buffer_writer = try js_printer.BufferWriter.init(default_allocator);
+    const buffer_writer = js_printer.BufferWriter.init(default_allocator);
     var writer = js_printer.BufferPrinter.init(buffer_writer);
     const written = try js_printer.printJSON(@TypeOf(&writer), &writer, expr, &source, .{
         .mangled_props = null,

--- a/src/main_wasm.zig
+++ b/src/main_wasm.zig
@@ -195,7 +195,7 @@ export fn init(heapsize: u32) void {
 
         JSAst.Stmt.Data.Store.create(default_allocator);
         JSAst.Expr.Data.Store.create(default_allocator);
-        buffer_writer = JSPrinter.BufferWriter.init(default_allocator) catch unreachable;
+        buffer_writer = JSPrinter.BufferWriter.init(default_allocator);
         buffer_writer.buffer.growBy(1024) catch unreachable;
         writer = JSPrinter.BufferPrinter.init(buffer_writer);
         define = Define.Define.init(default_allocator, null, null) catch unreachable;

--- a/src/string/MutableString.zig
+++ b/src/string/MutableString.zig
@@ -71,10 +71,13 @@ pub fn bufferedWriter(self: *MutableString) BufferedWriter {
 }
 
 pub fn init(allocator: Allocator, capacity: usize) Allocator.Error!MutableString {
-    return MutableString{ .allocator = allocator, .list = if (capacity > 0)
-        try std.ArrayListUnmanaged(u8).initCapacity(allocator, capacity)
-    else
-        std.ArrayListUnmanaged(u8){} };
+    return MutableString{
+        .allocator = allocator,
+        .list = if (capacity > 0)
+            try std.ArrayListUnmanaged(u8).initCapacity(allocator, capacity)
+        else
+            std.ArrayListUnmanaged(u8){},
+    };
 }
 
 pub fn initEmpty(allocator: Allocator) MutableString {

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -704,7 +704,7 @@ pub const Transpiler = struct {
                         );
                 }
 
-                const buffer_writer = try js_printer.BufferWriter.init(transpiler.allocator);
+                const buffer_writer = js_printer.BufferWriter.init(transpiler.allocator);
                 var writer = js_printer.BufferPrinter.init(buffer_writer);
 
                 output_file.size = switch (transpiler.options.target) {


### PR DESCRIPTION
### What does this PR do?
Remove `Allocator.Error!` from `BufferWriter`'s constructor, and update all of its call sites to reflect this change. It never returns an error, so we shouldn't have it in the return type.

### How did you verify your code works?
CI
