### PR TITLE
fix(node:http) fix missing comma in startFetch

### DIFF
--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -2773,7 +2773,7 @@ function ClientRequest(input, options, cb) {
       }
 
       if (path.startsWith("http://") || path.startsWith("https://")) {
-        return [path`${protocol}//${host}${this[kUseDefaultPort] ? "" : ":" + this[kPort]}`];
+        return [path, `${protocol}//${host}${this[kUseDefaultPort] ? "" : ":" + this[kPort]}`];
       } else {
         let proxy: string | undefined;
         const url = `${protocol}//${host}${this[kUseDefaultPort] ? "" : ":" + this[kPort]}${path}`;


### PR DESCRIPTION
I think there is a comma missing here, I noticed this because some tests in another project started to fail because of it.