### PR TITLE
Fixes #18869

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -1,3 +1,4 @@
 const kDeprecatedReplySymbol = Symbol("deprecatedReply");
+const kHandle = Symbol("kHandle");
 
-export default { kDeprecatedReplySymbol };
+export default { kDeprecatedReplySymbol, kHandle };

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -52,7 +52,6 @@ const headersSymbol = Symbol("headers");
 const isTlsSymbol = Symbol("is_tls");
 const kClearTimeout = Symbol("kClearTimeout");
 const kfakeSocket = Symbol("kfakeSocket");
-const kHandle = Symbol("handle");
 const kRealListen = Symbol("kRealListen");
 const noBodySymbol = Symbol("noBody");
 const optionsSymbol = Symbol("options");
@@ -73,7 +72,7 @@ const kCloseCallback = Symbol("closeCallback");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
-const { kDeprecatedReplySymbol } = require("internal/http");
+const { kDeprecatedReplySymbol, kHandle } = require("internal/http");
 const EventEmitter: typeof import("node:events").EventEmitter = require("node:events");
 const { isTypedArray, isArrayBuffer } = require("node:util/types");
 const { Duplex, Readable, Stream } = require("node:stream");

--- a/test/js/bun/http/bun-ws-invalid-path.fixture.js
+++ b/test/js/bun/http/bun-ws-invalid-path.fixture.js
@@ -1,0 +1,24 @@
+import { Server } from "node:http";
+import { WebSocketServer } from "ws";
+
+const HOST = "127.0.0.1";
+const PORT = 0;
+
+const server = new Server();
+
+const wss = new WebSocketServer({
+  server,
+  path: "/ws",
+});
+
+server.listen(PORT, HOST, () => {
+  const target = `http://${HOST}:${server.address()?.port}`;
+
+  const ws = new WebSocket(`${target}/crash`);
+
+  ws.onclose = () => {
+    setTimeout(() => {
+      process.exit(0);
+    }, 100);
+  };
+});

--- a/test/js/bun/http/bun-ws-invalid-path.test.ts
+++ b/test/js/bun/http/bun-ws-invalid-path.test.ts
@@ -1,0 +1,33 @@
+import { spawn } from "bun";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+describe("Websocket test", () => {
+  test("Handle calling ", async () => {
+    const fixturePath = path.join(import.meta.dir, "bun-ws-invalid-path.fixture.js");
+
+    const {
+      exited,
+      stdout: stdoutStream,
+      stderr: stderrStream,
+    } = spawn({
+      cmd: [bunExe(), fixturePath],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      exited,
+      new Response(stdoutStream).text(),
+      new Response(stderrStream).text(),
+    ]);
+
+    expect({ exitCode, stdout, stderr }).toMatchObject({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes: #18869

If a websocket was open on a path that does not exist, the `ws`'s server implementation would fail.

This fixes it by using the real socket instead of `_httpMessage`.

### How did you verify your code works?

Added a test that would trigger the bug. It does not anymore.
