### PR TITLE
Fix RefPtr compile errors

### DIFF
--- a/src/ptr/ref_count.zig
+++ b/src/ptr/ref_count.zig
@@ -129,10 +129,9 @@ pub fn RefCount(T: type, field_name: []const u8, destructor: fn (*T) void, optio
 
         // utility functions
 
-        pub fn hasOneRef(self: *T) bool {
-            const counter = getCounter(self);
-            counter.assertNonThreadSafeCountIsSingleThreaded();
-            return counter.active_counts == 1;
+        pub fn hasOneRef(count: *const @This()) bool {
+            count.assertNonThreadSafeCountIsSingleThreaded();
+            return count.active_counts == 1;
         }
 
         pub fn dumpActiveRefs(count: *@This()) void {
@@ -234,9 +233,8 @@ pub fn ThreadSafeRefCount(T: type, field_name: []const u8, destructor: fn (*T) v
 
         // utility functions
 
-        pub fn hasOneRef(self: *T) bool {
-            if (enable_debug) getCounter(self).debug.assertValid();
-            const counter = getCounter(self);
+        pub fn hasOneRef(counter: *const @This()) bool {
+            if (enable_debug) counter.debug.assertValid();
             return counter.active_counts.load(.seq_cst) == 1;
         }
 
@@ -316,9 +314,9 @@ pub fn RefPtr(T: type) type {
         pub fn adoptRef(raw_ptr: *T) @This() {
             if (enable_debug) {
                 bun.assert(raw_ptr.ref_count.hasOneRef());
-                bun.assert(!raw_ptr.ref_count.debug.isEmpty());
+                raw_ptr.ref_count.debug.assertValid();
             }
-            return uncheckedAndUnsafeInit(raw_ptr);
+            return uncheckedAndUnsafeInit(raw_ptr, @returnAddress());
         }
 
         /// This will assert that ALL references are cleaned up by the time the allocation scope ends.
@@ -392,7 +390,7 @@ pub fn DebugData(thread_safe: bool) type {
             .count_pointer = null,
         };
 
-        fn assertValid(debug: *@This()) void {
+        fn assertValid(debug: *const @This()) void {
             bun.assert(debug.magic == .valid);
         }
 


### PR DESCRIPTION
### What does this PR do?

Fixes some compile errors in the new RefPtr/RefCount implementation that I ran into when starting to use these types on #18768. The code in question clearly wasn't being analyzed, so this doesn't fix any errors that could occur compiling Bun right now, but this will make things smoother for anyone else who tries to adopt the new types before the worker_threads PR is merged.

### How did you verify your code works?

It compiles
