### PR TITLE
fix(NodeValidator): make object check less strict

### DIFF
--- a/src/bun.js/bindings/NodeValidator.cpp
+++ b/src/bun.js/bindings/NodeValidator.cpp
@@ -700,11 +700,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globa
 
     auto value = callFrame->argument(0);
 
-    if (value.isNull() || JSC::isArray(globalObject, value)) {
+    if (value.isNull() || JSC::isArray(globalObject, value) || value.isCallable()) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
     }
 
-    if (!value.isObject() || value.asCell()->type() != FinalObjectType) {
+    if (!value.isObject()) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
     }
 
@@ -713,11 +713,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globa
 
 JSC::EncodedJSValue V::validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name)
 {
-    if (value.isNull() || JSC::isArray(globalObject, value)) {
+    if (value.isNull() || JSC::isArray(globalObject, value) || value.isCallable()) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "object"_s, value);
     }
 
-    if (!value.isObject() || value.asCell()->type() != FinalObjectType) {
+    if (!value.isObject()) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "object"_s, value);
     }
 

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -25,8 +25,17 @@ describe("setTimeout", () => {
     expect(unhandledRejectionCaught).toBe(false);
   });
 
-  it("an instance of AbortController can be passed as the third argument", async () => {
-    await expect(async () => await setTimeout(0, undefined, new AbortController())).not.toThrow();
+  it("AbortController can be passed as the `options` argument", async () => {
+    expect(async () => await setTimeout(0, undefined, new AbortController())).not.toThrow();
+  });
+
+  it("should reject promise when AbortController is aborted", async () => {
+    const abortController = new AbortController();
+    const promise = setTimeout(100, undefined, abortController);
+    abortController.abort();
+
+    await expect(promise).rejects.toThrow("aborted");
+    expect(abortController.signal.aborted).toBe(true);
   });
 });
 

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -25,7 +25,7 @@ describe("setTimeout", () => {
     expect(unhandledRejectionCaught).toBe(false);
   });
 
-  it("AbortController can be passed as the `options` argument", async () => {
+  it("AbortController can be passed as the `options` argument", () => {
     expect(async () => await setTimeout(0, undefined, new AbortController())).not.toThrow();
   });
 

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -34,7 +34,7 @@ describe("setTimeout", () => {
     const promise = setTimeout(100, undefined, abortController);
     abortController.abort();
 
-    await expect(promise).rejects.toThrow("aborted");
+    await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
     expect(abortController.signal.aborted).toBe(true);
   });
 });

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -24,6 +24,10 @@ describe("setTimeout", () => {
     expect(c.signal.aborted).toBe(true);
     expect(unhandledRejectionCaught).toBe(false);
   });
+
+  it("an instance of AbortController can be passed as the thrid argument", async () => {
+    await expect(async () => await setTimeout(0, undefined, new AbortController())).not.toThrow();
+  });
 });
 
 describe("setImmediate", () => {

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -25,7 +25,7 @@ describe("setTimeout", () => {
     expect(unhandledRejectionCaught).toBe(false);
   });
 
-  it("an instance of AbortController can be passed as the thrid argument", async () => {
+  it("an instance of AbortController can be passed as the third argument", async () => {
     await expect(async () => await setTimeout(0, undefined, new AbortController())).not.toThrow();
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

fixes #19045

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
