### PR TITLE
feat(ci): add ASAN release builds with assertions

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -409,8 +409,10 @@ function getBuildEnv(target, options) {
     env.ENABLE_ASAN_RELEASE = "ON";
     env.ENABLE_ASSERTIONS = "ON";
     env.CMAKE_BUILD_TYPE = "Release";
-
-    // ASAN runtime options - disable leak detection to avoid excessive noise
+    // Disable LTO for ASAN builds as it's not necessary and can complicate debugging
+    env.ENABLE_LTO = "OFF";
+    
+    // Set ASAN runtime options to disable leak detection (too noisy)
     env.ASAN_OPTIONS = "detect_leaks=0:halt_on_error=0:detect_odr_violation=0";
     // Don't need LSAN options if we've disabled leak detection
     // env.LSAN_OPTIONS = "suppressions=lsan.supp:print_suppressions=0";

--- a/docs/project/asan.md
+++ b/docs/project/asan.md
@@ -35,7 +35,14 @@ The CI pipeline automatically:
 
 ## Local ASAN Builds
 
-To build Bun with ASAN locally:
+To build Bun with ASAN locally, you can use the npm script:
+
+```bash
+# Build a release build with ASAN and assertions (recommended)
+bun run build:asan
+```
+
+Or manually with CMake:
 
 ```bash
 # Debug build with ASAN
@@ -45,7 +52,7 @@ cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_ASAN_RELEASE=ON
 
 # Release build with ASAN and assertions
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_ASAN_RELEASE=ON -DENABLE_ASSERTIONS=ON
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_ASAN_RELEASE=ON -DENABLE_ASSERTIONS=ON -DENABLE_LTO=OFF
 ```
 
 ## Running with ASAN

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:logs": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_LOGS=ON -B build/release-logs",
     "build:safe": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DZIG_OPTIMIZE=ReleaseSafe -B build/release-safe",
     "build:smol": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=MinSizeRel -B build/release-smol",
+    "build:asan": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_ASAN_RELEASE=ON -DENABLE_ASSERTIONS=ON -DENABLE_LTO=OFF -B build/release-asan",
     "build:local": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -DWEBKIT_LOCAL=ON -B build/debug-local",
     "build:release:local": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DWEBKIT_LOCAL=ON -B build/release-local",
     "build:release:with_logs": "cmake . -DCMAKE_BUILD_TYPE=Release -DENABLE_LOGS=true -GNinja -Bbuild-release && ninja -Cbuild-release",


### PR DESCRIPTION
## Summary
- Add support for Address Sanitizer (ASAN) builds with assertions enabled in release mode
- Configure Linux x64 ASAN builds in CI pipeline with LTO disabled for better debugging
- Include ASAN builds in release artifacts with distinctive naming
- Add documentation and npm script for local ASAN builds

## Test plan
- Build pipeline should create a new ASAN build variant for Linux x64
- Tests should run successfully on the ASAN build, with adjusted parallelism and timeouts
- Release artifacts should include ASAN builds with proper naming
- ASAN builds should detect memory errors like use-after-free, buffer overflows, etc.
- Users can build ASAN locally with `bun run build:asan`

🤖 Generated with [Claude Code](https://claude.ai/code)