### PR TITLE
should setImmediate be this fast?

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -161,16 +161,12 @@ pub const All = struct {
                         // prevent libuv from polling forever
                     }
                 }.cb);
-            } else {
-                vm.uwsLoop().ref();
             }
         } else if (old > 0 and new <= 0) {
             if (comptime Environment.isWindows) {
                 if (this.uv_idle.data != null) {
                     this.uv_idle.stop();
                 }
-            } else {
-                vm.uwsLoop().unref();
             }
         }
     }
@@ -209,6 +205,10 @@ pub const All = struct {
 
     pub fn getTimeout(this: *All, spec: *timespec, vm: *VirtualMachine) bool {
         if (this.active_timer_count == 0) {
+            if (vm.eventLoop().immediate_tasks.items.len > 0) {
+                spec.* = .{ .nsec = 0, .sec = 0 };
+                return true;
+            }
             return false;
         }
 
@@ -234,9 +234,17 @@ pub const All = struct {
                 },
                 .lt => {
                     spec.* = min.next.duration(&now);
+                    if (vm.eventLoop().immediate_tasks.items.len > 0) {
+                        spec.* = .{ .nsec = 0, .sec = 0 };
+                    }
                     return true;
                 },
             }
+        }
+
+        if (vm.eventLoop().immediate_tasks.items.len > 0) {
+            spec.* = .{ .nsec = 0, .sec = 0 };
+            return true;
         }
 
         return false;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -1526,11 +1526,6 @@ pub const EventLoop = struct {
         var ctx = this.virtual_machine;
 
         this.tickImmediateTasks(ctx);
-        if (comptime Environment.isPosix) {
-            if (this.immediate_tasks.items.len > 0) {
-                this.wakeup();
-            }
-        }
 
         if (comptime Environment.isPosix) {
             // Some tasks need to keep the event loop alive for one more tick.
@@ -1553,6 +1548,7 @@ pub const EventLoop = struct {
             var event_loop_sleep_timer = if (comptime Environment.isDebug) std.time.Timer.start() catch unreachable;
             // for the printer, this is defined:
             var timespec: bun.timespec = if (Environment.isDebug) .{ .sec = 0, .nsec = 0 } else undefined;
+
             loop.tickWithTimeout(if (ctx.timer.getTimeout(&timespec, ctx)) &timespec else null);
 
             if (comptime Environment.isDebug) {
@@ -1611,11 +1607,6 @@ pub const EventLoop = struct {
         var ctx = this.virtual_machine;
 
         this.tickImmediateTasks(ctx);
-        if (comptime Environment.isPosix) {
-            if (this.immediate_tasks.items.len > 0) {
-                this.wakeup();
-            }
-        }
 
         if (comptime Environment.isPosix) {
             const pending_unref = ctx.pending_unref_counter;

--- a/test/js/node/test/parallel/test-timers-immediate-unref.js
+++ b/test/js/node/test/parallel/test-timers-immediate-unref.js
@@ -1,0 +1,40 @@
+
+const common = require('../common');
+const assert = require('assert');
+
+const immediate = setImmediate(() => {});
+assert.strictEqual(immediate.hasRef(), true);
+immediate.unref();
+assert.strictEqual(immediate.hasRef(), false);
+clearImmediate(immediate);
+
+// This immediate should execute as it was unrefed and refed again.
+// It also confirms that unref/ref are chainable.
+setImmediate(common.mustCall(firstStep)).ref().unref().unref().ref();
+
+function firstStep() {
+  // Unrefed setImmediate executes if it was unrefed but something else keeps
+  // the loop open
+  setImmediate(common.mustCall()).unref();
+  setTimeout(common.mustCall(() => { setImmediate(secondStep); }), 0);
+}
+
+function secondStep() {
+  // clearImmediate works just fine with unref'd immediates
+  const immA = setImmediate(() => {
+    clearImmediate(immA);
+    clearImmediate(immB);
+    // This should not keep the event loop open indefinitely
+    // or do anything else weird
+    immA.ref();
+    immB.ref();
+  }).unref();
+  const immB = setImmediate(common.mustNotCall()).unref();
+  setImmediate(common.mustCall(finalStep));
+}
+
+function finalStep() {
+  // This immediate should not execute as it was unrefed
+  // and nothing else is keeping the event loop alive
+  setImmediate(common.mustNotCall()).unref();
+}


### PR DESCRIPTION
### What does this PR do?

```js
let i = 0;
function iterate() {
  if (i++ < 100000) {
    setImmediate(iterate);
  } else {
    process.exit(0);
  }
}

setImmediate(iterate);
```

```js
Benchmark 1: bun a.js
  Time (mean ± σ):      17.6 ms ±   0.6 ms    [User: 14.7 ms, System: 3.2 ms]
  Range (min … max):    17.1 ms …  21.8 ms    153 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (19.5 ms ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--warmup' option which helps to fill these caches before the actual benchmark. You can either try to increase the warmup count further or re-run this benchmark on a quiet system in case it was a random outlier. Alternatively, consider using the '--prepare' option to clear the caches before each timing run.

Benchmark 2: bun-canary a.js
  Time (mean ± σ):      80.0 ms ±   0.7 ms    [User: 38.7 ms, System: 40.0 ms]
  Range (min … max):    78.6 ms …  81.8 ms    38 runs

Benchmark 3: node a.js
  Time (mean ± σ):      1.262 s ±  0.002 s    [User: 0.067 s, System: 0.109 s]
  Range (min … max):    1.260 s …  1.264 s    10 runs

Benchmark 4: bun-1.2.9 a.js
  Time (mean ± σ):      19.4 ms ±   0.4 ms    [User: 15.1 ms, System: 3.0 ms]
  Range (min … max):    18.8 ms …  21.7 ms    154 runs

Summary
  bun a.js ran
    1.10 ± 0.05 times faster than bun-1.2.9 a.js
    4.53 ± 0.17 times faster than bun-canary a.js
   71.53 ± 2.61 times faster than node a.js
```

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
