### PR TITLE
bump: update distroless docker image

### DIFF
--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update -qq \
     && which bun \
     && bun --version
 
-FROM gcr.io/distroless/base-nossl-debian11
+FROM gcr.io/distroless/base-nossl-debian12
 
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful


### PR DESCRIPTION
### What does this PR do?

Update distroless Bun docker image from [`gcr.io/distroless/base-nossl-debian11`](https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/base-nossl-debian11) to [`gcr.io/distroless/base-nossl-debian12`](https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/base-nossl-debian12).

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

Closes #9240