### PR TITLE
Revert "remove zig and zls path"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,8 @@
   // "zig.zls.enableBuildOnSave": true,
   // "zig.buildOnSave": true,
   "zig.buildFilePath": "${workspaceFolder}/build.zig",
+  "zig.path": "${workspaceFolder}/vendor/zig/zig.exe",
+  "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",
   "zig.formattingProvider": "zls",
   "zig.zls.enableInlayHints": false,
   "[zig]": {


### PR DESCRIPTION
https://github.com/ziglang/vscode-zig/issues/419 is fixed, it can be added again. Tested restarting vscode and using zls start/restart language server and it works.