### PR TITLE
refactor(bun:test): remove `undefined` struct field defaults

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -1359,7 +1359,7 @@ pub const EventLoopTimer = struct {
                 }
 
                 if (comptime t.Type() == JSC.Jest.TestRunner) {
-                    container.onTestTimeout(now, vm);
+                    container.onTestTimeout(now);
                     return .disarm;
                 }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1059,6 +1059,7 @@ pub const TestCommand = struct {
                 .bail = ctx.test_options.bail,
                 .filter_regex = ctx.test_options.test_filter_regex,
                 .filter_buffer = bun.MutableString.init(ctx.allocator, 0) catch unreachable,
+                .test_options = &ctx.test_options,
                 .snapshots = Snapshots{
                     .allocator = ctx.allocator,
                     .update_snapshots = ctx.test_options.update_snapshots,
@@ -1068,17 +1069,15 @@ pub const TestCommand = struct {
                     .inline_snapshots_to_write = &inline_snapshots_to_write,
                 },
             },
-            .callback = undefined,
+            .callback = TestRunner.Callback{
+                .onUpdateCount = CommandLineReporter.handleUpdateCount,
+                .onTestStart = CommandLineReporter.handleTestStart,
+                .onTestPass = CommandLineReporter.handleTestPass,
+                .onTestFail = CommandLineReporter.handleTestFail,
+                .onTestSkip = CommandLineReporter.handleTestSkip,
+                .onTestTodo = CommandLineReporter.handleTestTodo,
+            },
         };
-        reporter.callback = TestRunner.Callback{
-            .onUpdateCount = CommandLineReporter.handleUpdateCount,
-            .onTestStart = CommandLineReporter.handleTestStart,
-            .onTestPass = CommandLineReporter.handleTestPass,
-            .onTestFail = CommandLineReporter.handleTestFail,
-            .onTestSkip = CommandLineReporter.handleTestSkip,
-            .onTestTodo = CommandLineReporter.handleTestTodo,
-        };
-        reporter.repeat_count = @max(ctx.test_options.repeat_count, 1);
         reporter.jest.callback = &reporter.callback;
         jest.Jest.runner = &reporter.jest;
         reporter.jest.test_options = &ctx.test_options;

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -29,7 +29,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
   "== alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
   "!= alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
 
-  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 242, regex: true },
+  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 239, regex: true },
   "usingnamespace": { reason: "Zig deprecates this, and will not support it in incremental compilation.", limit: 19 },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 180 },


### PR DESCRIPTION
### What does this PR do?
- Remove all default `undefined`s for `TestRunner`'s fields
- remove unused `drainer` field from `TestRunner

### How did you verify your code works?
CI
