### PR TITLE
fix(sql): dynamic in with string array (fixes #18775)

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1304,7 +1304,7 @@ class SQLArrayParameter {
   value: any;
   columns: string[];
   constructor(value, keys) {
-    if (keys?.length === 0) {
+    if (keys?.length === 0 && typeof value[0] !== "string") {
       keys = Object.keys(value[0]);
     }
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -940,7 +940,7 @@ if (isDockerEnabled()) {
     const results = await sql`
     SELECT ${random_name}.*
     FROM ${random_name}
-    WHERE ${random_name}.hotel_id = ${user.hotel_id} 
+    WHERE ${random_name}.hotel_id = ${user.hotel_id}
     ${sortBy.should_sort ? orderBy(sortBy.field) : sql``}`;
     expect(results).toEqual([
       { id: 2, hotel_id: 1, created_at: new Date("2024-01-02T10:00:00.000Z") },
@@ -1753,6 +1753,20 @@ if (isDockerEnabled()) {
       expect(a).toBe(42);
     } finally {
       await sql`drop table test2`;
+    }
+  });
+
+  test("dynamic in with string array", async () => {
+    try {
+      await sql`create table test (x varchar)`
+      await sql`insert into test values ('a', 'b', 'c')`
+
+      const ac = await sql`select x as from test where x in ${sql(['a', 'c'])}`
+      expect(ac.length).toBe(2);
+      expect(ac[0].x).toBe('a');
+      expect(ac[1].x).toBe('a');
+    } finally {
+      await sql`drop table test`
     }
   });
 
@@ -3380,7 +3394,7 @@ CREATE TABLE ${table_name} (
     test("should handle array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY[true, false] @> ARRAY[true]::boolean[] as contains_true,
         ARRAY[true, false] @> ARRAY[false]::boolean[] as contains_false,
         ARRAY[true, false] @> ARRAY[true, false]::boolean[] as contains_both
@@ -3394,7 +3408,7 @@ CREATE TABLE ${table_name} (
     test("should handle array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY[true, false] && ARRAY[true]::boolean[] as overlaps_true,
         ARRAY[true, false] && ARRAY[false]::boolean[] as overlaps_false,
         ARRAY[true, true] && ARRAY[false]::boolean[] as no_overlap
@@ -3408,7 +3422,7 @@ CREATE TABLE ${table_name} (
     test("should handle array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY[true, false] || ARRAY[true]::boolean[] as concatenated,
         ARRAY[true] || ARRAY[false]::boolean[] || ARRAY[true]::boolean[] as triple_concat
     `;
@@ -3442,7 +3456,7 @@ CREATE TABLE ${table_name} (
     test("should handle array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY[true, false] = ARRAY[true, false]::boolean[] as equal_arrays,
         ARRAY[true, false] = ARRAY[false, true]::boolean[] as different_arrays,
         ARRAY[true, true] > ARRAY[true, false]::boolean[] as greater_than,
@@ -3458,7 +3472,7 @@ CREATE TABLE ${table_name} (
     test("should handle array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         array_dims(ARRAY[true, false]::boolean[]) as one_dim,
         array_dims(ARRAY[[true, false], [false, true]]::boolean[][]) as two_dim
     `;
@@ -3470,7 +3484,7 @@ CREATE TABLE ${table_name} (
     test("should handle array length", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         array_length(ARRAY[true, false]::boolean[], 1) as length_one_dim,
         array_length(ARRAY[[true, false], [false, true]]::boolean[][], 1) as rows_two_dim,
         array_length(ARRAY[[true, false], [false, true]]::boolean[][], 2) as cols_two_dim
@@ -3502,7 +3516,7 @@ CREATE TABLE ${table_name} (
 
       const result = await sql`
       SELECT ARRAY[
-        E'\\x41424344'::bytea, 
+        E'\\x41424344'::bytea,
         E'\\x45464748'::bytea
       ]::bytea[] as multiple_values
     `;
@@ -3537,14 +3551,14 @@ CREATE TABLE ${table_name} (
       await using sql = postgres({ ...options, max: 1 });
 
       const result = await sql`
-      SELECT 
-        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] @> 
+      SELECT
+        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] @>
         ARRAY[E'\\x41424344'::bytea]::bytea[] as contains_first,
-        
-        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] @> 
+
+        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] @>
         ARRAY[E'\\x45464748'::bytea]::bytea[] as contains_second,
-        
-        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] @> 
+
+        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] @>
         ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea]::bytea[] as contains_both
     `;
 
@@ -3557,14 +3571,14 @@ CREATE TABLE ${table_name} (
       await using sql = postgres({ ...options, max: 1 });
 
       const result = await sql`
-      SELECT 
-        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] && 
+      SELECT
+        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] &&
         ARRAY[E'\\x41424344'::bytea]::bytea[] as overlaps_first,
-        
-        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] && 
+
+        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] &&
         ARRAY[E'\\x45464748'::bytea]::bytea[] as overlaps_second,
-        
-        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] && 
+
+        ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea] &&
         ARRAY[E'\\x49504B4C'::bytea]::bytea[] as no_overlap
     `;
 
@@ -3577,8 +3591,8 @@ CREATE TABLE ${table_name} (
       await using sql = postgres({ ...options, max: 1 });
 
       const result = await sql`
-      SELECT 
-        ARRAY[E'\\x41424344'::bytea] || 
+      SELECT
+        ARRAY[E'\\x41424344'::bytea] ||
         ARRAY[E'\\x45464748'::bytea]::bytea[] as concatenated
     `;
 
@@ -3604,11 +3618,11 @@ CREATE TABLE ${table_name} (
       await using sql = postgres({ ...options, max: 1 });
 
       const result = await sql`
-      SELECT 
-        ARRAY[E'\\x41424344'::bytea] = 
+      SELECT
+        ARRAY[E'\\x41424344'::bytea] =
         ARRAY[E'\\x41424344'::bytea]::bytea[] as equal_arrays,
-        
-        ARRAY[E'\\x41424344'::bytea] = 
+
+        ARRAY[E'\\x41424344'::bytea] =
         ARRAY[E'\\x45464748'::bytea]::bytea[] as different_arrays
     `;
 
@@ -3620,7 +3634,7 @@ CREATE TABLE ${table_name} (
       await using sql = postgres({ ...options, max: 1 });
 
       const result = await sql`
-      SELECT 
+      SELECT
         array_length(
           ARRAY[E'\\x41424344'::bytea, E'\\x45464748'::bytea]::bytea[],
           1
@@ -3681,7 +3695,7 @@ CREATE TABLE ${table_name} (
     test("char[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         (ARRAY['A', 'B', 'C']::char[])[1] as first_element,
         (ARRAY['A', 'B', 'C']::char[])[2] as second_element,
         (ARRAY['A', 'B', 'C']::char[])[3] as third_element
@@ -3695,7 +3709,7 @@ CREATE TABLE ${table_name} (
     test("char[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY['A', 'B', 'C']::char[] @> ARRAY['A']::char[] as contains_a,
         ARRAY['A', 'B', 'C']::char[] @> ARRAY['B']::char[] as contains_b,
         ARRAY['A', 'B', 'C']::char[] @> ARRAY['D']::char[] as contains_d,
@@ -3711,7 +3725,7 @@ CREATE TABLE ${table_name} (
     test("char[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY['A', 'B']::char[] && ARRAY['B', 'C']::char[] as has_overlap,
         ARRAY['A', 'B']::char[] && ARRAY['C', 'D']::char[] as no_overlap
     `;
@@ -3723,7 +3737,7 @@ CREATE TABLE ${table_name} (
     test("char[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY['A', 'B']::char[] || ARRAY['C', 'D']::char[] as concatenated,
         ARRAY['A']::char[] || ARRAY['B']::char[] || ARRAY['C']::char[] as triple_concat
     `;
@@ -3751,7 +3765,7 @@ CREATE TABLE ${table_name} (
     test("char[] - case sensitivity", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY['a']::char[] = ARRAY['A']::char[] as case_sensitive,
         ARRAY['a']::char[] = ARRAY['a']::char[] as same_case
     `;
@@ -3763,7 +3777,7 @@ CREATE TABLE ${table_name} (
     test("char[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         ARRAY['A', 'B']::char[] = ARRAY['A', 'B']::char[] as equal_arrays,
         ARRAY['A', 'B']::char[] = ARRAY['B', 'A']::char[] as different_order,
         ARRAY['A', 'B']::char[] < ARRAY['B', 'B']::char[] as less_than,
@@ -3779,7 +3793,7 @@ CREATE TABLE ${table_name} (
     test("char[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-      SELECT 
+      SELECT
         array_length(ARRAY['A', 'B', 'C']::char[], 1) as array_length,
         array_dims(ARRAY['A', 'B', 'C']::char[]) as dimensions,
         array_upper(ARRAY['A', 'B', 'C']::char[], 1) as upper_bound,
@@ -3845,7 +3859,7 @@ CREATE TABLE ${table_name} (
     test("name[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['name1', 'name2', 'name3']::name[])[1] as first_element,
           (ARRAY['name1', 'name2', 'name3']::name[])[2] as second_element,
           (ARRAY['name1', 'name2', 'name3']::name[])[3] as third_element
@@ -3859,7 +3873,7 @@ CREATE TABLE ${table_name} (
     test("name[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['name1', 'name2', 'name3']::name[] @> ARRAY['name1']::name[] as contains_first,
           ARRAY['name1', 'name2', 'name3']::name[] @> ARRAY['name2']::name[] as contains_second,
           ARRAY['name1', 'name2', 'name3']::name[] @> ARRAY['name4']::name[] as contains_none,
@@ -3875,7 +3889,7 @@ CREATE TABLE ${table_name} (
     test("name[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['name1', 'name2']::name[] && ARRAY['name2', 'name3']::name[] as has_overlap,
           ARRAY['name1', 'name2']::name[] && ARRAY['name3', 'name4']::name[] as no_overlap
       `;
@@ -3887,7 +3901,7 @@ CREATE TABLE ${table_name} (
     test("name[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['name1', 'name2']::name[] || ARRAY['name3', 'name4']::name[] as concatenated,
           ARRAY['name1']::name[] || ARRAY['name2']::name[] || ARRAY['name3']::name[] as triple_concat
       `;
@@ -3909,7 +3923,7 @@ CREATE TABLE ${table_name} (
     test("name[] - case sensitivity", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['Name1']::name[] = ARRAY['name1']::name[] as case_sensitive,
           ARRAY['name1']::name[] = ARRAY['name1']::name[] as same_case
       `;
@@ -3921,7 +3935,7 @@ CREATE TABLE ${table_name} (
     test("name[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['name1', 'name2']::name[] = ARRAY['name1', 'name2']::name[] as equal_arrays,
           ARRAY['name1', 'name2']::name[] = ARRAY['name2', 'name1']::name[] as different_order,
           ARRAY['name1', 'name2']::name[] < ARRAY['name2', 'name2']::name[] as less_than,
@@ -3937,7 +3951,7 @@ CREATE TABLE ${table_name} (
     test("name[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['name1', 'name2', 'name3']::name[], 1) as array_length,
           array_dims(ARRAY['name1', 'name2', 'name3']::name[]) as dimensions,
           array_upper(ARRAY['name1', 'name2', 'name3']::name[], 1) as upper_bound,
@@ -4050,7 +4064,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array element access", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1, 2, 3]::int8[])[1] as first_element,
           (ARRAY[1, 2, 3]::int8[])[2] as second_element,
           (ARRAY[1, 2, 3]::int8[])[3] as third_element
@@ -4069,7 +4083,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array contains operator", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::int8[] @> ARRAY[1]::int8[] as contains_first,
           ARRAY[1, 2, 3]::int8[] @> ARRAY[2]::int8[] as contains_second,
           ARRAY[1, 2, 3]::int8[] @> ARRAY[4]::int8[] as contains_none,
@@ -4085,7 +4099,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array overlap operator", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int8[] && ARRAY[2, 3]::int8[] as has_overlap,
           ARRAY[1, 2]::int8[] && ARRAY[3, 4]::int8[] as no_overlap
       `;
@@ -4096,7 +4110,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array concatenation", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int8[] || ARRAY[3, 4]::int8[] as concatenated,
           ARRAY[1]::int8[] || ARRAY[2]::int8[] || ARRAY[3]::int8[] as triple_concat
       `;
@@ -4125,7 +4139,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array arithmetic operations", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           (SELECT array_agg(val + 1) FROM unnest(ARRAY[1, 2, 3]::int8[]) as val) as addition,
           (SELECT array_agg(val * 2) FROM unnest(ARRAY[1, 2, 3]::int8[]) as val) as multiplication
       `;
@@ -4141,7 +4155,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array comparison", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int8[] = ARRAY[1, 2]::int8[] as equal_arrays,
           ARRAY[1, 2]::int8[] = ARRAY[2, 1]::int8[] as different_order,
           ARRAY[1, 2]::int8[] < ARRAY[2, 2]::int8[] as less_than,
@@ -4163,7 +4177,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array dimensions", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1, 2, 3]::int8[], 1)::int8 as array_length,
           array_dims(ARRAY[1, 2, 3]::int8[]) as dimensions,
           array_upper(ARRAY[1, 2, 3]::int8[], 1)::int8 as upper_bound,
@@ -4201,7 +4215,7 @@ CREATE TABLE ${table_name} (
       test("int8[] - array mathematical functions", async () => {
         await using sql = postgres({ ...options, max: 1, bigint: bigint });
         const result = await sql`
-        SELECT 
+        SELECT
           (SELECT sum(val) FROM unnest(ARRAY[1, 2, 3]::int8[]) as val)::int8 as total,
           (SELECT avg(val) FROM unnest(ARRAY[1, 2, 3]::int8[]) as val)::int8 as average,
           (SELECT min(val) FROM unnest(ARRAY[1, 2, 3]::int8[]) as val)::int8 as minimum,
@@ -4271,7 +4285,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1, 2, 3]::int4[])[1] as first_element,
           (ARRAY[1, 2, 3]::int4[])[2] as second_element,
           (ARRAY[1, 2, 3]::int4[])[3] as third_element
@@ -4285,7 +4299,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::int4[] @> ARRAY[1]::int4[] as contains_first,
           ARRAY[1, 2, 3]::int4[] @> ARRAY[2]::int4[] as contains_second,
           ARRAY[1, 2, 3]::int4[] @> ARRAY[4]::int4[] as contains_none,
@@ -4301,7 +4315,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int4[] && ARRAY[2, 3]::int4[] as has_overlap,
           ARRAY[1, 2]::int4[] && ARRAY[3, 4]::int4[] as no_overlap
       `;
@@ -4313,7 +4327,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int4[] || ARRAY[3, 4]::int4[] as concatenated,
           ARRAY[1]::int4[] || ARRAY[2]::int4[] || ARRAY[3]::int4[] as triple_concat
       `;
@@ -4335,7 +4349,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array arithmetic operations", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT array_agg(val + 1) FROM unnest(ARRAY[1, 2, 3]::int4[]) as val) as addition,
           (SELECT array_agg(val * 2) FROM unnest(ARRAY[1, 2, 3]::int4[]) as val) as multiplication
       `;
@@ -4347,7 +4361,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int4[] = ARRAY[1, 2]::int4[] as equal_arrays,
           ARRAY[1, 2]::int4[] = ARRAY[2, 1]::int4[] as different_order,
           ARRAY[1, 2]::int4[] < ARRAY[2, 2]::int4[] as less_than,
@@ -4363,7 +4377,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1, 2, 3]::int4[], 1) as array_length,
           array_dims(ARRAY[1, 2, 3]::int4[]) as dimensions,
           array_upper(ARRAY[1, 2, 3]::int4[], 1) as upper_bound,
@@ -4392,7 +4406,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array mathematical functions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT sum(val) FROM unnest(ARRAY[1, 2, 3]::int4[]) as val)::int4 as total,
           (SELECT avg(val) FROM unnest(ARRAY[1, 2, 3]::int4[]) as val)::int4 as average,
           (SELECT min(val) FROM unnest(ARRAY[1, 2, 3]::int4[]) as val)::int4 as minimum,
@@ -4408,7 +4422,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array type casting", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::int8[] = ARRAY[1, 2, 3]::int4[]::int8[] as cast_to_int8,
           ARRAY[1, 2, 3]::float8[] = ARRAY[1, 2, 3]::int4[]::float8[] as cast_to_float8
       `;
@@ -4420,7 +4434,7 @@ CREATE TABLE ${table_name} (
     test("int4[] - array with zero values", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[0, 0, 0]::int4[] as zero_array,
           ARRAY[-0, 0, +0]::int4[] as signed_zeros
       `;
@@ -4478,7 +4492,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1, 2, 3]::int2[])[1] as first_element,
           (ARRAY[1, 2, 3]::int2[])[2] as second_element,
           (ARRAY[1, 2, 3]::int2[])[3] as third_element
@@ -4492,7 +4506,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::int2[] @> ARRAY[1]::int2[] as contains_first,
           ARRAY[1, 2, 3]::int2[] @> ARRAY[2]::int2[] as contains_second,
           ARRAY[1, 2, 3]::int2[] @> ARRAY[4]::int2[] as contains_none,
@@ -4508,7 +4522,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int2[] && ARRAY[2, 3]::int2[] as has_overlap,
           ARRAY[1, 2]::int2[] && ARRAY[3, 4]::int2[] as no_overlap
       `;
@@ -4520,7 +4534,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int2[] || ARRAY[3, 4]::int2[] as concatenated,
           ARRAY[1]::int2[] || ARRAY[2]::int2[] || ARRAY[3]::int2[] as triple_concat
       `;
@@ -4542,7 +4556,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array arithmetic operations", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT array_agg(val + 1) FROM unnest(ARRAY[1, 2, 3]::int2[]) as val) as addition,
           (SELECT array_agg(val * 2) FROM unnest(ARRAY[1, 2, 3]::int2[]) as val) as multiplication
       `;
@@ -4554,7 +4568,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::int2[] = ARRAY[1, 2]::int2[] as equal_arrays,
           ARRAY[1, 2]::int2[] = ARRAY[2, 1]::int2[] as different_order,
           ARRAY[1, 2]::int2[] < ARRAY[2, 2]::int2[] as less_than,
@@ -4570,7 +4584,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1, 2, 3]::int2[], 1) as array_length,
           array_dims(ARRAY[1, 2, 3]::int2[]) as dimensions,
           array_upper(ARRAY[1, 2, 3]::int2[], 1) as upper_bound,
@@ -4599,7 +4613,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array mathematical functions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT sum(val) FROM unnest(ARRAY[1, 2, 3]::int2[]) as val)::int2 as total,
           (SELECT avg(val) FROM unnest(ARRAY[1, 2, 3]::int2[]) as val)::int2 as average,
           (SELECT min(val) FROM unnest(ARRAY[1, 2, 3]::int2[]) as val)::int2 as minimum,
@@ -4615,7 +4629,7 @@ CREATE TABLE ${table_name} (
     test("int2[] - array type casting", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::int4[] = ARRAY[1, 2, 3]::int2[]::int4[] as cast_to_int4,
           ARRAY[1, 2, 3]::int8[] = ARRAY[1, 2, 3]::int2[]::int8[] as cast_to_int8,
           ARRAY[1, 2, 3]::float4[] = ARRAY[1, 2, 3]::int2[]::float4[] as cast_to_float4
@@ -4691,14 +4705,14 @@ CREATE TABLE ${table_name} (
     test("int2vector[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['1 2'::int2vector, '3 4'::int2vector] @> 
+        SELECT
+          ARRAY['1 2'::int2vector, '3 4'::int2vector] @>
           ARRAY['1 2'::int2vector] as contains_first,
-          
-          ARRAY['1 2'::int2vector, '3 4'::int2vector] @> 
+
+          ARRAY['1 2'::int2vector, '3 4'::int2vector] @>
           ARRAY['3 4'::int2vector] as contains_second,
-          
-          ARRAY['1 2'::int2vector, '3 4'::int2vector] @> 
+
+          ARRAY['1 2'::int2vector, '3 4'::int2vector] @>
           ARRAY['5 6'::int2vector] as contains_none
       `;
 
@@ -4802,7 +4816,7 @@ CREATE TABLE ${table_name} (
     test("text[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['first', 'second', 'third']::text[])[1] as first_element,
           (ARRAY['first', 'second', 'third']::text[])[2] as second_element,
           (ARRAY['first', 'second', 'third']::text[])[3] as third_element
@@ -4816,7 +4830,7 @@ CREATE TABLE ${table_name} (
     test("text[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['a', 'b', 'c']::text[] @> ARRAY['a']::text[] as contains_first,
           ARRAY['a', 'b', 'c']::text[] @> ARRAY['b']::text[] as contains_second,
           ARRAY['a', 'b', 'c']::text[] @> ARRAY['d']::text[] as contains_none,
@@ -4832,7 +4846,7 @@ CREATE TABLE ${table_name} (
     test("text[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['a', 'b']::text[] && ARRAY['b', 'c']::text[] as has_overlap,
           ARRAY['a', 'b']::text[] && ARRAY['c', 'd']::text[] as no_overlap
       `;
@@ -4844,7 +4858,7 @@ CREATE TABLE ${table_name} (
     test("text[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['a', 'b']::text[] || ARRAY['c', 'd']::text[] as concatenated,
           ARRAY['a']::text[] || ARRAY['b']::text[] || ARRAY['c']::text[] as triple_concat
       `;
@@ -4856,7 +4870,7 @@ CREATE TABLE ${table_name} (
     test("text[] - case sensitivity", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['Test']::text[] = ARRAY['test']::text[] as case_sensitive,
           ARRAY['test']::text[] = ARRAY['test']::text[] as same_case
       `;
@@ -4868,7 +4882,7 @@ CREATE TABLE ${table_name} (
     test("text[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['a', 'b', 'c']::text[], 1) as array_length,
           array_dims(ARRAY['a', 'b', 'c']::text[]) as dimensions,
           array_upper(ARRAY['a', 'b', 'c']::text[], 1) as upper_bound,
@@ -4884,7 +4898,7 @@ CREATE TABLE ${table_name} (
     test("text[] - array string functions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT array_agg(upper(val)) FROM unnest(ARRAY['a', 'b', 'c']::text[]) as val) as uppercase,
           (SELECT array_agg(length(val)) FROM unnest(ARRAY['a', 'bb', 'ccc']::text[]) as val) as lengths
       `;
@@ -5042,7 +5056,7 @@ CREATE TABLE ${table_name} (
             'Hello There'
           ]::text[]) as phrase
         )
-        SELECT 
+        SELECT
           array_agg(phrase ORDER BY phrase) FILTER (WHERE phrase LIKE 'Hello%') as hello_phrases,
           array_agg(phrase ORDER BY phrase) FILTER (WHERE phrase LIKE '%World') as world_phrases
         FROM texts
@@ -5055,7 +5069,7 @@ CREATE TABLE ${table_name} (
     test("text[] - comparison with spaces", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['Hello World']::text[] @> ARRAY['Hello World']::text[] as exact_match,
           ARRAY['Hello World']::text[] @> ARRAY['Hello']::text[] as partial_match,
           ARRAY['Hello', 'World']::text[] @> ARRAY['Hello World']::text[] as separate_words
@@ -5069,7 +5083,7 @@ CREATE TABLE ${table_name} (
     test("text[] - concatenation with spaces", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['Hello', 'World']::text[] || ARRAY['Good Morning']::text[] as concatenated,
           string_agg(word, ' ') as joined
         FROM unnest(ARRAY['Hello', 'World']::text[]) as word
@@ -5291,7 +5305,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1, 2, 3]::oid[])[1] as first_element,
           (ARRAY[1, 2, 3]::oid[])[2] as second_element,
           (ARRAY[1, 2, 3]::oid[])[3] as third_element
@@ -5305,7 +5319,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::oid[] @> ARRAY[1]::oid[] as contains_first,
           ARRAY[1, 2, 3]::oid[] @> ARRAY[2]::oid[] as contains_second,
           ARRAY[1, 2, 3]::oid[] @> ARRAY[4]::oid[] as contains_none,
@@ -5321,7 +5335,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::oid[] && ARRAY[2, 3]::oid[] as has_overlap,
           ARRAY[1, 2]::oid[] && ARRAY[3, 4]::oid[] as no_overlap
       `;
@@ -5333,7 +5347,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::oid[] || ARRAY[3, 4]::oid[] as concatenated,
           ARRAY[1]::oid[] || ARRAY[2]::oid[] || ARRAY[3]::oid[] as triple_concat
       `;
@@ -5355,7 +5369,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2]::oid[] = ARRAY[1, 2]::oid[] as equal_arrays,
           ARRAY[1, 2]::oid[] = ARRAY[2, 1]::oid[] as different_order,
           ARRAY[1, 2]::oid[] < ARRAY[2, 2]::oid[] as less_than,
@@ -5371,7 +5385,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1, 2, 3]::oid[], 1) as array_length,
           array_dims(ARRAY[1, 2, 3]::oid[]) as dimensions,
           array_upper(ARRAY[1, 2, 3]::oid[], 1) as upper_bound,
@@ -5387,7 +5401,7 @@ CREATE TABLE ${table_name} (
     test("oid[] - type casting", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1, 2, 3]::int4[] = ARRAY[1, 2, 3]::oid[]::int4[] as cast_to_int4,
           ARRAY[1, 2, 3]::int8[] = ARRAY[1, 2, 3]::oid[]::int8[] as cast_to_int8
       `;
@@ -5404,7 +5418,7 @@ CREATE TABLE ${table_name} (
           relowner::oid,
           relnamespace::oid
         ]::oid[] as class_oids
-        FROM pg_class 
+        FROM pg_class
         WHERE relname = 'pg_class'
       `;
 
@@ -5464,7 +5478,7 @@ CREATE TABLE ${table_name} (
     test("tid[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[])[1] as first_element,
           (ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[])[2] as second_element,
           (ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[])[3] as third_element
@@ -5478,7 +5492,7 @@ CREATE TABLE ${table_name} (
     test("tid[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[] @> ARRAY['(0,1)']::tid[] as contains_first,
           ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[] @> ARRAY['(0,2)']::tid[] as contains_second,
           ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[] @> ARRAY['(0,4)']::tid[] as contains_none,
@@ -5494,7 +5508,7 @@ CREATE TABLE ${table_name} (
     test("tid[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['(0,1)', '(0,2)']::tid[] && ARRAY['(0,2)', '(0,3)']::tid[] as has_overlap,
           ARRAY['(0,1)', '(0,2)']::tid[] && ARRAY['(0,3)', '(0,4)']::tid[] as no_overlap
       `;
@@ -5506,7 +5520,7 @@ CREATE TABLE ${table_name} (
     test("tid[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['(0,1)', '(0,2)']::tid[] || ARRAY['(0,3)', '(0,4)']::tid[] as concatenated,
           ARRAY['(0,1)']::tid[] || ARRAY['(0,2)']::tid[] || ARRAY['(0,3)']::tid[] as triple_concat
       `;
@@ -5528,7 +5542,7 @@ CREATE TABLE ${table_name} (
     test("tid[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['(0,1)', '(0,2)']::tid[] = ARRAY['(0,1)', '(0,2)']::tid[] as equal_arrays,
           ARRAY['(0,1)', '(0,2)']::tid[] = ARRAY['(0,2)', '(0,1)']::tid[] as different_order,
           ARRAY['(0,1)', '(0,2)']::tid[] < ARRAY['(0,2)', '(0,2)']::tid[] as less_than,
@@ -5544,7 +5558,7 @@ CREATE TABLE ${table_name} (
     test("tid[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[], 1) as array_length,
           array_dims(ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[]) as dimensions,
           array_upper(ARRAY['(0,1)', '(0,2)', '(0,3)']::tid[], 1) as upper_bound,
@@ -5631,7 +5645,7 @@ CREATE TABLE ${table_name} (
     test("xid[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[])[1] as first_element,
           (ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[])[2] as second_element,
           (ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[])[3] as third_element
@@ -5645,7 +5659,7 @@ CREATE TABLE ${table_name} (
     test("xid[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[] @> ARRAY['1'::xid]::xid[] as contains_first,
           ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[] @> ARRAY['2'::xid]::xid[] as contains_second,
           ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[] @> ARRAY['4'::xid]::xid[] as contains_none,
@@ -5661,7 +5675,7 @@ CREATE TABLE ${table_name} (
     test("xid[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['1'::xid, '2'::xid]::xid[] && ARRAY['2'::xid, '3'::xid]::xid[] as has_overlap,
           ARRAY['1'::xid, '2'::xid]::xid[] && ARRAY['3'::xid, '4'::xid]::xid[] as no_overlap
       `;
@@ -5673,7 +5687,7 @@ CREATE TABLE ${table_name} (
     test("xid[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['1'::xid, '2'::xid]::xid[] || ARRAY['3'::xid, '4'::xid]::xid[] as concatenated,
           ARRAY['1'::xid]::xid[] || ARRAY['2'::xid]::xid[] || ARRAY['3'::xid]::xid[] as triple_concat
       `;
@@ -5685,7 +5699,7 @@ CREATE TABLE ${table_name} (
     test("xid[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[], 1) as array_length,
           array_dims(ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[]) as dimensions,
           array_upper(ARRAY['1'::xid, '2'::xid, '3'::xid]::xid[], 1) as upper_bound,
@@ -5770,7 +5784,7 @@ CREATE TABLE ${table_name} (
     test("cid[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[])[1] as first_element,
           (ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[])[2] as second_element,
           (ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[])[3] as third_element
@@ -5784,7 +5798,7 @@ CREATE TABLE ${table_name} (
     test("cid[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[] @> ARRAY['0'::cid]::cid[] as contains_first,
           ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[] @> ARRAY['1'::cid]::cid[] as contains_second,
           ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[] @> ARRAY['3'::cid]::cid[] as contains_none,
@@ -5800,7 +5814,7 @@ CREATE TABLE ${table_name} (
     test("cid[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['0'::cid, '1'::cid]::cid[] && ARRAY['1'::cid, '2'::cid]::cid[] as has_overlap,
           ARRAY['0'::cid, '1'::cid]::cid[] && ARRAY['2'::cid, '3'::cid]::cid[] as no_overlap
       `;
@@ -5812,7 +5826,7 @@ CREATE TABLE ${table_name} (
     test("cid[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['0'::cid, '1'::cid]::cid[] || ARRAY['2'::cid, '3'::cid]::cid[] as concatenated,
           ARRAY['0'::cid]::cid[] || ARRAY['1'::cid]::cid[] || ARRAY['2'::cid]::cid[] as triple_concat
       `;
@@ -5824,7 +5838,7 @@ CREATE TABLE ${table_name} (
     test("cid[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[], 1) as array_length,
           array_dims(ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[]) as dimensions,
           array_upper(ARRAY['0'::cid, '1'::cid, '2'::cid]::cid[], 1) as upper_bound,
@@ -5939,7 +5953,7 @@ CREATE TABLE ${table_name} (
     test("json[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['{"a": 1}', '{"b": 2}', '{"c": 3}']::json[])[1] as first_element,
           (ARRAY['{"a": 1}', '{"b": 2}', '{"c": 3}']::json[])[2] as second_element,
           (ARRAY['{"a": 1}', '{"b": 2}', '{"c": 3}']::json[])[3] as third_element
@@ -5953,8 +5967,8 @@ CREATE TABLE ${table_name} (
     test("json[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['{"a": 1}', '{"b": 2}']::json[] || 
+        SELECT
+          ARRAY['{"a": 1}', '{"b": 2}']::json[] ||
           ARRAY['{"c": 3}', '{"d": 4}']::json[] as concatenated
       `;
 
@@ -5997,7 +6011,7 @@ CREATE TABLE ${table_name} (
     test("json[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['{"a": 1}', '{"b": 2}', '{"c": 3}']::json[], 1) as array_length,
           array_dims(ARRAY['{"a": 1}', '{"b": 2}', '{"c": 3}']::json[]) as dimensions,
           array_upper(ARRAY['{"a": 1}', '{"b": 2}', '{"c": 3}']::json[], 1) as upper_bound,
@@ -6086,7 +6100,7 @@ CREATE TABLE ${table_name} (
     test("xml[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['<a>1</a>', '<b>2</b>', '<c>3</c>']::xml[])[1] as first_element,
           (ARRAY['<a>1</a>', '<b>2</b>', '<c>3</c>']::xml[])[2] as second_element,
           (ARRAY['<a>1</a>', '<b>2</b>', '<c>3</c>']::xml[])[3] as third_element
@@ -6100,8 +6114,8 @@ CREATE TABLE ${table_name} (
     test("xml[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['<a>1</a>', '<b>2</b>']::xml[] || 
+        SELECT
+          ARRAY['<a>1</a>', '<b>2</b>']::xml[] ||
           ARRAY['<c>3</c>', '<d>4</d>']::xml[] as concatenated
       `;
 
@@ -6126,7 +6140,7 @@ CREATE TABLE ${table_name} (
     test("xml[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['<a>1</a>', '<b>2</b>', '<c>3</c>']::xml[], 1) as array_length,
           array_dims(ARRAY['<a>1</a>', '<b>2</b>', '<c>3</c>']::xml[]) as dimensions,
           array_upper(ARRAY['<a>1</a>', '<b>2</b>', '<c>3</c>']::xml[], 1) as upper_bound,
@@ -6250,7 +6264,7 @@ CREATE TABLE ${table_name} (
     test("point[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['(1,2)', '(3,4)', '(5,6)']::point[])[1] as first_element,
           (ARRAY['(1,2)', '(3,4)', '(5,6)']::point[])[2] as second_element,
           (ARRAY['(1,2)', '(3,4)', '(5,6)']::point[])[3] as third_element
@@ -6264,7 +6278,7 @@ CREATE TABLE ${table_name} (
     test("point[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['(1,2)', '(3,4)']::point[] || ARRAY['(5,6)', '(7,8)']::point[] as concatenated
       `;
 
@@ -6274,7 +6288,7 @@ CREATE TABLE ${table_name} (
     test("point[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['(1,2)', '(3,4)', '(5,6)']::point[], 1) as array_length,
           array_dims(ARRAY['(1,2)', '(3,4)', '(5,6)']::point[]) as dimensions,
           array_upper(ARRAY['(1,2)', '(3,4)', '(5,6)']::point[], 1) as upper_bound,
@@ -6387,7 +6401,7 @@ CREATE TABLE ${table_name} (
     test("lseg[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]', '[(9,10),(11,12)]']::lseg[])[1] as first_element,
           (ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]', '[(9,10),(11,12)]']::lseg[])[2] as second_element,
           (ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]', '[(9,10),(11,12)]']::lseg[])[3] as third_element
@@ -6401,8 +6415,8 @@ CREATE TABLE ${table_name} (
     test("lseg[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]']::lseg[] || 
+        SELECT
+          ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]']::lseg[] ||
           ARRAY['[(9,10),(11,12)]', '[(13,14),(15,16)]']::lseg[] as concatenated
       `;
 
@@ -6416,7 +6430,7 @@ CREATE TABLE ${table_name} (
     test("lseg[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]', '[(9,10),(11,12)]']::lseg[], 1) as array_length,
           array_dims(ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]', '[(9,10),(11,12)]']::lseg[]) as dimensions,
           array_upper(ARRAY['[(1,2),(3,4)]', '[(5,6),(7,8)]', '[(9,10),(11,12)]']::lseg[], 1) as upper_bound,
@@ -6534,7 +6548,7 @@ CREATE TABLE ${table_name} (
     test("path[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))', '[(9,10),(11,12)]']::path[])[1] as first_element,
           (ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))', '[(9,10),(11,12)]']::path[])[2] as second_element,
           (ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))', '[(9,10),(11,12)]']::path[])[3] as third_element
@@ -6548,8 +6562,8 @@ CREATE TABLE ${table_name} (
     test("path[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))']::path[] || 
+        SELECT
+          ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))']::path[] ||
           ARRAY['[(9,10),(11,12)]']::path[] as concatenated
       `;
 
@@ -6559,7 +6573,7 @@ CREATE TABLE ${table_name} (
     test("path[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))', '[(9,10),(11,12)]']::path[], 1) as array_length,
           array_dims(ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))', '[(9,10),(11,12)]']::path[]) as dimensions,
           array_upper(ARRAY['[(1,2),(3,4)]', '((5,6),(7,8))', '[(9,10),(11,12)]']::path[], 1) as upper_bound,
@@ -6663,7 +6677,7 @@ CREATE TABLE ${table_name} (
     test("box[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['((0,0),(1,1))', '((2,2),(3,3))', '((4,4),(5,5))']::box[])[1] as first_element,
           (ARRAY['((0,0),(1,1))', '((2,2),(3,3))', '((4,4),(5,5))']::box[])[2] as second_element,
           (ARRAY['((0,0),(1,1))', '((2,2),(3,3))', '((4,4),(5,5))']::box[])[3] as third_element
@@ -6677,8 +6691,8 @@ CREATE TABLE ${table_name} (
     test("box[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['((0,0),(1,1))', '((2,2),(3,3))']::box[] || 
+        SELECT
+          ARRAY['((0,0),(1,1))', '((2,2),(3,3))']::box[] ||
           ARRAY['((4,4),(5,5))']::box[] as concatenated
       `;
 
@@ -6688,7 +6702,7 @@ CREATE TABLE ${table_name} (
     test("box[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['((0,0),(1,1))', '((2,2),(3,3))']::box[], 1) as array_length,
           array_dims(ARRAY['((0,0),(1,1))', '((2,2),(3,3))']::box[]) as dimensions,
           array_upper(ARRAY['((0,0),(1,1))', '((2,2),(3,3))']::box[], 1) as upper_bound,
@@ -6704,7 +6718,7 @@ CREATE TABLE ${table_name} (
     test("box[] - box operators", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           box '((0,0),(1,1))' = box '((1,1),(0,0))' as same_box,
           box '((0,0),(2,2))' @> box '((1,1),(1.5,1.5))' as contains_box,
           box '((0,0),(2,2))' && box '((1,1),(3,3))' as overlaps_box
@@ -6810,7 +6824,7 @@ CREATE TABLE ${table_name} (
     test("polygon[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['((0,0),(1,1),(2,0))', '((0,0),(0,1),(1,1),(1,0))']::polygon[])[1] as first_element,
           (ARRAY['((0,0),(1,1),(2,0))', '((0,0),(0,1),(1,1),(1,0))']::polygon[])[2] as second_element
       `;
@@ -6822,8 +6836,8 @@ CREATE TABLE ${table_name} (
     test("polygon[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['((0,0),(1,1),(2,0))']::polygon[] || 
+        SELECT
+          ARRAY['((0,0),(1,1),(2,0))']::polygon[] ||
           ARRAY['((0,0),(0,1),(1,1),(1,0))']::polygon[] as concatenated
       `;
 
@@ -6833,7 +6847,7 @@ CREATE TABLE ${table_name} (
     test("polygon[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['((0,0),(1,1),(2,0))', '((0,0),(0,1),(1,1),(1,0))']::polygon[], 1) as array_length,
           array_dims(ARRAY['((0,0),(1,1),(2,0))', '((0,0),(0,1),(1,1),(1,0))']::polygon[]) as dimensions,
           array_upper(ARRAY['((0,0),(1,1),(2,0))', '((0,0),(0,1),(1,1),(1,0))']::polygon[], 1) as upper_bound,
@@ -6849,7 +6863,7 @@ CREATE TABLE ${table_name} (
     test("polygon[] - polygon operators", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           '((0,0),(1,1),(1,0))'::polygon @> point '(0.5,0.5)' as contains_point,
           '((0,0),(2,2),(2,0))'::polygon @> '((0.5,0.5),(1.5,1.5),(1.5,0.5))'::polygon as contains_polygon,
           '((0,0),(2,2),(2,0))'::polygon && '((1,1),(3,3),(3,1))'::polygon as overlaps_polygon
@@ -6942,7 +6956,7 @@ CREATE TABLE ${table_name} (
     test("line[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['{1,2,3}', '{4,5,6}', '{7,8,9}']::line[])[1] as first_element,
           (ARRAY['{1,2,3}', '{4,5,6}', '{7,8,9}']::line[])[2] as second_element,
           (ARRAY['{1,2,3}', '{4,5,6}', '{7,8,9}']::line[])[3] as third_element
@@ -6956,8 +6970,8 @@ CREATE TABLE ${table_name} (
     test("line[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['{1,2,3}', '{4,5,6}']::line[] || 
+        SELECT
+          ARRAY['{1,2,3}', '{4,5,6}']::line[] ||
           ARRAY['{7,8,9}']::line[] as concatenated
       `;
 
@@ -6967,7 +6981,7 @@ CREATE TABLE ${table_name} (
     test("line[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['{1,2,3}', '{4,5,6}']::line[], 1) as array_length,
           array_dims(ARRAY['{1,2,3}', '{4,5,6}']::line[]) as dimensions,
           array_upper(ARRAY['{1,2,3}', '{4,5,6}']::line[], 1) as upper_bound,
@@ -7085,7 +7099,7 @@ CREATE TABLE ${table_name} (
     test("cidr[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['192.168.1.0/24', '10.0.0.0/8', '172.16.0.0/16']::cidr[])[1] as first_element,
           (ARRAY['192.168.1.0/24', '10.0.0.0/8', '172.16.0.0/16']::cidr[])[2] as second_element,
           (ARRAY['192.168.1.0/24', '10.0.0.0/8', '172.16.0.0/16']::cidr[])[3] as third_element
@@ -7099,8 +7113,8 @@ CREATE TABLE ${table_name} (
     test("cidr[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['192.168.1.0/24', '10.0.0.0/8']::cidr[] || 
+        SELECT
+          ARRAY['192.168.1.0/24', '10.0.0.0/8']::cidr[] ||
           ARRAY['172.16.0.0/16']::cidr[] as concatenated
       `;
 
@@ -7110,7 +7124,7 @@ CREATE TABLE ${table_name} (
     test("cidr[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['192.168.1.0/24', '10.0.0.0/8']::cidr[], 1) as array_length,
           array_dims(ARRAY['192.168.1.0/24', '10.0.0.0/8']::cidr[]) as dimensions,
           array_upper(ARRAY['192.168.1.0/24', '10.0.0.0/8']::cidr[], 1) as upper_bound,
@@ -7240,7 +7254,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1.1, 2.2, 3.3]::float4[])[1] as first_element,
           (ARRAY[1.1, 2.2, 3.3]::float4[])[2] as second_element,
           (ARRAY[1.1, 2.2, 3.3]::float4[])[3] as third_element
@@ -7254,7 +7268,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.1, 2.2, 3.3]::float4[] @> ARRAY[1.1]::float4[] as contains_first,
           ARRAY[1.1, 2.2, 3.3]::float4[] @> ARRAY[2.2]::float4[] as contains_second,
           ARRAY[1.1, 2.2, 3.3]::float4[] @> ARRAY[4.4]::float4[] as contains_none,
@@ -7270,7 +7284,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.1, 2.2]::float4[] && ARRAY[2.2, 3.3]::float4[] as has_overlap,
           ARRAY[1.1, 2.2]::float4[] && ARRAY[3.3, 4.4]::float4[] as no_overlap
       `;
@@ -7282,7 +7296,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.1, 2.2]::float4[] || ARRAY[3.3, 4.4]::float4[] as concatenated
       `;
 
@@ -7292,7 +7306,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - mathematical operations", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT array_agg((value * 2)::float4) FROM unnest(ARRAY[1.1, 2.2, 3.3]::float4[]) as value) as multiplication,
           (SELECT array_agg((value + 1)::float4) FROM unnest(ARRAY[1.1, 2.2, 3.3]::float4[]) as value) as addition
       `;
@@ -7304,7 +7318,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1.1, 2.2, 3.3]::float4[], 1) as array_length,
           array_dims(ARRAY[1.1, 2.2, 3.3]::float4[]) as dimensions,
           array_upper(ARRAY[1.1, 2.2, 3.3]::float4[], 1) as upper_bound,
@@ -7320,7 +7334,7 @@ CREATE TABLE ${table_name} (
     test("float4[] - precision comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.23456789::float4]::float4[] as high_precision,
           ARRAY[1.23456789::float8::float4]::float4[] as converted_precision
       `;
@@ -7451,7 +7465,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1.1, 2.2, 3.3]::float8[])[1] as first_element,
           (ARRAY[1.1, 2.2, 3.3]::float8[])[2] as second_element,
           (ARRAY[1.1, 2.2, 3.3]::float8[])[3] as third_element
@@ -7465,7 +7479,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.1, 2.2, 3.3]::float8[] @> ARRAY[1.1]::float8[] as contains_first,
           ARRAY[1.1, 2.2, 3.3]::float8[] @> ARRAY[2.2]::float8[] as contains_second,
           ARRAY[1.1, 2.2, 3.3]::float8[] @> ARRAY[4.4]::float8[] as contains_none,
@@ -7481,7 +7495,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.1, 2.2]::float8[] && ARRAY[2.2, 3.3]::float8[] as has_overlap,
           ARRAY[1.1, 2.2]::float8[] && ARRAY[3.3, 4.4]::float8[] as no_overlap
       `;
@@ -7493,7 +7507,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.1, 2.2]::float8[] || ARRAY[3.3, 4.4]::float8[] as concatenated
       `;
 
@@ -7503,7 +7517,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - mathematical operations", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (SELECT array_agg((value * 2)::float8) FROM unnest(ARRAY[1.1, 2.2, 3.3]::float8[]) as value) as multiplication,
           (SELECT array_agg((value + 1)::float8) FROM unnest(ARRAY[1.1, 2.2, 3.3]::float8[]) as value) as addition,
           (SELECT array_agg(round(value::numeric, 10)) FROM unnest(ARRAY[1.1111111111, 2.2222222222]::float8[]) as value) as rounding
@@ -7517,7 +7531,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1.1, 2.2, 3.3]::float8[], 1) as array_length,
           array_dims(ARRAY[1.1, 2.2, 3.3]::float8[]) as dimensions,
           array_upper(ARRAY[1.1, 2.2, 3.3]::float8[], 1) as upper_bound,
@@ -7533,7 +7547,7 @@ CREATE TABLE ${table_name} (
     test("float8[] - precision comparison with float4", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.23456789012345::float8]::float8[] as double_precision,
           ARRAY[1.23456789012345::float4::float8]::float8[] as converted_precision
       `;
@@ -7629,7 +7643,7 @@ CREATE TABLE ${table_name} (
     test("circle[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['<(0,0),1>', '<(1,1),2>', '<(2,2),3>']::circle[])[1] as first_element,
           (ARRAY['<(0,0),1>', '<(1,1),2>', '<(2,2),3>']::circle[])[2] as second_element,
           (ARRAY['<(0,0),1>', '<(1,1),2>', '<(2,2),3>']::circle[])[3] as third_element
@@ -7643,8 +7657,8 @@ CREATE TABLE ${table_name} (
     test("circle[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['<(0,0),1>', '<(1,1),2>']::circle[] || 
+        SELECT
+          ARRAY['<(0,0),1>', '<(1,1),2>']::circle[] ||
           ARRAY['<(2,2),3>']::circle[] as concatenated
       `;
 
@@ -7654,7 +7668,7 @@ CREATE TABLE ${table_name} (
     test("circle[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['<(0,0),1>', '<(1,1),2>']::circle[], 1) as array_length,
           array_dims(ARRAY['<(0,0),1>', '<(1,1),2>']::circle[]) as dimensions,
           array_upper(ARRAY['<(0,0),1>', '<(1,1),2>']::circle[], 1) as upper_bound,
@@ -7764,7 +7778,7 @@ CREATE TABLE ${table_name} (
     test("macaddr8[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['08:00:2b:01:02:03:04:05', '08:00:2b:01:02:03:04:06']::macaddr8[])[1] as first_element,
           (ARRAY['08:00:2b:01:02:03:04:05', '08:00:2b:01:02:03:04:06']::macaddr8[])[2] as second_element
       `;
@@ -7776,8 +7790,8 @@ CREATE TABLE ${table_name} (
     test("macaddr8[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['08:00:2b:01:02:03:04:05']::macaddr8[] || 
+        SELECT
+          ARRAY['08:00:2b:01:02:03:04:05']::macaddr8[] ||
           ARRAY['08:00:2b:01:02:03:04:06']::macaddr8[] as concatenated
       `;
 
@@ -7787,7 +7801,7 @@ CREATE TABLE ${table_name} (
     test("macaddr8[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['08:00:2b:01:02:03:04:05', '08:00:2b:01:02:03:04:06']::macaddr8[], 1) as array_length,
           array_dims(ARRAY['08:00:2b:01:02:03:04:05', '08:00:2b:01:02:03:04:06']::macaddr8[]) as dimensions,
           array_upper(ARRAY['08:00:2b:01:02:03:04:05', '08:00:2b:01:02:03:04:06']::macaddr8[], 1) as upper_bound,
@@ -7911,7 +7925,7 @@ CREATE TABLE ${table_name} (
     test("money[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['$100.00', '$200.00', '$300.00']::money[])[1] as first_element,
           (ARRAY['$100.00', '$200.00', '$300.00']::money[])[2] as second_element,
           (ARRAY['$100.00', '$200.00', '$300.00']::money[])[3] as third_element
@@ -7925,7 +7939,7 @@ CREATE TABLE ${table_name} (
     test("money[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['$100.00', '$200.00']::money[] || ARRAY['$300.00']::money[] as concatenated
       `;
 
@@ -7938,7 +7952,7 @@ CREATE TABLE ${table_name} (
         WITH money_values AS (
           SELECT unnest(ARRAY['$100.00', '$200.00', '$300.00']::money[]) as amount
         )
-        SELECT 
+        SELECT
           sum(amount)::money as total,
           min(amount)::money as minimum,
           max(amount)::money as maximum
@@ -7953,7 +7967,7 @@ CREATE TABLE ${table_name} (
     test("money[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['$100.00', '$200.00']::money[], 1) as array_length,
           array_dims(ARRAY['$100.00', '$200.00']::money[]) as dimensions,
           array_upper(ARRAY['$100.00', '$200.00']::money[], 1) as upper_bound,
@@ -8058,7 +8072,7 @@ CREATE TABLE ${table_name} (
     test("macaddr[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['08:00:2b:01:02:03', '08:00:2b:01:02:04']::macaddr[])[1] as first_element,
           (ARRAY['08:00:2b:01:02:03', '08:00:2b:01:02:04']::macaddr[])[2] as second_element
       `;
@@ -8070,8 +8084,8 @@ CREATE TABLE ${table_name} (
     test("macaddr[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['08:00:2b:01:02:03']::macaddr[] || 
+        SELECT
+          ARRAY['08:00:2b:01:02:03']::macaddr[] ||
           ARRAY['08:00:2b:01:02:04']::macaddr[] as concatenated
       `;
 
@@ -8081,7 +8095,7 @@ CREATE TABLE ${table_name} (
     test("macaddr[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['08:00:2b:01:02:03', '08:00:2b:01:02:04']::macaddr[], 1) as array_length,
           array_dims(ARRAY['08:00:2b:01:02:03', '08:00:2b:01:02:04']::macaddr[]) as dimensions,
           array_upper(ARRAY['08:00:2b:01:02:03', '08:00:2b:01:02:04']::macaddr[], 1) as upper_bound,
@@ -8214,7 +8228,7 @@ CREATE TABLE ${table_name} (
     test("inet[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['192.168.1.1', '10.0.0.1']::inet[])[1] as first_element,
           (ARRAY['192.168.1.1', '10.0.0.1']::inet[])[2] as second_element
       `;
@@ -8226,7 +8240,7 @@ CREATE TABLE ${table_name} (
     test("inet[] - network containment operators", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           '192.168.1.0/24'::inet << '192.168.1.1'::inet as network_contains_address,
           '192.168.1.0/24'::inet <<= '192.168.1.0/24'::inet as network_contains_equals,
           '192.168.1.1'::inet >> '192.168.1.0/24'::inet as address_contained_by,
@@ -8242,8 +8256,8 @@ CREATE TABLE ${table_name} (
     test("inet[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['192.168.1.1', '10.0.0.1']::inet[] || 
+        SELECT
+          ARRAY['192.168.1.1', '10.0.0.1']::inet[] ||
           ARRAY['172.16.0.1']::inet[] as concatenated
       `;
 
@@ -8253,7 +8267,7 @@ CREATE TABLE ${table_name} (
     test("inet[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['192.168.1.1', '10.0.0.1']::inet[], 1) as array_length,
           array_dims(ARRAY['192.168.1.1', '10.0.0.1']::inet[]) as dimensions,
           array_upper(ARRAY['192.168.1.1', '10.0.0.1']::inet[], 1) as upper_bound,
@@ -8376,7 +8390,7 @@ CREATE TABLE ${table_name} (
     test("bpchar[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['A', 'B', 'C']::bpchar[])[1] as first_element,
           (ARRAY['A', 'B', 'C']::bpchar[])[2] as second_element,
           (ARRAY['A', 'B', 'C']::bpchar[])[3] as third_element
@@ -8390,7 +8404,7 @@ CREATE TABLE ${table_name} (
     test("bpchar[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['A', 'B', 'C']::bpchar[], 1) as array_length,
           array_dims(ARRAY['A', 'B', 'C']::bpchar[]) as dimensions,
           array_upper(ARRAY['A', 'B', 'C']::bpchar[], 1) as upper_bound,
@@ -8406,7 +8420,7 @@ CREATE TABLE ${table_name} (
     test("bpchar[] - string comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY['abc'::char(5)] = ARRAY['abc  '::char(5)]::bpchar[] as equal_with_padding,
           ARRAY['abc'::char(5)] = ARRAY['def  '::char(5)]::bpchar[] as not_equal,
           ARRAY['abc'::char(5)] < ARRAY['def  '::char(5)]::bpchar[] as less_than,
@@ -8529,7 +8543,7 @@ CREATE TABLE ${table_name} (
     test("varchar[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['first', 'second', 'third']::varchar[])[1] as first_element,
           (ARRAY['first', 'second', 'third']::varchar[])[2] as second_element,
           (ARRAY['first', 'second', 'third']::varchar[])[3] as third_element
@@ -8543,8 +8557,8 @@ CREATE TABLE ${table_name} (
     test("varchar[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['first', 'second']::varchar[] || 
+        SELECT
+          ARRAY['first', 'second']::varchar[] ||
           ARRAY['third']::varchar[] as concatenated
       `;
 
@@ -8554,7 +8568,7 @@ CREATE TABLE ${table_name} (
     test("varchar[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['first', 'second', 'third']::varchar[], 1) as array_length,
           array_dims(ARRAY['first', 'second', 'third']::varchar[]) as dimensions,
           array_upper(ARRAY['first', 'second', 'third']::varchar[], 1) as upper_bound,
@@ -8573,7 +8587,7 @@ CREATE TABLE ${table_name} (
         WITH test_array AS (
           SELECT ARRAY['test1', 'test2', 'other', 'test3']::varchar[] as values
         )
-        SELECT 
+        SELECT
           array_agg(v ORDER BY v) FILTER (WHERE v LIKE 'test%') as filtered
         FROM test_array, unnest(values) as v
       `;
@@ -8725,7 +8739,7 @@ CREATE TABLE ${table_name} (
     test("date[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['2024-01-01', '2024-01-02', '2024-01-03']::date[])[1] as first_element,
           (ARRAY['2024-01-01', '2024-01-02', '2024-01-03']::date[])[2] as second_element,
           (ARRAY['2024-01-01', '2024-01-02', '2024-01-03']::date[])[3] as third_element
@@ -8739,14 +8753,14 @@ CREATE TABLE ${table_name} (
     test("date[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['2024-01-01', '2024-01-02']::date[] @> 
+        SELECT
+          ARRAY['2024-01-01', '2024-01-02']::date[] @>
           ARRAY['2024-01-01']::date[] as contains_first,
-          
-          ARRAY['2024-01-01', '2024-01-02']::date[] @> 
+
+          ARRAY['2024-01-01', '2024-01-02']::date[] @>
           ARRAY['2024-01-02']::date[] as contains_second,
-          
-          ARRAY['2024-01-01', '2024-01-02']::date[] @> 
+
+          ARRAY['2024-01-01', '2024-01-02']::date[] @>
           ARRAY['2024-01-03']::date[] as contains_none
       `;
 
@@ -8758,11 +8772,11 @@ CREATE TABLE ${table_name} (
     test("date[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['2024-01-01', '2024-01-02']::date[] && 
+        SELECT
+          ARRAY['2024-01-01', '2024-01-02']::date[] &&
           ARRAY['2024-01-02', '2024-01-03']::date[] as has_overlap,
-          
-          ARRAY['2024-01-01', '2024-01-02']::date[] && 
+
+          ARRAY['2024-01-01', '2024-01-02']::date[] &&
           ARRAY['2024-01-03', '2024-01-04']::date[] as no_overlap
       `;
 
@@ -8773,8 +8787,8 @@ CREATE TABLE ${table_name} (
     test("date[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['2024-01-01', '2024-01-02']::date[] || 
+        SELECT
+          ARRAY['2024-01-01', '2024-01-02']::date[] ||
           ARRAY['2024-01-03']::date[] as concatenated
       `;
 
@@ -8788,14 +8802,14 @@ CREATE TABLE ${table_name} (
     test("date[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['2024-01-01', '2024-01-02']::date[] = 
+        SELECT
+          ARRAY['2024-01-01', '2024-01-02']::date[] =
           ARRAY['2024-01-01', '2024-01-02']::date[] as equal_arrays,
-          
-          ARRAY['2024-01-01', '2024-01-02']::date[] < 
+
+          ARRAY['2024-01-01', '2024-01-02']::date[] <
           ARRAY['2024-01-02', '2024-01-02']::date[] as less_than,
-          
-          ARRAY['2024-01-02', '2024-01-02']::date[] > 
+
+          ARRAY['2024-01-02', '2024-01-02']::date[] >
           ARRAY['2024-01-01', '2024-01-02']::date[] as greater_than
       `;
 
@@ -8807,7 +8821,7 @@ CREATE TABLE ${table_name} (
     test("date[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['2024-01-01', '2024-01-02']::date[], 1) as array_length,
           array_dims(ARRAY['2024-01-01', '2024-01-02']::date[]) as dimensions,
           array_upper(ARRAY['2024-01-01', '2024-01-02']::date[], 1) as upper_bound,
@@ -8940,7 +8954,7 @@ CREATE TABLE ${table_name} (
     test("time[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['12:34:56', '15:45:32', '23:59:59']::time[])[1] as first_element,
           (ARRAY['12:34:56', '15:45:32', '23:59:59']::time[])[2] as second_element,
           (ARRAY['12:34:56', '15:45:32', '23:59:59']::time[])[3] as third_element
@@ -8954,8 +8968,8 @@ CREATE TABLE ${table_name} (
     test("time[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['12:34:56', '15:45:32']::time[] || 
+        SELECT
+          ARRAY['12:34:56', '15:45:32']::time[] ||
           ARRAY['23:59:59']::time[] as concatenated
       `;
 
@@ -8965,14 +8979,14 @@ CREATE TABLE ${table_name} (
     test("time[] - array comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['12:34:56', '15:45:32']::time[] = 
+        SELECT
+          ARRAY['12:34:56', '15:45:32']::time[] =
           ARRAY['12:34:56', '15:45:32']::time[] as equal_arrays,
-          
-          ARRAY['12:34:56', '15:45:32']::time[] < 
+
+          ARRAY['12:34:56', '15:45:32']::time[] <
           ARRAY['15:45:32', '15:45:32']::time[] as less_than,
-          
-          ARRAY['15:45:32', '15:45:32']::time[] > 
+
+          ARRAY['15:45:32', '15:45:32']::time[] >
           ARRAY['12:34:56', '15:45:32']::time[] as greater_than
       `;
 
@@ -8984,7 +8998,7 @@ CREATE TABLE ${table_name} (
     test("time[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['12:34:56', '15:45:32']::time[], 1) as array_length,
           array_dims(ARRAY['12:34:56', '15:45:32']::time[]) as dimensions,
           array_upper(ARRAY['12:34:56', '15:45:32']::time[], 1) as upper_bound,
@@ -9142,7 +9156,7 @@ CREATE TABLE ${table_name} (
     test("timestamp[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[])[1] as first_element,
           (ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[])[2] as second_element
       `;
@@ -9154,8 +9168,8 @@ CREATE TABLE ${table_name} (
     test("timestamp[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[] || 
+        SELECT
+          ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[] ||
           ARRAY['2024-01-03 14:00:00']::timestamp[] as concatenated
       `;
 
@@ -9169,7 +9183,7 @@ CREATE TABLE ${table_name} (
     test("timestamp[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[], 1) as array_length,
           array_dims(ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[]) as dimensions,
           array_upper(ARRAY['2024-01-01 12:00:00', '2024-01-02 13:00:00']::timestamp[], 1) as upper_bound,
@@ -9361,7 +9375,7 @@ CREATE TABLE ${table_name} (
     test("timestamptz[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[])[1] as first_element,
           (ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[])[2] as second_element
       `;
@@ -9373,14 +9387,14 @@ CREATE TABLE ${table_name} (
     test("timestamptz[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[] @> 
+        SELECT
+          ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[] @>
           ARRAY['2024-01-01 12:00:00+00']::timestamptz[] as contains_first,
-          
-          ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[] @> 
+
+          ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[] @>
           ARRAY['2024-01-02 13:00:00+00']::timestamptz[] as contains_second,
-          
-          ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[] @> 
+
+          ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[] @>
           ARRAY['2024-01-03 14:00:00+00']::timestamptz[] as contains_none
       `;
 
@@ -9392,7 +9406,7 @@ CREATE TABLE ${table_name} (
     test("timestamptz[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[], 1) as array_length,
           array_dims(ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[]) as dimensions,
           array_upper(ARRAY['2024-01-01 12:00:00+00', '2024-01-02 13:00:00+00']::timestamptz[], 1) as upper_bound,
@@ -9536,7 +9550,7 @@ CREATE TABLE ${table_name} (
     test("timetz[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['12:00:00+00', '13:00:00+00']::timetz[])[1] as first_element,
           (ARRAY['12:00:00+00', '13:00:00+00']::timetz[])[2] as second_element
       `;
@@ -9548,14 +9562,14 @@ CREATE TABLE ${table_name} (
     test("timetz[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] @> 
+        SELECT
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] @>
           ARRAY['12:00:00+00']::timetz[] as contains_first,
-          
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] @> 
+
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] @>
           ARRAY['13:00:00+00']::timetz[] as contains_second,
-          
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] @> 
+
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] @>
           ARRAY['14:00:00+00']::timetz[] as contains_none
       `;
 
@@ -9567,11 +9581,11 @@ CREATE TABLE ${table_name} (
     test("timetz[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] && 
+        SELECT
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] &&
           ARRAY['13:00:00+00', '14:00:00+00']::timetz[] as has_overlap,
-          
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] && 
+
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] &&
           ARRAY['14:00:00+00', '15:00:00+00']::timetz[] as no_overlap
       `;
 
@@ -9582,8 +9596,8 @@ CREATE TABLE ${table_name} (
     test("timetz[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] || 
+        SELECT
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] ||
           ARRAY['14:00:00+00']::timetz[] as concatenated
       `;
 
@@ -9593,11 +9607,11 @@ CREATE TABLE ${table_name} (
     test("timetz[] - comparison of same time different zones", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] = 
+        SELECT
+          ARRAY['12:00:00+00', '13:00:00+00']::timetz[] =
           ARRAY['12:00:00+01', '13:00:00+01']::timetz[] as equal_arrays,
-          
-          ARRAY['12:00:00+00']::timetz[] = 
+
+          ARRAY['12:00:00+00']::timetz[] =
           ARRAY['13:00:00+01']::timetz[] as different_times
       `;
 
@@ -9609,7 +9623,7 @@ CREATE TABLE ${table_name} (
     test("timetz[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['12:00:00+00', '13:00:00+00']::timetz[], 1) as array_length,
           array_dims(ARRAY['12:00:00+00', '13:00:00+00']::timetz[]) as dimensions,
           array_upper(ARRAY['12:00:00+00', '13:00:00+00']::timetz[], 1) as upper_bound,
@@ -9781,7 +9795,7 @@ CREATE TABLE ${table_name} (
     test("interval[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['1 year', '2 months']::interval[])[1] as first_element,
           (ARRAY['1 year', '2 months']::interval[])[2] as second_element
       `;
@@ -9793,14 +9807,14 @@ CREATE TABLE ${table_name} (
     test("interval[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['1 year', '2 months']::interval[] @> 
+        SELECT
+          ARRAY['1 year', '2 months']::interval[] @>
           ARRAY['1 year']::interval[] as contains_first,
-          
-          ARRAY['1 year', '2 months']::interval[] @> 
+
+          ARRAY['1 year', '2 months']::interval[] @>
           ARRAY['2 months']::interval[] as contains_second,
-          
-          ARRAY['1 year', '2 months']::interval[] @> 
+
+          ARRAY['1 year', '2 months']::interval[] @>
           ARRAY['3 months']::interval[] as contains_none
       `;
 
@@ -9812,11 +9826,11 @@ CREATE TABLE ${table_name} (
     test("interval[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['1 year', '2 months']::interval[] && 
+        SELECT
+          ARRAY['1 year', '2 months']::interval[] &&
           ARRAY['2 months', '3 months']::interval[] as has_overlap,
-          
-          ARRAY['1 year', '2 months']::interval[] && 
+
+          ARRAY['1 year', '2 months']::interval[] &&
           ARRAY['3 months', '4 months']::interval[] as no_overlap
       `;
 
@@ -9827,8 +9841,8 @@ CREATE TABLE ${table_name} (
     test("interval[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['1 year', '2 months']::interval[] || 
+        SELECT
+          ARRAY['1 year', '2 months']::interval[] ||
           ARRAY['3 days']::interval[] as concatenated
       `;
 
@@ -9838,7 +9852,7 @@ CREATE TABLE ${table_name} (
     test("interval[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['1 year', '2 months']::interval[], 1) as array_length,
           array_dims(ARRAY['1 year', '2 months']::interval[]) as dimensions,
           array_upper(ARRAY['1 year', '2 months']::interval[], 1) as upper_bound,
@@ -9937,7 +9951,7 @@ CREATE TABLE ${table_name} (
     test("bit[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[B'101', B'111', B'000']::bit(3)[])[1] as first_element,
           (ARRAY[B'101', B'111', B'000']::bit(3)[])[2] as second_element,
           (ARRAY[B'101', B'111', B'000']::bit(3)[])[3] as third_element
@@ -9951,7 +9965,7 @@ CREATE TABLE ${table_name} (
     test("bit[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[B'101', B'111']::bit(3)[] @> ARRAY[B'101']::bit(3)[] as contains_first,
           ARRAY[B'101', B'111']::bit(3)[] @> ARRAY[B'111']::bit(3)[] as contains_second,
           ARRAY[B'101', B'111']::bit(3)[] @> ARRAY[B'000']::bit(3)[] as contains_none
@@ -9965,11 +9979,11 @@ CREATE TABLE ${table_name} (
     test("bit[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY[B'101', B'111']::bit(3)[] && 
+        SELECT
+          ARRAY[B'101', B'111']::bit(3)[] &&
           ARRAY[B'111', B'000']::bit(3)[] as has_overlap,
-          
-          ARRAY[B'101', B'111']::bit(3)[] && 
+
+          ARRAY[B'101', B'111']::bit(3)[] &&
           ARRAY[B'000', B'010']::bit(3)[] as no_overlap
       `;
 
@@ -9980,8 +9994,8 @@ CREATE TABLE ${table_name} (
     test("bit[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY[B'101', B'111']::bit(3)[] || 
+        SELECT
+          ARRAY[B'101', B'111']::bit(3)[] ||
           ARRAY[B'000']::bit(3)[] as concatenated
       `;
 
@@ -9991,7 +10005,7 @@ CREATE TABLE ${table_name} (
     test("bit[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[B'101', B'111']::bit(3)[], 1) as array_length,
           array_dims(ARRAY[B'101', B'111']::bit(3)[]) as dimensions,
           array_upper(ARRAY[B'101', B'111']::bit(3)[], 1) as upper_bound,
@@ -10136,7 +10150,7 @@ CREATE TABLE ${table_name} (
     test("varbit[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[B'101', B'11', B'1']::varbit[])[1] as first_element,
           (ARRAY[B'101', B'11', B'1']::varbit[])[2] as second_element,
           (ARRAY[B'101', B'11', B'1']::varbit[])[3] as third_element
@@ -10150,7 +10164,7 @@ CREATE TABLE ${table_name} (
     test("varbit[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[B'101', B'11']::varbit[] @> ARRAY[B'101']::varbit[] as contains_first,
           ARRAY[B'101', B'11']::varbit[] @> ARRAY[B'11']::varbit[] as contains_second,
           ARRAY[B'101', B'11']::varbit[] @> ARRAY[B'1111']::varbit[] as contains_none
@@ -10164,11 +10178,11 @@ CREATE TABLE ${table_name} (
     test("varbit[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY[B'101', B'11']::varbit[] && 
+        SELECT
+          ARRAY[B'101', B'11']::varbit[] &&
           ARRAY[B'11', B'1']::varbit[] as has_overlap,
-          
-          ARRAY[B'101', B'11']::varbit[] && 
+
+          ARRAY[B'101', B'11']::varbit[] &&
           ARRAY[B'000', B'0000']::varbit[] as no_overlap
       `;
 
@@ -10179,8 +10193,8 @@ CREATE TABLE ${table_name} (
     test("varbit[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY[B'101', B'11']::varbit[] || 
+        SELECT
+          ARRAY[B'101', B'11']::varbit[] ||
           ARRAY[B'1']::varbit[] as concatenated
       `;
 
@@ -10190,7 +10204,7 @@ CREATE TABLE ${table_name} (
     test("varbit[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[B'101', B'11']::varbit[], 1) as array_length,
           array_dims(ARRAY[B'101', B'11']::varbit[]) as dimensions,
           array_upper(ARRAY[B'101', B'11']::varbit[], 1) as upper_bound,
@@ -10341,7 +10355,7 @@ CREATE TABLE ${table_name} (
     test("numeric[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY[1.23, 4.56, 7.89]::numeric[])[1] as first_element,
           (ARRAY[1.23, 4.56, 7.89]::numeric[])[2] as second_element,
           (ARRAY[1.23, 4.56, 7.89]::numeric[])[3] as third_element
@@ -10355,7 +10369,7 @@ CREATE TABLE ${table_name} (
     test("numeric[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           ARRAY[1.23, 4.56]::numeric[] @> ARRAY[1.23]::numeric[] as contains_first,
           ARRAY[1.23, 4.56]::numeric[] @> ARRAY[4.56]::numeric[] as contains_second,
           ARRAY[1.23, 4.56]::numeric[] @> ARRAY[7.89]::numeric[] as contains_none
@@ -10369,11 +10383,11 @@ CREATE TABLE ${table_name} (
     test("numeric[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY[1.23, 4.56]::numeric[] && 
+        SELECT
+          ARRAY[1.23, 4.56]::numeric[] &&
           ARRAY[4.56, 7.89]::numeric[] as has_overlap,
-          
-          ARRAY[1.23, 4.56]::numeric[] && 
+
+          ARRAY[1.23, 4.56]::numeric[] &&
           ARRAY[7.89, 0.12]::numeric[] as no_overlap
       `;
 
@@ -10384,8 +10398,8 @@ CREATE TABLE ${table_name} (
     test("numeric[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY[1.23, 4.56]::numeric[] || 
+        SELECT
+          ARRAY[1.23, 4.56]::numeric[] ||
           ARRAY[7.89]::numeric[] as concatenated
       `;
 
@@ -10395,7 +10409,7 @@ CREATE TABLE ${table_name} (
     test("numeric[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY[1.23, 4.56]::numeric[], 1) as array_length,
           array_dims(ARRAY[1.23, 4.56]::numeric[]) as dimensions,
           array_upper(ARRAY[1.23, 4.56]::numeric[], 1) as upper_bound,
@@ -10414,7 +10428,7 @@ CREATE TABLE ${table_name} (
         WITH numbers AS (
           SELECT unnest(ARRAY[1.23, 4.56, 7.89]::numeric[]) as num
         )
-        SELECT 
+        SELECT
           sum(num) as total,
           avg(num) as average,
           min(num) as minimum,
@@ -10534,7 +10548,7 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - array operators", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           '{"a": 1, "b": 2}'::jsonb ? 'a' as has_key_a,
           '{"a": 1, "b": 2}'::jsonb ? 'c' as has_key_c,
           '{"a": 1, "b": 2}'::jsonb @> '{"a": 1}'::jsonb as contains_object,
@@ -10563,7 +10577,7 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - array element access", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           (ARRAY['{"a": 1}', '{"b": 2}']::jsonb[])[1] as first_element,
           (ARRAY['{"a": 1}', '{"b": 2}']::jsonb[])[2] as second_element
       `;
@@ -10575,14 +10589,14 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - array contains operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] @> 
+        SELECT
+          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] @>
           ARRAY['{"a": 1}']::jsonb[] as contains_first,
-          
-          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] @> 
+
+          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] @>
           ARRAY['{"b": 2}']::jsonb[] as contains_second,
-          
-          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] @> 
+
+          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] @>
           ARRAY['{"c": 3}']::jsonb[] as contains_none
       `;
 
@@ -10594,11 +10608,11 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - array overlap operator", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] && 
+        SELECT
+          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] &&
           ARRAY['{"b": 2}', '{"c": 3}']::jsonb[] as has_overlap,
-          
-          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] && 
+
+          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] &&
           ARRAY['{"c": 3}', '{"d": 4}']::jsonb[] as no_overlap
       `;
 
@@ -10609,8 +10623,8 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - array concatenation", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] || 
+        SELECT
+          ARRAY['{"a": 1}', '{"b": 2}']::jsonb[] ||
           ARRAY['{"c": 3}']::jsonb[] as concatenated
       `;
 
@@ -10620,7 +10634,7 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - array dimensions", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
+        SELECT
           array_length(ARRAY['{"a": 1}', '{"b": 2}']::jsonb[], 1) as array_length,
           array_dims(ARRAY['{"a": 1}', '{"b": 2}']::jsonb[]) as dimensions,
           array_upper(ARRAY['{"a": 1}', '{"b": 2}']::jsonb[], 1) as upper_bound,
@@ -10710,11 +10724,11 @@ CREATE TABLE ${table_name} (
     test("jsonb[] - unicode objects comparison", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const result = await sql`
-        SELECT 
-          '{"键": "值", "キー": "値"}'::jsonb = 
+        SELECT
+          '{"键": "值", "キー": "値"}'::jsonb =
           '{"キー": "値", "键": "值"}'::jsonb as equal_objects,
-          
-          '{"配列": [1, 2]}'::jsonb @> 
+
+          '{"配列": [1, 2]}'::jsonb @>
           '{"配列": [1]}'::jsonb as contains_check
       `;
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes `sql(["foo", "bar"])` so it doesn't try to extract keys

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

I think the overall wanted behavior would be _if no keys has been provided and the value is an object-like, then we should take its keys_ 

Fixes https://github.com/oven-sh/bun/issues/18775

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

