### PR TITLE
ci: use ReleaseSafe build of Zig compiler

### DIFF
--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -50,7 +50,7 @@ optionx(ZIG_OBJECT_FORMAT "obj|bc" "Output file format for Zig object files" DEF
 
 optionx(ZIG_LOCAL_CACHE_DIR FILEPATH "The path to local the zig cache directory" DEFAULT ${CACHE_PATH}/zig/local)
 optionx(ZIG_GLOBAL_CACHE_DIR FILEPATH "The path to the global zig cache directory" DEFAULT ${CACHE_PATH}/zig/global)
-optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT OFF)
+optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT ${CI})
 
 setenv(ZIG_LOCAL_CACHE_DIR ${ZIG_LOCAL_CACHE_DIR})
 setenv(ZIG_GLOBAL_CACHE_DIR ${ZIG_GLOBAL_CACHE_DIR})


### PR DESCRIPTION
### What does this PR do?

Makes our CI use a build of the Zig compiler with safety checks enabled. This will stop us from merging code that triggers undefined behavior in the compiler.

### How did you verify your code works?

[The first CI run from this PR shows the compiler panicking](https://buildkite.com/bun/bun/builds/15268), which proves that it was correctly using the ReleaseSafe compiler since #19114 hadn't merged yet. Now that this is rebased it should pass CI.

This makes our Zig builds slower, but not by very much (1.6% over 3 runs)

<details>
<summary>benchmark on M3 Max building bun for aarch64-macos</summary>

ReleaseSafe:
```
Benchmark 1: bun run build:ci --target bun-zig
  Time (mean ± σ):     285.889 s ±  1.916 s    [User: 280.831 s, System: 6.014 s]
  Range (min … max):   284.585 s … 288.090 s    3 runs
```
ReleaseFast:
```
Benchmark 1: bun run build:ci --target bun-zig
  Time (mean ± σ):     281.471 s ±  1.223 s    [User: 276.280 s, System: 5.975 s]
  Range (min … max):   280.095 s … 282.435 s    3 runs
```
</details>