### PR TITLE
ci: use ReleaseSafe build of Zig compiler only in Buildkite

### DIFF
--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -50,7 +50,7 @@ optionx(ZIG_OBJECT_FORMAT "obj|bc" "Output file format for Zig object files" DEF
 
 optionx(ZIG_LOCAL_CACHE_DIR FILEPATH "The path to local the zig cache directory" DEFAULT ${CACHE_PATH}/zig/local)
 optionx(ZIG_GLOBAL_CACHE_DIR FILEPATH "The path to the global zig cache directory" DEFAULT ${CACHE_PATH}/zig/global)
-optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT OFF)
+optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT ${BUILDKITE})
 
 setenv(ZIG_LOCAL_CACHE_DIR ${ZIG_LOCAL_CACHE_DIR})
 setenv(ZIG_GLOBAL_CACHE_DIR ${ZIG_GLOBAL_CACHE_DIR})

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -12,7 +12,7 @@ fn crash() packed struct { x: u8, y: u0 } {
 }
 
 comptime {
-_ = crash();
+    _ = crash();
 }
 
 pub const Environment = @import("env.zig");

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -7,6 +7,14 @@ const bun = @This();
 const builtin = @import("builtin");
 const std = @import("std");
 
+fn crash() packed struct { x: u8, y: u0 } {
+    return .{ .x = 0, .y = 0 };
+}
+
+comptime {
+_ = crash();
+}
+
 pub const Environment = @import("env.zig");
 
 pub const use_mimalloc = true;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -7,14 +7,6 @@ const bun = @This();
 const builtin = @import("builtin");
 const std = @import("std");
 
-fn crash() packed struct { x: u8, y: u0 } {
-    return .{ .x = 0, .y = 0 };
-}
-
-comptime {
-    _ = crash();
-}
-
 pub const Environment = @import("env.zig");
 
 pub const use_mimalloc = true;


### PR DESCRIPTION
### What does this PR do?

This is a copy of #19170 but only applies the change in Buildkite (where we compile our Zig code), not in GitHub Actions (where we check `zig fmt`, and we run on x86 machines that we don't have ReleaseSafe Zig built for).

Makes our CI use a build of the Zig compiler with safety checks enabled. This will stop us from merging code that triggers undefined behavior in the compiler.

This will start causing build errors if we ever start doing Zig builds on machines that aren't ARM Macs. I considered checking `CMAKE_HOST_SYSTEM_NAME` and `CMAKE_HOST_SYSTEM_PROCESSOR` instead to see if we are running the build process on a system we have built ReleaseSafe Zig for. I didn't do that because I think it will be better to see an error if we ever switch our Zig builds to a different machine, instead of silently switching back to ReleaseFast.

This makes our Zig builds slower, but not by very much (1.6% over 3 runs)

<details>
<summary>benchmark on M3 Max building bun for aarch64-macos</summary>

ReleaseSafe:
```
Benchmark 1: bun run build:ci --target bun-zig
  Time (mean ± σ):     285.889 s ±  1.916 s    [User: 280.831 s, System: 6.014 s]
  Range (min … max):   284.585 s … 288.090 s    3 runs
```
ReleaseFast:
```
Benchmark 1: bun run build:ci --target bun-zig
  Time (mean ± σ):     281.471 s ±  1.223 s    [User: 276.280 s, System: 5.975 s]
  Range (min … max):   280.095 s … 282.435 s    3 runs
```
</details>

### How did you verify your code works?

In commit 8a9a119a2667b6a21b84ccf9ee8b4f6bfad1fc1a, I added code to repro the crash in ziglang/zig#23307, and it wasn't correctly formatted.

- [The format action worked](https://github.com/oven-sh/bun/pull/19174/commits/0bb4e7fab6ac7098f23631dde755284d6932c871)
- [The Zig compiler panicked](https://buildkite.com/bun/bun/builds/15288#01965aa3-d3d1-45db-a1d9-272e0b7b3f9f/322-666) (this is good; the point of this PR is to prevent us merging code that invokes undefined behavior in the compiler like this).