### PR TITLE
fix(sql) fix flush

### DIFF
--- a/src/bun.js/api/postgres.classes.ts
+++ b/src/bun.js/api/postgres.classes.ts
@@ -29,6 +29,9 @@ export default [
       unref: {
         fn: "doUnref",
       },
+      flush: {
+        fn: "doFlush",
+      },
 
       queries: {
         getter: "getQueries",

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -2057,6 +2057,10 @@ pub const PostgresSQLConnection = struct {
         this.updateHasPendingActivity();
         return .undefined;
     }
+    pub fn doFlush(this: *PostgresSQLConnection, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
+        this.flushData();
+        return .undefined;
+    }
 
     pub fn deref(this: *@This()) void {
         const ref_count = this.ref_count;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -2255,6 +2255,12 @@ if (isDockerEnabled()) {
     expect(result).toBe("1.2");
   });
 
+  test("flush should work", async () => {
+    await using sql = postgres(options);
+    await sql`select 1`;
+    sql.flush();
+  });
+
   // t('Async stack trace', async() => {
   //   const sql = postgres({ ...options, debug: false })
   //   return [


### PR DESCRIPTION
### What does this PR do?
flush should be defined, and should not throw:

<img width="433" alt="Screenshot 2025-04-21 at 17 18 55" src="https://github.com/user-attachments/assets/1398702d-c6df-432c-90a8-a0c18b868851" />

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
