### PR TITLE
compress output of pack-codegen-for-zig-team.sh

### DIFF
--- a/scripts/pack-codegen-for-zig-team.sh
+++ b/scripts/pack-codegen-for-zig-team.sh
@@ -5,7 +5,7 @@ if ! test -d build/debug/codegen; then
 fi
 
 out="codegen-for-zig-team.tar.gz"
-tar -cf "$out" \
+tar -zcf "$out" \
   build/debug/codegen \
   src/bun.js/bindings/GeneratedBindings.zig \
   src/bun.js/bindings/GeneratedJS2Native.zig


### PR DESCRIPTION
### What does this PR do?

Enables gzip compression in this script by passing the `-z` flag to tar (previously it output files named `.tar.gz` but which were actually plain uncompressed archives).

### How did you verify your code works?

```
$ sh scripts/pack-codegen-for-zig-team.sh # before
-> codegen-for-zig-team.tar.gz
$ file codegen-for-zig-team.tar.gz
codegen-for-zig-team.tar.gz: POSIX tar archive
$ du -h codegen-for-zig-team.tar.gz
8.1M    codegen-for-zig-team.tar.gz

$ ./scripts/pack-codegen-for-zig-team.sh # after
-> codegen-for-zig-team.tar.gz
$ file codegen-for-zig-team.tar.gz
codegen-for-zig-team.tar.gz: gzip compressed data, last modified: Tue Apr 22 20:04:06 2025, from Unix, original size modulo 2^32 8510464
$ du -h codegen-for-zig-team.tar.gz
1.0M    codegen-for-zig-team.tar.gz