### PR TITLE
TLSSocket: Match Node.js behaviour in allowHalfOpen property

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -308,7 +308,7 @@ function TLSSocket(socket?, options?) {
   this[krenegotiationDisabled] = undefined;
   this.encrypted = true;
 
-  const isNetSocketOrDuplex = socket instanceof NetSocket || socket instanceof Duplex;
+  const isNetSocketOrDuplex = socket instanceof Duplex;
 
   options = isNetSocketOrDuplex ? { ...options, allowHalfOpen: false } : options || socket || {};
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -308,14 +308,19 @@ function TLSSocket(socket?, options?) {
   this[krenegotiationDisabled] = undefined;
   this.encrypted = true;
 
-  NetSocket.$call(this, socket instanceof NetSocket || socket instanceof Duplex ? options : options || socket);
-  options = options || socket || {};
+  const isNetSocketOrDuplex = socket instanceof NetSocket || socket instanceof Duplex;
+
+  options = isNetSocketOrDuplex ? { ...options, allowHalfOpen: false } : options || socket || {};
+
+  NetSocket.$call(this, options);
+
   if (typeof options === "object") {
     const { ALPNProtocols } = options;
     if (ALPNProtocols) {
       convertALPNProtocols(ALPNProtocols, this);
     }
-    if (socket instanceof NetSocket || socket instanceof Duplex) {
+
+    if (isNetSocketOrDuplex) {
       this._handle = socket;
       // keep compatibility with http2-wrapper or other places that try to grab JSStreamSocket in node.js, with here is just the TLSSocket
       this._handle._parentWrap = this;

--- a/test/js/node/test/parallel/test-tls-socket-allow-half-open-option.js
+++ b/test/js/node/test/parallel/test-tls-socket-allow-half-open-option.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+
+// Test the `allowHalfOpen` option of the `tls.TLSSocket` constructor.
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const net = require('net');
+const stream = require('stream');
+const tls = require('tls');
+
+{
+  // The option is ignored when the `socket` argument is a `net.Socket`.
+  const socket = new tls.TLSSocket(new net.Socket(), { allowHalfOpen: true });
+  assert.strictEqual(socket.allowHalfOpen, false);
+}
+
+{
+  // The option is ignored when the `socket` argument is a generic
+  // `stream.Duplex`.
+  const duplex = new stream.Duplex({
+    allowHalfOpen: false,
+    read() {}
+  });
+  const socket = new tls.TLSSocket(duplex, { allowHalfOpen: true });
+  assert.strictEqual(socket.allowHalfOpen, false);
+}
+
+{
+  const socket = new tls.TLSSocket();
+  assert.strictEqual(socket.allowHalfOpen, false);
+}
+
+{
+  // The option is honored when the `socket` argument is not specified.
+  const socket = new tls.TLSSocket(undefined, { allowHalfOpen: true });
+  assert.strictEqual(socket.allowHalfOpen, true);
+}

--- a/test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
+++ b/test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { Duplex } from "node:stream";
+import { TLSSocket } from "tls";
+
+describe("TLSSocket allowHalfOpen option with Duplex socket", () => {
+  // In both cases we should ignore allowHalfOpen option, regardless of read() {} implementation or not
+
+  it("ignores allowHalfOpen when socket is Duplex with or without read implementation", () => {
+    const duplexNoRead = new Duplex();
+    const socketNoRead = new TLSSocket(duplexNoRead, { allowHalfOpen: true });
+    expect(socketNoRead.allowHalfOpen).toBe(false);
+
+    const duplexWithRead = new Duplex({ read() {} });
+    const socketWithRead = new TLSSocket(duplexWithRead, { allowHalfOpen: true });
+    expect(socketWithRead.allowHalfOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Ignores the `allowHalfOpen` property when a passed socket is a `net.Socket` or `net.Duplex`

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Added the test, it passes