### PR TITLE
configure ZLS build on save (disabled by default)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,9 +39,9 @@
     "./build/debug/zls-cache/g"
     // intentionally not setting a local cache dir
   ],
-  "zig.zls.enableBuildOnSave": true,
+  "zig.zls.enableBuildOnSave": false,
   "zig.buildFilePath": "${workspaceFolder}/build.zig",
-  "zig.path": "${workspaceFolder}/vendor/zig/zig.exe",
+  "zig.pathas it spawns a new process every save which ": "${workspaceFolder}/vendor/zig/zig.exe",
   // TODO: make CI auto-install this commit of ZLS, to enable in-editor builds
   // https://github.com/paperclover/zls/commit/00195e6d6fcf9a79ca0fba81f80128aa8a5d9509
   // "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,18 +27,25 @@
   "git.ignoreLimitWarning": true,
 
   // Zig
-  "zig.initialSetupDone": true,
   "zig.buildOption": "build",
   "zig.zls.zigLibPath": "${workspaceFolder}/vendor/zig/lib",
-  "zig.buildArgs": ["-Dgenerated-code=./build/debug/codegen", "--watch", "-fincremental"],
-  "zig.zls.buildOnSaveStep": "check",
-  // "zig.zls.enableBuildOnSave": true,
-  // "zig.buildOnSave": true,
+  // To activate in-editor incremental builds, run "Zig: Build Workspace"
+  "zig.zls.buildOnSaveArgs": [
+    "check",
+    "-Dcodegen-path=./build/debug/codegen",
+    "-fincremental",
+    "-Dno-llvm",
+    "--global-cache-dir",
+    "./build/debug/zls-cache/g"
+    // intentionally not setting a local cache dir
+  ],
+  "zig.zls.enableBuildOnSave": true,
   "zig.buildFilePath": "${workspaceFolder}/build.zig",
   "zig.path": "${workspaceFolder}/vendor/zig/zig.exe",
-  "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",
+  // TODO: make CI auto-install this commit of ZLS, to enable in-editor builds
+  // https://github.com/paperclover/zls/commit/00195e6d6fcf9a79ca0fba81f80128aa8a5d9509
+  // "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",
   "zig.formattingProvider": "zls",
-  "zig.zls.enableInlayHints": false,
   "[zig]": {
     "editor.tabSize": 4,
     "editor.useTabStops": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,7 +41,7 @@
   ],
   "zig.zls.enableBuildOnSave": false,
   "zig.buildFilePath": "${workspaceFolder}/build.zig",
-  "zig.pathas it spawns a new process every save which ": "${workspaceFolder}/vendor/zig/zig.exe",
+  "zig.path": "${workspaceFolder}/vendor/zig/zig.exe",
   // TODO: make CI auto-install this commit of ZLS, to enable in-editor builds
   // https://github.com/paperclover/zls/commit/00195e6d6fcf9a79ca0fba81f80128aa8a5d9509
   // "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,7 +44,7 @@
   "zig.path": "${workspaceFolder}/vendor/zig/zig.exe",
   // TODO: make CI auto-install this commit of ZLS, to enable in-editor builds
   // https://github.com/paperclover/zls/commit/00195e6d6fcf9a79ca0fba81f80128aa8a5d9509
-  // "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",
+  "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",
   "zig.formattingProvider": "zls",
   "[zig]": {
     "editor.tabSize": 4,

--- a/build.zig
+++ b/build.zig
@@ -189,10 +189,10 @@ pub fn build(b: *Build) !void {
     const target = b.resolveTargetQuery(target_query);
 
     const codegen_path = b.pathFromRoot(
-        b.option([]const u8, "codegen_path", "Set the generated code directory") orelse
+        b.option([]const u8, "codegen-path", "Set the generated code directory") orelse
             "build/debug/codegen",
     );
-    const codegen_embed = b.option(bool, "codegen_embed", "If codegen files should be embedded in the binary") orelse switch (b.release_mode) {
+    const codegen_embed = b.option(bool, "codegen-embed", "If codegen files should be embedded in the binary") orelse switch (b.release_mode) {
         .off => false,
         else => true,
     };
@@ -201,9 +201,9 @@ pub fn build(b: *Build) !void {
 
     b.reference_trace = b.reference_trace orelse 32;
 
-    const obj_format = b.option(ObjectFormat, "obj_format", "Output file for object files") orelse .obj;
+    const obj_format = b.option(ObjectFormat, "obj-format", "Output file for object files") orelse .obj;
 
-    const no_llvm = b.option(bool, "no_llvm", "Experiment with Zig self hosted backends. No stability guaranteed") orelse false;
+    const no_llvm = b.option(bool, "no-llvm", "Experiment with Zig self hosted backends. No stability guaranteed") orelse false;
 
     var build_options = BunBuildOptions{
         .target = target,
@@ -223,7 +223,7 @@ pub fn build(b: *Build) !void {
         },
 
         .reported_nodejs_version = try Version.parse(
-            b.option([]const u8, "reported_nodejs_version", "Reported Node.js version") orelse
+            b.option([]const u8, "reported-nodejs-version", "Reported Node.js version") orelse
                 "0.0.0-unset",
         ),
 
@@ -263,9 +263,9 @@ pub fn build(b: *Build) !void {
             break :sha sha;
         },
 
-        .tracy_callstack_depth = b.option(u16, "tracy_callstack_depth", "") orelse 10,
-        .enable_logs = b.option(bool, "enable_logs", "Enable logs in release") orelse false,
-        .enable_asan = b.option(bool, "enable_asan", "Enable asan") orelse false,
+        .tracy_callstack_depth = b.option(u16, "tracy-callstack-depth", "Set the Tracy callstack depth") orelse 10,
+        .enable_logs = b.option(bool, "enable-logs", "Enable logs in release") orelse false,
+        .enable_asan = b.option(bool, "enable-asan", "Enable address sanitizer") orelse false,
     };
 
     // zig build obj
@@ -334,7 +334,6 @@ pub fn build(b: *Build) !void {
     }
 
     // zig build watch
-    // const enable_watch_step = b.option(bool, "watch_step", "Enable the watch step. This reads more files so it is off by default") orelse false;
     // if (no_llvm or enable_watch_step) {
     //     self_hosted_watch.selfHostedExeBuild(b, &build_options) catch @panic("OOM");
     // }
@@ -766,7 +765,7 @@ fn validateGeneratedPath(path: []const u8) void {
         std.debug.panic(
             \\Generated file '{s}' is missing!
             \\
-            \\Make sure to use CMake and Ninja, or pass a manual codegen folder with '-Dgenerated-code=...'
+            \\Make sure to use CMake and Ninja, or pass a manual codegen folder with '-Dcodegen-path=...'
         , .{path});
     }
 }

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -594,16 +594,16 @@ register_command(
       build ${ZIG_STEPS}
       ${CMAKE_ZIG_FLAGS}
       --prefix ${BUILD_PATH}
-      -Dobj_format=${ZIG_OBJECT_FORMAT}
+      -Dobj-format=${ZIG_OBJECT_FORMAT}
       -Dtarget=${ZIG_TARGET}
       -Doptimize=${ZIG_OPTIMIZE}
       -Dcpu=${ZIG_CPU}
-      -Denable_logs=$<IF:$<BOOL:${ENABLE_LOGS}>,true,false>
+      -Denable-logs=$<IF:$<BOOL:${ENABLE_LOGS}>,true,false>
       -Dversion=${VERSION}
-      -Dreported_nodejs_version=${NODEJS_VERSION}
+      -Dreported-nodejs-version=${NODEJS_VERSION}
       -Dcanary=${CANARY_REVISION}
-      -Dcodegen_path=${CODEGEN_PATH}
-      -Dcodegen_embed=$<IF:$<BOOL:${CODEGEN_EMBED}>,true,false>
+      -Dcodegen-path=${CODEGEN_PATH}
+      -Dcodegen-embed=$<IF:$<BOOL:${CODEGEN_EMBED}>,true,false>
       --prominent-compile-errors
       --summary all
       ${ZIG_FLAGS_BUN}


### PR DESCRIPTION
this is not good enough to enable by default. ZLS and the VSCode extension do not properly handle things.

to try what i have:

- Build this patch: https://github.com/paperclover/zls/commit/00195e6d6fcf9a79ca0fba81f80128aa8a5d9509
- Point to it in .vscode/settings.json
- `Zig: Build Workspace`

it is very finicky. i think there is room in the market for a new extension that only implements compile on save. this extension can focus on conveying status of the compilation into the editor, including progress bars and errors.

https://github.com/user-attachments/assets/f2370e3b-42a0-4cc9-99f5-2c13aacbaf53

