### PR TITLE
Fixes #16671

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -30,7 +30,7 @@
 #include "BunClientData.h"
 #include "JSCommonJSModule.h"
 #include "isBuiltinModule.h"
-
+#include "AsyncContextFrame.h"
 #include "ImportMetaObject.h"
 
 namespace Zig {
@@ -707,6 +707,8 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
 
     JSC::MarkedArgumentBuffer arguments;
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    scope.assertNoExceptionExceptTermination();
 
     JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
     const auto& builtinNames = WebCore::builtinNames(vm);
@@ -715,16 +717,8 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
         jsString(vm, pathString));
     arguments.append(paramsObject);
 
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
-    scope.assertNoExceptionExceptTermination();
-
-    JSC::CallData callData = JSC::getCallData(function);
-
-    auto result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
-    if (UNLIKELY(scope.exception())) {
-        return JSValue::encode(scope.exception());
-    }
+    auto result = AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (auto* promise = JSC::jsDynamicCast<JSPromise*>(result)) {
         switch (promise->status(vm)) {
@@ -740,11 +734,11 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
     }
 
     if (!result.isObject()) {
-        JSC::throwTypeError(globalObject, throwScope, "onLoad() expects an object returned"_s);
+        JSC::throwTypeError(globalObject, scope, "onLoad() expects an object returned"_s);
         return JSValue::encode({});
     }
 
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(result));
+    RELEASE_AND_RETURN(scope, JSValue::encode(result));
 }
 
 std::optional<String> BunPlugin::OnLoad::resolveVirtualModule(const String& path, const String& from)
@@ -780,8 +774,10 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
     }
 
     auto& callbacks = group.callbacks;
-
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     WTF::String pathString = path->toWTFString(BunString::ZeroCopy);
+
     for (size_t i = 0; i < filters.size(); i++) {
         if (!filters[i].get()->match(globalObject, pathString, 0)) {
             continue;
@@ -792,7 +788,6 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
         }
 
         JSC::MarkedArgumentBuffer arguments;
-        auto& vm = JSC::getVM(globalObject);
 
         JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
         const auto& builtinNames = WebCore::builtinNames(vm);
@@ -804,18 +799,8 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
             Bun::toJS(globalObject, *importer));
         arguments.append(paramsObject);
 
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
-        auto scope = DECLARE_CATCH_SCOPE(vm);
-        scope.assertNoExceptionExceptTermination();
-
-        JSC::CallData callData = JSC::getCallData(function);
-
-        auto result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
-        if (UNLIKELY(scope.exception())) {
-            JSC::Exception* exception = scope.exception();
-            scope.clearException();
-            return JSValue::encode(exception);
-        }
+        auto result = AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
+        RETURN_IF_EXCEPTION(scope, {});
 
         if (result.isUndefinedOrNull()) {
             continue;
@@ -824,7 +809,7 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
         if (auto* promise = JSC::jsDynamicCast<JSPromise*>(result)) {
             switch (promise->status(vm)) {
             case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, throwScope, "onResolve() doesn't support pending promises yet"_s);
+                JSC::throwTypeError(globalObject, scope, "onResolve() doesn't support pending promises yet"_s);
                 return JSValue::encode({});
             }
             case JSPromise::Status::Rejected: {
@@ -840,11 +825,11 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
         }
 
         if (!result.isObject()) {
-            JSC::throwTypeError(globalObject, throwScope, "onResolve() expects an object returned"_s);
+            JSC::throwTypeError(globalObject, scope, "onResolve() expects an object returned"_s);
             return JSValue::encode({});
         }
 
-        RELEASE_AND_RETURN(throwScope, JSValue::encode(result));
+        RELEASE_AND_RETURN(scope, JSValue::encode(result));
     }
 
     return JSValue::encode(JSC::jsUndefined());

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -230,7 +230,7 @@ pub const JSGlobalObject = opaque {
     extern fn Bun__runOnLoadPlugins(*JSC.JSGlobalObject, ?*const bun.String, *const bun.String, BunPluginTarget) JSValue;
     extern fn Bun__runOnResolvePlugins(*JSC.JSGlobalObject, ?*const bun.String, *const bun.String, *const String, BunPluginTarget) JSValue;
 
-    pub fn runOnLoadPlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, target: BunPluginTarget) !?JSValue {
+    pub fn runOnLoadPlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, target: BunPluginTarget) bun.JSError!?JSValue {
         JSC.markBinding(@src());
         const result = Bun__runOnLoadPlugins(this, if (namespace_.length() > 0) &namespace_ else null, &path, target);
         if (this.hasException()) {

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -230,9 +230,12 @@ pub const JSGlobalObject = opaque {
     extern fn Bun__runOnLoadPlugins(*JSC.JSGlobalObject, ?*const bun.String, *const bun.String, BunPluginTarget) JSValue;
     extern fn Bun__runOnResolvePlugins(*JSC.JSGlobalObject, ?*const bun.String, *const bun.String, *const String, BunPluginTarget) JSValue;
 
-    pub fn runOnLoadPlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, target: BunPluginTarget) ?JSValue {
+    pub fn runOnLoadPlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, target: BunPluginTarget) !?JSValue {
         JSC.markBinding(@src());
         const result = Bun__runOnLoadPlugins(this, if (namespace_.length() > 0) &namespace_ else null, &path, target);
+        if (this.hasException()) {
+            return error.JSError;
+        }
         if (result.isEmptyOrUndefinedOrNull()) {
             return null;
         }
@@ -240,10 +243,15 @@ pub const JSGlobalObject = opaque {
         return result;
     }
 
-    pub fn runOnResolvePlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, source: bun.String, target: BunPluginTarget) ?JSValue {
+    pub fn runOnResolvePlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, source: bun.String, target: BunPluginTarget) !?JSValue {
         JSC.markBinding(@src());
 
         const result = Bun__runOnResolvePlugins(this, if (namespace_.length() > 0) &namespace_ else null, &path, &source, target);
+
+        if (this.hasException()) {
+            return error.JSError;
+        }
+
         if (result.isEmptyOrUndefinedOrNull()) {
             return null;
         }

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -243,7 +243,7 @@ pub const JSGlobalObject = opaque {
         return result;
     }
 
-    pub fn runOnResolvePlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, source: bun.String, target: BunPluginTarget) !?JSValue {
+    pub fn runOnResolvePlugins(this: *JSGlobalObject, namespace_: bun.String, path: bun.String, source: bun.String, target: BunPluginTarget) bun.JSError!?JSValue {
         JSC.markBinding(@src());
 
         const result = Bun__runOnResolvePlugins(this, if (namespace_.length() > 0) &namespace_ else null, &path, &source, target);

--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -101,8 +101,7 @@ static JSC::SyntheticSourceProvider::SyntheticSourceGenerator generateInternalMo
         JSC::EnsureStillAliveScope stillAlive(object);
 
         PropertyNameArray properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-        object->getPropertyNames(globalObject, properties, DontEnumPropertiesMode::Exclude);
-
+        object->getOwnPropertyNames(object, globalObject, properties, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(throwScope, void());
 
         auto len = properties.size() + 1;
@@ -116,7 +115,9 @@ static JSC::SyntheticSourceProvider::SyntheticSourceGenerator generateInternalMo
                 hasDefault = true;
             }
             exportNames.append(entry);
-            exportValues.append(object->get(globalObject, entry));
+            JSValue value = object->get(globalObject, entry);
+            RETURN_IF_EXCEPTION(throwScope, void());
+            exportValues.append(value);
         }
 
         if (!hasDefault) {

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -151,7 +151,7 @@ pub const PluginRunner = struct {
             bun.String.init(namespace_slice)
         else
             bun.String.empty;
-        const on_resolve_plugin = global.runOnResolvePlugins(
+        const on_resolve_plugin = try global.runOnResolvePlugins(
             namespace,
             bun.String.init(specifier).substring(if (namespace.length() > 0) namespace.length() + 1 else 0),
             bun.String.init(importer),
@@ -241,7 +241,7 @@ pub const PluginRunner = struct {
 
     pub fn onResolveJSC(this: *const PluginRunner, namespace: bun.String, specifier: bun.String, importer: bun.String, target: JSC.JSGlobalObject.BunPluginTarget) bun.JSError!?JSC.ErrorableString {
         var global = this.global_object;
-        const on_resolve_plugin = global.runOnResolvePlugins(
+        const on_resolve_plugin = try global.runOnResolvePlugins(
             if (namespace.length() > 0 and !namespace.eqlComptime("file"))
                 namespace
             else

--- a/test/js/bun/plugin/plugin-recursive-fixture-run.ts
+++ b/test/js/bun/plugin/plugin-recursive-fixture-run.ts
@@ -1,0 +1,7 @@
+try {
+  require("recursive:recursive");
+} catch (e: any) {
+  console.log(e.message);
+}
+
+await import("recursive:recursive");

--- a/test/js/bun/plugin/plugin-recursive-fixture.ts
+++ b/test/js/bun/plugin/plugin-recursive-fixture.ts
@@ -1,0 +1,11 @@
+Bun.plugin({
+  name: "recursive",
+  setup(build) {
+    build.onResolve({ filter: /recursive$/, namespace: "recursive" }, args => {
+      return {
+        path: require.resolve("recursive:" + args.path),
+        namespace: "recursive",
+      };
+    });
+  },
+});


### PR DESCRIPTION
### What does this PR do?

Adds missing exception checks to onLoad & onResolve plugin handling code. Also adds missing exception checks to JS builtin errors (useful for debug). 

Fixes #16671
Fixes #2200 

Potentially breaking change: using getOwnPropertyNames instead of getPropertyNames for builtin exports objects. This should be fine, but we will see if CI disagrees.

### How did you verify your code works?

There is a test.
