### PR TITLE
introduce basic devserver stress testing, fix two crashes

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -3237,11 +3237,7 @@ pub fn IncrementalGraph(side: bake.Side) type {
             switch (file.flags.kind) {
                 .js, .asset => {
                     g.owner().allocator.free(file.jsCode());
-                    const map = &g.source_maps.items[index.get()];
-                    g.owner().allocator.free(map.vlq());
-                    if (map.quoted_contents_flags.is_owned) {
-                        map.quotedContentsCowString().deinit(g.owner().allocator);
-                    }
+                    g.source_maps.items[index.get()].clearRetainingCapacity(g.owner().allocator);
                 },
                 .css => if (css == .unref_css) {
                     g.owner().assets.unrefByPath(key);
@@ -3308,6 +3304,37 @@ pub fn IncrementalGraph(side: bake.Side) type {
 
             pub fn quotedContents(self: @This()) []const u8 {
                 return self.quoted_contents_ptr[0..self.quoted_contents_flags.len];
+            }
+
+            pub fn clearRetainingCapacity(map: *@This(), alloc: Allocator) void {
+                alloc.free(map.vlq());
+                if (map.quoted_contents_flags.is_owned) {
+                    map.quotedContentsCowString().deinit(alloc);
+                }
+                map.* = .{
+                    // preserve `html_bundle_route_index` when the file is being
+                    // cleared so a route file can locate it's RouteBundle. It
+                    // is a bit jank that this data is stored in the PackedMap,
+                    // but it is a very convenient piece of unused memory
+                    // (remember, HTML has no source maps).
+                    .extra = if (map.vlq_len == 0)
+                        .{ .empty = .{
+                            .line_count = .none,
+                            .html_bundle_route_index = map.extra.empty.html_bundle_route_index,
+                        } }
+                    else
+                        .{ .end_state = .{
+                            .original_line = 0,
+                            .original_column = 0,
+                        } },
+                    .vlq_ptr = comptime &[0]u8{},
+                    .vlq_len = 0,
+                    .quoted_contents_ptr = comptime &[0]u8{},
+                    .quoted_contents_flags = .{
+                        .len = 0,
+                        .is_owned = false,
+                    },
+                };
             }
 
             pub fn fromNonEmptySourceMap(source_map: SourceMap.Chunk, quoted_contents: bun.ptr.CowString) !PackedMap {
@@ -6417,9 +6444,7 @@ const WatcherAtomics = struct {
         var ev: *HotReloadEvent = &state.events[state.current];
         switch (ev.contention_indicator.swap(1, .seq_cst)) {
             0 => {
-                // New event, initialize the timer if it is empty.
-                if (ev.isEmpty())
-                    ev.timer = std.time.Timer.start() catch unreachable;
+                // New event is unreferenced by the DevServer thread.
             },
             1 => {
                 @branchHint(.unlikely);
@@ -6433,6 +6458,10 @@ const WatcherAtomics = struct {
             },
             else => unreachable,
         }
+
+        // Initialize the timer if it is empty.
+        if (ev.isEmpty())
+            ev.timer = std.time.Timer.start() catch unreachable;
 
         ev.owner.bun_watcher.thread_lock.assertLocked();
 

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -39,6 +39,12 @@ const verboseSynchronization = process.env.BUN_DEV_SERVER_VERBOSE_SYNC
  */
 const fastBatches = !!process.env.BUN_DEV_SERVER_FAST_BATCHES;
 
+/**
+ * Set to `ALL` to run all stress tests for 10 minutes each.
+ * Set to a filter to run a specific filter for 10 minutes.
+ */
+const stressTestSelect = process.env.DEV_SERVER_STRESS;
+
 /** For testing bundler related bugs in the DevServer */
 export const minimalFramework: Bake.Framework = {
   fileSystemRouterTypes: [
@@ -188,6 +194,7 @@ export class Dev extends EventEmitter {
   options: { files: Record<string, string> };
   nodeEnv: "development" | "production";
   batchingChanges: { write?: () => void } | null = null;
+  stressTestEndurance = false;
 
   socket?: WebSocket;
 
@@ -485,6 +492,8 @@ export class Dev extends EventEmitter {
       errors?: ErrorSpec[];
       /** Allow using `getMostRecentHmrChunk` */
       storeHotChunks?: boolean;
+      /** Disable the logic that fails a test from a reload */
+      allowUnlimitedReloads?: boolean;
     } = {},
   ) {
     await maybeWaitInteractive("open client " + url);
@@ -492,6 +501,7 @@ export class Dev extends EventEmitter {
       storeHotChunks: options.storeHotChunks,
       hmr: this.nodeEnv === "development",
       expectErrors: !!options.errors,
+      allowUnlimitedReloads: options.allowUnlimitedReloads,
     });
     const onPanic = () => client.output.emit("panic");
     this.output.on("panic", onPanic);
@@ -534,6 +544,46 @@ export class Dev extends EventEmitter {
 
   mkdir(dir: string) {
     return fs.mkdirSync(path.join(this.rootDir, dir), { recursive: true });
+  }
+
+  /**
+   * Run a stress test. The function should perform I/O in a loop, for about a
+   * couple of seconds. In CI, this round is run once. In development, this can
+   * be run forever using `DEV_SERVER_STRESS=FILTER`.
+   * 
+   * Tests using this should go in `stress.test.ts`
+   */
+  async stressTest(round: () => (Promise<void> | void)) {
+    if (!this.stressTestEndurance) {
+      await round();
+      await Bun.sleep(250);
+      if (this.output.panicked) {
+        throw new Error("DevServer panicked in stress test");
+      }
+      return;
+    }
+
+    const endTime = Date.now() + 10 * 60 * 1000;
+    let iteration = 0;
+    
+    using log = new TrailingLog;
+    while (Date.now() < endTime) {
+      const timeRemaining = endTime - Date.now();
+      const minutes = Math.floor(timeRemaining / 60000);
+      const seconds = Math.floor((timeRemaining % 60000) / 1000);
+      log.setMessage(`[STRESS] Time remaining: ${minutes}:${seconds.toString().padStart(2, '0')}. Iteration ${++iteration}`);
+
+      await round();
+      
+      if (this.output.panicked) {
+        throw new Error("DevServer panicked in stress test");
+      }
+    }
+
+    await Bun.sleep(250);
+    if (this.output.panicked) {
+      throw new Error("DevServer panicked in stress test");
+    }
   }
 }
 
@@ -697,7 +747,7 @@ export class Client extends EventEmitter {
   hmr = false;
   webSocketMessagesAllowed = true;
 
-  constructor(url: string, options: { storeHotChunks?: boolean; hmr: boolean; expectErrors?: boolean }) {
+  constructor(url: string, options: { storeHotChunks?: boolean; hmr: boolean; expectErrors?: boolean; allowUnlimitedReloads?: boolean, }) {
     super();
     activeClient = this;
     const proc = Bun.spawn({
@@ -709,6 +759,7 @@ export class Client extends EventEmitter {
         url,
         options.storeHotChunks ? "--store-hot-chunks" : "",
         options.expectErrors ? "--expect-errors" : "",
+        options.allowUnlimitedReloads ? "--allow-unlimited-reloads" : "",
       ].filter(Boolean) as string[],
       env: bunEnv,
       serialization: "json",
@@ -741,7 +792,6 @@ export class Client extends EventEmitter {
     });
     this.#proc = proc;
     this.hmr = options.hmr;
-    // @ts-expect-error
     this.output = new OutputLineStream("web", proc.stdout, proc.stderr);
   }
 
@@ -1484,6 +1534,18 @@ function testImpl<T extends DevServerTest>(
   const basename = path.basename(caller, ".test" + path.extname(caller));
   const count = (counts[basename] = (counts[basename] ?? 0) + 1);
 
+  const name = `${
+    NODE_ENV === "development" //
+      ? Bun.enableANSIColors
+        ? " \x1b[35mDEV\x1b[0m"
+        : " DEV"
+      : Bun.enableANSIColors
+        ? "\x1b[36mPROD\x1b[0m"
+        : "PROD"
+  }:${basename}-${count}: ${description}`;
+
+  const isStressTest = stressTestSelect === "ALL" || (stressTestSelect && name.includes(stressTestSelect));
+
   async function run() {
     const root = path.join(tempDir, basename + count);
 
@@ -1633,14 +1695,15 @@ function testImpl<T extends DevServerTest>(
     if (interactive) {
       console.log("\x1b[35mDev Server PID: " + devProcess.pid + "\x1b[0m");
     }
-    // @ts-expect-error
     using stream = new OutputLineStream("dev", devProcess.stdout, devProcess.stderr);
     devProcess.exited.then(exitCode => (stream.exitCode = exitCode));
     const port = parseInt((await stream.waitForLine(/localhost:(\d+)/))[1], 10);
-    // @ts-expect-error
     const dev = new Dev(root, port, devProcess, stream, NODE_ENV, options);
     if (dev.nodeEnv === "development") {
       await dev.connectSocket();
+    }
+    if (isStressTest) {
+      dev.stressTestEndurance = true;
     }
 
     await maybeWaitInteractive("start");
@@ -1672,15 +1735,6 @@ function testImpl<T extends DevServerTest>(
     await dev.gracefulExit();
   }
 
-  const name = `${
-    NODE_ENV === "development" //
-      ? Bun.enableANSIColors
-        ? " \x1b[35mDEV\x1b[0m"
-        : " DEV"
-      : Bun.enableANSIColors
-        ? "\x1b[36mPROD\x1b[0m"
-        : "PROD"
-  }:${basename}-${count}: ${description}`;
   try {
     if (options.skip && options.skip.some(x => skipTargets.includes(x))) {
       jest.test.todo(name, run);
@@ -1689,9 +1743,11 @@ function testImpl<T extends DevServerTest>(
     jest.test(
       name,
       run,
-      interactive
-        ? interactive_timeout
-        : (options.timeoutMultiplier ?? 1) * (isWindows ? 15_000 : 10_000) * (Bun.version.includes("debug") ? 2 : 1),
+      isStressTest
+        ? 11 * 60 * 1000
+        : interactive
+            ? interactive_timeout
+            : (options.timeoutMultiplier ?? 1) * (isWindows ? 15_000 : 10_000) * (Bun.version.includes("debug") ? 2 : 1),
     );
     return options;
   } catch {
@@ -1724,6 +1780,61 @@ function logErr(err: any) {
     console.error(err.stackLine);
   } else {
     console.error(err);
+  }
+}
+
+// Loosely modelled after the widget system in @paperclover/console
+// Only works with a single log
+let hasTrailingLog = false;
+class TrailingLog {
+  lines = 0;
+  message = "";
+  realConsole;
+
+  constructor() {
+    if (hasTrailingLog) throw new Error("Only one trailing log is allowed");
+    hasTrailingLog = true;
+    this.realConsole = {};
+    console.log = this.#wrapLog("log");
+    console.error = this.#wrapLog("error");
+    console.warn = this.#wrapLog("warn");
+    console.info = this.#wrapLog("info");
+    console.debug = this.#wrapLog("debug");
+  }
+
+  #wrapLog(method: keyof Console) {
+    const m: Function = this.realConsole[method] = console[method];
+    return (...args: any[]) => {
+      if (this.lines > 0) {
+        process.stderr.write('\u001B[?2026h' + this.#clear());
+        this.realConsole[method](...args);
+        process.stderr.write(this.message + '\u001B[?2026l');
+      } else {
+        m.apply(console, args);
+      }
+    } 
+  }
+
+  #clear() {
+    return '\x1b[2K' + ("\x1b[1A\x1b[2K").repeat(this.lines) + '\r';
+  }
+
+  [Symbol.dispose] = () => {
+    if (this.lines > 0) {
+      process.stderr.write(this.#clear());
+    }
+    hasTrailingLog = false;
+    console.log = this.realConsole.log;
+    console.error = this.realConsole.error;
+    console.warn = this.realConsole.warn;
+    console.info = this.realConsole.info;
+    console.debug = this.realConsole.debug;
+  }
+
+  setMessage(message: string) {
+    this.message = message.trim() + "\n";
+    this.lines = this.message.split("\n").length - 1;
+    process.stderr.write('\u001B[?2026h'  + this.#clear() + this.message + '\u001B[?2026l');
   }
 }
 

--- a/test/bake/client-fixture.mjs
+++ b/test/bake/client-fixture.mjs
@@ -16,6 +16,7 @@ url = new URL(url, "http://localhost:3000");
 const storeHotChunks = args.includes("--store-hot-chunks");
 const expectErrors = args.includes("--expect-errors");
 const verboseWebSockets = args.includes("--verbose-web-sockets");
+const allowUnlimitedReloads = args.includes("--allow-unlimited-reloads");
 
 // Create a new window instance
 let window;
@@ -205,6 +206,10 @@ function createWindow(windowUrl) {
 
   window.location.reload = async () => {
     reset();
+    if (allowUnlimitedReloads) {
+      handleReload();
+      return;
+    }
     if (expectingReload) {
       // Permission already granted, proceed with reload
       handleReload();

--- a/test/bake/dev/stress.test.ts
+++ b/test/bake/dev/stress.test.ts
@@ -1,5 +1,10 @@
 // Stress tests perform a large number of filesystem or network operations in a test.
-// Run with DEV_SERVER_STRESS=FILTER to have the test run forever.
+//
+// Run with `DEV_SERVER_STRESS=` to run tests for 10 minutes each.
+// - "DEV_SERVER_STRESS='crash #18910'" will run the first test for 10 min.
+// - "DEV_SERVER_STRESS=ALL" will run all for 10 min each.
+//
+// Without this flag, each test is a "smoke test", running the iteration once.
 import { expect } from "bun:test";
 import { devTest, minimalFramework } from "../bake-harness";
 

--- a/test/bake/dev/stress.test.ts
+++ b/test/bake/dev/stress.test.ts
@@ -1,0 +1,29 @@
+// Stress tests perform a large number of filesystem or network operations in a test.
+// Run with DEV_SERVER_STRESS=FILTER to have the test run forever.
+import { expect } from "bun:test";
+import { devTest, minimalFramework } from "../bake-harness";
+
+// https://github.com/oven-sh/bun/issues/18910
+devTest("crash #18910", {
+  files: {
+    "index.html": `<script src="./b.js"></script>`,
+    "b.js": ``,
+  },
+  async test(dev) {
+    await using c = await dev.client('/', { allowUnlimitedReloads: true });
+
+    const absPath = dev.join("b.js");
+
+    await dev.stressTest(async() => {
+      for (let i = 0; i < 100; i++) {
+        await Bun.write(absPath, "let a = 0;");
+        await Bun.sleep(2);
+        await Bun.write(absPath, "// let a = 0;");
+        await Bun.sleep(2);
+      } 
+    });
+
+    await dev.write("b.js", "globalThis.a = 1;");
+    expect(await c.js<number>`a`).toBe(1);
+  },
+});


### PR DESCRIPTION
Fixes #18910. I verify my fix works by introducing a new category of dev server tests: `bake/dev/stress.test.ts`. These tests run a few seconds in CI, but can run in "endurance" mode locally to run each stress test for 10 minutes. The CI mode is enough of a smoke test to reproduce the crashes, but short enough to keep CI times low.

The crash in this PR is applicable to basically anyone using DevServer, so I am going to declare all of the HMR-related crashes as resolved.
- Fixes #17828
- Fixes #18267
- Fixes #18215
- Fixes #18311
- Fixes #18522
- Fixes #18581
- Fixes #18993
- Fixes #19064
- Fixes #19109
- Fixes #19187
- Fixes #19206

These above bugs are all, likely, duplicates of each other.

If you run into the crash still, please open a new bug using the crash reporter's URL, or if possible, contribute a new stress test case.

The following bugs are possibly fixed, but the reported stack trace is iffy.
- #17688 (has repro attached, TODO: verify manually)
- #18520 (is a safety lock violation. no repro)
- #19053 (during visiting. but possible if the memory allocator is corrupted)

https://github.com/user-attachments/assets/15e6a498-4f3c-4639-b7d1-e4f39716b285

It likely fixes many of these: https://github.com/oven-sh/bun/issues?q=is%3Aissue%20state%3Aopen%20label%3Abake%3Adev%20label%3Acrash