### PR TITLE
compat(node:http) more passing part 2

### DIFF
--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -111,6 +111,10 @@ export default [
         fn: "end",
         length: 2,
       },
+      getBytesWritten: {
+        fn: "getBytesWritten",
+        length: 0,
+      },
       flushHeaders: {
         fn: "flushHeaders",
         length: 0,

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -853,19 +853,28 @@ fn writeOrEnd(
     }
 
     const bytes = string_or_buffer.slice();
-    this.bytes_written +|= bytes.len;
+
     if (comptime is_end) {
         log("end('{s}', {d})", .{ bytes[0..@min(bytes.len, 128)], bytes.len });
     } else {
         log("write('{s}', {d})", .{ bytes[0..@min(bytes.len, 128)], bytes.len });
     }
+    if (strict_content_length) |content_length| {
+        const bytes_written = this.bytes_written + bytes.len;
 
-    if (is_end) {
-        if (strict_content_length) |content_length| {
-            if (this.bytes_written != content_length) {
+        if (is_end) {
+            if (bytes_written != content_length) {
                 return globalObject.ERR(.HTTP_CONTENT_LENGTH_MISMATCH, "Content-Length mismatch", .{}).throw();
             }
+        } else if (bytes_written > content_length) {
+            return globalObject.ERR(.HTTP_CONTENT_LENGTH_MISMATCH, "Content-Length mismatch", .{}).throw();
         }
+        this.bytes_written = bytes_written;
+    } else {
+        this.bytes_written +|= bytes.len;
+    }
+    if (is_end) {
+
         // Discard the body read ref if it's pending and no onData callback is set at this point.
         // This is the equivalent of req._dump().
         if (this.body_read_ref.has and this.body_read_state == .pending and (!this.flags.hasCustomOnData or js.onDataGetCached(this_value) == null)) {
@@ -1008,7 +1017,7 @@ pub fn setOnData(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalObject: 
 }
 
 pub fn write(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(3).slice();
+    const arguments = callframe.arguments_old(4).slice();
 
     return writeOrEnd(this, globalObject, arguments, .zero, false);
 }
@@ -1019,10 +1028,14 @@ pub fn flushHeaders(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.Cal
 }
 
 pub fn end(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const arguments = callframe.arguments_old(3).slice();
+    const arguments = callframe.arguments_old(4).slice();
     //We dont wanna a paused socket when we call end, so is important to resume the socket
     resumeSocket(this);
     return writeOrEnd(this, globalObject, arguments, callframe.this(), true);
+}
+
+pub fn getBytesWritten(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) JSC.JSValue {
+    return JSC.JSValue.jsNumber(this.bytes_written);
 }
 
 fn handleCorked(globalObject: *JSC.JSGlobalObject, function: JSC.JSValue, result: *JSValue, is_exception: *bool) void {

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -79,6 +79,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_FS_EISDIR", Error],
   ["ERR_HTTP_BODY_NOT_ALLOWED", Error],
   ["ERR_HTTP_HEADERS_SENT", Error],
+  ["ERR_HTTP_CONTENT_LENGTH_MISMATCH", Error],
   ["ERR_HTTP_INVALID_HEADER_VALUE", TypeError],
   ["ERR_HTTP_INVALID_STATUS_CODE", RangeError],
   ["ERR_HTTP_SOCKET_ASSIGNED", Error],
@@ -267,7 +268,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_REDIS_INVALID_RESPONSE_TYPE", Error, "RedisError"],
   ["ERR_REDIS_CONNECTION_TIMEOUT", Error, "RedisError"],
   ["ERR_REDIS_IDLE_TIMEOUT", Error, "RedisError"],
-  // HTTP Parser
   ["HPE_UNEXPECTED_CONTENT_LENGTH", Error],
   ["HPE_INVALID_TRANSFER_ENCODING", Error],
   ["HPE_INVALID_EOF_STATE", Error],

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -82,6 +82,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP_CONTENT_LENGTH_MISMATCH", Error],
   ["ERR_HTTP_INVALID_HEADER_VALUE", TypeError],
   ["ERR_HTTP_INVALID_STATUS_CODE", RangeError],
+  ["ERR_HTTP_TRAILER_INVALID", Error],
   ["ERR_HTTP_SOCKET_ASSIGNED", Error],
   ["ERR_HTTP2_ALTSVC_INVALID_ORIGIN", TypeError],
   ["ERR_HTTP2_ALTSVC_LENGTH", TypeError],

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -106,4 +106,5 @@ export default {
   validateBuffer: $newCppFunction("NodeValidator.cpp", "jsFunction_validateBuffer", 0),
   /** `(value, name, oneOf)` */
   validateOneOf: $newCppFunction("NodeValidator.cpp", "jsFunction_validateOneOf", 0),
+  isUint8Array: value => typeof value === "object" && value !== null && value instanceof Uint8Array,
 };

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -790,7 +790,13 @@ function ClientRequest(input, options, cb) {
   } else {
     if (headers) {
       for (let key in headers) {
-        this.setHeader(key, headers[key]);
+        const value = headers[key];
+        if (key === "host" || key === "hostname") {
+          if (value !== null && value !== undefined && typeof value !== "string") {
+            throw $ERR_INVALID_ARG_TYPE(`options.${key}`, ["string", "undefined", "null"], value);
+          }
+        }
+        this.setHeader(key, value);
       }
     }
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -781,11 +781,31 @@ function ClientRequest(input, options, cb) {
   const headersArray = $isJSArray(headers);
   if (headersArray) {
     const length = headers.length;
-    if (length % 2 !== 0) {
-      throw $ERR_INVALID_ARG_VALUE("options.headers", "headers");
-    }
-    for (let i = 0; i < length; ) {
-      this.appendHeader(headers[i++], headers[i++]);
+    if ($isJSArray(headers[0])) {
+      // [[key, value], [key, value], ...]
+      for (let i = 0; i < length; i++) {
+        const actualHeader = headers[i];
+        if (actualHeader.length !== 2) {
+          throw $ERR_INVALID_ARG_VALUE("options.headers", "expected array of [key, value]");
+        }
+        const key = actualHeader[0];
+        const lowerKey = key?.toLowerCase();
+        if (lowerKey === "host") {
+          if (!this.getHeader(key)) {
+            this.setHeader(key, actualHeader[1]);
+          }
+        } else {
+          this.appendHeader(key, actualHeader[1]);
+        }
+      }
+    } else {
+      // [key, value, key, value, ...]
+      if (length % 2 !== 0) {
+        throw $ERR_INVALID_ARG_VALUE("options.headers", "expected [key, value, key, value, ...]");
+      }
+      for (let i = 0; i < length; ) {
+        this.appendHeader(headers[i++], headers[i++]);
+      }
     }
   } else {
     if (headers) {

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -85,11 +85,9 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
       strictContentLength(msg) &&
       (fromEnd ? msg[kBytesWritten] + len !== msg._contentLength : msg[kBytesWritten] + len > msg._contentLength)
     ) {
-      const err = new Error(
+      throw $ERR_HTTP_CONTENT_LENGTH_MISMATCH(
         `Response body's content-length of ${len + msg[kBytesWritten]} byte(s) does not match the content-length of ${msg._contentLength} byte(s) set in header`,
       );
-      err.code = "ERR_HTTP_CONTENT_LENGTH_MISMATCH";
-      throw err;
     }
 
     msg[kBytesWritten] += len;

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -1,5 +1,5 @@
 const { Stream } = require("internal/stream");
-const { validateFunction, isUint8Array } = require("internal/validators");
+const { validateFunction, isUint8Array, validateString } = require("internal/validators");
 
 const {
   headerStateSymbol,
@@ -199,6 +199,7 @@ const OutgoingMessagePrototype = {
   _closed: false,
 
   appendHeader(name, value) {
+    validateString(name, "name");
     var headers = (this[headersSymbol] ??= new Headers());
     headers.append(name, value);
     return this;
@@ -209,6 +210,7 @@ const OutgoingMessagePrototype = {
   },
   flushHeaders() {},
   getHeader(name) {
+    validateString(name, "name");
     return getHeader(this[headersSymbol], name);
   },
 
@@ -241,6 +243,7 @@ const OutgoingMessagePrototype = {
   },
 
   removeHeader(name) {
+    validateString(name, "name");
     if ((this._header !== undefined && this._header !== null) || this[headerStateSymbol] === NodeHTTPHeaderState.sent) {
       throw $ERR_HTTP_HEADERS_SENT("remove");
     }
@@ -294,6 +297,7 @@ const OutgoingMessagePrototype = {
     return this;
   },
   hasHeader(name) {
+    validateString(name, "name");
     const headers = this[headersSymbol];
     if (!headers) return false;
     return headers.has(name);

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -85,9 +85,11 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
       strictContentLength(msg) &&
       (fromEnd ? msg[kBytesWritten] + len !== msg._contentLength : msg[kBytesWritten] + len > msg._contentLength)
     ) {
-      throw $ERR_HTTP_CONTENT_LENGTH_MISMATCH(
+      const err = new Error(
         `Response body's content-length of ${len + msg[kBytesWritten]} byte(s) does not match the content-length of ${msg._contentLength} byte(s) set in header`,
       );
+
+      throw err;
     }
 
     msg[kBytesWritten] += len;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -747,6 +747,8 @@ const ServerPrototype = {
     }
     this[serverSymbol] = undefined;
     this[kConnectionsCheckingInterval]._destroyed = true;
+    this.listening = false;
+
     server.stop(true);
   },
 
@@ -763,6 +765,7 @@ const ServerPrototype = {
     this[serverSymbol] = undefined;
     this[kConnectionsCheckingInterval]._destroyed = true;
     if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
+    this.listening = false;
     server.stop();
   },
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1393,7 +1393,13 @@ function _writeHead(statusCode, reason, obj, response) {
         if (length % 2 !== 0) {
           throw $ERR_INVALID_ARG_VALUE("headers", obj);
         }
-
+        // Test non-chunked message does not have trailer header set,
+        // message will be terminated by the first empty line after the
+        // header fields, regardless of the header fields present in the
+        // message, and thus cannot contain a message body or 'trailers'.
+        if (this.chunkedEncoding !== true && state.trailer) {
+          throw new ERR_HTTP_TRAILER_INVALID();
+        }
         // Headers in obj should override previous headers but still
         // allow explicit duplicates. To do so, we first remove any
         // existing conflicts, then use appendHeader.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1416,7 +1416,7 @@ function _writeHead(statusCode, reason, obj, response) {
         // header fields, regardless of the header fields present in the
         // message, and thus cannot contain a message body or 'trailers'.
         if (response.chunkedEncoding !== true && response._trailer) {
-          throw $ERR_HTTP_TRAILER_INVALID();
+          throw $ERR_HTTP_TRAILER_INVALID("Trailers are invalid with this transfer encoding");
         }
         // Headers in obj should override previous headers but still
         // allow explicit duplicates. To do so, we first remove any

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -616,7 +616,7 @@ const Server = function Server(options, callback) {
   this.maxRequestsPerSocket = 0;
   this[kInternalSocketData] = undefined;
   this[tlsSymbol] = null;
-
+  this.noDelay = true;
   if (typeof options === "function") {
     callback = options;
     options = {};

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1389,6 +1389,9 @@ function _normalizeArgs(args) {
 }
 
 function _writeHead(statusCode, reason, obj, response) {
+  if (response.headersSent) {
+    throw $ERR_HTTP_HEADERS_SENT("writeHead");
+  }
   const originalStatusCode = statusCode;
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999) {

--- a/test/js/node/test/parallel/test-http-byteswritten.js
+++ b/test/js/node/test/parallel/test-http-byteswritten.js
@@ -1,0 +1,55 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const body = 'hello world\n';
+
+const httpServer = http.createServer(common.mustCall(function(req, res) {
+  httpServer.close();
+
+  res.on('finish', common.mustCall(function() {
+    assert.strictEqual(typeof req.connection.bytesWritten, 'number');
+    assert(req.connection.bytesWritten > 0);
+  }));
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+
+  // Write 1.5mb to cause some requests to buffer
+  // Also, mix up the encodings a bit.
+  const chunk = '7'.repeat(1024);
+  const bchunk = Buffer.from(chunk);
+  for (let i = 0; i < 1024; i++) {
+    res.write(chunk);
+    res.write(bchunk);
+    res.write(chunk, 'hex');
+  }
+  // Get .bytesWritten while buffer is not empty
+  assert(res.connection.bytesWritten > 0);
+
+  res.end(body);
+}));
+
+httpServer.listen(0, function() {
+  http.get({ port: this.address().port });
+});

--- a/test/js/node/test/parallel/test-http-client-headers-host-array.js
+++ b/test/js/node/test/parallel/test-http-client-headers-host-array.js
@@ -1,0 +1,23 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const http = require('http');
+
+{
+
+  const options = {
+    port: '80',
+    path: '/',
+    headers: {
+      host: []
+    }
+  };
+
+  assert.throws(() => {
+    http.request(options);
+  }, {
+    code: /ERR_INVALID_ARG_TYPE/
+  }, 'http request should throw when passing array as header host');
+}

--- a/test/js/node/test/parallel/test-http-content-length-mismatch.js
+++ b/test/js/node/test/parallel/test-http-content-length-mismatch.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+function shouldThrowOnMoreBytes() {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.strictContentLength = true;
+    res.setHeader('Content-Length', 5);
+    res.write('hello');
+    assert.throws(() => {
+      res.write('a');
+    }, {
+      code: 'ERR_HTTP_CONTENT_LENGTH_MISMATCH'
+    });
+    res.statusCode = 200;
+    res.end();
+  }));
+
+  server.listen(0, () => {
+    const req = http.get({
+      port: server.address().port,
+    }, common.mustCall((res) => {
+      res.resume();
+      assert.strictEqual(res.statusCode, 200);
+      server.close();
+    }));
+    req.end();
+  });
+}
+
+function shouldNotThrow() {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.strictContentLength = true;
+    res.write('helloaa');
+    res.statusCode = 200;
+    res.end('ending');
+  }));
+
+  server.listen(0, () => {
+    http.get({
+      port: server.address().port,
+    }, common.mustCall((res) => {
+      res.resume();
+      assert.strictEqual(res.statusCode, 200);
+      server.close();
+    }));
+  });
+}
+
+
+function shouldThrowOnFewerBytes() {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.strictContentLength = true;
+    res.setHeader('Content-Length', 5);
+    res.write('a');
+    res.statusCode = 200;
+    assert.throws(() => {
+      res.end('aaa');
+    }, {
+      code: 'ERR_HTTP_CONTENT_LENGTH_MISMATCH'
+    });
+    res.end('aaaa');
+  }));
+
+  server.listen(0, () => {
+    http.get({
+      port: server.address().port,
+    }, common.mustCall((res) => {
+      res.resume();
+      assert.strictEqual(res.statusCode, 200);
+      server.close();
+    }));
+  });
+}
+
+shouldThrowOnMoreBytes();
+shouldNotThrow();
+shouldThrowOnFewerBytes();

--- a/test/js/node/test/parallel/test-http-listening.js
+++ b/test/js/node/test/parallel/test-http-listening.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer();
+
+assert.strictEqual(server.listening, false);
+
+server.listen(0, common.mustCall(() => {
+  assert.strictEqual(server.listening, true);
+
+  server.close(common.mustCall(() => {
+    assert.strictEqual(server.listening, false);
+  }));
+}));

--- a/test/js/node/test/parallel/test-http-outgoing-proto.js
+++ b/test/js/node/test/parallel/test-http-outgoing-proto.js
@@ -1,0 +1,136 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const http = require('http');
+const OutgoingMessage = http.OutgoingMessage;
+const ClientRequest = http.ClientRequest;
+const ServerResponse = http.ServerResponse;
+
+assert.strictEqual(
+  typeof ClientRequest.prototype._implicitHeader, 'function');
+assert.strictEqual(
+  typeof ServerResponse.prototype._implicitHeader, 'function');
+
+// validateHeader
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader();
+}, {
+  code: 'ERR_INVALID_HTTP_TOKEN',
+  name: 'TypeError',
+  message: 'Header name must be a valid HTTP token ["undefined"]'
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader('test');
+}, {
+  code: 'ERR_HTTP_INVALID_HEADER_VALUE',
+  name: 'TypeError',
+  message: 'Invalid value "undefined" for header "test"'
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader(404);
+}, {
+  code: 'ERR_INVALID_HTTP_TOKEN',
+  name: 'TypeError',
+  message: 'Header name must be a valid HTTP token ["404"]'
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader.call({ _header: 'test' }, 'test', 'value');
+}, {
+  code: 'ERR_HTTP_HEADERS_SENT',
+  name: 'Error',
+  message: 'Cannot set headers after they are sent to the client'
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader('200', 'あ');
+}, {
+  code: 'ERR_INVALID_CHAR',
+  name: 'TypeError',
+  message: 'Invalid character in header content ["200"]'
+});
+
+// write
+{
+  const outgoingMessage = new OutgoingMessage();
+
+  assert.throws(
+    () => {
+      outgoingMessage.write('');
+    },
+    {
+      code: 'ERR_METHOD_NOT_IMPLEMENTED',
+      name: 'Error',
+      message: 'The _implicitHeader() method is not implemented'
+    }
+  );
+}
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.write.call({ _header: 'test', _hasBody: 'test' });
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError',
+    message: 'The "chunk" argument must be of type string, Buffer, or Uint8Array. Received undefined'
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.write.call({ _header: 'test', _hasBody: 'test' }, 1);
+}, {
+  code: "ERR_INVALID_ARG_TYPE",
+  name: "TypeError",
+  message:
+    'The "chunk" argument must be of type string, Buffer, or Uint8Array. Received type number (1)',
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.write.call({ _header: 'test', _hasBody: 'test' }, null);
+}, {
+  code: 'ERR_STREAM_NULL_VALUES',
+  name: 'TypeError'
+});
+
+// addTrailers()
+// The `Error` comes from the JavaScript engine so confirm that it is a
+// `TypeError` but do not check the message. It will be different in different
+// JavaScript engines.
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.addTrailers();
+}, TypeError);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.addTrailers({ 'あ': 'value' });
+}, {
+  code: 'ERR_INVALID_HTTP_TOKEN',
+  name: 'TypeError',
+  message: 'Trailer name must be a valid HTTP token ["あ"]'
+});
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.addTrailers({ 404: 'あ' });
+}, {
+  code: 'ERR_INVALID_CHAR',
+  name: 'TypeError',
+  message: 'Invalid character in trailer content ["404"]'
+});
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  assert.strictEqual(outgoingMessage.destroyed, false);
+  outgoingMessage.destroy();
+  assert.strictEqual(outgoingMessage.destroyed, true);
+}

--- a/test/js/node/test/parallel/test-http-response-setheaders.js
+++ b/test/js/node/test/parallel/test-http-response-setheaders.js
@@ -1,0 +1,174 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    res.writeHead(200); // Headers already sent
+    const headers = new globalThis.Headers({ foo: '1' });
+    assert.throws(() => {
+      res.setHeaders(headers);
+    }, {
+      code: 'ERR_HTTP_HEADERS_SENT'
+    });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.headers.foo, undefined);
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    assert.throws(() => {
+      res.setHeaders(['foo', '1']);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    assert.throws(() => {
+      res.setHeaders({ foo: '1' });
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    assert.throws(() => {
+      res.setHeaders(null);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    assert.throws(() => {
+      res.setHeaders(undefined);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    assert.throws(() => {
+      res.setHeaders('test');
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    assert.throws(() => {
+      res.setHeaders(1);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.headers.foo, undefined);
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new globalThis.Headers({ foo: '1', bar: '2' });
+    res.setHeaders(headers);
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '1');
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new globalThis.Headers({ foo: '1', bar: '2' });
+    res.setHeaders(headers);
+    res.writeHead(200, ['foo', '3']);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '3'); // Override by writeHead
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new Map([['foo', '1'], ['bar', '2']]);
+    res.setHeaders(headers);
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '1');
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new Headers();
+    headers.append('Set-Cookie', 'a=b');
+    headers.append('Set-Cookie', 'c=d');
+    res.setHeaders(headers);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert(Array.isArray(res.headers['set-cookie']));
+      assert.strictEqual(res.headers['set-cookie'].length, 2);
+      assert.strictEqual(res.headers['set-cookie'][0], 'a=b');
+      assert.strictEqual(res.headers['set-cookie'][1], 'c=d');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new Map();
+    headers.set('Set-Cookie', ['a=b', 'c=d']);
+    res.setHeaders(headers);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert(Array.isArray(res.headers['set-cookie']));
+      assert.strictEqual(res.headers['set-cookie'].length, 2);
+      assert.strictEqual(res.headers['set-cookie'][0], 'a=b');
+      assert.strictEqual(res.headers['set-cookie'][1], 'c=d');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}

--- a/test/js/node/test/parallel/test-http-server-multiheaders.js
+++ b/test/js/node/test/parallel/test-http-server-multiheaders.js
@@ -1,0 +1,80 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Verify that the HTTP server implementation handles multiple instances
+// of the same header as per RFC2616: joining the handful of fields by ', '
+// that support it, and dropping duplicates for other fields.
+
+require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(function(req, res) {
+  assert.strictEqual(req.headers.accept, 'abc, def, ghijklmnopqrst');
+  assert.strictEqual(req.headers.host, 'foo');
+  assert.strictEqual(req.headers['www-authenticate'], 'foo, bar, baz');
+  assert.strictEqual(req.headers['proxy-authenticate'], 'foo, bar, baz');
+  assert.strictEqual(req.headers['x-foo'], 'bingo');
+  assert.strictEqual(req.headers['x-bar'], 'banjo, bango');
+  assert.strictEqual(req.headers['sec-websocket-protocol'], 'chat, share');
+  assert.strictEqual(req.headers['sec-websocket-extensions'],
+                     'foo; 1, bar; 2, baz');
+  assert.strictEqual(req.headers.constructor, 'foo, bar, baz');
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('EOF');
+
+  server.close();
+});
+
+server.listen(0, function() {
+  http.get({
+    host: 'localhost',
+    port: this.address().port,
+    path: '/',
+    headers: [
+      ['accept', 'abc'],
+      ['accept', 'def'],
+      ['Accept', 'ghijklmnopqrst'],
+      ['host', 'foo'],
+      ['Host', 'bar'],
+      ['hOst', 'baz'],
+      ['www-authenticate', 'foo'],
+      ['WWW-Authenticate', 'bar'],
+      ['WWW-AUTHENTICATE', 'baz'],
+      ['proxy-authenticate', 'foo'],
+      ['Proxy-Authenticate', 'bar'],
+      ['PROXY-AUTHENTICATE', 'baz'],
+      ['x-foo', 'bingo'],
+      ['x-bar', 'banjo'],
+      ['x-bar', 'bango'],
+      ['sec-websocket-protocol', 'chat'],
+      ['sec-websocket-protocol', 'share'],
+      ['sec-websocket-extensions', 'foo; 1'],
+      ['sec-websocket-extensions', 'bar; 2'],
+      ['sec-websocket-extensions', 'baz'],
+      ['constructor', 'foo'],
+      ['constructor', 'bar'],
+      ['constructor', 'baz'],
+    ]
+  });
+});

--- a/test/js/node/test/parallel/test-http-write-head-2.js
+++ b/test/js/node/test/parallel/test-http-write-head-2.js
@@ -1,0 +1,79 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Verify that ServerResponse.writeHead() works with arrays.
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.setHeader('test', '1');
+    res.writeHead(200, [ 'test', '2', 'test2', '2' ]);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers.test, '2');
+      assert.strictEqual(res.headers.test2, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200, [ 'test', '1', 'test2', '2' ]);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers.test, '1');
+      assert.strictEqual(res.headers.test2, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    try {
+      res.writeHead(200, [ 'test', '1', 'test2', '2', 'asd' ]);
+    } catch (err) {
+      assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+    }
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200, undefined, [ 'foo', 'bar' ]);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusMessage, 'OK');
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, 'bar');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}

--- a/test/js/node/test/parallel/test-http-write-head.js
+++ b/test/js/node/test/parallel/test-http-write-head.js
@@ -1,0 +1,106 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Verify that ServerResponse.writeHead() works as setHeader.
+// Issue 5036 on github.
+
+const s = http.createServer(common.mustCall((req, res) => {
+  res.setHeader('test', '1');
+
+  // toLowerCase() is used on the name argument, so it must be a string.
+  // Non-String header names should throw
+  assert.throws(
+    () => res.setHeader(0xf00, 'bar'),
+    {
+      code: 'ERR_INVALID_HTTP_TOKEN',
+      name: 'TypeError',
+      message: 'Header name must be a valid HTTP token ["3840"]'
+    }
+  );
+
+  // Undefined value should throw, via 979d0ca8
+  assert.throws(
+    () => res.setHeader('foo', undefined),
+    {
+      code: 'ERR_HTTP_INVALID_HEADER_VALUE',
+      name: 'TypeError',
+      message: 'Invalid value "undefined" for header "foo"'
+    }
+  );
+
+  assert.throws(() => {
+    res.writeHead(200, ['invalid', 'headers', 'args']);
+  }, {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+
+  res.writeHead(200, { Test: '2' });
+
+  assert.throws(() => {
+    res.writeHead(100, {});
+  }, {
+    code: 'ERR_HTTP_HEADERS_SENT',
+    name: 'Error',
+  });
+
+  res.end();
+}));
+
+s.listen(0, common.mustCall(runTest));
+
+function runTest() {
+  http.get({ port: this.address().port }, common.mustCall((response) => {
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(response.headers.test, '2');
+      assert(response.rawHeaders.includes('test'));
+      s.close();
+    }));
+    response.resume();
+  }));
+}
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(220, [ 'test', '1' ]); // 220 is not a standard status code
+    assert.strictEqual(res.statusMessage, 'unknown');
+
+    assert.throws(() => res.writeHead(200, [ 'test2', '2' ]), {
+      code: 'ERR_HTTP_HEADERS_SENT',
+      name: 'Error',
+    });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.headers.test, '1');
+      assert.strictEqual('test2' in res.headers, false);
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}

--- a/test/js/node/test/parallel/test-https-byteswritten.js
+++ b/test/js/node/test/parallel/test-https-byteswritten.js
@@ -1,0 +1,54 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const https = require('https');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+const body = 'hello world\n';
+
+const httpsServer = https.createServer(options, function(req, res) {
+  res.on('finish', function() {
+    assert.strictEqual(typeof req.connection.bytesWritten, 'number');
+    assert(req.connection.bytesWritten > 0);
+    httpsServer.close();
+    console.log('ok');
+  });
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end(body);
+});
+
+httpsServer.listen(0, function() {
+  https.get({
+    port: this.address().port,
+    rejectUnauthorized: false
+  });
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
