### PR TITLE
fix `test-queue-microtask.js`

### DIFF
--- a/test/js/node/test/parallel/test-queue-microtask.js
+++ b/test/js/node/test/parallel/test-queue-microtask.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+assert.strictEqual(typeof queueMicrotask, 'function');
+
+[
+  undefined,
+  null,
+  0,
+  'x = 5',
+].forEach((t) => {
+  assert.throws(common.mustCall(() => {
+    queueMicrotask(t);
+  }), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+});
+
+{
+  let called = false;
+  queueMicrotask(common.mustCall(() => {
+    called = true;
+  }));
+  assert.strictEqual(called, false);
+}
+
+queueMicrotask(common.mustCall(function() {
+  assert.strictEqual(arguments.length, 0);
+}), 'x', 'y');
+
+{
+  const q = [];
+  Promise.resolve().then(() => q.push('a'));
+  queueMicrotask(common.mustCall(() => q.push('b')));
+  Promise.reject().catch(() => q.push('c'));
+
+  queueMicrotask(common.mustCall(() => {
+    assert.deepStrictEqual(q, ['a', 'b', 'c']);
+  }));
+}
+
+const eq = [];
+process.on('uncaughtException', (e) => {
+  eq.push(e);
+});
+
+process.on('exit', () => {
+  assert.strictEqual(eq.length, 2);
+  assert.strictEqual(eq[0].message, 'E1');
+  assert.strictEqual(
+    eq[1].message, 'Cannot call a class constructor without |new|');
+});
+
+queueMicrotask(common.mustCall(() => {
+  throw new Error('E1');
+}));
+
+queueMicrotask(class {});


### PR DESCRIPTION
### What does this PR do?
matches invalid arg type message with node
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
