### PR TITLE
implement `process.ref` and `process.unref`

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3073,6 +3073,60 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionOpenStdin, (JSGlobalObject * globalObje
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsUndefined()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(Process_ref, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue maybeRefable = callFrame->argument(0);
+
+    JSValue ref = maybeRefable.get(globalObject, Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.ref"_s)));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto refBoolean = ref.toBoolean(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (!refBoolean) {
+        ref = maybeRefable.get(globalObject, Identifier::fromString(vm, "ref"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    if (ref.isCallable()) {
+        CallData callData = getCallData(ref);
+        JSC::profiledCall(globalObject, ProfilingReason::API, ref, callData, maybeRefable, {});
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(Process_unref, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue maybeUnrefable = callFrame->argument(0);
+
+    JSValue unref = maybeUnrefable.get(globalObject, Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.unref"_s)));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto unrefBoolean = unref.toBoolean(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (!unrefBoolean) {
+        unref = maybeUnrefable.get(globalObject, Identifier::fromString(vm, "unref"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    if (unref.isCallable()) {
+        CallData callData = getCallData(unref);
+        JSC::profiledCall(globalObject, ProfilingReason::API, unref, callData, maybeUnrefable, {});
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_stubEmptyFunction, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(jsUndefined());
@@ -3550,6 +3604,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   platform                         constructPlatform                                   PropertyCallback
   ppid                             constructPpid                                       PropertyCallback
   reallyExit                       Process_functionReallyExit                          Function 1
+  ref                              Process_ref                                         Function 1
   release                          constructProcessReleaseObject                       PropertyCallback
   report                           constructProcessReportObject                        PropertyCallback
   revision                         constructRevision                                   PropertyCallback
@@ -3562,6 +3617,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   throwDeprecation                 processThrowDeprecation                             CustomAccessor
   title                            processTitle                                        CustomAccessor
   umask                            Process_functionUmask                               Function 1
+  unref                            Process_unref                                        Function 1
   uptime                           Process_functionUptime                              Function 1
   version                          constructVersion                                    PropertyCallback
   versions                         constructVersions                                   PropertyCallback

--- a/test/js/node/test/parallel/test-process-ref-unref.js
+++ b/test/js/node/test/parallel/test-process-ref-unref.js
@@ -1,0 +1,60 @@
+'use strict';
+
+require('../common');
+
+const {
+  describe,
+  it,
+} = require('node:test');
+
+const {
+  strictEqual,
+} = require('node:assert');
+
+class Foo {
+  refCalled = 0;
+  unrefCalled = 0;
+  ref() {
+    this.refCalled++;
+  }
+  unref() {
+    this.unrefCalled++;
+  }
+}
+
+class Foo2 {
+  refCalled = 0;
+  unrefCalled = 0;
+  [Symbol.for('nodejs.ref')]() {
+    this.refCalled++;
+  }
+  [Symbol.for('nodejs.unref')]() {
+    this.unrefCalled++;
+  }
+}
+
+describe('process.ref/unref work as expected', () => {
+  it('refs...', () => {
+    // Objects that implement the new Symbol-based API
+    // just work.
+    const foo1 = new Foo();
+    const foo2 = new Foo2();
+    process.ref(foo1);
+    process.unref(foo1);
+    process.ref(foo2);
+    process.unref(foo2);
+    strictEqual(foo1.refCalled, 1);
+    strictEqual(foo1.unrefCalled, 1);
+    strictEqual(foo2.refCalled, 1);
+    strictEqual(foo2.unrefCalled, 1);
+
+    // Objects that implement the legacy API also just work.
+    const i = setInterval(() => {}, 1000);
+    strictEqual(i.hasRef(), true);
+    process.unref(i);
+    strictEqual(i.hasRef(), false);
+    process.ref(i);
+    strictEqual(i.hasRef(), true);
+    clearInterval(i);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
