### PR TITLE
chore: Remove custom clamp function

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -28,36 +28,6 @@ pub const callconv_inline: std.builtin.CallingConvention = if (builtin.mode == .
 pub extern "c" fn powf(x: f32, y: f32) f32;
 pub extern "c" fn pow(x: f64, y: f64) f64;
 
-/// Restrict a value to a certain interval unless it is a float and NaN.
-pub inline fn clamp(self: anytype, min: @TypeOf(self), max: @TypeOf(self)) @TypeOf(self) {
-    bun.debugAssert(min <= max);
-    if (comptime (@TypeOf(self) == f32 or @TypeOf(self) == f64)) {
-        return clampFloat(self, min, max);
-    }
-    return std.math.clamp(self, min, max);
-}
-
-/// Restrict a value to a certain interval unless it is NaN.
-///
-/// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-/// less than `min`. Otherwise this returns `self`.
-///
-/// Note that this function returns NaN if the initial value was NaN as
-/// well.
-pub inline fn clampFloat(_self: anytype, min: @TypeOf(_self), max: @TypeOf(_self)) @TypeOf(_self) {
-    if (comptime !(@TypeOf(_self) == f32 or @TypeOf(_self) == f64)) {
-        @compileError("Only call this on floats.");
-    }
-    var self = _self;
-    if (self < min) {
-        self = min;
-    }
-    if (self > max) {
-        self = max;
-    }
-    return self;
-}
-
 /// We cannot use a threadlocal memory allocator for FileSystem-related things
 /// FileSystem is a singleton.
 pub const fs_allocator = default_allocator;

--- a/src/css/properties/custom.zig
+++ b/src/css/properties/custom.zig
@@ -802,7 +802,7 @@ pub const UnresolvedColor = union(enum) {
     ) PrintErr!void {
         const Helper = struct {
             pub fn conv(c: f32) i32 {
-                return @intFromFloat(bun.clamp(@round(c * 255.0), 0.0, 255.0));
+                return @intFromFloat(std.math.clamp(@round(c * 255.0), 0.0, 255.0));
             }
         };
 


### PR DESCRIPTION
Remove custom clamp function written before std.math supported floats and does nothing different other than separate the two.
