### PR TITLE
Add `BroadcastChannel.prototype[util.inspect.custom]`

### DIFF
--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -1390,6 +1390,15 @@ EncodedJSValue CLOSED_MESSAGE_PORT(ThrowScope& scope, JSGlobalObject* globalObje
     return {};
 }
 
+JSC::EncodedJSValue INVALID_THIS(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral expectedType)
+{
+    WTF::StringBuilder builder;
+    builder.append("Value of \"this\" must be of type "_s);
+    builder.append(expectedType);
+    scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_THIS, builder.toString()));
+    return {};
+}
+
 } // namespace ERR
 
 static JSC::JSValue ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue arg0, JSValue arg1, JSValue arg2)

--- a/src/bun.js/bindings/ErrorCode.h
+++ b/src/bun.js/bindings/ErrorCode.h
@@ -132,6 +132,7 @@ JSC::EncodedJSValue KEY_GENERATION_JOB_FAILED(JSC::ThrowScope&, JSC::JSGlobalObj
 JSC::EncodedJSValue INCOMPATIBLE_OPTION_PAIR(JSC::ThrowScope&, JSC::JSGlobalObject*, ASCIILiteral opt1, ASCIILiteral opt2);
 JSC::EncodedJSValue MISSING_OPTION(JSC::ThrowScope&, JSC::JSGlobalObject*, ASCIILiteral message);
 JSC::EncodedJSValue CLOSED_MESSAGE_PORT(JSC::ThrowScope&, JSC::JSGlobalObject*);
+JSC::EncodedJSValue INVALID_THIS(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral expectedType);
 
 // URL
 

--- a/src/bun.js/bindings/webcore/BroadcastChannel.h
+++ b/src/bun.js/bindings/webcore/BroadcastChannel.h
@@ -63,6 +63,7 @@ public:
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message);
     void close();
+    bool isClosed() const { return m_isClosed; }
 
     WEBCORE_EXPORT static void dispatchMessageTo(BroadcastChannelIdentifier, Ref<SerializedScriptValue>&&);
 

--- a/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
@@ -48,6 +48,8 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
+#include "ErrorCode.h"
+#include <JavaScriptCore/PropertyNameArray.h>
 
 namespace WebCore {
 using namespace JSC;
@@ -74,7 +76,7 @@ public:
     static JSBroadcastChannelPrototype* create(JSC::VM& vm, JSDOMGlobalObject* globalObject, JSC::Structure* structure)
     {
         JSBroadcastChannelPrototype* ptr = new (NotNull, JSC::allocateCell<JSBroadcastChannelPrototype>(vm)) JSBroadcastChannelPrototype(vm, globalObject, structure);
-        ptr->finishCreation(vm);
+        ptr->finishCreation(vm, globalObject);
         return ptr;
     }
 
@@ -96,7 +98,7 @@ private:
     {
     }
 
-    void finishCreation(JSC::VM&);
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject* globalObject);
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSBroadcastChannelPrototype, JSBroadcastChannelPrototype::Base);
 
@@ -160,11 +162,82 @@ static const HashTableValue JSBroadcastChannelPrototypeTableValues[] = {
 
 const ClassInfo JSBroadcastChannelPrototype::s_info = { "BroadcastChannel"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBroadcastChannelPrototype) };
 
-void JSBroadcastChannelPrototype::finishCreation(VM& vm)
+JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototype_inspectCustom, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+
+    auto* channel = JSBroadcastChannel::toWrapped(vm, callFrame->thisValue());
+    if (!channel) {
+        return Bun::ERR::INVALID_THIS(throwScope, lexicalGlobalObject, "BroadcastChannel"_s);
+    }
+
+    JSValue depthValue = callFrame->argument(0);
+    JSValue optionsValue = callFrame->argument(1);
+
+    auto depth = depthValue.toNumber(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    if (depth < 0) {
+        return JSValue::encode(jsNontrivialString(vm, "BroadcastChannel"_s));
+    }
+
+    if (!depthValue.isUndefinedOrNull()) {
+        depthValue = jsNumber(depth - 1);
+    }
+
+    JSObject* options = optionsValue.toObject(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    PropertyNameArray optionsArray(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+    options->getPropertyNames(lexicalGlobalObject, optionsArray, DontEnumPropertiesMode::Exclude);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    JSObject* newOptions = constructEmptyObject(lexicalGlobalObject);
+    for (size_t i = 0; i < optionsArray.size(); i++) {
+        auto name = optionsArray[i];
+
+        JSValue value = options->get(lexicalGlobalObject, name);
+        RETURN_IF_EXCEPTION(throwScope, {});
+
+        newOptions->putDirect(vm, name, value, 0);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+
+    PutPropertySlot slot(newOptions);
+    newOptions->put(newOptions, lexicalGlobalObject, Identifier::fromString(vm, "depth"_s), depthValue, slot);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    JSObject* inputObj = constructEmptyObject(lexicalGlobalObject);
+    inputObj->putDirect(vm, vm.propertyNames->name, jsString(vm, channel->name()), 0);
+    inputObj->putDirect(vm, Identifier::fromString(vm, "active"_s), jsBoolean(!channel->isClosed()), 0);
+
+    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    auto callData = JSC::getCallData(utilInspect);
+    MarkedArgumentBuffer arguments;
+    arguments.append(inputObj);
+    arguments.append(newOptions);
+
+    auto inspectResult = JSC::profiledCall(globalObject, ProfilingReason::API, utilInspect, callData, inputObj, arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    auto* inspectString = inspectResult.toString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    auto inspectStringView = inspectString->view(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    JSValue result = jsString(vm, makeString("BroadcastChannel "_s, inspectStringView.data));
+
+    return JSValue::encode(result);
+}
+
+void JSBroadcastChannelPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSBroadcastChannel::info(), JSBroadcastChannelPrototypeTableValues, *this);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    BunBuiltinNames builtinNames(vm);
+    putDirectNativeFunction(vm, globalObject, builtinNames.inspectCustomPublicName(), 2, jsBroadcastChannelPrototype_inspectCustom, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
 }
 
 const ClassInfo JSBroadcastChannel::s_info = { "BroadcastChannel"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBroadcastChannel) };

--- a/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
@@ -236,7 +236,7 @@ void JSBroadcastChannelPrototype::finishCreation(VM& vm, JSGlobalObject* globalO
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSBroadcastChannel::info(), JSBroadcastChannelPrototypeTableValues, *this);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
-    BunBuiltinNames builtinNames(vm);
+    BunBuiltinNames& builtinNames = WebCore::builtinNames(vm);
     putDirectNativeFunction(vm, globalObject, builtinNames.inspectCustomPublicName(), 2, jsBroadcastChannelPrototype_inspectCustom, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
 }
 

--- a/test/js/node/test/parallel/test-broadcastchannel-custom-inspect.js
+++ b/test/js/node/test/parallel/test-broadcastchannel-custom-inspect.js
@@ -1,0 +1,40 @@
+'use strict';
+
+require('../common');
+const { BroadcastChannel } = require('worker_threads');
+const { inspect } = require('util');
+const assert = require('assert');
+
+// This test checks BroadcastChannel custom inspect outputs
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.throws(() => bc[inspect.custom].call(), {
+    code: 'ERR_INVALID_THIS',
+  });
+  bc.close();
+}
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.strictEqual(inspect(bc, { depth: -1 }), 'BroadcastChannel');
+  bc.close();
+}
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.strictEqual(
+    inspect(bc),
+    "BroadcastChannel { name: 'name', active: true }"
+  );
+  bc.close();
+}
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.strictEqual(
+    inspect(bc, { depth: null }),
+    "BroadcastChannel { name: 'name', active: true }"
+  );
+  bc.close();
+}

--- a/test/js/web/broadcastchannel/broadcast-channel.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel.test.ts
@@ -1,3 +1,5 @@
+import util from "util";
+
 test("postMessage results in correct event", done => {
   let c1 = new BroadcastChannel("eventType");
   let c2 = new BroadcastChannel("eventType");
@@ -213,3 +215,10 @@ test("broadcast channel used with workers", async () => {
     console.count("Batch complete");
   }
 }, 99999);
+
+test("user options are forwarded through custom inspect", () => {
+  const bc = new BroadcastChannel("hello");
+  expect(util.inspect(bc, { compact: true, breakLength: 2 })).toBe(
+    "BroadcastChannel { name:\n   'hello',\n  active:\n   true }",
+  );
+});


### PR DESCRIPTION
### What does this PR do?
Passes `test-broadcastchannel-custom-inspect`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added an additional test for forwarding user options
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
