### PR TITLE
docs: Add route types to Websocket docs

### DIFF
--- a/docs/api/websockets.md
+++ b/docs/api/websockets.md
@@ -115,7 +115,7 @@ type WebSocketData = {
 };
 
 // TypeScript: specify the type of `data`
-Bun.serve<WebSocketData>({
+Bun.serve<WebSocketData, {}>({
   fetch(req, server) {
     const cookies = new Bun.CookieMap(req.headers.get("cookie")!);
 
@@ -164,7 +164,7 @@ socket.addEventListener("message", event => {
 Bun's `ServerWebSocket` implementation implements a native publish-subscribe API for topic-based broadcasting. Individual sockets can `.subscribe()` to a topic (specified with a string identifier) and `.publish()` messages to all other subscribers to that topic (excluding itself). This topic-based broadcast API is similar to [MQTT](https://en.wikipedia.org/wiki/MQTT) and [Redis Pub/Sub](https://redis.io/topics/pubsub).
 
 ```ts
-const server = Bun.serve<{ username: string }>({
+const server = Bun.serve<{ username: string }, {}>({
   fetch(req, server) {
     const url = new URL(req.url);
     if (url.pathname === "/chat") {


### PR DESCRIPTION
### What does this PR do?

`serve` types now require 2 args, second being routes.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
