### PR TITLE
Better LLVM version safe-guards in CMake

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -468,7 +468,10 @@ function getBuildZigStep(platform, options) {
     agents: getZigAgent(platform, options),
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    env: getBuildEnv(platform, options),
+    env: {
+      ...getBuildEnv(platform, options),
+      ENABLE_LLVM: "OFF",
+    },
     command: `bun run build:ci --target bun-zig --toolchain ${toolchain}`,
     timeout_in_minutes: 35,
   };

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -399,7 +399,6 @@ function getBuildEnv(target, options) {
     ENABLE_ASSERTIONS: release ? "OFF" : "ON",
     ENABLE_LOGS: release ? "OFF" : "ON",
     ABI: isMusl ? "musl" : undefined,
-    CMAKE_TLS_VERIFY: "0",
   };
 }
 

--- a/cmake/Globals.cmake
+++ b/cmake/Globals.cmake
@@ -190,7 +190,7 @@ endfunction()
 #   Check if a version satisfies a version range
 # Arguments:
 #   version  string - The version to check (e.g. "1.2.3")
-#   range    string - The range to check against (e.g. ">=1.2.3")
+#   range    string - The range to check against (e.g. ">=1.2.3" or "~1.2.3")
 #   variable string - The variable to store the result in
 function(satisfies_range version range variable)
   if(range STREQUAL "ignore")
@@ -204,14 +204,26 @@ function(satisfies_range version range variable)
   if(NOT match)
     return()
   endif()
-  set(version ${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3})
+  set(version_major ${CMAKE_MATCH_1})
+  set(version_minor ${CMAKE_MATCH_2})
+  set(version_patch ${CMAKE_MATCH_3})
+  set(version ${version_major}.${version_minor}.${version_patch})
 
-  string(REGEX MATCH "(>=|<=|>|<)?([0-9]+)\\.([0-9]+)\\.([0-9]+)" match "${range}")
+  string(REGEX MATCH "(~|>=|<=|>|<)?([0-9]+)\\.([0-9]+)\\.([0-9]+)" match "${range}")
   if(NOT match)
     return()
   endif()
   set(comparator ${CMAKE_MATCH_1})
-  set(range ${CMAKE_MATCH_2}.${CMAKE_MATCH_3}.${CMAKE_MATCH_4})
+  set(range_major ${CMAKE_MATCH_2})
+  set(range_minor ${CMAKE_MATCH_3})
+  set(range_patch ${CMAKE_MATCH_4})
+  set(range ${range_major}.${range_minor}.${range_patch})
+
+  # If tilde comparator, check only if the major and minor versions match
+  if(comparator STREQUAL "~")
+    set(comparator "=")
+    set(version ${version_major}.${version_minor}.${range_patch})
+  endif()
 
   if(comparator STREQUAL ">=")
     set(comparator VERSION_GREATER_EQUAL)

--- a/cmake/tools/SetupLLVM.cmake
+++ b/cmake/tools/SetupLLVM.cmake
@@ -65,7 +65,9 @@ macro(find_llvm_command variable command)
   # In CI, we want to make sure we're using an exact version of LLVM.
   # Otherwise, it's okay if the patch version is different.
   if(CI)
-    set(LLVM_VERSION_REQUIREMENT "=${LLVM_VERSION}")
+    # FIXME: re-enable once we've updated build image
+    # set(LLVM_VERSION_REQUIREMENT "=${LLVM_VERSION}")
+    set(LLVM_VERSION_REQUIREMENT "~${LLVM_VERSION}")
   else()
     set(LLVM_VERSION_REQUIREMENT "~${LLVM_VERSION}")
   endif()


### PR DESCRIPTION
In CI, an exact version of LLVM is required. Outside of CI, it's okay if the patch version of LLVM is different. This fixes a regression where if you accidentally upgraded your LLVM to 20, it would not error (since we're on 19).

<img width="548" alt="Screenshot_2025-04-25_at_11 39 50_AM" src="https://github.com/user-attachments/assets/1c87fb7c-7c8a-4686-946a-c695d4ebac7d" />