### PR TITLE
compatibility: invalid arg error if error is nullptr in napi_throw

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1414,16 +1414,13 @@ extern "C" napi_status napi_fatal_exception(napi_env env,
 extern "C" napi_status napi_throw(napi_env env, napi_value error)
 {
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
+    NAPI_CHECK_ARG(env, error);
     auto globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSValue value = toJS(error);
-    if (value) {
-        JSC::throwException(globalObject, throwScope, value);
-    } else {
-        JSC::throwException(globalObject, throwScope, JSC::createError(globalObject, "Error (via napi)"_s));
-    }
+    JSC::throwException(globalObject, throwScope, value);
 
     return napi_set_last_error(env, napi_ok);
 }

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -363,6 +363,18 @@ static napi_value test_napi_run_script(const Napi::CallbackInfo &info) {
   return ret;
 }
 
+static napi_value test_napi_throw_with_nullptr(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  const napi_status status = napi_throw(env, nullptr);
+  printf("napi_throw -> %d\n", status);
+
+  bool is_exception_pending;
+  NODE_API_CALL(env, napi_is_exception_pending(env, &is_exception_pending));
+  printf("napi_is_exception_pending -> %s\n", is_exception_pending ? "true" : "false");
+
+  return ok(env);
+}
+
 // Call Node-API functions in ways that result in different error handling
 // (erroneous call, valid call, or valid call while an exception is pending) and
 // log information from napi_get_last_error_info
@@ -526,6 +538,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_many_args);
   REGISTER_FUNCTION(env, exports, test_napi_ref);
   REGISTER_FUNCTION(env, exports, test_napi_run_script);
+  REGISTER_FUNCTION(env, exports, test_napi_throw_with_nullptr);
   REGISTER_FUNCTION(env, exports, test_extended_error_messages);
   REGISTER_FUNCTION(env, exports, bigint_to_i64);
   REGISTER_FUNCTION(env, exports, bigint_to_u64);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -346,6 +346,10 @@ describe("napi", () => {
     it("has the right code and message", () => {
       checkSameOutput("test_throw_functions_exhaustive", []);
     });
+
+    it("does not throw with nullptr", () => {
+      checkSameOutput("test_napi_throw_with_nullptr", []);
+    });
   });
   describe("napi_create_error functions", () => {
     it("has the right code and message", () => {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

https://github.com/temporalio/sdk-typescript/issues/1334#issuecomment-2643336701

Resolves compatibility issue with Neon.

https://github.com/nodejs/node/blob/5fad0b93667ffc6e4def52996b9529ac99b26319/src/js_native_api_v8.cc#L1924-L1934
https://github.com/neon-bindings/neon/blob/7f4feb10631cfd3e654112d42a3b5ed472f851e8/crates/neon/src/sys/no_panic.rs#L135-L137

Difference in logic causes Bun to throw an error where Node does not, breaking the logic Neon uses.

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

Run a temporal worker and it works as expected.

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
