### PR TITLE
fix `test-fs-read-position-validation.mjs`

### DIFF
--- a/src/bun.js/bindings/JSBigInt.zig
+++ b/src/bun.js/bindings/JSBigInt.zig
@@ -7,9 +7,9 @@ const JSError = bun.JSError;
 const String = bun.String;
 
 pub const JSBigInt = opaque {
-    extern fn JSC__JSBigInt__dynamicCast(JSValue) ?*JSBigInt;
-    pub fn dynamicCast(value: JSValue) ?*JSBigInt {
-        return JSC__JSBigInt__dynamicCast(value);
+    extern fn JSC__JSBigInt__fromJS(JSValue) ?*JSBigInt;
+    pub fn fromJS(value: JSValue) ?*JSBigInt {
+        return JSC__JSBigInt__fromJS(value);
     }
 
     extern fn JSC__JSBigInt__orderDouble(*JSBigInt, f64) i8;

--- a/src/bun.js/bindings/JSBigInt.zig
+++ b/src/bun.js/bindings/JSBigInt.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const bun = @import("bun");
+const jsc = bun.jsc;
+const JSValue = jsc.JSValue;
+const JSGlobalObject = jsc.JSGlobalObject;
+const JSError = bun.JSError;
+const String = bun.String;
+
+pub const JSBigInt = opaque {
+    extern fn JSC__JSBigInt__dynamicCast(JSValue) ?*JSBigInt;
+    pub fn dynamicCast(value: JSValue) ?*JSBigInt {
+        return JSC__JSBigInt__dynamicCast(value);
+    }
+
+    extern fn JSC__JSBigInt__orderDouble(*JSBigInt, f64) i8;
+    extern fn JSC__JSBigInt__orderUint64(*JSBigInt, u64) i8;
+    extern fn JSC__JSBigInt__orderInt64(*JSBigInt, i64) i8;
+    pub fn order(this: *JSBigInt, comptime T: type, num: T) std.math.Order {
+        const result = switch (T) {
+            f64 => brk: {
+                bun.debugAssert(!std.math.isNan(num));
+                break :brk JSC__JSBigInt__orderDouble(this, num);
+            },
+            u64 => JSC__JSBigInt__orderUint64(this, num),
+            i64 => JSC__JSBigInt__orderInt64(this, num),
+            else => @compileError("Unsupported BigInt.order type"),
+        };
+        if (result == 0) return .eq;
+        if (result < 0) return .lt;
+        return .gt;
+    }
+
+    extern fn JSC__JSBigInt__toInt64(*JSBigInt) i64;
+    pub fn toInt64(this: *JSBigInt) i64 {
+        return JSC__JSBigInt__toInt64(this);
+    }
+
+    extern fn JSC__JSBigInt__toString(*JSBigInt, *JSGlobalObject) bun.String;
+    pub fn toString(this: *JSBigInt, global: *JSGlobalObject) JSError!bun.String {
+        const str = JSC__JSBigInt__toString(this, global);
+        if (global.hasException()) {
+            return error.JSError;
+        }
+        return str;
+    }
+};

--- a/src/bun.js/bindings/JSBigIntBinding.cpp
+++ b/src/bun.js/bindings/JSBigIntBinding.cpp
@@ -1,0 +1,82 @@
+#include "root.h"
+#include "helpers.h"
+
+#include <JavaScriptCore/JSBigInt.h>
+
+using namespace JSC;
+using namespace Bun;
+
+extern "C" JSBigInt* JSC__JSBigInt__dynamicCast(EncodedJSValue encodedValue)
+{
+    JSValue value = JSValue::decode(encodedValue);
+    ASSERT(!value.isEmpty());
+    if (auto* bigInt = jsDynamicCast<JSBigInt*>(value)) {
+        return bigInt;
+    }
+    return nullptr;
+}
+
+extern "C" int8_t JSC__JSBigInt__orderDouble(JSBigInt* bigInt, double num)
+{
+    ASSERT(!std::isnan(num));
+    JSBigInt::ComparisonResult result = JSBigInt::compareToDouble(bigInt, num);
+
+    switch (result) {
+    case JSBigInt::ComparisonResult::Equal:
+        return 0;
+    case JSBigInt::ComparisonResult::GreaterThan:
+        return 1;
+    case JSBigInt::ComparisonResult::LessThan:
+        return -1;
+    case JSBigInt::ComparisonResult::Undefined:
+        UNREACHABLE();
+    }
+}
+
+extern "C" int8_t JSC__JSBigInt__orderUint64(JSBigInt* bigInt, uint64_t num)
+{
+    JSBigInt::ComparisonResult result = JSBigInt::compare(bigInt, num);
+
+    switch (result) {
+    case JSBigInt::ComparisonResult::Equal:
+        return 0;
+    case JSBigInt::ComparisonResult::GreaterThan:
+        return 1;
+    case JSBigInt::ComparisonResult::LessThan:
+        return -1;
+    case JSBigInt::ComparisonResult::Undefined:
+        UNREACHABLE();
+    }
+}
+
+extern "C" int8_t JSC__JSBigInt__orderInt64(JSBigInt* bigInt, int64_t num)
+{
+    JSBigInt::ComparisonResult result = JSBigInt::compare(bigInt, num);
+
+    switch (result) {
+    case JSBigInt::ComparisonResult::Equal:
+        return 0;
+    case JSBigInt::ComparisonResult::GreaterThan:
+        return 1;
+    case JSBigInt::ComparisonResult::LessThan:
+        return -1;
+    case JSBigInt::ComparisonResult::Undefined:
+        UNREACHABLE();
+    }
+}
+
+extern "C" int64_t JSC__JSBigInt__toInt64(JSBigInt* bigInt, JSGlobalObject* globalObject)
+{
+    return JSBigInt::toBigInt64(bigInt);
+}
+
+extern "C" BunString JSC__JSBigInt__toString(JSBigInt* bigInt, JSGlobalObject* globalObject)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String result = bigInt->toString(globalObject, 10);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return toStringRef(result);
+}

--- a/src/bun.js/bindings/JSBigIntBinding.cpp
+++ b/src/bun.js/bindings/JSBigIntBinding.cpp
@@ -6,7 +6,7 @@
 using namespace JSC;
 using namespace Bun;
 
-extern "C" JSBigInt* JSC__JSBigInt__dynamicCast(EncodedJSValue encodedValue)
+extern "C" JSBigInt* JSC__JSBigInt__fromJS(EncodedJSValue encodedValue)
 {
     JSValue value = JSValue::decode(encodedValue);
     ASSERT(!value.isEmpty());

--- a/src/bun.js/bindings/JSBigIntBinding.cpp
+++ b/src/bun.js/bindings/JSBigIntBinding.cpp
@@ -65,7 +65,7 @@ extern "C" int8_t JSC__JSBigInt__orderInt64(JSBigInt* bigInt, int64_t num)
     }
 }
 
-extern "C" int64_t JSC__JSBigInt__toInt64(JSBigInt* bigInt, JSGlobalObject* globalObject)
+extern "C" int64_t JSC__JSBigInt__toInt64(JSBigInt* bigInt)
 {
     return JSBigInt::toBigInt64(bigInt);
 }

--- a/src/bun.js/jsc.zig
+++ b/src/bun.js/jsc.zig
@@ -65,6 +65,7 @@ pub const JSPromiseRejectionOperation = @import("bindings/JSPromiseRejectionOper
 pub const JSRef = @import("bindings/JSRef.zig").JSRef;
 pub const JSString = @import("bindings/JSString.zig").JSString;
 pub const JSUint8Array = @import("bindings/JSUint8Array.zig").JSUint8Array;
+pub const JSBigInt = @import("bindings/JSBigInt.zig").JSBigInt;
 pub const RefString = @import("jsc/RefString.zig");
 pub const ScriptExecutionStatus = @import("bindings/ScriptExecutionStatus.zig").ScriptExecutionStatus;
 pub const SourceType = @import("bindings/SourceType.zig").SourceType;

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2619,7 +2619,7 @@ pub const Arguments = struct {
                 -1
             else if (position_value.isNumber())
                 try JSC.Node.validators.validateInteger(ctx, position_value, "position", -1, JSC.MAX_SAFE_INTEGER)
-            else if (JSC.JSBigInt.dynamicCast(position_value)) |position| pos: {
+            else if (JSC.JSBigInt.fromJS(position_value)) |position| pos: {
                 // const maxPosition = 2n ** 63n - 1n - BigInt(length)
                 const max_position = std.math.maxInt(i64) - length_int;
                 if (position.order(i64, -1) == .lt or position.order(i64, max_position) == .gt) {

--- a/src/bun.js/node/util/validators.zig
+++ b/src/bun.js/node/util/validators.zig
@@ -54,10 +54,7 @@ pub fn throwRangeError(
     return globalThis.ERR(.OUT_OF_RANGE, fmt, args).throw();
 }
 
-pub fn validateInteger(globalThis: *JSGlobalObject, value: JSValue, comptime name: string, min_value: ?i64, max_value: ?i64) bun.JSError!i64 {
-    const min = min_value orelse JSC.MIN_SAFE_INTEGER;
-    const max = max_value orelse JSC.MAX_SAFE_INTEGER;
-
+pub fn validateInteger(globalThis: *JSGlobalObject, value: JSValue, comptime name: string, comptime min_value: ?i64, comptime max_value: ?i64) bun.JSError!i64 {
     if (!value.isNumber()) {
         return globalThis.throwInvalidArgumentTypeValue(name, "number", value);
     }
@@ -66,13 +63,29 @@ pub fn validateInteger(globalThis: *JSGlobalObject, value: JSValue, comptime nam
         return globalThis.throwRangeError(value.asNumber(), .{ .field_name = name, .msg = "an integer" });
     }
 
-    const int: i64 = @intFromFloat(value.asNumber());
-
-    if (int < min or int > max) {
-        return globalThis.throwRangeError(int, .{ .field_name = name, .min = min, .max = max });
+    comptime {
+        if (min_value) |min| {
+            if (min < JSC.MIN_SAFE_INTEGER) {
+                @compileError("min_value must be greater than or equal to JSC.MIN_SAFE_INTEGER");
+            }
+        }
+        if (max_value) |max| {
+            if (max > JSC.MAX_SAFE_INTEGER) {
+                @compileError("max_value must be less than or equal to JSC.MAX_SAFE_INTEGER");
+            }
+        }
     }
 
-    return int;
+    const min: f64 = @floatFromInt(min_value orelse JSC.MIN_SAFE_INTEGER);
+    const max: f64 = @floatFromInt(max_value orelse JSC.MAX_SAFE_INTEGER);
+
+    const num = value.asNumber();
+
+    if (num < min or num > max) {
+        return globalThis.throwRangeError(num, .{ .field_name = name, .min = @intFromFloat(min), .max = @intFromFloat(max) });
+    }
+
+    return @intFromFloat(num);
 }
 
 pub fn validateIntegerOrBigInt(globalThis: *JSGlobalObject, value: JSValue, comptime name: string, min_value: ?i64, max_value: ?i64) bun.JSError!i64 {

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1839,12 +1839,15 @@ fn NewOutOfRangeFormatter(comptime T: type) type {
 const DoubleOutOfRangeFormatter = NewOutOfRangeFormatter(f64);
 const IntOutOfRangeFormatter = NewOutOfRangeFormatter(i64);
 const StringOutOfRangeFormatter = NewOutOfRangeFormatter([]const u8);
+const BunStringOutOfRangeFormatter = NewOutOfRangeFormatter(bun.String);
 
 fn OutOfRangeFormatter(comptime T: type) type {
     if (T == f64 or T == f32) {
         return DoubleOutOfRangeFormatter;
     } else if (T == []const u8) {
         return StringOutOfRangeFormatter;
+    } else if (T == bun.String) {
+        return BunStringOutOfRangeFormatter;
     }
 
     return IntOutOfRangeFormatter;

--- a/test/js/node/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/js/node/test/parallel/test-fs-read-position-validation.mjs
@@ -1,0 +1,93 @@
+import * as common from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import fs from 'fs';
+import assert from 'assert';
+
+// This test ensures that "position" argument is correctly validated
+
+const filepath = fixtures.path('x.txt');
+
+const buffer = Buffer.from('xyz\n');
+const offset = 0;
+const length = buffer.byteLength;
+
+// allowedErrors is an array of acceptable internal errors
+// For example, on some platforms read syscall might return -EFBIG or -EOVERFLOW
+async function testValid(position, allowedErrors = []) {
+  return new Promise((resolve, reject) => {
+    fs.open(filepath, 'r', common.mustSucceed((fd) => {
+      let callCount = 3;
+      const handler = common.mustCall((err) => {
+        callCount--;
+        if (err && !allowedErrors.includes(err.code)) {
+          fs.close(fd, common.mustSucceed());
+          reject(err);
+        } else if (callCount === 0) {
+          fs.close(fd, common.mustSucceed(resolve));
+        }
+      }, callCount);
+      fs.read(fd, buffer, offset, length, position, handler);
+      fs.read(fd, { buffer, offset, length, position }, handler);
+      fs.read(fd, buffer, common.mustNotMutateObjectDeep({ offset, length, position }), handler);
+    }));
+  });
+}
+
+async function testInvalid(code, position) {
+  return new Promise((resolve, reject) => {
+    fs.open(filepath, 'r', common.mustSucceed((fd) => {
+      try {
+        assert.throws(
+          () => fs.read(fd, buffer, offset, length, position, common.mustNotCall()),
+          { code }
+        );
+        assert.throws(
+          () => fs.read(fd, { buffer, offset, length, position }, common.mustNotCall()),
+          { code }
+        );
+        assert.throws(
+          () => fs.read(fd, buffer, common.mustNotMutateObjectDeep({ offset, length, position }), common.mustNotCall()),
+          { code }
+        );
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        fs.close(fd, common.mustSucceed());
+      }
+    }));
+  });
+}
+
+{
+  await testValid(undefined);
+  await testValid(null);
+  await testValid(-1);
+  await testValid(-1n);
+
+  await testValid(0);
+  await testValid(0n);
+  await testValid(1);
+  await testValid(1n);
+  await testValid(9);
+  await testValid(9n);
+  await testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG', 'EOVERFLOW' ]);
+
+  await testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG', 'EOVERFLOW' ]);
+  await testInvalid('ERR_OUT_OF_RANGE', 2n ** 63n);
+  await testInvalid('ERR_OUT_OF_RANGE', 2n ** 63n - BigInt(length));
+
+  await testInvalid('ERR_OUT_OF_RANGE', NaN);
+  await testInvalid('ERR_OUT_OF_RANGE', -Infinity);
+  await testInvalid('ERR_OUT_OF_RANGE', Infinity);
+  await testInvalid('ERR_OUT_OF_RANGE', -0.999);
+  await testInvalid('ERR_OUT_OF_RANGE', -(2n ** 64n));
+  await testInvalid('ERR_OUT_OF_RANGE', Number.MAX_SAFE_INTEGER + 1);
+  await testInvalid('ERR_OUT_OF_RANGE', Number.MAX_VALUE);
+
+  for (const badTypeValue of [
+    false, true, '1', Symbol(1), {}, [], () => {}, Promise.resolve(1),
+  ]) {
+    await testInvalid('ERR_INVALID_ARG_TYPE', badTypeValue);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Fixes the bigint position validation for `fs.read`

Added opaque `JSBigInt*` binding for casting, comparing, and stringifying
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
