### PR TITLE
ci: merge build c++ and build vendor steps

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -419,7 +419,7 @@ function getBuildCppStep(platform, options) {
       BUN_CPP_ONLY: "ON",
       ...getBuildEnv(platform, options),
     },
-    command: "bun run build:ci --target bun --target dependencies",
+    command: ["bun run build:ci --target dependencies", "bun run build:ci --target bun"],
   };
 }
 


### PR DESCRIPTION
* Merges `build-cpp` and `build-vendor` into 1 step, because both sequentially take longer than `build-zig`.
* Can be merged when CI tests run.