### PR TITLE
Clean up usage of .destroy in sinks

### DIFF
--- a/src/bun.js/webcore/ArrayBufferSink.zig
+++ b/src/bun.js/webcore/ArrayBufferSink.zig
@@ -57,23 +57,15 @@ pub fn flushFromJS(this: *ArrayBufferSink, globalThis: *JSGlobalObject, wait: bo
 }
 
 pub fn finalize(this: *ArrayBufferSink) void {
-    if (this.bytes.len > 0) {
-        this.bytes.listManaged(this.allocator).deinit();
-        this.bytes = bun.ByteList.init("");
-        this.done = true;
-    }
-
-    this.allocator.destroy(this);
+    this.destroy();
 }
 
 pub fn init(allocator: std.mem.Allocator, next: ?Sink) !*ArrayBufferSink {
-    const this = try allocator.create(ArrayBufferSink);
-    this.* = ArrayBufferSink{
+    return bun.new(ArrayBufferSink, .{
         .bytes = bun.ByteList.init(&.{}),
         .allocator = allocator,
         .next = next,
-    };
-    return this;
+    });
 }
 
 pub fn construct(
@@ -129,7 +121,7 @@ pub fn end(this: *ArrayBufferSink, err: ?Syscall.Error) JSC.Maybe(void) {
 }
 pub fn destroy(this: *ArrayBufferSink) void {
     this.bytes.deinitWithAllocator(this.allocator);
-    this.allocator.destroy(this);
+    bun.destroy(this);
 }
 pub fn toJS(this: *ArrayBufferSink, globalThis: *JSGlobalObject, as_uint8array: bool) JSValue {
     if (this.streaming) {

--- a/src/bun.js/webcore/Sink.zig
+++ b/src/bun.js/webcore/Sink.zig
@@ -305,11 +305,8 @@ pub fn JSSink(comptime SinkType: type, comptime abi_name: []const u8) type {
                 return globalThis.throwValue(err.toErrorInstance(globalThis));
             }
 
-            var allocator = globalThis.bunVM().allocator;
-            var this = allocator.create(ThisSink) catch {
-                return globalThis.throwValue(Syscall.Error.oom.toJSC(globalThis));
-            };
-            this.sink.construct(allocator);
+            var this = bun.new(SinkType, undefined);
+            this.construct(bun.default_allocator);
             return createObject(globalThis, this, 0);
         }
 

--- a/src/ptr/ref_count.zig
+++ b/src/ptr/ref_count.zig
@@ -94,11 +94,13 @@ pub fn RefCount(T: type, field_name: []const u8, destructor_untyped: anytype, op
             if (enable_debug) {
                 counter.debug.assertValid();
             }
-            scope.log("0x{x}   ref {d} -> {d}", .{
-                @intFromPtr(self),
-                counter.active_counts,
-                counter.active_counts + 1,
-            });
+            if (comptime bun.Environment.enable_logs) {
+                scope.log("0x{x}   ref {d} -> {d}", .{
+                    @intFromPtr(self),
+                    counter.active_counts,
+                    counter.active_counts + 1,
+                });
+            }
             counter.assertNonThreadSafeCountIsSingleThreaded();
             counter.active_counts += 1;
         }
@@ -108,11 +110,13 @@ pub fn RefCount(T: type, field_name: []const u8, destructor_untyped: anytype, op
             if (enable_debug) {
                 counter.debug.assertValid();
             }
-            scope.log("0x{x} deref {d} -> {d}", .{
-                @intFromPtr(self),
-                counter.active_counts,
-                counter.active_counts - 1,
-            });
+            if (comptime bun.Environment.enable_logs) {
+                scope.log("0x{x} deref {d} -> {d}", .{
+                    @intFromPtr(self),
+                    counter.active_counts,
+                    counter.active_counts - 1,
+                });
+            }
             counter.assertNonThreadSafeCountIsSingleThreaded();
             counter.active_counts -= 1;
             if (counter.active_counts == 0) {
@@ -200,11 +204,13 @@ pub fn ThreadSafeRefCount(T: type, field_name: []const u8, destructor: fn (*T) v
             const counter = getCounter(self);
             if (enable_debug) counter.debug.assertValid();
             const new_count = counter.active_counts.fetchAdd(1, .seq_cst);
-            scope.log("0x{x}   ref {d} -> {d}", .{
-                @intFromPtr(self),
-                new_count - 1,
-                new_count,
-            });
+            if (comptime bun.Environment.enable_logs) {
+                scope.log("0x{x}   ref {d} -> {d}", .{
+                    @intFromPtr(self),
+                    new_count - 1,
+                    new_count,
+                });
+            }
             bun.debugAssert(new_count > 0);
         }
 
@@ -212,11 +218,13 @@ pub fn ThreadSafeRefCount(T: type, field_name: []const u8, destructor: fn (*T) v
             const counter = getCounter(self);
             if (enable_debug) counter.debug.assertValid();
             const new_count = counter.active_counts.fetchSub(1, .seq_cst);
-            scope.log("0x{x} deref {d} -> {d}", .{
-                @intFromPtr(self),
-                new_count + 1,
-                new_count,
-            });
+            if (comptime bun.Environment.enable_logs) {
+                scope.log("0x{x} deref {d} -> {d}", .{
+                    @intFromPtr(self),
+                    new_count + 1,
+                    new_count,
+                });
+            }
             bun.debugAssert(new_count > 0);
             if (new_count == 1) {
                 if (enable_debug) {

--- a/test/js/bun/util/fuzzy-wuzzy.test.ts
+++ b/test/js/bun/util/fuzzy-wuzzy.test.ts
@@ -19,10 +19,15 @@
 
 const ENABLE_LOGGING = false;
 
-import { describe, test } from "bun:test";
+import { describe, test, afterAll } from "bun:test";
 import { isWindows } from "harness";
 import { EventEmitter } from "events";
-
+var calls = 0,
+  constructs = 0,
+  subclasses = 0;
+afterAll(() => {
+  process.stdout.write(`\nStats: ${calls} calls, ${constructs} constructs, ${subclasses} subclasses\n`);
+});
 const Promise = globalThis.Promise;
 globalThis.Promise = function (...args) {
   if (args.length === 0) {
@@ -107,22 +112,6 @@ delete console.timeLog;
 delete console.assert;
 Bun.generateHeapSnapshot = () => {};
 
-const TODOs = [
-  "ByteLengthQueuingStrategy",
-  "CountQueuingStrategy",
-  "ReadableByteStreamController",
-  "ReadableStream",
-  "ReadableStreamBYOBReader",
-  "ReadableStreamBYOBRequest",
-  "ReadableStreamDefaultController",
-  "ReadableStreamDefaultReader",
-  "TransformStream",
-  "TransformStreamDefaultController",
-  "WritableStream",
-  "WritableStreamDefaultController",
-  "WritableStreamDefaultWriter",
-];
-
 const ignoreList = [
   Object.prototype,
   Function.prototype,
@@ -156,13 +145,10 @@ const ignoreList = [
   RegExp.prototype,
   Date.prototype,
   String.prototype,
-
-  // TODO: getFunctionRealm() on these.
-  ReadableStream.prototype,
 ];
 
 const constructBanned = banned;
-const callBanned = [...TODOs, ...banned];
+const callBanned = [...banned];
 
 function allThePropertyNames(object, banned) {
   if (!object) {
@@ -225,9 +211,11 @@ function callAllMethods(object) {
         }
         const returnValue = wrap(Reflect.apply(object?.[methodName], object, []));
         Bun.inspect?.(returnValue), queue.push(returnValue);
+        calls++;
       } catch (e) {
         const returnValue = wrap(Reflect.apply(object.constructor?.[methodName], object?.constructor, []));
         Bun.inspect?.(returnValue), queue.push(returnValue);
+        calls++;
       }
     } catch (e) {
       const val = object?.[methodName];
@@ -257,6 +245,7 @@ function callAllMethods(object) {
             continue;
           }
           Bun.inspect?.(returnValue), queue.push(returnValue);
+          calls++;
         } catch (e) {}
       }
     }
@@ -268,18 +257,22 @@ function constructAllConstructors(object) {
   const seen = new Set([object?.subarray]);
   for (const methodName of allThePropertyNames(object, constructBanned)) {
     const method = object?.[methodName];
+
     try {
       try {
         const returnValue = Reflect.construct(object, [], method);
         Bun.inspect?.(returnValue), queue.push(returnValue);
+        constructs++;
       } catch (e) {
         const returnValue = Reflect.construct(object?.constructor, [], method);
         Bun.inspect?.(returnValue), queue.push(returnValue);
+        constructs++;
       }
     } catch (e) {
       try {
         const returnValue = Reflect.construct(object?.prototype?.constructor, [], method);
         Bun.inspect?.(returnValue), queue.push(returnValue);
+        constructs++;
       } catch (e) {
         Error.captureStackTrace(e);
       }
@@ -302,6 +295,87 @@ function constructAllConstructors(object) {
 
         Bun.inspect?.(returnValue), queue.push(returnValue);
         seen.add(returnValue);
+        constructs++;
+      } catch (e) {}
+    }
+  }
+}
+
+function constructAllConstructorsWithSubclassing(object) {
+  const queue = [];
+  const seen = new Set([object?.subarray]);
+  for (const methodName of allThePropertyNames(object, constructBanned)) {
+    const method = object?.[methodName];
+
+    try {
+      try {
+        // Create a subclass of the constructor
+        class Subclass extends object {}
+        const returnValue = Reflect.construct(object, [], Subclass);
+        Bun.inspect?.(returnValue), queue.push(returnValue);
+        subclasses++;
+      } catch (e) {
+        try {
+          // Try with the constructor property
+          class Subclass extends object?.constructor {}
+          const returnValue = Reflect.construct(object?.constructor, [], Subclass);
+          Bun.inspect?.(returnValue), queue.push(returnValue);
+          subclasses++;
+        } catch (e) {
+          // Fallback to a more generic approach
+          const Subclass = function () {};
+          Object.setPrototypeOf(Subclass.prototype, object);
+          const returnValue = Reflect.construct(object, [], Subclass);
+          Bun.inspect?.(returnValue), queue.push(returnValue);
+          subclasses++;
+        }
+      }
+    } catch (e) {
+      try {
+        // Try with prototype constructor
+        class Subclass extends object?.prototype?.constructor {}
+        const returnValue = Reflect.construct(object?.prototype?.constructor, [], Subclass);
+        Bun.inspect?.(returnValue), queue.push(returnValue);
+        subclasses++;
+      } catch (e) {
+        Error.captureStackTrace(e);
+      }
+    }
+  }
+
+  while (queue.length) {
+    const value = queue.shift();
+    for (const methodName of allThePropertyNames(value, constructBanned)) {
+      try {
+        const method = value?.[methodName];
+        if (method && seen.has(method)) {
+          continue;
+        }
+
+        // Create a subclass of the value
+        try {
+          class Subclass extends value {}
+          const returnValue = Reflect.construct(value, [], Subclass);
+          if (seen.has(returnValue)) {
+            continue;
+          }
+
+          Bun.inspect?.(returnValue), queue.push(returnValue);
+          seen.add(returnValue);
+          subclasses++;
+        } catch (e) {
+          // Fallback to a more generic approach
+          const Subclass = function () {};
+          Object.setPrototypeOf(Subclass.prototype, value);
+          const returnValue = Reflect.construct(value, [], Subclass);
+          if (seen.has(returnValue)) {
+            continue;
+          }
+
+          Bun.inspect?.(returnValue), queue.push(returnValue);
+          seen.add(returnValue);
+          subclasses++;
+        }
       } catch (e) {}
     }
   }
@@ -318,7 +392,18 @@ const modules = [
   "os",
   "dgram",
   "domain",
-  // "crypto",
+  "crypto",
+  "util/types",
+  "http",
+  "_http_agent",
+  "_http_client",
+  "_http_common",
+  "_http_incoming",
+  "_http_outgoing",
+  "_http_server",
+  "http2",
+  "process",
+  "undici",
   "timers",
   "punycode",
   "trace_events",
@@ -328,12 +413,14 @@ const modules = [
   "bun:ffi",
   "string_decoder",
   "bun:sqlite",
+  "fs/promises",
 ];
 
 for (const mod of modules) {
   describe(mod, () => {
     test("call", () => callAllMethods(require(mod)));
     test("construct", () => constructAllConstructors(require(mod)));
+    test("construct-subclass", () => constructAllConstructorsWithSubclassing(require(mod)));
   });
 }
 
@@ -362,6 +449,9 @@ for (const HardCodedClass of [
 ]) {
   test("call " + (HardCodedClass.name || HardCodedClass.toString()), () => constructAllConstructors(HardCodedClass));
   test("construct " + (HardCodedClass.name || HardCodedClass.toString()), () => callAllMethods(HardCodedClass));
+  test("construct-subclass " + (HardCodedClass.name || HardCodedClass.toString()), () =>
+    constructAllConstructorsWithSubclassing(HardCodedClass),
+  );
 }
 
 const globals = [
@@ -381,6 +471,11 @@ for (const [Global, name] of globals) {
     test.skipIf(isWindows && Global === Bun)("construct", async () => {
       await Bun.sleep(1);
       constructAllConstructors(Global);
+      await Bun.sleep(1);
+    });
+    test.skipIf(isWindows && Global === Bun)("construct-subclass", async () => {
+      await Bun.sleep(1);
+      constructAllConstructorsWithSubclassing(Global);
       await Bun.sleep(1);
     });
   });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
