### PR TITLE
fix `test-parse-args.mjs`

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2830,6 +2830,8 @@ void Process::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_uncaughtExceptionCaptureCallback);
     visitor.append(thisObject->m_nextTickFunction);
     visitor.append(thisObject->m_cachedCwd);
+    visitor.append(thisObject->m_argv);
+    visitor.append(thisObject->m_execArgv);
 
     thisObject->m_cpuUsageStructure.visit(visitor);
     thisObject->m_memoryUsageStructure.visit(visitor);

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -135,14 +135,7 @@ using JSObject = JSC::JSObject;
 using JSNonFinalObject = JSC::JSNonFinalObject;
 namespace JSCastingHelpers = JSC::JSCastingHelpers;
 
-JSC_DECLARE_CUSTOM_SETTER(Process_setTitle);
-JSC_DECLARE_CUSTOM_GETTER(Process_getArgv);
-JSC_DECLARE_CUSTOM_SETTER(Process_setArgv);
-JSC_DECLARE_CUSTOM_GETTER(Process_getTitle);
-JSC_DECLARE_CUSTOM_GETTER(Process_getPID);
-JSC_DECLARE_CUSTOM_GETTER(Process_getPPID);
 JSC_DECLARE_HOST_FUNCTION(Process_functionCwd);
-JSC_DEFINE_HOST_FUNCTION(jsFunction_ERR_IPC_DISCONNECTED, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*));
 
 extern "C" uint8_t Bun__getExitCode(void*);
 extern "C" uint8_t Bun__setExitCode(void*, uint8_t);
@@ -156,6 +149,7 @@ BUN_DECLARE_HOST_FUNCTION(Bun__Process__send);
 extern "C" void Process__emitDisconnectEvent(Zig::GlobalObject* global);
 extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValue value);
 
+static Process* getProcessObject(JSC::JSGlobalObject* lexicalGlobalObject, JSValue thisValue);
 bool setProcessExitCodeInner(JSC::JSGlobalObject* lexicalGlobalObject, Process* process, JSValue code);
 
 static JSValue constructArch(VM& vm, JSObject* processObject)
@@ -1857,7 +1851,7 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
             header->putDirect(vm, JSC::Identifier::fromString(vm, "cwd"_s), JSC::jsString(vm, String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const LChar*>(cwd), strlen(cwd) })), 0);
         }
 
-        header->putDirect(vm, JSC::Identifier::fromString(vm, "commandLine"_s), JSValue::decode(Bun__Process__getExecArgv(globalObject)), 0);
+        header->putDirect(vm, JSC::Identifier::fromString(vm, "commandLine"_s), JSValue::decode(Bun__Process__createExecArgv(globalObject)), 0);
         header->putDirect(vm, JSC::Identifier::fromString(vm, "nodejsVersion"_s), JSC::jsString(vm, String::fromLatin1(REPORTED_NODEJS_VERSION)), 0);
         header->putDirect(vm, JSC::Identifier::fromString(vm, "wordSize"_s), JSC::jsNumber(64), 0);
         header->putDirect(vm, JSC::Identifier::fromString(vm, "arch"_s), constructArch(vm, header), 0);
@@ -2364,13 +2358,7 @@ static JSValue constructPpid(VM& vm, JSObject* processObject)
 static JSValue constructArgv0(VM& vm, JSObject* processObject)
 {
     auto* globalObject = processObject->globalObject();
-    return JSValue::decode(Bun__Process__getArgv0(globalObject));
-}
-
-static JSValue constructExecArgv(VM& vm, JSObject* processObject)
-{
-    auto* globalObject = processObject->globalObject();
-    return JSValue::decode(Bun__Process__getExecArgv(globalObject));
+    return JSValue::decode(Bun__Process__createArgv0(globalObject));
 }
 
 static JSValue constructExecPath(VM& vm, JSObject* processObject)
@@ -2379,10 +2367,106 @@ static JSValue constructExecPath(VM& vm, JSObject* processObject)
     return JSValue::decode(Bun__Process__getExecPath(globalObject));
 }
 
-static JSValue constructArgv(VM& vm, JSObject* processObject)
+// get from zig
+extern "C" EncodedJSValue Bun__Process__getArgv(JSGlobalObject* lexicalGlobalObject)
 {
-    auto* globalObject = processObject->globalObject();
-    return JSValue::decode(Bun__Process__getArgv(globalObject));
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto* process = jsCast<Process*>(globalObject->processObject());
+    if (!process) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(process->getArgv(globalObject));
+}
+
+// get from js
+JSC_DEFINE_CUSTOM_GETTER(processArgv, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    Process* process = getProcessObject(globalObject, JSValue::decode(thisValue));
+    if (!process) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(process->getArgv(globalObject));
+}
+
+JSValue Process::getArgv(JSGlobalObject* globalObject)
+{
+    if (auto argv = m_argv.get()) {
+        return argv;
+    }
+
+    JSValue argv = JSValue::decode(Bun__Process__createArgv(globalObject));
+    setArgv(globalObject, argv);
+    return argv;
+}
+
+void Process::setArgv(JSGlobalObject* globalObject, JSValue value)
+{
+    auto& vm = globalObject->vm();
+    m_argv.set(vm, this, value);
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setProcessArgv, (JSGlobalObject * globalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName))
+{
+    Process* process = getProcessObject(globalObject, JSValue::decode(thisValue));
+    if (!process) {
+        return true;
+    }
+
+    JSValue value = JSValue::decode(encodedValue);
+    process->setArgv(globalObject, value);
+    return true;
+}
+
+extern "C" EncodedJSValue Bun__Process__getExecArgv(JSGlobalObject* lexicalGlobalObject)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto* process = jsCast<Process*>(globalObject->processObject());
+    if (!process) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(process->getExecArgv(globalObject));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(processExecArgv, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    Process* process = getProcessObject(globalObject, JSValue::decode(thisValue));
+    if (!process) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(process->getExecArgv(globalObject));
+}
+
+JSValue Process::getExecArgv(JSGlobalObject* globalObject)
+{
+    if (auto argv = m_execArgv.get()) {
+        return argv;
+    }
+
+    JSValue argv = JSValue::decode(Bun__Process__createExecArgv(globalObject));
+    setExecArgv(globalObject, argv);
+    return argv;
+}
+
+void Process::setExecArgv(JSGlobalObject* globalObject, JSValue value)
+{
+    auto& vm = globalObject->vm();
+    m_execArgv.set(vm, this, value);
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setProcessExecArgv, (JSGlobalObject * globalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName))
+{
+    Process* process = getProcessObject(globalObject, JSValue::decode(thisValue));
+    if (!process) {
+        return true;
+    }
+
+    JSValue value = JSValue::decode(encodedValue);
+    process->setExecArgv(globalObject, value);
+    return true;
 }
 
 static JSValue constructBrowser(VM& vm, JSObject* processObject)
@@ -3079,6 +3163,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_ref, (JSGlobalObject * globalObject, CallFrame*
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue maybeRefable = callFrame->argument(0);
+    if (maybeRefable.isUndefinedOrNull()) {
+        return JSValue::encode(jsUndefined());
+    }
 
     JSValue ref = maybeRefable.get(globalObject, Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.ref"_s)));
     RETURN_IF_EXCEPTION(scope, {});
@@ -3106,6 +3193,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_unref, (JSGlobalObject * globalObject, CallFram
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue maybeUnrefable = callFrame->argument(0);
+    if (maybeUnrefable.isUndefinedOrNull()) {
+        return JSValue::encode(jsUndefined());
+    }
 
     JSValue unref = maybeUnrefable.get(globalObject, Identifier::fromUid(vm.symbolRegistry().symbolForKey("nodejs.unref"_s)));
     RETURN_IF_EXCEPTION(scope, {});
@@ -3566,7 +3656,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   abort                            Process_functionAbort                               Function 1
   allowedNodeEnvironmentFlags      Process_stubEmptySet                                PropertyCallback
   arch                             constructArch                                       PropertyCallback
-  argv                             constructArgv                                       PropertyCallback
+  argv                             processArgv                                         CustomAccessor
   argv0                            constructArgv0                                      PropertyCallback
   assert                           Process_functionAssert                              Function 1
   availableMemory                  Process_availableMemory                             Function 0
@@ -3584,7 +3674,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   dlopen                           Process_functionDlopen                              Function 1
   emitWarning                      Process_emitWarning                                 Function 1
   env                              constructEnv                                        PropertyCallback
-  execArgv                         constructExecArgv                                   PropertyCallback
+  execArgv                         processExecArgv                                     CustomAccessor
   execPath                         constructExecPath                                   PropertyCallback
   exit                             Process_functionExit                                Function 1
   exitCode                         processExitCode                                     CustomAccessor|DontDelete
@@ -3617,7 +3707,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   throwDeprecation                 processThrowDeprecation                             CustomAccessor
   title                            processTitle                                        CustomAccessor
   umask                            Process_functionUmask                               Function 1
-  unref                            Process_unref                                        Function 1
+  unref                            Process_unref                                       Function 1
   uptime                           Process_functionUptime                              Function 1
   version                          constructVersion                                    PropertyCallback
   versions                         constructVersions                                   PropertyCallback

--- a/src/bun.js/bindings/BunProcess.h
+++ b/src/bun.js/bindings/BunProcess.h
@@ -26,6 +26,8 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<JSObject> m_nextTickFunction;
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L113-L116
     WriteBarrier<JSString> m_cachedCwd;
+    WriteBarrier<Unknown> m_argv;
+    WriteBarrier<Unknown> m_execArgv;
 
 public:
     Process(JSC::Structure* structure, WebCore::JSDOMGlobalObject& globalObject, Ref<WebCore::EventEmitter>&& impl)
@@ -59,6 +61,12 @@ public:
 
     JSString* cachedCwd() { return m_cachedCwd.get(); }
     void setCachedCwd(JSC::VM& vm, JSString* cwd) { m_cachedCwd.set(vm, this, cwd); }
+
+    JSValue getArgv(JSGlobalObject* globalObject);
+    void setArgv(JSGlobalObject* globalObject, JSValue argv);
+
+    JSValue getExecArgv(JSGlobalObject* globalObject);
+    void setExecArgv(JSGlobalObject* globalObject, JSValue execArgv);
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject,
         JSC::JSValue prototype)

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -745,7 +745,7 @@ extern "C" void JSC__JSValue__putBunString(
     JSC::JSObject* target = JSC::JSValue::decode(encodedTarget).getObject();
     JSC::JSValue value = JSC::JSValue::decode(encodedValue);
     auto& vm = global->vm();
-    WTF::String str = key->tag == BunStringTag::Empty ? WTF::String(""_s) : key->toWTFString();
+    WTF::String str = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();
     Identifier id = Identifier::fromString(vm, str);
     target->putDirect(vm, id, value, 0);
 }

--- a/src/bun.js/bindings/JSWrappingFunction.cpp
+++ b/src/bun.js/bindings/JSWrappingFunction.cpp
@@ -27,7 +27,7 @@ JS_EXPORT_PRIVATE JSWrappingFunction* JSWrappingFunction::create(
     JSC::JSFunction* wrappedFn = jsCast<JSC::JSFunction*>(wrappedFnValue.asCell());
     ASSERT(wrappedFn != nullptr);
 
-    auto nameStr = symbolName->tag == BunStringTag::Empty ? WTF::String(""_s) : symbolName->toWTFString();
+    auto nameStr = symbolName->tag == BunStringTag::Empty ? WTF::emptyString() : symbolName->toWTFString();
     auto name = Identifier::fromString(vm, nameStr);
     NativeExecutable* executable = vm.getHostFunction(functionPointer, ImplementationVisibility::Public, nullptr, nameStr);
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3629,7 +3629,7 @@ extern "C" void JSC__JSValue__putMayBeIndex(JSC__JSValue target, JSC__JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
-    WTF::String keyStr = key->tag == BunStringTag::Empty ? WTF::String(""_s) : key->toWTFString();
+    WTF::String keyStr = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();
     JSC::Identifier identifier = JSC::Identifier::fromString(vm, keyStr);
 
     JSC::JSObject* object = JSC::JSValue::decode(target).asCell()->getObject();
@@ -3968,7 +3968,7 @@ extern "C" JSC__JSValue JSC__JSValue__getOwn(JSC__JSValue JSValue0, JSC__JSGloba
 
     VM& vm = globalObject->vm();
     JSValue value = JSC::JSValue::decode(JSValue0);
-    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::String(""_s) : propertyName->toWTFString(BunString::ZeroCopy);
+    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::emptyString() : propertyName->toWTFString(BunString::ZeroCopy);
     auto identifier = JSC::Identifier::fromString(vm, propertyNameString);
     auto property = JSC::PropertyName(identifier);
     PropertySlot slot(value, PropertySlot::InternalMethodType::GetOwnProperty);

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -742,10 +742,10 @@ ZIG_DECL size_t Bun__WebSocketClientTLS__memoryCost(WebSocketClientTLS* arg0);
 #ifdef __cplusplus
 
 ZIG_DECL /*[[noreturn]]*/ void Bun__Process__exit(JSC__JSGlobalObject* arg0, uint8_t arg1); // TODO(@190n) figure out why with a real [[noreturn]] annotation this trips ASan before calling the function
-ZIG_DECL JSC__JSValue Bun__Process__getArgv(JSC__JSGlobalObject* arg0);
-ZIG_DECL JSC__JSValue Bun__Process__getArgv0(JSC__JSGlobalObject* arg0);
+ZIG_DECL JSC__JSValue Bun__Process__createArgv(JSC__JSGlobalObject* arg0);
+ZIG_DECL JSC__JSValue Bun__Process__createArgv0(JSC__JSGlobalObject* arg0);
 ZIG_DECL JSC__JSValue Bun__Process__getCwd(JSC__JSGlobalObject* arg0);
-ZIG_DECL JSC__JSValue Bun__Process__getExecArgv(JSC__JSGlobalObject* arg0);
+ZIG_DECL JSC__JSValue Bun__Process__createExecArgv(JSC__JSGlobalObject* arg0);
 ZIG_DECL JSC__JSValue Bun__Process__getExecPath(JSC__JSGlobalObject* arg0);
 ZIG_DECL void Bun__Process__getTitle(JSC__JSGlobalObject* arg0, ZigString* arg1);
 ZIG_DECL JSC__JSValue Bun__Process__setCwd(JSC__JSGlobalObject* arg0, ZigString* arg1);

--- a/src/bun.js/node/util/parse_args.zig
+++ b/src/bun.js/node/util/parse_args.zig
@@ -79,6 +79,7 @@ const OptionToken = struct {
     inline_value: bool,
     optgroup_idx: ?u32 = null,
     option_idx: ?usize,
+    negative: bool = false,
 
     /// The full raw arg string (e.g. "--arg=1").
     /// If the value existed as-is in the input "args" list, it is stored as so, otherwise is null
@@ -154,25 +155,31 @@ pub fn findOptionByLongName(long_name: String, options: []const OptionDefinition
 fn getDefaultArgs(globalThis: *JSGlobalObject) !ArgsSlice {
     // Work out where to slice process.argv for user supplied arguments
 
-    // Check options for scenarios where user CLI args follow executable
-    const argv: JSValue = bun.api.node.process.getArgv(globalThis);
+    const exec_argv = bun.api.node.process.getExecArgv(globalThis);
+    const argv = bun.api.node.process.getArgv(globalThis);
+    if (argv.isArray() and exec_argv.isArray()) {
+        var iter = exec_argv.arrayIterator(globalThis);
+        while (iter.next()) |item| {
+            if (item.isString()) {
+                const str = try item.toBunString(globalThis);
+                defer str.deref();
+                if (str.eqlComptime("-e") or str.eqlComptime("--eval") or str.eqlComptime("-p") or str.eqlComptime("--print")) {
+                    return .{
+                        .array = argv,
+                        .start = 1,
+                        .end = @intCast(argv.getLength(globalThis)),
+                    };
+                }
+            }
+        }
+        return .{ .array = argv, .start = 2, .end = @intCast(argv.getLength(globalThis)) };
+    }
 
-    //var found = false;
-    //var iter = argv.arrayIterator(globalThis);
-    //while (iter.next()) |arg| {
-    //    const str = arg.toBunString(globalThis);
-    //    if (str.eqlComptime("-e") or str.eqlComptime("--eval") or str.eqlComptime("-p") or str.eqlComptime("--print")) {
-    //        found = true;
-    //        break;
-    //    }
-    //}
-    // Normally first two arguments are executable and script, then CLI arguments
-    //args_offset.* = if (found) 1 else 2;
-
-    // argv[0] is the bun executable name
-    // argv[1] is the script path, or a placeholder in case of eval
-    // so actual args start from argv[2]
-    return .{ .array = argv, .start = 2, .end = @intCast(argv.getLength(globalThis)) };
+    return .{
+        .array = .undefined,
+        .start = 0,
+        .end = 0,
+    };
 }
 
 /// In strict mode, throw for possible usage errors like "--foo --bar" where foo was defined as a string-valued arg
@@ -206,6 +213,13 @@ fn checkOptionUsage(globalThis: *JSGlobalObject, options: []const OptionDefiniti
         const option = options[option_idx];
         switch (option.type) {
             .string => if (token.value == .jsvalue and !token.value.jsvalue.isString()) {
+                if (token.negative) {
+                    // the option was found earlier because we trimmed 'no-' from the name, so we throw
+                    // the expected unknown option error.
+                    const raw_name: OptionToken.RawNameFormatter = .{ .token = token, .globalThis = globalThis };
+                    const err = globalThis.toTypeError(.PARSE_ARGS_UNKNOWN_OPTION, "Unknown option '{}'", .{raw_name});
+                    return globalThis.throwValue(err);
+                }
                 const err = globalThis.toTypeError(
                     .PARSE_ARGS_INVALID_OPTION_VALUE,
                     "Option '{s}{s}{s}--{s} <value>' argument missing",
@@ -254,7 +268,7 @@ fn checkOptionUsage(globalThis: *JSGlobalObject, options: []const OptionDefiniti
 /// - `option_value`: value from user args
 /// - `options`: option configs, from `parseArgs({ options })`
 /// - `values`: option values returned in `values` by parseArgs
-fn storeOption(globalThis: *JSGlobalObject, option_name: ValueRef, option_value: ValueRef, option_idx: ?usize, options: []const OptionDefinition, values: JSValue) void {
+fn storeOption(globalThis: *JSGlobalObject, option_name: ValueRef, option_value: ValueRef, option_idx: ?usize, negative: bool, options: []const OptionDefinition, values: JSValue) void {
     var key = option_name.asBunString(globalThis);
     if (key.eqlComptime("__proto__")) {
         return;
@@ -264,7 +278,7 @@ fn storeOption(globalThis: *JSGlobalObject, option_name: ValueRef, option_value:
 
     // We store based on the option value rather than option type,
     // preserving the users intent for author to deal with.
-    const new_value = if (value.isUndefined()) JSValue.true else value;
+    const new_value = if (value.isUndefined()) JSC.jsBoolean(!negative) else value;
 
     const is_multiple = if (option_idx) |idx| options[idx].multiple else false;
     if (is_multiple) {
@@ -361,12 +375,10 @@ fn parseOptionDefinitions(globalThis: *JSGlobalObject, options_obj: JSValue, opt
 /// - positional
 /// - option-terminator
 fn tokenizeArgs(
-    comptime T: type,
+    ctx: *ParseArgsState,
     globalThis: *JSGlobalObject,
     args: ArgsSlice,
     options: []const OptionDefinition,
-    ctx: *T,
-    emitToken: fn (ctx: *T, token: Token) bun.JSError!void,
 ) bun.JSError!void {
     const num_args: u32 = args.end - args.start;
     var index: u32 = 0;
@@ -382,13 +394,13 @@ fn tokenizeArgs(
             // Guideline 10 in https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
             .option_terminator => {
                 // Everything after a bare '--' is considered a positional argument.
-                try emitToken(ctx, Token{ .@"option-terminator" = .{
+                try ctx.handleToken(.{ .@"option-terminator" = .{
                     .index = index,
                 } });
                 index += 1;
 
                 while (index < num_args) : (index += 1) {
-                    try emitToken(ctx, Token{ .positional = .{
+                    try ctx.handleToken(.{ .positional = .{
                         .index = index,
                         .value = ValueRef{ .jsvalue = args.get(globalThis, index) },
                     } });
@@ -410,7 +422,7 @@ fn tokenizeArgs(
                     has_inline_value = false;
                     log("   (lone_short_option consuming next token as value)", .{});
                 }
-                try emitToken(ctx, Token{ .option = .{
+                try ctx.handleToken(.{ .option = .{
                     .index = index,
                     .value = value,
                     .inline_value = has_inline_value,
@@ -444,7 +456,7 @@ fn tokenizeArgs(
                             has_inline_value = false;
                             log("   (short_option_group short option consuming next token as value)", .{});
                         }
-                        try emitToken(ctx, Token{ .option = .{
+                        try ctx.handleToken(.{ .option = .{
                             .index = original_arg_idx,
                             .optgroup_idx = @intCast(idx_in_optgroup),
                             .value = value,
@@ -461,7 +473,7 @@ fn tokenizeArgs(
                         // Expand -abfFILE to -a -b -fFILE
 
                         // Immediately process as a short_option_and_value
-                        try emitToken(ctx, Token{ .option = .{
+                        try ctx.handleToken(.{ .option = .{
                             .index = original_arg_idx,
                             .optgroup_idx = @intCast(idx_in_optgroup),
                             .value = ValueRef{ .bunstr = arg.substring(idx_in_optgroup + 1) },
@@ -483,7 +495,7 @@ fn tokenizeArgs(
                 const option_idx = findOptionByShortName(short_option, options);
                 const value = arg.substring(2);
 
-                try emitToken(ctx, Token{ .option = .{
+                try ctx.handleToken(.{ .option = .{
                     .index = index,
                     .value = ValueRef{ .bunstr = value },
                     .inline_value = true,
@@ -496,16 +508,24 @@ fn tokenizeArgs(
 
             .lone_long_option => {
                 // e.g. '--foo'
-                const long_option = arg.substring(2);
-                var value: ?JSValue = null;
+                var long_option = arg.substring(2);
+
+                long_option, const negative = if (ctx.allow_negative and long_option.hasPrefixComptime("no-"))
+                    .{ long_option.substring(3), true }
+                else
+                    .{ long_option, false };
+
                 const option_idx = findOptionByLongName(long_option, options);
                 const option_type: OptionValueType = if (option_idx) |idx| options[idx].type else .boolean;
-                if (option_type == .string and index + 1 < num_args) {
+
+                var value: ?JSValue = null;
+                if (option_type == .string and index + 1 < num_args and !negative) {
                     // e.g. '--foo', "bar"
                     value = args.get(globalThis, index + 1);
                     log("  (consuming next as value)", .{});
                 }
-                try emitToken(ctx, Token{ .option = .{
+
+                try ctx.handleToken(.{ .option = .{
                     .index = index,
                     .value = ValueRef{ .jsvalue = value orelse JSValue.jsUndefined() },
                     .inline_value = (value == null),
@@ -513,7 +533,9 @@ fn tokenizeArgs(
                     .parse_type = .lone_long_option,
                     .raw = arg_ref,
                     .option_idx = option_idx,
+                    .negative = negative,
                 } });
+
                 if (value != null) index += 1;
             },
 
@@ -523,7 +545,7 @@ fn tokenizeArgs(
                 const long_option = arg.substringWithLen(2, equal_index.?);
                 const value = arg.substring(equal_index.? + 1);
 
-                try emitToken(ctx, Token{ .option = .{
+                try ctx.handleToken(.{ .option = .{
                     .index = index,
                     .value = ValueRef{ .bunstr = value },
                     .inline_value = true,
@@ -535,7 +557,7 @@ fn tokenizeArgs(
             },
 
             .positional => {
-                try emitToken(ctx, Token{ .positional = .{
+                try ctx.handleToken(.{ .positional = .{
                     .index = index,
                     .value = arg_ref,
                 } });
@@ -550,6 +572,7 @@ const ParseArgsState = struct {
     option_defs: []const OptionDefinition,
     allow_positionals: bool,
     strict: bool,
+    allow_negative: bool,
 
     // Output
     values: JSValue,
@@ -568,7 +591,7 @@ const ParseArgsState = struct {
                     try checkOptionUsage(globalThis, this.option_defs, this.allow_positionals, token);
                     try checkOptionLikeValue(globalThis, token);
                 }
-                storeOption(globalThis, token.name, token.value, token.option_idx, this.option_defs, this.values);
+                storeOption(globalThis, token.name, token.value, token.option_idx, token.negative, this.option_defs, this.values);
             },
             .positional => |token| {
                 if (!this.allow_positionals) {
@@ -671,6 +694,7 @@ pub fn parseArgsImpl(globalThis: *JSGlobalObject, config_obj: JSValue) bun.JSErr
     const config_strict: JSValue = (if (config) |c| c.getOwn(globalThis, "strict") else null) orelse JSValue.jsBoolean(true);
     const config_allow_positionals: ?JSValue = if (config) |c| c.getOwn(globalThis, "allowPositionals") else null;
     const config_return_tokens: JSValue = (if (config) |c| c.getOwn(globalThis, "tokens") else null) orelse JSValue.jsBoolean(false);
+    const config_allow_negative: JSValue = if (config) |c| c.getOwn(globalThis, "allowNegative") orelse .false else .false;
     const config_options_obj: ?JSValue = if (config) |c| c.getOwn(globalThis, "options") else null;
 
     const strict = try validators.validateBoolean(globalThis, config_strict, "strict", .{});
@@ -681,6 +705,7 @@ pub fn parseArgsImpl(globalThis: *JSGlobalObject, config_obj: JSValue) bun.JSErr
     }
 
     const return_tokens = try validators.validateBoolean(globalThis, config_return_tokens, "tokens", .{});
+    const allow_negative = try validators.validateBoolean(globalThis, config_allow_negative, "allowNegative", .{});
 
     // Phase 0.C: Parse the options definitions
 
@@ -710,13 +735,14 @@ pub fn parseArgsImpl(globalThis: *JSGlobalObject, config_obj: JSValue) bun.JSErr
         .option_defs = option_defs.items,
         .allow_positionals = allow_positionals,
         .strict = strict,
+        .allow_negative = allow_negative,
 
         .values = values,
         .positionals = positionals,
         .tokens = tokens,
     };
 
-    try tokenizeArgs(ParseArgsState, globalThis, args, option_defs.items, &state, ParseArgsState.handleToken);
+    try tokenizeArgs(&state, globalThis, args, option_defs.items);
 
     //
     // Phase 3: fill in default values for missing args

--- a/test/js/node/test/parallel/test-parse-args.mjs
+++ b/test/js/node/test/parallel/test-parse-args.mjs
@@ -1,0 +1,1064 @@
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { parseArgs } from 'node:util';
+
+test('when short option used as flag then stored as flag', () => {
+  const args = ['-f'];
+  const expected = { values: { __proto__: null, f: true }, positionals: [] };
+  const result = parseArgs({ strict: false, args });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when short option used as flag before positional then stored as flag and positional (and not value)', () => {
+  const args = ['-f', 'bar'];
+  const expected = { values: { __proto__: null, f: true }, positionals: [ 'bar' ] };
+  const result = parseArgs({ strict: false, args });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when short option `type: "string"` used with value then stored as value', () => {
+  const args = ['-f', 'bar'];
+  const options = { f: { type: 'string' } };
+  const expected = { values: { __proto__: null, f: 'bar' }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when short option listed in short used as flag then long option stored as flag', () => {
+  const args = ['-f'];
+  const options = { foo: { short: 'f', type: 'boolean' } };
+  const expected = { values: { __proto__: null, foo: true }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when short option listed in short and long listed in `type: "string"` and ' +
+     'used with value then long option stored as value', () => {
+  const args = ['-f', 'bar'];
+  const options = { foo: { short: 'f', type: 'string' } };
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when short option `type: "string"` used without value then stored as flag', () => {
+  const args = ['-f'];
+  const options = { f: { type: 'string' } };
+  const expected = { values: { __proto__: null, f: true }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('short option group behaves like multiple short options', () => {
+  const args = ['-rf'];
+  const options = { };
+  const expected = { values: { __proto__: null, r: true, f: true }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('short option group does not consume subsequent positional', () => {
+  const args = ['-rf', 'foo'];
+  const options = { };
+  const expected = { values: { __proto__: null, r: true, f: true }, positionals: ['foo'] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+// See: Guideline 5 https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html
+test('if terminal of short-option group configured `type: "string"`, subsequent positional is stored', () => {
+  const args = ['-rvf', 'foo'];
+  const options = { f: { type: 'string' } };
+  const expected = { values: { __proto__: null, r: true, v: true, f: 'foo' }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('handles short-option groups in conjunction with long-options', () => {
+  const args = ['-rf', '--foo', 'foo'];
+  const options = { foo: { type: 'string' } };
+  const expected = { values: { __proto__: null, r: true, f: true, foo: 'foo' }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('handles short-option groups with "short" alias configured', () => {
+  const args = ['-rf'];
+  const options = { remove: { short: 'r', type: 'boolean' } };
+  const expected = { values: { __proto__: null, remove: true, f: true }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('handles short-option followed by its value', () => {
+  const args = ['-fFILE'];
+  const options = { foo: { short: 'f', type: 'string' } };
+  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('Everything after a bare `--` is considered a positional argument', () => {
+  const args = ['--', 'barepositionals', 'mopositionals'];
+  const expected = { values: { __proto__: null }, positionals: ['barepositionals', 'mopositionals'] };
+  const result = parseArgs({ allowPositionals: true, args });
+  assert.deepStrictEqual(result, expected, Error('testing bare positionals'));
+});
+
+test('args are true', () => {
+  const args = ['--foo', '--bar'];
+  const expected = { values: { __proto__: null, foo: true, bar: true }, positionals: [] };
+  const result = parseArgs({ strict: false, args });
+  assert.deepStrictEqual(result, expected, Error('args are true'));
+});
+
+test('arg is true and positional is identified', () => {
+  const args = ['--foo=a', '--foo', 'b'];
+  const expected = { values: { __proto__: null, foo: true }, positionals: ['b'] };
+  const result = parseArgs({ strict: false, args });
+  assert.deepStrictEqual(result, expected, Error('arg is true and positional is identified'));
+});
+
+test('args equals are passed `type: "string"`', () => {
+  const args = ['--so=wat'];
+  const options = { so: { type: 'string' } };
+  const expected = { values: { __proto__: null, so: 'wat' }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected, Error('arg value is passed'));
+});
+
+test('when args include single dash then result stores dash as positional', () => {
+  const args = ['-'];
+  const expected = { values: { __proto__: null }, positionals: ['-'] };
+  const result = parseArgs({ allowPositionals: true, args });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('zero config args equals are parsed as if `type: "string"`', () => {
+  const args = ['--so=wat'];
+  const options = { };
+  const expected = { values: { __proto__: null, so: 'wat' }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected, Error('arg value is passed'));
+});
+
+test('same arg is passed twice `type: "string"` and last value is recorded', () => {
+  const args = ['--foo=a', '--foo', 'b'];
+  const options = { foo: { type: 'string' } };
+  const expected = { values: { __proto__: null, foo: 'b' }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected, Error('last arg value is passed'));
+});
+
+test('args equals pass string including more equals', () => {
+  const args = ['--so=wat=bing'];
+  const options = { so: { type: 'string' } };
+  const expected = { values: { __proto__: null, so: 'wat=bing' }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected, Error('arg value is passed'));
+});
+
+test('first arg passed for `type: "string"` and "multiple" is in array', () => {
+  const args = ['--foo=a'];
+  const options = { foo: { type: 'string', multiple: true } };
+  const expected = { values: { __proto__: null, foo: ['a'] }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected, Error('first multiple in array'));
+});
+
+test('args are passed `type: "string"` and "multiple"', () => {
+  const args = ['--foo=a', '--foo', 'b'];
+  const options = {
+    foo: {
+      type: 'string',
+      multiple: true,
+    },
+  };
+  const expected = { values: { __proto__: null, foo: ['a', 'b'] }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected, Error('both arg values are passed'));
+});
+
+test('when expecting `multiple:true` boolean option and option used multiple times then result includes array of ' +
+     'booleans matching usage', () => {
+  const args = ['--foo', '--foo'];
+  const options = {
+    foo: {
+      type: 'boolean',
+      multiple: true,
+    },
+  };
+  const expected = { values: { __proto__: null, foo: [true, true] }, positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('order of option and positional does not matter (per README)', () => {
+  const args1 = ['--foo=bar', 'baz'];
+  const args2 = ['baz', '--foo=bar'];
+  const options = { foo: { type: 'string' } };
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: ['baz'] };
+  assert.deepStrictEqual(
+    parseArgs({ allowPositionals: true, args: args1, options }),
+    expected,
+    Error('option then positional')
+  );
+  assert.deepStrictEqual(
+    parseArgs({ allowPositionals: true, args: args2, options }),
+    expected,
+    Error('positional then option')
+  );
+});
+
+test('correct default args when use node -p', () => {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['-p', '0'];
+  const result = parseArgs({ strict: false });
+
+  const expected = { values: { __proto__: null, foo: true },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when use node --print', () => {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['--print', '0'];
+  const result = parseArgs({ strict: false });
+
+  const expected = { values: { __proto__: null, foo: true },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when use node -e', () => {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['-e', '0'];
+  const result = parseArgs({ strict: false });
+
+  const expected = { values: { __proto__: null, foo: true },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when use node --eval', () => {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = ['--eval', '0'];
+  const result = parseArgs({ strict: false });
+  const expected = { values: { __proto__: null, foo: true },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('correct default args when normal arguments', () => {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, 'script.js', '--foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = [];
+  const result = parseArgs({ strict: false });
+
+  const expected = { values: { __proto__: null, foo: true },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});
+
+test('excess leading dashes on options are retained', () => {
+  // Enforce a design decision for an edge case.
+  const args = ['---triple'];
+  const options = { };
+  const expected = {
+    values: { '__proto__': null, '-triple': true },
+    positionals: []
+  };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected, Error('excess option dashes are retained'));
+});
+
+test('positional arguments are allowed by default in strict:false', () => {
+  const args = ['foo'];
+  const options = { };
+  const expected = {
+    values: { __proto__: null },
+    positionals: ['foo']
+  };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('positional arguments may be explicitly disallowed in strict:false', () => {
+  const args = ['foo'];
+  const options = { };
+  assert.throws(() => { parseArgs({ strict: false, allowPositionals: false, args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL'
+  });
+});
+
+// Test bad inputs
+
+test('invalid argument passed for options', () => {
+  const args = ['--so=wat'];
+  const options = 'bad value';
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+test('type property missing for option then throw', () => {
+  const knownOptions = { foo: { } };
+  assert.throws(() => { parseArgs({ options: knownOptions }); }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+test('boolean passed to "type" option', () => {
+  const args = ['--so=wat'];
+  const options = { foo: { type: true } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+test('invalid union value passed to "type" option', () => {
+  const args = ['--so=wat'];
+  const options = { foo: { type: 'str' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+// Test strict mode
+
+test('unknown long option --bar', () => {
+  const args = ['--foo', '--bar'];
+  const options = { foo: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  });
+});
+
+test('unknown short option -b', () => {
+  const args = ['--foo', '-b'];
+  const options = { foo: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  });
+});
+
+test('unknown option -r in short option group -bar', () => {
+  const args = ['-bar'];
+  const options = { b: { type: 'boolean' }, a: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  });
+});
+
+test('unknown option with explicit value', () => {
+  const args = ['--foo', '--bar=baz'];
+  const options = { foo: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  });
+});
+
+test('unexpected positional', () => {
+  const args = ['foo'];
+  const options = { foo: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL'
+  });
+});
+
+test('unexpected positional after --', () => {
+  const args = ['--', 'foo'];
+  const options = { foo: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL'
+  });
+});
+
+test('-- by itself is not a positional', () => {
+  const args = ['--foo', '--'];
+  const options = { foo: { type: 'boolean' } };
+  const result = parseArgs({ args, options });
+  const expected = { values: { __proto__: null, foo: true },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+});
+
+test('string option used as boolean', () => {
+  const args = ['--foo'];
+  const options = { foo: { type: 'string' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+  });
+});
+
+test('boolean option used with value', () => {
+  const args = ['--foo=bar'];
+  const options = { foo: { type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+  });
+});
+
+test('invalid short option length', () => {
+  const args = [];
+  const options = { foo: { short: 'fo', type: 'boolean' } };
+  assert.throws(() => { parseArgs({ args, options }); }, {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+});
+
+test('null prototype: when no options then values.toString is undefined', () => {
+  const result = parseArgs({ args: [] });
+  assert.strictEqual(result.values.toString, undefined);
+});
+
+test('null prototype: when --toString then values.toString is true', () => {
+  const args = ['--toString'];
+  const options = { toString: { type: 'boolean' } };
+  const expectedResult = { values: { __proto__: null, toString: true }, positionals: [] };
+
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expectedResult);
+});
+
+const candidateGreedyOptions = [
+  '',
+  '-',
+  '--',
+  'abc',
+  '123',
+  '-s',
+  '--foo',
+];
+
+for (const value of candidateGreedyOptions) {
+  test(`greedy: when short option with value '${value}' then eaten`, () => {
+    const args = ['-w', value];
+    const options = { with: { type: 'string', short: 'w' } };
+    const expectedResult = { values: { __proto__: null, with: value }, positionals: [] };
+
+    const result = parseArgs({ args, options, strict: false });
+    assert.deepStrictEqual(result, expectedResult);
+  });
+
+  test(`greedy: when long option with value '${value}' then eaten`, () => {
+    const args = ['--with', value];
+    const options = { with: { type: 'string', short: 'w' } };
+    const expectedResult = { values: { __proto__: null, with: value }, positionals: [] };
+
+    const result = parseArgs({ args, options, strict: false });
+    assert.deepStrictEqual(result, expectedResult);
+  });
+}
+
+test('strict: when candidate option value is plain text then does not throw', () => {
+  const args = ['--with', 'abc'];
+  const options = { with: { type: 'string' } };
+  const expectedResult = { values: { __proto__: null, with: 'abc' }, positionals: [] };
+
+  const result = parseArgs({ args, options, strict: true });
+  assert.deepStrictEqual(result, expectedResult);
+});
+
+test("strict: when candidate option value is '-' then does not throw", () => {
+  const args = ['--with', '-'];
+  const options = { with: { type: 'string' } };
+  const expectedResult = { values: { __proto__: null, with: '-' }, positionals: [] };
+
+  const result = parseArgs({ args, options, strict: true });
+  assert.deepStrictEqual(result, expectedResult);
+});
+
+test("strict: when candidate option value is '--' then throws", () => {
+  const args = ['--with', '--'];
+  const options = { with: { type: 'string' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+  });
+});
+
+test('strict: when candidate option value is short option then throws', () => {
+  const args = ['--with', '-a'];
+  const options = { with: { type: 'string' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+  });
+});
+
+test('strict: when candidate option value is short option digit then throws', () => {
+  const args = ['--with', '-1'];
+  const options = { with: { type: 'string' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+  });
+});
+
+test('strict: when candidate option value is long option then throws', () => {
+  const args = ['--with', '--foo'];
+  const options = { with: { type: 'string' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+  });
+});
+
+test('strict: when short option and suspect value then throws with short option in error message', () => {
+  const args = ['-w', '--foo'];
+  const options = { with: { type: 'string', short: 'w' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /for '-w'/
+  );
+});
+
+test('strict: when long option and suspect value then throws with long option in error message', () => {
+  const args = ['--with', '--foo'];
+  const options = { with: { type: 'string' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /for '--with'/
+  );
+});
+
+test('strict: when short option and suspect value then throws with whole expected message', () => {
+  const args = ['-w', '--foo'];
+  const options = { with: { type: 'string', short: 'w' } };
+
+  try {
+    parseArgs({ args, options });
+  } catch (err) {
+    console.info(err.message);
+  }
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /To specify an option argument starting with a dash use '--with=-XYZ' or '-w-XYZ'/
+  );
+});
+
+test('strict: when long option and suspect value then throws with whole expected message', () => {
+  const args = ['--with', '--foo'];
+  const options = { with: { type: 'string', short: 'w' } };
+
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /To specify an option argument starting with a dash use '--with=-XYZ'/
+  );
+});
+
+test('tokens: positional', () => {
+  const args = ['one'];
+  const expectedTokens = [
+    { kind: 'positional', index: 0, value: 'one' },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: -- followed by option-like', () => {
+  const args = ['--', '--foo'];
+  const expectedTokens = [
+    { kind: 'option-terminator', index: 0 },
+    { kind: 'positional', index: 1, value: '--foo' },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true boolean short', () => {
+  const args = ['-f'];
+  const options = {
+    file: { short: 'f', type: 'boolean' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '-f',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true boolean long', () => {
+  const args = ['--file'];
+  const options = {
+    file: { short: 'f', type: 'boolean' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false boolean short', () => {
+  const args = ['-f'];
+  const expectedTokens = [
+    { kind: 'option', name: 'f', rawName: '-f',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false boolean long', () => {
+  const args = ['--file'];
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false boolean option group', () => {
+  const args = ['-ab'];
+  const expectedTokens = [
+    { kind: 'option', name: 'a', rawName: '-a',
+      index: 0, value: undefined, inlineValue: undefined },
+    { kind: 'option', name: 'b', rawName: '-b',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false boolean option group with repeated option', () => {
+  // Also positional to check index correct after grouop
+  const args = ['-aa', 'pos'];
+  const expectedTokens = [
+    { kind: 'option', name: 'a', rawName: '-a',
+      index: 0, value: undefined, inlineValue: undefined },
+    { kind: 'option', name: 'a', rawName: '-a',
+      index: 0, value: undefined, inlineValue: undefined },
+    { kind: 'positional', index: 1, value: 'pos' },
+  ];
+  const { tokens } = parseArgs({ strict: false, allowPositionals: true, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true string short with value after space', () => {
+  // Also positional to check index correct after out-of-line.
+  const args = ['-f', 'bar', 'ppp'];
+  const options = {
+    file: { short: 'f', type: 'string' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '-f',
+      index: 0, value: 'bar', inlineValue: false },
+    { kind: 'positional', index: 2, value: 'ppp' },
+  ];
+  const { tokens } = parseArgs({ strict: true, allowPositionals: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true string short with value inline', () => {
+  const args = ['-fBAR'];
+  const options = {
+    file: { short: 'f', type: 'string' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '-f',
+      index: 0, value: 'BAR', inlineValue: true },
+  ];
+  const { tokens } = parseArgs({ strict: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false string short missing value', () => {
+  const args = ['-f'];
+  const options = {
+    file: { short: 'f', type: 'string' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '-f',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true string long with value after space', () => {
+  // Also positional to check index correct after out-of-line.
+  const args = ['--file', 'bar', 'ppp'];
+  const options = {
+    file: { short: 'f', type: 'string' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: 'bar', inlineValue: false },
+    { kind: 'positional', index: 2, value: 'ppp' },
+  ];
+  const { tokens } = parseArgs({ strict: true, allowPositionals: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true string long with value inline', () => {
+  // Also positional to check index correct after out-of-line.
+  const args = ['--file=bar', 'pos'];
+  const options = {
+    file: { short: 'f', type: 'string' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: 'bar', inlineValue: true },
+    { kind: 'positional', index: 1, value: 'pos' },
+  ];
+  const { tokens } = parseArgs({ strict: true, allowPositionals: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false string long with value inline', () => {
+  const args = ['--file=bar'];
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: 'bar', inlineValue: true },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false string long missing value', () => {
+  const args = ['--file'];
+  const options = {
+    file: { short: 'f', type: 'string' }
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: undefined, inlineValue: undefined },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true complex option group with value after space', () => {
+  // Also positional to check index correct afterwards.
+  const args = ['-ab', 'c', 'pos'];
+  const options = {
+    alpha: { short: 'a', type: 'boolean' },
+    beta: { short: 'b', type: 'string' },
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'alpha', rawName: '-a',
+      index: 0, value: undefined, inlineValue: undefined },
+    { kind: 'option', name: 'beta', rawName: '-b',
+      index: 0, value: 'c', inlineValue: false },
+    { kind: 'positional', index: 2, value: 'pos' },
+  ];
+  const { tokens } = parseArgs({ strict: true, allowPositionals: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:true complex option group with inline value', () => {
+  // Also positional to check index correct afterwards.
+  const args = ['-abc', 'pos'];
+  const options = {
+    alpha: { short: 'a', type: 'boolean' },
+    beta: { short: 'b', type: 'string' },
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'alpha', rawName: '-a',
+      index: 0, value: undefined, inlineValue: undefined },
+    { kind: 'option', name: 'beta', rawName: '-b',
+      index: 0, value: 'c', inlineValue: true },
+    { kind: 'positional', index: 1, value: 'pos' },
+  ];
+  const { tokens } = parseArgs({ strict: true, allowPositionals: true, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false with single dashes', () => {
+  const args = ['--file', '-', '-'];
+  const options = {
+    file: { short: 'f', type: 'string' },
+  };
+  const expectedTokens = [
+    { kind: 'option', name: 'file', rawName: '--file',
+      index: 0, value: '-', inlineValue: false },
+    { kind: 'positional', index: 2, value: '-' },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens: strict:false with -- --', () => {
+  const args = ['--', '--'];
+  const expectedTokens = [
+    { kind: 'option-terminator', index: 0 },
+    { kind: 'positional', index: 1, value: '--' },
+  ];
+  const { tokens } = parseArgs({ strict: false, args, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('default must be a boolean when option type is boolean', () => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', default: 'not a boolean' } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default" property must be of type boolean/
+  );
+});
+
+test('default must accept undefined value', () => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', default: undefined } };
+  const result = parseArgs({ args, options });
+  const expected = {
+    values: {
+      __proto__: null,
+    },
+    positionals: []
+  };
+  assert.deepStrictEqual(result, expected);
+});
+
+test('default must be a boolean array when option type is boolean and multiple', () => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', multiple: true, default: 'not an array' } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default" property must be an instance of Array/
+  );
+});
+
+test('default must be a boolean array when option type is string and multiple is true', () => {
+  const args = [];
+  const options = { alpha: { type: 'boolean', multiple: true, default: [true, true, 42] } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default\[2\]" property must be of type boolean/
+  );
+});
+
+test('default must be a string when option type is string', () => {
+  const args = [];
+  const options = { alpha: { type: 'string', default: true } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default" property must be of type string/
+  );
+});
+
+test('default must be an array when option type is string and multiple is true', () => {
+  const args = [];
+  const options = { alpha: { type: 'string', multiple: true, default: 'not an array' } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default" property must be an instance of Array/
+  );
+});
+
+test('default must be a string array when option type is string and multiple is true', () => {
+  const args = [];
+  const options = { alpha: { type: 'string', multiple: true, default: ['str', 42] } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default\[1\]" property must be of type string/
+  );
+});
+
+test('default accepted input when multiple is true', () => {
+  const args = ['--inputStringArr', 'c', '--inputStringArr', 'd', '--inputBoolArr', '--inputBoolArr'];
+  const options = {
+    inputStringArr: { type: 'string', multiple: true, default: ['a', 'b'] },
+    emptyStringArr: { type: 'string', multiple: true, default: [] },
+    fullStringArr: { type: 'string', multiple: true, default: ['a', 'b'] },
+    inputBoolArr: { type: 'boolean', multiple: true, default: [false, true, false] },
+    emptyBoolArr: { type: 'boolean', multiple: true, default: [] },
+    fullBoolArr: { type: 'boolean', multiple: true, default: [false, true, false] },
+  };
+  const expected = { values: { __proto__: null,
+                               inputStringArr: ['c', 'd'],
+                               inputBoolArr: [true, true],
+                               emptyStringArr: [],
+                               fullStringArr: ['a', 'b'],
+                               emptyBoolArr: [],
+                               fullBoolArr: [false, true, false] },
+                     positionals: [] };
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when default is set, the option must be added as result', () => {
+  const args = [];
+  const options = {
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
+  };
+  const expected = { values: { __proto__: null, a: 'HELLO', b: false, c: true }, positionals: [] };
+
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when default is set, the args value takes precedence', () => {
+  const args = ['--a', 'WORLD', '--b', '-c'];
+  const options = {
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
+  };
+  const expected = { values: { __proto__: null, a: 'WORLD', b: true, c: true }, positionals: [] };
+
+  const result = parseArgs({ args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('tokens should not include the default options', () => {
+  const args = [];
+  const options = {
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
+  };
+
+  const expectedTokens = [];
+
+  const { tokens } = parseArgs({ args, options, tokens: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('tokens:true should not include the default options after the args input', () => {
+  const args = ['--z', 'zero', 'positional-item'];
+  const options = {
+    z: { type: 'string' },
+    a: { type: 'string', default: 'HELLO' },
+    b: { type: 'boolean', default: false },
+    c: { type: 'boolean', default: true }
+  };
+
+  const expectedTokens = [
+    { kind: 'option', name: 'z', rawName: '--z', index: 0, value: 'zero', inlineValue: false },
+    { kind: 'positional', index: 2, value: 'positional-item' },
+  ];
+
+  const { tokens } = parseArgs({ args, options, tokens: true, allowPositionals: true });
+  assert.deepStrictEqual(tokens, expectedTokens);
+});
+
+test('proto as default value must be ignored', () => {
+  const args = [];
+  const options = { __proto__: null };
+
+  // eslint-disable-next-line no-proto
+  options.__proto__ = { type: 'string', default: 'HELLO' };
+
+  const result = parseArgs({ args, options, allowPositionals: true });
+  const expected = { values: { __proto__: null }, positionals: [] };
+  assert.deepStrictEqual(result, expected);
+});
+
+
+test('multiple as false should expect a String', () => {
+  const args = [];
+  const options = { alpha: { type: 'string', multiple: false, default: ['array'] } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.default" property must be of type string/
+  );
+});
+
+// Test negative options
+test('disable negative options and args are started with "--no-" prefix', () => {
+  const args = ['--no-alpha'];
+  const options = { alpha: { type: 'boolean' } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, {
+    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  });
+});
+
+test('args are passed `type: "string"` and allow negative options', () => {
+  const args = ['--no-alpha', 'value'];
+  const options = { alpha: { type: 'string' } };
+  assert.throws(() => {
+    parseArgs({ args, options, allowNegative: true });
+  }, {
+    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  });
+});
+
+test('args are passed `type: "boolean"` and allow negative options', () => {
+  const args = ['--no-alpha'];
+  const options = { alpha: { type: 'boolean' } };
+  const expected = { values: { __proto__: null, alpha: false }, positionals: [] };
+  assert.deepStrictEqual(parseArgs({ args, options, allowNegative: true }), expected);
+});
+
+test('args are passed `default: "true"` and allow negative options', () => {
+  const args = ['--no-alpha'];
+  const options = { alpha: { type: 'boolean', default: true } };
+  const expected = { values: { __proto__: null, alpha: false }, positionals: [] };
+  assert.deepStrictEqual(parseArgs({ args, options, allowNegative: true }), expected);
+});
+
+test('args are passed `default: "false" and allow negative options', () => {
+  const args = ['--no-alpha'];
+  const options = { alpha: { type: 'boolean', default: false } };
+  const expected = { values: { __proto__: null, alpha: false }, positionals: [] };
+  assert.deepStrictEqual(parseArgs({ args, options, allowNegative: true }), expected);
+});
+
+test('allow negative options and multiple as true', () => {
+  const args = ['--no-alpha', '--alpha', '--no-alpha'];
+  const options = { alpha: { type: 'boolean', multiple: true } };
+  const expected = { values: { __proto__: null, alpha: [false, true, false] }, positionals: [] };
+  assert.deepStrictEqual(parseArgs({ args, options, allowNegative: true }), expected);
+});
+
+test('allow negative options and passed multiple arguments', () => {
+  const args = ['--no-alpha', '--alpha'];
+  const options = { alpha: { type: 'boolean' } };
+  const expected = { values: { __proto__: null, alpha: true }, positionals: [] };
+  assert.deepStrictEqual(parseArgs({ args, options, allowNegative: true }), expected);
+});
+
+test('auto-detect --no-foo as negated when strict:false and allowNegative', () => {
+  const holdArgv = process.argv;
+  process.argv = [process.argv0, 'script.js', '--no-foo'];
+  const holdExecArgv = process.execArgv;
+  process.execArgv = [];
+  const result = parseArgs({ strict: false, allowNegative: true });
+
+  const expected = { values: { __proto__: null, foo: false },
+                     positionals: [] };
+  assert.deepStrictEqual(result, expected);
+  process.argv = holdArgv;
+  process.execArgv = holdExecArgv;
+});

--- a/test/js/node/util/parse_args/parse-args.test.mjs
+++ b/test/js/node/util/parse_args/parse-args.test.mjs
@@ -1064,4 +1064,13 @@ describe("parseArgs extra tests", () => {
       expect(Object.keys(result.values)).toHaveLength(93);
     });
   });
+
+  test("undefined or null options", () => {
+    expect(parseArgs({ args: undefined })).toEqual({ values: { __proto__: null }, positionals: [] });
+    expect(parseArgs({ args: null })).toEqual({ values: { __proto__: null }, positionals: [] });
+    expect(parseArgs({ options: undefined })).toEqual({ values: { __proto__: null }, positionals: [] });
+    expect(parseArgs({ options: null })).toEqual({ values: { __proto__: null }, positionals: [] });
+    expect(parseArgs({ allowPositionals: undefined })).toEqual({ values: { __proto__: null }, positionals: [] });
+    expect(parseArgs({ allowPositionals: null })).toEqual({ values: { __proto__: null }, positionals: [] });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Add support for negative options `--no-foo` and parsing `process.argv`.

```js
const { parseArgs } = require("util");
process.argv = [process.argv0, "script.js", "--foo"];
process.execArgv = [];
console.log(parseArgs({ strict: false }));
```
```bash
$ bun index.js
{ values: { foo: true }, positionals: [] }
```

Cached write barriers are added for `process.argv` and `process.execArgv`.

Also fixes `undefined` or `null` values for `args`, `allowPositionals`, and `options`. Fixes #11451 
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
`test-parse-args.mjs`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
