### PR TITLE
Windows debug fix

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -28,36 +28,6 @@ pub const callconv_inline: std.builtin.CallingConvention = if (builtin.mode == .
 pub extern "c" fn powf(x: f32, y: f32) f32;
 pub extern "c" fn pow(x: f64, y: f64) f64;
 
-/// Restrict a value to a certain interval unless it is a float and NaN.
-pub inline fn clamp(self: anytype, min: @TypeOf(self), max: @TypeOf(self)) @TypeOf(self) {
-    bun.debugAssert(min <= max);
-    if (comptime (@TypeOf(self) == f32 or @TypeOf(self) == f64)) {
-        return clampFloat(self, min, max);
-    }
-    return std.math.clamp(self, min, max);
-}
-
-/// Restrict a value to a certain interval unless it is NaN.
-///
-/// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-/// less than `min`. Otherwise this returns `self`.
-///
-/// Note that this function returns NaN if the initial value was NaN as
-/// well.
-pub inline fn clampFloat(_self: anytype, min: @TypeOf(_self), max: @TypeOf(_self)) @TypeOf(_self) {
-    if (comptime !(@TypeOf(_self) == f32 or @TypeOf(_self) == f64)) {
-        @compileError("Only call this on floats.");
-    }
-    var self = _self;
-    if (self < min) {
-        self = min;
-    }
-    if (self > max) {
-        self = max;
-    }
-    return self;
-}
-
 /// We cannot use a threadlocal memory allocator for FileSystem-related things
 /// FileSystem is a singleton.
 pub const fs_allocator = default_allocator;

--- a/src/css/properties/custom.zig
+++ b/src/css/properties/custom.zig
@@ -802,7 +802,7 @@ pub const UnresolvedColor = union(enum) {
     ) PrintErr!void {
         const Helper = struct {
             pub fn conv(c: f32) i32 {
-                return @intFromFloat(bun.clamp(@round(c * 255.0), 0.0, 255.0));
+                return @intFromFloat(std.math.clamp(@round(c * 255.0), 0.0, 255.0));
             }
         };
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1397,7 +1397,7 @@ pub fn openFileAtWindowsNtPath(
                 bun.Output.debugWarn("NtCreateFile({}, {}) = {s} (file) = {d}\nYou are calling this function without normalizing the path correctly!!!", .{ dir, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(result) });
             } else {
                 if (rc == .SUCCESS) {
-                    log("NtCreateFile({}, {}) = {s} (file) = {}", .{ dir, bun.fmt.utf16(path), @tagName(rc), bun.toFD(result) });
+                    log("NtCreateFile({}, {}) = {s} (file) = {}", .{ dir, bun.fmt.utf16(path), @tagName(rc), bun.FileDescriptor.fromNative(result) });
                 } else {
                     log("NtCreateFile({}, {}) = {s} (file) = {}", .{ dir, bun.fmt.utf16(path), @tagName(rc), rc });
                 }


### PR DESCRIPTION
### What does this PR do?
Removes a call to bun.toFD that (I assume used to exist and was replaced) no longer works with bun.FileDescriptor.fromNative

Also replaced the custom bun.clamp function with std.math.clamp as std.math.clamp now supports floats.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->
`bun run build` now works when before it was throwing an error.
<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
