### PR TITLE
fix `node:process`: avoid duplicate `default` export

### DIFF
--- a/src/bun.js/modules/NodeProcessModule.h
+++ b/src/bun.js/modules/NodeProcessModule.h
@@ -1,60 +1,26 @@
-#include "../bindings/ZigGlobalObject.h"
+#include "ZigGlobalObject.h"
 #include "_NativeModule.h"
 #include <JavaScriptCore/CustomGetterSetter.h>
 #include <JavaScriptCore/JSGlobalObject.h>
+#include "BunProcess.h"
 
 namespace Zig {
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionProcessModuleCommonJS,
-    (JSGlobalObject * globalObject,
-        CallFrame* callFrame))
-{
-
-    return JSValue::encode(
-        reinterpret_cast<Zig::GlobalObject*>(globalObject)->processObject());
-}
-
-JSC_DEFINE_CUSTOM_GETTER(jsFunctionProcessModuleCommonJSGetter,
-    (JSGlobalObject * globalObject,
-        JSC::EncodedJSValue thisValue,
-        PropertyName propertyName))
-{
-
-    return JSValue::encode(reinterpret_cast<Zig::GlobalObject*>(globalObject)
-            ->processObject()
-            ->get(globalObject, propertyName));
-}
-
-JSC_DEFINE_CUSTOM_SETTER(jsFunctionProcessModuleCommonJSSetter,
-    (JSGlobalObject * globalObject,
-        JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue encodedValue,
-        PropertyName propertyName))
-{
-    VM& vm = globalObject->vm();
-
-    return reinterpret_cast<Zig::GlobalObject*>(globalObject)
-        ->processObject()
-        ->putDirect(vm, propertyName, JSValue::decode(encodedValue), 0);
-}
-
 DEFINE_NATIVE_MODULE(NodeProcess)
 {
-    auto& vm = JSC::getVM(lexicalGlobalObject);
-    GlobalObject* globalObject = reinterpret_cast<GlobalObject*>(lexicalGlobalObject);
-
-    JSC::JSObject* process = globalObject->processObject();
+    auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+
+    Bun::Process* process = jsCast<Bun::Process*>(globalObject->processObject());
     if (!process->staticPropertiesReified()) {
         process->reifyAllStaticProperties(globalObject);
         if (scope.exception())
             return;
     }
 
-    PropertyNameArray properties(vm, PropertyNameMode::Strings,
-        PrivateSymbolMode::Exclude);
-    process->getPropertyNames(globalObject, properties,
-        DontEnumPropertiesMode::Exclude);
+    PropertyNameArray properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+    process->getPropertyNames(globalObject, properties, DontEnumPropertiesMode::Exclude);
     if (scope.exception())
         return;
 
@@ -62,6 +28,12 @@ DEFINE_NATIVE_MODULE(NodeProcess)
     exportValues.append(process);
 
     for (auto& entry : properties) {
+        if (entry == vm.propertyNames->defaultKeyword) {
+            // skip because it's already on the default
+            // export (the Process object itself)
+            continue;
+        }
+
         exportNames.append(entry);
         auto catchScope = DECLARE_CATCH_SCOPE(vm);
         JSValue result = process->get(globalObject, entry);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1099,3 +1099,14 @@ it("process.memoryUsage.arrayBuffers", () => {
   array.buffer;
   expect(process.memoryUsage().arrayBuffers).toBeGreaterThanOrEqual(initial + 16 * 1024 * 1024);
 });
+
+it("should handle user assigned `default` properties", () => {
+  process.default = 1;
+  process.hello = 2;
+  import("node:process").then(processModule => {
+    expect(processModule.default).toBe(process);
+    expect(processModule.default.default).toBe(1);
+    expect(processModule.hello).toBe(2);
+    expect(processModule.default.hello).toBe(2);
+  });
+});

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1100,13 +1100,17 @@ it("process.memoryUsage.arrayBuffers", () => {
   expect(process.memoryUsage().arrayBuffers).toBeGreaterThanOrEqual(initial + 16 * 1024 * 1024);
 });
 
-it("should handle user assigned `default` properties", () => {
+it("should handle user assigned `default` properties", async () => {
   process.default = 1;
   process.hello = 2;
+  const { promise, resolve } = Promise.withResolvers();
   import("node:process").then(processModule => {
     expect(processModule.default).toBe(process);
     expect(processModule.default.default).toBe(1);
     expect(processModule.hello).toBe(2);
     expect(processModule.default.hello).toBe(2);
+    resolve();
   });
+
+  await promise;
 });

--- a/test/js/node/test/parallel/test-process-default.js
+++ b/test/js/node/test/parallel/test-process-default.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+
+process.default = 1;
+import('node:process').then(common.mustCall((processModule) => {
+  assert.strictEqual(processModule.default.default, 1);
+}));


### PR DESCRIPTION
### What does this PR do?
When a `default` property is assigned to the `process` object before importing, we need to skip appending it to export names/values because it already exists on the object.

fixes `test-process-default.js`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added an additional test for a non default property
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
