### PR TITLE
fix(node:http) proper send chunked encoding, dont send \r\b twice after headers are flushed

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -128,7 +128,7 @@ public:
             
 
             /* Terminating 0 chunk */
-            Super::write("\r\n0\r\n\r\n", 7);
+            Super::write("0\r\n\r\n", 5);
 
             httpResponseData->markDone();
 
@@ -453,6 +453,7 @@ public:
             writeMark();
 
             writeHeader("Transfer-Encoding", "chunked");
+            Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
         }
 
@@ -569,6 +570,11 @@ public:
             auto [written, failed] = Super::write(data.data(), (int) length);
             has_failed = has_failed || failed;
             total_written += written;
+        }
+
+        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest) {
+            // Write End of Chunked Encoding after data has been written
+            Super::write("\r\n", 2);
         }
         
         /* Reset timeout on each sended chunk */

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -468,11 +468,6 @@ public:
         writeStatus(HTTP_200_OK);
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-        if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) == 0) {
-            writeHeader("Connection", "close");
-        }
-        httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
-
         
         if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest) {
             if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -539,10 +539,10 @@ public:
                 writeMark();
 
                 writeHeader("Transfer-Encoding", "chunked");
+                Super::write("\r\n", 2);
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
             }
-
-            Super::write("\r\n", 2);
+            
             writeUnsignedHex((unsigned int) data.length());
             Super::write("\r\n", 2);
         } else if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -468,7 +468,12 @@ public:
         writeStatus(HTTP_200_OK);
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) == 0) {
+            writeHeader("Connection", "close");
+        }
+        httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
 
+        
         if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest) {
             if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
                 /* Write mark on first call to write */

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3272,7 +3272,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             if (!this.flags.has_written_status) {
                 this.renderMetadata();
             }
-            resp.flushHeaders();
+
             // We are already corked!
             const assignment_result: JSValue = ResponseStream.JSSink.assignToStream(
                 globalThis,

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -4258,6 +4258,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         pub fn renderMetadata(this: *RequestContext) void {
             if (this.resp == null) return;
             const resp = this.resp.?;
+            defer resp.flushHeaders();
 
             var response: *JSC.WebCore.Response = this.response_ptr.?;
             var status = response.statusCode();

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -3272,6 +3272,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
             if (!this.flags.has_written_status) {
                 this.renderMetadata();
             }
+            resp.flushHeaders();
             // We are already corked!
             const assignment_result: JSValue = ResponseStream.JSSink.assignToStream(
                 globalThis,
@@ -3858,7 +3859,7 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
                     }
                 }
             }
-            req.endStream(true);
+            req.endStream(req.shouldCloseConnection());
         }
 
         pub fn doRenderWithBody(this: *RequestContext, value: *JSC.WebCore.Body.Value) void {
@@ -4258,7 +4259,6 @@ fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comp
         pub fn renderMetadata(this: *RequestContext) void {
             if (this.resp == null) return;
             const resp = this.resp.?;
-            defer resp.flushHeaders();
 
             var response: *JSC.WebCore.Response = this.response_ptr.?;
             var status = response.statusCode();

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1282,10 +1282,7 @@ extern "C"
         }
         data->state |= uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE;
       }
-      if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
-      {
-        uwsRes->AsyncSocket<true>::write("\r\n", 2);
-      }
+      uwsRes->flushHeaders();
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone();
       uwsRes->resetTimeout();
@@ -1308,6 +1305,7 @@ extern "C"
         // If not, they may throw a ConnectionError.
         uwsRes->AsyncSocket<false>::write("\r\n", 2);
       }
+      uwsRes->flushHeaders();
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone();
       uwsRes->resetTimeout();

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1299,6 +1299,12 @@ extern "C"
         }
         data->state |= uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE;
       }
+      if (!(data->state & uWS::HttpResponseData<false>::HTTP_END_CALLED))
+      {
+        // Some HTTP clients require the complete "<header>\r\n\r\n" to be sent.
+        // If not, they may throw a ConnectionError.
+        uwsRes->AsyncSocket<false>::write("\r\n", 2);
+      }
       uwsRes->flushHeaders();
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone();

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1299,12 +1299,6 @@ extern "C"
         }
         data->state |= uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE;
       }
-      if (!(data->state & uWS::HttpResponseData<false>::HTTP_END_CALLED))
-      {
-        // Some HTTP clients require the complete "<header>\r\n\r\n" to be sent.
-        // If not, they may throw a ConnectionError.
-        uwsRes->AsyncSocket<false>::write("\r\n", 2);
-      }
       uwsRes->flushHeaders();
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone();

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1282,7 +1282,10 @@ extern "C"
         }
         data->state |= uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE;
       }
-      uwsRes->flushHeaders();
+      if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
+      {
+        uwsRes->AsyncSocket<true>::write("\r\n", 2);
+      }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone();
       uwsRes->resetTimeout();
@@ -1305,7 +1308,6 @@ extern "C"
         // If not, they may throw a ConnectionError.
         uwsRes->AsyncSocket<false>::write("\r\n", 2);
       }
-      uwsRes->flushHeaders();
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone();
       uwsRes->resetTimeout();

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -33,7 +33,6 @@ import * as stream from "node:stream";
 import { PassThrough } from "node:stream";
 import * as zlib from "node:zlib";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
-import { sleep } from "bun";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
 function listen(server: Server, protocol: string = "http"): Promise<URL> {
   return new Promise((resolve, reject) => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -33,6 +33,7 @@ import * as stream from "node:stream";
 import { PassThrough } from "node:stream";
 import * as zlib from "node:zlib";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
+import { sleep } from "bun";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
 function listen(server: Server, protocol: string = "http"): Promise<URL> {
   return new Promise((resolve, reject) => {
@@ -2705,4 +2706,268 @@ test("clientError should fire when receiving invalid method", async () => {
 test("throw inside clientError should be propagated to uncaughtException", async () => {
   const testFile = path.join(import.meta.dir, "node-http-clientError-uncaughtException-fixture.js");
   expect([testFile]).toRun("", 0);
+});
+
+test("chunked encoding must be valid after flushHeaders", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  await using server = http.createServer(async (req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain", "Transfer-Encoding": "chunked" });
+    res.flushHeaders();
+    // make sure headers are flushed
+    await Bun.sleep(10);
+    // send some chunks at once
+    res.write("chunk 1");
+    res.write("chunk 2");
+    res.write("chunk 3");
+    res.write("chunk 4");
+    res.write("chunk 5");
+    await Bun.sleep(10);
+    // send some more chunk
+    res.write("chunk 6");
+    res.write("chunk 7");
+    await Bun.sleep(10);
+    // send the last chunk
+    res.end();
+  });
+
+  server.listen(3000);
+  await once(server, "listening");
+
+  const socket = connect(3000, () => {
+    socket.write("GET / HTTP/1.1\r\nHost: localhost:3000\r\nConnection: close\r\n\r\n");
+  });
+
+  const chunks = [];
+  let received_headers = false;
+  socket.on("data", data => {
+    if (!received_headers) {
+      received_headers = true;
+      const headers = data.toString("utf-8").split("\r\n");
+      expect(headers[0]).toBe("HTTP/1.1 200 OK");
+      expect(headers[1]).toBe("Content-Type: text/plain");
+      expect(headers[2]).toBe("Transfer-Encoding: chunked");
+      expect(headers[3].startsWith("Date:")).toBe(true);
+      // empty line for end of headers aka flushHeaders works
+      expect(headers[headers.length - 1]).toBe("");
+      expect(headers[headers.length - 2]).toBe("");
+    } else {
+      chunks.push(data);
+    }
+  });
+
+  function parseChunkedData(buffer) {
+    let offset = 0;
+    let result = Buffer.alloc(0);
+
+    while (offset < buffer.length) {
+      // Find the CRLF that terminates the chunk size line
+      let lineEnd = buffer.indexOf("\r\n", offset);
+      if (lineEnd === -1) break;
+
+      // Parse the chunk size (in hex)
+      const chunkSizeHex = buffer.toString("ascii", offset, lineEnd);
+      const chunkSize = parseInt(chunkSizeHex, 16);
+      expect(isNaN(chunkSize)).toBe(false);
+      // If chunk size is 0, we've reached the end
+      if (chunkSize === 0) {
+        // Skip the final CRLF after the 0-size chunk
+        offset = lineEnd + 4;
+        break;
+      }
+
+      // Move past the chunk size line's CRLF
+      offset = lineEnd + 2;
+
+      // Extract the chunk data
+      const chunkData = buffer.slice(offset, offset + chunkSize);
+
+      // Concatenate this chunk to our result
+      result = Buffer.concat([result, chunkData]);
+
+      // Move past this chunk's data and its terminating CRLF
+      offset += chunkSize + 2;
+    }
+
+    return result;
+  }
+
+  socket.on("end", () => {
+    try {
+      const body = parseChunkedData(Buffer.concat(chunks));
+      expect(body.toString("utf-8")).toBe("chunk 1chunk 2chunk 3chunk 4chunk 5chunk 6chunk 7");
+      resolve();
+    } catch (e) {
+      reject(e);
+    } finally {
+      socket.end();
+    }
+  });
+  await promise;
+});
+
+test("chunked encoding must be valid using minimal code", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  await using server = http.createServer(async (req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain", "Transfer-Encoding": "chunked" });
+    res.write("chunk 1");
+    res.end("chunk 2");
+  });
+
+  server.listen(3000);
+  await once(server, "listening");
+
+  const socket = connect(3000, () => {
+    socket.write("GET / HTTP/1.1\r\nHost: localhost:3000\r\nConnection: close\r\n\r\n");
+  });
+
+  const chunks = [];
+  socket.on("data", data => {
+    chunks.push(data);
+  });
+
+  function parseChunkedData(buffer) {
+    let offset = 0;
+    let result = Buffer.alloc(0);
+
+    while (offset < buffer.length) {
+      // Find the CRLF that terminates the chunk size line
+      let lineEnd = buffer.indexOf("\r\n", offset);
+      if (lineEnd === -1) break;
+
+      // Parse the chunk size (in hex)
+      const chunkSizeHex = buffer.toString("ascii", offset, lineEnd);
+      const chunkSize = parseInt(chunkSizeHex, 16);
+      expect(isNaN(chunkSize)).toBe(false);
+      // If chunk size is 0, we've reached the end
+      if (chunkSize === 0) {
+        // Skip the final CRLF after the 0-size chunk
+        offset = lineEnd + 4;
+        break;
+      }
+
+      // Move past the chunk size line's CRLF
+      offset = lineEnd + 2;
+
+      // Extract the chunk data
+      const chunkData = buffer.slice(offset, offset + chunkSize);
+
+      // Concatenate this chunk to our result
+      result = Buffer.concat([result, chunkData]);
+
+      // Move past this chunk's data and its terminating CRLF
+      offset += chunkSize + 2;
+    }
+
+    return result;
+  }
+
+  socket.on("end", () => {
+    try {
+      const data = Buffer.concat(chunks);
+
+      const headersEnd = data.indexOf("\r\n\r\n");
+      const headers = data.toString("utf-8", 0, headersEnd).split("\r\n");
+      expect(headers[0]).toBe("HTTP/1.1 200 OK");
+      expect(headers[1]).toBe("Content-Type: text/plain");
+      expect(headers[2]).toBe("Transfer-Encoding: chunked");
+      expect(headers[3].startsWith("Date:")).toBe(true);
+      const body = parseChunkedData(data.slice(headersEnd + 4));
+      expect(body.toString("utf-8")).toBe("chunk 1chunk 2");
+      resolve();
+    } catch (e) {
+      reject(e);
+    } finally {
+      socket.end();
+    }
+  });
+  await promise;
+});
+
+test("chunked encoding must be valid after without flushHeaders", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  await using server = http.createServer(async (req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain", "Transfer-Encoding": "chunked" });
+    // send some chunks at once
+    res.write("chunk 1");
+    res.write("chunk 2");
+    res.write("chunk 3");
+    res.write("chunk 4");
+    res.write("chunk 5");
+    await Bun.sleep(10);
+    // send some more chunk
+    res.write("chunk 6");
+    res.write("chunk 7");
+    await Bun.sleep(10);
+    // send the last chunk
+    res.end();
+  });
+
+  server.listen(3000);
+  await once(server, "listening");
+
+  const socket = connect(3000, () => {
+    socket.write("GET / HTTP/1.1\r\nHost: localhost:3000\r\nConnection: close\r\n\r\n");
+  });
+
+  const chunks = [];
+  socket.on("data", data => {
+    chunks.push(data);
+  });
+
+  function parseChunkedData(buffer) {
+    let offset = 0;
+    let result = Buffer.alloc(0);
+
+    while (offset < buffer.length) {
+      // Find the CRLF that terminates the chunk size line
+      let lineEnd = buffer.indexOf("\r\n", offset);
+      if (lineEnd === -1) break;
+
+      // Parse the chunk size (in hex)
+      const chunkSizeHex = buffer.toString("ascii", offset, lineEnd);
+      const chunkSize = parseInt(chunkSizeHex, 16);
+      expect(isNaN(chunkSize)).toBe(false);
+      // If chunk size is 0, we've reached the end
+      if (chunkSize === 0) {
+        // Skip the final CRLF after the 0-size chunk
+        offset = lineEnd + 4;
+        break;
+      }
+
+      // Move past the chunk size line's CRLF
+      offset = lineEnd + 2;
+
+      // Extract the chunk data
+      const chunkData = buffer.slice(offset, offset + chunkSize);
+
+      // Concatenate this chunk to our result
+      result = Buffer.concat([result, chunkData]);
+
+      // Move past this chunk's data and its terminating CRLF
+      offset += chunkSize + 2;
+    }
+
+    return result;
+  }
+
+  socket.on("end", () => {
+    try {
+      const data = Buffer.concat(chunks);
+
+      const headersEnd = data.indexOf("\r\n\r\n");
+      const headers = data.toString("utf-8", 0, headersEnd).split("\r\n");
+      expect(headers[0]).toBe("HTTP/1.1 200 OK");
+      expect(headers[1]).toBe("Content-Type: text/plain");
+      expect(headers[2]).toBe("Transfer-Encoding: chunked");
+      expect(headers[3].startsWith("Date:")).toBe(true);
+      const body = parseChunkedData(data.slice(headersEnd + 4));
+      expect(body.toString("utf-8")).toBe("chunk 1chunk 2chunk 3chunk 4chunk 5chunk 6chunk 7");
+      resolve();
+    } catch (e) {
+      reject(e);
+    } finally {
+      socket.end();
+    }
+  });
+  await promise;
 });

--- a/test/regression/issue/04298/04298.fixture.js
+++ b/test/regression/issue/04298/04298.fixture.js
@@ -12,6 +12,15 @@ server.listen({ port: 0 }, async err => {
     process.exit(1);
   }
   const hostname = isIPv6(host) ? `[${host}]` : host;
-
   (process?.connected ? process.send : console.log)(`http://${hostname}:${port}/`);
+});
+
+process.on("uncaughtException", err => {
+  // we expect this to happen
+  if (err.message.includes("Oops!") || err.message.includes("ECONNRESET")) {
+    process.exit(0);
+  } else {
+    console.error(err);
+    process.exit(1);
+  }
 });

--- a/test/regression/issue/04298/04298.test.ts
+++ b/test/regression/issue/04298/04298.test.ts
@@ -3,21 +3,28 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("node:http should not crash when server throws, and should abruptly close the socket", async () => {
-  const { promise, resolve, reject } = Promise.withResolvers();
+  const { promise: urlPromise, resolve: resolveUrl, reject: rejectUrl } = Promise.withResolvers();
+  const { promise: serverPromise, resolve: resolveServer, reject: rejectServer } = Promise.withResolvers();
   await using server = spawn({
     cwd: import.meta.dirname,
     cmd: [bunExe(), "04298.fixture.js"],
     env: bunEnv,
     stderr: "inherit",
     ipc(url) {
-      resolve(url);
+      resolveUrl(url);
     },
-    onExit(exitCode, signalCode) {
-      if (signalCode || exitCode !== 0) {
-        reject(new Error(`process exited with code ${signalCode || exitCode}`));
+    onExit(subprocess, exitCode) {
+      if (exitCode !== 0) {
+        const err = new Error(`process exited with code ${exitCode}`);
+        rejectUrl(err);
+        rejectServer(err);
+      } else {
+        resolveServer();
       }
     },
   });
-  const url = await promise;
-  const response = await fetch(url);
+  const url = await urlPromise;
+  // we dont wanna to error out ECONNRESET here, we just care about the exit code
+  await fetch(url).catch(() => {});
+  await serverPromise;
 });


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/oven-sh/bun/issues/19323
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
