### PR TITLE
Support >= 3 arguments in Spawn.stdio

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6433,7 +6433,8 @@ declare module "bun" {
        * @default ["ignore", "pipe", "inherit"] for `spawn`
        * ["ignore", "pipe", "pipe"] for `spawnSync`
        */
-      stdio?: [In, Out, Err];
+      stdio?: [In, Out, Err, ...(Readable | "ipc")[]];
+
       /**
        * The file descriptor for the standard input. It may be:
        *
@@ -6735,6 +6736,11 @@ declare module "bun" {
     readonly stderr: SpawnOptions.ReadableToIO<Err>;
 
     /**
+     * Access extra file descriptors passed to the `stdio` option in the options object.
+     */
+    readonly stdio: [null, null, null, ...number[]];
+
+    /**
      * This returns the same value as {@link Subprocess.stdout}
      *
      * It exists for compatibility with {@link ReadableStream.pipeThrough}
@@ -6750,6 +6756,7 @@ declare module "bun" {
      * ```
      */
     readonly pid: number;
+
     /**
      * The exit code of the process
      *

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6433,7 +6433,7 @@ declare module "bun" {
        * @default ["ignore", "pipe", "inherit"] for `spawn`
        * ["ignore", "pipe", "pipe"] for `spawnSync`
        */
-      stdio?: [In, Out, Err, ...(Readable | "ipc")[]];
+      stdio?: [In, Out, Err, ...Readable[]];
 
       /**
        * The file descriptor for the standard input. It may be:

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -65,6 +65,21 @@ function depromise<T>(_promise: Promise<T>): T {
 
 {
   const proc = Bun.spawn(["cat"], {
+    stdio: ["pipe", "pipe", "pipe", Bun.file("build.zip")],
+  });
+
+  tsd.expectType(proc.stdio[0]).is<null>();
+  tsd.expectType(proc.stdio[1]).is<null>();
+  tsd.expectType(proc.stdio[2]).is<null>();
+  tsd.expectType(proc.stdio[3]).is<number | undefined>();
+
+  tsd.expectType(proc.stdin).is<FileSink>();
+  tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array>>();
+  tsd.expectType(proc.stderr).is<ReadableStream<Uint8Array>>();
+}
+
+{
+  const proc = Bun.spawn(["cat"], {
     stdin: "pipe", // return a FileSink for writing
   });
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes allowing additional stdio arguments in the types.

Fixes #16726

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

Updated the shell tests and they passed