### PR TITLE
Add test for fs.watch (#18919)

### DIFF
--- a/test/regression/issue/18919.test.ts
+++ b/test/regression/issue/18919.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "bun:test";
+import { mkdirSync, rmSync, watch, writeFileSync } from "fs";
+import { tmpdirSync } from "harness";
+import { join } from "path";
+import { setImmediate } from "timers/promises";
+
+// https://github.com/oven-sh/bun/issues/18919
+it("fs.watch() properly triggers, closes and re-runs", async () => {
+  const testDir = tmpdirSync();
+  const testFile = join(testDir, "test.txt");
+
+  // Make sure there is an empty directory to work with
+  rmSync(testDir, { recursive: true, force: true });
+  mkdirSync(testDir, { recursive: true });
+
+  let firstTriggerCount = 0;
+  let secondTriggerCount = 0;
+
+  writeFileSync(testFile, "A");
+
+  // First watcher
+  {
+    const watcher_first = watch(testFile, () => {
+      firstTriggerCount++;
+      watcher_first.close();
+    });
+  }
+
+  // Trigger the first watcher
+  writeFileSync(testFile, "B");
+  // Give watchers time to react
+  await setImmediate();
+
+  // Second watcher
+  {
+    const watcher_second = watch(testFile, () => {
+      secondTriggerCount++;
+      watcher_second.close();
+    });
+  }
+
+  // Trigger the second watcher
+  writeFileSync(testFile, "C");
+  // Give watchers time to react
+  await setImmediate();
+
+  // Nobody should care about this
+  writeFileSync(testFile, "D");
+  // Give watchers time to react
+  await setImmediate();
+
+  expect(firstTriggerCount, "first watcher did not trigger exactly once").toBe(1);
+  expect(secondTriggerCount, "second watcher did not trigger exactly once").toBe(1);
+});


### PR DESCRIPTION
### What does this PR do?

As reported in #18919, fs.watch is quirky. I see @Jarred-Sumner is somewhat working on it but **here is the test file** I created for it.

### How did you verify your code works?

I wrote an automated test that shows the existing code does not work right now.

```
bun$ bun test 18919
bun test v1.2.11-canary.77 (ec6cb828)

test/regression/issue/18919.test.ts:
48 |   writeFileSync(testFile, "D");
49 |   // Give watchers time to react
50 |   await setImmediate();
51 | 
52 |   expect(firstTriggerCount, "first watcher did not trigger exactly once").toBe(1);
53 |   expect(secondTriggerCount, "second watcher did not trigger exactly once").toBe(1);
                                                                                 ^
error: second watcher did not trigger exactly once

Expected: 1
Received: 0

      at <anonymous> (/media/Archiv/Entwicklung/zig/bun/test/regression/issue/18919.test.ts:53:77)
✗ fs.watch() properly triggers, closes and re-runs [1.91ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 tests across 1 files. [165.00ms]
```