### PR TITLE
fix: #19394 zsh completion for bun link

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -885,7 +885,7 @@ _bun_link_param_package_completion() {
     global_node_modules=$install_dir/install/global/node_modules
 
     local -a packages_full_path=(${global_node_modules}/*(N))
-    packages=$(echo $packages_full_path | tr ' ' '\n' | xargs  basename)
+    packages=$(echo $packages_full_path | tr ' ' '\n' | xargs -l basename)
     _alternative "dirs:directory:(($packages))"
 }
 


### PR DESCRIPTION
Fixed a bug in bun zsh completions where xargs was passing an argument list as a single argument to basename.

fixes: https://github.com/oven-sh/bun/issues/19394

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Affects ZSH completions only. --> xargs should split argumnet list on new lines as indicated by `tr` just before.
