### PR TITLE
Wrong unit in ResourceUsage.maxRSS

### DIFF
--- a/docs/api/spawn.md
+++ b/docs/api/spawn.md
@@ -204,7 +204,7 @@ const proc = Bun.spawn(["bun", "--version"]);
 await proc.exited;
 
 const usage = proc.resourceUsage();
-console.log(`Max memory used: ${usage.maxRSS} bytes`);
+console.log(`Max memory used: ${usage.maxRSS} KB`);
 console.log(`CPU time (user): ${usage.cpuTime.user} µs`);
 console.log(`CPU time (system): ${usage.cpuTime.system} µs`);
 ```

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6770,7 +6770,7 @@ declare module "bun" {
       total: number;
     };
     /**
-     * The maximum amount of resident set size (in bytes) used by the process during its lifetime.
+     * The maximum amount of resident set size (in kilobytes) used by the process during its lifetime.
      */
     maxRSS: number;
 


### PR DESCRIPTION
### What does this PR do?

ResourceUsage.maxRSS is reported in kilobytes. See [libuv api documentation](https://docs.libuv.org/en/v1.x/misc.html#c.uv_rusage_t).

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes