### PR TITLE
Bring back default type arguments for Bun.[Sync]Subprocess

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6727,9 +6727,9 @@ declare module "bun" {
    * - {@link NullSubprocess} (ignore, ignore, ignore)
    */
   interface Subprocess<
-    In extends SpawnOptions.Writable,
-    Out extends SpawnOptions.Readable,
-    Err extends SpawnOptions.Readable,
+    In extends SpawnOptions.Writable = SpawnOptions.Writable,
+    Out extends SpawnOptions.Readable = SpawnOptions.Readable,
+    Err extends SpawnOptions.Readable = SpawnOptions.Readable,
   > extends AsyncDisposable {
     readonly stdin: SpawnOptions.WritableToIO<In>;
     readonly stdout: SpawnOptions.ReadableToIO<Out>;
@@ -6840,7 +6840,10 @@ declare module "bun" {
    * - {@link ReadableSyncSubprocess} (pipe, pipe)
    * - {@link NullSyncSubprocess} (ignore, ignore)
    */
-  interface SyncSubprocess<Out extends SpawnOptions.Readable, Err extends SpawnOptions.Readable> {
+  interface SyncSubprocess<
+    Out extends SpawnOptions.Readable = SpawnOptions.Readable,
+    Err extends SpawnOptions.Readable = SpawnOptions.Readable,
+  > {
     stdout: SpawnOptions.ReadableToSyncIO<Out>;
     stderr: SpawnOptions.ReadableToSyncIO<Err>;
     exitCode: number;


### PR DESCRIPTION
### What does this PR do?

Fixes #19422

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

We will look at removing these in 1.3 or other significant releases

### How did you verify your code works?

`bun-types` integration test passes