### PR TITLE
test-whatwg-encoding-custom-textdecoder-api-invalid-label.js

### DIFF
--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -68,6 +68,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_DLOPEN_FAILED", Error],
   ["ERR_DNS_SET_SERVERS_FAILED", Error],
   ["ERR_ENCODING_INVALID_ENCODED_DATA", TypeError],
+  ["ERR_ENCODING_NOT_SUPPORTED", RangeError],
   ["ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE", Error],
   ["ERR_FORMDATA_PARSE_ERROR", TypeError],
   ["ERR_FS_CP_DIR_TO_NON_DIR", Error],

--- a/src/bun.js/webcore/EncodingLabel.zig
+++ b/src/bun.js/webcore/EncodingLabel.zig
@@ -1,156 +1,98 @@
 /// https://encoding.spec.whatwg.org/encodings.json
 pub const EncodingLabel = enum {
+    // commented out = not supported yet
     @"UTF-8",
-    IBM866,
-    @"ISO-8859-2",
-    @"ISO-8859-3",
-    @"ISO-8859-4",
-    @"ISO-8859-5",
-    @"ISO-8859-6",
-    @"ISO-8859-7",
-    @"ISO-8859-8",
-    @"ISO-8859-8-I",
-    @"ISO-8859-10",
-    @"ISO-8859-13",
-    @"ISO-8859-14",
-    @"ISO-8859-15",
-    @"ISO-8859-16",
-    @"KOI8-R",
-    @"KOI8-U",
-    macintosh,
-    @"windows-874",
-    @"windows-1250",
-    @"windows-1251",
+    // IBM866,
+    // @"ISO-8859-2",
+    // @"ISO-8859-3",
+    // @"ISO-8859-4",
+    // @"ISO-8859-5",
+    // @"ISO-8859-6",
+    // @"ISO-8859-7",
+    // @"ISO-8859-8",
+    // @"ISO-8859-8-I",
+    // @"ISO-8859-10",
+    // @"ISO-8859-13",
+    // @"ISO-8859-14",
+    // @"ISO-8859-15",
+    // @"ISO-8859-16",
+    // @"KOI8-R",
+    // @"KOI8-U",
+    // macintosh,
+    // @"windows-874",
+    // @"windows-1250",
+    // @"windows-1251",
     /// Also known as
     /// - ASCII
     /// - latin1
     @"windows-1252",
-    @"windows-1253",
-    @"windows-1254",
-    @"windows-1255",
-    @"windows-1256",
-    @"windows-1257",
-    @"windows-1258",
-    @"x-mac-cyrillic",
-    Big5,
-    @"EUC-JP",
-    @"ISO-2022-JP",
-    Shift_JIS,
-    @"EUC-KR",
+    // @"windows-1253",
+    // @"windows-1254",
+    // @"windows-1255",
+    // @"windows-1256",
+    // @"windows-1257",
+    // @"windows-1258",
+    // @"x-mac-cyrillic",
+    // Big5,
+    // @"EUC-JP",
+    // @"ISO-2022-JP",
+    // Shift_JIS,
+    // @"EUC-KR",
     @"UTF-16BE",
     @"UTF-16LE",
-    @"x-user-defined",
+    // @"x-user-defined",
 
-    pub const Map = std.enums.EnumMap(EncodingLabel, string);
-    pub const label: Map = brk: {
-        var map = Map.initFull("");
-        map.put(EncodingLabel.@"UTF-8", "utf-8");
-        map.put(EncodingLabel.@"UTF-16LE", "utf-16le");
-        map.put(EncodingLabel.@"windows-1252", "windows-1252");
-        break :brk map;
-    };
-
-    const utf16_names = [_]string{
-        "ucs-2",
-        "utf-16",
-        "unicode",
-        "utf-16le",
-        "csunicode",
-        "unicodefeff",
-        "iso-10646-ucs-2",
-    };
-
-    const utf8_names = [_]string{
-        "utf8",
-        "utf-8",
-        "unicode11utf8",
-        "unicode20utf8",
-        "x-unicode20utf8",
-        "unicode-1-1-utf-8",
-    };
-
-    const latin1_names = [_]string{
-        "l1",
-        "ascii",
-        "cp819",
-        "cp1252",
-        "ibm819",
-        "latin1",
-        "iso88591",
-        "us-ascii",
-        "x-cp1252",
-        "iso8859-1",
-        "iso_8859-1",
-        "iso-8859-1",
-        "iso-ir-100",
-        "csisolatin1",
-        "windows-1252",
-        "ansi_x3.4-1968",
-        "iso_8859-1:1987",
-    };
+    pub fn getLabel(this: EncodingLabel) []const u8 {
+        return switch (this) {
+            .@"UTF-8" => "utf-8",
+            .@"UTF-16LE" => "utf-16le",
+            .@"UTF-16BE" => "utf-16be",
+            .@"windows-1252" => "windows-1252",
+        };
+    }
 
     pub const latin1 = EncodingLabel.@"windows-1252";
 
+    const string_map = bun.ComptimeStringMap(EncodingLabel, .{
+        .{ "l1", latin1 },
+        .{ "ascii", latin1 },
+        .{ "cp819", latin1 },
+        .{ "cp1252", latin1 },
+        .{ "ibm819", latin1 },
+        .{ "latin1", latin1 },
+        .{ "iso88591", latin1 },
+        .{ "us-ascii", latin1 },
+        .{ "x-cp1252", latin1 },
+        .{ "iso8859-1", latin1 },
+        .{ "iso_8859-1", latin1 },
+        .{ "iso-8859-1", latin1 },
+        .{ "iso-ir-100", latin1 },
+        .{ "csisolatin1", latin1 },
+        .{ "windows-1252", latin1 },
+        .{ "ansi_x3.4-1968", latin1 },
+        .{ "iso_8859-1:1987", latin1 },
+
+        .{ "ucs-2", .@"UTF-16LE" },
+        .{ "utf-16", .@"UTF-16LE" },
+        .{ "unicode", .@"UTF-16LE" },
+        .{ "utf-16le", .@"UTF-16LE" },
+        .{ "csunicode", .@"UTF-16LE" },
+        .{ "unicodefeff", .@"UTF-16LE" },
+        .{ "iso-10646-ucs-2", .@"UTF-16LE" },
+
+        .{ "utf-16be", .@"UTF-16BE" },
+
+        .{ "utf8", .@"UTF-8" },
+        .{ "utf-8", .@"UTF-8" },
+        .{ "unicode11utf8", .@"UTF-8" },
+        .{ "unicode20utf8", .@"UTF-8" },
+        .{ "x-unicode20utf8", .@"UTF-8" },
+        .{ "unicode-1-1-utf-8", .@"UTF-8" },
+    });
+
     pub fn which(input_: string) ?EncodingLabel {
         const input = strings.trim(input_, " \t\r\n");
-        const ExactMatcher = strings.ExactSizeMatcher;
-        const Eight = ExactMatcher(8);
-        const Sixteen = ExactMatcher(16);
-        return switch (input.len) {
-            1, 0 => null,
-            2...8 => switch (Eight.matchLower(input)) {
-                Eight.case("l1"),
-                Eight.case("ascii"),
-                Eight.case("cp819"),
-                Eight.case("cp1252"),
-                Eight.case("ibm819"),
-                Eight.case("latin1"),
-                Eight.case("iso88591"),
-                Eight.case("us-ascii"),
-                Eight.case("x-cp1252"),
-                => EncodingLabel.latin1,
-
-                Eight.case("ucs-2"),
-                Eight.case("utf-16"),
-                Eight.case("unicode"),
-                Eight.case("utf-16le"),
-                => EncodingLabel.@"UTF-16LE",
-
-                Eight.case("utf-16be"),
-                => EncodingLabel.@"UTF-16BE",
-
-                Eight.case("utf8"), Eight.case("utf-8") => EncodingLabel.@"UTF-8",
-                else => null,
-            },
-
-            9...16 => switch (Sixteen.matchLower(input)) {
-                Sixteen.case("iso8859-1"),
-                Sixteen.case("iso_8859-1"),
-                Sixteen.case("iso-8859-1"),
-                Sixteen.case("iso-ir-100"),
-                Sixteen.case("csisolatin1"),
-                Sixteen.case("windows-1252"),
-                Sixteen.case("ansi_x3.4-1968"),
-                Sixteen.case("iso_8859-1:1987"),
-                => EncodingLabel.latin1,
-
-                Sixteen.case("unicode11utf8"),
-                Sixteen.case("unicode20utf8"),
-                Sixteen.case("x-unicode20utf8"),
-                => EncodingLabel.@"UTF-8",
-
-                Sixteen.case("csunicode"),
-                Sixteen.case("unicodefeff"),
-                Sixteen.case("iso-10646-ucs-2"),
-                => EncodingLabel.@"UTF-16LE",
-
-                else => null,
-            },
-            else => if (strings.eqlCaseInsensitiveASCII(input, "unicode-1-1-utf-8", true))
-                EncodingLabel.@"UTF-8"
-            else
-                null,
-        };
+        return string_map.getAnyCase(input);
     }
 };
 const std = @import("std");

--- a/src/bun.js/webcore/TextDecoder.zig
+++ b/src/bun.js/webcore/TextDecoder.zig
@@ -45,7 +45,7 @@ pub fn getEncoding(
     this: *TextDecoder,
     globalThis: *JSC.JSGlobalObject,
 ) JSC.JSValue {
-    return ZigString.init(EncodingLabel.label.get(this.encoding).?).toJS(globalThis);
+    return ZigString.init(EncodingLabel.getLabel(this.encoding)).toJS(globalThis);
 }
 const Vector16 = std.meta.Vector(16, u16);
 const max_16_ascii: Vector16 = @splat(@as(u16, 127));
@@ -276,9 +276,6 @@ fn decodeSlice(this: *TextDecoder, globalThis: *JSC.JSGlobalObject, buffer_slice
             var output = bun.String.fromUTF16(decoded.items);
             return output.toJS(globalThis);
         },
-        else => {
-            return globalThis.throwInvalidArguments("TextDecoder.decode set to unsupported encoding", .{});
-        },
     }
 }
 
@@ -297,7 +294,7 @@ pub fn constructor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) b
             if (EncodingLabel.which(str.slice())) |label| {
                 decoder.encoding = label;
             } else {
-                return globalThis.throwInvalidArguments("Unsupported encoding label \"{s}\"", .{str.slice()});
+                return globalThis.ERR(.ENCODING_NOT_SUPPORTED, "Unsupported encoding label \"{s}\"", .{str.slice()}).throw();
             }
         } else if (arguments[0].isUndefined()) {
             // default to utf-8

--- a/src/exact_size_matcher.zig
+++ b/src/exact_size_matcher.zig
@@ -19,13 +19,8 @@ pub fn ExactSizeMatcher(comptime max_bytes: usize) type {
             switch (str.len) {
                 1...max_bytes - 1 => {
                     var tmp: [max_bytes]u8 = undefined;
-                    if (comptime bun.trait.isSlice(@TypeOf(str))) {
-                        @memcpy(tmp[0..str.len], str);
-                        @memset(tmp[str.len..], 0);
-                    } else {
-                        @memcpy(tmp[0..str.len], str);
-                        @memset(tmp[str.len..], 0);
-                    }
+                    @memcpy(tmp[0..str.len], str);
+                    @memset(tmp[str.len..], 0);
 
                     return std.mem.readInt(T, &tmp, .little);
                 },

--- a/test/js/node/test/parallel/test-whatwg-encoding-custom-textdecoder-api-invalid-label.js
+++ b/test/js/node/test/parallel/test-whatwg-encoding-custom-textdecoder-api-invalid-label.js
@@ -1,0 +1,50 @@
+'use strict';
+// From: https://github.com/w3c/web-platform-tests/blob/master/encoding/api-invalid-label.html
+// With the twist that we specifically test for Node.js error codes
+
+require('../common');
+const assert = require('assert');
+
+[
+  'utf-8',
+  'unicode-1-1-utf-8',
+  'unicode11utf8',
+  'unicode20utf8',
+  'x-unicode20utf8',
+  'utf8',
+  'unicodefffe',
+  'utf-16be',
+  'csunicode',
+  'iso-10646-ucs-2',
+  'ucs-2',
+  'unicode',
+  'unicodefeff',
+  'utf-16le',
+  'utf-16',
+].forEach((i) => {
+  ['\u0000', '\u000b', '\u00a0', '\u2028', '\u2029'].forEach((ws) => {
+    assert.throws(
+      () => new TextDecoder(`${ws}${i}`),
+      {
+        code: 'ERR_ENCODING_NOT_SUPPORTED',
+        name: 'RangeError'
+      }
+    );
+
+    assert.throws(
+      () => new TextDecoder(`${i}${ws}`),
+      {
+        code: 'ERR_ENCODING_NOT_SUPPORTED',
+        name: 'RangeError'
+      }
+    );
+
+    assert.throws(
+      () => new TextDecoder(`${ws}${i}${ws}`),
+      {
+        code: 'ERR_ENCODING_NOT_SUPPORTED',
+        name: 'RangeError'
+      }
+    );
+  });
+});

--- a/test/js/web/encoding/text-decoder-stream.test.ts
+++ b/test/js/web/encoding/text-decoder-stream.test.ts
@@ -132,7 +132,7 @@ import { readableStreamFromArray } from "harness";
   test("constructing with an invalid encoding should throw", () => {
     expect(() => {
       new TextDecoderStream("");
-    }).toThrow(TypeError);
+    }).toThrow(RangeError);
   });
 
   test("constructing with a non-stringifiable encoding should throw", () => {


### PR DESCRIPTION
- fixes `new TextDecoder("utf-8\x00")` being allowed when it should error
- fixes `new TextDecoder("utf-16be").encoding` returning the empty string instead of "utf16-be"