### PR TITLE
Fix local ASan build

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1219,19 +1219,18 @@ if(NOT BUN_CPP_ONLY)
   # ==856230==See https://github.com/google/sanitizers/issues/856 for possible workarounds.
   # the linked issue refers to very old kernels but this still happens to us on modern ones.
   # disabling ASLR to run the binary works around it
+  set(TEST_BUN_COMMAND_BASE
+    env BUN_DEBUG_QUIET_LOGS=1
+    ${BUILD_PATH}/${bunExe} --revision)
+  set(TEST_BUN_COMMAND_ENV_WRAP
+    ${CMAKE_COMMAND} -E env BUN_DEBUG_QUIET_LOGS=1)
   if (LINUX AND ENABLE_ASAN)
     set(TEST_BUN_COMMAND
-      ${CMAKE_COMMAND}
-      -E env BUN_DEBUG_QUIET_LOGS=1
-      setarch ${CMAKE_HOST_SYSTEM_PROCESSOR} -R
-      ${BUILD_PATH}/${bunExe}
-      --revision)
+      ${TEST_BUN_COMMAND_ENV_WRAP} setarch ${CMAKE_HOST_SYSTEM_PROCESSOR} -R ${TEST_BUN_COMMAND_BASE}
+      || ${TEST_BUN_COMMAND_ENV_WRAP} ${TEST_BUN_COMMAND_BASE})
   else()
     set(TEST_BUN_COMMAND
-      ${CMAKE_COMMAND}
-      -E env BUN_DEBUG_QUIET_LOGS=1
-      ${BUILD_PATH}/${bunExe}
-      --revision)
+      ${TEST_BUN_COMMAND_ENV_WRAP} ${TEST_BUN_COMMAND_BASE})
   endif()
 
   register_command(

--- a/patches/tinycc/CMakeLists.txt
+++ b/patches/tinycc/CMakeLists.txt
@@ -109,11 +109,25 @@ endif()
 add_executable(c2str.exe conftest.c)
 target_compile_options(c2str.exe PRIVATE -DC2STR)
 
+# somehow on some Linux systems we need to disable ASLR for ASAN-instrumented binaries to run
+# when spawned by cmake (they run fine from a shell!)
+# otherwise they crash with:
+# ==856230==Shadow memory range interleaves with an existing memory mapping. ASan cannot proceed correctly. ABORTING.
+# ==856230==ASan shadow was supposed to be located in the [0x00007fff7000-0x10007fff7fff] range.
+# ==856230==This might be related to ELF_ET_DYN_BASE change in Linux 4.12.
+# ==856230==See https://github.com/google/sanitizers/issues/856 for possible workarounds.
+# the linked issue refers to very old kernels but this still happens to us on modern ones.
+# disabling ASLR to run the binary works around it
+set(C2STR_COMMAND c2str.exe include/tccdefs.h tccdefs_.h)
+if(LINUX AND (CMAKE_C_FLAGS MATCHES "-fsanitize"))
+  set(C2STR_COMMAND setarch ${CMAKE_HOST_SYSTEM_PROCESSOR} -R ${C2STR_COMMAND})
+endif()
+
 add_custom_command(
   TARGET
     c2str.exe POST_BUILD
   COMMAND
-    c2str.exe include/tccdefs.h tccdefs_.h
+    ${C2STR_COMMAND}
   WORKING_DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/patches/tinycc/CMakeLists.txt
+++ b/patches/tinycc/CMakeLists.txt
@@ -120,7 +120,10 @@ target_compile_options(c2str.exe PRIVATE -DC2STR)
 # disabling ASLR to run the binary works around it
 set(C2STR_COMMAND $<TARGET_FILE:c2str.exe> include/tccdefs.h tccdefs_.h)
 if(LINUX AND (CMAKE_C_FLAGS MATCHES "-fsanitize"))
-  set(C2STR_COMMAND setarch ${CMAKE_HOST_SYSTEM_PROCESSOR} -R ${C2STR_COMMAND})
+  # our CI builds run in a container where setarch isn't allowed to change the personality.
+  # but the ASan binaries seem to run fine there without ASLR disabled
+  # so, if the command fails with setarch, we try again without (|| ${C2STR_COMMAND}) as a fallback
+  set(C2STR_COMMAND setarch ${CMAKE_HOST_SYSTEM_PROCESSOR} -R ${C2STR_COMMAND} || ${C2STR_COMMAND})
 endif()
 
 add_custom_command(

--- a/patches/tinycc/CMakeLists.txt
+++ b/patches/tinycc/CMakeLists.txt
@@ -118,7 +118,7 @@ target_compile_options(c2str.exe PRIVATE -DC2STR)
 # ==856230==See https://github.com/google/sanitizers/issues/856 for possible workarounds.
 # the linked issue refers to very old kernels but this still happens to us on modern ones.
 # disabling ASLR to run the binary works around it
-set(C2STR_COMMAND c2str.exe include/tccdefs.h tccdefs_.h)
+set(C2STR_COMMAND $<TARGET_FILE:c2str.exe> include/tccdefs.h tccdefs_.h)
 if(LINUX AND (CMAKE_C_FLAGS MATCHES "-fsanitize"))
   set(C2STR_COMMAND setarch ${CMAKE_HOST_SYSTEM_PROCESSOR} -R ${C2STR_COMMAND})
 endif()


### PR DESCRIPTION
### What does this PR do?

When compiling Bun with ASan support (`bun run build:asan` as of #19057) on Linux x86_64, I found that the build would fail because somehow ASan-instrumented binaries weren't running properly when started by CMake:

```
==856230==Shadow memory range interleaves with an existing memory mapping. ASan cannot proceed correctly. ABORTING.
==856230==ASan shadow was supposed to be located in the [0x00007fff7000-0x10007fff7fff] range.
==856230==This might be related to ELF_ET_DYN_BASE change in Linux 4.12.
==856230==See https://github.com/google/sanitizers/issues/856 for possible workarounds.
```

This happens two times:

- the TinyCC build process runs a program called `c2str`
- the main build runs `bun --revision` at the end to check that the built binary works

Both these executables would fail. Bizarrely, they work fine when run in a shell, even with the same arguments and environment variables CMake is passing -- the failure is somehow related to being spawned as a child of CMake. The linked GitHub issue refers to very old kernel versions; I saw this on two systems with kernels 6.12 and 6.13.

I have worked around this by running both executables with ASLR disabled, which seems to fix the issue.

### How did you verify your code works?

Built locally (on platforms with and without this workaround)