### PR TITLE
Experiment: call ZigString__freeGlobal when calling deref on an exter…

### DIFF
--- a/src/bun.js/bindings/helpers.h
+++ b/src/bun.js/bindings/helpers.h
@@ -26,42 +26,6 @@ extern "C" const char* Bun__errnoName(int);
 
 namespace Zig {
 
-// 8 bit byte
-// we tag the final two bits
-// so 56 bits are copied over
-// rest we zero out for consistentcy
-static const unsigned char* untag(const unsigned char* ptr)
-{
-    return reinterpret_cast<const unsigned char*>(
-        (((reinterpret_cast<uintptr_t>(ptr) & ~(static_cast<uint64_t>(1) << 63) & ~(static_cast<uint64_t>(1) << 62)) & ~(static_cast<uint64_t>(1) << 61)) & ~(static_cast<uint64_t>(1) << 60)));
-}
-
-static void* untagVoid(const unsigned char* ptr)
-{
-    return const_cast<void*>(reinterpret_cast<const void*>(untag(ptr)));
-}
-
-static void* untagVoid(const char16_t* ptr)
-{
-    return untagVoid(reinterpret_cast<const unsigned char*>(ptr));
-}
-
-static bool isTaggedUTF16Ptr(const unsigned char* ptr)
-{
-    return (reinterpret_cast<uintptr_t>(ptr) & (static_cast<uint64_t>(1) << 63)) != 0;
-}
-
-// Do we need to convert the string from UTF-8 to UTF-16?
-static bool isTaggedUTF8Ptr(const unsigned char* ptr)
-{
-    return (reinterpret_cast<uintptr_t>(ptr) & (static_cast<uint64_t>(1) << 61)) != 0;
-}
-
-static bool isTaggedExternalPtr(const unsigned char* ptr)
-{
-    return (reinterpret_cast<uintptr_t>(ptr) & (static_cast<uint64_t>(1) << 62)) != 0;
-}
-
 static void free_global_string(void* str, void* ptr, unsigned len)
 {
     // i don't understand why this happens


### PR DESCRIPTION
…nal string

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
