### PR TITLE
Slightly reduce number of comptime fn instantiations

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -44,24 +44,23 @@ pub const JSGlobalObject = opaque {
         return this.throwValue(err);
     }
 
-    pub inline fn throwMissingArgumentsValue(this: *JSGlobalObject, comptime arg_names: []const []const u8) bun.JSError {
+    pub inline fn throwMissingArgumentsValue(this: *JSGlobalObject, arg_names: []const []const u8) bun.JSError {
         return switch (arg_names.len) {
-            0 => @compileError("requires at least one argument"),
             1 => this.ERR(.MISSING_ARGS, "The \"{s}\" argument must be specified", .{arg_names[0]}).throw(),
             2 => this.ERR(.MISSING_ARGS, "The \"{s}\" and \"{s}\" arguments must be specified", .{ arg_names[0], arg_names[1] }).throw(),
             3 => this.ERR(.MISSING_ARGS, "The \"{s}\", \"{s}\", and \"{s}\" arguments must be specified", .{ arg_names[0], arg_names[1], arg_names[2] }).throw(),
-            else => @compileError("implement this message"),
+            else => bun.unreachablePanic("implement this message", .{}),
         };
     }
 
     /// "Expected {field} to be a {typename} for '{name}'."
     pub fn createInvalidArgumentType(
         this: *JSGlobalObject,
-        comptime name_: []const u8,
-        comptime field: []const u8,
-        comptime typename: []const u8,
+        name_: []const u8,
+        field: []const u8,
+        typename: []const u8,
     ) JSC.JSValue {
-        return this.ERR(.INVALID_ARG_TYPE, comptime std.fmt.comptimePrint("Expected {s} to be a {s} for '{s}'.", .{ field, typename, name_ }), .{}).toJS();
+        return this.ERR(.INVALID_ARG_TYPE, "Expected {s} to be a {s} for '{s}'.", .{ field, typename, name_ }).toJS();
     }
 
     pub fn toJS(this: *JSC.JSGlobalObject, value: anytype, comptime lifetime: JSC.JSValue.FromAnyLifetime) JSC.JSValue {
@@ -71,9 +70,9 @@ pub const JSGlobalObject = opaque {
     /// "Expected {field} to be a {typename} for '{name}'."
     pub fn throwInvalidArgumentType(
         this: *JSGlobalObject,
-        comptime name_: []const u8,
-        comptime field: []const u8,
-        comptime typename: []const u8,
+        name_: []const u8,
+        field: []const u8,
+        typename: []const u8,
     ) bun.JSError {
         return this.throwValue(this.createInvalidArgumentType(name_, field, typename));
     }
@@ -107,12 +106,12 @@ pub const JSGlobalObject = opaque {
     pub fn throwInvalidArgumentPropertyValue(
         this: *JSGlobalObject,
         argname: []const u8,
-        comptime expected: ?[]const u8,
+        expected: ?[]const u8,
         value: JSValue,
     ) bun.JSError {
         const actual_string_value = try determineSpecificType(this, value);
         defer actual_string_value.deref();
-        if (comptime expected) |_expected| {
+        if (expected) |_expected| {
             return this.ERR(.INVALID_ARG_VALUE, "The property \"{s}\" is invalid. Expected {s}, received {}", .{ argname, _expected, actual_string_value }).throw();
         } else {
             return this.ERR(.INVALID_ARG_VALUE, "The property \"{s}\" is invalid. Received {}", .{ argname, actual_string_value }).throw();
@@ -208,18 +207,18 @@ pub const JSGlobalObject = opaque {
 
     pub fn createNotEnoughArguments(
         this: *JSGlobalObject,
-        comptime name_: []const u8,
-        comptime expected: usize,
+        name_: []const u8,
+        expected: usize,
         got: usize,
     ) JSC.JSValue {
-        return this.toTypeError(.MISSING_ARGS, "Not enough arguments to '" ++ name_ ++ "'. Expected {d}, got {d}.", .{ expected, got });
+        return this.toTypeError(.MISSING_ARGS, "Not enough arguments to '{s}'. Expected {d}, got {d}.", .{ name_, expected, got });
     }
 
     /// Not enough arguments passed to function named `name_`
     pub fn throwNotEnoughArguments(
         this: *JSGlobalObject,
-        comptime name_: []const u8,
-        comptime expected: usize,
+        name_: []const u8,
+        expected: usize,
         got: usize,
     ) bun.JSError {
         return this.throwValue(this.createNotEnoughArguments(name_, expected, got));
@@ -636,7 +635,7 @@ pub const JSGlobalObject = opaque {
     // returns false if it throws
     pub fn validateObject(
         this: *JSGlobalObject,
-        comptime arg_name: [:0]const u8,
+        arg_name: [:0]const u8,
         value: JSValue,
         opts: struct {
             allowArray: bool = false,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
