### PR TITLE
ci: Switch build-zig to use EC2

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -323,9 +323,25 @@ function getCppAgent(platform, options) {
 function getZigAgent(platform, options) {
   const { arch } = platform;
 
-  return {
-    queue: "build-zig",
-  };
+  // Uncomment to restore to using macOS on-prem for Zig.
+  // return {
+  //   queue: "build-zig",
+  // };
+
+  return getEc2Agent(
+    {
+      os: "linux",
+      arch: "x64",
+      distro: "debian",
+      release: "11",
+    },
+    options,
+    {
+      instanceType: "c7i.2xlarge",
+      cpuCount: 4,
+      threadsPerCore: 1,
+    },
+  );
 }
 
 /**

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -332,6 +332,7 @@ function getZigAgent(platform, options) {
     {
       os: "linux",
       arch: "x64",
+      abi: "musl",
       distro: "alpine",
       release: "3.21",
     },

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -332,8 +332,8 @@ function getZigAgent(platform, options) {
     {
       os: "linux",
       arch: "x64",
-      distro: "debian",
-      release: "11",
+      distro: "alpine",
+      release: "3.21",
     },
     options,
     {

--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -56,9 +56,9 @@ optionx(ZIG_LOCAL_CACHE_DIR FILEPATH "The path to local the zig cache directory"
 optionx(ZIG_GLOBAL_CACHE_DIR FILEPATH "The path to the global zig cache directory" DEFAULT ${CACHE_PATH}/zig/global)
 
 if(CI AND CMAKE_HOST_APPLE)
-  set(ZIG_COMPILER_SAFE_DEFAULT OFF)
-else()
   set(ZIG_COMPILER_SAFE_DEFAULT ON)
+else()
+  set(ZIG_COMPILER_SAFE_DEFAULT OFF)
 endif()
 
 optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT ${ZIG_COMPILER_SAFE_DEFAULT})

--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -54,7 +54,14 @@ optionx(ZIG_OBJECT_FORMAT "obj|bc" "Output file format for Zig object files" DEF
 
 optionx(ZIG_LOCAL_CACHE_DIR FILEPATH "The path to local the zig cache directory" DEFAULT ${CACHE_PATH}/zig/local)
 optionx(ZIG_GLOBAL_CACHE_DIR FILEPATH "The path to the global zig cache directory" DEFAULT ${CACHE_PATH}/zig/global)
-optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT ${BUILDKITE})
+
+if(CI AND CMAKE_HOST_APPLE)
+  set(ZIG_COMPILER_SAFE_DEFAULT OFF)
+else()
+  set(ZIG_COMPILER_SAFE_DEFAULT ON)
+endif()
+
+optionx(ZIG_COMPILER_SAFE BOOL "Download a ReleaseSafe build of the Zig compiler. Only availble on macos aarch64." DEFAULT ${ZIG_COMPILER_SAFE_DEFAULT})
 
 setenv(ZIG_LOCAL_CACHE_DIR ${ZIG_LOCAL_CACHE_DIR})
 setenv(ZIG_GLOBAL_CACHE_DIR ${ZIG_GLOBAL_CACHE_DIR})


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
