### PR TITLE
fix `test-abortsignal-any.mjs`

### DIFF
--- a/src/bun.js/bindings/webcore/JSAbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/JSAbortSignal.cpp
@@ -53,6 +53,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
+#include "ErrorCode.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -308,14 +309,28 @@ static inline JSC::EncodedJSValue jsAbortSignalConstructorFunction_anyBody(JSC::
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
-    if (UNLIKELY(callFrame->argumentCount() < 1))
-        return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
     if (UNLIKELY(!context))
         return JSValue::encode(jsUndefined());
-    EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto signals = convert<IDLSequence<IDLInterface<AbortSignal>>>(*lexicalGlobalObject, argument0.value());
-    RETURN_IF_EXCEPTION(throwScope, {});
+    EnsureStillAliveScope argument0 = callFrame->argument(0);
+
+    // manual conversion to nodejs error handling
+    Vector<RefPtr<AbortSignal>> signals;
+    if (argument0.value().isUndefinedOrNull()) {
+        Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "signals can not be converted to sequence"_s);
+        return {};
+    }
+
+    size_t i = 0;
+    forEachInIterable(lexicalGlobalObject, argument0.value(), [&](VM& vm, JSGlobalObject* globalObject, JSValue item) {
+        if (auto* signal = JSAbortSignal::toWrapped(vm, item)) {
+            signals.append(signal);
+        } else {
+            Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, makeString("signals["_s, i, "]"_s), "AbortSignal"_s, item);
+        }
+        i++;
+    });
+
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJSNewlyCreated<IDLInterface<AbortSignal>>(*lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), throwScope, AbortSignal::any(*context, WTFMove(signals)))));
 }
 

--- a/test/js/node/test/parallel/test-abortsignal-any.mjs
+++ b/test/js/node/test/parallel/test-abortsignal-any.mjs
@@ -1,0 +1,134 @@
+import * as common from '../common/index.mjs';
+import { describe, it } from 'node:test';
+import { once } from 'node:events';
+import assert from 'node:assert';
+
+describe('AbortSignal.any()', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  it('should throw when not receiving an array', () => {
+    const expectedError = { code: 'ERR_INVALID_ARG_TYPE' };
+    assert.throws(() => AbortSignal.any(), expectedError);
+    assert.throws(() => AbortSignal.any(null), expectedError);
+    assert.throws(() => AbortSignal.any(undefined), expectedError);
+  });
+
+  it('should throw when input contains non-signal values', () => {
+    assert.throws(
+      () => AbortSignal.any([AbortSignal.abort(), undefined]),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: 'The "signals[1]" argument must be an instance of AbortSignal. Received undefined'
+      },
+    );
+  });
+
+  it('creates a non-aborted signal for an empty input', () => {
+    const signal = AbortSignal.any([]);
+    assert.strictEqual(signal.aborted, false);
+    signal.addEventListener('abort', common.mustNotCall());
+  });
+
+  it('returns a new signal', () => {
+    const originalSignal = new AbortController().signal;
+    const signalAny = AbortSignal.any([originalSignal]);
+    assert.notStrictEqual(originalSignal, signalAny);
+  });
+
+  it('returns an aborted signal if input has an aborted signal', () => {
+    const signal = AbortSignal.any([AbortSignal.abort('some reason')]);
+    assert.strictEqual(signal.aborted, true);
+    assert.strictEqual(signal.reason, 'some reason');
+    signal.addEventListener('abort', common.mustNotCall());
+  });
+
+  it('returns an aborted signal with the reason of first aborted signal input', () => {
+    const signal = AbortSignal.any([AbortSignal.abort('some reason'), AbortSignal.abort('another reason')]);
+    assert.strictEqual(signal.aborted, true);
+    assert.strictEqual(signal.reason, 'some reason');
+    signal.addEventListener('abort', common.mustNotCall());
+  });
+
+  it('returns the correct signal in the event target', async () => {
+    const signal = AbortSignal.any([AbortSignal.timeout(5)]);
+    const interval = setInterval(() => {}, 100000); // Keep event loop alive
+    const [{ target }] = await once(signal, 'abort');
+    clearInterval(interval);
+    assert.strictEqual(target, signal);
+    assert.ok(signal.aborted);
+    assert.strictEqual(signal.reason.name, 'TimeoutError');
+  });
+
+  it('aborts with reason of first aborted signal', () => {
+    const controllers = Array.from({ length: 3 }, () => new AbortController());
+    const combinedSignal = AbortSignal.any(controllers.map((c) => c.signal));
+    controllers[1].abort(1);
+    controllers[2].abort(2);
+    assert.ok(combinedSignal.aborted);
+    assert.strictEqual(combinedSignal.reason, 1);
+  });
+
+  it('can accept the same signal more than once', () => {
+    const controller = new AbortController();
+    const signal = AbortSignal.any([controller.signal, controller.signal]);
+    assert.strictEqual(signal.aborted, false);
+    controller.abort('reason');
+    assert.ok(signal.aborted);
+    assert.strictEqual(signal.reason, 'reason');
+  });
+
+  it('handles deeply aborted signals', async () => {
+    const controllers = Array.from({ length: 2 }, () => new AbortController());
+    const composedSignal1 = AbortSignal.any([controllers[0].signal]);
+    const composedSignal2 = AbortSignal.any([composedSignal1, controllers[1].signal]);
+
+    composedSignal2.onabort = common.mustCall();
+    controllers[0].abort();
+    assert.ok(composedSignal2.aborted);
+    assert.ok(composedSignal2.reason instanceof DOMException);
+    assert.strictEqual(composedSignal2.reason.name, 'AbortError');
+  });
+
+  it('executes abort handlers in correct order', () => {
+    const controller = new AbortController();
+    const signals = [];
+    signals.push(controller.signal);
+    signals.push(AbortSignal.any([controller.signal]));
+    signals.push(AbortSignal.any([controller.signal]));
+    signals.push(AbortSignal.any([signals[0]]));
+    signals.push(AbortSignal.any([signals[1]]));
+
+    let result = '';
+    signals.forEach((signal, i) => signal.addEventListener('abort', () => result += i));
+    controller.abort();
+    assert.strictEqual(result, '01234');
+  });
+
+  it('must accept WebIDL sequence', () => {
+    const controller = new AbortController();
+    const iterable = {
+      *[Symbol.iterator]() {
+        yield controller.signal;
+        yield new AbortController().signal;
+        yield new AbortController().signal;
+        yield new AbortController().signal;
+      },
+    };
+    const signal = AbortSignal.any(iterable);
+    let result = 0;
+    signal.addEventListener('abort', () => result += 1);
+    controller.abort();
+    assert.strictEqual(result, 1);
+  });
+
+  it('throws TypeError if any value does not implement AbortSignal', () => {
+    const expectedError = { code: 'ERR_INVALID_ARG_TYPE' };
+    assert.throws(() => AbortSignal.any([ null ]), expectedError);
+    assert.throws(() => AbortSignal.any([ undefined ]), expectedError);
+    assert.throws(() => AbortSignal.any([ '123' ]), expectedError);
+    assert.throws(() => AbortSignal.any([ 123 ]), expectedError);
+    assert.throws(() => AbortSignal.any([{}]), expectedError);
+    assert.throws(() => AbortSignal.any([{ aborted: true }]), expectedError);
+    assert.throws(() => AbortSignal.any([{
+      aborted: true, reason: '', throwIfAborted: null,
+    }]), expectedError);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Matches invalid argument errors with node
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
