### PR TITLE
chore: flag vscode JSON files as jsonc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,3 +52,5 @@ test/js/node/test/fixtures linguist-vendored
 test/js/node/test/common linguist-vendored
 
 test/js/bun/css/files linguist-vendored
+
+.vscode/*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
### What does this PR do?

Add `linguist-language=JSON-with-Comments` attribute to fix syntax highlighting for VSCode JSON files on GitHub.

> refer to https://github.com/github-linguist/linguist/pull/4171

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
