### PR TITLE
use .env.local for tests (#19542)

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -645,13 +645,6 @@ pub const Loader = struct {
             try this.loadEnvFile(dir_handle, ".env", false);
             Analytics.Features.dotenv += 1;
         }
-
-        if (comptime suffix == .@"test") {
-            if (dir.hasComptimeQuery(".env.local")) {
-                try this.loadEnvFile(dir_handle, ".env.local", false);
-                Analytics.Features.dotenv += 1;
-            }
-        }
     }
 
     pub fn printLoaded(this: *Loader, start: i128) void {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -600,6 +600,11 @@ pub const Loader = struct {
                     try this.loadEnvFile(dir_handle, ".env.test.local", false);
                     Analytics.Features.dotenv += 1;
                 }
+
+                if (dir.hasComptimeQuery(".env.local")) {
+                    try this.loadEnvFile(dir_handle, ".env.local", false);
+                    Analytics.Features.dotenv += 1;
+                }
             },
         }
 
@@ -626,6 +631,11 @@ pub const Loader = struct {
             .@"test" => {
                 if (dir.hasComptimeQuery(".env.test")) {
                     try this.loadEnvFile(dir_handle, ".env.test", false);
+                    Analytics.Features.dotenv += 1;
+                }
+
+                if (dir.hasComptimeQuery(".env.local")) {
+                    try this.loadEnvFile(dir_handle, ".env.local", false);
                     Analytics.Features.dotenv += 1;
                 }
             },

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -603,9 +603,11 @@ pub const Loader = struct {
             },
         }
 
-        if (dir.hasComptimeQuery(".env.local")) {
-            try this.loadEnvFile(dir_handle, ".env.local", false);
-            Analytics.Features.dotenv += 1;
+        if (comptime suffix != .@"test") {
+            if (dir.hasComptimeQuery(".env.local")) {
+                try this.loadEnvFile(dir_handle, ".env.local", false);
+                Analytics.Features.dotenv += 1;
+            }
         }
 
         switch (comptime suffix) {
@@ -632,6 +634,13 @@ pub const Loader = struct {
         if (dir.hasComptimeQuery(".env")) {
             try this.loadEnvFile(dir_handle, ".env", false);
             Analytics.Features.dotenv += 1;
+        }
+
+        if (comptime suffix == .@"test") {
+            if (dir.hasComptimeQuery(".env.local")) {
+                try this.loadEnvFile(dir_handle, ".env.local", false);
+                Analytics.Features.dotenv += 1;
+            }
         }
     }
 

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -603,11 +603,9 @@ pub const Loader = struct {
             },
         }
 
-        if (comptime suffix != .@"test") {
-            if (dir.hasComptimeQuery(".env.local")) {
-                try this.loadEnvFile(dir_handle, ".env.local", false);
-                Analytics.Features.dotenv += 1;
-            }
+        if (dir.hasComptimeQuery(".env.local")) {
+            try this.loadEnvFile(dir_handle, ".env.local", false);
+            Analytics.Features.dotenv += 1;
         }
 
         switch (comptime suffix) {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -113,7 +113,7 @@ describe(".env file is loaded", () => {
       "index.test.ts": "console.log(process.env.FAILED);",
     });
     const { stdout } = bunTest(`${dir}/index.test.ts`, {});
-    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "false");
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "true");
   });
   test(".env.development and .env.production ignored when bun test", () => {
     const dir = tempDirWithFiles("dotenv", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -108,12 +108,12 @@ describe(".env file is loaded", () => {
   });
   test(".env.local when bun test", () => {
     const dir = tempDirWithFiles("dotenv", {
-      ".env": "ENV=true\n",
-      ".env.local": "LOCAL=true\n",
-      "index.test.ts": "console.log(process.env.LOCAL);",
+      ".env": "FAILED=false\n",
+      ".env.local": "FAILED=true\n",
+      "index.test.ts": "console.log(process.env.FAILED);",
     });
     const { stdout } = bunTest(`${dir}/index.test.ts`, {});
-    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "true");
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "false");
   });
   test(".env.development and .env.production ignored when bun test", () => {
     const dir = tempDirWithFiles("dotenv", {
@@ -189,9 +189,8 @@ describe("dotenv priority", () => {
     expect(stdout_dev).toBe(".env.local");
     const { stdout: stdout_prod } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
     expect(stdout_prod).toBe(".env.local");
-    // .env.local is "not checked when `NODE_ENV` is `test`"
     const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
-    expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.local");
+    expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.test");
   });
   test(".env.{NODE_ENV} overrides .env", () => {
     const dir = tempDirWithFiles("dotenv", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -190,7 +190,7 @@ describe("dotenv priority", () => {
     const { stdout: stdout_prod } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
     expect(stdout_prod).toBe(".env.local");
     const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
-    expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.test");
+    expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.local");
   });
   test(".env.{NODE_ENV} overrides .env", () => {
     const dir = tempDirWithFiles("dotenv", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -106,14 +106,14 @@ describe(".env file is loaded", () => {
     const { stdout } = bunTest(`${dir}/index.test.ts`, {});
     expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "a b c undefined");
   });
-  test(".env.local ignored when bun test", () => {
+  test(".env.local when bun test", () => {
     const dir = tempDirWithFiles("dotenv", {
-      ".env": "FAILED=false\n",
-      ".env.local": "FAILED=true\n",
-      "index.test.ts": "console.log(process.env.FAILED);",
+      ".env": "ENV=true\n",
+      ".env.local": "LOCAL=true\n",
+      "index.test.ts": "console.log(process.env.LOCAL);",
     });
     const { stdout } = bunTest(`${dir}/index.test.ts`, {});
-    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "false");
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "true");
   });
   test(".env.development and .env.production ignored when bun test", () => {
     const dir = tempDirWithFiles("dotenv", {
@@ -191,7 +191,7 @@ describe("dotenv priority", () => {
     expect(stdout_prod).toBe(".env.local");
     // .env.local is "not checked when `NODE_ENV` is `test`"
     const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
-    expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.test");
+    expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.local");
   });
   test(".env.{NODE_ENV} overrides .env", () => {
     const dir = tempDirWithFiles("dotenv", {


### PR DESCRIPTION
### What does this PR do?

This pull request fixes an issue that when running `bun test`, `.env.local` was not read for the environment variables. This pull request closes https://github.com/oven-sh/bun/issues/19542.

### How did you verify your code works?

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [X] I updated TypeScript/JavaScript tests and they pass locally (`test/cli/run/env.test.ts`)