### PR TITLE
add missing snapshot from `esbuild/css.test.ts`

### DIFF
--- a/test/bundler/esbuild/__snapshots__/css.test.ts.snap
+++ b/test/bundler/esbuild/__snapshots__/css.test.ts.snap
@@ -1434,3 +1434,28 @@ exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /d.c
 "@import "./shared.css";
 body { color: blue }"
 `;
+
+exports[`bundler css/ComposesWithSharedPropertiesError 1`] = `
+"// styles.module.css
+var styles_module_default = {
+  button: "otherButton_NlEjJA button_-MSaAA"
+};
+
+// entry.js
+console.log(styles_module_default);
+"
+`;
+
+exports[`bundler css/ComposesWithSharedPropertiesError 2`] = `
+"/* other.module.css */
+.otherButton_NlEjJA {
+  color: red;
+  font-size: 16px;
+}
+
+/* styles.module.css */
+.button_-MSaAA {
+  color: #00f;
+}
+"
+`;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
