### PR TITLE
fix `test-http-agent-getname.js`

### DIFF
--- a/src/js/node/_http_agent.ts
+++ b/src/js/node/_http_agent.ts
@@ -96,14 +96,23 @@ Agent.prototype.createConnection = function () {
 };
 
 Agent.prototype.getName = function (options = kEmptyObject) {
-  let name = `http:${options.host || "localhost"}:`;
-  if (options.port) name += options.port;
+  let name = options.host || "localhost";
   name += ":";
-  if (options.localAddress) name += options.localAddress;
+  if (options.port) {
+    name += options.port;
+  }
+  name += ":";
+  if (options.localAddress) {
+    name += options.localAddress;
+  }
   // Pacify parallel/test-http-agent-getname by only appending
   // the ':' when options.family is set.
-  if (options.family === 4 || options.family === 6) name += `:${options.family}`;
-  if (options.socketPath) name += `:${options.socketPath}`;
+  if (options.family === 4 || options.family === 6) {
+    name += `:${options.family}`;
+  }
+  if (options.socketPath) {
+    name += `:${options.socketPath}`;
+  }
   return name;
 };
 

--- a/test/js/node/test/parallel/test-http-agent-getname.js
+++ b/test/js/node/test/parallel/test-http-agent-getname.js
@@ -1,0 +1,55 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const tmpdir = require('../common/tmpdir');
+
+const agent = new http.Agent();
+
+// Default to localhost
+assert.strictEqual(
+  agent.getName({
+    port: 80,
+    localAddress: '192.168.1.1'
+  }),
+  'localhost:80:192.168.1.1'
+);
+
+// empty argument
+assert.strictEqual(
+  agent.getName(),
+  'localhost::'
+);
+
+// empty options
+assert.strictEqual(
+  agent.getName({}),
+  'localhost::'
+);
+
+// pass all arguments
+assert.strictEqual(
+  agent.getName({
+    host: '0.0.0.0',
+    port: 80,
+    localAddress: '192.168.1.1'
+  }),
+  '0.0.0.0:80:192.168.1.1'
+);
+
+// unix socket
+const socketPath = tmpdir.resolve('foo', 'bar');
+assert.strictEqual(
+  agent.getName({
+    socketPath
+  }),
+  `localhost:::${socketPath}`
+);
+
+for (const family of [0, null, undefined, 'bogus'])
+  assert.strictEqual(agent.getName({ family }), 'localhost::');
+
+for (const family of [4, 6])
+  assert.strictEqual(agent.getName({ family }), `localhost:::${family}`);


### PR DESCRIPTION
### What does this PR do?
Removes `http` prefix
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
