### PR TITLE
fix `test-http-client-finished.js`

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -803,7 +803,8 @@ const ServerPrototype = {
     }
     if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
     this.listening = false;
-    server.stop();
+    server.stop(true);
+    return this;
   },
   [EventEmitter.captureRejectionSymbol]: function (err, event, ...args) {
     switch (event) {

--- a/test/js/node/test/parallel/test-http-client-finished.js
+++ b/test/js/node/test/parallel/test-http-client-finished.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const { finished } = require('stream');
+
+{
+  // Test abort before finished.
+
+  const server = http.createServer(function(req, res) {
+    res.write('asd');
+  });
+
+  server.listen(0, common.mustCall(function() {
+    http.request({
+      port: this.address().port
+    })
+    .on('response', (res) => {
+      res.on('readable', () => {
+        res.destroy();
+      });
+      finished(res, common.mustCall(() => {
+        server.close();
+      }));
+    })
+    .end();
+  }));
+}


### PR DESCRIPTION
### What does this PR do?
WIP
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
