### PR TITLE
compat(http2) passing macos

### DIFF
--- a/test/js/node/test/parallel/test-http2-server-close-callback.js
+++ b/test/js/node/test/parallel/test-http2-server-close-callback.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const Countdown = require('../common/countdown');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+let session;
+
+const countdown = new Countdown(2, () => {
+  server.close(common.mustSucceed());
+  session.close();
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  client.on('connect', common.mustCall(() => countdown.dec()));
+}));
+
+server.on('session', common.mustCall((s) => {
+  session = s;
+  countdown.dec();
+}));

--- a/test/js/node/test/parallel/test-http2-session-unref.js
+++ b/test/js/node/test/parallel/test-http2-session-unref.js
@@ -1,0 +1,58 @@
+'use strict';
+// Tests that calling unref() on Http2Session:
+// (1) Prevents it from keeping the process alive
+// (2) Doesn't crash
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const Countdown = require('../common/countdown');
+const { duplexPair } = require('stream');
+
+const server = http2.createServer();
+const [ clientSide, serverSide ] = duplexPair();
+
+const counter = new Countdown(3, () => server.unref());
+
+// 'session' event should be emitted 3 times:
+// - the vanilla client
+// - the destroyed client
+// - manual 'connection' event emission with generic Duplex stream
+server.on('session', common.mustCallAtLeast((session) => {
+  counter.dec();
+  session.unref();
+}, 3));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+
+  // unref new client
+  {
+    const client = http2.connect(`http://localhost:${port}`);
+    client.unref();
+  }
+
+  // Unref destroyed client
+  {
+    const client = http2.connect(`http://localhost:${port}`);
+
+    client.on('connect', common.mustCall(() => {
+      client.destroy();
+      client.unref();
+    }));
+  }
+
+  // Unref destroyed client
+  {
+    const client = http2.connect(`http://localhost:${port}`, {
+      createConnection: common.mustCall(() => clientSide)
+    });
+
+    client.on('connect', common.mustCall(() => {
+      client.destroy();
+      client.unref();
+    }));
+  }
+}));
+server.emit('connection', serverSide);


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
