### PR TITLE
add more tests for autoinstall

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -228,7 +228,7 @@ pub const Arguments = struct {
         clap.parseParam("--inspect-brk <STR>?              Activate Bun's debugger, set breakpoint on first line of code and wait") catch unreachable,
         clap.parseParam("--if-present                      Exit without an error if the entrypoint does not exist") catch unreachable,
         clap.parseParam("--no-install                      Disable auto install in the Bun runtime") catch unreachable,
-        clap.parseParam("--install <STR>                   Configure auto-install behavior. One of \"auto\" (default, auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always).") catch unreachable,
+        clap.parseParam("--install <STR>                   Configure auto-install behavior. One of \"auto\" (default, auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always), \"disable\" (never).") catch unreachable,
         clap.parseParam("-i                                Auto-install dependencies during execution. Equivalent to --install=fallback.") catch unreachable,
         clap.parseParam("-e, --eval <STR>                  Evaluate argument as a script") catch unreachable,
         clap.parseParam("-p, --print <STR>                 Evaluate argument as a script and print the result") catch unreachable,

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,45 +1,52 @@
-import { describe, expect, test } from "bun:test";
+import { expect, test, describe } from "bun:test";
 import { mkdirSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 
-//   --install=<val>                 Configure auto-install behavior. One of "auto" (default, auto-installs when no node_modules), "fallback" (missing packages only), "force" (always).
+//   --install=<val>                 Configure auto-install behavior. One of "auto" (default, auto-installs when no node_modules), "fallback" (missing packages only), "force" (always), "disable" (never).
 //   -i                              Auto-install dependencies during execution. Equivalent to --install=fallback.
 
-describe("basic autoinstall", () => {
-  for (const install of ["", "-i", "--install=auto", "--install=fallback", "--install=force"]) {
+describe("basic autoinstall", async () => {
+  for (const install of ["", "-i", "--install=auto", "--install=fallback", "--install=force", "--install=disable"]) {
     for (const has_node_modules of [true, false]) {
       let should_install = false;
       if (has_node_modules) {
-        if (install === "" || install === "--install=auto") {
+        if (install === "" || install === "--install=auto" || install === "--install=disable") {
           should_install = false;
         } else {
           should_install = true;
         }
       } else {
-        should_install = true;
+        if (install === "--install=disable") {
+          should_install = false;
+        } else {
+          should_install = true;
+        }
+      }
+
+      const dir = tmpdirSync();
+      mkdirSync(dir, { recursive: true });
+      await Bun.write(
+        join(dir, "index.js"),
+        "import isEven from 'is-even'; console.log(isEven(2)); console.log((await import('is-odd')).default(2));",
+      );
+
+      if (has_node_modules) {
+        mkdirSync(join(dir, "node_modules/abc"), { recursive: true });
       }
 
       test(`${install || "<no flag>"} ${has_node_modules ? "with" : "without"} node_modules ${should_install ? "should" : "should not"} autoinstall`, async () => {
-        const dir = tmpdirSync();
-        mkdirSync(dir, { recursive: true });
-        await Bun.write(join(dir, "index.js"), "import isEven from 'is-even'; console.log(isEven(2));");
-        const env = bunEnv;
-        env.BUN_INSTALL = install;
-        if (has_node_modules) {
-          mkdirSync(join(dir, "node_modules/abc"), { recursive: true });
-        }
         const { stdout, stderr } = Bun.spawnSync({
           cmd: [bunExe(), ...(install === "" ? [] : [install]), join(dir, "index.js")],
           cwd: dir,
-          env,
+          env: bunEnv,
           stdout: "pipe",
           stderr: "pipe",
         });
 
         if (should_install) {
           expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'is-even'");
-          expect(stdout?.toString("utf8")).toBe("true\n");
+          expect(stdout?.toString("utf8")).toBe("true\nfalse\n");
         } else {
           expect(stderr?.toString("utf8")).toContain("error: Cannot find package 'is-even'");
         }
@@ -48,39 +55,152 @@ describe("basic autoinstall", () => {
   }
 });
 
-test("--install=fallback to install missing packages", async () => {
+// test that falllback prefers node_modules and force prefers its own cache
+// https://bun.sh/docs/runtime/autoimport#version-specifiers
+describe("autoinstall fallback and force", () => {
+  for (const install of ["--install=fallback", "--install=force"]) {
+    test(`${install} to install missing packages`, async () => {
+      const dir = tmpdirSync();
+      mkdirSync(dir, { recursive: true });
+      await Promise.all([
+        Bun.write(
+          join(dir, "index.js"),
+          "import {version as cowsayVersion} from 'cowsay/package.json'; import isOdd from 'is-odd'; console.log(cowsayVersion, isOdd(2));",
+        ),
+        Bun.write(
+          join(dir, "package.json"),
+          JSON.stringify({
+            name: "test",
+            dependencies: {
+              "cowsay": "1.5.0", // latest is >=1.6.0
+            },
+          }),
+        ),
+      ]);
+
+      Bun.spawnSync({
+        cmd: [bunExe(), "install"],
+        cwd: dir,
+        env: bunEnv,
+      });
+
+      const { stdout, stderr } = Bun.spawnSync({
+        cmd: [bunExe(), install, join(dir, "index.js")],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      if (install === "--install=fallback") {
+        expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'is-odd'");
+        expect(stdout?.toString("utf8")).toBe("1.5.0 false\n");
+      } else {
+        // latest should be >1.6.0
+        expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'is-odd'");
+        expect(stdout?.toString("utf8")).not.toBe("1.5.0 false\n");
+        expect(stdout?.toString("utf8")).toEndWith("false\n");
+      }
+    });
+  }
+});
+
+// test that version specifiers are respected
+test("version specifiers are respected", async () => {
   const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });
-  await Promise.all([
-    Bun.write(
-      join(dir, "index.js"),
-      "import isEven from 'is-even'; import isOdd from 'is-odd'; console.log(isEven(2), isOdd(2));",
-    ),
-    Bun.write(
-      join(dir, "package.json"),
-      JSON.stringify({
-        name: "test",
-        dependencies: {
-          "is-odd": "1.0.0",
-        },
-      }),
-    ),
-  ]);
+  await Bun.write(
+    join(dir, "index.js"),
+    `
+import { version as version1 } from "cowsay@1.5.0/package.json";
+import { version as version2 } from "cowsay@latest/package.json";
+import { version as version3 } from "cowsay@^1.5.0/package.json";
 
-  Bun.spawnSync({
-    cmd: [bunExe(), "install"],
-    cwd: dir,
-    env: bunEnv,
-  });
+console.log(version1, version2, version3);
+`,
+  );
 
   const { stdout, stderr } = Bun.spawnSync({
-    cmd: [bunExe(), "--install=fallback", join(dir, "index.js")],
+    cmd: [bunExe(), join(dir, "index.js")],
     cwd: dir,
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'is-odd'");
-  expect(stdout?.toString("utf8")).toBe("true false\n");
+  console.log(stderr?.toString("utf8"));
+
+  const [version1, version2, version3] = stdout?.toString("utf8").split(" ");
+
+  expect(version1).toBe("1.5.0");
+  expect(Bun.semver.satisfies(version2, ">=1.6.0")).toBeTrue();
+  expect(Bun.semver.satisfies(version3, ">=1.6.0")).toBeTrue();
+});
+
+// test that version is fetched from package.json or bun.lock
+// https://bun.sh/docs/runtime/autoimport#version-resolution
+
+// ======= currently it doesn't appear to being used,
+// but will still have it here for now =========
+describe.todo("version is fetched from", () => {
+  for (const install of ["package.json", "bun.lock", "bun.lock (with package.json)"]) {
+    // latest `true` is 0.0.4 at time of writing
+    const bunLock = {
+      "lockfileVersion": 1,
+      "workspaces": {
+        "": {
+          "dependencies": {
+            "true": "0.0.3",
+          },
+        },
+      },
+      "packages": {
+        "true": [
+          "true@0.0.3",
+          "",
+          { "bin": { "true": "bin/cli.js" } },
+          "sha512-X8PXKLAGnpaJUMJj9LqE2MNSIgNNDHzYmC8lBU6StSV9SGVHDuViHMZ8tUKDqDXhx3KRlPGAgLbh8lYKpHvBiQ==",
+        ],
+      },
+    };
+    const packageJson = {
+      "dependencies": {
+        "true": "0.0.2",
+      },
+    };
+
+    test(`${install}`, async () => {
+      const dir = tmpdirSync();
+      mkdirSync(dir, { recursive: true });
+
+      if (install === "package.json") {
+        await Bun.write(join(dir, "package.json"), JSON.stringify(packageJson));
+      } else if (install === "bun.lock") {
+        await Bun.write(join(dir, "bun.lockb"), JSON.stringify(bunLock));
+      } else if (install === "bun.lock (with package.json)") {
+        await Bun.write(join(dir, "bun.lockb"), JSON.stringify(bunLock));
+        await Bun.write(join(dir, "package.json"), JSON.stringify(packageJson));
+      }
+
+      await Bun.write(join(dir, "index.js"), "import { version } from 'true/package.json'; console.log(version);");
+
+      const { stdout, stderr } = Bun.spawnSync({
+        cmd: [bunExe(), join(dir, "index.js")],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'true'");
+
+      if (install === "package.json") {
+        expect(stdout?.toString("utf8")).toBe("0.0.2\n");
+      } else if (install === "bun.lock") {
+        expect(stdout?.toString("utf8")).toBe("0.0.3\n");
+      } else if (install === "bun.lock (with package.json)") {
+        expect(stdout?.toString("utf8")).toBe("0.0.3\n");
+      }
+    });
+  }
 });


### PR DESCRIPTION
### What does this PR do?

followup for #19638 to add some more tests for more documented behaviour.

Right now the [getting version from package.json or bun.lock](https://bun.sh/docs/runtime/autoimport#version-resolution) doesn't appear to work, but I still included it with `.todo`.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
