### PR TITLE
fix `test-set-process-debug-port.js`

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3310,7 +3310,7 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     return object;
 }
 
-static int32_t debugPort;
+static uint16_t debugPort;
 
 JSC_DEFINE_CUSTOM_GETTER(processDebugPort, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3310,15 +3310,11 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     return object;
 }
 
-static int _debugPort;
+static int32_t debugPort;
 
 JSC_DEFINE_CUSTOM_GETTER(processDebugPort, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
-    if (_debugPort == 0) {
-        _debugPort = 9229;
-    }
-
-    return JSC::JSValue::encode(jsNumber(_debugPort));
+    return JSC::JSValue::encode(jsNumber(debugPort));
 }
 
 JSC_DEFINE_CUSTOM_SETTER(setProcessDebugPort, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName))
@@ -3327,21 +3323,19 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessDebugPort, (JSC::JSGlobalObject * globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue value = JSValue::decode(encodedValue);
 
-    if (!value.isInt32AsAnyInt()) {
-        throwNodeRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
+    double port = value.toNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (std::isnan(port) || std::isinf(port)) {
+        port = 0;
+    }
+
+    if ((port != 0 && port < 1024) || port > 65535) {
+        throwNodeRangeError(globalObject, scope, "process.debugPort must be 0 or in range 1024 to 65535"_s);
         return false;
     }
 
-    int port = value.toInt32(globalObject);
-
-    if (port != 0) {
-        if (port < 1024 || port > 65535) {
-            throwNodeRangeError(globalObject, scope, "debugPort must be 0 or in range 1024 to 65535"_s);
-            return false;
-        }
-    }
-
-    _debugPort = port;
+    debugPort = floor(port);
     return true;
 }
 

--- a/test/js/node/test/parallel/test-set-process-debug-port.js
+++ b/test/js/node/test/parallel/test-set-process-debug-port.js
@@ -1,0 +1,64 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('This test only works on a main thread');
+}
+
+const assert = require('assert');
+const kMinPort = 1024;
+const kMaxPort = 65535;
+
+function check(value, expected) {
+  process.debugPort = value;
+  assert.strictEqual(process.debugPort, expected);
+}
+
+// Expected usage with numbers.
+check(0, 0);
+check(kMinPort, kMinPort);
+check(kMinPort + 1, kMinPort + 1);
+check(kMaxPort - 1, kMaxPort - 1);
+check(kMaxPort, kMaxPort);
+
+// Numeric strings coerce.
+check('0', 0);
+check(`${kMinPort}`, kMinPort);
+check(`${kMinPort + 1}`, kMinPort + 1);
+check(`${kMaxPort - 1}`, kMaxPort - 1);
+check(`${kMaxPort}`, kMaxPort);
+
+// Most other values are coerced to 0.
+check('', 0);
+check(false, 0);
+check(NaN, 0);
+check(Infinity, 0);
+check(-Infinity, 0);
+check(function() {}, 0);
+check({}, 0);
+check([], 0);
+
+// Symbols do not coerce.
+assert.throws(() => {
+  process.debugPort = Symbol();
+}, /^TypeError: Cannot convert a symbol to a number$/);
+
+// Verify port bounds checking.
+[
+  true,
+  -1,
+  1,
+  kMinPort - 1,
+  kMaxPort + 1,
+  '-1',
+  '1',
+  `${kMinPort - 1}`,
+  `${kMaxPort + 1}`,
+].forEach((value) => {
+  assert.throws(() => {
+    process.debugPort = value;
+  }, /^RangeError: process\.debugPort must be 0 or in range 1024 to 65535$/);
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
