### PR TITLE
Fix parse segfault

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -7018,7 +7018,7 @@ fn NewParser_(
                     }
 
                     if (p.scopes_in_order.items[last_i]) |prev_scope| {
-                        if (prev_scope.loc.start >= loc.start) {
+                        if (prev_scope.loc.start >= loc.start and p.lexer.token != .t_end_of_file) {
                             p.log.level = .verbose;
                             p.log.addDebugFmt(p.source, prev_scope.loc, p.allocator, "Previous Scope", .{}) catch bun.outOfMemory();
                             p.log.addDebugFmt(p.source, loc, p.allocator, "Next Scope", .{}) catch bun.outOfMemory();

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -7018,7 +7018,7 @@ fn NewParser_(
                     }
 
                     if (p.scopes_in_order.items[last_i]) |prev_scope| {
-                        if (prev_scope.loc.start >= loc.start and p.lexer.token != .t_end_of_file) {
+                        if (prev_scope.loc.start >= loc.start) {
                             p.log.level = .verbose;
                             p.log.addDebugFmt(p.source, prev_scope.loc, p.allocator, "Previous Scope", .{}) catch bun.outOfMemory();
                             p.log.addDebugFmt(p.source, loc, p.allocator, "Next Scope", .{}) catch bun.outOfMemory();


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

Fixes [#18888](https://github.com/oven-sh/bun/issues/18888)

#### Bug Description

The parser creates a new scope (`s1`) after encountering the `function` keyword to handle parsing of function arguments. It then creates another nested scope (`s2`) when parsing the function's body.

A segmentation fault occurs when `s1`'s start location is **greater than or equal** to the lexer's current position at the time `s2` is created.

- **Case 1**: "function a:" => no seg-fault
- **Case 2**: "function a" => seg-fault
- **Case 3**: "function:" = seg-fault

When `s1` is created, its start location is where the parser expects a left parenthesis.

When `s2` is created, its start location is where the parser expects the function body (typically after the `{`)

In **Case 1**, when `s2` is created, `s1` start location is where the parser expects a right parenthesis (but meets a ':' token) and `s2` start location is at the end-of-file token. This `s2` start location is beyond the `s1` start location, so the [positional scope check](https://github.com/oven-sh/bun/blob/adab0f64f97c9240026df715006b7a0c42658069/src/js_parser.zig#L7022) passes and there's no seg-fault.

In **Cases 2 and 3** however, when `s2` is created, both `s1` and `s2` are initialized at the same position (EOF). `s1` start location is where the parser expects a right parenthesis (but meets an end-of-file token) and `s2` start location holds same (no tokens follow an EOF). This violates the invariant that later scopes must begin strictly _after_ earlier ones, failing the [positional scope check](https://github.com/oven-sh/bun/blob/adab0f64f97c9240026df715006b7a0c42658069/src/js_parser.zig#L7022) and causing a seg fault.

#### Bug Fix

A new scope must start a lexically later position than any previous one. However, when both scopes are initialized at **end-of-file**, it is an ambiguous edge case that should be better handled. The fix adds an extra condition: If the parser is at EOF, there are no further tokens, so scope hierarchy can be ignored in parsing malformed user input. It's a one line change!

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed: -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [x] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
