### PR TITLE
Implement Worker.getHeapSnapshot

### DIFF
--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -251,6 +251,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_VM_MODULE_LINK_FAILURE", Error],
   ["ERR_WASI_NOT_STARTED", Error],
   ["ERR_WORKER_INIT_FAILED", Error],
+  ["ERR_WORKER_NOT_RUNNING", Error],
   ["ERR_ZLIB_INITIALIZATION_FAILED", Error],
   ["MODULE_NOT_FOUND", Error],
   ["ERR_INTERNAL_ASSERTION", Error],

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -312,6 +312,11 @@ bool Worker::isClosingOrTerminated() const
     return m_onlineClosingFlags & ClosingFlag;
 }
 
+bool Worker::isOnline() const
+{
+    return m_onlineClosingFlags & OnlineFlag;
+}
+
 void Worker::dispatchEvent(Event& event)
 {
     if (!m_terminationFlags)

--- a/src/bun.js/bindings/webcore/Worker.h
+++ b/src/bun.js/bindings/webcore/Worker.h
@@ -67,6 +67,7 @@ public:
     bool wasTerminated() const;
     bool hasPendingActivity() const;
     bool isClosingOrTerminated() const;
+    bool isOnline() const;
     bool updatePtr();
 
     String identifier() const { return m_identifier; }

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -4,6 +4,7 @@ declare const self: typeof globalThis;
 type WebWorker = InstanceType<typeof globalThis.Worker>;
 
 const EventEmitter = require("node:events");
+const { Readable } = require("node:stream");
 const { throwNotImplemented, warnNotImplementedOnce } = require("internal/shared");
 const { validateObject, validateBoolean } = require("internal/validators");
 
@@ -233,7 +234,6 @@ class Worker extends EventEmitter {
   // either is the exit code if exited, a promise resolving to the exit code, or undefined if we haven't sent .terminate() yet
   #onExitPromise: Promise<number> | number | undefined = undefined;
   #urlToRevoke = "";
-  #isRunning = false;
 
   constructor(filename: string, options: NodeWorkerOptions = {}) {
     super();
@@ -321,7 +321,6 @@ class Worker extends EventEmitter {
   }
 
   terminate(callback: unknown) {
-    this.#isRunning = false;
     if (typeof callback === "function") {
       process.emitWarning(
         "Passing a callback to worker.terminate() is deprecated. It returns a Promise instead.",
@@ -353,14 +352,17 @@ class Worker extends EventEmitter {
     return this.#worker.postMessage.$apply(this.#worker, args);
   }
 
+  getHeapSnapshot(options: unknown) {
+    const stringPromise = this.#worker.getHeapSnapshot(options);
+    return stringPromise.then(s => new HeapSnapshotStream(s));
+  }
+
   #onClose(e) {
-    this.#isRunning = false;
     this.#onExitPromise = e.code;
     this.emit("exit", e.code);
   }
 
   #onError(event: ErrorEvent) {
-    this.#isRunning = false;
     let error = event?.error;
     // if the thrown value serialized successfully, the message will be empty
     // if not the message is the actual error
@@ -385,23 +387,24 @@ class Worker extends EventEmitter {
   }
 
   #onOpen() {
-    this.#isRunning = true;
     this.emit("online");
   }
+}
 
-  getHeapSnapshot(options: any) {
-    if (options !== undefined) {
-      // These errors must be thrown synchronously.
-      validateObject(options, "options");
-      validateBoolean(options.exposeInternals, "options.exposeInternals");
-      validateBoolean(options.exposeNumericValues, "options.exposeNumericValues");
+class HeapSnapshotStream extends Readable {
+  #json: string | undefined;
+
+  constructor(json: string) {
+    super();
+    this.#json = json;
+  }
+
+  _read() {
+    if (this.#json !== undefined) {
+      this.push(this.#json);
+      this.push(null);
+      this.#json = undefined;
     }
-    if (!this.#isRunning) {
-      const err = new Error("Worker instance not running");
-      err.code = "ERR_WORKER_NOT_RUNNING";
-      return Promise.$reject(err);
-    }
-    throwNotImplemented("worker_threads.Worker.getHeapSnapshot");
   }
 }
 

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -6,7 +6,6 @@ type WebWorker = InstanceType<typeof globalThis.Worker>;
 const EventEmitter = require("node:events");
 const { Readable } = require("node:stream");
 const { throwNotImplemented, warnNotImplementedOnce } = require("internal/shared");
-const { validateObject, validateBoolean } = require("internal/validators");
 
 const {
   MessageChannel,

--- a/test/js/node/test/parallel/test-worker-heap-snapshot.js
+++ b/test/js/node/test/parallel/test-worker-heap-snapshot.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const { once } = require('events');
+
+// Ensure that worker.getHeapSnapshot() returns a valid JSON
+(async () => {
+  const worker = new Worker('setInterval(() => {}, 1000);', { eval: true });
+  await once(worker, 'online');
+  const stream = await worker.getHeapSnapshot();
+  assert.ok(JSON.parse(stream.read()));
+
+  await worker.terminate();
+})().then(common.mustCall());

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -423,7 +423,7 @@ describe("error event", () => {
   });
 });
 
-describe.only("getHeapSnapshot", () => {
+describe("getHeapSnapshot", () => {
   test("throws if the wrong options are passed", () => {
     const worker = new Worker("", { eval: true });
     // @ts-expect-error

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2,6 +2,7 @@ import { bunEnv, bunExe } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
+import { Readable } from "node:stream";
 import wt, {
   BroadcastChannel,
   getEnvironmentData,
@@ -19,7 +20,6 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
-import { Readable } from "node:stream";
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {


### PR DESCRIPTION
### What does this PR do?

Implements the `getHeapSnapshot` function from `node:worker_threads`.

- It validates the same options as Node.js (`exposeInternals` and `exposeNumericValues`) but doesn't do anything with them yet
- It always returns the snapshot in V8 format (alternatively we could add an option for JSC format)
- For `globalThis.Worker`, `getHeapSnapshot` returns a Promise resolving to a string of JSON data. For `worker_threads.Worker`, it returns a Promise resolving to a `stream.Readable` of JSON data.

### How did you verify your code works?

Node test + new Bun test