### PR TITLE
fix constant folding bug

### DIFF
--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -2489,6 +2489,7 @@ pub const E = struct {
         }
 
         pub fn eqlComptime(s: *const String, comptime value: []const u8) bool {
+            bun.assert(s.next == null);
             return if (s.isUTF8())
                 strings.eqlComptime(s.data, value)
             else

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6209,6 +6209,7 @@ pub const Expr = struct {
                         },
                         .e_number => |r| {
                             if (comptime kind == .loose) {
+                                l.resolveRopeIfNeeded(p.allocator);
                                 if (r.value == 0 and (l.isBlank() or l.eqlComptime("0"))) {
                                     return Equality.true;
                                 }

--- a/test/bundler/transpiler_constant_fold_eqeq.test.ts
+++ b/test/bundler/transpiler_constant_fold_eqeq.test.ts
@@ -1,0 +1,4 @@
+test("constant fold ==", () => {
+  // @ts-expect-error
+  expect("0" + "1" == 0).toBe(false);
+});


### PR DESCRIPTION
`"0" + "1" == 0` was true instead of false because it didn't resolve the rope before calling eqlComptime which requires the string to have a resolved rope