### PR TITLE
Use JSC's fancy math functions

### DIFF
--- a/src/bun.js/jsc.zig
+++ b/src/bun.js/jsc.zig
@@ -337,7 +337,7 @@ pub const generic = struct {
 };
 
 pub fn toInt32(f: f64) i32 {
-    if (bun.Environment.isAarch64) {
+    if (bun.Environment.isAarch64 and bun.Environment.isMac) {
         const arm = aarch64.toInt32(f);
         if (bun.Environment.isDebug) {
             bun.debugAssert(arm == generic.toInt32(f));
@@ -349,7 +349,7 @@ pub fn toInt32(f: f64) i32 {
 }
 
 pub fn jsMaxDouble(lhs: f64, rhs: f64) f64 {
-    if (bun.Environment.isAarch64) {
+    if (bun.Environment.isAarch64 and bun.Environment.isMac) {
         const arm = aarch64.jsMaxDouble(lhs, rhs);
         if (bun.Environment.isDebug) {
             bun.debugAssert(arm == generic.jsMaxDouble(lhs, rhs));
@@ -361,7 +361,7 @@ pub fn jsMaxDouble(lhs: f64, rhs: f64) f64 {
 }
 
 pub fn jsMinDouble(lhs: f64, rhs: f64) f64 {
-    if (bun.Environment.isAarch64) {
+    if (bun.Environment.isAarch64 and bun.Environment.isMac) {
         const arm = aarch64.jsMinDouble(lhs, rhs);
         if (bun.Environment.isDebug) {
             bun.debugAssert(arm == generic.jsMinDouble(lhs, rhs));

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -24814,13 +24814,4 @@ pub const ConvertESMExportsForHmr = struct {
     }
 };
 
-/// Equivalent of esbuild's js_ast_helpers.ToInt32
-fn floatToInt32(f: f64) i32 {
-    // Special-case non-finite numbers
-    if (!std.math.isFinite(f))
-        return 0;
-
-    const uint: u32 = @intFromFloat(@mod(@abs(f), std.math.maxInt(u32) + 1));
-    const int: i32 = @bitCast(uint);
-    return if (f < 0) @as(i32, 0) -% int else int;
-}
+const floatToInt32 = bun.JSC.toInt32;


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
