### PR TITLE
Fix chunked decoder buffer handling

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -4165,21 +4165,23 @@ fn handleResponseBodyChunkedEncodingFromMultiplePackets(
     var decoder = &this.state.chunked_decoder;
     const buffer_ptr = this.state.getBodyBuffer();
     var buffer = buffer_ptr.*;
+    const prev_len = buffer.list.items.len;
     try buffer.appendSlice(incoming_data);
 
     // set consume_trailer to 1 to discard the trailing header
     // using content-encoding per chunk is not supported
     decoder.consume_trailer = 1;
 
-    var bytes_decoded = incoming_data.len;
+    var buf_len = buffer.list.items.len;
     // phr_decode_chunked mutates in-place
     const pret = picohttp.phr_decode_chunked(
         decoder,
-        buffer.list.items.ptr + (buffer.list.items.len -| incoming_data.len),
-        &bytes_decoded,
+        buffer.list.items.ptr,
+        &buf_len,
     );
-    buffer.list.items.len -|= incoming_data.len - bytes_decoded;
-    this.state.total_body_received += bytes_decoded;
+    const consumed = buf_len - prev_len;
+    this.state.total_body_received += consumed;
+    buffer.list.items.len = buf_len;
 
     buffer_ptr.* = buffer;
 
@@ -4249,15 +4251,16 @@ fn handleResponseBodyChunkedEncodingFromSinglePacket(
         @memcpy(buffer[0..incoming_data.len], incoming_data);
     }
 
-    var bytes_decoded = incoming_data.len;
+    var buf_len = buffer.len;
     // phr_decode_chunked mutates in-place
     const pret = picohttp.phr_decode_chunked(
         decoder,
-        buffer.ptr + (buffer.len -| incoming_data.len),
-        &bytes_decoded,
+        buffer.ptr,
+        &buf_len,
     );
-    buffer.len -|= incoming_data.len - bytes_decoded;
-    this.state.total_body_received += bytes_decoded;
+    const consumed = buf_len;
+    this.state.total_body_received += consumed;
+    buffer.len = buf_len;
 
     switch (pret) {
         // Invalid HTTP response body

--- a/test/js/web/fetch/chunked-trailing.test.ts
+++ b/test/js/web/fetch/chunked-trailing.test.ts
@@ -1,0 +1,31 @@
+import { it, expect } from "bun:test";
+
+it("handles trailing headers split across packets", async () => {
+  const server = await Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("7\r\n, world\r\n");
+        socket.write("0\r\n");
+        socket.flush();
+        setTimeout(() => {
+          socket.write("X-Trail: ok\r\n\r\n");
+          socket.end();
+        }, 10).unref();
+      },
+      data() {},
+      close() {},
+    },
+  });
+
+  const res = await fetch(`http://${server.hostname}:${server.port}`);
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("Hello, world");
+  server.stop(true);
+});

--- a/test/js/web/fetch/chunked-trailing.test.ts
+++ b/test/js/web/fetch/chunked-trailing.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from "bun:test";
+import { expect, it } from "bun:test";
 
 it("handles trailing headers split across packets", async () => {
   const server = await Bun.listen({


### PR DESCRIPTION
## Summary
- update chunked decoding logic for HTTP responses
- add regression test covering split trailing headers

## Testing
- `bun agent test test/js/web/fetch/chunked-trailing.test.ts` *(fails: file RENAME failed to rename /workspace/bun/build/debug/cache/bun-webkit)*