### PR TITLE
[bun install] Do not prefetch dns for npm registry if proxy 

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -176,6 +176,10 @@ pub const Loader = struct {
         return this.getHttpProxy(url.isHTTP(), url.hostname);
     }
 
+    pub fn hasHTTPProxy(this: *const Loader) bool {
+        return this.has("http_proxy") or this.has("HTTP_PROXY") or this.has("https_proxy") or this.has("HTTPS_PROXY");
+    }
+
     pub fn getHttpProxy(this: *Loader, is_http: bool, hostname: ?[]const u8) ?URL {
         // TODO: When Web Worker support is added, make sure to intern these strings
         var http_proxy: ?URL = null;

--- a/src/url.zig
+++ b/src/url.zig
@@ -153,6 +153,10 @@ pub const URL = struct {
         return if (this.isHTTPS()) @as(u16, 443) else @as(u16, 80);
     }
 
+    pub fn isIPAddress(this: *const URL) bool {
+        return bun.strings.isIPAddress(this.hostname);
+    }
+
     pub fn hasValidPort(this: *const URL) bool {
         return (this.getPort() orelse 0) > 0;
     }


### PR DESCRIPTION

### What does this PR do?

We shouldn't prefetch DNS that we will never actually use


### How did you verify your code works?

Checked strace