### PR TITLE
[bun install] Fix race condition when error occurs while extracting tarballs

### DIFF
--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -32,20 +32,20 @@ integrity: Integrity = .{},
 url: strings.StringOrTinyString,
 package_manager: *PackageManager,
 
-pub inline fn run(this: *const ExtractTarball, bytes: []const u8) !Install.ExtractData {
+pub inline fn run(this: *const ExtractTarball, log: *logger.Log, bytes: []const u8) !Install.ExtractData {
     if (!this.skip_verify and this.integrity.tag.isSupported()) {
         if (!this.integrity.verify(bytes)) {
-            this.package_manager.log.addErrorFmt(
+            log.addErrorFmt(
                 null,
                 logger.Loc.Empty,
-                this.package_manager.allocator,
+                bun.default_allocator,
                 "Integrity check failed<r> for tarball: {s}",
                 .{this.name.slice()},
             ) catch unreachable;
             return error.IntegrityCheckFailed;
         }
     }
-    return this.extract(bytes);
+    return this.extract(log, bytes);
 }
 
 pub fn buildURL(
@@ -127,7 +127,7 @@ threadlocal var final_path_buf: bun.PathBuffer = undefined;
 threadlocal var folder_name_buf: bun.PathBuffer = undefined;
 threadlocal var json_path_buf: bun.PathBuffer = undefined;
 
-fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractData {
+fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8) !Install.ExtractData {
     const tracer = bun.perf.trace("ExtractTarball.extract");
     defer tracer.end();
 
@@ -161,10 +161,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     const tmpname = try FileSystem.instance.tmpname(basename[0..@min(basename.len, 32)], std.mem.asBytes(&tmpname_buf), bun.fastRandom());
     {
         var extract_destination = bun.MakePath.makeOpenPath(tmpdir, bun.span(tmpname), .{}) catch |err| {
-            this.package_manager.log.addErrorFmt(
+            log.addErrorFmt(
                 null,
                 logger.Loc.Empty,
-                this.package_manager.allocator,
+                bun.default_allocator,
                 "{s} when create temporary directory named \"{s}\" (while extracting \"{s}\")",
                 .{ @errorName(err), tmpname, name },
             ) catch unreachable;
@@ -220,10 +220,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
             zlib_pool.data.list.clearRetainingCapacity();
             var zlib_entry = try Zlib.ZlibReaderArrayList.init(tgz_bytes, &zlib_pool.data.list, default_allocator);
             zlib_entry.readAll() catch |err| {
-                this.package_manager.log.addErrorFmt(
+                log.addErrorFmt(
                     null,
                     logger.Loc.Empty,
-                    this.package_manager.allocator,
+                    bun.default_allocator,
                     "{s} decompressing \"{s}\" to \"{}\"",
                     .{ @errorName(err), name, bun.fmt.fmtPath(u8, std.mem.span(tmpname), .{}) },
                 ) catch unreachable;
@@ -251,7 +251,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                 var dirname_reader = DirnameReader{ .outdirname = &resolved };
 
                 switch (PackageManager.verbose_install) {
-                    inline else => |log| _ = try Archiver.extractToDir(
+                    inline else => |verbose_log| _ = try Archiver.extractToDir(
                         zlib_pool.data.list.items,
                         extract_destination,
                         null,
@@ -260,7 +260,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                         .{
                             // for GitHub tarballs, the root dir is always <user>-<repo>-<commit_id>
                             .depth_to_skip = 1,
-                            .log = log,
+                            .log = verbose_log,
                         },
                     ),
                 }
@@ -277,14 +277,14 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                 }
             },
             else => switch (PackageManager.verbose_install) {
-                inline else => |log| _ = try Archiver.extractToDir(
+                inline else => |verbose_log| _ = try Archiver.extractToDir(
                     zlib_pool.data.list.items,
                     extract_destination,
                     null,
                     void,
                     {},
                     .{
-                        .log = log,
+                        .log = verbose_log,
                         // packages usually have root directory `package/`, and scoped packages usually have root `<scopename>/`
                         // https://github.com/npm/cli/blob/93883bb6459208a916584cad8c6c72a315cf32af/node_modules/pacote/lib/fetcher.js#L442
                         .depth_to_skip = 1,
@@ -334,10 +334,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                 .read_only = true,
             }).unwrap() catch |err| {
                 // i guess we just
-                this.package_manager.log.addErrorFmt(
+                log.addErrorFmt(
                     null,
                     logger.Loc.Empty,
-                    this.package_manager.allocator,
+                    bun.default_allocator,
                     "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
                     .{ name, err, tmpname, folder_name },
                 ) catch unreachable;
@@ -383,10 +383,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                         }
                     }
                     dir_to_move.close();
-                    this.package_manager.log.addErrorFmt(
+                    log.addErrorFmt(
                         null,
                         logger.Loc.Empty,
-                        this.package_manager.allocator,
+                        bun.default_allocator,
                         "moving \"{s}\" to cache dir failed\n{}\n  From: {s}\n    To: {s}",
                         .{ name, err, tmpname, folder_name },
                     ) catch unreachable;
@@ -423,10 +423,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
             folder_name,
             .{ .move_fallback = true },
         ).asErr()) |err| {
-            this.package_manager.log.addErrorFmt(
+            log.addErrorFmt(
                 null,
                 logger.Loc.Empty,
-                this.package_manager.allocator,
+                bun.default_allocator,
                 "moving \"{s}\" to cache dir failed: {}\n  From: {s}\n    To: {s}",
                 .{ name, err, tmpname, folder_name },
             ) catch unreachable;
@@ -437,10 +437,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     // We return a resolved absolute absolute file path to the cache dir.
     // To get that directory, we open the directory again.
     var final_dir = bun.openDir(cache_dir, folder_name) catch |err| {
-        this.package_manager.log.addErrorFmt(
+        log.addErrorFmt(
             null,
             logger.Loc.Empty,
-            this.package_manager.allocator,
+            bun.default_allocator,
             "failed to verify cache dir for \"{s}\": {s}",
             .{ name, @errorName(err) },
         ) catch unreachable;
@@ -452,10 +452,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
         .fromStdDir(final_dir),
         &final_path_buf,
     ) catch |err| {
-        this.package_manager.log.addErrorFmt(
+        log.addErrorFmt(
             null,
             logger.Loc.Empty,
-            this.package_manager.allocator,
+            bun.default_allocator,
             "failed to resolve cache dir for \"{s}\": {s}",
             .{ name, @errorName(err) },
         ) catch unreachable;
@@ -474,7 +474,7 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
     }) {
         const json_file, json_buf = bun.sys.File.readFileFrom(
             bun.FD.fromStdDir(cache_dir),
-            bun.path.joinZ(&[_]string{ folder_name, "package.json" }, .auto),
+            bun.path.joinZBuf(&json_path_buf, &[_]string{ folder_name, "package.json" }, .auto),
             bun.default_allocator,
         ).unwrap() catch |err| {
             if (this.resolution.tag == .github and err == error.ENOENT) {
@@ -485,10 +485,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
                 };
             }
 
-            this.package_manager.log.addErrorFmt(
+            log.addErrorFmt(
                 null,
                 logger.Loc.Empty,
-                this.package_manager.allocator,
+                bun.default_allocator,
                 "\"package.json\" for \"{s}\" failed to open: {s}",
                 .{ name, @errorName(err) },
             ) catch unreachable;
@@ -498,10 +498,10 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
         json_path = json_file.getPath(
             &json_path_buf,
         ).unwrap() catch |err| {
-            this.package_manager.log.addErrorFmt(
+            log.addErrorFmt(
                 null,
                 logger.Loc.Empty,
-                this.package_manager.allocator,
+                bun.default_allocator,
                 "\"package.json\" for \"{s}\" failed to resolve: {s}",
                 .{ name, @errorName(err) },
             ) catch unreachable;
@@ -509,37 +509,39 @@ fn extract(this: *const ExtractTarball, tgz_bytes: []const u8) !Install.ExtractD
         };
     }
 
-    // create an index storing each version of a package installed
-    if (strings.indexOfChar(basename, '/') == null) create_index: {
-        const dest_name = switch (this.resolution.tag) {
-            .github => folder_name["@GH@".len..],
-            // trim "name@" from the prefix
-            .npm => folder_name[name.len + 1 ..],
-            else => folder_name,
-        };
-
-        if (comptime Environment.isWindows) {
-            bun.MakePath.makePath(u8, cache_dir, name) catch {
-                break :create_index;
+    if (!bun.getRuntimeFeatureFlag("BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX")) {
+        // create an index storing each version of a package installed
+        if (strings.indexOfChar(basename, '/') == null) create_index: {
+            const dest_name = switch (this.resolution.tag) {
+                .github => folder_name["@GH@".len..],
+                // trim "name@" from the prefix
+                .npm => folder_name[name.len + 1 ..],
+                else => folder_name,
             };
 
-            var dest_buf: bun.PathBuffer = undefined;
-            const dest_path = bun.path.joinAbsStringBufZ(
-                // only set once, should be fine to read not on main thread
-                this.package_manager.cache_directory_path,
-                &dest_buf,
-                &[_]string{ name, dest_name },
-                .windows,
-            );
+            if (comptime Environment.isWindows) {
+                bun.MakePath.makePath(u8, cache_dir, name) catch {
+                    break :create_index;
+                };
 
-            bun.sys.sys_uv.symlinkUV(final_path, dest_path, bun.windows.libuv.UV_FS_SYMLINK_JUNCTION).unwrap() catch {
-                break :create_index;
-            };
-        } else {
-            var index_dir = bun.FD.fromStdDir(bun.MakePath.makeOpenPath(cache_dir, name, .{}) catch break :create_index);
-            defer index_dir.close();
+                var dest_buf: bun.PathBuffer = undefined;
+                const dest_path = bun.path.joinAbsStringBufZ(
+                    // only set once, should be fine to read not on main thread
+                    this.package_manager.cache_directory_path,
+                    &dest_buf,
+                    &[_]string{ name, dest_name },
+                    .windows,
+                );
 
-            bun.sys.symlinkat(final_path, index_dir, dest_name).unwrap() catch break :create_index;
+                bun.sys.sys_uv.symlinkUV(final_path, dest_path, bun.windows.libuv.UV_FS_SYMLINK_JUNCTION).unwrap() catch {
+                    break :create_index;
+                };
+            } else {
+                var index_dir = bun.FD.fromStdDir(bun.MakePath.makeOpenPath(cache_dir, name, .{}) catch break :create_index);
+                defer index_dir.close();
+
+                bun.sys.symlinkat(final_path, index_dir, dest_name).unwrap() catch break :create_index;
+            }
         }
     }
 

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -777,6 +777,7 @@ pub const Task = struct {
                 }
 
                 const result = this.request.extract.tarball.run(
+                    &this.log,
                     bytes,
                 ) catch |err| {
                     bun.handleErrorReturnTrace(err, @errorReturnTrace());
@@ -798,7 +799,7 @@ pub const Task = struct {
                     if (Repository.tryHTTPS(url)) |https| break :brk Repository.download(
                         manager.allocator,
                         this.request.git_clone.env,
-                        manager.log,
+                        &this.log,
                         manager.getCacheDirectory(),
                         this.id,
                         name,
@@ -822,7 +823,7 @@ pub const Task = struct {
                 } orelse if (Repository.trySSH(url)) |ssh| Repository.download(
                     manager.allocator,
                     this.request.git_clone.env,
-                    manager.log,
+                    &this.log,
                     manager.getCacheDirectory(),
                     this.id,
                     name,
@@ -846,7 +847,7 @@ pub const Task = struct {
                 const data = Repository.checkout(
                     manager.allocator,
                     this.request.git_checkout.env,
-                    manager.log,
+                    &this.log,
                     manager.getCacheDirectory(),
                     git_checkout.repo_dir.stdDir(),
                     git_checkout.name.slice(),
@@ -897,6 +898,7 @@ pub const Task = struct {
                     &this.request.local_tarball.tarball,
                     tarball_path,
                     normalize,
+                    &this.log,
                 ) catch |err| {
                     bun.handleErrorReturnTrace(err, @errorReturnTrace());
 
@@ -918,13 +920,14 @@ pub const Task = struct {
         tarball: *const ExtractTarball,
         tarball_path: string,
         normalize: bool,
+        log: *logger.Log,
     ) !ExtractData {
         const bytes = if (normalize)
             try File.readFromUserInput(std.fs.cwd(), tarball_path, allocator).unwrap()
         else
             try File.readFrom(bun.FD.cwd(), tarball_path, allocator).unwrap();
         defer allocator.free(bytes);
-        return tarball.run(bytes);
+        return tarball.run(log, bytes);
     }
 
     pub const Tag = enum(u3) {
@@ -2164,7 +2167,7 @@ pub fn NewPackageInstall(comptime kind: PkgInstallKind) type {
                             const basename = std.fs.path.basename(unintall_task.absolute_path);
 
                             var dir = bun.openDirA(std.fs.cwd(), dirname) catch |err| {
-                                if (comptime Environment.isDebug) {
+                                if (comptime Environment.isDebug or Environment.enable_asan) {
                                     Output.debugWarn("Failed to delete {s}: {s}", .{ unintall_task.absolute_path, @errorName(err) });
                                 }
                                 return;
@@ -2172,7 +2175,7 @@ pub fn NewPackageInstall(comptime kind: PkgInstallKind) type {
                             defer bun.FD.fromStdDir(dir).close();
 
                             dir.deleteTree(basename) catch |err| {
-                                if (comptime Environment.isDebug) {
+                                if (comptime Environment.isDebug or Environment.enable_asan) {
                                     Output.debugWarn("Failed to delete {s} in {s}: {s}", .{ basename, dirname, @errorName(err) });
                                 }
                             };
@@ -6780,6 +6783,10 @@ pub const PackageManager = struct {
 
             if (task.log.msgs.items.len > 0) {
                 try task.log.print(Output.errorWriter());
+                if (task.log.errors > 0) {
+                    manager.any_failed_to_install = true;
+                }
+                task.log.deinit();
             }
 
             switch (task.tag) {


### PR DESCRIPTION
### What does this PR do?

This fixes a race condition when an error occurs while extracting tarballs caused by re-using the package manager's logger.Log while on a different thread.

This also adds `BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX`.

This also makes bun install exit with a non-zero status code when failing to install packages where before we would only do that sometimes. I'm not totally sure if that's the right call.

### How did you verify your code works?

This could use a test. One interesting thing: we now duplicate error messages more consistently. We should remove the duplicate error too.