### PR TITLE
Fix FileHandle kFd sharing

### DIFF
--- a/src/js/internal/fs/FileHandle.ts
+++ b/src/js/internal/fs/FileHandle.ts
@@ -7,7 +7,7 @@ const PromisePrototypeFinally = Promise.prototype.finally;
 const SymbolAsyncDispose = Symbol.asyncDispose;
 const ObjectFreeze = Object.freeze;
 
-const kFd = Symbol("kFd");
+const { kFd } = require("internal/shared");
 const kRefs = Symbol("kRefs");
 const kClosePromise = Symbol("kClosePromise");
 const kCloseResolve = Symbol("kCloseResolve");


### PR DESCRIPTION
## Summary
- share the kFd symbol in FileHandle with the rest of the fs implementation

## Testing
- `bun agent test test/js/node/fs/fs.test.ts` *(fails: CMake Error: file RENAME failed)*