### PR TITLE
Add shell highlight to Bun template literals

### DIFF
--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -83,6 +83,12 @@
           "type": "string",
           "default": "",
           "description": "Custom script to use instead of `bun test`, for example script from `package.json`"
+        },
+        "bun.shellTaggedTemplates.enabled": {
+          "type": "boolean",
+          "scope": "window",
+          "default": true,
+          "description": "Highlight `$` tagged template literals from Bun as shell scripts."
         }
       }
     },
@@ -338,6 +344,19 @@
             "description": "The script to execute"
           }
         }
+      }
+    ],
+    "grammars": [
+      {
+        "scopeName": "bun.inline.shell",
+        "path": "./syntaxes/bun-shell.tmLanguage.json",
+        "language": "shellscript",
+        "injectTo": [
+          "source.ts",
+          "source.tsx",
+          "source.js",
+          "source.jsx"
+        ]
       }
     ]
   },

--- a/packages/bun-vscode/syntaxes/bun-shell.tmLanguage.json
+++ b/packages/bun-vscode/syntaxes/bun-shell.tmLanguage.json
@@ -1,0 +1,33 @@
+{
+  "scopeName": "bun.inline.shell",
+  "injectionSelector": "L:source -comment -string",
+  "patterns": [
+    {
+      "name": "string.template.shell.bun",
+      "begin": "(\\bBun\\.\\$|\\$)\\s*(?=`)",
+      "beginCaptures": {
+        "0": { "name": "entity.name.function.tagged-template.js" }
+      },
+      "end": "(?<=`)",
+      "patterns": [
+        { "include": "#embedded-shell" }
+      ]
+    }
+  ],
+  "repository": {
+    "embedded-shell": {
+      "name": "string.template.js",
+      "contentName": "meta.embedded.block.shell",
+      "begin": "`",
+      "beginCaptures": { "0": { "name": "punctuation.definition.string.template.begin.js" } },
+      "end": "`",
+      "endCaptures": { "0": { "name": "punctuation.definition.string.template.end.js" } },
+      "patterns": [
+        { "include": "source.ts#template-substitution-element" },
+        { "include": "source.ts#string-character-escape" },
+        { "include": "source.shell" },
+        { "match": "." }
+      ]
+    }
+  }
+}

--- a/packages/bun-vscode/syntaxes/bun-shell.tmLanguage.json
+++ b/packages/bun-vscode/syntaxes/bun-shell.tmLanguage.json
@@ -9,9 +9,7 @@
         "0": { "name": "entity.name.function.tagged-template.js" }
       },
       "end": "(?<=`)",
-      "patterns": [
-        { "include": "#embedded-shell" }
-      ]
+      "patterns": [{ "include": "#embedded-shell" }]
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
- add Shell tagged-template grammar for Bun `$` calls
- expose `bun.shellTaggedTemplates.enabled` config option

## Testing
- `bun run build` *(fails: cannot find package 'esbuild')*