### PR TITLE
fix: make CHANGELOG files respect .npmignore settings

### DIFF
--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1066,7 +1066,7 @@ pub const PackCommand = struct {
         if (dir_depth == 1) {
             // first, check files that can never be ignored. project root
             // directory only
-            if (isUnconditionallyIncludedFile(entry_name) or isSpecialFileOrVariant(entry_name, "CHANGELOG")) {
+            if (isUnconditionallyIncludedFile(entry_name)) {
                 return null;
             }
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -931,7 +931,7 @@ describe("files", () => {
     ]);
   });
 
-  test(".npmignore cannot exclude CHANGELOG", async () => {
+  test(".npmignore can exclude CHANGELOG", async () => {
     await Promise.all([
       write(
         join(packageDir, "package.json"),
@@ -949,9 +949,6 @@ describe("files", () => {
     const tarball = readTarball(join(packageDir, "pack-files-changelog-1.1.2.tgz"));
     expect(tarball.entries).toMatchObject([
       { "pathname": "package/package.json" },
-      { "pathname": "package/CHANGELOG" },
-      { "pathname": "package/CHANGELOG.md" },
-      { "pathname": "package/CHANGELOG.txt" },
     ]);
   });
 

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -947,9 +947,7 @@ describe("files", () => {
     ]);
     await pack(packageDir, bunEnv);
     const tarball = readTarball(join(packageDir, "pack-files-changelog-1.1.2.tgz"));
-    expect(tarball.entries).toMatchObject([
-      { "pathname": "package/package.json" },
-    ]);
+    expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }]);
   });
 
   test("'files' field cannot exclude LICENSE", async () => {


### PR DESCRIPTION
CHANGELOG files should obey .npmignore directives like any other file. Previously, CHANGELOG files were being unconditionally included in packages, even when listed in .npmignore, which is inconsistent with npm's behavior.

This change removes the special treatment of CHANGELOG files so they can be properly ignored when listed in .npmignore.

Fixes #18691

Generated with [Claude Code](https://claude.ai/code)