### PR TITLE
Import assert.ok instead of assert in zlib

### DIFF
--- a/src/js/internal/assert/utils.ts
+++ b/src/js/internal/assert/utils.ts
@@ -243,7 +243,7 @@ function getErrMessage(_message: string, _value: unknown, _fn: Function): string
   //   }
 }
 
-export function innerOk(fn, argLen, value, message) {
+function innerOk(fn, argLen, value, message) {
   if (!value) {
     let generatedMessage = false;
 
@@ -270,3 +270,5 @@ export function innerOk(fn, argLen, value, message) {
     throw err;
   }
 }
+
+export default innerOk;

--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -34,7 +34,7 @@ const {
   isWeakMap,
   isAnyArrayBuffer,
 } = require("node:util/types");
-const { innerOk } = require("internal/assert/utils");
+const innerOk = require("internal/assert/utils");
 const { validateFunction } = require("internal/validators");
 
 const ArrayFrom = Array.from;

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -1,6 +1,6 @@
 // Hardcoded module "node:zlib"
 
-const assert = require("node:assert");
+const assert = require("internal/assert/utils");
 const BufferModule = require("node:buffer");
 
 const crc32 = $newZigFunction("node_zlib_binding.zig", "crc32", 1);


### PR DESCRIPTION
### What does this PR do?

Import assert.ok instead of assert in zlib

Slightly less code in zlib to load

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
