### PR TITLE
Fix RuntimeError.from return value

### DIFF
--- a/packages/bun-error/runtime-error.ts
+++ b/packages/bun-error/runtime-error.ts
@@ -42,7 +42,7 @@ export default class RuntimeError {
   original: Error;
   stack: StackFrame[];
 
-  static from(error: Error) {
+  static from(error: Error): RuntimeError {
     const runtime = new RuntimeError();
     runtime.original = error;
     runtime.stack = this.parseStack(error);

--- a/packages/bun-error/runtime-error.ts
+++ b/packages/bun-error/runtime-error.ts
@@ -46,7 +46,7 @@ export default class RuntimeError {
     const runtime = new RuntimeError();
     runtime.original = error;
     runtime.stack = this.parseStack(error);
-    return RuntimeError;
+    return runtime;
   }
 
   /**

--- a/test/js/bun/runtime-error.test.ts
+++ b/test/js/bun/runtime-error.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import RuntimeError from "../../../packages/bun-error/runtime-error";
 
 test("RuntimeError.from returns instance", () => {

--- a/test/js/bun/runtime-error.test.ts
+++ b/test/js/bun/runtime-error.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "bun:test";
+import RuntimeError from "../../../packages/bun-error/runtime-error";
+
+test("RuntimeError.from returns instance", () => {
+  const err = new Error("boom");
+  const runtime = RuntimeError.from(err);
+  expect(runtime.original).toBe(err);
+  expect(Array.isArray(runtime.stack)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- correct RuntimeError.from so it returns an instance instead of the class
- add regression test for RuntimeError.from

## Testing
- `bun agent test test/js/bun/runtime-error.test.ts` *(fails: CMake Error at cmake/tools/SetupWebKit.cmake:97 (file) - No such file or directory)*