### PR TITLE
test-worker-stack-overflow.js + stricter environmentData tests

### DIFF
--- a/test/js/node/test/parallel/test-worker-stack-overflow.js
+++ b/test/js/node/test/parallel/test-worker-stack-overflow.js
@@ -1,0 +1,10 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+const worker = new Worker('function f() { f(); } f();', { eval: true });
+
+worker.on('error', common.expectsError({
+  constructor: RangeError,
+  message: /Maximum call stack size exceeded\.?/
+}));

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -27,7 +27,7 @@ function setEnvironmentDataInScope(key: string, data: wt.Serializable): Disposab
   return {
     [Symbol.dispose]() {
       // delete the key. ignored because @types/node does not think you can pass undefined to setEnvironmentData
-      // @ts-ignore
+      // @ts-expect-error
       setEnvironmentData(key);
     },
   };


### PR DESCRIPTION
### What does this PR do?

- adds test-worker-stack-overflow.js (this is basically fixed since #19509 but it needed a tiny error message adjustment to pass)
- tests putting transferable objects in envrionmentData (it should cause spawning any worker to throw unless you put the value in transferList)

### How did you verify your code works?

New tests + CI for existing ones
