### PR TITLE
Use ARM EC2 instances for build-zig

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -331,16 +331,14 @@ function getZigAgent(platform, options) {
   return getEc2Agent(
     {
       os: "linux",
-      arch: "x64",
+      arch: "aarch64",
       abi: "musl",
       distro: "alpine",
       release: "3.21",
     },
     options,
     {
-      instanceType: "c7i.2xlarge",
-      cpuCount: 4,
-      threadsPerCore: 1,
+      instanceType: "r8g.large",
     },
   );
 }


### PR DESCRIPTION
### What does this PR do?

Switches our build-zig steps from c7i.2xlarge (8 cores, 16 GB RAM, Intel) to r8g.large (2 cores, 16 GB RAM, AWS Graviton4/ARM). This has the following benefits:

- the instances are cheaper, since we only pay for 2 cores (our Zig compile doesn't need more)
- these ARM CPUs compile faster

I compared our previous instance type, this new one, and a memory-optimized AMD EPYC instance (r7a.large). I tested only the Zig build step, in release mode targeting macOS aarch64, and after downloading everything:

```
hyperfine -r 5 -p 'rm -rf /home/alpine/bun/build/release/bun-zig.o /home/alpine/bun/build/release/cache/zig' 'bun run build:release --target bun-zig --toolchain darwin-aarch64'
```

The results so far are:

```
Current Intel instance (c7i.2xlarge):
  Time (mean ± σ):     633.367 s ± 22.359 s    [User: 609.148 s, System: 24.984 s]
  Range (min … max):   612.351 s … 660.673 s    5 runs
Possible AMD instance (r7a.large):
  Time (mean ± σ):     609.691 s ±  1.332 s    [User: 568.475 s, System: 40.134 s]
  Range (min … max):   608.037 s … 611.330 s    5 runs
Proposed ARM instance (r8g.large):
  Time (mean ± σ):     583.926 s ±  9.222 s    [User: 556.664 s, System: 27.720 s]
  Range (min … max):   579.348 s … 600.393 s    5 runs
```

Before merging this I want to make sure our x86 builds perform the same way.

### How did you verify your code works?

Benchmarks + I will see if CI works on this PR.
