### PR TITLE
Dockerfile distroless setup

### DIFF
--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -1,84 +1,55 @@
-FROM debian:bookworm-slim AS build
+FROM debian:bullseye-slim AS build
 
-# https://github.com/oven-sh/bun/releases
-ARG BUN_VERSION=latest
+ARG  BUN_VERSION=latest
 
-RUN apt-get update -qq \
-    && apt-get install -qq --no-install-recommends \
-      ca-certificates \
-      curl \
-      dirmngr \
-      gpg \
-      gpg-agent \
-      unzip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && arch="$(dpkg --print-architecture)" \
-    && case "${arch##*-}" in \
-      amd64) build="x64-baseline";; \
-      arm64) build="aarch64";; \
-      *) echo "error: unsupported architecture: $arch"; exit 1 ;; \
-    esac \
-    && version="$BUN_VERSION" \
-    && case "$version" in \
-      latest | canary | bun-v*) tag="$version"; ;; \
-      v*)                       tag="bun-$version"; ;; \
-      *)                        tag="bun-v$version"; ;; \
-    esac \
-    && case "$tag" in \
-      latest) release="latest/download"; ;; \
-      *)      release="download/$tag"; ;; \
-    esac \
-    && curl "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" \
-      -fsSLO \
-      --compressed \
-      --retry 5 \
-      || (echo "error: failed to download: $tag" && exit 1) \
-    && for key in \
-      "F3DCC08A8572C0749B3E18888EAB4D40A7B22B59" \
-    ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" \
-      || gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-    done \
-    && curl "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" \
-      -fsSLO \
-      --compressed \
-      --retry 5 \
-    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-      || (echo "error: failed to verify: $tag" && exit 1) \
-    && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
-      || (echo "error: failed to verify: $tag" && exit 1) \
-    && unzip "bun-linux-$build.zip" \
-    && mv "bun-linux-$build/bun" /usr/local/bin/bun \
-    && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
-    && chmod +x /usr/local/bin/bun \
-    && which bun \
-    && bun --version
+RUN apt-get update -qq && \
+    apt-get install -qq --no-install-recommends \
+        ca-certificates curl dirmngr gpg gpg-agent unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "${arch##*-}" in \
+        amd64) build="x64-baseline" ;; \
+        arm64) build="aarch64" ;; \
+        *) echo "Unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    tag="$BUN_VERSION"; \
+    case "$tag" in \
+        latest | canary | bun-v*) ;; \
+        v*)  tag="bun-$tag" ;; \
+        *)   tag="bun-v$tag" ;; \
+    esac; \
+    release="download/$tag"; \
+    [ "$tag" = "latest" ] && release="latest/download"; \
+    curl -fsSLo bun.zip \
+         "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" \
+         --retry 5 --compressed; \
+    curl -fsSLo SHASUMS256.txt.asc \
+         "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" \
+         --retry 5 --compressed; \
+    gpg --batch --keyserver hkps://keys.openpgp.org \
+        --recv-keys F3DCC08A8572C0749B3E18888EAB4D40A7B22B59 || \
+    gpg --batch --keyserver keyserver.ubuntu.com \
+        --recv-keys F3DCC08A8572C0749B3E18888EAB4D40A7B22B59; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc; \
+    grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c -; \
+    unzip bun.zip; \
+    mv bun-linux-$build/bun /usr/local/bin/bun; \
+    chmod +x /usr/local/bin/bun; \
+    ln -s /usr/local/bin/bun /usr/local/bin/bunx; \
+    mkdir -p /usr/local/bun-node-fallback-bin; \
+    ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun; \
+    bun --version
 
 FROM gcr.io/distroless/base-nossl-debian11
 
-# Disable the runtime transpiler cache by default inside Docker containers.
-# On ephemeral containers, the cache is not useful
-ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
-ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 \
+    BUN_INSTALL_BIN=/usr/local/bin \
+    PATH="/usr/local/bun-node-fallback-bin:${PATH}"
 
-# Ensure `bun install -g` works
-ARG BUN_INSTALL_BIN=/usr/local/bin
-ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
-
-COPY --from=build /usr/local/bin/bun /usr/local/bin/
-ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
-
-# Temporarily use the `build`-stage image binaries to create a symlink:
-RUN --mount=type=bind,from=build,source=/usr/bin,target=/usr/bin \
-    --mount=type=bind,from=build,source=/bin,target=/bin \
-    --mount=type=bind,from=build,source=/usr/lib,target=/usr/lib \
-    --mount=type=bind,from=build,source=/lib,target=/lib \
-    <<EOF
-  ln -s /usr/local/bin/bun /usr/local/bin/bunx
-  which bunx
-  mkdir -p /usr/local/bun-node-fallback-bin
-  ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun
-EOF
+COPY --from=build /usr/local/bin/bun    /usr/local/bin/bun
+COPY --from=build /usr/local/bin/bunx   /usr/local/bin/bunx
+COPY --from=build /usr/local/bun-node-fallback-bin /usr/local/bun-node-fallback-bin
 
 ENTRYPOINT ["/usr/local/bin/bun"]


### PR DESCRIPTION
fix: not using ln -s which won't work in distroless env

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
