### PR TITLE
Distroless patch

### DIFF
--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS build
+FROM debian:bookworm-slim AS build
 
 # https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=latest

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -21,38 +21,32 @@ RUN apt-get update -qq \
     esac \
     && version="$BUN_VERSION" \
     && case "$version" in \
-      latest | canary | bun-v*) tag="$version"; ;; \
-      v*)                       tag="bun-$version"; ;; \
-      *)                        tag="bun-v$version"; ;; \
+      latest | canary | bun-v*) tag="$version";; \
+      v*)                       tag="bun-$version";; \
+      *)                        tag="bun-v$version";; \
     esac \
     && case "$tag" in \
-      latest) release="latest/download"; ;; \
-      *)      release="download/$tag"; ;; \
+      latest) release="latest/download";; \
+      *)      release="download/$tag";; \
     esac \
-    && curl "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" \
-      -fsSLO \
-      --compressed \
-      --retry 5 \
+    && curl "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" -fsSLO --compressed --retry 5 \
       || (echo "error: failed to download: $tag" && exit 1) \
     && for key in \
       "F3DCC08A8572C0749B3E18888EAB4D40A7B22B59" \
     ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" \
-      || gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+      || gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
     done \
-    && curl "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" \
-      -fsSLO \
-      --compressed \
-      --retry 5 \
+    && curl "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" -fsSLO --compressed --retry 5 \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
       || (echo "error: failed to verify: $tag" && exit 1) \
     && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \
       || (echo "error: failed to verify: $tag" && exit 1) \
     && unzip "bun-linux-$build.zip" \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
-    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \          # ← added
-    && mkdir -p /usr/local/bun-node-fallback-bin \             # ← added
-    && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun \  # ← added
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
+    && mkdir -p /usr/local/bun-node-fallback-bin \
+    && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun \
     && which bun \
@@ -68,8 +62,8 @@ ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 ARG BUN_INSTALL_BIN=/usr/local/bin
 ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 
-COPY --from=build /usr/local/bin/ /usr/local/bin/                 # ← changed
-COPY --from=build /usr/local/bun-node-fallback-bin /usr/local/bun-node-fallback-bin  # ← added
+COPY --from=build /usr/local/bin/ /usr/local/bin/
+COPY --from=build /usr/local/bun-node-fallback-bin /usr/local/bun-node-fallback-bin
 
 ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
 

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS build
+FROM debian:bullseye-slim AS build
 
 # https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=latest
@@ -50,6 +50,9 @@ RUN apt-get update -qq \
       || (echo "error: failed to verify: $tag" && exit 1) \
     && unzip "bun-linux-$build.zip" \
     && mv "bun-linux-$build/bun" /usr/local/bin/bun \
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \          # ← added
+    && mkdir -p /usr/local/bun-node-fallback-bin \             # ← added
+    && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun \  # ← added
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun \
     && which bun \
@@ -58,7 +61,6 @@ RUN apt-get update -qq \
 FROM gcr.io/distroless/base-nossl-debian11
 
 # Disable the runtime transpiler cache by default inside Docker containers.
-# On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
 ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 
@@ -66,19 +68,9 @@ ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 ARG BUN_INSTALL_BIN=/usr/local/bin
 ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 
-COPY --from=build /usr/local/bin/bun /usr/local/bin/
-ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
+COPY --from=build /usr/local/bin/ /usr/local/bin/                 # ← changed
+COPY --from=build /usr/local/bun-node-fallback-bin /usr/local/bun-node-fallback-bin  # ← added
 
-# Temporarily use the `build`-stage image binaries to create a symlink:
-RUN --mount=type=bind,from=build,source=/usr/bin,target=/usr/bin \
-    --mount=type=bind,from=build,source=/bin,target=/bin \
-    --mount=type=bind,from=build,source=/usr/lib,target=/usr/lib \
-    --mount=type=bind,from=build,source=/lib,target=/lib \
-    <<EOF
-  ln -s /usr/local/bin/bun /usr/local/bin/bunx
-  which bunx
-  mkdir -p /usr/local/bun-node-fallback-bin
-  ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun
-EOF
+ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
 
 ENTRYPOINT ["/usr/local/bin/bun"]

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:bookworm-slim AS build
 
 # https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=latest
-
 RUN apt-get update -qq \
     && apt-get install -qq --no-install-recommends \
       ca-certificates \
@@ -21,23 +20,29 @@ RUN apt-get update -qq \
     esac \
     && version="$BUN_VERSION" \
     && case "$version" in \
-      latest | canary | bun-v*) tag="$version";; \
-      v*)                       tag="bun-$version";; \
-      *)                        tag="bun-v$version";; \
+      latest | canary | bun-v*) tag="$version"; ;; \
+      v*)                       tag="bun-$version"; ;; \
+      *)                        tag="bun-v$version"; ;; \
     esac \
     && case "$tag" in \
-      latest) release="latest/download";; \
-      *)      release="download/$tag";; \
+      latest) release="latest/download"; ;; \
+      *)      release="download/$tag"; ;; \
     esac \
-    && curl "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" -fsSLO --compressed --retry 5 \
+    && curl "https://github.com/oven-sh/bun/releases/$release/bun-linux-$build.zip" \
+      -fsSLO \
+      --compressed \
+      --retry 5 \
       || (echo "error: failed to download: $tag" && exit 1) \
     && for key in \
       "F3DCC08A8572C0749B3E18888EAB4D40A7B22B59" \
     ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" \
-      || gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+      || gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
     done \
-    && curl "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" -fsSLO --compressed --retry 5 \
+    && curl "https://github.com/oven-sh/bun/releases/$release/SHASUMS256.txt.asc" \
+      -fsSLO \
+      --compressed \
+      --retry 5 \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
       || (echo "error: failed to verify: $tag" && exit 1) \
     && grep " bun-linux-$build.zip\$" SHASUMS256.txt | sha256sum -c - \


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Fix distroless build by not using `ln -s` in distroless environment. fixes https://github.com/oven-sh/bun/discussions/19786 and fixes #20414
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
