### PR TITLE
Do not use TCP cork in proxied HTTPS

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -407,8 +407,8 @@ const ProxyTunnel = struct {
     pub fn write(this: *HTTPClient, encoded_data: []const u8) void {
         if (this.proxy_tunnel) |proxy| {
             const written = switch (proxy.socket) {
-                .ssl => |socket| socket.write(encoded_data, true),
-                .tcp => |socket| socket.write(encoded_data, true),
+                .ssl => |socket| socket.write(encoded_data, false),
+                .tcp => |socket| socket.write(encoded_data, false),
                 .none => 0,
             };
             const pending = encoded_data[@intCast(written)..];

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -300,9 +300,9 @@ describe("TextDecoder", () => {
   });
 
   it("should support undefined options", () => {
-      expect(() => {
-          const decoder = new TextDecoder("utf-8", undefined);
-      }).not.toThrow();
+    expect(() => {
+      const decoder = new TextDecoder("utf-8", undefined);
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Does not fix the Codex issue, but it should also make proxied data slightly faster.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
