### PR TITLE
Add Zstd decompression to HTTP client

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5403,6 +5403,36 @@ declare module "bun" {
     options?: ZlibCompressionOptions | LibdeflateCompressionOptions,
   ): Uint8Array;
 
+  /**
+   * Compresses a chunk of data with the Zstandard (zstd) compression algorithm.
+   * @param data The buffer of data to compress
+   * @param options Compression options to use
+   * @returns The output buffer with the compressed data
+   */
+  function zstdCompressSync(data: Uint8Array | string | ArrayBuffer, options?: { level?: number }): Uint8Array;
+
+  /**
+   * Compresses a chunk of data with the Zstandard (zstd) compression algorithm.
+   * @param data The buffer of data to compress
+   * @param options Compression options to use
+   * @returns A promise that resolves to the output buffer with the compressed data
+   */
+  function zstdCompress(data: Uint8Array | string | ArrayBuffer, options?: { level?: number }): Promise<Uint8Array>;
+
+  /**
+   * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
+   * @param data The buffer of data to decompress
+   * @returns The output buffer with the decompressed data
+   */
+  function zstdDecompressSync(data: Uint8Array | string | ArrayBuffer): Uint8Array;
+
+  /**
+   * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
+   * @param data The buffer of data to decompress
+   * @returns A promise that resolves to the output buffer with the decompressed data
+   */
+  function zstdDecompress(data: Uint8Array | string | ArrayBuffer): Promise<Uint8Array>;
+
   type Target =
     /**
      * For generating bundles that are intended to be run by the Bun runtime. In many cases,

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5409,7 +5409,7 @@ declare module "bun" {
    * @param options Compression options to use
    * @returns The output buffer with the compressed data
    */
-  function zstdCompressSync(data: Uint8Array | string | ArrayBuffer, options?: { level?: number }): Uint8Array;
+  function zstdCompressSync(data: NodeJS.TypedArray | string | ArrayBuffer, options?: { level?: number }): Buffer;
 
   /**
    * Compresses a chunk of data with the Zstandard (zstd) compression algorithm.
@@ -5417,21 +5417,21 @@ declare module "bun" {
    * @param options Compression options to use
    * @returns A promise that resolves to the output buffer with the compressed data
    */
-  function zstdCompress(data: Uint8Array | string | ArrayBuffer, options?: { level?: number }): Promise<Uint8Array>;
+  function zstdCompress(data: NodeJS.TypedArray | string | ArrayBuffer, options?: { level?: number }): Promise<Buffer>;
 
   /**
    * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
    * @param data The buffer of data to decompress
    * @returns The output buffer with the decompressed data
    */
-  function zstdDecompressSync(data: Uint8Array | string | ArrayBuffer): Uint8Array;
+  function zstdDecompressSync(data: NodeJS.TypedArray | string | ArrayBuffer): Buffer;
 
   /**
    * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
    * @param data The buffer of data to decompress
    * @returns A promise that resolves to the output buffer with the decompressed data
    */
-  function zstdDecompress(data: Uint8Array | string | ArrayBuffer): Promise<Uint8Array>;
+  function zstdDecompress(data: NodeJS.TypedArray | string | ArrayBuffer): Promise<Buffer>;
 
   type Target =
     /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5409,7 +5409,10 @@ declare module "bun" {
    * @param options Compression options to use
    * @returns The output buffer with the compressed data
    */
-  function zstdCompressSync(data: NodeJS.TypedArray | string | ArrayBuffer, options?: { level?: number }): Buffer;
+  function zstdCompressSync(
+    data: NodeJS.TypedArray | Buffer | string | ArrayBuffer,
+    options?: { level?: number },
+  ): Buffer;
 
   /**
    * Compresses a chunk of data with the Zstandard (zstd) compression algorithm.
@@ -5417,21 +5420,24 @@ declare module "bun" {
    * @param options Compression options to use
    * @returns A promise that resolves to the output buffer with the compressed data
    */
-  function zstdCompress(data: NodeJS.TypedArray | string | ArrayBuffer, options?: { level?: number }): Promise<Buffer>;
+  function zstdCompress(
+    data: NodeJS.TypedArray | Buffer | string | ArrayBuffer,
+    options?: { level?: number },
+  ): Promise<Buffer>;
 
   /**
    * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
    * @param data The buffer of data to decompress
    * @returns The output buffer with the decompressed data
    */
-  function zstdDecompressSync(data: NodeJS.TypedArray | string | ArrayBuffer): Buffer;
+  function zstdDecompressSync(data: NodeJS.TypedArray | Buffer | string | ArrayBuffer): Buffer;
 
   /**
    * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
    * @param data The buffer of data to decompress
    * @returns A promise that resolves to the output buffer with the decompressed data
    */
-  function zstdDecompress(data: NodeJS.TypedArray | string | ArrayBuffer): Promise<Buffer>;
+  function zstdDecompress(data: NodeJS.TypedArray | Buffer | string | ArrayBuffer): Promise<Buffer>;
 
   type Target =
     /**

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1820,7 +1820,7 @@ pub const JSZstd = struct {
 
         // Resize to actual compressed size
         if (compressed_size < output.len) {
-            output = allocator.realloc(output, compressed_size) catch output[0..compressed_size];
+            output = try allocator.realloc(output, compressed_size)
         }
 
         var array_buffer = JSC.ArrayBuffer.fromBytes(output, .Uint8Array);

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1839,7 +1839,7 @@ pub const JSZstd = struct {
         // Try to get the decompressed size
         const decompressed_size = bun.zstd.getDecompressedSize(input);
 
-        if (decompressed_size == 0) {
+        if (decompressed_size == std.math.maxInt(c_ulonglong) - 1 or decompressed_size == std.math.maxInt(c_ulonglong) - 2) {
             // If size is unknown, we'll need to decompress in chunks
             return globalThis.ERR(.ZSTD, "Decompressed size is unknown. Either the input is not a valid zstd compressed buffer or the decompressed size is too large. If you run into this error with a valid input, please file an issue at https://github.com/oven-sh/bun/issues", .{}).throw();
         }
@@ -1920,7 +1920,7 @@ pub const JSZstd = struct {
                 // Try to get the decompressed size
                 const decompressed_size = bun.zstd.getDecompressedSize(input);
 
-                if (decompressed_size == 0) {
+                if (decompressed_size == std.math.maxInt(c_ulonglong) - 1 or decompressed_size == std.math.maxInt(c_ulonglong) - 2) {
                     job.error_message = "Decompressed size is unknown. Either the input is not a valid zstd compressed buffer or the decompressed size is too large";
                     return;
                 }

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -38,6 +38,10 @@ pub const BunObject = struct {
     pub const udpSocket = toJSCallback(host_fn.wrapStaticMethod(api.UDPSocket, "udpSocket", false));
     pub const which = toJSCallback(Bun.which);
     pub const write = toJSCallback(JSC.WebCore.Blob.writeFile);
+    pub const zstdCompressSync = toJSCallback(JSZstd.compressSync);
+    pub const zstdDecompressSync = toJSCallback(JSZstd.decompressSync);
+    pub const zstdCompress = toJSCallback(JSZstd.compress);
+    pub const zstdDecompress = toJSCallback(JSZstd.decompress);
 
     // --- Callbacks ---
 
@@ -168,7 +172,10 @@ pub const BunObject = struct {
         @export(&BunObject.udpSocket, .{ .name = callbackName("udpSocket") });
         @export(&BunObject.which, .{ .name = callbackName("which") });
         @export(&BunObject.write, .{ .name = callbackName("write") });
-
+        @export(&BunObject.zstdCompressSync, .{ .name = callbackName("zstdCompressSync") });
+        @export(&BunObject.zstdDecompressSync, .{ .name = callbackName("zstdDecompressSync") });
+        @export(&BunObject.zstdCompress, .{ .name = callbackName("zstdCompress") });
+        @export(&BunObject.zstdDecompress, .{ .name = callbackName("zstdDecompress") });
         // -- Callbacks --
     }
 };
@@ -1713,6 +1720,297 @@ pub const JSZlib = struct {
                 return array_buffer.toJSWithContext(globalThis, list.items.ptr, global_deallocator, null);
             },
         }
+    }
+};
+
+pub const JSZstd = struct {
+    export fn deallocator(_: ?*anyopaque, ctx: ?*anyopaque) void {
+        comptime assert(bun.use_mimalloc);
+        bun.Mimalloc.mi_free(ctx);
+    }
+
+    inline fn getOptions(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!struct { JSC.Node.StringOrBuffer, ?JSValue } {
+        const arguments = callframe.arguments();
+        const buffer_value = if (arguments.len > 0) arguments[0] else .undefined;
+        const options_val: ?JSValue =
+            if (arguments.len > 1 and arguments[1].isObject())
+                arguments[1]
+            else if (arguments.len > 1 and !arguments[1].isUndefined()) {
+                return globalThis.throwInvalidArguments("Expected options to be an object", .{});
+            } else null;
+
+        if (try JSC.Node.StringOrBuffer.fromJS(globalThis, bun.default_allocator, buffer_value)) |buffer| {
+            return .{ buffer, options_val };
+        }
+
+        return globalThis.throwInvalidArguments("Expected buffer to be a string or buffer", .{});
+    }
+
+    inline fn getOptionsAsync(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!struct { JSC.Node.StringOrBuffer, ?JSValue, i32 } {
+        const arguments = callframe.arguments();
+        const buffer_value = if (arguments.len > 0) arguments[0] else .undefined;
+        const options_val: ?JSValue =
+            if (arguments.len > 1 and arguments[1].isObject())
+                arguments[1]
+            else if (arguments.len > 1 and !arguments[1].isUndefined()) {
+                return globalThis.throwInvalidArguments("Expected options to be an object", .{});
+            } else null;
+
+        var level: i32 = 3; // Default compression level
+
+        if (options_val) |option_obj| {
+            if (try option_obj.get(globalThis, "level")) |level_val| {
+                level = level_val.coerce(i32, globalThis);
+                if (globalThis.hasException()) return .{ JSC.Node.StringOrBuffer.empty, null, 0 };
+
+                // Validate level range (1-22 for zstd)
+                if (level < 1 or level > 22) {
+                    return globalThis.throwInvalidArguments("Compression level must be between 1 and 22", .{});
+                }
+            }
+        }
+
+        const allow_string_object = true;
+        if (try JSC.Node.StringOrBuffer.fromJSMaybeAsync(globalThis, bun.default_allocator, buffer_value, true, allow_string_object)) |buffer| {
+            return .{ buffer, options_val, level };
+        }
+
+        return globalThis.throwInvalidArguments("Expected buffer to be a string or buffer", .{});
+    }
+
+    pub fn compressSync(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+        const buffer, const options_val = try getOptions(globalThis, callframe);
+        defer buffer.deinit();
+
+        var level: i32 = 3; // Default compression level
+
+        if (options_val) |option_obj| {
+            if (try option_obj.get(globalThis, "level")) |level_val| {
+                level = level_val.coerce(i32, globalThis);
+                if (globalThis.hasException()) return .zero;
+
+                // Validate level range (1-22 for zstd)
+                if (level < 1 or level > 22) {
+                    return globalThis.throwInvalidArguments("Compression level must be between 1 and 22", .{});
+                }
+            }
+        }
+
+        const input = buffer.slice();
+        const allocator = bun.default_allocator;
+
+        // Calculate max compressed size
+        const max_size = bun.zstd.compressBound(input.len);
+        var output = allocator.alloc(u8, max_size) catch {
+            return globalThis.throwOutOfMemory();
+        };
+
+        // Perform compression
+        const compressed_size = switch (bun.zstd.compress(output, input, level)) {
+            .success => |size| size,
+            .err => |err| {
+                allocator.free(output);
+                return globalThis.ERR(.ZSTD, "{s}", .{err}).throw();
+            },
+        };
+
+        // Resize to actual compressed size
+        if (compressed_size < output.len) {
+            output = allocator.realloc(output, compressed_size) catch output[0..compressed_size];
+        }
+
+        var array_buffer = JSC.ArrayBuffer.fromBytes(output, .Uint8Array);
+        return array_buffer.toJSWithContext(globalThis, output.ptr, deallocator, null);
+    }
+
+    pub fn decompressSync(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+        const buffer, _ = try getOptions(globalThis, callframe);
+        defer buffer.deinit();
+
+        const input = buffer.slice();
+        const allocator = bun.default_allocator;
+
+        // Try to get the decompressed size
+        const decompressed_size = bun.zstd.getDecompressedSize(input);
+
+        if (decompressed_size == 0) {
+            // If size is unknown, we'll need to decompress in chunks
+            return globalThis.ERR(.ZSTD, "Decompressed size is unknown. Either the input is not a valid zstd compressed buffer or the decompressed size is too large. If you run into this error with a valid input, please file an issue at https://github.com/oven-sh/bun/issues", .{}).throw();
+        }
+
+        // Allocate output buffer based on decompressed size
+        var output = allocator.alloc(u8, decompressed_size) catch {
+            return globalThis.throwOutOfMemory();
+        };
+
+        // Perform decompression
+        const actual_size = switch (bun.zstd.decompress(output, input)) {
+            .success => |actual_size| actual_size,
+            .err => |err| {
+                allocator.free(output);
+                return globalThis.ERR(.ZSTD, "{s}", .{err}).throw();
+            },
+        };
+
+        bun.debugAssert(actual_size <= output.len);
+
+        // mimalloc doesn't care about the self-reported size of the slice.
+        output.len = actual_size;
+
+        var array_buffer = JSC.ArrayBuffer.fromBytes(output, .Uint8Array);
+        return array_buffer.toJSWithContext(globalThis, output.ptr, deallocator, null);
+    }
+
+    // --- Async versions ---
+
+    pub const ZstdJob = struct {
+        buffer: JSC.Node.StringOrBuffer = JSC.Node.StringOrBuffer.empty,
+        is_compress: bool = true,
+        level: i32 = 3,
+        task: JSC.WorkPoolTask = .{ .callback = &runTask },
+        promise: JSC.JSPromise.Strong = .{},
+        vm: *JSC.VirtualMachine,
+        output: []u8 = &[_]u8{},
+        error_message: ?[]const u8 = null,
+        any_task: JSC.AnyTask = undefined,
+        poll: Async.KeepAlive = .{},
+
+        pub const new = bun.TrivialNew(@This());
+
+        pub fn runTask(task: *JSC.WorkPoolTask) void {
+            const job: *ZstdJob = @fieldParentPtr("task", task);
+            defer job.vm.enqueueTaskConcurrent(JSC.ConcurrentTask.create(job.any_task.task()));
+
+            const input = job.buffer.slice();
+            const allocator = bun.default_allocator;
+
+            if (job.is_compress) {
+                // Compression path
+                // Calculate max compressed size
+                const max_size = bun.zstd.compressBound(input.len);
+                job.output = allocator.alloc(u8, max_size) catch {
+                    job.error_message = "Out of memory";
+                    return;
+                };
+
+                // Perform compression
+                job.output = switch (bun.zstd.compress(job.output, input, job.level)) {
+                    .success => |size| blk: {
+                        // Resize to actual compressed size
+                        if (size < job.output.len) {
+                            break :blk allocator.realloc(job.output, size) catch job.output[0..size];
+                        }
+                        break :blk job.output;
+                    },
+                    .err => |err| {
+                        allocator.free(job.output);
+                        job.output = &[_]u8{};
+                        job.error_message = err;
+                        return;
+                    },
+                };
+            } else {
+                // Decompression path
+                // Try to get the decompressed size
+                const decompressed_size = bun.zstd.getDecompressedSize(input);
+
+                if (decompressed_size == 0) {
+                    job.error_message = "Decompressed size is unknown. Either the input is not a valid zstd compressed buffer or the decompressed size is too large";
+                    return;
+                }
+
+                // Allocate output buffer based on decompressed size
+                job.output = allocator.alloc(u8, decompressed_size) catch {
+                    job.error_message = "Out of memory";
+                    return;
+                };
+
+                // Perform decompression
+                switch (bun.zstd.decompress(job.output, input)) {
+                    .success => |actual_size| {
+                        if (actual_size < job.output.len) {
+                            job.output.len = actual_size;
+                        }
+                    },
+                    .err => |err| {
+                        allocator.free(job.output);
+                        job.output = &[_]u8{};
+                        job.error_message = err;
+                        return;
+                    },
+                }
+            }
+        }
+
+        pub fn runFromJS(this: *ZstdJob) void {
+            defer this.deinit();
+            if (this.vm.isShuttingDown()) {
+                return;
+            }
+
+            const globalThis = this.vm.global;
+            const promise = this.promise.swap();
+
+            if (this.error_message) |err_msg| {
+                promise.reject(globalThis, globalThis.ERR(.ZSTD, "{s}", .{err_msg}).toJS());
+                return;
+            }
+
+            const output_slice = this.output;
+            const buffer_value = JSC.JSValue.createBuffer(globalThis, output_slice, bun.default_allocator);
+            if (globalThis.hasException()) {
+                promise.reject(globalThis, globalThis.takeError(error.JSError));
+                return;
+            }
+            if (buffer_value == .zero) {
+                promise.reject(globalThis, ZigString.init("Failed to create buffer").toErrorInstance(globalThis));
+                return;
+            }
+
+            this.output = &[_]u8{};
+            promise.resolve(globalThis, buffer_value);
+        }
+
+        pub fn deinit(this: *ZstdJob) void {
+            this.poll.unref(this.vm);
+            this.buffer.deinitAndUnprotect();
+            this.promise.deinit();
+            bun.default_allocator.free(this.output);
+            bun.destroy(this);
+        }
+
+        pub fn create(vm: *JSC.VirtualMachine, globalThis: *JSC.JSGlobalObject, buffer: JSC.Node.StringOrBuffer, is_compress: bool, level: i32) *ZstdJob {
+            var job = ZstdJob.new(.{
+                .buffer = buffer,
+                .is_compress = is_compress,
+                .level = level,
+                .vm = vm,
+                .any_task = undefined,
+            });
+
+            job.promise = JSC.JSPromise.Strong.init(globalThis);
+            job.any_task = JSC.AnyTask.New(@This(), &runFromJS).init(job);
+            job.poll.ref(vm);
+            JSC.WorkPool.schedule(&job.task);
+
+            return job;
+        }
+    };
+
+    pub fn compress(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+        const buffer, _, const level = try getOptionsAsync(globalThis, callframe);
+
+        const vm = globalThis.bunVM();
+        var job = ZstdJob.create(vm, globalThis, buffer, true, level);
+        return job.promise.value();
+    }
+
+    pub fn decompress(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+        const buffer, _, _ = try getOptionsAsync(globalThis, callframe);
+
+        const vm = globalThis.bunVM();
+        var job = ZstdJob.create(vm, globalThis, buffer, false, 0); // level is ignored for decompression
+        return job.promise.value();
     }
 };
 

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1949,7 +1949,7 @@ pub const JSZstd = struct {
             const output_slice = this.output;
             const buffer_value = JSC.JSValue.createBuffer(globalThis, output_slice, bun.default_allocator);
             if (globalThis.hasException()) {
-                promise.reject(globalThis, globalThis.takeError(error.JSError));
+                promise.reject(globalThis, error.JSError);
                 return;
             }
             if (buffer_value == .zero) {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1900,7 +1900,7 @@ pub const JSZstd = struct {
                     .success => |size| blk: {
                         // Resize to actual compressed size
                         if (size < job.output.len) {
-                            break :blk allocator.realloc(job.output, size) catch job.output[0..size];
+                            break :blk allocator.realloc(job.output, size) catch { job.error_message = "Out of memory"; return ;}
                         }
                         break :blk job.output;
                     },

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1787,7 +1787,7 @@ pub const JSZstd = struct {
         if (options_val) |option_obj| {
             if (try option_obj.get(globalThis, "level")) |level_val| {
                 level = level_val.coerce(i32, globalThis);
-                if (globalThis.hasException()) return .zero;
+                if (globalThis.hasException()) return error.JSError;
 
                 // Validate level range (1-22 for zstd)
                 if (level < 1 or level > 22) {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1801,9 +1801,7 @@ pub const JSZstd = struct {
 
         // Calculate max compressed size
         const max_size = bun.zstd.compressBound(input.len);
-        var output = allocator.alloc(u8, max_size) catch {
-            return globalThis.throwOutOfMemory();
-        };
+        var output = try allocator.alloc(u8, max_size)
 
         // Create a context for better control
         const cctx = bun.zstd.ZSTD_createCCtx() orelse {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1843,9 +1843,7 @@ pub const JSZstd = struct {
         }
 
         // Allocate output buffer based on decompressed size
-        var output = allocator.alloc(u8, decompressed_size) catch {
-            return globalThis.throwOutOfMemory();
-        };
+        var output = try allocator.alloc(u8, decompressed_size)
 
         // Perform decompression
         const actual_size = switch (bun.zstd.decompress(output, input)) {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1761,7 +1761,7 @@ pub const JSZstd = struct {
         if (options_val) |option_obj| {
             if (try option_obj.get(globalThis, "level")) |level_val| {
                 level = level_val.coerce(i32, globalThis);
-                if (globalThis.hasException()) return .{ JSC.Node.StringOrBuffer.empty, null, 0 };
+                if (globalThis.hasException()) return error.JSError;
 
                 // Validate level range (1-22 for zstd)
                 if (level < 1 or level > 22) {

--- a/src/bun.js/bindings/BunObject+exports.h
+++ b/src/bun.js/bindings/BunObject+exports.h
@@ -74,6 +74,10 @@
     macro(udpSocket) \
     macro(which) \
     macro(write) \
+    macro(zstdCompressSync) \
+    macro(zstdDecompressSync) \
+    macro(zstdCompress) \
+    macro(zstdDecompress) \
 
 #define DECLARE_ZIG_BUN_OBJECT_CALLBACK(name) BUN_DECLARE_HOST_FUNCTION(BunObject_callback_##name);
 FOR_EACH_CALLBACK(DECLARE_ZIG_BUN_OBJECT_CALLBACK);

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -791,6 +791,10 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     RedisClient                                   BunObject_getter_wrap_ValkeyClient                                  DontDelete|PropertyCallback
     redis                                         BunObject_getter_wrap_valkey                                        DontDelete|PropertyCallback
     write                                          BunObject_callback_write                                            DontDelete|Function 1
+    zstdCompressSync                               BunObject_callback_zstdCompressSync                                DontDelete|Function 1
+    zstdDecompressSync                             BunObject_callback_zstdDecompressSync                              DontDelete|Function 1
+    zstdCompress                                 BunObject_callback_zstdCompress                                    DontDelete|Function 1
+    zstdDecompress                                 BunObject_callback_zstdDecompress                                    DontDelete|Function 1
 @end
 */
 

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -22,6 +22,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_ASYNC_TYPE", TypeError],
   ["ERR_BODY_ALREADY_USED", Error],
   ["ERR_BORINGSSL", Error],
+  ["ERR_ZSTD", Error],
   ["ERR_BROTLI_INVALID_PARAM", RangeError],
   ["ERR_BUFFER_CONTEXT_NOT_AVAILABLE", Error],
   ["ERR_BUFFER_OUT_OF_BOUNDS", RangeError],

--- a/src/deps/zstd.zig
+++ b/src/deps/zstd.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+const bun = @import("bun");
 pub extern fn ZSTD_versionNumber() c_uint;
 pub extern fn ZSTD_versionString() [*c]const u8;
 pub extern fn ZSTD_compress(dst: ?*anyopaque, dstCapacity: usize, src: ?*const anyopaque, srcSize: usize, compressionLevel: c_int) usize;
@@ -224,4 +226,119 @@ pub const Result = union(enum) {
     err: [:0]const u8,
 };
 
-const bun = @import("bun");
+pub const ZstdReaderArrayList = struct {
+    const State = enum {
+        Uninitialized,
+        Inflating,
+        End,
+        Error,
+    };
+
+    input: []const u8,
+    list: std.ArrayListUnmanaged(u8),
+    list_allocator: std.mem.Allocator,
+    list_ptr: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+    zstd: *ZSTD_DStream,
+    state: State = State.Uninitialized,
+    total_out: usize = 0,
+    total_in: usize = 0,
+
+    pub const new = bun.TrivialNew(ZstdReaderArrayList);
+
+    pub fn init(
+        input: []const u8,
+        list: *std.ArrayListUnmanaged(u8),
+        allocator: std.mem.Allocator,
+    ) !*ZstdReaderArrayList {
+        return initWithListAllocator(input, list, allocator, allocator);
+    }
+
+    pub fn initWithListAllocator(
+        input: []const u8,
+        list: *std.ArrayListUnmanaged(u8),
+        list_allocator: std.mem.Allocator,
+        allocator: std.mem.Allocator,
+    ) !*ZstdReaderArrayList {
+        var reader = try allocator.create(ZstdReaderArrayList);
+        reader.* = .{
+            .input = input,
+            .list = list.*,
+            .list_allocator = list_allocator,
+            .list_ptr = list,
+            .allocator = allocator,
+            .zstd = undefined,
+        };
+
+        reader.zstd = ZSTD_createDStream() orelse {
+            allocator.destroy(reader);
+            return error.ZstdFailedToCreateInstance;
+        };
+        _ = ZSTD_initDStream(reader.zstd);
+        return reader;
+    }
+
+    pub fn end(this: *ZstdReaderArrayList) void {
+        if (this.state != .End) {
+            _ = ZSTD_freeDStream(this.zstd);
+            this.state = .End;
+        }
+    }
+
+    pub fn deinit(this: *ZstdReaderArrayList) void {
+        var alloc = this.allocator;
+        this.end();
+        alloc.destroy(this);
+    }
+
+    pub fn readAll(this: *ZstdReaderArrayList, is_done: bool) !void {
+        defer this.list_ptr.* = this.list;
+
+        if (this.state == .End or this.state == .Error) return;
+
+        while (this.state == .Uninitialized or this.state == .Inflating) {
+            var unused = this.list.unusedCapacitySlice();
+            if (unused.len < 4096) {
+                try this.list.ensureUnusedCapacity(this.list_allocator, 4096);
+                unused = this.list.unusedCapacitySlice();
+            }
+
+            var next_in = this.input[this.total_in..];
+            var in_buf = ZSTD_inBuffer{
+                .src = if (next_in.len > 0) next_in.ptr else null,
+                .size = next_in.len,
+                .pos = 0,
+            };
+            var out_buf = ZSTD_outBuffer{
+                .dst = if (unused.len > 0) unused.ptr else null,
+                .size = unused.len,
+                .pos = 0,
+            };
+
+            const rc = ZSTD_decompressStream(this.zstd, &out_buf, &in_buf);
+            if (ZSTD_isError(rc) != 0) {
+                this.state = .Error;
+                return error.ZstdDecompressionError;
+            }
+
+            const bytes_written = out_buf.pos;
+            const bytes_read = in_buf.pos;
+            this.list.items.len += bytes_written;
+            this.total_in += bytes_read;
+            this.total_out += bytes_written;
+
+            if (rc == 0) {
+                this.end();
+                return;
+            }
+
+            if (bytes_read == next_in.len) {
+                this.state = .Inflating;
+                if (is_done) {
+                    this.state = .Error;
+                }
+                return error.ShortRead;
+            }
+        }
+    }
+};

--- a/src/http.zig
+++ b/src/http.zig
@@ -22,6 +22,7 @@ const Lock = bun.Mutex;
 const HTTPClient = @This();
 const Zlib = @import("./zlib.zig");
 const Brotli = bun.brotli;
+const zstd = bun.zstd;
 const StringBuilder = bun.StringBuilder;
 const ThreadPool = bun.ThreadPool;
 const ObjectPool = @import("./pool.zig").ObjectPool;
@@ -1906,11 +1907,12 @@ pub const CertificateInfo = struct {
 const Decompressor = union(enum) {
     zlib: *Zlib.ZlibReaderArrayList,
     brotli: *Brotli.BrotliReaderArrayList,
+    zstd: *zstd.ZstdReaderArrayList,
     none: void,
 
     pub fn deinit(this: *Decompressor) void {
         switch (this.*) {
-            inline .brotli, .zlib => |that| {
+            inline .brotli, .zlib, .zstd => |that| {
                 that.deinit();
                 this.* = .{ .none = {} };
             },
@@ -1954,6 +1956,17 @@ const Decompressor = union(enum) {
                     };
                     return;
                 },
+                .zstd => {
+                    this.* = .{
+                        .zstd = try zstd.ZstdReaderArrayList.initWithListAllocator(
+                            buffer,
+                            &body_out_str.list,
+                            body_out_str.allocator,
+                            default_allocator,
+                        ),
+                    };
+                    return;
+                },
                 else => @panic("Invalid encoding. This code should not be reachable"),
             }
         }
@@ -1984,6 +1997,14 @@ const Decompressor = union(enum) {
                 reader.list = body_out_str.list;
                 reader.total_out = @truncate(initial);
             },
+            .zstd => |reader| {
+                reader.input = buffer;
+                reader.total_in = 0;
+
+                const initial = body_out_str.list.items.len;
+                reader.list = body_out_str.list;
+                reader.total_out = @truncate(initial);
+            },
             else => @panic("Invalid encoding. This code should not be reachable"),
         }
     }
@@ -1992,6 +2013,7 @@ const Decompressor = union(enum) {
         switch (this.*) {
             .zlib => |zlib| try zlib.readAll(),
             .brotli => |brotli| try brotli.readAll(is_done),
+            .zstd => |reader| try reader.readAll(is_done),
             .none => {},
         }
     }
@@ -2196,7 +2218,7 @@ pub const InternalState = struct {
         var body_out_str = this.body_out_str.?;
 
         switch (this.encoding) {
-            Encoding.brotli, Encoding.gzip, Encoding.deflate => {
+            Encoding.brotli, Encoding.gzip, Encoding.deflate, Encoding.zstd => {
                 try this.decompress(buffer, body_out_str, is_final_chunk);
             },
             else => {
@@ -2351,6 +2373,7 @@ pub const Encoding = enum {
     gzip,
     deflate,
     brotli,
+    zstd,
     chunked,
 
     pub fn canUseLibDeflate(this: Encoding) bool {
@@ -2362,7 +2385,7 @@ pub const Encoding = enum {
 
     pub fn isCompressed(this: Encoding) bool {
         return switch (this) {
-            .brotli, .gzip, .deflate => true,
+            .brotli, .gzip, .deflate, .zstd => true,
             else => false,
         };
     }
@@ -2376,7 +2399,7 @@ const connection_closing_header = picohttp.Header{ .name = "Connection", .value 
 const accept_header = picohttp.Header{ .name = "Accept", .value = "*/*" };
 
 const accept_encoding_no_compression = "identity";
-const accept_encoding_compression = "gzip, deflate, br";
+const accept_encoding_compression = "gzip, deflate, br, zstd";
 const accept_encoding_header_compression = picohttp.Header{ .name = "Accept-Encoding", .value = accept_encoding_compression };
 const accept_encoding_header_no_compression = picohttp.Header{ .name = "Accept-Encoding", .value = accept_encoding_no_compression };
 
@@ -4341,6 +4364,9 @@ pub fn handleResponseMetadata(
                     } else if (strings.eqlComptime(header.value, "br")) {
                         this.state.encoding = Encoding.brotli;
                         this.state.content_encoding_i = @as(u8, @truncate(header_i));
+                    } else if (strings.eqlComptime(header.value, "zstd")) {
+                        this.state.encoding = Encoding.zstd;
+                        this.state.content_encoding_i = @as(u8, @truncate(header_i));
                     }
                 }
             },
@@ -4356,6 +4382,10 @@ pub fn handleResponseMetadata(
                 } else if (strings.eqlComptime(header.value, "br")) {
                     if (!this.flags.disable_decompression) {
                         this.state.transfer_encoding = .brotli;
+                    }
+                } else if (strings.eqlComptime(header.value, "zstd")) {
+                    if (!this.flags.disable_decompression) {
+                        this.state.transfer_encoding = .zstd;
                     }
                 } else if (strings.eqlComptime(header.value, "identity")) {
                     this.state.transfer_encoding = Encoding.identity;

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -32,7 +32,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
   "== alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
   "!= alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
 
-  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 240, regex: true },
+  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 241, regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
   "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1849 },
 

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -35,48 +35,127 @@ describe("Zstandard compression", async () => {
   });
 
   // Test with known zstd-compressed data
-  describe("zstd CLI compatibility", () => {
-    const binaryData = Buffer.from(
-      "d99672ce993fec2d180320aef27f9d05617958e6e67eb2e734cd976034d9301f410ccfca695075f02c5c2969b525a54b7e95ea61797a591daf09a8764800a8d99ad06ba3fcc5c89bd074a47f6a11c1",
-      "hex",
-    );
-
-    const testDataCases = [
+  describe.only("zstd CLI compatibility", () => {
+    for (const { name, compressed, original } of [
       {
-        name: "binary data level 1",
+        name: "package.json",
         compressed: Buffer.from(
-          "KLUv/WQAAwEgANmWcs6ZP+wtGAMgrvJ/nQVheVjm5n6y5zTNl2A02TAfQQzPymlQdfAsXClptSWlS36V6mF5elkdrwmodkgAqNma0Guj/MXIm9B0pH9qEcF",
+          `KLUv/WSNFW02AJpFEA0swI6MHj4FfolQucJR+D/dUfm04dDfbha4DpjPR5DcwT8VjwrYBlgWQSBZVCDAAMkAwgDN0Fnp0emTbzV3s8XzzePrP5tnXee6lFcSy0tZXkqS5Hx74axOMwq0A80A9vRxGnOx/dE7qyPOqh0QDaJJXIAsnVj89s9Ld9HZ8q8LsTbQIqi/tU6xiCbRIC42zx1zOJrDWWc/SjRHgQZRwb9U9YgW0RA4LtjnnGL8k15Jx3ySeWWBuQFSUB27sC0vFVW/nMVzWNQgZuYGCixB1Z/DqgWdHQlHK9AcEEuQnF+pZ5C8FBSdbPilliXIrcueYhBzA0aXCsZyoWQqJgwGMi1JoXyysR/BUq/VbapTq06KetbN//pBkUwqlAWaCXOJVEwQ/lVU59DpxEKpmKhAIEwWSmXCQCLy6QVd1pbLwwLBQDRTJQKxTBPpqpMizZPH5EBCRjOpUB5ENFMDCIVk0uw48i0TzZUTW9SiRoCAg+173KLNkbIAAda9AZwhA18TttawaCNOIICtdPi1e4D0y3VmJb/T1MOIzkp6Rj3s5r7+E0X0q/bNc6+hoya8urnSSam3w8fifG2ly4+TYh2PWTntcb0l5+tmz2SPfHj9x0U6rb6kgw97ko1WtKpbrp79OE3Zza9aLGLxUhpNdrNbL/mVfCqqnCYvRV1b2/N1Yp1d2zRuHXXpVxTV+qJHq6WO1fouF78bm9Azr3pTW3o2o/mNvs3F3GmGKkR2ThpJkwgOAkAVOGvmSLupW7xZea58KMlLJbIjjd3CxafZ2O90BSK5VDQZSoPIFGHi3oTQK/zzGPkUcEbLYSZQKCgZBxfNBGWCW67Wa8JLprJgQWMmAg0ZDRnMDZC9s7HDbA8ObD22SdzCUUiiKJLO4ePa3ZqIyQAP638xODy0B6fXet4C4MAOGdW+RuXERrWx4amcRuU0PNU2qsVoGc+x2sBoD9HDQ+TA9c2K2T7t0MYPBxV4+qJ6a1lfSdYv6mxTQKjEDMKeUpoYSCASCQUjoQKxfL2ATjrouuOSL6iL8VoeRDKYKaOxPIhI13883q7/dKsVnZ2Wjoqgk9St/MildBTEHEkb67B+7vFu1KW8lL2a0vP8lsSh7sb+FYGEqOGZQWhoRkRSkIIU0gFBBAiCgayUED0SwOIkh7QYUwwhYsyIiIiIiCgoKUhB0xqNm0CdtADU/RPtR76+iC/H0LlxiV3RVBFQVEMfxTGI2Zki6LAMtubw2rzhYzwPwg87PQlElpR2/Ls7SocTKT+QmoPqFjbSRY1GAW4NB/JyQLGOudpTBRZdeSqepHTFnuc4a8Ss72CugyxKenYUVOMaAoFYx+FohmwccIUOgMWQzG4VloyBA5vfdcuCzhKsy5eskQlhKnttUeMRaPlYFHi3OfDbo4Algi5qE4hp5wnxnh7+G+EQhWKqZozIPSmLpnluDThpmqjQqBljNYyKGkDcPw/5oT7PwZRMx7KYCsfB3ACkfW+7kwKchL/+pMOJBRpNiCOl9SZO/Gva20fQ65DnhOl6GVzhO9S+5S9c1fx4Qgf06Kk8smDpbO63cRVeSUZnNUjq2sQY2VGFLA3jD9FRQYS9WIomzkhQD+AlQZRL5Csjm/Xw4aq5wb+UMQG2qucFzKTE7fAJ/KuFs8akw8bEwRiIpbD9tihD+Dv+YXx2LnC/f1CFDfi4KbAEv6wR3OLofbPh4M7hQtr8wc/fl55p8gyO2oeK6MM25EiwttB6VmfH+CogsSoe0iY36kzdeRr7rnhQWj9TwbtxgGbMBHaMocqY5+7Q5wBo3WheMOyhzEU6mvwwx4GXHTEfe8dwOwOIDnMSYk/GvsB1w8VguyIACtHwOL6QwLn3howqxiWgx3DAg2meUJA55NgAECWRKmD31H2+aJNmGATiaCOL0ktbox3NImajx4kQIZQFuSp3UahXx74rUnSNLYda0Urr7WVd5VgSSO0y+MOEODnzh0uaDYohHCQQIF50S1NW5ySRld+sch5S+BoQhwDmEHZUNor7k0GZ9F1cRc5TJPHsnxicpUq8/LO0gACwagmWA3U+X1d13YqBcolfjqRQ7udoZq6QWR4+ErRi5nzuMeEm28nfnwwJrisZqooPIw9kuaYpJyKdZBLqaGte3r2nr5z0FiRCALP2h6JGshUEkMIo/eYWNTBa6lKeuTVPb+XAGE4XzyTEM62qLNLnMGV8FuL0iqvzvKJ+AO0t4i/yc8fwHyK4Qheni3NOna2pYKszuq2MsSxBNUALonv3UJNZo6HwDH1zg+VvIe2KZpTDIeg6DLxcPf2ZbhipV1fEllrxJ2kfnMhggh9ZURGN`,
           "base64",
         ),
-        original: binaryData,
-      },
-      {
-        name: "binary data level 10",
-        compressed: Buffer.from(
-          "KLUv/WQAAwEgANmWcs6ZP+wtGAMgrvJ/nQVheVjm5n6y5zTNl2A02TAfQQzPymlQdfAsXClptSWlS36V6mF5elkdrwmodkgAqNma0Guj/MXIm9B0pH9qEcF",
-          "base64",
+        original: Buffer.from(
+          JSON.stringify(
+            {
+              "private": true,
+              "name": "bun",
+              "version": "1.2.14",
+              "workspaces": ["./packages/bun-types", "./packages/@types/bun"],
+              "devDependencies": {
+                "@types/react": "^18.3.3",
+                "esbuild": "^0.21.4",
+                "mitata": "^0.1.11",
+                "peechy": "0.4.34",
+                "prettier": "^3.5.3",
+                "prettier-plugin-organize-imports": "^4.0.0",
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1",
+                "source-map-js": "^1.2.0",
+                "typescript": "^5.7.2",
+              },
+              "resolutions": {
+                "bun-types": "workspace:packages/bun-types",
+                "@types/bun": "workspace:packages/@types/bun",
+              },
+              "scripts": {
+                "build": "bun run build:debug",
+                "watch":
+                  "zig build check --watch -fincremental --prominent-compile-errors --global-cache-dir build/debug/zig-check-cache --zig-lib-dir vendor/zig/lib",
+                "watch-windows":
+                  "zig build check-windows --watch -fincremental --prominent-compile-errors --global-cache-dir build/debug/zig-check-cache --zig-lib-dir vendor/zig/lib",
+                "agent":
+                  "(bun run --silent build:debug &> /tmp/bun.debug.build.log || (cat /tmp/bun.debug.build.log && rm -rf /tmp/bun.debug.build.log && exit 1)) && rm -f /tmp/bun.debug.build.log && ./build/debug/bun-debug",
+                "build:debug": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -B build/debug",
+                "build:debug:asan":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -B build/debug-asan",
+                "build:valgrind":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_BASELINE=ON -ENABLE_VALGRIND=ON -B build/debug-valgrind",
+                "build:release": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -B build/release",
+                "build:ci":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCI=true -B build/release-ci --verbose --fresh",
+                "build:assert":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_ASSERTIONS=ON -DENABLE_LOGS=ON -B build/release-assert",
+                "build:asan":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_ASSERTIONS=ON -DENABLE_LOGS=OFF -DENABLE_ASAN=ON -DENABLE_LTO=OFF -B build/release-asan",
+                "build:logs":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_LOGS=ON -B build/release-logs",
+                "build:safe":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DZIG_OPTIMIZE=ReleaseSafe -B build/release-safe",
+                "build:smol": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=MinSizeRel -B build/release-smol",
+                "build:local":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -DWEBKIT_LOCAL=ON -B build/debug-local",
+                "build:release:local":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DWEBKIT_LOCAL=ON -B build/release-local",
+                "build:release:with_logs":
+                  "cmake . -DCMAKE_BUILD_TYPE=Release -DENABLE_LOGS=true -GNinja -Bbuild-release && ninja -Cbuild-release",
+                "build:debug-zig-release":
+                  "cmake . -DCMAKE_BUILD_TYPE=Release -DZIG_OPTIMIZE=Debug -GNinja -Bbuild-debug-zig-release && ninja -Cbuild-debug-zig-release",
+                "run:linux":
+                  'docker run --rm  -v "$PWD:/root/bun/" -w /root/bun ghcr.io/oven-sh/bun-development-docker-image',
+                "css-properties": "bun run src/css/properties/generate_properties.ts",
+                "uv-posix-stubs": "bun run src/bun.js/bindings/libuv/generate_uv_posix_stubs.ts",
+                "bump": "bun ./scripts/bump.ts",
+                "typecheck": "tsc --noEmit && cd test && bun run typecheck",
+                "fmt": "bun run prettier",
+                "fmt:cpp": "bun run clang-format",
+                "fmt:zig": "bun run zig-format",
+                "lint": "bunx oxlint --config=oxlint.json --format=github src/js",
+                "lint:fix": "oxlint --config oxlint.json --fix",
+                "test": "node scripts/runner.node.mjs --exec-path ./build/debug/bun-debug",
+                "test:release": "node scripts/runner.node.mjs --exec-path ./build/release/bun",
+                "banned": "bun test test/internal/ban-words.test.ts",
+                "glob-sources": "bun scripts/glob-sources.mjs",
+                "zig": "vendor/zig/zig.exe",
+                "zig:test": "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUN_TEST=ON -B build/debug",
+                "zig:test:release":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DBUNTEST=ON -B build/release",
+                "zig:test:ci":
+                  "bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Release -DBUN_TEST=ON -DZIG_OPTIMIZE=ReleaseSafe -DCMAKE_VERBOSE_MAKEFILE=ON -DCI=true -B build/release-ci --verbose --fresh",
+                "zig:fmt": "bun run zig-format",
+                "zig:check": "bun run zig build check --summary new",
+                "zig:check-all": "bun run zig build check-all --summary new",
+                "zig:check-windows": "bun run zig build check-windows --summary new",
+                "analysis":
+                  "bun ./scripts/build.mjs -DCMAKE_BUILD_TYPE=Debug -DENABLE_ANALYSIS=ON -DENABLE_CCACHE=OFF -B build/analysis",
+                "analysis:no-llvm": "bun run analysis -DENABLE_LLVM=OFF",
+                "clang-format": "bun run analysis --target clang-format",
+                "clang-format:check": "bun run analysis --target clang-format-check",
+                "clang-format:diff": "bun run analysis --target clang-format-diff",
+                "clang-tidy": "bun run analysis --target clang-tidy",
+                "clang-tidy:check": "bun run analysis --target clang-tidy-check",
+                "clang-tidy:diff": "bun run analysis --target clang-tidy-diff",
+                "zig-format": "bun run analysis:no-llvm --target zig-format",
+                "zig-format:check": "bun run analysis:no-llvm --target zig-format-check",
+                "prettier":
+                  "bunx prettier@latest --plugin=prettier-plugin-organize-imports --config .prettierrc --write scripts packages src docs 'test/**/*.{test,spec}.{ts,tsx,js,jsx,mts,mjs,cjs,cts}' '!test/**/*fixture*.*'",
+                "node:test": "node ./scripts/runner.node.mjs --quiet --exec-path=$npm_execpath --node-tests ",
+                "clean:zig":
+                  "rm -rf build/debug/cache/zig build/debug/CMakeCache.txt 'build/debug/*.o' .zig-cache zig-out || true",
+              },
+            },
+            null,
+            2,
+          ),
         ),
-        original: binaryData,
       },
-      {
-        name: "binary data level 19",
-        compressed: Buffer.from(
-          "KLUv/WQAAwEgANmWcs6ZP+wtGAMgrvJ/nQVheVjm5n6y5zTNl2A02TAfQQzPymlQdfAsXClptSWlS36V6mF5elkdrwmodkgAqNma0Guj/MXIm9B0pH9qEcF",
-          "base64",
-        ),
-        original: binaryData,
-      },
-    ];
-
-    for (const { name, compressed, original } of testDataCases) {
+    ] as const) {
       it(`can decompress ${name}`, async () => {
         // Test sync decompression
         const syncDecompressed = zstdDecompressSync(compressed);
-        expect(syncDecompressed).toStrictEqual(original);
+        expect(syncDecompressed.toString()).toStrictEqual(original.toString());
 
         // Test async decompression
         const asyncDecompressed = await zstdDecompress(compressed);
-        expect(asyncDecompressed).toStrictEqual(original);
+        expect(asyncDecompressed.toString()).toStrictEqual(original.toString());
       });
     }
   });

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, afterAll, beforeAll } from "bun:test";
 import { randomBytes } from "crypto";
 import { zstdCompressSync, zstdDecompressSync, zstdCompress, zstdDecompress } from "bun";
 import path from "path";
@@ -18,8 +18,12 @@ describe("Zstandard compression", async () => {
   ] as const;
 
   it("throws with invalid level", () => {
-    expect(() => zstdCompressSync(new Uint8Array(123), { level: 0 })).toThrowErrorMatchingInlineSnapshot();
-    expect(() => zstdCompress(new Uint8Array(123), { level: 0 })).toThrowErrorMatchingInlineSnapshot();
+    expect(() => zstdCompressSync(new Uint8Array(123), { level: 0 })).toThrowErrorMatchingInlineSnapshot(
+      `"Compression level must be between 1 and 22"`,
+    );
+    expect(() => zstdCompress(new Uint8Array(123), { level: 0 })).toThrowErrorMatchingInlineSnapshot(
+      `"Compression level must be between 1 and 22"`,
+    );
   });
 
   it("throws with invalid input", () => {
@@ -29,6 +33,53 @@ describe("Zstandard compression", async () => {
     valid[0] = 0;
     valid[valid.length - 1] = 0;
     expect(() => zstdDecompressSync(valid)).toThrow();
+  });
+
+  // Test with known zstd-compressed data
+  describe("zstd CLI compatibility", () => {
+    const binaryData = Buffer.from(
+      "d99672ce993fec2d180320aef27f9d05617958e6e67eb2e734cd976034d9301f410ccfca695075f02c5c2969b525a54b7e95ea61797a591daf09a8764800a8d99ad06ba3fcc5c89bd074a47f6a11c1",
+      "hex",
+    );
+
+    const testDataCases = [
+      {
+        name: "binary data level 1",
+        compressed: Buffer.from(
+          "KLUv/WQAAwEgANmWcs6ZP+wtGAMgrvJ/nQVheVjm5n6y5zTNl2A02TAfQQzPymlQdfAsXClptSWlS36V6mF5elkdrwmodkgAqNma0Guj/MXIm9B0pH9qEcF",
+          "base64",
+        ),
+        original: binaryData,
+      },
+      {
+        name: "binary data level 10",
+        compressed: Buffer.from(
+          "KLUv/WQAAwEgANmWcs6ZP+wtGAMgrvJ/nQVheVjm5n6y5zTNl2A02TAfQQzPymlQdfAsXClptSWlS36V6mF5elkdrwmodkgAqNma0Guj/MXIm9B0pH9qEcF",
+          "base64",
+        ),
+        original: binaryData,
+      },
+      {
+        name: "binary data level 19",
+        compressed: Buffer.from(
+          "KLUv/WQAAwEgANmWcs6ZP+wtGAMgrvJ/nQVheVjm5n6y5zTNl2A02TAfQQzPymlQdfAsXClptSWlS36V6mF5elkdrwmodkgAqNma0Guj/MXIm9B0pH9qEcF",
+          "base64",
+        ),
+        original: binaryData,
+      },
+    ];
+
+    for (const { name, compressed, original } of testDataCases) {
+      it(`can decompress ${name}`, async () => {
+        // Test sync decompression
+        const syncDecompressed = zstdDecompressSync(compressed);
+        expect(syncDecompressed).toStrictEqual(original);
+
+        // Test async decompression
+        const asyncDecompressed = await zstdDecompress(compressed);
+        expect(asyncDecompressed).toStrictEqual(original);
+      });
+    }
   });
 
   for (const { data: input, name } of testCases) {
@@ -60,4 +111,172 @@ describe("Zstandard compression", async () => {
       }
     });
   }
+});
+
+describe("Zstandard HTTP compression", () => {
+  // Sample data for HTTP tests
+  const testData = {
+    text: "This is a test string for zstd HTTP compression tests. Repeating content to improve compression: This is a test string for zstd HTTP compression tests.",
+    json: { id: 1234, name: "Test Object", values: [1, 2, 3, 4, 5], nested: { prop1: "value1", prop2: "value2" } },
+    binary: Buffer.from(
+      "d99672ce993fec2d180320aef27f9d05617958e6e67eb2e734cd976034d9301f410ccfca695075f02c5c2969b525a54b7e95ea61797a591daf09a8764800a8d99ad06ba3fcc5c89bd074a47f6a11c1",
+      "hex",
+    ),
+  };
+
+  let server;
+  let serverBaseUrl;
+
+  // Start HTTP server that can serve zstd-compressed content
+  beforeAll(async () => {
+    server = Bun.serve({
+      port: 0, // Use a random available port
+      async fetch(req) {
+        const url = new URL(req.url);
+        const acceptEncoding = req.headers.get("Accept-Encoding") || "";
+        const supportsZstd = acceptEncoding.includes("zstd");
+
+        // Route: /text
+        if (url.pathname === "/text") {
+          if (supportsZstd) {
+            const compressed = await zstdCompress(testData.text, { level: 3 });
+            return new Response(compressed, {
+              headers: {
+                "Content-Type": "text/plain",
+                "Content-Encoding": "zstd",
+              },
+            });
+          }
+          return new Response(testData.text, {
+            headers: { "Content-Type": "text/plain" },
+          });
+        }
+
+        // Route: /json
+        else if (url.pathname === "/json") {
+          const jsonString = JSON.stringify(testData.json);
+          if (supportsZstd) {
+            const compressed = await zstdCompress(jsonString, { level: 3 });
+            return new Response(compressed, {
+              headers: {
+                "Content-Type": "application/json",
+                "Content-Encoding": "zstd",
+              },
+            });
+          }
+          return new Response(jsonString, {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        // Route: /binary
+        else if (url.pathname === "/binary") {
+          if (supportsZstd) {
+            const compressed = await zstdCompress(testData.binary, { level: 3 });
+            return new Response(compressed, {
+              headers: {
+                "Content-Type": "application/octet-stream",
+                "Content-Encoding": "zstd",
+              },
+            });
+          }
+          return new Response(testData.binary, {
+            headers: { "Content-Type": "application/octet-stream" },
+          });
+        }
+
+        // Route: /echo
+        else if (url.pathname === "/echo") {
+          // Echo back the request body, with zstd compression if supported
+          const body = await req.arrayBuffer();
+          if (supportsZstd) {
+            const compressed = await zstdCompress(new Uint8Array(body), { level: 3 });
+            return new Response(compressed, {
+              headers: {
+                "Content-Type": req.headers.get("Content-Type") || "application/octet-stream",
+                "Content-Encoding": "zstd",
+              },
+            });
+          }
+          return new Response(body, {
+            headers: { "Content-Type": req.headers.get("Content-Type") || "application/octet-stream" },
+          });
+        }
+
+        // Default: 404
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    serverBaseUrl = `http://localhost:${server.port}`;
+  });
+
+  // Clean up the server after tests
+  afterAll(() => {
+    server.stop();
+  });
+
+  it("can fetch and automatically decompress zstd-encoded text", async () => {
+    const response = await fetch(`${serverBaseUrl}/text`, {
+      headers: { "Accept-Encoding": "gzip, deflate, br, zstd" },
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBe("zstd");
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+
+    const text = await response.text();
+    expect(text).toBe(testData.text);
+  });
+
+  it("can fetch and automatically decompress zstd-encoded JSON", async () => {
+    const response = await fetch(`${serverBaseUrl}/json`, {
+      headers: { "Accept-Encoding": "gzip, deflate, br, zstd" },
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBe("zstd");
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(json).toEqual(testData.json);
+  });
+
+  it("can fetch and automatically decompress zstd-encoded binary data", async () => {
+    const response = await fetch(`${serverBaseUrl}/binary`, {
+      headers: { "Accept-Encoding": "zstd" },
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBe("zstd");
+    expect(response.headers.get("Content-Type")).toBe("application/octet-stream");
+
+    const buffer = await response.bytes();
+    expect(buffer).toStrictEqual(testData.binary);
+  });
+
+  it("doesn't use zstd when not in Accept-Encoding", async () => {
+    const response = await fetch(`${serverBaseUrl}/text`, {
+      headers: { "Accept-Encoding": "gzip, deflate, br" },
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBeNull();
+
+    const text = await response.text();
+    expect(text).toBe(testData.text);
+  });
+
+  it("can POST and receive zstd-compressed echo response", async () => {
+    const testString = "Echo this back with zstd compression";
+
+    const response = await fetch(`${serverBaseUrl}/echo`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        "Accept-Encoding": "zstd",
+      },
+      body: testString,
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBe("zstd");
+    const echoed = await response.text();
+    expect(echoed).toBe(testString);
+  });
 });

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -15,7 +15,7 @@ describe("Zstandard compression", async () => {
         (await Bun.file(path.join(__dirname, "..", "..", "..", "..", "src", "js_parser.zig")).text()).repeat(50),
       ),
     },
-  ];
+  ] as const;
 
   // Test various input types
   const inputTypes = [

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -18,10 +18,8 @@ describe("Zstandard compression", async () => {
   ] as const;
 
   it("throws with invalid level", () => {
-    expect(() => zstdCompressSync(new Uint8Array(), { level: 0 })).toThrow();
-    expect(() => zstdCompress(new Uint8Array(), { level: 0 })).toThrow();
-    expect(() => zstdDecompressSync(new Uint8Array(), { level: -1 })).toThrow();
-    expect(() => zstdDecompress(new Uint8Array(), { level: -1 })).toThrow();
+    expect(() => zstdCompressSync(new Uint8Array(123), { level: 0 })).toThrowErrorMatchingInlineSnapshot();
+    expect(() => zstdCompress(new Uint8Array(123), { level: 0 })).toThrowErrorMatchingInlineSnapshot();
   });
 
   it("throws with invalid input", () => {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, afterAll, beforeAll } from "bun:test";
-import { randomBytes } from "crypto";
-import { zstdCompressSync, zstdDecompressSync, zstdCompress, zstdDecompress } from "bun";
+import { zstdCompress, zstdCompressSync, zstdDecompress, zstdDecompressSync } from "bun";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import path from "path";
 
 describe("Zstandard compression", async () => {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -17,6 +17,22 @@ describe("Zstandard compression", async () => {
     },
   ] as const;
 
+  it("throws with invalid level", () => {
+    expect(() => zstdCompressSync(new Uint8Array(), { level: 0 })).toThrow();
+    expect(() => zstdCompress(new Uint8Array(), { level: 0 })).toThrow();
+    expect(() => zstdDecompressSync(new Uint8Array(), { level: -1 })).toThrow();
+    expect(() => zstdDecompress(new Uint8Array(), { level: -1 })).toThrow();
+  });
+
+  it("throws with invalid input", () => {
+    expect(() => zstdDecompressSync("wow such compressed")).toThrow();
+    expect(() => zstdDecompress("veryyy such compressed")).toThrow();
+    const valid = zstdCompressSync(Buffer.from("wow such compressed"));
+    valid[0] = 0;
+    valid[valid.length - 1] = 0;
+    expect(() => zstdDecompressSync(valid)).toThrow();
+  });
+
   for (const { data: input, name } of testCases) {
     describe(name + " (" + input.length + " bytes)", () => {
       for (let level = 1; level <= 22; level++) {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -12,193 +12,38 @@ describe("Zstandard compression", async () => {
     {
       name: "large",
       data: Buffer.from(
-        (await Bun.file(path.join(__dirname, "..", "..", "..", "..", "src", "js_parser.zig")).text()).repeat(50),
+        (await Bun.file(path.join(__dirname, "..", "..", "..", "..", "src", "js_parser.zig")).text()).repeat(5),
       ),
     },
   ] as const;
 
-  // Test various input types
-  const inputTypes = [
-    {
-      name: "Uint8Array",
-      convert: (data: Uint8Array) => data,
-      extract: (data: Uint8Array) => data,
-    },
-    {
-      name: "Buffer",
-      convert: (data: Uint8Array) => Buffer.from(data),
-      extract: (data: Buffer) => new Uint8Array(data),
-    },
-    {
-      name: "string",
-      convert: (data: Uint8Array) => new TextDecoder().decode(data),
-      extract: (data: string) => new TextEncoder().encode(data),
-      skip: (testCase: (typeof testCases)[number]) =>
-        // Skip random bytes for strings as they may contain invalid UTF-8
-        testCase.name === "medium" || testCase.name === "large",
-    },
-  ];
+  for (const { data: input, name } of testCases) {
+    describe(name + " (" + input.length + " bytes)", () => {
+      for (let level = 1; level <= 22; level++) {
+        it("level " + level, async () => {
+          // Sync compression
+          const syncCompressed = zstdCompressSync(input, { level });
 
-  // Test compression levels
-  const compressionLevels = [1, 3, 9, 22]; // Min, default, higher, max
+          // Async compression
+          const asyncCompressed = await zstdCompress(input, { level });
 
-  describe("zstdCompressSync", () => {
-    for (const testCase of testCases) {
-      for (const inputType of inputTypes) {
-        if (inputType.skip?.(testCase)) continue;
+          // Compare compressed results (they should be identical with same level)
+          expect(syncCompressed).toStrictEqual(asyncCompressed);
 
-        describe(`with ${testCase.name} ${inputType.name}`, () => {
-          for (const level of compressionLevels) {
-            it(`compresses at level ${level}`, () => {
-              const input = inputType.convert(testCase.data);
-              const compressed = zstdCompressSync(input, { level });
+          // Sync decompression of async compressed data
+          const syncDecompressed = zstdDecompressSync(asyncCompressed);
 
-              expect(compressed).toBeInstanceOf(Uint8Array);
+          // Async decompression of sync compressed data
+          const asyncDecompressed = await zstdDecompress(syncCompressed);
 
-              // Empty data should compress to very small size
-              if (testCase.name === "empty") {
-                expect(compressed.byteLength).toBeLessThan(20);
-              }
-              // Non-empty data should compress to smaller size (unless very small)
-              else if (testCase.name !== "small") {
-                expect(compressed.byteLength).toBeLessThan(testCase.data.byteLength);
-              }
+          // Compare decompressed results
+          expect(syncDecompressed).toStrictEqual(asyncDecompressed);
 
-              // Verify compressed format header
-              if (compressed.byteLength > 4) {
-                // Check for Zstandard frame magic number (0xFD2FB528)
-                expect(compressed[0]).toBe(0xfd);
-                expect(compressed[1]).toBe(0x2f);
-                expect(compressed[2]).toBe(0xb5);
-                // We don't check the last byte as version might change
-              }
-            });
-          }
+          // Verify both match original
+          expect(syncDecompressed).toStrictEqual(input);
+          expect(asyncDecompressed).toStrictEqual(input);
         });
       }
-    }
-
-    it("throws on invalid compression level", () => {
-      expect(() => zstdCompressSync("test", { level: 0 })).toThrow();
-      expect(() => zstdCompressSync("test", { level: 23 })).toThrow();
-      expect(() => zstdCompressSync("test", { level: -1 })).toThrow();
     });
-  });
-
-  describe("zstdDecompressSync", () => {
-    for (const testCase of testCases) {
-      for (const inputType of inputTypes) {
-        if (inputType.skip?.(testCase)) continue;
-
-        it(`decompresses ${testCase.name} ${inputType.name}`, () => {
-          const input = inputType.convert(testCase.data);
-          const compressed = zstdCompressSync(input);
-          const decompressed = zstdDecompressSync(compressed);
-
-          expect(decompressed).toBeInstanceOf(Uint8Array);
-
-          // Compare with original data
-          expect(new Uint8Array(decompressed)).toEqual(inputType.extract(input));
-        });
-      }
-    }
-
-    it("throws on invalid compressed data", () => {
-      expect(() => zstdDecompressSync(new Uint8Array([1, 2, 3, 4]))).toThrow();
-      expect(() => zstdDecompressSync("not compressed")).toThrow();
-    });
-  });
-
-  describe("zstdCompress/zstdDecompress", () => {
-    for (const testCase of testCases) {
-      if (testCase.name === "large") continue; // Skip large for faster async tests
-
-      for (const inputType of inputTypes) {
-        if (inputType.skip?.(testCase)) continue;
-
-        for (const level of [1, 22]) {
-          // Test min and max levels
-          it(`async compresses and decompresses ${testCase.name} ${inputType.name} at level ${level}`, async () => {
-            const input = inputType.convert(testCase.data);
-
-            // Test async compression
-            const compressed = await zstdCompress(input, { level });
-            expect(compressed).toBeInstanceOf(Uint8Array);
-
-            // Test async decompression
-            const decompressed = await zstdDecompress(compressed);
-            expect(decompressed).toBeInstanceOf(Uint8Array);
-
-            // Compare with original data
-            expect(new Uint8Array(decompressed)).toEqual(inputType.extract(input));
-          });
-        }
-      }
-    }
-
-    it("rejects on invalid compression level", async () => {
-      await expect(zstdCompress("test", { level: 0 })).rejects.toThrow();
-      await expect(zstdCompress("test", { level: 23 })).rejects.toThrow();
-    });
-
-    it("rejects on invalid compressed data", async () => {
-      await expect(zstdDecompress(new Uint8Array([1, 2, 3, 4]))).rejects.toThrow();
-      await expect(zstdDecompress("not compressed")).rejects.toThrow();
-    });
-  });
-
-  describe("roundtrip consistency", () => {
-    it("gives identical results between sync and async methods", async () => {
-      const input = "Test data for consistency check";
-
-      // Sync compression
-      const syncCompressed = zstdCompressSync(input, { level: 5 });
-
-      // Async compression
-      const asyncCompressed = await zstdCompress(input, { level: 5 });
-
-      // Compare compressed results (they should be identical with same level)
-      expect(new Uint8Array(syncCompressed)).toEqual(new Uint8Array(asyncCompressed));
-
-      // Sync decompression of async compressed data
-      const syncDecompressed = zstdDecompressSync(asyncCompressed);
-
-      // Async decompression of sync compressed data
-      const asyncDecompressed = await zstdDecompress(syncCompressed);
-
-      // Compare decompressed results
-      expect(new Uint8Array(syncDecompressed)).toEqual(new Uint8Array(asyncDecompressed));
-
-      // Verify both match original
-      const original = new TextEncoder().encode(input);
-      expect(new Uint8Array(syncDecompressed)).toEqual(original);
-      expect(new Uint8Array(asyncDecompressed)).toEqual(original);
-    });
-  });
-
-  describe("performance tests", () => {
-    // Performance checks are not assertions but provide useful information
-    it("measures compression/decompression performance", () => {
-      const SIZE = 1_000_000; // 1MB
-      const testData = randomBytes(SIZE);
-
-      // Test sync compression performance
-      console.log("\nCompression performance:");
-      for (const level of [1, 3, 9, 22]) {
-        const start = performance.now();
-        const compressed = zstdCompressSync(testData, { level });
-        const duration = performance.now() - start;
-        const ratio = compressed.byteLength / SIZE;
-        console.log(`  Level ${level}: ${(SIZE / duration / 1000).toFixed(2)} MB/s, ratio: ${ratio.toFixed(3)}`);
-      }
-
-      // Test sync decompression performance
-      console.log("\nDecompression performance:");
-      const compressed = zstdCompressSync(testData, { level: 3 });
-      const start = performance.now();
-      zstdDecompressSync(compressed);
-      const duration = performance.now() - start;
-      console.log(`  Speed: ${(SIZE / duration / 1000).toFixed(2)} MB/s`);
-    });
-  });
+  }
 });

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test";
+import { randomBytes } from "crypto";
+import { zstdCompressSync, zstdDecompressSync, zstdCompress, zstdDecompress } from "bun";
+import path from "path";
+
+describe("Zstandard compression", async () => {
+  // Test data of various sizes
+  const testCases = [
+    // { name: "empty", data: new Uint8Array(0) },
+    { name: "small", data: new TextEncoder().encode("Hello, World!") },
+    { name: "medium", data: await Bun.file(path.join(__dirname, "..", "..", "..", "bun.lock")).bytes() },
+    {
+      name: "large",
+      data: Buffer.from(
+        (await Bun.file(path.join(__dirname, "..", "..", "..", "..", "src", "js_parser.zig")).text()).repeat(50),
+      ),
+    },
+  ];
+
+  // Test various input types
+  const inputTypes = [
+    {
+      name: "Uint8Array",
+      convert: (data: Uint8Array) => data,
+      extract: (data: Uint8Array) => data,
+    },
+    {
+      name: "Buffer",
+      convert: (data: Uint8Array) => Buffer.from(data),
+      extract: (data: Buffer) => new Uint8Array(data),
+    },
+    {
+      name: "string",
+      convert: (data: Uint8Array) => new TextDecoder().decode(data),
+      extract: (data: string) => new TextEncoder().encode(data),
+      skip: (testCase: (typeof testCases)[number]) =>
+        // Skip random bytes for strings as they may contain invalid UTF-8
+        testCase.name === "medium" || testCase.name === "large",
+    },
+  ];
+
+  // Test compression levels
+  const compressionLevels = [1, 3, 9, 22]; // Min, default, higher, max
+
+  describe("zstdCompressSync", () => {
+    for (const testCase of testCases) {
+      for (const inputType of inputTypes) {
+        if (inputType.skip?.(testCase)) continue;
+
+        describe(`with ${testCase.name} ${inputType.name}`, () => {
+          for (const level of compressionLevels) {
+            it(`compresses at level ${level}`, () => {
+              const input = inputType.convert(testCase.data);
+              const compressed = zstdCompressSync(input, { level });
+
+              expect(compressed).toBeInstanceOf(Uint8Array);
+
+              // Empty data should compress to very small size
+              if (testCase.name === "empty") {
+                expect(compressed.byteLength).toBeLessThan(20);
+              }
+              // Non-empty data should compress to smaller size (unless very small)
+              else if (testCase.name !== "small") {
+                expect(compressed.byteLength).toBeLessThan(testCase.data.byteLength);
+              }
+
+              // Verify compressed format header
+              if (compressed.byteLength > 4) {
+                // Check for Zstandard frame magic number (0xFD2FB528)
+                expect(compressed[0]).toBe(0xfd);
+                expect(compressed[1]).toBe(0x2f);
+                expect(compressed[2]).toBe(0xb5);
+                // We don't check the last byte as version might change
+              }
+            });
+          }
+        });
+      }
+    }
+
+    it("throws on invalid compression level", () => {
+      expect(() => zstdCompressSync("test", { level: 0 })).toThrow();
+      expect(() => zstdCompressSync("test", { level: 23 })).toThrow();
+      expect(() => zstdCompressSync("test", { level: -1 })).toThrow();
+    });
+  });
+
+  describe("zstdDecompressSync", () => {
+    for (const testCase of testCases) {
+      for (const inputType of inputTypes) {
+        if (inputType.skip?.(testCase)) continue;
+
+        it(`decompresses ${testCase.name} ${inputType.name}`, () => {
+          const input = inputType.convert(testCase.data);
+          const compressed = zstdCompressSync(input);
+          const decompressed = zstdDecompressSync(compressed);
+
+          expect(decompressed).toBeInstanceOf(Uint8Array);
+
+          // Compare with original data
+          expect(new Uint8Array(decompressed)).toEqual(inputType.extract(input));
+        });
+      }
+    }
+
+    it("throws on invalid compressed data", () => {
+      expect(() => zstdDecompressSync(new Uint8Array([1, 2, 3, 4]))).toThrow();
+      expect(() => zstdDecompressSync("not compressed")).toThrow();
+    });
+  });
+
+  describe("zstdCompress/zstdDecompress", () => {
+    for (const testCase of testCases) {
+      if (testCase.name === "large") continue; // Skip large for faster async tests
+
+      for (const inputType of inputTypes) {
+        if (inputType.skip?.(testCase)) continue;
+
+        for (const level of [1, 22]) {
+          // Test min and max levels
+          it(`async compresses and decompresses ${testCase.name} ${inputType.name} at level ${level}`, async () => {
+            const input = inputType.convert(testCase.data);
+
+            // Test async compression
+            const compressed = await zstdCompress(input, { level });
+            expect(compressed).toBeInstanceOf(Uint8Array);
+
+            // Test async decompression
+            const decompressed = await zstdDecompress(compressed);
+            expect(decompressed).toBeInstanceOf(Uint8Array);
+
+            // Compare with original data
+            expect(new Uint8Array(decompressed)).toEqual(inputType.extract(input));
+          });
+        }
+      }
+    }
+
+    it("rejects on invalid compression level", async () => {
+      await expect(zstdCompress("test", { level: 0 })).rejects.toThrow();
+      await expect(zstdCompress("test", { level: 23 })).rejects.toThrow();
+    });
+
+    it("rejects on invalid compressed data", async () => {
+      await expect(zstdDecompress(new Uint8Array([1, 2, 3, 4]))).rejects.toThrow();
+      await expect(zstdDecompress("not compressed")).rejects.toThrow();
+    });
+  });
+
+  describe("roundtrip consistency", () => {
+    it("gives identical results between sync and async methods", async () => {
+      const input = "Test data for consistency check";
+
+      // Sync compression
+      const syncCompressed = zstdCompressSync(input, { level: 5 });
+
+      // Async compression
+      const asyncCompressed = await zstdCompress(input, { level: 5 });
+
+      // Compare compressed results (they should be identical with same level)
+      expect(new Uint8Array(syncCompressed)).toEqual(new Uint8Array(asyncCompressed));
+
+      // Sync decompression of async compressed data
+      const syncDecompressed = zstdDecompressSync(asyncCompressed);
+
+      // Async decompression of sync compressed data
+      const asyncDecompressed = await zstdDecompress(syncCompressed);
+
+      // Compare decompressed results
+      expect(new Uint8Array(syncDecompressed)).toEqual(new Uint8Array(asyncDecompressed));
+
+      // Verify both match original
+      const original = new TextEncoder().encode(input);
+      expect(new Uint8Array(syncDecompressed)).toEqual(original);
+      expect(new Uint8Array(asyncDecompressed)).toEqual(original);
+    });
+  });
+
+  describe("performance tests", () => {
+    // Performance checks are not assertions but provide useful information
+    it("measures compression/decompression performance", () => {
+      const SIZE = 1_000_000; // 1MB
+      const testData = randomBytes(SIZE);
+
+      // Test sync compression performance
+      console.log("\nCompression performance:");
+      for (const level of [1, 3, 9, 22]) {
+        const start = performance.now();
+        const compressed = zstdCompressSync(testData, { level });
+        const duration = performance.now() - start;
+        const ratio = compressed.byteLength / SIZE;
+        console.log(`  Level ${level}: ${(SIZE / duration / 1000).toFixed(2)} MB/s, ratio: ${ratio.toFixed(3)}`);
+      }
+
+      // Test sync decompression performance
+      console.log("\nDecompression performance:");
+      const compressed = zstdCompressSync(testData, { level: 3 });
+      const start = performance.now();
+      zstdDecompressSync(compressed);
+      const duration = performance.now() - start;
+      console.log(`  Speed: ${(SIZE / duration / 1000).toFixed(2)} MB/s`);
+    });
+  });
+});

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -35,7 +35,7 @@ describe("Zstandard compression", async () => {
   });
 
   // Test with known zstd-compressed data
-  describe.only("zstd CLI compatibility", () => {
+  describe("zstd CLI compatibility", () => {
     for (const { name, compressed, original } of [
       {
         name: "package.json",
@@ -144,7 +144,7 @@ describe("Zstandard compression", async () => {
             },
             null,
             2,
-          ),
+          ) + "\n",
         ),
       },
     ] as const) {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -300,9 +300,9 @@ describe("TextDecoder", () => {
   });
 
   it("should support undefined options", () => {
-      expect(() => {
-          const decoder = new TextDecoder("utf-8", undefined);
-      }).not.toThrow();
+    expect(() => {
+      const decoder = new TextDecoder("utf-8", undefined);
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- support `zstd` in HTTP Accept-Encoding and decoding
- implement `ZstdReaderArrayList` for streaming decompression
- update Decompressor and encoding logic to handle zstd

## Testing
- `bun agent test test/js/web/fetch/client-fetch.test.ts` *(fails: CMake error downloading WebKit)*