### PR TITLE
test-net-socket-constructor.js

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -494,6 +494,16 @@ function Socket(options?) {
   if (options?.writableObjectMode)
     throw $ERR_INVALID_ARG_VALUE("options.writableObjectMode", options.writableObjectMode, "is not supported");
 
+  if (options?.fd !== undefined) {
+    if (options.fd < 0) {
+      throw $ERR_OUT_OF_RANGE("options.fd", options.fd, 0);
+    }
+
+    if (typeof options.fd !== "number") {
+      throw $ERR_INVALID_ARG_TYPE("options.fd", options.fd, "number");
+    }
+  }
+
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -31,7 +31,7 @@ const { ExceptionWithHostPort } = require("internal/shared");
 import type { SocketHandler, SocketListener } from "bun";
 import type { ServerOpts } from "node:net";
 const { getTimerDuration } = require("internal/timers");
-const { validateFunction, validateNumber, validateAbortSignal } = require("internal/validators");
+const { validateFunction, validateInt32, validateNumber, validateAbortSignal } = require("internal/validators");
 
 const getDefaultAutoSelectFamily = $zig("node_net_binding.zig", "getDefaultAutoSelectFamily");
 const setDefaultAutoSelectFamily = $zig("node_net_binding.zig", "setDefaultAutoSelectFamily");
@@ -495,13 +495,7 @@ function Socket(options?) {
     throw $ERR_INVALID_ARG_VALUE("options.writableObjectMode", options.writableObjectMode, "is not supported");
 
   if (options?.fd !== undefined) {
-    if (options.fd < 0) {
-      throw $ERR_OUT_OF_RANGE("options.fd", options.fd, 0);
-    }
-
-    if (typeof options.fd !== "number") {
-      throw $ERR_INVALID_ARG_TYPE("options.fd", options.fd, "number");
-    }
+    validateInt32(options.fd, "options.fd", 0);
   }
 
   Duplex.$call(this, {

--- a/test/js/node/test/parallel/test-net-socket-constructor.js
+++ b/test/js/node/test/parallel/test-net-socket-constructor.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+
+assert.throws(() => {
+  new net.Socket({ fd: -1 });
+}, { code: 'ERR_OUT_OF_RANGE' });
+
+assert.throws(() => {
+  new net.Socket({ fd: 'foo' });
+}, { code: 'ERR_INVALID_ARG_TYPE' });
+
+function test(sock, readable, writable) {
+  let socket;
+  if (sock instanceof net.Socket) {
+    socket = sock;
+  } else {
+    socket = new net.Socket(sock);
+    socket.unref();
+  }
+
+  assert.strictEqual(socket.readable, readable);
+  assert.strictEqual(socket.writable, writable);
+}
+
+if (cluster.isPrimary) {
+  test(undefined, true, true);
+
+  const server = net.createServer(common.mustCall((socket) => {
+    socket.unref();
+    test(socket, true, true);
+    test({ handle: socket._handle }, true, true);
+    test({ handle: socket._handle, readable: true, writable: true },
+         true, true);
+    server.close();
+  }));
+
+  server.listen(common.mustCall(() => {
+    const { port } = server.address();
+    const socket = net.connect(port, common.mustCall(() => {
+      test(socket, true, true);
+      socket.end();
+    }));
+
+    test(socket, true, true);
+  }));
+
+  cluster.setupPrimary({
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe', 'pipe', 'pipe']
+  });
+
+  const worker = cluster.fork();
+  worker.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+} else {
+  test(4, true, true);
+  test({ fd: 5 }, true, true);
+  test({ fd: 6, readable: true, writable: true }, true, true);
+  process.disconnect();
+}

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -300,9 +300,9 @@ describe("TextDecoder", () => {
   });
 
   it("should support undefined options", () => {
-      expect(() => {
-          const decoder = new TextDecoder("utf-8", undefined);
-      }).not.toThrow();
+    expect(() => {
+      const decoder = new TextDecoder("utf-8", undefined);
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

test
