### PR TITLE
pass test-worker-unsupported-things.js

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -2023,6 +2023,11 @@ export fn Bun__VirtualMachine__setOverrideModuleRunMainPromise(vm: *VirtualMachi
     }
 }
 
+export fn Bun__VirtualMachine__getWorker(vm: *VirtualMachine) ?*anyopaque {
+    const worker = vm.worker orelse return null;
+    return worker.cpp_worker;
+}
+
 pub fn reloadEntryPointForTestRunner(this: *VirtualMachine, entry_path: []const u8) !*JSInternalPromise {
     this.has_loaded = false;
     this.main = entry_path;

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3320,7 +3320,7 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     return object;
 }
 
-static uint16_t debugPort;
+static uint16_t debugPort = 9229;
 
 JSC_DEFINE_CUSTOM_GETTER(processDebugPort, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {

--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -999,6 +999,13 @@ JSC::EncodedJSValue INVALID_FILE_URL_PATH(JSC::ThrowScope& throwScope, JSC::JSGl
     return {};
 }
 
+JSC::EncodedJSValue WORKER_UNSUPPORTED_OPERATION(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const ASCIILiteral operation)
+{
+    auto message = makeString(operation, " is not supported in workers"_s);
+    throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_WORKER_UNSUPPORTED_OPERATION, message));
+    return {};
+}
+
 JSC::EncodedJSValue UNKNOWN_ENCODING(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::StringView encoding)
 {
     auto message = makeString("Unknown encoding: "_s, encoding);

--- a/src/bun.js/bindings/ErrorCode.h
+++ b/src/bun.js/bindings/ErrorCode.h
@@ -145,6 +145,11 @@ JSC::EncodedJSValue INVALID_FILE_URL_HOST(JSC::ThrowScope& throwScope, JSC::JSGl
 /// `File URL path {suffix}`
 JSC::EncodedJSValue INVALID_FILE_URL_PATH(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const ASCIILiteral suffix);
 
+// Worker
+
+// `{operation} is not supported in workers`
+JSC::EncodedJSValue WORKER_UNSUPPORTED_OPERATION(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const ASCIILiteral operation);
+
 }
 
 void throwBoringSSLError(JSC::VM& vm, JSC::ThrowScope& scope, JSGlobalObject* globalObject, int errorCode);

--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -252,6 +252,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_VM_MODULE_LINK_FAILURE", Error],
   ["ERR_WASI_NOT_STARTED", Error],
   ["ERR_WORKER_INIT_FAILED", Error],
+  ["ERR_WORKER_UNSUPPORTED_OPERATION", TypeError],
   ["ERR_ZLIB_INITIALIZATION_FAILED", Error],
   ["MODULE_NOT_FOUND", Error],
   ["ERR_INTERNAL_ASSERTION", Error],

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -4376,6 +4376,14 @@ bool GlobalObject::hasNapiFinalizers() const
 
 void GlobalObject::setNodeWorkerEnvironmentData(JSMap* data) { m_nodeWorkerEnvironmentData.set(vm(), this, data); }
 
+extern "C" WebCore::Worker* Bun__VirtualMachine__getWorker(VirtualMachine* bunVM);
+
+WebCore::Worker* GlobalObject::worker()
+{
+    // TODO make bunVM typed instead of void* everywhere
+    return Bun__VirtualMachine__getWorker(reinterpret_cast<VirtualMachine*>(bunVM()));
+}
+
 extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -25,6 +25,7 @@ class WorkerGlobalScope;
 class SubtleCrypto;
 class EventTarget;
 class Performance;
+class Worker;
 } // namespace WebCore
 
 namespace Bun {
@@ -387,6 +388,10 @@ public:
         barrier.set(vm(), this, func);
         return func;
     }
+
+    // Return the Worker object if this global object is running in a worker, or nullptr
+    // if it is not.
+    WebCore::Worker* worker();
 
     bool asyncHooksNeedsCleanup = false;
     double INSPECT_MAX_BYTES = 50;

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -514,8 +514,6 @@ extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
     }
 }
 
-extern "C" WebCore::Worker* WebWorker__getParentWorker(void* bunVM);
-
 JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -551,7 +549,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     JSValue threadId = jsNumber(0);
     JSMap* environmentData = nullptr;
 
-    if (auto* worker = WebWorker__getParentWorker(globalObject->bunVM())) {
+    if (auto* worker = globalObject->worker()) {
         auto& options = worker->options();
         auto ports = MessagePort::entanglePorts(*ScriptExecutionContext::getScriptExecutionContext(worker->clientIdentifier()), WTFMove(options.dataMessagePorts));
         RefPtr<WebCore::SerializedScriptValue> serialized = WTFMove(options.workerDataAndEnvironmentData);
@@ -597,7 +595,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionPostMessage,
     if (UNLIKELY(!globalObject))
         return JSValue::encode(jsUndefined());
 
-    Worker* worker = WebWorker__getParentWorker(globalObject->bunVM());
+    Worker* worker = globalObject->worker();
     if (worker == nullptr)
         return JSValue::encode(jsUndefined());
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -57,11 +57,6 @@ extern fn WebWorker__dispatchOnline(cpp_worker: *anyopaque, *jsc.JSGlobalObject)
 extern fn WebWorker__fireEarlyMessages(cpp_worker: *anyopaque, *jsc.JSGlobalObject) void;
 extern fn WebWorker__dispatchError(*jsc.JSGlobalObject, *anyopaque, bun.String, JSValue) void;
 
-export fn WebWorker__getParentWorker(vm: *jsc.VirtualMachine) ?*anyopaque {
-    const worker = vm.worker orelse return null;
-    return worker.cpp_worker;
-}
-
 pub fn hasRequestedTerminate(this: *const WebWorker) bool {
     return this.requested_terminate.load(.monotonic);
 }

--- a/test/js/node/test/parallel/test-worker-unsupported-things.js
+++ b/test/js/node/test/parallel/test-worker-unsupported-things.js
@@ -1,0 +1,70 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker, parentPort } = require('worker_threads');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  process.env.NODE_CHANNEL_FD = 'foo'; // Make worker think it has IPC.
+  const w = new Worker(__filename);
+  w.on('message', common.mustCall((message) => {
+    assert.strictEqual(message, true);
+  }));
+} else {
+  {
+    const before = process.title;
+    const after = before + ' in worker';
+    process.title = after;
+    assert.strictEqual(process.title, after);
+  }
+
+  {
+    const before = process.debugPort;
+    const after = before + 1;
+    process.debugPort = after;
+    assert.strictEqual(process.debugPort, after);
+  }
+
+  {
+    const mask = 0o600;
+    assert.throws(() => { process.umask(mask); }, {
+      code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
+      message: 'Setting process.umask() is not supported in workers'
+    });
+  }
+
+  const stubs = ['abort', 'chdir', 'send', 'disconnect'];
+
+  if (!common.isWindows) {
+    stubs.push('setuid', 'seteuid', 'setgid',
+               'setegid', 'setgroups', 'initgroups');
+  }
+
+  stubs.forEach((fn) => {
+    assert.strictEqual(process[fn].disabled, true);
+    assert.throws(() => {
+      process[fn]();
+    }, {
+      code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
+      message: `process.${fn}() is not supported in workers`
+    });
+  });
+
+  ['channel', 'connected'].forEach((fn) => {
+    assert.throws(() => {
+      process[fn]; // eslint-disable-line no-unused-expressions
+    }, {
+      code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
+      message: `process.${fn} is not supported in workers`
+    });
+  });
+
+  assert.strictEqual('_startProfilerIdleNotifier' in process, false);
+  assert.strictEqual('_stopProfilerIdleNotifier' in process, false);
+  assert.strictEqual('_debugProcess' in process, false);
+  assert.strictEqual('_debugPause' in process, false);
+  assert.strictEqual('_debugEnd' in process, false);
+
+  parentPort.postMessage(true);
+}


### PR DESCRIPTION
### What does this PR do?

DRAFT because the Windows failure is real.

Passes this Node test by disabling various `process` APIs in workers:

- some functions are replaced by ones that throw when called and have `disabled` set to true
- some properties are replaced by getters that throw
- some properties are deleted

### How did you verify your code works?

Node test + new Bun test