### PR TITLE
Fix BroadcastChannel.unref() return value

### DIFF
--- a/scripts/sync-webkit-source.ts
+++ b/scripts/sync-webkit-source.ts
@@ -1,5 +1,5 @@
-import { join, dirname } from "node:path";
 import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const bunRepo = dirname(import.meta.dir);
 const webkitRepo = join(bunRepo, "vendor/WebKit");

--- a/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
@@ -401,7 +401,8 @@ static inline JSC::EncodedJSValue jsBroadcastChannelPrototypeFunction_unrefBody(
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.jsUnref(lexicalGlobalObject); })));
+    impl.jsUnref(lexicalGlobalObject);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(castedThis));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototypeFunction_unref, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
@@ -402,7 +402,7 @@ static inline JSC::EncodedJSValue jsBroadcastChannelPrototypeFunction_unrefBody(
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
     impl.jsUnref(lexicalGlobalObject);
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(&castedThis));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(castedThis));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototypeFunction_unref, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/JSBroadcastChannel.cpp
@@ -402,7 +402,7 @@ static inline JSC::EncodedJSValue jsBroadcastChannelPrototypeFunction_unrefBody(
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
     impl.jsUnref(lexicalGlobalObject);
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(castedThis));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(&castedThis));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototypeFunction_unref, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -300,9 +300,9 @@ describe("TextDecoder", () => {
   });
 
   it("should support undefined options", () => {
-      expect(() => {
-          const decoder = new TextDecoder("utf-8", undefined);
-      }).not.toThrow();
+    expect(() => {
+      const decoder = new TextDecoder("utf-8", undefined);
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- make `BroadcastChannel.prototype.unref()` return the channel instance

## Testing
- `bun agent test test/js/web/broadcastchannel/broadcast-channel.test.ts` *(fails: network access required for build)*