### PR TITLE
update `bun.lock` types for `catalog(s)`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7479,10 +7479,15 @@ declare module "bun" {
     workspaces: {
       [workspace: string]: BunLockFileWorkspacePackage;
     };
+    /** @see https://bun.sh/docs/install/overrides */
     overrides?: Record<string, string>;
+    /** @see https://bun.sh/docs/install/patch */
     patchedDependencies?: Record<string, string>;
+    /** @see https://bun.sh/docs/install/lifecycle#trusteddependencies */
     trustedDependencies?: string[];
+    /** @see https://bun.sh/docs/install/catalogs */
     catalog?: Record<string, string>;
+    /** @see https://bun.sh/docs/install/catalogs */
     catalogs?: Record<string, Record<string, string>>;
 
     /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7482,6 +7482,8 @@ declare module "bun" {
     overrides?: Record<string, string>;
     patchedDependencies?: Record<string, string>;
     trustedDependencies?: string[];
+    catalog?: Record<string, string>;
+    catalogs?: Record<string, Record<string, string>>;
 
     /**
      * ```

--- a/packages/bun-vscode/assets/package.json
+++ b/packages/bun-vscode/assets/package.json
@@ -785,6 +785,23 @@
               "items": {
                 "type": "string"
               }
+            },
+            "catalog": {
+              "type": "object",
+              "description": "A single default catalog for commonly used dependencies. Referenced with 'catalog:' in workspace package dependencies.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "catalogs": {
+              "type": "object",
+              "description": "Multiple named catalogs for grouping dependencies. Referenced with 'catalog:catalogName' in workspace package dependencies.",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
### What does this PR do?
update for #19809
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
