### PR TITLE
Fixed: radians rewritten to degrees without converting

### DIFF
--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -7322,3 +7322,19 @@ fn restrict_prec(buf: []u8, comptime prec: u8) struct { []u8, Notation } {
 pub inline fn fract(val: f32) f32 {
     return val - @trunc(val);
 }
+
+pub fn f32_length_with_5_digits(n_input: f32) usize {
+    var n = std.math.round(n_input * 100000.0);
+    var count: usize = 0;
+    var i: usize = 0;
+
+    while (n >= 1.0) : (i += 1) {
+        const rem = @mod(n, 10.0);
+        if (i > 4 or rem != 0.0) {
+            count += 1;
+        }
+        n = n / 10.0;
+    }
+
+    return count;
+}

--- a/src/css/values/angle.zig
+++ b/src/css/values/angle.zig
@@ -81,7 +81,17 @@ pub const Angle = union(Tag) {
         const value, const unit = switch (this.*) {
             .deg => |val| .{ val, "deg" },
             .grad => |val| .{ val, "grad" },
-            .rad => |val| .{ val, "rad" },
+            .rad => |val| brk: {
+                const deg = this.toDegrees();
+
+                // We print 5 digits of precision by default.
+                // Switch to degrees if length is smaller than rad.
+                if (css.f32_length_with_5_digits(deg) < css.f32_length_with_5_digits(val)) {
+                    break :brk .{ deg, "deg" };
+                } else {
+                    break :brk .{ val, "rad" };
+                }
+            },
             .turn => |val| .{ val, "turn" },
         };
         css.serializer.serializeDimension(value, unit, W, dest) catch return dest.addFmtError();

--- a/src/css/values/angle.zig
+++ b/src/css/values/angle.zig
@@ -81,17 +81,7 @@ pub const Angle = union(Tag) {
         const value, const unit = switch (this.*) {
             .deg => |val| .{ val, "deg" },
             .grad => |val| .{ val, "grad" },
-            .rad => |val| brk: {
-                const deg = this.toDegrees();
-
-                // We print 5 digits of precision by default.
-                // Switch to degrees if there are an even number of them.
-                if (css.fract(std.math.round(deg * 100000.0)) == 0) {
-                    break :brk .{ val, "deg" };
-                } else {
-                    break :brk .{ val, "rad" };
-                }
-            },
+            .rad => |val| .{ val, "rad" },
             .turn => |val| .{ val, "turn" },
         };
         css.serializer.serializeDimension(value, unit, W, dest) catch return dest.addFmtError();

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6943,6 +6943,10 @@ describe("css tests", () => {
     minify_test(".foo { transform: rotateX(20rad)", ".foo{transform:rotateX(20rad)}");
     minify_test(".foo { transform: rotateY(20rad)", ".foo{transform:rotateY(20rad)}");
     minify_test(".foo { transform: rotateZ(20rad)", ".foo{transform:rotate(20rad)}");
+    minify_test(".foo { transform: rotateX(0.017453293rad)", ".foo{transform:rotateX(1deg)}");
+    minify_test(".foo { transform: rotateY(0.017453293rad)", ".foo{transform:rotateY(1deg)}");
+    minify_test(".foo { transform: rotateZ(0.017453293rad)", ".foo{transform:rotate(1deg)}");
+    minify_test(".foo { transform: rotate(0.017453293rad)", ".foo{transform:rotate(1deg)}");
     minify_test(".foo { transform: rotate(20deg)", ".foo{transform:rotate(20deg)}");
     minify_test(".foo { transform: rotateX(20deg)", ".foo{transform:rotateX(20deg)}");
     minify_test(".foo { transform: rotateY(20deg)", ".foo{transform:rotateY(20deg)}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6939,6 +6939,10 @@ describe("css tests", () => {
     minify_test(".foo { transform: scale3d(1, 2, 1)", ".foo{transform:scaleY(2)}");
     minify_test(".foo { transform: scale3d(1, 1, 2)", ".foo{transform:scaleZ(2)}");
     minify_test(".foo { transform: scale3d(2, 2, 1)", ".foo{transform:scale(2)}");
+    minify_test(".foo { transform: rotate(20rad)", ".foo{transform:rotate(20rad)}");
+    minify_test(".foo { transform: rotateX(20rad)", ".foo{transform:rotateX(20rad)}");
+    minify_test(".foo { transform: rotateY(20rad)", ".foo{transform:rotateY(20rad)}");
+    minify_test(".foo { transform: rotateZ(20rad)", ".foo{transform:rotate(20rad)}");
     minify_test(".foo { transform: rotate(20deg)", ".foo{transform:rotate(20deg)}");
     minify_test(".foo { transform: rotateX(20deg)", ".foo{transform:rotateX(20deg)}");
     minify_test(".foo { transform: rotateY(20deg)", ".foo{transform:rotateY(20deg)}");


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
Fixes #19619
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)



<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
