### PR TITLE
Use `operationMathPow` for parser constant folding

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -6453,3 +6453,8 @@ CPP_DECL const char* Bun__CallFrame__describeFrame(JSC::CallFrame* callFrame)
     return callFrame->describeFrame();
 }
 #endif
+
+extern "C" double Bun__JSC__operationMathPow(double x, double y)
+{
+    return operationMathPow(x, y);
+}

--- a/src/bun.js/jsc.zig
+++ b/src/bun.js/jsc.zig
@@ -278,3 +278,10 @@ fn onJSCInvalidEnvVar(name: [*]const u8, len: usize) callconv(.C) void {
 
 const bun = @import("bun");
 const std = @import("std");
+
+pub const math = struct {
+    extern "c" fn Bun__JSC__operationMathPow(f64, f64) f64;
+    pub fn pow(x: f64, y: f64) f64 {
+        return Bun__JSC__operationMathPow(x, y);
+    }
+};

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -7461,7 +7461,7 @@ fn NewParser_(
                     .bin_pow => {
                         if (p.should_fold_typescript_constant_expressions) {
                             if (Expr.extractNumericValues(e_.left.data, e_.right.data)) |vals| {
-                                return p.newExpr(E.Number{ .value = bun.pow(vals[0], vals[1]) }, v.loc);
+                                return p.newExpr(E.Number{ .value = JSC.math.pow(vals[0], vals[1]) }, v.loc);
                             }
                         }
                     },

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -196,10 +196,16 @@ describe("with statement", () => {
 });
 
 test("math.pow", () => {
-  function func_result(foo) {
+  function foo1(foo) {
     return 10 ** (foo / 20);
   }
 
-  expect(func_result(-1) + "").toEqual("0.8912509381337456");
+  function foo2(foo) {
+    return foo ** -0.5;
+  }
+
+  expect(foo1(-1) + "").toEqual("0.8912509381337456");
   expect(10 ** (-1 / 20) + "").toEqual("0.8912509381337456");
+  expect(foo2(20.4) + "").toEqual("0.22140372138502384");
+  expect(20.4 ** -0.5 + "").toEqual("0.22140372138502384");
 });


### PR DESCRIPTION
### What does this PR do?
This is the same function used in JSC in their parser and Math.pow. -0.5 and 0.5 are handled differently.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
added a test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
