### PR TITLE
fix(css): preserve angle units like `rad` in `rotate()` during minification

### DIFF
--- a/src/css/values/angle.zig
+++ b/src/css/values/angle.zig
@@ -82,17 +82,7 @@ pub const Angle = union(Tag) {
         const value, const unit = switch (this.*) {
             .deg => |val| .{ val, "deg" },
             .grad => |val| .{ val, "grad" },
-            .rad => |val| brk: {
-                const deg = this.toDegrees();
-
-                // We print 5 digits of precision by default.
-                // Switch to degrees if there are an even number of them.
-                if (css.fract(std.math.round(deg * 100000.0)) == 0) {
-                    break :brk .{ val, "deg" };
-                } else {
-                    break :brk .{ val, "rad" };
-                }
-            },
+            .rad => |val| .{ val, "rad" },
             .turn => |val| .{ val, "turn" },
         };
         css.serializer.serializeDimension(value, unit, W, dest) catch return dest.addFmtError();


### PR DESCRIPTION
## What

Fixes [#19619](https://github.com/oven-sh/bun/issues/19619)

This patch ensures that angle units like `rad`, `grad`, and `turn` are preserved when serializing `rotate(...)` in CSS. Previously, Bun incorrectly rewrote `rotate(1rad)` as `rotate(1deg)`, which is semantically wrong and lossy.

## Why

This change makes Bun’s CSS minifier behavior consistent with the CSS specification and matches the expectations of users who use non-degree units.

## How

Modified `Angle.toCss()` to always serialize using the original unit tag instead of converting based on rounding heuristics.

## Test Plan

Manually verified with:

```css
.bun {
  transform: rotate(1rad);
}
```
Output before: rotate(1deg)
Output after: rotate(1rad)

## Limitation
This fix only applies to Bun’s serializer. Lightning CSS (used internally in minification) still rewrites rad → deg. Full resolution requires a change upstream in [lightningcss](https://github.com/parcel-bundler/lightningcss).