### PR TITLE
docs(bun:sqlite): update reference to fix type parameter order and add missing methods

### DIFF
--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -639,18 +639,29 @@ class Database {
           readonly?: boolean;
           create?: boolean;
           readwrite?: boolean;
+          safeIntegers?: boolean;
+          strict?: boolean;
         },
   );
 
-  query<Params, ReturnType>(sql: string): Statement<Params, ReturnType>;
+  prepare<ReturnType, Params>(sql: string): Statement<ReturnType, Params>;
+  query<ReturnType, Params>(sql: string): Statement<ReturnType, Params>;
   run(
     sql: string,
     params?: SQLQueryBindings,
   ): { lastInsertRowid: number; changes: number };
   exec = this.run;
+
+  transaction(insideTransaction: (...args: any) => void): CallableFunction & {
+    deferred: (...args: any) => void;
+    immediate: (...args: any) => void;
+    exclusive: (...args: any) => void;
+  };
+
+  close(throwOnError?: boolean): void;
 }
 
-class Statement<Params, ReturnType> {
+class Statement<ReturnType, Params> {
   all(params: Params): ReturnType[];
   get(params: Params): ReturnType | undefined;
   run(params: Params): {


### PR DESCRIPTION
### What does this PR do?

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

I noticed that the order of `bun:sqlite`'s `Statement`'s type parameters was wrong. See https://github.com/oven-sh/bun/blob/76f6574729cd3cbf90f9a3a5250893ced81c345d/packages/bun-types/sqlite.d.ts#L593: it should be `<ReturnType, Params>`, not `<Params, ReturnType>`. While fixing this I also added a few methods to the reference that are mentioned in the docs.