### PR TITLE
fix(windows): respect NO_COLOR in filter_run

### DIFF
--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -528,7 +528,7 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
     var state = State{
         .handles = try ctx.allocator.alloc(ProcessHandle, scripts.items.len),
         .event_loop = event_loop,
-        .pretty_output = if (Environment.isWindows) windowsIsTerminal() else Output.enable_ansi_colors_stdout,
+        .pretty_output = if (Environment.isWindows) windowsIsTerminal() and Output.enable_ansi_colors_stdout else Output.enable_ansi_colors_stdout,
         .shell_bin = shell_bin,
         .env = this_transpiler.env,
     };


### PR DESCRIPTION
### What does this PR do?

Fixes #19887 where `bun run --filter` didn't check if the user specified `NO_COLOR` on Windows, because it only checked if a TTY was present.
