### PR TITLE
Enable reloc info for BOLT

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -966,7 +966,6 @@ if(LINUX)
     -Wl,--as-needed
     -Wl,--gc-sections
     -Wl,-z,stack-size=12800000
-    -Wl,--compress-debug-sections=zlib
     -Wl,-z,lazy
     -Wl,-z,norelro
     # enable string tail merging

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -980,6 +980,12 @@ if(LINUX)
     -Wl,--build-id=sha1  # Better for debugging than default
     -Wl,-Map=${bun}.linker-map
   )
+  if(RELEASE)
+    target_link_options(${bun} PUBLIC
+      -Wl,--emit-relocs
+      -Wl,-q
+    )
+  endif()
 endif()
 
 # --- Symbols list ---

--- a/src/cli/audit_command.zig
+++ b/src/cli/audit_command.zig
@@ -10,7 +10,6 @@ const HeaderBuilder = http.HeaderBuilder;
 const MutableString = bun.MutableString;
 const URL = @import("../url.zig").URL;
 const logger = bun.logger;
-const semver = @import("../semver.zig");
 const libdeflate = @import("../deps/libdeflate.zig");
 
 const VulnerabilityInfo = struct {

--- a/test/regression/issue/18547.test.ts
+++ b/test/regression/issue/18547.test.ts
@@ -16,7 +16,6 @@ test("18547", async () => {
         expect(request.cookies.get("sessionToken")).toEqual("123456");
         expect(clone.cookies.get("sessionToken")).toEqual("654321");
 
-
         return new Response("OK");
       },
     },


### PR DESCRIPTION
## Summary
- allow `--emit-relocs -q` on Linux release builds so BOLT can post-process Bun

## Testing
- `ld.lld --help | head`