### PR TITLE
fix: "bun run" to print syntax errors in package.json

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -37,8 +37,6 @@ const yarn_commands = @import("./list-of-yarn-commands.zig").all_yarn_commands;
 
 const ShellCompletions = @import("./shell_completions.zig");
 
-
-
 const windows = std.os.windows;
 
 pub const RunCommand = struct {
@@ -1400,6 +1398,7 @@ pub const RunCommand = struct {
                 RunCommand.printHelp(null);
                 if (ctx.log.hasErrors()) {
                     try ctx.log.print(Output.errorWriter());
+                    Output.prettyln("\n<r><yellow>Failed parsing package.json.<r>\n", .{});
                 } else {
                     Output.prettyln("\n<r><yellow>No package.json found.<r>\n", .{});
                 }

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1398,7 +1398,11 @@ pub const RunCommand = struct {
                 RunCommand.printHelp(package_json);
             } else {
                 RunCommand.printHelp(null);
-                Output.prettyln("\n<r><yellow>No package.json found.<r>\n", .{});
+                if (ctx.log.hasErrors()) {
+                    try ctx.log.print(Output.errorWriter());
+                } else {
+                    Output.prettyln("\n<r><yellow>No package.json found.<r>\n", .{});
+                }
                 Output.flush();
             }
 

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isWindows } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, tempDirWithFiles } from "harness";
 
 let cwd: string;
 
@@ -17,6 +17,71 @@ describe("bun", () => {
     expect(stdout.toString()).toBeEmpty();
     expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
+  });
+
+  test("should work with valid package.json", () => {
+    const dir = tempDirWithFiles("tmp", {
+      "package.json": JSON.stringify({
+        name: "test",
+        scripts: {
+          start: "echo VALID_PACKAGE_JSON",
+        },
+      }),
+    });
+
+    const { stdout, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stdout.toString()).toInclude("VALID_PACKAGE_JSON");
+    expect(stderr.toString()).toBeEmpty();
+  });
+
+  test("should show specific error when package.json has a syntax error", () => {
+    // `"private": True` should be `"private": true`
+    const dir = tempDirWithFiles("tmp", {
+      "package.json": `{
+        "name": "test",
+        "scripts": {
+          "start": "echo INVALID_PACKAGE_JSON"
+        },
+        "private": True
+      }`,
+    });
+
+    const { stdout, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stderr.toString()).toInclude("error:");
+    expect(stderr.toString()).toInclude("Unexpected True");
+    expect(stdout.toString()).toInclude("Failed parsing package.json");
+    expect(stdout.toString()).not.toInclude("No package.json found");
+  });
+
+  test("should handle missing package.json correctly", () => {
+    const dir = tempDirWithFiles("pkg-json-missing", {
+      "index.js": "console.log('Hello World!');",
+    });
+
+    const { stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stdout.toString()).toInclude("No package.json found");
+    expect(stdout.toString()).not.toInclude("Failed parsing package.json");
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

this PR prints syntax errors in package.json.


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->
I added some test cases at run_command.test.ts.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

- [x] I included a test for the new code, or an existing test covers it
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)

Also, when I tested the "bun run" with an invalid package.json, it no longer printed "No package.json found." Instead, it printed syntax errors and the message "Failed parsing package.json."

Here are some screen shots.

package.json
```json
{
    "name": "bun-bug",
    "scripts": {
      "start": "pwd",
      "install": "echo DDDD"
    },
    "module": "index.ts",
    "type": "module",
    "private": True,
    "devDependencies": {
      "@types/bun": "latest",
      "prettier":"latest"
    },
    "peerDependencies": {
      "typescript": "^5"
    }
}
```

| before(The "No package.json found" message was printed out even though the package.json(has a syntax error though) file does exist.) | after(syntax error in package.json was printed out) |
| --- | --- |
| <img width="1027" alt="スクリーンショット 2025-05-25 17 51 43" src="https://github.com/user-attachments/assets/a75d20b5-f446-416c-bf51-dc95d221e6ef" /> | <img width="1023" alt="スクリーンショット 2025-05-25 17 48 22" src="https://github.com/user-attachments/assets/23b78c6d-dc95-4ce7-a211-1173aa1cbace" /> | 


<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
