### PR TITLE
`bun pm audit` -> `bun audit`

### DIFF
--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -95,14 +95,6 @@ To print the hash stored in the current lockfile:
 $ bun pm hash-print
 ```
 
-## audit
-
-To run a security audit for packages in bun.lock or bun.lockb
-
-```bash
-$ bun pm audit
-```
-
 ## cache
 
 To print the path to Bun's global module cache:

--- a/docs/install/audit.md
+++ b/docs/install/audit.md
@@ -1,9 +1,9 @@
-`bun pm audit` checks your installed packages for known security vulnerabilities.
+`bun audit` checks your installed packages for known security vulnerabilities.
 
 Run the command in a project with a `bun.lock` file:
 
 ```bash
-$ bun pm audit
+$ bun audit
 ```
 
 Bun sends the list of installed packages and versions to NPM, and prints a report of any vulnerabilities that were found. Packages installed from registries other than the default registry are skipped.
@@ -29,9 +29,9 @@ To update all dependencies to the latest versions (including breaking changes):
 Use the `--json` flag to print the raw JSON response from the registry instead of the formatted report:
 
 ```bash
-$ bun pm audit --json
+$ bun audit --json
 ```
 
 ### Exit code
 
-`bun pm audit` will exit with code `0` if no vulnerabilities are found and `1` if the report lists any vulnerabilities. This will still happen even if `--json` is passed.
+`bun audit` will exit with code `0` if no vulnerabilities are found and `1` if the report lists any vulnerabilities. This will still happen even if `--json` is passed.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1365,6 +1365,7 @@ pub const HelpCommand = struct {
         \\  <b><blue>add<r>       <d>{s:<16}<r>     Add a dependency to package.json <d>(bun a)<r>
         \\  <b><blue>remove<r>    <d>{s:<16}<r>     Remove a dependency from package.json <d>(bun rm)<r>
         \\  <b><blue>update<r>    <d>{s:<16}<r>     Update outdated dependencies
+        \\  <b><blue>audit<r>                          Check installed packages for vulnerabilities
         \\  <b><blue>outdated<r>                       Display latest versions of outdated dependencies
         \\  <b><blue>link<r>      <d>[\<package\>]<r>          Register or link a local npm package
         \\  <b><blue>unlink<r>                         Unregister a local npm package

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1757,6 +1757,7 @@ pub const Command = struct {
 
             RootCommandMatcher.case("outdated") => .OutdatedCommand,
             RootCommandMatcher.case("publish") => .PublishCommand,
+            RootCommandMatcher.case("audit") => .AuditCommand,
 
             // These are reserved for future use by Bun, so that someone
             // doing `bun deploy` to run a script doesn't accidentally break
@@ -1905,6 +1906,13 @@ pub const Command = struct {
 
                 try PublishCommand.exec(ctx);
                 return;
+            },
+            .AuditCommand => {
+                if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .AuditCommand) unreachable;
+                const ctx = try Command.init(allocator, log, .AuditCommand);
+
+                try AuditCommand.exec(ctx);
+                unreachable;
             },
             .BunxCommand => {
                 if (comptime bun.fast_debug_build_mode and bun.fast_debug_build_cmd != .BunxCommand) unreachable;
@@ -2333,6 +2341,7 @@ pub const Command = struct {
         PatchCommitCommand,
         OutdatedCommand,
         PublishCommand,
+        AuditCommand,
 
         /// Used by crash reports.
         ///
@@ -2366,6 +2375,7 @@ pub const Command = struct {
                 .PatchCommitCommand => 'z',
                 .OutdatedCommand => 'o',
                 .PublishCommand => 'k',
+                .AuditCommand => 'A',
             };
         }
 
@@ -2617,10 +2627,11 @@ pub const Command = struct {
                     , .{});
                     Output.flush();
                 },
-                .OutdatedCommand, .PublishCommand => {
+                .OutdatedCommand, .PublishCommand, .AuditCommand => {
                     Install.PackageManager.CommandLineArguments.printHelp(switch (cmd) {
                         .OutdatedCommand => .outdated,
                         .PublishCommand => .publish,
+                        .AuditCommand => .audit,
                     });
                 },
                 else => {
@@ -2641,6 +2652,7 @@ pub const Command = struct {
                 .PatchCommitCommand,
                 .OutdatedCommand,
                 .PublishCommand,
+                .AuditCommand,
                 => true,
                 else => false,
             };
@@ -2660,6 +2672,7 @@ pub const Command = struct {
                 .PatchCommitCommand,
                 .OutdatedCommand,
                 .PublishCommand,
+                .AuditCommand,
                 => true,
                 else => false,
             };
@@ -2681,6 +2694,7 @@ pub const Command = struct {
             .RunAsNodeCommand = true,
             .OutdatedCommand = true,
             .PublishCommand = true,
+            .AuditCommand = true,
         });
 
         pub const always_loads_config: std.EnumArray(Tag, bool) = std.EnumArray(Tag, bool).initDefault(false, .{
@@ -2696,6 +2710,7 @@ pub const Command = struct {
             .BunxCommand = true,
             .OutdatedCommand = true,
             .PublishCommand = true,
+            .AuditCommand = true,
         });
 
         pub const uses_global_options: std.EnumArray(Tag, bool) = std.EnumArray(Tag, bool).initDefault(true, .{
@@ -2712,6 +2727,7 @@ pub const Command = struct {
             .BunxCommand = false,
             .OutdatedCommand = false,
             .PublishCommand = false,
+            .AuditCommand = false,
         });
     };
 };

--- a/src/cli/audit_command.zig
+++ b/src/cli/audit_command.zig
@@ -63,8 +63,8 @@ const AuditResult = struct {
 
 pub const AuditCommand = struct {
     pub fn exec(ctx: Command.Context) !noreturn {
-        const cli = try PackageManager.CommandLineArguments.parse(ctx.allocator, .pm);
-        const manager, _ = PackageManager.init(ctx, cli, .pm) catch |err| {
+        const cli = try PackageManager.CommandLineArguments.parse(ctx.allocator, .audit);
+        const manager, _ = PackageManager.init(ctx, cli, .audit) catch |err| {
             if (err == error.MissingPackageJSON) {
                 var cwd_buf: bun.PathBuffer = undefined;
                 if (bun.getcwd(&cwd_buf)) |cwd| {

--- a/src/cli/audit_command.zig
+++ b/src/cli/audit_command.zig
@@ -87,8 +87,8 @@ pub const AuditCommand = struct {
     /// The exception is when you pass --json, it will simply return 0 as that was considered a successful "request
     /// for the audit information"
     pub fn audit(ctx: Command.Context, pm: *PackageManager, json_output: bool) bun.OOM!u32 {
-        // Output.prettyError(comptime Output.prettyFmt("<r><b>bun audit <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>\n", true), .{});
-        // Output.flush();
+        Output.prettyError(comptime Output.prettyFmt("<r><b>bun audit <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>\n", true), .{});
+        Output.flush();
 
         const load_lockfile = pm.lockfile.loadFromCwd(pm, ctx.allocator, ctx.log, true);
         @import("./package_manager_command.zig").PackageManagerCommand.handleLoadLockfileErrors(load_lockfile, pm);

--- a/src/cli/audit_command.zig
+++ b/src/cli/audit_command.zig
@@ -87,8 +87,8 @@ pub const AuditCommand = struct {
     /// The exception is when you pass --json, it will simply return 0 as that was considered a successful "request
     /// for the audit information"
     pub fn audit(ctx: Command.Context, pm: *PackageManager, json_output: bool) bun.OOM!u32 {
-        Output.prettyError(comptime Output.prettyFmt("<r><b>bun pm audit <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>\n", true), .{});
-        Output.flush();
+        // Output.prettyError(comptime Output.prettyFmt("<r><b>bun audit <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>\n", true), .{});
+        // Output.flush();
 
         const load_lockfile = pm.lockfile.loadFromCwd(pm, ctx.allocator, ctx.log, true);
         @import("./package_manager_command.zig").PackageManagerCommand.handleLoadLockfileErrors(load_lockfile, pm);

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -20,7 +20,6 @@ const TrustCommand = @import("./pm_trusted_command.zig").TrustCommand;
 const DefaultTrustedCommand = @import("./pm_trusted_command.zig").DefaultTrustedCommand;
 const Environment = bun.Environment;
 pub const PackCommand = @import("./pack_command.zig").PackCommand;
-pub const AuditCommand = @import("./audit_command.zig").AuditCommand;
 const Npm = Install.Npm;
 const PmViewCommand = @import("./pm_view_command.zig");
 const File = bun.sys.File;
@@ -247,9 +246,6 @@ pub const PackageManagerCommand = struct {
 
             _ = try pm.lockfile.hasMetaHashChanged(true, pm.lockfile.packages.len);
             Global.exit(0);
-        } else if (strings.eqlComptime(subcommand, "audit")) {
-            const code = try AuditCommand.exec(ctx, pm, args);
-            Global.exit(code);
         } else if (strings.eqlComptime(subcommand, "cache")) {
             var dir: bun.PathBuffer = undefined;
             var fd = pm.getCacheDirectory();

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -26,7 +26,6 @@ const FD = bun.FD;
 const JSON = bun.JSON;
 const JSPrinter = bun.js_printer;
 
-
 const Api = @import("../api/schema.zig").Api;
 const Path = bun.path;
 const Command = @import("../cli.zig").Command;
@@ -58,7 +57,6 @@ pub const Lockfile = @import("./lockfile.zig");
 pub const TextLockfile = @import("./lockfile/bun.lock.zig");
 pub const PatchedDep = Lockfile.PatchedDep;
 const Walker = @import("../walker_skippable.zig");
-
 
 pub const bun_hash_tag = ".bun-tag-";
 pub const max_hex_hash_len: comptime_int = brk: {
@@ -8668,6 +8666,7 @@ pub const PackageManager = struct {
         outdated,
         pack,
         publish,
+        audit,
 
         // bin,
         // hash,
@@ -8692,6 +8691,16 @@ pub const PackageManager = struct {
                 .outdated => true,
                 .install => true,
                 // .pack => true,
+                // .add => true,
+                else => false,
+            };
+        }
+
+        pub fn supportsJsonOutput(this: Subcommand) bool {
+            return switch (this) {
+                .audit,
+                .pm,
+                => true,
                 else => false,
             };
         }
@@ -9740,9 +9749,13 @@ pub const PackageManager = struct {
     });
 
     const outdated_params: []const ParamType = &(shared_params ++ [_]ParamType{
-        clap.parseParam("--json                                 Output outdated information in JSON format") catch unreachable,
+        // clap.parseParam("--json                                 Output outdated information in JSON format") catch unreachable,
         clap.parseParam("-F, --filter <STR>...                        Display outdated dependencies for each matching workspace") catch unreachable,
         clap.parseParam("<POS> ...                              Package patterns to filter by") catch unreachable,
+    });
+
+    const audit_params: []const ParamType = &(shared_params ++ [_]ParamType{
+        clap.parseParam("--json                                 Output in JSON format") catch unreachable,
     });
 
     const pack_params: []const ParamType = &(shared_params ++ [_]ParamType{
@@ -10105,6 +10118,28 @@ pub const PackageManager = struct {
                     Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
                     Output.flush();
                 },
+                .audit => {
+                    const intro_text =
+                        \\<b>Usage<r>: <b><green>bun audit<r> <cyan>[flags]<r>
+                    ;
+
+                    const outro_text =
+                        \\<b>Examples:<r>
+                        \\  <d>Check installed packages for vulnerabilities.<r>
+                        \\  <b><green>bun audit<r>
+                        \\
+                        \\  <d>Output package vulnerabilities in JSON format.<r>
+                        \\  <b><green>bun audit --json<r>
+                        \\
+                    ;
+
+                    Output.pretty("\n" ++ intro_text ++ "\n", .{});
+                    Output.pretty("\n<b>Flags:<r>", .{});
+                    Output.flush();
+                    clap.simpleHelp(PackageManager.audit_params);
+                    Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+                    Output.flush();
+                },
             }
         }
 
@@ -10124,6 +10159,7 @@ pub const PackageManager = struct {
                 .outdated => outdated_params,
                 .pack => pack_params,
                 .publish => publish_params,
+                .audit => audit_params,
             };
 
             var diag = clap.Diagnostic{};
@@ -10204,16 +10240,17 @@ pub const PackageManager = struct {
                 cli.filters = args.options("--filter");
             }
 
-            if (comptime subcommand == .outdated) {
-                // fake --dry-run, we don't actually resolve+clean the lockfile
-                cli.dry_run = true;
+            if (comptime subcommand.supportsJsonOutput()) {
                 cli.json_output = args.flag("--json");
             }
 
+            if (comptime subcommand == .outdated) {
+                // fake --dry-run, we don't actually resolve+clean the lockfile
+                cli.dry_run = true;
+                // cli.json_output = args.flag("--json");
+            }
+
             if (comptime subcommand == .pack or subcommand == .pm or subcommand == .publish) {
-                if (comptime subcommand == .pm) {
-                    cli.json_output = args.flag("--json");
-                }
                 if (comptime subcommand != .publish) {
                     if (args.option("--destination")) |dest| {
                         cli.pack_destination = dest;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -9755,7 +9755,7 @@ pub const PackageManager = struct {
     });
 
     const audit_params: []const ParamType = &([_]ParamType{
-        clap.parseParam("<POS>                                  Check installed packages for vulnerabilities") catch unreachable,
+        clap.parseParam("<POS> ...                              Check installed packages for vulnerabilities") catch unreachable,
         clap.parseParam("--json                                 Output in JSON format") catch unreachable,
     });
 

--- a/test/cli/install/__snapshots__/bun-audit.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-audit.test.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`\`bun pm audit\` should exit code 1 when there are vulnerabilities: bun-audit-expect-vulnerabilities-found 1`] = `
+exports[`\`bun audit\` should exit code 1 when there are vulnerabilities: bun-audit-expect-vulnerabilities-found 1`] = `
 "minimist  <0.2.4
   express › mkdirp › minimist
   critical: Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
@@ -78,9 +78,9 @@ To update all dependencies to the latest versions (including breaking changes):
 "
 `;
 
-exports[`\`bun pm audit\` should print valid JSON and exit 0 when --json is passed and there are no vulnerabilities: bun-audit-expect-valid-json-stdout-report-no-vulnerabilities 1`] = `{}`;
+exports[`\`bun audit\` should print valid JSON and exit 0 when --json is passed and there are no vulnerabilities: bun-audit-expect-valid-json-stdout-report-no-vulnerabilities 1`] = `{}`;
 
-exports[`\`bun pm audit\` should print valid JSON and exit 1 when --json is passed and there are vulnerabilities: bun-audit-expect-valid-json-stdout-report-vulnerabilities 1`] = `
+exports[`\`bun audit\` should print valid JSON and exit 1 when --json is passed and there are vulnerabilities: bun-audit-expect-valid-json-stdout-report-vulnerabilities 1`] = `
 {
   "base64-url": [
     {
@@ -410,7 +410,7 @@ exports[`\`bun pm audit\` should print valid JSON and exit 1 when --json is pass
 }
 `;
 
-exports[`\`bun pm audit\` should exit 1 and behave exactly the same when there are vulnerabilities when only devDependencies are specified: bun-audit-expect-vulnerabilities-found 1`] = `
+exports[`\`bun audit\` should exit 1 and behave exactly the same when there are vulnerabilities when only devDependencies are specified: bun-audit-expect-vulnerabilities-found 1`] = `
 "ms  <2.0.0
   (direct dependency)
   moderate: Vercel ms Inefficient Regular Expression Complexity vulnerability - https://github.com/advisories/GHSA-w9mr-4mfr-499f
@@ -427,7 +427,7 @@ To update all dependencies to the latest versions (including breaking changes):
 "
 `;
 
-exports[`\`bun pm audit\` when a project has some safe dependencies and some vulnerable dependencies, we should not print the safe dependencies: bun-audit-expect-vulnerabilities-found 1`] = `
+exports[`\`bun audit\` when a project has some safe dependencies and some vulnerable dependencies, we should not print the safe dependencies: bun-audit-expect-vulnerabilities-found 1`] = `
 "ms  <2.0.0
   (direct dependency)
   moderate: Vercel ms Inefficient Regular Expression Complexity vulnerability - https://github.com/advisories/GHSA-w9mr-4mfr-499f

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -47,9 +47,9 @@ function doAuditTest(
   },
 ) {
   test(label, async () => {
-    const dir = tempDirWithFiles("bun-test-pm-audit-" + label.replace(/[^a-zA-Z0-9]/g, "-"), options.files);
+    const dir = tempDirWithFiles("bun-test-audit-" + label.replace(/[^a-zA-Z0-9]/g, "-"), options.files);
 
-    const cmd = [bunExe(), "pm", "audit", ...(options.args ?? [])];
+    const cmd = [bunExe(), "audit", ...(options.args ?? [])];
 
     const url = server.url.toString().slice(0, -1);
 
@@ -87,7 +87,7 @@ function doAuditTest(
   });
 }
 
-describe("`bun pm audit`", () => {
+describe("`bun audit`", () => {
   doAuditTest("should fail with no package.json", {
     exitCode: 1,
     files: {

--- a/test/cli/run/jsx-namespaced-attributes.test.ts
+++ b/test/cli/run/jsx-namespaced-attributes.test.ts
@@ -7,4 +7,3 @@ it("parses namespaced attributes correctly", () => {
   expect(nsExample3.props).toEqual({ "ns:bar42bar": "baz" });
   expect(nsExample4.props).toEqual({ "ns42:bar": "baz" });
 });
-

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -34,7 +34,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
 
   [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 241, regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
-  "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1851 },
+  "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1852 },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 180 },
   "std.fs.cwd": { reason: "Prefer bun.FD.cwd()", limit: 103 },


### PR DESCRIPTION
### What does this PR do?
Also removes `bun outdated --json` from help text
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
