### PR TITLE
Implement automatic workspace folders support for Chrome DevTools

### DIFF
--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -206,6 +206,38 @@ Each call to `console.log` or `console.error` will be broadcast to the terminal 
 
 Internally, this reuses the existing WebSocket connection from hot module reloading to send the logs.
 
+### Edit files in the browser
+
+Bun's frontend dev server has support for [Automatic Workspace Folders](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md) in Chrome DevTools, which lets you save edits to files in the browser.
+
+{% image src="/images/bun-chromedevtools.gif" alt="Bun's frontend dev server has support for Automatic Workspace Folders in Chrome DevTools, which lets you save edits to files in the browser." /%}
+
+{% details summary="How it works" %}
+
+Bun's dev server automatically adds a `/.well-known/appspecific/com.chrome.devtools.json` route to the server.
+
+This route returns a JSON object with the following shape:
+
+```json
+{
+  "workspace": {
+    "root": "/path/to/your/project",
+    "uuid": "a-unique-identifier-for-this-workspace"
+  }
+}
+```
+
+For security reasons, this is only enabled when:
+
+1. The request is coming from localhost, 127.0.0.1, or ::1.
+2. Hot Module Reloading is enabled.
+3. The `chromeDevToolsAutomaticWorkspaceFolders` flag is set to `true` or `undefined`.
+4. There are no other routes that match the request.
+
+You can disable this by passing `development: { chromeDevToolsAutomaticWorkspaceFolders: false }` in `Bun.serve`'s options.
+
+{% /details %}
+
 ## Keyboard Shortcuts
 
 While the server is running:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3357,6 +3357,30 @@ declare module "bun" {
            * @default false
            */
           console?: boolean;
+
+          /**
+           * Enable automatic workspace folders for Chrome DevTools
+           *
+           * This lets you persistently edit files in the browser. It works by adding the following route to the server:
+           * `/.well-known/appspecific/com.chrome.devtools.json`
+           *
+           * The response is a JSON object with the following shape:
+           * ```json
+           * {
+           *   "workspace": {
+           *     "root": "<cwd>",
+           *     "uuid": "<uuid>"
+           *   }
+           * }
+           * ```
+           *
+           * The `root` field is the current working directory of the server.
+           * The `"uuid"` field is a hash of the file that started the server and a hash of the current working directory.
+           *
+           * For security reasons, if the remote socket address is not from localhost, 127.0.0.1, or ::1, the request is ignored.
+           * @default true
+           */
+          chromeDevToolsAutomaticWorkspaceFolders?: boolean;
         };
 
     error?: (this: Server, error: ErrorLike) => Response | Promise<Response> | void | Promise<void>;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -7151,8 +7151,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             //     uuid: string,
             //   }
             // }
-            const json_string = std.fmt.allocPrint(bun.default_allocator, "{{ \"workspace\": {{ \"root\": \"{s}\", \"uuid\": \"{}\" }} }}", .{
-                this.dev_server.?.root,
+            const json_string = std.fmt.allocPrint(bun.default_allocator, "{{ \"workspace\": {{ \"root\": {}, \"uuid\": \"{}\" }} }}", .{
+                bun.fmt.formatJSONStringUTF8(this.dev_server.?.root, .{}),
                 uuid,
             }) catch bun.outOfMemory();
             defer bun.default_allocator.free(json_string);

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -199,3 +199,26 @@ devTest("memory leak case 1", {
     await dev.fetch("/"); // previously leaked source map
   },
 });
+
+devTest("chrome devtools automatic workspace folders", {
+  files: {
+    "index.html": `
+      <script type="module" src="/script.ts"></script>
+    `,
+    "script.ts": `
+      console.log("hello");
+    `,
+  },
+  async test(dev) {
+    const response = await dev.fetch("/.well-known/appspecific/com.chrome.devtools.json");
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    const root = dev.join(".");
+    expect(json).toMatchObject({
+      workspace: {
+        root,
+        uuid: expect.any(String),
+      },
+    });
+  },
+});


### PR DESCRIPTION
### What does this PR do?

Implement automatic workspace folders support for Chrome DevTools
![CleanShot 2025-05-27 at 22 15 57](https://github.com/user-attachments/assets/0cb84780-57fe-42dd-a32a-ccd8ae8fd97f)


### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
