### PR TITLE
Fix Node net bytesWritten with pending strings

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -839,7 +839,14 @@ Object.defineProperty(Socket.prototype, "bytesWritten", {
         else bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);
       }
     } else if (data) {
-      bytes += data.byteLength;
+      if (typeof data === "string") {
+        bytes += Buffer.byteLength(data, this._pendingEncoding || "utf8");
+      } else if (data.byteLength !== undefined) {
+        bytes += data.byteLength;
+      } else {
+        // Fallback for Buffer or other typed arrays
+        bytes += Buffer.byteLength(data);
+      }
     }
     return bytes;
   },

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -839,14 +839,9 @@ Object.defineProperty(Socket.prototype, "bytesWritten", {
         else bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);
       }
     } else if (data) {
-      if (typeof data === "string") {
-        bytes += Buffer.byteLength(data, this._pendingEncoding || "utf8");
-      } else if (data.byteLength !== undefined) {
-        bytes += data.byteLength;
-      } else {
-        // Fallback for Buffer or other typed arrays
-        bytes += Buffer.byteLength(data);
-      }
+      // Writes are either a string or a Buffer.
+      if (typeof data !== "string") bytes += data.length;
+      else bytes += Buffer.byteLength(data, this._pendingEncoding || "utf8");
     }
     return bytes;
   },

--- a/test/js/node/test/parallel/test-net-connect-buffer.js
+++ b/test/js/node/test/parallel/test-net-connect-buffer.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const tcp = net.Server(
+  common.mustCall((s) => {
+    tcp.close();
+
+    let buf = '';
+    s.setEncoding('utf8');
+    s.on('data', function (d) {
+      buf += d;
+    });
+
+    s.on(
+      'end',
+      common.mustCall(function () {
+        console.error('SERVER: end', buf);
+        assert.strictEqual(buf, "L'État, c'est moi");
+        s.end();
+      }),
+    );
+  }),
+);
+
+tcp.listen(
+  0,
+  common.mustCall(function () {
+    const socket = net.Stream({ highWaterMark: 0 });
+
+    let connected = false;
+    assert.strictEqual(socket.pending, true);
+    socket.connect(
+      this.address().port,
+      common.mustCall(() => (connected = true)),
+    );
+
+    assert.strictEqual(socket.pending, true);
+    assert.strictEqual(socket.connecting, true);
+    assert.strictEqual(socket.readyState, 'opening');
+
+    const a = "L'État, c'est ";
+    const b = 'moi';
+
+    const r = socket.write(
+      a,
+      common.mustCall((er) => {
+        console.error('write cb');
+        assert.ok(connected);
+        assert.strictEqual(socket.bytesWritten, Buffer.from(a + b).length);
+        assert.strictEqual(socket.pending, false);
+      }),
+    );
+    socket.on(
+      'close',
+      common.mustCall(() => {
+        assert.strictEqual(socket.pending, true);
+      }),
+    );
+
+    assert.strictEqual(socket.bytesWritten, Buffer.from(a).length);
+    assert.strictEqual(r, false);
+    socket.end(b);
+
+    assert.strictEqual(socket.readyState, 'opening');
+  }),
+);

--- a/test/js/node/test/parallel/test-net-connect-buffer2.js
+++ b/test/js/node/test/parallel/test-net-connect-buffer2.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
## Summary
- add Node.js test `test-net-connect-buffer`
- fix `bytesWritten` to account for pending string writes

## Testing
- `bun --silent node:test test/js/node/test/parallel/test-net-connect-buffer.js`
- `bun bd --silent node:test test-net-access-byteswritten.js` *(fails: missing WebKit artifact)*