### PR TITLE
Fix ECONNREFUSED connecting state

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -227,6 +227,7 @@ const SocketHandlers: SocketHandler = {
     if (!self) return;
     if (self._hadError) return;
     self._hadError = true;
+    self.connecting = false;
 
     const callback = self[kwriteCallback];
     if (callback) {
@@ -633,6 +634,7 @@ const SocketHandlers2: SocketHandler<SocketHandleData> = {
   connectError(socket, error) {
     $debug("Bun.Socket connectError");
     let { self, req } = socket.data;
+    self.connecting = false;
     socket[owner_symbol] = self;
     req!.oncomplete(error.errno, self._handle, req, true, true);
     socket.data.req = undefined;

--- a/test/js/node/test/sequential/test-net-connect-handle-econnrefused.js
+++ b/test/js/node/test/sequential/test-net-connect-handle-econnrefused.js
@@ -1,0 +1,11 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+
+const c = net.createConnection(common.PORT);
+c.on('connect', common.mustNotCall());
+c.on('error', common.mustCall((e) => {
+  assert.strictEqual(c.connecting, false);
+  assert.strictEqual(e.code, 'ECONNREFUSED');
+}));


### PR DESCRIPTION
## Summary
- add a node test for ECONNREFUSED handling
- ensure Socket.connecting is false on errors

## Testing
- `bun bd --silent node:test test/js/node/test/sequential/test-net-connect-handle-econnrefused.js` *(fails: could not build bun due to missing WebKit)*