### PR TITLE
Add drop connections test & fix maxConnections check

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -388,7 +388,7 @@ const ServerHandlers: SocketHandler = {
         return;
       }
     }
-    if (self.maxConnections && self[bunSocketServerConnections] >= self.maxConnections) {
+    if (self.maxConnections != null && self[bunSocketServerConnections] >= self.maxConnections) {
       const data = {
         localAddress: _socket.localAddress,
         localPort: _socket.localPort || this.localPort,

--- a/test/js/node/test/parallel/test-net-server-drop-connections.js
+++ b/test/js/node/test/parallel/test-net-server-drop-connections.js
@@ -1,0 +1,49 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+let firstSocket;
+const dormantServer = net.createServer(common.mustNotCall());
+const server = net.createServer(
+  common.mustCall((socket) => {
+    firstSocket = socket;
+  }),
+);
+
+dormantServer.maxConnections = 0;
+server.maxConnections = 1;
+
+dormantServer.on(
+  'drop',
+  common.mustCall((data) => {
+    assert.strictEqual(!!data.localAddress, true);
+    assert.strictEqual(!!data.localPort, true);
+    assert.strictEqual(!!data.remoteAddress, true);
+    assert.strictEqual(!!data.remotePort, true);
+    assert.strictEqual(!!data.remoteFamily, true);
+    dormantServer.close();
+  }),
+);
+
+server.on(
+  'drop',
+  common.mustCall((data) => {
+    assert.strictEqual(!!data.localAddress, true);
+    assert.strictEqual(!!data.localPort, true);
+    assert.strictEqual(!!data.remoteAddress, true);
+    assert.strictEqual(!!data.remotePort, true);
+    assert.strictEqual(!!data.remoteFamily, true);
+    firstSocket.destroy();
+    server.close();
+  }),
+);
+
+dormantServer.listen(0, () => {
+  net.createConnection(dormantServer.address().port);
+});
+
+server.listen(0, () => {
+  net.createConnection(server.address().port);
+  net.createConnection(server.address().port);
+});


### PR DESCRIPTION
## Summary
- port Node.js test for handling server drop events when connections exceed `maxConnections`
- fix the check in `node:net` so `maxConnections = 0` rejects all connections

## Testing
- `bun bd --silent node:test test-net-server-drop-connections.js` *(fails: missing WebKit build)*