### PR TITLE
Fix node net test with large string

### DIFF
--- a/src/bun.js/node/node_net_binding.zig
+++ b/src/bun.js/node/node_net_binding.zig
@@ -5,7 +5,12 @@ const validators = @import("./util/validators.zig");
 //
 //
 
-pub var autoSelectFamilyDefault: bool = true;
+// Node.js defaults to `false` which means that network connections only try a
+// single address family unless `autoSelectFamily` is explicitly enabled. Using
+// `true` here results in duplicate connection attempts which causes extra
+// connection events to be emitted. This breaks tests expecting only one
+// connection, such as `test-net-large-string.js`.
+pub var autoSelectFamilyDefault: bool = false;
 
 pub fn getDefaultAutoSelectFamily(global: *JSC.JSGlobalObject) JSC.JSValue {
     return JSC.JSFunction.create(global, "getDefaultAutoSelectFamily", (struct {

--- a/test/js/node/test/parallel/test-net-large-string.js
+++ b/test/js/node/test/parallel/test-net-large-string.js
@@ -1,0 +1,34 @@
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const kPoolSize = 40 * 1024;
+const data = 'あ'.repeat(kPoolSize);
+const encoding = 'UTF-8';
+
+const server = net.createServer(
+  common.mustCall(function (socket) {
+    let receivedSize = 0;
+
+    socket.setEncoding(encoding);
+    socket.on('data', function (data) {
+      receivedSize += data.length;
+    });
+    socket.on(
+      'end',
+      common.mustCall(function () {
+        assert.strictEqual(receivedSize, kPoolSize);
+        socket.end();
+      }),
+    );
+  }),
+);
+
+server.listen(0, function () {
+  const client = net.createConnection(this.address().port);
+  client.on('end', function () {
+    server.close();
+  });
+  client.write(data, encoding);
+  client.end();
+});


### PR DESCRIPTION
## Summary
- add Node.js `test-net-large-string` test
- avoid duplicate connection attempts by default

## Testing
- `bun bd --silent node:test test-net-large-string` *(fails: file RENAME failed because WebKit is missing)*