### PR TITLE
Fix server capture rejection in net

### DIFF
--- a/cmake/sources/JavaScriptSources.txt
+++ b/cmake/sources/JavaScriptSources.txt
@@ -84,6 +84,7 @@ src/js/internal/streams/state.ts
 src/js/internal/streams/transform.ts
 src/js/internal/streams/utils.ts
 src/js/internal/streams/writable.ts
+src/js/internal/test/binding.ts
 src/js/internal/timers.ts
 src/js/internal/tls.ts
 src/js/internal/tty.ts

--- a/src/js/internal/test/binding.ts
+++ b/src/js/internal/test/binding.ts
@@ -1,0 +1,6 @@
+// Hardcoded module "internal/test/binding"
+// Provides access to internal bindings for Node.js test suite compatibility.
+
+module.exports = {
+  internalBinding: process.binding,
+};

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -363,7 +363,7 @@ const ServerHandlers: SocketHandler = {
     const self = this.data;
     socket[kServerSocket] = self._handle;
     const options = self[bunSocketServerOptions];
-    const { pauseOnConnect, connectionListener, [kSocketClass]: SClass, requestCert, rejectUnauthorized } = options;
+    const { pauseOnConnect, [kSocketClass]: SClass, requestCert, rejectUnauthorized } = options;
     const _socket = new SClass({});
     _socket.isServer = true;
     _socket.server = self;
@@ -409,12 +409,7 @@ const ServerHandlers: SocketHandler = {
 
     self[bunSocketServerConnections]++;
 
-    if (typeof connectionListener === "function") {
-      this.pauseOnConnect = pauseOnConnect;
-      if (!isTLS) {
-        connectionListener.$call(self, _socket);
-      }
-    }
+    this.pauseOnConnect = pauseOnConnect;
     self.emit("connection", _socket);
     // the duplex implementation start paused, so we resume when pauseOnConnect is falsy
     if (!pauseOnConnect && !isTLS) {
@@ -454,10 +449,6 @@ const ServerHandlers: SocketHandler = {
       }
     } else {
       self.authorized = true;
-    }
-    const connectionListener = server[bunSocketServerOptions]?.connectionListener;
-    if (typeof connectionListener === "function") {
-      connectionListener.$call(server, self);
     }
     server.emit("secureConnection", self);
     // after secureConnection event we emmit secure and secureConnect
@@ -2091,6 +2082,9 @@ function Server(options?, connectionListener?) {
 
   options.connectionListener = connectionListener;
   this[bunSocketServerOptions] = options;
+  if (typeof connectionListener === "function") {
+    this.on("connection", connectionListener);
+  }
 
   if (options.blockList) {
     if (!BlockList.isBlockList(options.blockList)) {

--- a/test/js/node/test/parallel/test-net-server-capture-rejection.js
+++ b/test/js/node/test/parallel/test-net-server-capture-rejection.js
@@ -1,0 +1,30 @@
+const common = require('../common');
+const assert = require('assert');
+const events = require('events');
+const { createServer, connect } = require('net');
+
+events.captureRejections = true;
+
+const server = createServer(
+  common.mustCall(async (sock) => {
+    server.close();
+
+    const _err = new Error('kaboom');
+    sock.on(
+      'error',
+      common.mustCall((err) => {
+        assert.strictEqual(err, _err);
+      }),
+    );
+    throw _err;
+  }),
+);
+
+server.listen(
+  0,
+  common.mustCall(() => {
+    const sock = connect(server.address().port, server.address().host);
+
+    sock.on('close', common.mustCall());
+  }),
+);


### PR DESCRIPTION
## Summary
- implement `internal/test/binding` used by several Node tests
- hook up connection listener in `net.Server`
- emit `connection`/`secureConnection` events so `captureRejections` works
- add Node.js test `test-net-server-capture-rejection.js`

## Testing
- `bun bd --silent node:test test-net-server-capture-rejection.js` *(fails: Configuring WebKit)*