### PR TITLE
Fix allowHalfOpen in net server sockets

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -364,7 +364,9 @@ const ServerHandlers: SocketHandler = {
     socket[kServerSocket] = self._handle;
     const options = self[bunSocketServerOptions];
     const { pauseOnConnect, connectionListener, [kSocketClass]: SClass, requestCert, rejectUnauthorized } = options;
-    const _socket = new SClass({});
+    const _socket = new SClass({
+      allowHalfOpen: self.allowHalfOpen,
+    });
     _socket.isServer = true;
     _socket.server = self;
     _socket._requestCert = requestCert;

--- a/test/js/node/test/parallel/test-net-connect-options-allowhalfopen.js
+++ b/test/js/node/test/parallel/test-net-connect-options-allowhalfopen.js
@@ -1,0 +1,118 @@
+'use strict';
+const common = require("../common");
+const assert = require("assert");
+const net = require("net");
+
+// Test allowHalfOpen
+{
+  let clientReceivedFIN = 0;
+  let serverConnections = 0;
+  let clientSentFIN = 0;
+  let serverReceivedFIN = 0;
+  const host = common.localhostIPv4;
+
+  function serverOnConnection(socket) {
+    console.log(`'connection' ${++serverConnections} emitted on server`);
+    const srvConn = serverConnections;
+    socket.resume();
+    socket.on(
+      "data",
+      common.mustCall(function socketOnData(data) {
+        this.clientId = data.toString();
+        console.log(
+          `server connection ${srvConn} is started by client ${this.clientId}`,
+        );
+      }),
+    );
+    // 'end' on each socket must not be emitted twice
+    socket.on(
+      "end",
+      common.mustCall(function socketOnEnd() {
+        console.log(`Server received FIN sent by client ${this.clientId}`);
+        if (++serverReceivedFIN < CLIENT_VARIANTS) return;
+        setTimeout(() => {
+          server.close();
+          console.log(
+            `connection ${this.clientId} is closing the server:
+FIN ${serverReceivedFIN} received by server,
+FIN ${clientReceivedFIN} received by client
+FIN ${clientSentFIN} sent by client,
+FIN ${serverConnections} sent by server`.replace(/ {3,}/g, ""),
+          );
+        }, 50);
+      }, 1),
+    );
+    socket.end();
+    console.log(`Server has sent ${serverConnections} FIN`);
+  }
+
+  // These two levels of functions (and not arrows) are necessary in order to
+  // bind the `index`, and the calling socket (`this`)
+  function clientOnConnect(index) {
+    return common.mustCall(function clientOnConnectInner() {
+      const client = this;
+      console.log(`'connect' emitted on Client ${index}`);
+      client.resume();
+      client.on(
+        "end",
+        common.mustCall(function clientOnEnd() {
+          setTimeout(function closeServer() {
+            // When allowHalfOpen is true, client must still be writable
+            // after the server closes the connections, but not readable
+            console.log(`client ${index} received FIN`);
+            assert(!client.readable);
+            assert(client.writable);
+            assert(client.write(String(index)));
+            client.end();
+            clientSentFIN++;
+            console.log(
+              `client ${index} sent FIN, ${clientSentFIN} have been sent`,
+            );
+          }, 50);
+        }),
+      );
+      client.on(
+        "close",
+        common.mustCall(function clientOnClose() {
+          clientReceivedFIN++;
+          console.log(
+            `connection ${index} has been closed by both sides,` +
+              ` ${clientReceivedFIN} clients have closed`,
+          );
+        }),
+      );
+    });
+  }
+
+  function serverOnClose() {
+    console.log(
+      `Server has been closed:
+FIN ${serverReceivedFIN} received by server
+FIN ${clientReceivedFIN} received by client
+FIN ${clientSentFIN} sent by client
+FIN ${serverConnections} sent by server`.replace(/ {3,}/g, ""),
+    );
+  }
+
+  function serverOnListen() {
+    const port = server.address().port;
+    console.log(`Server started listening at ${host}:${port}`);
+    const opts = { allowHalfOpen: true, host, port };
+    // 6 variations === CLIENT_VARIANTS
+    net.connect(opts, clientOnConnect(1));
+    net.connect(opts).on("connect", clientOnConnect(2));
+    net.createConnection(opts, clientOnConnect(3));
+    net.createConnection(opts).on("connect", clientOnConnect(4));
+    new net.Socket(opts).connect(opts, clientOnConnect(5));
+    new net.Socket(opts).connect(opts).on("connect", clientOnConnect(6));
+  }
+
+  const CLIENT_VARIANTS = 6;
+
+  // The trigger
+  const server = net
+    .createServer({ allowHalfOpen: true })
+    .on("connection", common.mustCall(serverOnConnection, CLIENT_VARIANTS))
+    .on("close", common.mustCall(serverOnClose))
+    .listen(0, host, common.mustCall(serverOnListen));
+}


### PR DESCRIPTION
## Summary
- copy Node's `test-net-connect-options-allowhalfopen.js` into the repo
- ensure server sockets respect `allowHalfOpen`

## Testing
- `bun bd --silent node:test test-net-connect-options-allowhalfopen` *(fails: SetupWebKit.cmake: file RENAME failed)*