### PR TITLE
Add net autoselectfamily default test

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -235,12 +235,7 @@ const SocketHandlers: SocketHandler = {
     }
 
     if (error?.syscall === "connect") {
-      const ex = new ExceptionWithHostPort(
-        error.errno,
-        "connect",
-        self._host,
-        self._port,
-      );
+      const ex = new ExceptionWithHostPort(error.errno, "connect", self._host, self._port);
       self.emit("error", ex);
       if (!self.destroyed) process.nextTick(destroyNT, self, ex);
       return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -233,6 +233,19 @@ const SocketHandlers: SocketHandler = {
       self[kwriteCallback] = null;
       callback(error);
     }
+
+    if (error?.syscall === "connect") {
+      const ex = new ExceptionWithHostPort(
+        error.errno,
+        "connect",
+        self._host,
+        self._port,
+      );
+      self.emit("error", ex);
+      if (!self.destroyed) process.nextTick(destroyNT, self, ex);
+      return;
+    }
+
     self.emit("error", error);
   },
   open(socket) {
@@ -724,6 +737,8 @@ function Socket(options?) {
   this[kclosed] = false;
   this[kended] = false;
   this.connecting = false;
+  this._host = undefined;
+  this._port = undefined;
   this[bunTLSConnectOptions] = null;
   this.timeout = 0;
   this[kwriteCallback] = undefined;
@@ -1546,6 +1561,7 @@ function lookupAndConnect(self, options) {
   $debug("connect: find host", host, addressType);
   $debug("connect: dns options", dnsopts);
   self._host = host;
+  self._port = port;
   const lookup = options.lookup || dns.lookup;
 
   if (dnsopts.family !== 4 && dnsopts.family !== 6 && !localAddress && autoSelectFamily) {

--- a/test/js/node/test/parallel/test-net-autoselectfamily-default.js
+++ b/test/js/node/test/parallel/test-net-autoselectfamily-default.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const common = require('../common');
+const { createMockedLookup } = require('../common/dns');
+
+const assert = require('assert');
+const {
+  createConnection,
+  createServer,
+  setDefaultAutoSelectFamily,
+} = require('net');
+
+const autoSelectFamilyAttemptTimeout =
+  common.defaultAutoSelectFamilyAttemptTimeout;
+
+// Test that IPV4 is reached by default if IPV6 is not reachable and the default is enabled
+{
+  const ipv4Server = createServer((socket) => {
+    socket.on(
+      'data',
+      common.mustCall(() => {
+        socket.write('response-ipv4');
+        socket.end();
+      }),
+    );
+  });
+
+  ipv4Server.listen(
+    0,
+    '127.0.0.1',
+    common.mustCall(() => {
+      setDefaultAutoSelectFamily(true);
+
+      const connection = createConnection({
+        host: 'example.org',
+        port: ipv4Server.address().port,
+        lookup: createMockedLookup('::1', '127.0.0.1'),
+        autoSelectFamilyAttemptTimeout,
+      });
+
+      let response = '';
+      connection.setEncoding('utf-8');
+
+      connection.on('data', (chunk) => {
+        response += chunk;
+      });
+
+      connection.on(
+        'end',
+        common.mustCall(() => {
+          assert.strictEqual(response, 'response-ipv4');
+          ipv4Server.close();
+        }),
+      );
+
+      connection.write('request');
+    }),
+  );
+}
+
+// Test that IPV4 is not reached by default if IPV6 is not reachable and the default is disabled
+{
+  const ipv4Server = createServer((socket) => {
+    socket.on(
+      'data',
+      common.mustCall(() => {
+        socket.write('response-ipv4');
+        socket.end();
+      }),
+    );
+  });
+
+  ipv4Server.listen(
+    0,
+    '127.0.0.1',
+    common.mustCall(() => {
+      setDefaultAutoSelectFamily(false);
+
+      const port = ipv4Server.address().port;
+
+      const connection = createConnection({
+        host: 'example.org',
+        port,
+        lookup: createMockedLookup('::1', '127.0.0.1'),
+      });
+
+      connection.on('ready', common.mustNotCall());
+      connection.on(
+        'error',
+        common.mustCall((error) => {
+          if (common.hasIPv6) {
+            assert.strictEqual(error.code, 'ECONNREFUSED');
+            assert.strictEqual(
+              error.message,
+              `connect ECONNREFUSED ::1:${port}`,
+            );
+          } else if (error.code === 'EAFNOSUPPORT') {
+            assert.strictEqual(
+              error.message,
+              `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`,
+            );
+          } else if (error.code === 'EUNATCH') {
+            assert.strictEqual(
+              error.message,
+              `connect EUNATCH ::1:${port} - Local (:::0)`,
+            );
+          } else {
+            assert.strictEqual(error.code, 'EADDRNOTAVAIL');
+            assert.strictEqual(
+              error.message,
+              `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`,
+            );
+          }
+
+          ipv4Server.close();
+        }),
+      );
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- add Node.js net test for default autoSelectFamily behavior
- track host & port on sockets and map connect errors to `ExceptionWithHostPort`

## Testing
- `bun --enable-source-maps test/js/node/test/parallel/test-net-autoselectfamily-default.js` *(fails: Failed to connect)*
