### PR TITLE
Add node server close test

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -857,7 +857,7 @@ Socket.prototype[kAttach] = function (port, socket) {
   }
 
   if (this[kSetKeepAlive]) {
-    socket.setKeepAlive(true, self[kSetKeepAliveInitialDelay]);
+    socket.setKeepAlive(true, this[kSetKeepAliveInitialDelay]);
   }
 
   if (!this[kupgraded]) {

--- a/test/js/node/test/parallel/test-net-server-close.js
+++ b/test/js/node/test/parallel/test-net-server-close.js
@@ -1,3 +1,24 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -7,7 +28,9 @@ const sockets = [];
 
 const server = net.createServer(function(c) {
   c.on('close', common.mustCall());
+
   sockets.push(c);
+
   if (sockets.length === 2) {
     assert.strictEqual(server.close(), server);
     sockets.forEach((c) => c.destroy());
@@ -16,10 +39,7 @@ const server = net.createServer(function(c) {
 
 server.on('close', common.mustCall());
 
-assert.strictEqual(
-  server,
-  server.listen(0, () => {
-    net.createConnection(server.address().port);
-    net.createConnection(server.address().port);
-  }),
-);
+assert.strictEqual(server, server.listen(0, () => {
+  net.createConnection(server.address().port);
+  net.createConnection(server.address().port);
+}));

--- a/test/js/node/test/parallel/test-net-server-close.js
+++ b/test/js/node/test/parallel/test-net-server-close.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const sockets = [];
+
+const server = net.createServer(function(c) {
+  c.on('close', common.mustCall());
+  sockets.push(c);
+  if (sockets.length === 2) {
+    assert.strictEqual(server.close(), server);
+    sockets.forEach((c) => c.destroy());
+  }
+});
+
+server.on('close', common.mustCall());
+
+assert.strictEqual(
+  server,
+  server.listen(0, () => {
+    net.createConnection(server.address().port);
+    net.createConnection(server.address().port);
+  }),
+);


### PR DESCRIPTION
## Summary
- add Node.js test `test-net-server-close`
- fix `Socket.prototype[kAttach]` to reference the correct object when setting the keep-alive delay

## Testing
- `bun bd --silent node:test test-net-server-close` *(fails: missing WebKit build dependency)*