### PR TITLE
Fix socket reset behavior

### DIFF
--- a/test/js/node/test/parallel/test-net-socket-reset-send.js
+++ b/test/js/node/test/parallel/test-net-socket-reset-send.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+
+const server = net.createServer();
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const conn = net.createConnection(port);
+  server.on('connection', (socket) => {
+    socket.on('error', common.expectsError({
+      code: 'ECONNRESET',
+      message: 'read ECONNRESET',
+      name: 'Error',
+    }));
+  });
+
+  conn.on('connect', common.mustCall(() => {
+    assert.strictEqual(conn, conn.resetAndDestroy().destroy());
+    conn.on('error', common.mustNotCall());
+    conn.write(Buffer.from('fzfzfzfzfz'), common.expectsError({
+      code: 'ERR_STREAM_DESTROYED',
+      message: 'Cannot call write after a stream was destroyed',
+      name: 'Error',
+    }));
+    server.close();
+  }));
+}));


### PR DESCRIPTION
## Summary
- add missing node test `test-net-socket-reset-send`
- keep socket writable state open during `resetAndDestroy`
- return `ERR_STREAM_DESTROYED` when writing to a destroyed socket

## Testing
- `bun bd --silent node:test test-net-socket-reset-send.js` *(fails: file RENAME failed)*