### PR TITLE
Fix net lookup in createConnection

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1493,7 +1493,7 @@ function createConnection(...args) {
       dnsopts.hints = dns.ADDRCONFIG;
     }
     process.nextTick(() => {
-      options.lookup(options.host, dnsopts, function(err, ip, addressType) {
+      options.lookup(options.host, dnsopts, function (err, ip, addressType) {
         socket.emit("lookup", err, ip, addressType, options.host);
         if (err) {
           process.nextTick(destroyNT, socket, err);

--- a/test/js/node/parallel/test-net-connect-immediate-finish.js
+++ b/test/js/node/parallel/test-net-connect-immediate-finish.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+// This tests that if the socket is still in the 'connecting' state
+// when the user calls socket.end() ('finish'), the socket would emit
+// 'connect' and defer the handling until the 'connect' event is handled.
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const { addresses } = require('../common/internet');
+const {
+  errorLookupMock,
+  mockedErrorCode,
+  mockedSysCall
+} = require('../common/dns');
+
+const client = net.connect({
+  host: addresses.INVALID_HOST,
+  port: 80, // Port number doesn't matter because host name is invalid
+  lookup: common.mustCall(errorLookupMock())
+}, common.mustNotCall());
+
+client.once('error', common.mustCall((error) => {
+  // TODO(BridgeAR): Add a better way to handle not defined properties using
+  // `assert.throws(fn, object)`.
+  assert.ok(!('port' in error));
+  assert.ok(!('host' in error));
+  assert.throws(() => { throw error; }, {
+    code: mockedErrorCode,
+    errno: mockedErrorCode,
+    syscall: mockedSysCall,
+    hostname: addresses.INVALID_HOST,
+    message: 'getaddrinfo ENOTFOUND something.invalid'
+  });
+}));
+
+client.end();


### PR DESCRIPTION
## Notes
- Added `test-net-connect-immediate-finish.js` from Node's parallel test suite
- Updated `createConnection` to honor custom `lookup` option

## Summary
- ensure custom lookup function is executed and its error propagated
- include missing Node test for immediate finish during connect
