### PR TITLE
Add Node.js net bytes stats test

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -883,6 +883,11 @@ Socket.prototype.connect = function connect(...args) {
   {
     const [options, connectListener] =
       $isArray(args[0]) && args[0][normalizedArgsSymbol] ? args[0] : normalizeArgs(args);
+    if (this.destroyed) {
+      this._undestroy();
+      this.bytesRead = 0;
+      this[kBytesWritten] = undefined;
+    }
     let connection = this[ksocket];
     let upgradeDuplex = false;
     let { port, host, path, socket, rejectUnauthorized, checkServerIdentity, session, fd, pauseOnConnect } = options;

--- a/test/js/node/test/parallel/test-net-bytes-stats.js
+++ b/test/js/node/test/parallel/test-net-bytes-stats.js
@@ -1,0 +1,56 @@
+require('../common');
+const assert = require('assert');
+const net = require('net');
+
+let bytesRead = 0;
+let bytesWritten = 0;
+let count = 0;
+
+const tcp = net.Server(function(s) {
+  console.log('tcp server connection');
+
+  // trigger old mode.
+  s.resume();
+
+  s.on('end', function() {
+    bytesRead += s.bytesRead;
+    console.log(`tcp socket disconnect #${count}`);
+  });
+});
+
+tcp.listen(0, function doTest() {
+  console.error('listening');
+  const socket = net.createConnection(this.address().port);
+
+  socket.on('connect', function() {
+    count++;
+    console.error('CLIENT connect #%d', count);
+
+    socket.write('foo', function() {
+      console.error('CLIENT: write cb');
+      socket.end('bar');
+    });
+  });
+
+  socket.on('finish', function() {
+    bytesWritten += socket.bytesWritten;
+    console.error('CLIENT end event #%d', count);
+  });
+
+  socket.on('close', function() {
+    console.error('CLIENT close event #%d', count);
+    console.log(`Bytes read: ${bytesRead}`);
+    console.log(`Bytes written: ${bytesWritten}`);
+    if (count < 2) {
+      console.error('RECONNECTING');
+      socket.connect(tcp.address().port);
+    } else {
+      tcp.close();
+    }
+  });
+});
+
+process.on('exit', function() {
+  assert.strictEqual(bytesRead, 12);
+  assert.strictEqual(bytesWritten, 12);
+});


### PR DESCRIPTION
## Summary
- add `test-net-bytes-stats.js` from Node.js upstream
- reset socket state before reconnecting so bytes counters start from zero

## Testing
- `bun bd --silent node:test test-net-bytes-stats.js` *(fails: could not build Bun)*