### PR TITLE
Fix net server noDelay handling

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -372,6 +372,10 @@ const ServerHandlers: SocketHandler = {
 
     _socket[kAttach](this.localPort, socket);
 
+    if (self.noDelay) {
+      _socket.setNoDelay(self.noDelay);
+    }
+
     if (self.blockList) {
       const addressType = isIP(socket.remoteAddress);
       if (addressType && self.blockList.check(socket.remoteAddress, `ipv${addressType}`)) {

--- a/test/js/node/test/parallel/test-net-server-nodelay.js
+++ b/test/js/node/test/parallel/test-net-server-nodelay.js
@@ -1,0 +1,33 @@
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const server = net
+  .createServer(
+    {
+      noDelay: true,
+    },
+    common.mustCall((socket) => {
+      socket._handle.setNoDelay = common.mustNotCall();
+      socket.setNoDelay(true);
+      socket.destroy();
+      server.close();
+    }),
+  )
+  .listen(
+    0,
+    common.mustCall(() => {
+      net.connect(server.address().port);
+    }),
+  );
+
+const onconnection = server._handle.onconnection;
+server._handle.onconnection = common.mustCall((err, clientHandle) => {
+  const setNoDelay = clientHandle.setNoDelay;
+  clientHandle.setNoDelay = common.mustCall((enable) => {
+    assert.strictEqual(enable, server.noDelay);
+    setNoDelay.call(clientHandle, enable);
+    clientHandle.setNoDelay = setNoDelay;
+  });
+  onconnection.call(server._handle, err, clientHandle);
+});


### PR DESCRIPTION
## Summary
- add Node.js test `test-net-server-nodelay`
- call `Socket.setNoDelay()` when server `noDelay` option is enabled

## Testing
- `bun bd --silent node:test test-net-server-nodelay` *(fails: missing webkit build files)*