### PR TITLE
Fix net.setNoDelay handle support

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -685,6 +685,7 @@ function Socket(options?) {
     noDelay = false,
     keepAlive = false,
     keepAliveInitialDelay = 0,
+    handle = null,
     ...opts
   } = options || {};
 
@@ -782,6 +783,14 @@ function Socket(options?) {
       throw $ERR_INVALID_ARG_TYPE("options.blockList", "net.BlockList", opts.blockList);
     }
     this.blockList = opts.blockList;
+  }
+
+  if (handle) {
+    this._handle = handle;
+    initSocketHandle(this);
+    if (typeof handle.readStart === "function") {
+      handle.readStart();
+    }
   }
 }
 $toClass(Socket, "Socket", Duplex);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -788,9 +788,6 @@ function Socket(options?) {
   if (handle) {
     this._handle = handle;
     initSocketHandle(this);
-    if (typeof handle.readStart === "function") {
-      handle.readStart();
-    }
   }
 }
 $toClass(Socket, "Socket", Duplex);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -788,6 +788,8 @@ function Socket(options?) {
   if (handle) {
     this._handle = handle;
     initSocketHandle(this);
+    // We don't implement this, but some node tests expect a readStart function
+    // to exist. And user's code might too.
     if (typeof handle.readStart === "function") {
       handle.readStart();
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -788,6 +788,9 @@ function Socket(options?) {
   if (handle) {
     this._handle = handle;
     initSocketHandle(this);
+    if (typeof handle.readStart === "function") {
+      handle.readStart();
+    }
   }
 }
 $toClass(Socket, "Socket", Duplex);

--- a/test/js/node/test/parallel/test-net-socket-setnodelay.js
+++ b/test/js/node/test/parallel/test-net-socket-setnodelay.js
@@ -1,0 +1,56 @@
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const truthyValues = [true, 1, 'true', {}, []];
+const falseyValues = [false, 0, ''];
+const genSetNoDelay = (desiredArg) => (enable) => {
+  assert.strictEqual(enable, desiredArg);
+};
+
+// setNoDelay should default to true
+let socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(genSetNoDelay(true)),
+    readStart() {},
+  },
+});
+socket.setNoDelay();
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(genSetNoDelay(true), 1),
+    readStart() {},
+  },
+});
+truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustNotCall(),
+    readStart() {},
+  },
+});
+falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(3),
+    readStart() {},
+  },
+});
+truthyValues
+  .concat(falseyValues)
+  .concat(truthyValues)
+  .forEach((testVal) => socket.setNoDelay(testVal));
+
+// If a handler doesn't have a setNoDelay function it shouldn't be called.
+// In the case below, if it is called an exception will be thrown
+socket = new net.Socket({
+  handle: {
+    setNoDelay: null,
+    readStart() {},
+  },
+});
+const returned = socket.setNoDelay(true);
+assert.ok(returned instanceof net.Socket);


### PR DESCRIPTION
## Summary
- add Node.js test for socket `setNoDelay` handle option
- implement `handle` option in `net.Socket`

## Testing
- `bun bd --silent node:test test-net-socket-setnodelay.js` *(fails: missing WebKit build)*