### PR TITLE
Fix pauseOnConnect semantics for node:net server

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -409,6 +409,10 @@ const ServerHandlers: SocketHandler = {
 
     self[bunSocketServerConnections]++;
 
+    if (pauseOnConnect) {
+      _socket.pause();
+    }
+
     if (typeof connectionListener === "function") {
       this.pauseOnConnect = pauseOnConnect;
       if (!isTLS) {
@@ -463,7 +467,9 @@ const ServerHandlers: SocketHandler = {
     // after secureConnection event we emmit secure and secureConnect
     self.emit("secure", self);
     self.emit("secureConnect", verifyError);
-    if (!server.pauseOnConnect) {
+    if (server.pauseOnConnect) {
+      self.pause();
+    } else {
       self.resume();
     }
   },
@@ -517,6 +523,9 @@ const SocketHandlers2: SocketHandler<SocketHandleData> = {
     $debug("self[kupgraded]", String(self[kupgraded]));
     if (!self[kupgraded]) req!.oncomplete(0, self._handle, req, true, true);
     socket.data.req = undefined;
+    if (self.pauseOnConnect) {
+      self.pause();
+    }
     if (self[kupgraded]) {
       self.connecting = false;
       const options = self[bunTLSConnectOptions];
@@ -904,7 +913,9 @@ Socket.prototype.connect = function connect(...args) {
       });
     }
     this.pauseOnConnect = pauseOnConnect;
-    if (!pauseOnConnect) {
+    if (pauseOnConnect) {
+      this.pause();
+    } else {
       process.nextTick(() => {
         this.resume();
       });

--- a/test/js/node/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/js/node/test/parallel/test-net-server-pause-on-connect.js
@@ -1,0 +1,49 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const msg = 'test';
+let stopped = true;
+let server1Sock;
+
+const server1ConnHandler = (socket) => {
+  socket.on('data', function(data) {
+    if (stopped) {
+      assert.fail('data event should not have happened yet');
+    }
+    assert.strictEqual(data.toString(), msg);
+    socket.end();
+    server1.close();
+  });
+
+  server1Sock = socket;
+};
+
+const server1 = net.createServer({ pauseOnConnect: true }, server1ConnHandler);
+
+const server2ConnHandler = (socket) => {
+  socket.on('data', function(data) {
+    assert.strictEqual(data.toString(), msg);
+    socket.end();
+    server2.close();
+
+    assert.strictEqual(server1Sock.bytesRead, 0);
+    server1Sock.resume();
+    stopped = false;
+  });
+};
+
+const server2 = net.createServer({ pauseOnConnect: false }, server2ConnHandler);
+
+server1.listen(0, function() {
+  const clientHandler = common.mustCall(function() {
+    server2.listen(0, function() {
+      net.createConnection({ port: this.address().port }).write(msg);
+    });
+  });
+  net.createConnection({ port: this.address().port }).write(msg, clientHandler);
+});
+
+process.on('exit', function() {
+  assert.strictEqual(stopped, false);
+});


### PR DESCRIPTION
## Summary
- add Node.js test for pauseOnConnect
- ensure new sockets remain paused when pauseOnConnect is enabled
- keep TLS sockets paused when pauseOnConnect is set
- keep client sockets paused when `pauseOnConnect` is requested

## Testing
- `bun bd --silent node:test test-net-server-pause-on-connect` *(fails: file rename, webkit missing)*