### PR TITLE
Add IPv6 link-local server listen test

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2359,13 +2359,9 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
         return;
       }
       if (addresses.length > 1) {
-        const hasNonLinkLocal = addresses.some(
-          (a) => !(a.family === 6 && isIPv6LinkLocal(a.address)),
-        );
+        const hasNonLinkLocal = addresses.some(a => !(a.family === 6 && isIPv6LinkLocal(a.address)));
         if (hasNonLinkLocal) {
-          addresses = addresses.filter(
-            (a) => !(a.family === 6 && isIPv6LinkLocal(a.address)),
-          );
+          addresses = addresses.filter(a => !(a.family === 6 && isIPv6LinkLocal(a.address)));
         }
       }
       const { address } = addresses[0];

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -21,7 +21,7 @@ class MockTracker {
       throw new TypeError("object[methodName] is not a function");
     }
     const fn = function (this: any, ...args: any[]) {
-      return implementation.apply(this, args);
+      return implementation.$apply(this, args);
     } as any;
     (fn as any).wrappedMethod = original;
     this.#mocks.push({ object, method: methodName, original });

--- a/test/js/node/test/sequential/test-net-server-listen-ipv6-link-local.js
+++ b/test/js/node/test/sequential/test-net-server-listen-ipv6-link-local.js
@@ -1,0 +1,140 @@
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const dns = require('dns');
+const { mock } = require('node:test');
+
+if (!common.hasIPv6) {
+  common.printSkipMessage('IPv6 support is required for this test');
+  return;
+}
+
+// Test on IPv6 Server, dns.lookup throws an error
+{
+  mock.method(dns, 'lookup', (hostname, options, callback) => {
+    callback(new Error('Mocked error'));
+  });
+  const host = 'ipv6-link-local';
+
+  const server = net.createServer();
+
+  server.on(
+    'error',
+    common.mustCall((e) => {
+      assert.strictEqual(e.message, 'Mocked error');
+    }),
+  );
+
+  server.listen(common.PORT + 2, host);
+}
+
+// Test on IPv6 Server, server.listen throws an error
+{
+  mock.method(dns, 'lookup', (hostname, options, callback) => {
+    if (hostname === 'ipv6-link-local') {
+      callback(null, [{ address: 'fe80::1', family: 6 }]);
+    } else {
+      dns.lookup.wrappedMethod(hostname, options, callback);
+    }
+  });
+  const host = 'ipv6-link-local';
+
+  const server = net.createServer();
+
+  server.on(
+    'error',
+    common.mustCall((e) => {
+      assert.strictEqual(e.address, 'fe80::1');
+      assert.strictEqual(e.syscall, 'listen');
+    }),
+  );
+
+  server.listen(common.PORT + 2, host);
+}
+
+// Test on IPv6 Server, picks 127.0.0.1 between that and a bunch of link-local addresses
+{
+  mock.method(dns, 'lookup', (hostname, options, callback) => {
+    if (hostname === 'ipv6-link-local-with-many-entries') {
+      callback(null, [
+        { address: 'fe80::1', family: 6 },
+        { address: 'fe80::abcd:1234', family: 6 },
+        { address: 'fe80::1ff:fe23:4567:890a', family: 6 },
+        { address: 'fe80::200:5aee:feaa:20a2', family: 6 },
+        { address: 'fe80::f2de:f1ff:fe2b:3c4b', family: 6 },
+        { address: 'fe81::1', family: 6 },
+        { address: 'fe82::abcd:1234', family: 6 },
+        { address: 'fe83::1ff:fe23:4567:890a', family: 6 },
+        { address: 'fe84::200:5aee:feaa:20a2', family: 6 },
+        { address: 'fe85::f2de:f1ff:fe2b:3c4b', family: 6 },
+        { address: 'fe86::1', family: 6 },
+        { address: 'fe87::abcd:1234', family: 6 },
+        { address: 'fe88::1ff:fe23:4567:890a', family: 6 },
+        { address: 'fe89::200:5aee:feaa:20a2', family: 6 },
+        { address: 'fe8a::f2de:f1ff:fe2b:3c4b', family: 6 },
+        { address: 'fe8b::1', family: 6 },
+        { address: 'fe8c::abcd:1234', family: 6 },
+        { address: 'fe8d::1ff:fe23:4567:890a', family: 6 },
+        { address: 'fe8e::200:5aee:feaa:20a2', family: 6 },
+        { address: 'fe8f::f2de:f1ff:fe2b:3c4b', family: 6 },
+        { address: 'fea0::1', family: 6 },
+        { address: 'febf::abcd:1234', family: 6 },
+        { address: 'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff', family: 6 },
+        { address: '127.0.0.1', family: 4 },
+      ]);
+    } else {
+      dns.lookup.wrappedMethod(hostname, options, callback);
+    }
+  });
+
+  const host = 'ipv6-link-local-with-many-entries';
+
+  const server = net.createServer();
+
+  server.on('error', common.mustNotCall());
+
+  server.listen(
+    common.PORT + 3,
+    host,
+    common.mustCall(() => {
+      const address = server.address();
+      assert.strictEqual(address.address, '127.0.0.1');
+      assert.strictEqual(address.port, common.PORT + 3);
+      assert.strictEqual(address.family, 'IPv4');
+      server.close();
+    }),
+  );
+}
+
+// Test on IPv6 Server, picks ::1 because the other address is a link-local address
+{
+  const host = 'ipv6-link-local-with-double-entry';
+  const validIpv6Address = '::1';
+
+  mock.method(dns, 'lookup', (hostname, options, callback) => {
+    if (hostname === 'ipv6-link-local-with-double-entry') {
+      callback(null, [
+        { address: 'fe80::1', family: 6 },
+        { address: validIpv6Address, family: 6 },
+      ]);
+    } else {
+      dns.lookup.wrappedMethod(hostname, options, callback);
+    }
+  });
+
+  const server = net.createServer();
+
+  server.on('error', common.mustNotCall());
+
+  server.listen(
+    common.PORT + 4,
+    host,
+    common.mustCall(() => {
+      const address = server.address();
+      assert.strictEqual(address.address, validIpv6Address);
+      assert.strictEqual(address.port, common.PORT + 4);
+      assert.strictEqual(address.family, 'IPv6');
+      server.close();
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- add Node.js test for IPv6 link-local server listen
- implement minimal test.mock tracker
- resolve hostnames in `net.Server.prototype.listen` and ignore IPv6 link‑local addresses

## Testing
- `bunx tsc -p tsconfig.json --noEmit` *(passed)*
- `bun run lint` *(fails: bunx not found / connection refused)*
- `bun bd --silent node:test test/js/node/test/sequential/test-net-server-listen-ipv6-link-local.js` *(fails: build step requires network)*