### PR TITLE
Fix node:net listen options parsing

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2220,7 +2220,7 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
     if (typeof port === "function") {
       onListen = port;
       port = 0;
-    } else if (typeof port === "object") {
+    } else if (typeof port === "object" && port !== null) {
       const options = port;
       addServerAbortSignalOption(this, options);
 
@@ -2228,6 +2228,10 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
       exclusive = options.exclusive;
       path = options.path;
       port = options.port;
+      if (typeof port === "string") {
+        const numPort = toNumber(port);
+        if (numPort !== false) port = numPort;
+      }
       ipv6Only = options.ipv6Only;
       allowHalfOpen = options.allowHalfOpen;
       reusePort = options.reusePort;
@@ -2239,7 +2243,11 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
 
       const isLinux = process.platform === "linux";
 
-      if (!Number.isSafeInteger(port) || port < 0) {
+      if (port === undefined && "port" in options) {
+        port = 0;
+      } else if (port === null) {
+        port = 0;
+      } else if (!Number.isSafeInteger(port) || port < 0) {
         if (path) {
           const isAbstractPath = path.startsWith("\0");
           if (isLinux && isAbstractPath && (options.writableAll || options.readableAll)) {

--- a/test/js/node/test/parallel/test-net-server-listen-options.js
+++ b/test/js/node/test/parallel/test-net-server-listen-options.js
@@ -1,0 +1,91 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+function close() {
+  this.close();
+}
+
+{
+  // Test listen()
+  net.createServer().listen().on('listening', common.mustCall(close));
+  // Test listen(cb)
+  net.createServer().listen(common.mustCall(close));
+  // Test listen(port)
+  net.createServer().listen(0).on('listening', common.mustCall(close));
+  // Test listen({port})
+  net.createServer().listen({ port: 0 }).on('listening', common.mustCall(close));
+}
+
+// Test listen(port, cb) and listen({ port }, cb) combinations
+const listenOnPort = [
+  (port, cb) => net.createServer().listen({ port }, cb),
+  (port, cb) => net.createServer().listen(port, cb),
+];
+
+{
+  const assertPort = () => {
+    return common.expectsError({
+      code: 'ERR_SOCKET_BAD_PORT',
+      name: 'RangeError',
+    });
+  };
+
+  for (const listen of listenOnPort) {
+    // Arbitrary unused ports
+    listen('0', common.mustCall(close));
+    listen(0, common.mustCall(close));
+    listen(undefined, common.mustCall(close));
+    listen(null, common.mustCall(close));
+    // Test invalid ports
+    assert.throws(() => listen(-1, common.mustNotCall()), assertPort());
+    assert.throws(() => listen(NaN, common.mustNotCall()), assertPort());
+    assert.throws(() => listen(123.456, common.mustNotCall()), assertPort());
+    assert.throws(() => listen(65536, common.mustNotCall()), assertPort());
+    assert.throws(() => listen(1 / 0, common.mustNotCall()), assertPort());
+    assert.throws(() => listen(-1 / 0, common.mustNotCall()), assertPort());
+  }
+  // In listen(options, cb), port takes precedence over path
+  assert.throws(() => {
+    net.createServer().listen({ port: -1, path: common.PIPE }, common.mustNotCall());
+  }, assertPort());
+}
+
+{
+  function shouldFailToListen(options) {
+    const fn = () => {
+      net.createServer().listen(options, common.mustNotCall());
+    };
+
+    if (typeof options === 'object' && !('port' in options || 'path' in options)) {
+      assert.throws(fn, {
+        code: 'ERR_INVALID_ARG_VALUE',
+        name: 'TypeError',
+        message: /^The argument 'options' must have the property "port" or "path"\. Received .+$/,
+      });
+    } else {
+      assert.throws(fn, {
+        code: 'ERR_INVALID_ARG_VALUE',
+        name: 'TypeError',
+        message: /^The argument 'options' is invalid\. Received .+$/,
+      });
+    }
+  }
+
+  shouldFailToListen(false, { port: false });
+  shouldFailToListen({ port: false });
+  shouldFailToListen(true);
+  shouldFailToListen({ port: true });
+  // Invalid fd as listen(handle)
+  shouldFailToListen({ fd: -1 });
+  // Invalid path in listen(options)
+  shouldFailToListen({ path: -1 });
+
+  // Neither port or path are specified in options
+  shouldFailToListen({});
+  shouldFailToListen({ host: 'localhost' });
+  shouldFailToListen({ host: 'localhost:3000' });
+  shouldFailToListen({ host: { port: 3000 } });
+  shouldFailToListen({ exclusive: true });
+}


### PR DESCRIPTION
## Summary
- port strings in `Server.listen` options are now converted to numbers
- allow `null`/undefined to not be treated as options
- add upstream `test-net-server-listen-options` to node suite
- support undefined ports in options

## Testing
- `node scripts/runner.node.mjs --exec-path=$(which bun) --node-tests test/js/node/test/parallel/test-net-server-listen-options.js` *(fails: build requires downloading dependencies)*
