### PR TITLE
Fix net server max connections

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -93,6 +93,7 @@ const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
 const owner_symbol = Symbol("owner_symbol");
 
 const kServerSocket = Symbol("kServerSocket");
+const kServerCounted = Symbol("kServerCounted");
 const kBytesWritten = Symbol("kBytesWritten");
 const bunTLSConnectOptions = Symbol.for("::buntlsconnectoptions::");
 const kReinitializeHandle = Symbol("kReinitializeHandle");
@@ -342,7 +343,10 @@ const ServerHandlers: SocketHandler = {
     const data = this.data;
     if (!data) return;
 
-    data.server[bunSocketServerConnections]--;
+    if (data[kServerCounted]) {
+      data.server[bunSocketServerConnections]--;
+      data[kServerCounted] = false;
+    }
     {
       if (!data[kclosed]) {
         data[kclosed] = true;
@@ -408,6 +412,7 @@ const ServerHandlers: SocketHandler = {
     const isTLS = typeof bunTLS === "function";
 
     self[bunSocketServerConnections]++;
+    _socket[kServerCounted] = true;
 
     if (typeof connectionListener === "function") {
       this.pauseOnConnect = pauseOnConnect;

--- a/test/js/node/test/parallel/test-net-server-max-connections.js
+++ b/test/js/node/test/parallel/test-net-server-max-connections.js
@@ -1,0 +1,95 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+// This test creates 20 connections to a server and sets the server's
+// maxConnections property to 10. The first 10 connections make it through
+// and the last 10 connections are rejected.
+
+const N = 20;
+let closes = 0;
+const waits = [];
+
+const server = net.createServer(
+  common.mustCall(function (connection) {
+    connection.write('hello');
+    waits.push(function () {
+      connection.end();
+    });
+  }, N / 2),
+);
+
+server.listen(0, function () {
+  makeConnection(0);
+});
+
+server.maxConnections = N / 2;
+
+function makeConnection(index) {
+  const c = net.createConnection(server.address().port);
+  let gotData = false;
+
+  c.on('connect', function () {
+    if (index + 1 < N) {
+      makeConnection(index + 1);
+    }
+
+    c.on('close', function () {
+      console.error(`closed ${index}`);
+      closes++;
+
+      if (closes < N / 2) {
+        assert.ok(
+          server.maxConnections <= index,
+          `${index} should not have been one of the first closed connections`,
+        );
+      }
+
+      if (closes === N / 2) {
+        let cb;
+        console.error('calling wait callback.');
+        while ((cb = waits.shift()) !== undefined) {
+          cb();
+        }
+        server.close();
+      }
+
+      if (index < server.maxConnections) {
+        assert.strictEqual(
+          gotData,
+          true,
+          `${index} didn't get data, but should have`,
+        );
+      } else {
+        assert.strictEqual(
+          gotData,
+          false,
+          `${index} got data, but shouldn't have`,
+        );
+      }
+    });
+  });
+
+  c.on('end', function () {
+    c.end();
+  });
+
+  c.on('data', function (b) {
+    gotData = true;
+    assert.ok(b.length > 0);
+  });
+
+  c.on('error', function (e) {
+    // Retry if SmartOS and ECONNREFUSED. See
+    // https://github.com/nodejs/node/issues/2663.
+    if (common.isSunOS && e.code === 'ECONNREFUSED') {
+      c.connect(server.address().port);
+    }
+    console.error(`error ${index}: ${e}`);
+  });
+}
+
+process.on('exit', function () {
+  assert.strictEqual(closes, N);
+});


### PR DESCRIPTION
## Summary
- add node:test fixture for `net` server maxConnections
- fix server connection accounting when dropping connections

## Testing
- `bun bd --silent node:test test/js/node/test/parallel/test-net-server-max-connections.js` *(fails: file RENAME failed to rename bun-webkit)*