### PR TITLE
Fix http response destroy status

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -503,15 +503,18 @@ const ServerResponsePrototype = {
     // throw new Error('not implemented');
   },
 
-  destroy(_err?: Error) {
+  destroy(err?: Error) {
     if (this.destroyed) return this;
     const handle = this[kHandle];
     this.destroyed = true;
     if (handle) {
       handle.abort();
     }
+    if (err !== undefined) {
+      this.errored = err;
+    }
     this?.socket?.destroy();
-    this.emit("close");
+    emitCloseNT(this);
     return this;
   },
 
@@ -1576,6 +1579,7 @@ function ServerResponse(req, options) {
   this[headerStateSymbol] = NodeHTTPHeaderState.none;
   this[kPendingCallbacks] = [];
   this.finished = false;
+  this.errored = undefined;
 
   // this is matching node's behaviour
   // https://github.com/nodejs/node/blob/cf8c6994e0f764af02da4fa70bc5962142181bf3/lib/_http_server.js#L192

--- a/test/js/node/test/parallel/test-http-outgoing-destroyed.js
+++ b/test/js/node/test/parallel/test-http-outgoing-destroyed.js
@@ -1,0 +1,76 @@
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+{
+const server = http.createServer(common.mustCall((req, res) => {
+assert.strictEqual(res.closed, false);
+req.pipe(res);
+res.on('error', common.mustNotCall());
+res.on('close', common.mustCall(() => {
+assert.strictEqual(res.closed, true);
+res.end('asd');
+process.nextTick(() => {
+server.close();
+});
+}));
+})).listen(0, () => {
+http
+.request({
+port: server.address().port,
+method: 'PUT'
+})
+.on('response', (res) => {
+res.destroy();
+})
+.write('asd');
+});
+}
+
+{
+const server = http.createServer(common.mustCall((req, res) => {
+assert.strictEqual(res.closed, false);
+req.pipe(res);
+res.on('error', common.mustNotCall());
+res.on('close', common.mustCall(() => {
+assert.strictEqual(res.closed, true);
+process.nextTick(() => {
+server.close();
+});
+}));
+const err = new Error('Destroy test');
+res.destroy(err);
+assert.strictEqual(res.errored, err);
+})).listen(0, () => {
+http
+.request({
+port: server.address().port,
+method: 'PUT'
+})
+.on('error', common.mustCall())
+.write('asd');
+});
+}
+
+{
+const server = http.createServer(common.mustCall((req, res) => {
+assert.strictEqual(res.closed, false);
+res.end();
+res.destroy();
+// Make sure not to emit 'error' after .destroy().
+res.end('asd');
+assert.strictEqual(res.errored, undefined);
+})).listen(0, () => {
+http
+.request({
+port: server.address().port,
+method: 'GET'
+})
+.on('response', common.mustCall((res) => {
+res.resume().on('end', common.mustCall(() => {
+server.close();
+}));
+}))
+.end();
+});
+}


### PR DESCRIPTION
## Summary
- add node test `test-http-outgoing-destroyed`
- track `errored` state and close ServerResponse/OutgoingMessage via `emitCloseNT`

## Testing
- `bun bd --silent node:test test-http-outgoing-destroyed.js` *(fails: Configuring incomplete, errors occurred)*