### PR TITLE
Fix Host header for IPv6 requests

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -481,11 +481,7 @@ function ClientRequest(input, options, cb) {
       if (!this.hasHeader("Host")) {
         let hostHeader = host;
         const posColon = hostHeader.indexOf(":");
-        if (
-          posColon !== -1 &&
-          hostHeader.includes(":", posColon + 1) &&
-          hostHeader.charCodeAt(0) !== 91 /* '[' */
-        ) {
+        if (posColon !== -1 && hostHeader.includes(":", posColon + 1) && hostHeader.charCodeAt(0) !== 91 /* '[' */) {
           hostHeader = `[${hostHeader}]`;
         }
         this.setHeader("Host", `${hostHeader}:${port}`);
@@ -522,11 +518,7 @@ function ClientRequest(input, options, cb) {
         if (!this.hasHeader("Host")) {
           let hostHeader = host;
           const posColon = hostHeader.indexOf(":");
-          if (
-            posColon !== -1 &&
-            hostHeader.includes(":", posColon + 1) &&
-            hostHeader.charCodeAt(0) !== 91 /* '[' */
-          ) {
+          if (posColon !== -1 && hostHeader.includes(":", posColon + 1) && hostHeader.charCodeAt(0) !== 91 /* '[' */) {
             hostHeader = `[${hostHeader}]`;
           }
           this.setHeader("Host", `${hostHeader}:${port}`);

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -478,6 +478,18 @@ function ClientRequest(input, options, cb) {
 
     if (isIP(host) || !options.lookup) {
       // Don't need to bother with lookup if it's already an IP address or no lookup function is provided.
+      if (!this.hasHeader("Host")) {
+        let hostHeader = host;
+        const posColon = hostHeader.indexOf(":");
+        if (
+          posColon !== -1 &&
+          hostHeader.includes(":", posColon + 1) &&
+          hostHeader.charCodeAt(0) !== 91 /* '[' */
+        ) {
+          hostHeader = `[${hostHeader}]`;
+        }
+        this.setHeader("Host", `${hostHeader}:${port}`);
+      }
       const [url, proxy] = getURL(host);
       go(url, proxy, false);
       return true;
@@ -508,7 +520,16 @@ function ClientRequest(input, options, cb) {
         }
 
         if (!this.hasHeader("Host")) {
-          this.setHeader("Host", `${host}:${port}`);
+          let hostHeader = host;
+          const posColon = hostHeader.indexOf(":");
+          if (
+            posColon !== -1 &&
+            hostHeader.includes(":", posColon + 1) &&
+            hostHeader.charCodeAt(0) !== 91 /* '[' */
+          ) {
+            hostHeader = `[${hostHeader}]`;
+          }
+          this.setHeader("Host", `${hostHeader}:${port}`);
         }
 
         // We want to try all possible addresses, beginning with the IPv6 ones, until one succeeds.

--- a/test/js/node/test/parallel/test-http-host-header-ipv6-fail.js
+++ b/test/js/node/test/parallel/test-http-host-header-ipv6-fail.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// When using the object form of http.request and using an IPv6 address
+// as a hostname, and using a non-standard port, the Host header
+// is improperly formatted.
+// Issue: https://github.com/nodejs/node/issues/5308
+// As per https://tools.ietf.org/html/rfc7230#section-5.4 and
+// https://tools.ietf.org/html/rfc3986#section-3.2.2
+// the IPv6 address should be enclosed in square brackets
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+const requests = [
+  { host: 'foo:1234', headers: { expectedhost: 'foo:1234:80' } },
+  { host: '::1', headers: { expectedhost: '[::1]:80' } },
+];
+
+function createLocalConnection(options) {
+  options.host = undefined;
+  options.port = this.port;
+  options.path = undefined;
+  return net.createConnection(options);
+}
+
+http.createServer(common.mustCall(function(req, res) {
+  this.requests ||= 0;
+  assert.strictEqual(req.headers.host, req.headers.expectedhost);
+  res.end();
+  if (++this.requests === requests.length)
+    this.close();
+}, requests.length)).listen(0, function() {
+  const address = this.address();
+  for (let i = 0; i < requests.length; ++i) {
+    requests[i].createConnection =
+      common.mustCall(createLocalConnection.bind(address));
+    http.get(requests[i]);
+  }
+});


### PR DESCRIPTION
## Summary
- copy upstream test for IPv6 host header parsing
- ensure ClientRequest encloses IPv6 hosts in brackets when setting Host header

## Testing
- `bun bd --silent node:test test/js/node/test/parallel/test-http-host-header-ipv6-fail.js` *(fails: file rename to WebKit cache because host download is blocked)*