### PR TITLE
Fix http.writable after close

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -166,6 +166,9 @@ function callCloseCallback(self) {
 }
 function emitCloseNT(self) {
   if (!self._closed) {
+    if (self._ended !== undefined) {
+      self._ended = true;
+    }
     self.destroyed = true;
     self._closed = true;
     callCloseCallback(self);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -272,9 +272,7 @@ const ServerResponsePrototype = {
     }
     this.detachSocket(socket);
     this.finished = true;
-    process.nextTick(self => {
-      self._ended = true;
-    }, this);
+    // Marking _ended happens on 'close' to align with Node.js behavior
     this.emit("prefinish");
     this._callPendingCallbacks();
 

--- a/test/js/node/test/parallel/test-http-writable-true-after-close.js
+++ b/test/js/node/test/parallel/test-http-writable-true-after-close.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { get, createServer } = require('http');
+
+// res.writable should not be set to false after it has finished sending
+// Ref: https://github.com/nodejs/node/issues/15029
+
+let internal;
+let external;
+
+// Proxy server
+const server = createServer(common.mustCall((req, res) => {
+  const listener = common.mustCall(() => {
+    assert.strictEqual(res.writable, true);
+  });
+
+  // on CentOS 5, 'finish' is emitted
+  res.on('finish', listener);
+  // Everywhere else, 'close' is emitted
+  res.on('close', listener);
+
+  get(`http://127.0.0.1:${internal.address().port}`, common.mustCall((inner) => {
+    inner.pipe(res);
+  }));
+})).listen(0, () => {
+  // Http server
+  internal = createServer((req, res) => {
+    res.writeHead(200);
+    setImmediate(common.mustCall(() => {
+      external.abort();
+      res.end('Hello World\n');
+    }));
+  }).listen(0, () => {
+    external = get(`http://127.0.0.1:${server.address().port}`);
+    external.on('error', common.mustCall(() => {
+      server.close();
+      internal.close();
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add nodejs test `test-http-writable-true-after-close`
- update ServerResponse to mark `_ended` when socket closes
- ensure close handler updates `_ended` state

## Testing
- `bun bd --silent node:test test-js/node/test/parallel/test-http-writable-true-after-close.js` *(fails: file rename failed - missing webkit)*
- `bun run fmt` *(fails: bunx not found)*
- `bun run lint` *(fails: bunx not found)*