### PR TITLE
Fix Node http Agent test

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -567,7 +567,7 @@ function ClientRequest(input, options, cb) {
     try {
       const createConnection = this[kAgent]?.createConnection;
       if (typeof createConnection === "function" && createConnection.length > 1) {
-        createConnection.call(this[kAgent], connOptions, (err) => {
+        createConnection.call(this[kAgent], connOptions, err => {
           if (err) {
             if (!!$debug) globalReportError(err);
             this.emit("error", err);

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -548,15 +548,48 @@ function ClientRequest(input, options, cb) {
 
     var body = this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
 
+    const doFetch = () => {
+      try {
+        startFetch(body);
+        onEnd = () => {
+          handleResponse?.();
+        };
+      } catch (err) {
+        if (!!$debug) globalReportError(err);
+        this.emit("error", err);
+        process.nextTick(maybeEmitFinish.bind(this));
+        return;
+      }
+      process.nextTick(maybeEmitFinish.bind(this));
+    };
+
+    const connOptions = { host: this[kHost], port: this[kPort] };
     try {
-      startFetch(body);
-      onEnd = () => {
-        handleResponse?.();
-      };
+      const createConnection = this[kAgent]?.createConnection;
+      if (typeof createConnection === "function" && createConnection.length > 1) {
+        createConnection.call(this[kAgent], connOptions, (err) => {
+          if (err) {
+            if (!!$debug) globalReportError(err);
+            this.emit("error", err);
+            process.nextTick(maybeEmitFinish.bind(this));
+            return;
+          }
+          doFetch();
+        });
+      } else {
+        try {
+          createConnection?.call(this[kAgent], connOptions);
+        } catch (err) {
+          if (!!$debug) globalReportError(err);
+          this.emit("error", err);
+          process.nextTick(maybeEmitFinish.bind(this));
+          return;
+        }
+        doFetch();
+      }
     } catch (err) {
       if (!!$debug) globalReportError(err);
       this.emit("error", err);
-    } finally {
       process.nextTick(maybeEmitFinish.bind(this));
     }
   };

--- a/test/js/node/test/parallel/test-http-agent.js
+++ b/test/js/node/test/parallel/test-http-agent.js
@@ -1,0 +1,66 @@
+const common = require('../common');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+const http = require('http');
+
+const N = 4;
+const M = 4;
+const server = http.Server(common.mustCall(function(req, res) {
+  res.writeHead(200);
+  res.end('hello world\n');
+}, (N * M))); // N * M = good requests (the errors will not be counted)
+
+function makeRequests(outCount, inCount, shouldFail) {
+  const countdown = new Countdown(
+    outCount * inCount,
+    common.mustCall(() => server.close())
+  );
+  let onRequest = common.mustNotCall(); // Temporary
+  const p = new Promise((resolve) => {
+    onRequest = common.mustCall((res) => {
+      if (countdown.dec() === 0) {
+        resolve();
+      }
+
+      if (!shouldFail)
+        res.resume();
+    }, outCount * inCount);
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+    for (let i = 0; i < outCount; i++) {
+      setTimeout(() => {
+        for (let j = 0; j < inCount; j++) {
+          const req = http.get({ port: port, path: '/' }, onRequest);
+          if (shouldFail)
+            req.on('error', common.mustCall(onRequest));
+          else
+            req.on('error', (e) => assert.fail(e));
+        }
+      }, i);
+    }
+  });
+  return p;
+}
+
+const test1 = makeRequests(N, M);
+
+const test2 = () => {
+  // Should not explode if can not create sockets.
+  // Ref: https://github.com/nodejs/node/issues/13045
+  // Ref: https://github.com/nodejs/node/issues/13831
+  http.Agent.prototype.createConnection = function createConnection(_, cb) {
+    process.nextTick(cb, new Error('nothing'));
+  };
+  return makeRequests(N, M, true);
+};
+
+test1
+  .then(test2)
+  .catch((e) => {
+    // This is currently the way to fail a test with a Promise.
+    console.error(e);
+    process.exit(1);
+  }
+  );


### PR DESCRIPTION
## Notes
- Added Node test `test-http-agent.js` under `test/js/node/test/parallel`.
- Updated `ClientRequest` send logic to respect `Agent.prototype.createConnection` callbacks and propagate errors before performing fetch.
- `bun bd --silent node:test test-http-agent` fails to run in this environment due to missing build dependencies.
