### PR TITLE
Fix machine.mjs for Windows instances

### DIFF
--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -858,7 +858,8 @@ function getSshKeys() {
     const sshFiles = readdirSync(sshPath, { withFileTypes: true, encoding: "utf-8" });
     const publicPaths = sshFiles
       .filter(entry => entry.isFile() && entry.name.endsWith(".pub"))
-      .map(({ name }) => join(sshPath, name));
+      .map(({ name }) => join(sshPath, name))
+      .filter(path => !readFile(path, { cache: true }).startsWith("ssh-ed25519"));
 
     sshKeys.push(
       ...publicPaths.map(publicPath => ({

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync } from "fs";
-import { bunEnv, bunExe, hideFromStackTrace, tmpdirSync } from "harness";
+import { bunEnv, bunExe, hideFromStackTrace } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {


### PR DESCRIPTION
### What does this PR do?

The script previously would not work if you have any Ed25519 SSH keys:

> ED25519 key pairs are not supported with Windows AMIs. Choose a different key pair type and try again.

Now we filter those out when scanning the `.ssh` directory. If you only have an Ed25519 key the script should automatically generate an RSA key (like it already did if you have no keys).

### How did you verify your code works?

Used machine.mjs to connect to a Windows instance