### PR TITLE
Fix http Expect header handling

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1082,7 +1082,7 @@ const ServerPrototype = {
             } else if (server.listenerCount("checkExpectation") > 0) {
               server.emit("checkExpectation", http_req, http_res);
             } else {
-              http_res.statusCode = 417;
+              http_res.writeHead(417);
               http_res.end();
             }
           } else {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1071,12 +1071,19 @@ const ServerPrototype = {
                 http_res.assignSocket(socket);
               }
             }
-          } else if (http_req.headers.expect === "100-continue") {
-            if (server.listenerCount("checkContinue") > 0) {
-              server.emit("checkContinue", http_req, http_res);
+          } else if (http_req.headers.expect !== undefined) {
+            if (http_req.headers.expect === "100-continue") {
+              if (server.listenerCount("checkContinue") > 0) {
+                server.emit("checkContinue", http_req, http_res);
+              } else {
+                http_res.writeContinue();
+                server.emit("request", http_req, http_res);
+              }
+            } else if (server.listenerCount("checkExpectation") > 0) {
+              server.emit("checkExpectation", http_req, http_res);
             } else {
-              http_res.writeContinue();
-              server.emit("request", http_req, http_res);
+              http_res.statusCode = 417;
+              http_res.end();
             }
           } else {
             server.emit("request", http_req, http_res);

--- a/test/js/node/test/parallel/test-http-expect-handling.js
+++ b/test/js/node/test/parallel/test-http-expect-handling.js
@@ -1,3 +1,5 @@
+// Spec documentation http://httpwg.github.io/specs/rfc7231.html#header.expect
+'use strict';
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');

--- a/test/js/node/test/parallel/test-http-expect-handling.js
+++ b/test/js/node/test/parallel/test-http-expect-handling.js
@@ -1,0 +1,53 @@
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const tests = [417, 417];
+
+let testsComplete = 0;
+let testIdx = 0;
+
+const s = http.createServer((req, res) => {
+  throw new Error('this should never be executed');
+});
+
+s.listen(0, nextTest);
+
+function nextTest() {
+  const options = {
+    port: s.address().port,
+    headers: { 'Expect': 'meoww' }
+  };
+
+  if (testIdx === tests.length) {
+    return s.close();
+  }
+
+  const test = tests[testIdx];
+
+  if (testIdx > 0) {
+    s.on('checkExpectation', common.mustCall((req, res) => {
+      res.statusCode = 417;
+      res.end();
+    }));
+  }
+
+  http.get(options, (response) => {
+    console.log(`client: expected status: ${test}`);
+    console.log(`client: statusCode: ${response.statusCode}`);
+    assert.strictEqual(response.statusCode, test);
+    assert.strictEqual(response.statusMessage, 'Expectation Failed');
+
+    response.on('end', () => {
+      testsComplete++;
+      testIdx++;
+      nextTest();
+    });
+    response.resume();
+  });
+}
+
+
+process.on('exit', () => {
+  assert.strictEqual(testsComplete, 2);
+});


### PR DESCRIPTION
## Summary
- add Node.js test for http Expect header handling
- implement checkExpectation logic for http

## Testing
- `bun bd --silent node:test test-http-expect-handling.js` *(fails: download error)*