### PR TITLE
Fix server socket resume and add unconsume test

### DIFF
--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -559,7 +559,7 @@ pub fn onTimeout(this: *NodeHTTPResponse, _: uws.AnyResponse) void {
 
 pub fn doPause(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.CallFrame, thisValue: JSC.JSValue) bun.JSError!JSC.JSValue {
     log("doPause", .{});
-    if (this.flags.request_has_completed or this.flags.socket_closed or this.flags.ended) {
+    if (this.flags.request_has_completed or this.flags.socket_closed) {
         return .false;
     }
     if (this.body_read_ref.has and js.onDataGetCached(thisValue) == null) {
@@ -589,7 +589,7 @@ fn drainBufferedRequestBodyFromPause(this: *NodeHTTPResponse, globalObject: *JSC
 
 pub fn doResume(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     log("doResume", .{});
-    if (this.flags.request_has_completed or this.flags.socket_closed or this.flags.ended) {
+    if (this.flags.request_has_completed or this.flags.socket_closed) {
         return .false;
     }
 

--- a/test/js/node/test/parallel/test-http-server-unconsume.js
+++ b/test/js/node/test/parallel/test-http-server-unconsume.js
@@ -1,0 +1,40 @@
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+['on', 'addListener', 'prependListener'].forEach((testFn) => {
+  let received = '';
+
+  const server = http
+    .createServer(function(req, res) {
+      res.writeHead(200);
+      res.end();
+
+      req.socket[testFn]('data', function(data) {
+        received += data;
+      });
+
+      server.close();
+    })
+    .listen(0, function() {
+      const socket = net.connect(this.address().port, function() {
+        socket.write('PUT / HTTP/1.1\r\nHost: example.com\r\n\r\n');
+
+        socket.once('data', function() {
+          socket.end('hello world');
+        });
+
+        socket.on(
+          'end',
+          common.mustCall(() => {
+            assert.strictEqual(
+              received,
+              'hello world',
+              `failed for socket.${testFn}`
+            );
+          })
+        );
+      });
+    });
+});


### PR DESCRIPTION
## Summary
- add Node.js test `test-http-server-unconsume`
- allow resuming sockets after a response is finished

## Testing
- `bun bd --silent node:test test-http-server-unconsume` *(fails: unable to download WebKit)*
- `bun bd --silent node:test test-http-keep-alive-timeout-race-condition` *(fails: unable to download WebKit)*