### PR TITLE
Find any tests that don't runCallChecks

### DIFF
--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -447,7 +447,7 @@ if (process.env.NODE_TEST_KNOWN_GLOBALS !== '0') {
 const mustCallChecks = [];
 
 function runCallChecks(exitCode) {
-  if (exitCode !== 0) return;
+  if (exitCode !== 200) return;
 
   const failed = mustCallChecks.filter(function(context) {
     if ('minimum' in context) {
@@ -467,6 +467,7 @@ function runCallChecks(exitCode) {
   });
 
   if (failed.length) process.exit(1);
+  process.exit(0);
 }
 
 function mustCall(fn, exact) {
@@ -506,6 +507,7 @@ function _mustCallInner(fn, criteria = 1, field) {
   };
 
   // Add the exit listener only once to avoid listener leak warnings
+  process.exitCode = 200
   if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
 
   mustCallChecks.push(context);


### PR DESCRIPTION
Set exitCode to 200 if mustCall is called, and only exit with code 0 if the exit handler is called

test/js/node/test/parallel/test-worker-terminate-nested.js : debug assertion failure with exit code 0
-   ASSERTION FAILED: m_normalWorld->hasOneRef()
-   ../../src/bun.js/bindings/BunClientData.cpp(77) : virtual WebCore::JSVMClientData::~JSVMClientData()

==60834==ERROR: AddressSanitizer: use-after-poison on address 0x00011e650ec1 at pc 0x00010520b670 bp 0x00016f403610 sp 0x00016f403608
- test/js/node/test/parallel/test-worker-unref-from-message-during-exit.js 

child exited with code 200:
- test/js/node/test/parallel/test-promise-unhandled-throw-handler.js 

process.on("exit") is not executed:
- test/js/node/test/parallel/test-worker-message-channel-sharedarraybuffer.js
- test/js/node/test/parallel/test-worker-workerdata-sharedarraybuffer.js
- test/js/node/test/parallel/test-worker-sharedarraybuffer-from-worker-thread.js
- test/js/node/test/parallel/test-worker-console-listeners.js
- test/js/node/test/parallel/test-worker-ref.js 
- test/js/node/test/parallel/test-worker-nested-on-process-exit.js
- test/js/node/test/parallel/test-file-write-stream5.js
- test/js/node/test/parallel/test-crypto-worker-thread.js
- test/js/node/test/parallel/test-worker.mjs
- test/js/node/test/parallel/test-require-symlink.js 
- test/js/node/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
- test/js/node/test/parallel/test-worker-safe-getters.js 
- test/js/node/test/parallel/test-worker-process-argv.js 
- test/js/node/test/parallel/test-assert-fail-deprecation.js 
- test/js/node/test/parallel/test-worker-non-fatal-uncaught-exception.js 
- test/js/node/test/parallel/test-worker-message-port-wasm-module.js 
- test/js/node/test/parallel/test-worker-mjs-workerdata.js 
- test/js/node/test/parallel/test-worker.js 
- test/js/node/test/parallel/test-worker-exit-heapsnapshot.js
- test/js/node/test/parallel/test-worker-terminate-null-handler.js 
- test/js/node/test/parallel/test-worker-memory.js 
- test/js/node/test/parallel/test-no-addons-resolution-condition.js 
- test/js/node/test/parallel/test-worker-relative-path.js 
- test/js/node/test/parallel/test-worker-parent-port-ref.js 
- test/js/node/test/parallel/test-events-add-abort-listener.mjs 
- test/js/node/test/parallel/test-worker-esmodule.js 
- test/js/node/test/parallel/test-worker-no-sab.js 
- test/js/node/test/parallel/test-worker-esm-exit.js 
- test/js/node/test/parallel/test-fs-append-file-flush.js 
- test/js/node/test/parallel/test-child-process-windows-hide.js 
- test/js/node/test/parallel/test-worker-abort-on-uncaught-exception.js 
- test/js/node/test/parallel/test-worker-exit-from-uncaught-exception.js 
- test/js/node/test/parallel/test-async-hooks-worker-asyncfn-terminate-2.js 
- test/js/node/test/parallel/test-runner-subtest-after-hook.js
- test/js/node/test/parallel/test-abortsignal-any.mjs 
- test/js/node/test/parallel/test-crypto-prime.js
- test/js/node/test/parallel/test-worker-relative-path-double-dot.js 
- test/js/node/test/parallel/test-fs-write-stream-flush.js
- test/js/node/test/parallel/test-worker-http2-generic-streams-terminate.js
- test/js/node/test/parallel/test-async-hooks-worker-asyncfn-terminate-1.js
- test/js/node/test/parallel/test-worker-nested-uncaught.js 
- test/js/node/test/parallel/test-async-hooks-worker-asyncfn-terminate-4.js 
- test/js/node/test/parallel/test-runner-root-after-with-refed-handles.js 
- test/js/node/test/parallel/test-worker-cjs-workerdata.js 
- test/js/node/test/parallel/test-fs-write-file-flush.js 
