### PR TITLE
Fix http socket encoding check

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1409,9 +1409,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   setEncoding(_encoding) {
-    const err = new Error(
-      "Changing the socket encoding is not allowed per RFC7230 Section 3."
-    );
+    const err = new Error("Changing the socket encoding is not allowed per RFC7230 Section 3.");
     err.code = "ERR_HTTP_SOCKET_ENCODING";
     throw err;
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1408,6 +1408,14 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     return this;
   }
 
+  setEncoding(_encoding) {
+    const err = new Error(
+      "Changing the socket encoding is not allowed per RFC7230 Section 3."
+    );
+    err.code = "ERR_HTTP_SOCKET_ENCODING";
+    throw err;
+  }
+
   unref() {
     return this;
   }

--- a/test/js/node/parallel/test-http-socket-encoding-error.js
+++ b/test/js/node/parallel/test-http-socket-encoding-error.js
@@ -1,0 +1,26 @@
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer().listen(0, connectToServer);
+
+server.on('connection', common.mustCall((socket) => {
+  assert.throws(
+    () => {
+      socket.setEncoding('');
+    },
+    {
+      code: 'ERR_HTTP_SOCKET_ENCODING',
+      name: 'Error',
+      message: 'Changing the socket encoding is not allowed per RFC7230 Section 3.'
+    }
+  );
+
+  socket.end();
+}));
+
+function connectToServer() {
+  const client = new http.Agent().createConnection(this.address().port, () => {
+    client.end();
+  }).on('end', () => server.close());
+}


### PR DESCRIPTION
## Summary
- add Node test for http socket encoding error
- throw ERR_HTTP_SOCKET_ENCODING when changing the encoding of an http socket

## Testing
- `bun bd --silent node:test test/js/node/parallel/test-http-socket-encoding-error.js` *(fails: Configuring incomplete, errors occurred)*