### PR TITLE
Fix http server response standalone test

### DIFF
--- a/test/js/node/test/parallel/test-http-server-response-standalone.js
+++ b/test/js/node/test/parallel/test-http-server-response-standalone.js
@@ -1,0 +1,38 @@
+const common = require('../common');
+const { ServerResponse } = require('http');
+const { Writable } = require('stream');
+const assert = require('assert');
+
+// Check that ServerResponse can be used without a proper Socket
+// Refs: https://github.com/nodejs/node/issues/14386
+// Refs: https://github.com/nodejs/node/issues/14381
+
+const res = new ServerResponse({
+  method: 'GET',
+  httpVersionMajor: 1,
+  httpVersionMinor: 1
+});
+
+let firstChunk = true;
+
+const ws = new Writable({
+  write: common.mustCall((chunk, encoding, callback) => {
+    if (firstChunk) {
+      assert(chunk.toString().endsWith('hello world'));
+      firstChunk = false;
+    } else {
+      assert.strictEqual(chunk.length, 0);
+    }
+    setImmediate(callback);
+  }, 2)
+});
+
+res.assignSocket(ws);
+
+assert.throws(function() {
+  res.assignSocket(ws);
+}, {
+  code: 'ERR_HTTP_SOCKET_ASSIGNED'
+});
+
+res.end('hello world');


### PR DESCRIPTION
## Summary
- add Node.js test `test-http-server-response-standalone.js`
- handle standalone `ServerResponse.end()` when only a writable socket is attached

## Testing
- `bun bd --silent node:test test-js/node/test/parallel/test-http-server-response-standalone.js` *(fails: WebKit build download missing)*