### PR TITLE
Fix http server tests

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -796,7 +796,6 @@ const ServerPrototype = {
       if (typeof optionalCallback === "function") process.nextTick(optionalCallback, $ERR_SERVER_NOT_RUNNING());
       return;
     }
-    this[serverSymbol] = undefined;
     const connectionsCheckingInterval = this[kConnectionsCheckingInterval];
     if (connectionsCheckingInterval) {
       connectionsCheckingInterval._destroyed = true;

--- a/test/js/node/test/parallel/test-http-server-unconsume.js
+++ b/test/js/node/test/parallel/test-http-server-unconsume.js
@@ -1,0 +1,32 @@
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+['on', 'addListener', 'prependListener'].forEach((testFn) => {
+  let received = '';
+
+  const server = http.createServer(function(req, res) {
+    res.writeHead(200);
+    res.end();
+
+    req.socket[testFn]('data', function(data) {
+      received += data;
+    });
+
+    server.close();
+  }).listen(0, function() {
+    const socket = net.connect(this.address().port, function() {
+      socket.write('PUT / HTTP/1.1\r\nHost: example.com\r\n\r\n');
+
+      socket.once('data', function() {
+        socket.end('hello world');
+      });
+
+      socket.on('end', common.mustCall(() => {
+        assert.strictEqual(received, 'hello world',
+                           `failed for socket.${testFn}`);
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Node.js test for unconsume
- tweak `Server.close()` to keep server alive while stopping

## Testing
- `bun bd --silent node:test test/js/node/test/parallel/test-http-server-unconsume.js` *(fails: Configuring incomplete, errors occurred)*