### PR TITLE
Fix setSourceMapsEnabled node test

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3139,6 +3139,21 @@ JSC_DEFINE_HOST_FUNCTION(Process_stubEmptyFunction, (JSGlobalObject * globalObje
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(Process_setSourceMapsEnabled, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue arg0 = callFrame->argument(0);
+    if (!arg0.isBoolean()) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "enabled"_s, "boolean"_s, arg0);
+    }
+
+    globalObject->processObject()->m_sourceMapsEnabled = arg0.toBoolean(globalObject);
+    return JSValue::encode(jsUndefined());
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_stubFunctionReturningArray, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(JSC::constructEmptyArray(globalObject, nullptr));
@@ -3645,7 +3660,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   resourceUsage                    Process_functionResourceUsage                       Function 0
   revision                         constructRevision                                   PropertyCallback
   send                             constructProcessSend                                PropertyCallback
-  setSourceMapsEnabled             Process_stubEmptyFunction                           Function 1
+  setSourceMapsEnabled             Process_setSourceMapsEnabled                           Function 1
   setUncaughtExceptionCaptureCallback Process_setUncaughtExceptionCaptureCallback      Function 1
   stderr                           constructStderr                                     PropertyCallback
   stdin                            constructStdin                                      PropertyCallback

--- a/src/bun.js/bindings/BunProcess.h
+++ b/src/bun.js/bindings/BunProcess.h
@@ -50,6 +50,7 @@ public:
     ~Process();
 
     bool m_isExitCodeObservable = false;
+    bool m_sourceMapsEnabled = false;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
 

--- a/test/js/node/test/parallel/test-process-setsourcemapsenabled.js
+++ b/test/js/node/test/parallel/test-process-setsourcemapsenabled.js
@@ -1,0 +1,15 @@
+require('../common');
+const assert = require('assert');
+
+const unexpectedValues = [
+  undefined,
+  null,
+  1,
+  {},
+  () => {},
+];
+for (const it of unexpectedValues) {
+  assert.throws(() => {
+    process.setSourceMapsEnabled(it);
+  }, /ERR_INVALID_ARG_TYPE/);
+}

--- a/test/js/node/test/parallel/test-process-setsourcemapsenabled.js
+++ b/test/js/node/test/parallel/test-process-setsourcemapsenabled.js
@@ -1,3 +1,4 @@
+'use strict';
 require('../common');
 const assert = require('assert');
 


### PR DESCRIPTION
## Summary
- port Node's `test-process-setsourcemapsenabled.js`
- implement `process.setSourceMapsEnabled` with argument validation

## Testing
- `bun bd --silent node:test test-process-setsourcemapsenabled` *(fails: unable to download webkit while building)*