### PR TITLE
Add process.initgroups stub and test

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2565,9 +2565,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObj
         }
         username = pp->pw_name;
     } else {
-        JSString* str = user.getString(globalObject);
+        auto userString = user.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        auto utf8 = str->utf8();
+        auto utf8 = userString.utf8();
         username = utf8.data();
     }
 

--- a/test/js/node/test/parallel/test-process-initgroups.js
+++ b/test/js/node/test/parallel/test-process-initgroups.js
@@ -1,0 +1,59 @@
+const common = require('../common');
+const assert = require('assert');
+
+if (common.isWindows) {
+  assert.strictEqual(process.initgroups, undefined);
+  return;
+}
+
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  return;
+}
+
+[undefined, null, true, {}, [], () => {}].forEach((val) => {
+  assert.throws(
+    () => {
+      process.initgroups(val);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+      message:
+        'The "user" argument must be ' +
+        'one of type number or string.' +
+        common.invalidArgTypeHelper(val)
+    }
+  );
+});
+
+[undefined, null, true, {}, [], () => {}].forEach((val) => {
+  assert.throws(
+    () => {
+      process.initgroups('foo', val);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+      message:
+        'The "extraGroup" argument must be ' +
+        'one of type number or string.' +
+        common.invalidArgTypeHelper(val)
+    }
+  );
+});
+
+assert.throws(
+  () => {
+    process.initgroups(
+      'fhqwhgadshgnsdhjsdbkhsdabkfabkveyb',
+      'fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
+    );
+  },
+  {
+    code: 'ERR_UNKNOWN_CREDENTIAL',
+    message:
+      'Group identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
+  }
+);

--- a/test/js/node/test/parallel/test-process-initgroups.js
+++ b/test/js/node/test/parallel/test-process-initgroups.js
@@ -1,3 +1,4 @@
+'use strict';
 const common = require('../common');
 const assert = require('assert');
 


### PR DESCRIPTION
## Summary
- port Node's `test-process-initgroups.js`
- implement `process.initgroups()` on non‑Windows platforms
- gate `process.initgroups` to Linux and macOS only

## Testing
- `bun bd --silent node:test test-process-initgroups.js` *(fails: file rename error)*