### PR TITLE
Fix override of globalAgent

### DIFF
--- a/src/js/node/_http_agent.ts
+++ b/src/js/node/_http_agent.ts
@@ -82,6 +82,9 @@ ObjectDefineProperty(AgentClass, "globalAgent", {
   get: function () {
     return globalAgent;
   },
+  set: function (value) {
+    globalAgent = value;
+  },
 });
 
 ObjectDefineProperty(AgentClass, "defaultMaxSockets", {
@@ -144,10 +147,20 @@ Agent.prototype.destroy = function () {
 
 var globalAgent = new Agent();
 
-const http_agent_exports = {
+const http_agent_exports: any = {
   Agent: AgentClass,
-  globalAgent,
   NODE_HTTP_WARNING,
 };
+
+ObjectDefineProperty(http_agent_exports, "globalAgent", {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return globalAgent;
+  },
+  set(value) {
+    globalAgent = value;
+  },
+});
 
 export default http_agent_exports;

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -1,5 +1,5 @@
 const { validateInteger } = require("internal/validators");
-const { Agent, globalAgent, NODE_HTTP_WARNING } = require("node:_http_agent");
+const { Agent, NODE_HTTP_WARNING } = require("node:_http_agent");
 const { ClientRequest } = require("node:_http_client");
 const { validateHeaderName, validateHeaderValue } = require("node:_http_common");
 const { IncomingMessage } = require("node:_http_incoming");
@@ -60,12 +60,22 @@ const http_exports = {
     validateInteger(max, "max", 1);
     $debug(`${NODE_HTTP_WARNING}\n`, "setMaxIdleHTTPParsers() is a no-op");
   },
-  globalAgent,
   ClientRequest,
   OutgoingMessage,
   WebSocket,
   CloseEvent,
   MessageEvent,
 };
+
+Object.defineProperty(http_exports, "globalAgent", {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return Agent.globalAgent;
+  },
+  set(value) {
+    Agent.globalAgent = value;
+  },
+});
 
 export default http_exports;

--- a/test/js/node/test/parallel/test-http-client-override-global-agent.js
+++ b/test/js/node/test/parallel/test-http-client-override-global-agent.js
@@ -1,3 +1,4 @@
+'use strict';
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');

--- a/test/js/node/test/parallel/test-http-client-override-global-agent.js
+++ b/test/js/node/test/parallel/test-http-client-override-global-agent.js
@@ -1,0 +1,27 @@
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.Server(common.mustCall((req, res) => {
+  res.writeHead(200);
+  res.end('Hello, World!');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const agent = new http.Agent();
+  const name = agent.getName({ port: server.address().port });
+  http.globalAgent = agent;
+
+  makeRequest();
+  assert(name in agent.sockets); // Agent has indeed been used
+}));
+
+function makeRequest() {
+  const req = http.get({
+    port: server.address().port
+  });
+  req.on('close', () => {
+    assert.strictEqual(req.destroyed, true);
+    server.close();
+  });
+}


### PR DESCRIPTION
## Summary
- add Node.js test for http globalAgent override
- implement setter for `Agent.globalAgent`
- export `globalAgent` with getter/setter
- re-export globalAgent via getter/setter in `http` module

## Testing
- `bun bd --silent node:test test-http-client-override-global-agent` *(fails: could not build bun due to missing WebKit)*