### PR TITLE
Implement _renderHeaders and add test

### DIFF
--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -321,10 +321,7 @@ const OutgoingMessagePrototype = {
   },
 
   _renderHeaders() {
-    if (
-      (this._header !== undefined && this._header !== null) ||
-      this[headerStateSymbol] === NodeHTTPHeaderState.sent
-    ) {
+    if ((this._header !== undefined && this._header !== null) || this[headerStateSymbol] === NodeHTTPHeaderState.sent) {
       throw $ERR_HTTP_HEADERS_SENT("render");
     }
 

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -320,6 +320,29 @@ const OutgoingMessagePrototype = {
     this[headersSymbol] = new Headers(value);
   },
 
+  _renderHeaders() {
+    if (
+      (this._header !== undefined && this._header !== null) ||
+      this[headerStateSymbol] === NodeHTTPHeaderState.sent
+    ) {
+      throw $ERR_HTTP_HEADERS_SENT("render");
+    }
+
+    const out = this[kOutHeaders];
+    if (out == null) return {};
+
+    const keys = ObjectKeys(out);
+    if (keys.length === 0) return {};
+
+    const ret = { __proto__: null } as any;
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const arr = out[key];
+      ret[arr[0]] = arr[1];
+    }
+    return ret;
+  },
+
   addTrailers(headers) {
     this._trailer = "";
     const keys = Object.keys(headers);

--- a/test/js/node/test/parallel/test-http-outgoing-renderHeaders.js
+++ b/test/js/node/test/parallel/test-http-outgoing-renderHeaders.js
@@ -1,0 +1,49 @@
+// Flags: --expose-internals
+
+require('../common');
+const assert = require('assert');
+
+const kOutHeaders = require('internal/http').kOutHeaders;
+const http = require('http');
+const OutgoingMessage = http.OutgoingMessage;
+
+{
+const outgoingMessage = new OutgoingMessage();
+outgoingMessage._header = {};
+assert.throws(
+() => outgoingMessage._renderHeaders(),
+{
+code: 'ERR_HTTP_HEADERS_SENT',
+name: 'Error',
+message: 'Cannot render headers after they are sent to the client'
+}
+);
+}
+
+{
+const outgoingMessage = new OutgoingMessage();
+outgoingMessage[kOutHeaders] = null;
+const result = outgoingMessage._renderHeaders();
+assert.deepStrictEqual(result, {});
+}
+
+
+{
+const outgoingMessage = new OutgoingMessage();
+outgoingMessage[kOutHeaders] = {};
+const result = outgoingMessage._renderHeaders();
+assert.deepStrictEqual(result, {});
+}
+
+{
+const outgoingMessage = new OutgoingMessage();
+outgoingMessage[kOutHeaders] = {
+host: ['host', 'nodejs.org'],
+origin: ['Origin', 'localhost']
+};
+const result = outgoingMessage._renderHeaders();
+assert.deepStrictEqual(result, {
+host: 'nodejs.org',
+Origin: 'localhost'
+});
+}

--- a/test/js/node/test/parallel/test-http-outgoing-renderHeaders.js
+++ b/test/js/node/test/parallel/test-http-outgoing-renderHeaders.js
@@ -1,3 +1,4 @@
+'use strict';
 // Flags: --expose-internals
 
 require('../common');
@@ -8,42 +9,42 @@ const http = require('http');
 const OutgoingMessage = http.OutgoingMessage;
 
 {
-const outgoingMessage = new OutgoingMessage();
-outgoingMessage._header = {};
-assert.throws(
-() => outgoingMessage._renderHeaders(),
-{
-code: 'ERR_HTTP_HEADERS_SENT',
-name: 'Error',
-message: 'Cannot render headers after they are sent to the client'
-}
-);
-}
-
-{
-const outgoingMessage = new OutgoingMessage();
-outgoingMessage[kOutHeaders] = null;
-const result = outgoingMessage._renderHeaders();
-assert.deepStrictEqual(result, {});
-}
-
-
-{
-const outgoingMessage = new OutgoingMessage();
-outgoingMessage[kOutHeaders] = {};
-const result = outgoingMessage._renderHeaders();
-assert.deepStrictEqual(result, {});
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage._header = {};
+  assert.throws(
+    () => outgoingMessage._renderHeaders(),
+    {
+      code: 'ERR_HTTP_HEADERS_SENT',
+      name: 'Error',
+      message: 'Cannot render headers after they are sent to the client'
+    }
+  );
 }
 
 {
-const outgoingMessage = new OutgoingMessage();
-outgoingMessage[kOutHeaders] = {
-host: ['host', 'nodejs.org'],
-origin: ['Origin', 'localhost']
-};
-const result = outgoingMessage._renderHeaders();
-assert.deepStrictEqual(result, {
-host: 'nodejs.org',
-Origin: 'localhost'
-});
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage[kOutHeaders] = null;
+  const result = outgoingMessage._renderHeaders();
+  assert.deepStrictEqual(result, {});
+}
+
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage[kOutHeaders] = {};
+  const result = outgoingMessage._renderHeaders();
+  assert.deepStrictEqual(result, {});
+}
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage[kOutHeaders] = {
+    host: ['host', 'nodejs.org'],
+    origin: ['Origin', 'localhost']
+  };
+  const result = outgoingMessage._renderHeaders();
+  assert.deepStrictEqual(result, {
+    host: 'nodejs.org',
+    Origin: 'localhost'
+  });
 }


### PR DESCRIPTION
## Summary
- port Node.js test `test-http-outgoing-renderHeaders`
- implement `OutgoingMessage.prototype._renderHeaders`

## Testing
- `bun bd --silent node:test test-http-outgoing-renderHeaders.js` *(fails: build requires WebKit)*