### PR TITLE
Fix TLS generic stream connecting property

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -920,7 +920,9 @@ Socket.prototype.connect = function connect(...args) {
       process.nextTick(() => {
         this.resume();
       });
-      this.connecting = true;
+      if (!connection && !fd) {
+        this.connecting = true;
+      }
     }
     if (fd) {
       return this;

--- a/test/js/node/test/parallel/test-tls-generic-stream.js
+++ b/test/js/node/test/parallel/test-tls-generic-stream.js
@@ -1,0 +1,37 @@
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+const { duplexPair } = require('stream');
+const assert = require('assert');
+const { TLSSocket, connect } = require('tls');
+
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
+
+const [ clientSide, serverSide ] = duplexPair();
+
+const clientTLS = connect({
+  socket: clientSide,
+  ca,
+  host: 'agent1'  // Hostname from certificate
+});
+const serverTLS = new TLSSocket(serverSide, {
+  isServer: true,
+  key,
+  cert,
+  ca
+});
+
+assert.strictEqual(clientTLS.connecting, false);
+assert.strictEqual(serverTLS.connecting, false);
+
+clientTLS.on('secureConnect', common.mustCall(() => {
+  clientTLS.write('foobar', common.mustCall(() => {
+    assert.strictEqual(serverTLS.read().toString(), 'foobar');
+    assert.strictEqual(clientTLS._handle.writeQueueSize, 0);
+  }));
+  assert.ok(clientTLS._handle.writeQueueSize > 0);
+}));

--- a/test/js/node/test/parallel/test-tls-generic-stream.js
+++ b/test/js/node/test/parallel/test-tls-generic-stream.js
@@ -1,3 +1,4 @@
+'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');


### PR DESCRIPTION
## Notes
- Copied Node.js test for TLS duplex stream handling
- Ensure `Socket.prototype.connect` keeps `connecting` false when using an existing socket

## Testing
- `bun bd --silent node:test test-tls-generic-stream.js` *(fails: could not download WebKit)*