### PR TITLE
Implement TLS secureProtocol validation

### DIFF
--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -1985,6 +1985,13 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_TLS_INVALID_PROTOCOL_VERSION, message));
     }
 
+    case Bun::ErrorCode::ERR_TLS_INVALID_PROTOCOL_METHOD: {
+        auto arg0 = callFrame->argument(1);
+        auto message = arg0.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_TLS_INVALID_PROTOCOL_METHOD, message));
+    }
+
     case Bun::ErrorCode::ERR_TLS_PROTOCOL_VERSION_CONFLICT: {
         auto arg0 = callFrame->argument(1);
         auto str0 = arg0.toWTFString(globalObject);

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -705,6 +705,7 @@ declare function $ERR_MISSING_ARGS(oneOf: string[]): TypeError;
 declare function $ERR_INVALID_RETURN_VALUE(expected_type: string, name: string, actual_value: any): TypeError;
 declare function $ERR_TLS_INVALID_PROTOCOL_VERSION(a: string, b: string): TypeError;
 declare function $ERR_TLS_PROTOCOL_VERSION_CONFLICT(a: string, b: string): TypeError;
+declare function $ERR_TLS_INVALID_PROTOCOL_METHOD(message: string): TypeError;
 declare function $ERR_INVALID_IP_ADDRESS(ip: any): TypeError;
 declare function $ERR_INVALID_ADDRESS_FAMILY(addressType, host, port): RangeError;
 declare function $ERR_OUT_OF_RANGE(name: string, reason: string, value): RangeError;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -6,6 +6,35 @@ const [addServerName] = $zig("socket.zig", "createNodeTLSBinding");
 const { throwNotImplemented } = require("internal/shared");
 const { throwOnInvalidTLSArray, DEFAULT_CIPHERS, validateCiphers } = require("internal/tls");
 
+function validateSecureProtocol(proto: string) {
+  switch (proto) {
+    case "SSLv23_method":
+    case "SSLv23_client_method":
+    case "SSLv23_server_method":
+    case "TLSv1_method":
+    case "TLSv1_client_method":
+    case "TLSv1_server_method":
+    case "TLSv1_1_method":
+    case "TLSv1_1_client_method":
+    case "TLSv1_1_server_method":
+    case "TLSv1_2_method":
+    case "TLSv1_2_client_method":
+    case "TLSv1_2_server_method":
+    case "TLS_method":
+      return;
+    case "SSLv2_method":
+    case "SSLv2_client_method":
+    case "SSLv2_server_method":
+      throw $ERR_TLS_INVALID_PROTOCOL_METHOD("SSLv2 methods disabled");
+    case "SSLv3_method":
+    case "SSLv3_client_method":
+    case "SSLv3_server_method":
+      throw $ERR_TLS_INVALID_PROTOCOL_METHOD("SSLv3 methods disabled");
+    default:
+      throw $ERR_TLS_INVALID_PROTOCOL_METHOD(`Unknown method: ${proto}`);
+  }
+}
+
 const { Server: NetServer, Socket: NetSocket } = net;
 
 const { rootCertificates, canonicalizeIP } = $cpp("NodeTLS.cpp", "createNodeTLSBinding");
@@ -271,6 +300,9 @@ function SecureContext(options): void {
 }
 
 function createSecureContext(options) {
+  if (options && typeof options === "object" && options.secureProtocol) {
+    validateSecureProtocol(options.secureProtocol);
+  }
   return new SecureContext(options);
 }
 

--- a/test/js/node/test/parallel/test-tls-no-sslv23.js
+++ b/test/js/node/test/parallel/test-tls-no-sslv23.js
@@ -56,4 +56,3 @@ tls.createSecureContext({ secureProtocol: 'TLSv1_1_server_method' });
 tls.createSecureContext({ secureProtocol: 'TLSv1_2_method' });
 tls.createSecureContext({ secureProtocol: 'TLSv1_2_client_method' });
 tls.createSecureContext({ secureProtocol: 'TLSv1_2_server_method' });
-

--- a/test/js/node/test/parallel/test-tls-no-sslv23.js
+++ b/test/js/node/test/parallel/test-tls-no-sslv23.js
@@ -1,0 +1,59 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'blargh' });
+}, {
+  code: 'ERR_TLS_INVALID_PROTOCOL_METHOD',
+  message: 'Unknown method: blargh',
+});
+
+const errMessageSSLv2 = /SSLv2 methods disabled/;
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv2_method' });
+}, errMessageSSLv2);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv2_client_method' });
+}, errMessageSSLv2);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv2_server_method' });
+}, errMessageSSLv2);
+
+const errMessageSSLv3 = /SSLv3 methods disabled/;
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv3_method' });
+}, errMessageSSLv3);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv3_client_method' });
+}, errMessageSSLv3);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv3_server_method' });
+}, errMessageSSLv3);
+
+// Note that SSLv2 and SSLv3 are disallowed but SSLv2_method and friends are
+// still accepted.  They are OpenSSL's way of saying that all known protocols
+// are supported unless explicitly disabled (which we do for SSLv2 and SSLv3.)
+tls.createSecureContext({ secureProtocol: 'SSLv23_method' });
+tls.createSecureContext({ secureProtocol: 'SSLv23_client_method' });
+tls.createSecureContext({ secureProtocol: 'SSLv23_server_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_client_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_server_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_1_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_1_client_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_1_server_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_2_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_2_client_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_2_server_method' });
+


### PR DESCRIPTION
## Summary
- add Node.js test `test-tls-no-sslv23`
- implement `validateSecureProtocol` in tls module
- generate `ERR_TLS_INVALID_PROTOCOL_METHOD` errors
- expose `$ERR_TLS_INVALID_PROTOCOL_METHOD` builtin

## Testing
- `bun bd --silent node:test test-tls-no-sslv23.js` *(fails: Configuring incomplete, errors occurred)*