### PR TITLE
Fix https lookup family handling

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -484,7 +484,7 @@ function ClientRequest(input, options, cb) {
     }
 
     try {
-      options.lookup(host, { all: true }, (err, results) => {
+      options.lookup(host, { all: true, family: options.family }, (err, results) => {
         if (err) {
           if (!!$debug) globalReportError(err);
           process.nextTick((self, err) => self.emit("error", err), this, err);

--- a/test/js/node/parallel/test-https-connect-address-family.js
+++ b/test/js/node/parallel/test-https-connect-address-family.js
@@ -1,0 +1,40 @@
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+if (!common.hasIPv6)
+  common.skip('no IPv6 support');
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const https = require('https');
+
+{
+  // Test that `https` machinery passes host name, and receives IP.
+  const hostAddrIPv6 = '::1';
+  const HOSTNAME = 'dummy';
+  https.createServer({
+    cert: fixtures.readKey('agent1-cert.pem'),
+    key: fixtures.readKey('agent1-key.pem'),
+  }, common.mustCall(function(req, res) {
+    this.close();
+    res.end();
+  })).listen(0, hostAddrIPv6, common.mustCall(function() {
+    const options = {
+      host: HOSTNAME,
+      port: this.address().port,
+      family: 6,
+      rejectUnauthorized: false,
+      lookup: common.mustCall((addr, opt, cb) => {
+        assert.strictEqual(addr, HOSTNAME);
+        assert.strictEqual(opt.family, 6);
+        cb(null, hostAddrIPv6, opt.family);
+      })
+    };
+    // Will fail with ECONNREFUSED if the address family is not honored.
+    https.get(options, common.mustCall(function() {
+      assert.strictEqual(this.socket.remoteAddress, hostAddrIPv6);
+      this.destroy();
+    }));
+  }));
+}


### PR DESCRIPTION
## Summary
- add Node.js test for https lookup family
- pass `options.family` through to the custom DNS lookup in `_http_client.ts`

## Testing
- `bun bd --silent node:test test/js/node/parallel/test-https-connect-address-family.js` *(fails: could not fetch WebKit)*