### PR TITLE
Fix process prototype for node test

### DIFF
--- a/test/js/node/parallel/test-process-prototype.js
+++ b/test/js/node/parallel/test-process-prototype.js
@@ -1,0 +1,15 @@
+require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const proto = Object.getPrototypeOf(process);
+
+assert(process instanceof process.constructor);
+assert(proto instanceof EventEmitter);
+
+const desc = Object.getOwnPropertyDescriptor(proto, 'constructor');
+
+assert.strictEqual(desc.value, process.constructor);
+assert.strictEqual(desc.writable, true);
+assert.strictEqual(desc.enumerable, false);
+assert.strictEqual(desc.configurable, true);


### PR DESCRIPTION
## Summary
- copy Node.js `test-process-prototype` test
- make `process` prototype an actual `EventEmitter` instance

## Testing
- `bun bd --silent node:test test/js/node/parallel/test-process-prototype.js` *(fails: script "bd:v" exited with code 1)*