### PR TITLE
Fix util.inspect for URLSearchParams

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -349,7 +349,7 @@ const codes = {}; // exported from errors.js
   // Add ERR_INVALID_THIS error code
   const messages = new SafeMap();
   const sym = "ERR_INVALID_THIS";
-  messages.set(sym, (type) => {
+  messages.set(sym, type => {
     return `Value of "this" must be of type ${type}`;
   });
   codes[sym] = function NodeError(...args) {
@@ -2344,7 +2344,7 @@ function formatIterator(braces, ctx, value, recurseTimes) {
 function formatURLSearchParamsIterator(braces, ctx, value, recurseTimes) {
   const items = [];
   let isEntries = false;
-  
+
   // Consume the iterator to determine the format
   for (const item of value) {
     items.push(item);
@@ -2353,7 +2353,7 @@ function formatURLSearchParamsIterator(braces, ctx, value, recurseTimes) {
       isEntries = Array.isArray(item) && item.length === 2;
     }
   }
-  
+
   if (isEntries) {
     // Entries iterator: convert to flat array for formatMapIterInner
     const entries = [];
@@ -2835,14 +2835,14 @@ function internalGetConstructorName(val) {
 }
 
 // Add custom inspect method to URLSearchParams
-if (typeof URLSearchParams !== 'undefined') {
+if (typeof URLSearchParams !== "undefined") {
   URLSearchParams.prototype[customInspectSymbol] = function urlSearchParamsCustomInspect(depth, options, inspect) {
-    if (this == null || typeof this.forEach !== 'function') {
-      throw codes.ERR_INVALID_THIS('URLSearchParams');
+    if (this == null || typeof this.forEach !== "function") {
+      throw codes.ERR_INVALID_THIS("URLSearchParams");
     }
-    
+
     if (depth != null && depth < 0) {
-      return '[Object]';
+      return "[Object]";
     }
 
     const entries = [];
@@ -2851,17 +2851,17 @@ if (typeof URLSearchParams !== 'undefined') {
     });
 
     if (entries.length === 0) {
-      return 'URLSearchParams {}';
+      return "URLSearchParams {}";
     }
 
-    const inner = entries.join(', ');
-    
+    const inner = entries.join(", ");
+
     // Handle breakLength for multiline formatting
     if (options && options.breakLength != null && inner.length > options.breakLength) {
-      const formattedEntries = entries.join(',\n  ');
+      const formattedEntries = entries.join(",\n  ");
       return `URLSearchParams {\n  ${formattedEntries}\n}`;
     }
-    
+
     return `URLSearchParams { ${inner} }`;
   };
 }

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -363,19 +363,11 @@ function isURL(value) {
 }
 
 function isURLSearchParams(value) {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    value[Symbol.toStringTag] === "URLSearchParams"
-  );
+  return value !== null && typeof value === "object" && value[Symbol.toStringTag] === "URLSearchParams";
 }
 
 function isURLSearchParamsIterator(value) {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    value[Symbol.toStringTag] === "URLSearchParams Iterator"
-  );
+  return value !== null && typeof value === "object" && value[Symbol.toStringTag] === "URLSearchParams Iterator";
 }
 
 const builtInObjects = new SafeSet(

--- a/test/js/node/parallel/test-whatwg-url-custom-searchparams-inspect.js
+++ b/test/js/node/parallel/test-whatwg-url-custom-searchparams-inspect.js
@@ -1,0 +1,37 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+const sp = new URLSearchParams('?a=a&b=b&b=c');
+assert.strictEqual(util.inspect(sp),
+"URLSearchParams { 'a' => 'a', 'b' => 'b', 'b' => 'c' }");
+assert.strictEqual(util.inspect(sp, { depth: -1 }), '[Object]');
+assert.strictEqual(
+  util.inspect(sp, { breakLength: 1 }),
+  "URLSearchParams {\n  'a' => 'a',\n  'b' => 'b',\n  'b' => 'c' }"
+);
+assert.strictEqual(util.inspect(sp.keys()),
+"URLSearchParams Iterator { 'a', 'b', 'b' }");
+assert.strictEqual(util.inspect(sp.values()),
+"URLSearchParams Iterator { 'a', 'b', 'c' }");
+assert.strictEqual(util.inspect(sp.keys(), { breakLength: 1 }),
+"URLSearchParams Iterator {\n  'a',\n  'b',\n  'b' }");
+assert.throws(() => sp[util.inspect.custom].call(), {
+  code: 'ERR_INVALID_THIS',
+});
+
+const iterator = sp.entries();
+assert.strictEqual(util.inspect(iterator),
+"URLSearchParams Iterator { [ 'a', 'a' ], [ 'b', 'b' ], " +
+"[ 'b', 'c' ] }");
+iterator.next();
+assert.strictEqual(util.inspect(iterator),
+"URLSearchParams Iterator { [ 'b', 'b' ], [ 'b', 'c' ] }");
+iterator.next();
+iterator.next();
+assert.strictEqual(util.inspect(iterator),
+'URLSearchParams Iterator {  }');
+const emptySp = new URLSearchParams();
+assert.strictEqual(util.inspect(emptySp), 'URLSearchParams {}');

--- a/test/js/node/util-inspect-urlsearchparams.test.ts
+++ b/test/js/node/util-inspect-urlsearchparams.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import util from "util";
+
+describe("util.inspect URLSearchParams", () => {
+  it("should format URLSearchParams with key-value pairs", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    expect(util.inspect(sp)).toBe("URLSearchParams { 'a' => 'a', 'b' => 'b', 'b' => 'c' }");
+  });
+
+  it("should format empty URLSearchParams", () => {
+    const emptySp = new URLSearchParams();
+    expect(util.inspect(emptySp)).toBe("URLSearchParams {}");
+  });
+
+  it("should respect depth option", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    expect(util.inspect(sp, { depth: -1 })).toBe("[Object]");
+  });
+
+  it("should respect breakLength option for multiline formatting", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    expect(util.inspect(sp, { breakLength: 1 })).toBe(
+      "URLSearchParams {\n  'a' => 'a',\n  'b' => 'b',\n  'b' => 'c'\n}"
+    );
+  });
+
+  it("should format URLSearchParams keys iterator", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    expect(util.inspect(sp.keys())).toBe("URLSearchParams Iterator { 'a', 'b', 'b' }");
+  });
+
+  it("should format URLSearchParams values iterator", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    expect(util.inspect(sp.values())).toBe("URLSearchParams Iterator { 'a', 'b', 'c' }");
+  });
+
+  it("should format URLSearchParams keys iterator with breakLength", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    expect(util.inspect(sp.keys(), { breakLength: 1 })).toBe(
+      "URLSearchParams Iterator {\n  'a',\n  'b',\n  'b'\n}"
+    );
+  });
+
+  it("should format URLSearchParams entries iterator", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    const iterator = sp.entries();
+    expect(util.inspect(iterator)).toBe(
+      "URLSearchParams Iterator { [ 'a', 'a' ], [ 'b', 'b' ], [ 'b', 'c' ] }"
+    );
+  });
+
+  it("should format URLSearchParams entries iterator after consuming entries", () => {
+    const sp = new URLSearchParams("?a=a&b=b&b=c");
+    const iterator = sp.entries();
+    iterator.next(); // consume first entry
+    expect(util.inspect(iterator)).toBe(
+      "URLSearchParams Iterator { [ 'b', 'b' ], [ 'b', 'c' ] }"
+    );
+    
+    iterator.next(); // consume second entry
+    iterator.next(); // consume third entry
+    expect(util.inspect(iterator)).toBe("URLSearchParams Iterator {  }");
+  });
+
+  it("should throw error when custom inspect is called incorrectly", () => {
+    const sp = new URLSearchParams("?a=a&b=b");
+    expect(() => sp[util.inspect.custom].call()).toThrow({
+      code: "ERR_INVALID_THIS"
+    });
+  });
+
+  it("should handle URLSearchParams with special characters", () => {
+    const sp = new URLSearchParams("?key%20with%20spaces=value%20with%20spaces&special=!@%23$%25");
+    const result = util.inspect(sp);
+    expect(result).toContain("URLSearchParams");
+    expect(result).toContain("'key with spaces' => 'value with spaces'");
+    expect(result).toContain("'special' => '!@#$%'");
+  });
+
+  it("should handle URLSearchParams with unicode characters", () => {
+    const sp = new URLSearchParams("?emoji=😀&unicode=🌟");
+    const result = util.inspect(sp);
+    expect(result).toContain("URLSearchParams");
+    expect(result).toContain("'emoji' => '😀'");
+    expect(result).toContain("'unicode' => '🌟'");
+  });
+
+  it("should handle URLSearchParams with duplicate keys", () => {
+    const sp = new URLSearchParams();
+    sp.append("key", "value1");
+    sp.append("key", "value2");
+    sp.append("key", "value3");
+    const result = util.inspect(sp);
+    expect(result).toContain("URLSearchParams");
+    expect(result).toContain("'key' => 'value1'");
+    expect(result).toContain("'key' => 'value2'");
+    expect(result).toContain("'key' => 'value3'");
+  });
+});

--- a/test/js/node/util-inspect-urlsearchparams.test.ts
+++ b/test/js/node/util-inspect-urlsearchparams.test.ts
@@ -20,7 +20,7 @@ describe("util.inspect URLSearchParams", () => {
   it("should respect breakLength option for multiline formatting", () => {
     const sp = new URLSearchParams("?a=a&b=b&b=c");
     expect(util.inspect(sp, { breakLength: 1 })).toBe(
-      "URLSearchParams {\n  'a' => 'a',\n  'b' => 'b',\n  'b' => 'c'\n}"
+      "URLSearchParams {\n  'a' => 'a',\n  'b' => 'b',\n  'b' => 'c'\n}",
     );
   });
 
@@ -36,27 +36,21 @@ describe("util.inspect URLSearchParams", () => {
 
   it("should format URLSearchParams keys iterator with breakLength", () => {
     const sp = new URLSearchParams("?a=a&b=b&b=c");
-    expect(util.inspect(sp.keys(), { breakLength: 1 })).toBe(
-      "URLSearchParams Iterator {\n  'a',\n  'b',\n  'b'\n}"
-    );
+    expect(util.inspect(sp.keys(), { breakLength: 1 })).toBe("URLSearchParams Iterator {\n  'a',\n  'b',\n  'b'\n}");
   });
 
   it("should format URLSearchParams entries iterator", () => {
     const sp = new URLSearchParams("?a=a&b=b&b=c");
     const iterator = sp.entries();
-    expect(util.inspect(iterator)).toBe(
-      "URLSearchParams Iterator { [ 'a', 'a' ], [ 'b', 'b' ], [ 'b', 'c' ] }"
-    );
+    expect(util.inspect(iterator)).toBe("URLSearchParams Iterator { [ 'a', 'a' ], [ 'b', 'b' ], [ 'b', 'c' ] }");
   });
 
   it("should format URLSearchParams entries iterator after consuming entries", () => {
     const sp = new URLSearchParams("?a=a&b=b&b=c");
     const iterator = sp.entries();
     iterator.next(); // consume first entry
-    expect(util.inspect(iterator)).toBe(
-      "URLSearchParams Iterator { [ 'b', 'b' ], [ 'b', 'c' ] }"
-    );
-    
+    expect(util.inspect(iterator)).toBe("URLSearchParams Iterator { [ 'b', 'b' ], [ 'b', 'c' ] }");
+
     iterator.next(); // consume second entry
     iterator.next(); // consume third entry
     expect(util.inspect(iterator)).toBe("URLSearchParams Iterator {  }");
@@ -65,7 +59,7 @@ describe("util.inspect URLSearchParams", () => {
   it("should throw error when custom inspect is called incorrectly", () => {
     const sp = new URLSearchParams("?a=a&b=b");
     expect(() => sp[util.inspect.custom].call()).toThrow({
-      code: "ERR_INVALID_THIS"
+      code: "ERR_INVALID_THIS",
     });
   });
 


### PR DESCRIPTION
## Summary
- add Node.js test `test-whatwg-url-custom-searchparams-inspect`
- implement custom formatting for URLSearchParams and its iterator in `util.inspect`

## Testing
- `bun bd --silent node:test test-whatwg-url-custom-searchparams-inspect.js` *(fails: missing WebKit download)*