### PR TITLE
Fix http agent queuing for node test

### DIFF
--- a/test/js/node/parallel/test-http.js
+++ b/test/js/node/parallel/test-http.js
@@ -1,0 +1,114 @@
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const url = require('url');
+
+const expectedRequests = ['/hello', '/there', '/world'];
+
+const server = http.Server(common.mustCall((req, res) => {
+  assert.strictEqual(expectedRequests.shift(), req.url);
+
+  switch (req.url) {
+    case '/hello':
+      assert.strictEqual(req.method, 'GET');
+      assert.strictEqual(req.headers.accept, '*/*');
+      assert.strictEqual(req.headers.foo, 'bar');
+      assert.strictEqual(req.headers.cookie, 'foo=bar; bar=baz; baz=quux');
+      break;
+    case '/there':
+      assert.strictEqual(req.method, 'PUT');
+      assert.strictEqual(req.headers.cookie, 'node=awesome; ta=da');
+      break;
+    case '/world':
+      assert.strictEqual(req.method, 'POST');
+      assert.strictEqual(req.headers.cookie, 'abc=123; def=456; ghi=789');
+      break;
+    default:
+      assert(false, `Unexpected request for ${req.url}`);
+  }
+
+  if (expectedRequests.length === 0)
+    server.close();
+
+  req.on('end', () => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.write(`The path was ${url.parse(req.url).pathname}`);
+    res.end();
+  });
+  req.resume();
+}, 3));
+server.listen(0);
+
+server.on('listening', () => {
+  const agent = new http.Agent({ port: server.address().port, maxSockets: 1 });
+  const req = http.get({
+    port: server.address().port,
+    path: '/hello',
+    headers: {
+      Accept: '*/*',
+      Foo: 'bar',
+      Cookie: [ 'foo=bar', 'bar=baz', 'baz=quux' ]
+    },
+    agent: agent
+  }, common.mustCall((res) => {
+    const cookieHeaders = req._header.match(/^Cookie: .+$/img);
+    assert.deepStrictEqual(cookieHeaders,
+                           ['Cookie: foo=bar; bar=baz; baz=quux']);
+    assert.strictEqual(res.statusCode, 200);
+    let body = '';
+    res.setEncoding('utf8');
+    res.on('data', (chunk) => { body += chunk; });
+    res.on('end', common.mustCall(() => {
+      assert.strictEqual(body, 'The path was /hello');
+    }));
+  }));
+
+  setTimeout(common.mustCall(() => {
+    const req = http.request({
+      port: server.address().port,
+      method: 'PUT',
+      path: '/there',
+      agent: agent
+    }, common.mustCall((res) => {
+      const cookieHeaders = req._header.match(/^Cookie: .+$/img);
+      assert.deepStrictEqual(cookieHeaders, ['Cookie: node=awesome; ta=da']);
+      assert.strictEqual(res.statusCode, 200);
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', common.mustCall(() => {
+        assert.strictEqual(body, 'The path was /there');
+      }));
+    }));
+    req.setHeader('Cookie', ['node=awesome', 'ta=da']);
+    req.end();
+  }), 1);
+
+  setTimeout(common.mustCall(() => {
+    const req = http.request({
+      port: server.address().port,
+      method: 'POST',
+      path: '/world',
+      headers: [ ['Cookie', 'abc=123'],
+                 ['Cookie', 'def=456'],
+                 ['Cookie', 'ghi=789'],
+                 ['Host', 'example.com'],
+               ],
+      agent: agent
+    }, common.mustCall((res) => {
+      const cookieHeaders = req._header.match(/^Cookie: .+$/img);
+      assert.deepStrictEqual(cookieHeaders,
+                             ['Cookie: abc=123',
+                              'Cookie: def=456',
+                              'Cookie: ghi=789']);
+      assert.strictEqual(res.statusCode, 200);
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', common.mustCall(() => {
+        assert.strictEqual(body, 'The path was /world');
+      }));
+    }));
+    req.end();
+  }), 2);
+});


### PR DESCRIPTION
## Summary
- add Node test `test-http.js`
- implement a minimal queue in `http.Agent`
- queue ClientRequests when `maxSockets` is limited

## Testing
- `bun bd --silent node:test test/js/node/parallel/test-http` *(fails: missing WebKit build)*