### PR TITLE
Fix test-child-process-server-close

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1498,10 +1498,12 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
   }
   if (isNodeStreamReadable(item)) {
     if (Object.hasOwn(item, "fd") && typeof item.fd === "number") return item.fd;
+    if (item._handle && typeof item._handle.fd === "number") return item._handle.fd;
     throw new Error(`TODO: stream.Readable stdio @ ${index}`);
   }
   if (isNodeStreamWritable(item)) {
     if (Object.hasOwn(item, "fd") && typeof item.fd === "number") return item.fd;
+    if (item._handle && typeof item._handle.fd === "number") return item._handle.fd;
     throw new Error(`TODO: stream.Writable stdio @ ${index}`);
   }
   const result = nodeToBunLookup[item];

--- a/test/js/node/parallel/test-child-process-server-close.js
+++ b/test/js/node/parallel/test-child-process-server-close.js
@@ -1,0 +1,38 @@
+const common = require('../common');
+const assert = require('assert');
+const { fork, spawn } = require('child_process');
+const net = require('net');
+
+const tmpdir = require('../common/tmpdir');
+
+// Run in a child process because the PIPE file descriptor stays open until
+// Node.js completes, blocking the tmpdir and preventing cleanup.
+
+if (process.argv[2] !== 'child') {
+// Parent
+tmpdir.refresh();
+
+// Run test
+const child = fork(__filename, ['child'], { stdio: 'inherit' });
+child.on('exit', common.mustCall(function(code) {
+assert.strictEqual(code, 0);
+}));
+
+return;
+}
+
+// Child
+const server = net.createServer((conn) => {
+spawn(process.execPath, ['-v'], {
+stdio: ['ignore', conn, 'ignore']
+}).on('close', common.mustCall(() => {
+conn.end();
+}));
+}).listen(common.PIPE, () => {
+const client = net.connect(common.PIPE, common.mustCall());
+client.once('data', () => {
+client.end(() => {
+server.close();
+});
+});
+});


### PR DESCRIPTION
## Summary
- add node test `test-child-process-server-close`
- support sockets used as stdio when spawning child processes

## Testing
- `bun bd --silent node:test test-child-process-server-close.js` *(fails: CMake failed to download webkit)*