### PR TITLE
fix assertion in JSSocketAddressDTO__create

### DIFF
--- a/src/bun.js/api/bun/socket/SocketAddress.zig
+++ b/src/bun.js/api/bun/socket/SocketAddress.zig
@@ -327,7 +327,6 @@ pub fn finalize(this: *SocketAddress) void {
 pub fn intoDTO(this: *SocketAddress, global: *JSC.JSGlobalObject) JSC.JSValue {
     var addr_str = this.address();
     defer this._presentation = .dead;
-    defer this.* = undefined; // removed in release builds, so setting _presentation to dead is still needed.
     return JSSocketAddressDTO__create(global, addr_str.transferToJS(global), this.port(), this.family() == AF.INET6);
 }
 
@@ -337,21 +336,15 @@ pub fn intoDTO(this: *SocketAddress, global: *JSC.JSGlobalObject) JSC.JSValue {
 ///
 /// - The address string is assumed to be ASCII and a valid IP address (either v4 or v6).
 /// - Port is a valid `in_port_t` (between 0 and 2^16) in host byte order.
-pub fn createDTO(globalObject: *JSC.JSGlobalObject, addr_: []const u8, port_: i32, is_ipv6: bool) JSC.JSValue {
+pub fn createDTO(globalObject: *JSC.JSGlobalObject, addr_: []const u8, port_: u16, is_ipv6: bool) JSC.JSValue {
     if (comptime bun.Environment.isDebug) {
-        bun.assertWithLocation(port_ >= 0 and port_ <= std.math.maxInt(i32), @src());
         bun.assertWithLocation(addr_.len > 0, @src());
     }
 
-    return JSSocketAddressDTO__create(
-        globalObject,
-        bun.String.createUTF8ForJS(globalObject, addr_),
-        port_,
-        is_ipv6,
-    );
+    return JSSocketAddressDTO__create(globalObject, bun.String.createUTF8ForJS(globalObject, addr_), port_, is_ipv6);
 }
 
-extern "c" fn JSSocketAddressDTO__create(globalObject: *JSC.JSGlobalObject, address_: JSC.JSValue, port_: c_int, is_ipv6: bool) JSC.JSValue;
+extern "c" fn JSSocketAddressDTO__create(globalObject: *JSC.JSGlobalObject, address_: JSC.JSValue, port_: u16, is_ipv6: bool) JSC.JSValue;
 
 // =============================================================================
 

--- a/src/bun.js/bindings/JSSocketAddressDTO.cpp
+++ b/src/bun.js/bindings/JSSocketAddressDTO.cpp
@@ -67,10 +67,8 @@ Structure* createStructure(VM& vm, JSGlobalObject* globalObject)
 } // namespace JSSocketAddress
 } // namespace Bun
 
-extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* globalObject, EncodedJSValue address, int32_t port, bool isIPv6)
+extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* globalObject, EncodedJSValue address, uint16_t port, bool isIPv6)
 {
-    ASSERT(port < std::numeric_limits<uint16_t>::max());
-
     VM& vm = globalObject->vm();
     auto* global = jsCast<Zig::GlobalObject*>(globalObject);
 

--- a/src/bun.js/bindings/JSSocketAddressDTO.h
+++ b/src/bun.js/bindings/JSSocketAddressDTO.h
@@ -16,4 +16,4 @@ JSObject* create(Zig::GlobalObject* globalObject, JSString* value, int port, boo
 } // namespace JSSocketAddress
 } // namespace Bun
 
-extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* globalObject, EncodedJSValue address, int32_t port, bool isIPv6);
+extern "C" JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject* globalObject, EncodedJSValue address, uint16_t port, bool isIPv6);


### PR DESCRIPTION
investigating the occasional hang in `test/js/node/test/parallel/test-http-pipeline-requests-connection-leak.js` and observed:

```
ASSERTION FAILED: port < std::numeric_limits<uint16_t>::max()
../../src/bun.js/bindings/JSSocketAddressDTO.cpp(72) : JSC::EncodedJSValue JSSocketAddressDTO__create(JSGlobalObject *, EncodedJSValue, int32_t, bool)
1   0x100afb4dc JSSocketAddressDTO__create
2   0x107bcae30 bun.js.api.bun.socket.SocketAddress.intoDTO
3   0x107bf868c DebugHTTPServerPrototype__getAddress
4   0x101b923b0 WebCore::DebugHTTPServerPrototype__addressGetterWrap(JSC::JSGlobalObject*, long long, JSC::PropertyName)
5   0x10b6e5218 JSC::PropertySlot::customGetter(JSC::VM&, JSC::PropertyName) const
6   0x10b0bffc8 JSC::JSValue::get(JSC::JSGlobalObject*, JSC::PropertyName, JSC::PropertySlot&) const
7   0x10aa92408 JSC::LLInt::performLLIntGetByID(JSC::BytecodeIndex, JSC::CodeBlock*, JSC::JSGlobalObject*, JSC::JSValue, JSC::Identifier const&, JSC::GetByIdModeMetadata&)
8   0x10aa91d64 llint_slow_path_get_by_id
9   0x10d36043c jsc_llint_llintOpWithMetadata__llintOpWithReturn__llintOp__commonOp__fn__fn__makeReturn__fn__fn__fn__opGetByIdSlow_LowLevelInterpreter_asm_510
10  0x10d37cadc op_call_return_location
11  0x30003016c 10  ???                                 0x000000030003016c 0x0 + 12885098860
12  0x10d37e074 op_call_ignore_result_return_location
13  0x10d37e074 op_call_ignore_result_return_location
14  0x10d353558 llint_call_javascript
15  0x10a7d2794 JSC::Interpreter::executeCallImpl(JSC::VM&, JSC::JSObject*, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&)
16  0x10a7d3128 JSC::Interpreter::executeCall(JSC::JSObject*, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&)
17  0x10ae4e87c JSC::call(JSC::JSGlobalObject*, JSC::JSValue, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&)
18  0x10ae4efd0 JSC::profiledCall(JSC::JSGlobalObject*, JSC::ProfilingReason, JSC::JSValue, JSC::CallData const&, JSC::JSValue, JSC::ArgList const&)
19  0x100d81304 Bun::call(JSC::JSGlobalObject*, JSC::JSValue, JSC::JSValue, JSC::JSValue)
20  0x100d80b34 Bun__JSTimeout__call
21  0x104569818 bun.js.api.Timer.TimerObjectInternals.run
22  0x103e73f44 bun.js.api.Timer.TimerObjectInternals.fire
23  0x10361ed08 bun.js.api.Timer.EventLoopTimer.fire
24  0x10308da3c bun.js.api.Timer.All.drainTimers
25  0x102bb69f4 bun.js.event_loop.EventLoop.autoTickActive
26  0x102d74098 bun_js.Run.start
27  0x1026fe754 bun.js.jsc.OpaqueWrap__anon_31152__struct_239871.callback
28  0x1003bcae4 JSC__VM__holdAPILock
29  0x1020e4d04 bun.js.bindings.VM.VM.holdAPILock
30  0x10263896c bun_js.Run.boot
31  0x10263f7bc cli.run_command.RunCommand._bootAndHandleError
```

since this was not `<=` the assertion would trigger when `port` was 65535.
edited to rely on the type system instead of a manual assertion, which will not have this issue
