### PR TITLE
Fix net.listen path with cluster

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2313,10 +2313,17 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
       options[kSocketClass] = Socket;
     }
 
+    let address = hostname;
+    let portOrPath = port;
+    if (path) {
+      address = path;
+      portOrPath = -1;
+    }
+
     listenInCluster(
       this,
-      null,
-      port,
+      address,
+      portOrPath,
       4,
       backlog,
       fd,

--- a/test/js/node/test/parallel/test-cluster-net-server-drop-connection.js
+++ b/test/js/node/test/parallel/test-cluster-net-server-drop-connection.js
@@ -1,0 +1,88 @@
+const common = require("../common");
+const assert = require("assert");
+const net = require("net");
+const cluster = require("cluster");
+const tmpdir = require("../common/tmpdir");
+
+// The core has bug in handling pipe handle by ipc when platform is win32,
+// it can be triggered on win32. I will fix it in another pr.
+if (common.isWindows) common.skip("no setSimultaneousAccepts on pipe handle");
+
+const totalConns = 10;
+const totalWorkers = 3;
+let worker0;
+let worker1;
+let worker2;
+let connectionCount = 0;
+let listenCount = 0;
+
+function request(path) {
+  for (let i = 0; i < totalConns; i++) {
+    net.connect(path);
+  }
+}
+
+function handleMessage(message) {
+  assert.match(message.action, /listen|connection/);
+  if (message.action === "listen") {
+    if (++listenCount === totalWorkers) {
+      request(common.PIPE);
+    }
+  } else if (message.action === "connection") {
+    if (++connectionCount === totalConns) {
+      worker0.send({ action: "disconnect" });
+      worker1.send({ action: "disconnect" });
+      worker2.send({ action: "disconnect" });
+    }
+  }
+}
+
+if (cluster.isPrimary) {
+  cluster.schedulingPolicy = cluster.SCHED_RR;
+  tmpdir.refresh();
+  worker0 = cluster.fork({ maxConnections: 0, pipePath: common.PIPE });
+  worker1 = cluster.fork({ maxConnections: 1, pipePath: common.PIPE });
+  worker2 = cluster.fork({ maxConnections: 9, pipePath: common.PIPE });
+  // expected = { action: 'listen' } + maxConnections * { action: 'connection' }
+  worker0.on(
+    "message",
+    common.mustCall((message) => {
+      handleMessage(message);
+    }, 1),
+  );
+  worker1.on(
+    "message",
+    common.mustCall((message) => {
+      handleMessage(message);
+    }, 2),
+  );
+  worker2.on(
+    "message",
+    common.mustCall((message) => {
+      handleMessage(message);
+    }, 10),
+  );
+} else {
+  const server = net.createServer(
+    common.mustCall((socket) => {
+      process.send({ action: "connection" });
+    }, +process.env.maxConnections),
+  );
+
+  server.listen(
+    process.env.pipePath,
+    common.mustCall(() => {
+      process.send({ action: "listen" });
+    }),
+  );
+
+  server.maxConnections = +process.env.maxConnections;
+
+  process.on(
+    "message",
+    common.mustCall((message) => {
+      assert.strictEqual(message.action, "disconnect");
+      process.disconnect();
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- add Node.js test `test-cluster-net-server-drop-connection`
- fix server.listen so cluster round‑robin gets pipe path

## Testing
- `bun bd --silent node:test test-cluster-net-server-drop-connection.js` *(fails: CMake configure error)*