### PR TITLE
Move LLDB initialization commands to make attach configuration work

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,16 +1,1 @@
-# Tell LLDB what to do when the debugged process receives SIGPWR: pass it through to the process
-# (-p), but do not stop the process (-s) or notify the user (-n).
-#
-# JSC's garbage collector sends this signal (as configured by Bun WebKit in
-# Thread::initializePlatformThreading() in ThreadingPOSIX.cpp) to the JS thread to suspend or resume
-# it. So stopping the process would just create noise when debugging any long-running script.
-process handle -p true -s false -n false SIGPWR
-
-command script import misctools/lldb/lldb_pretty_printers.py
-type category enable zig.lang
-type category enable zig.std
-
-command script import misctools/lldb/lldb_webkit.py
-
-command script delete btjs
-command alias btjs p {printf("gathering btjs trace...\n");printf("%s\n", (char*)dumpBtjsTrace())}
+command source -C -s true -e true misctools/lldb/init.lldb

--- a/misctools/lldb/init.lldb
+++ b/misctools/lldb/init.lldb
@@ -1,0 +1,19 @@
+# This file is separate from .lldbinit because it has to be in the same directory as the Python
+# modules in order for the "attach" action to work.
+
+# Tell LLDB what to do when the debugged process receives SIGPWR: pass it through to the process
+# (-p), but do not stop the process (-s) or notify the user (-n).
+#
+# JSC's garbage collector sends this signal (as configured by Bun WebKit in
+# Thread::initializePlatformThreading() in ThreadingPOSIX.cpp) to the JS thread to suspend or resume
+# it. So stopping the process would just create noise when debugging any long-running script.
+process handle -p true -s false -n false SIGPWR
+
+command script import -c lldb_pretty_printers.py
+type category enable zig.lang
+type category enable zig.std
+
+command script import -c lldb_webkit.py
+
+command script delete btjs
+command alias btjs p {printf("gathering btjs trace...\n");printf("%s\n", (char*)dumpBtjsTrace())}


### PR DESCRIPTION
### What does this PR do?

The CodeLLDB "Attach" configuration doesn't spawn LLDB in the workspace directory. This means it used to break because the `command source import` lines to import our Zig and WebKit debugger features pointed to paths that did not exist relative to where LLDB was running. LLDB has a `-c` option to treat these paths as relative, but it errors when the path has slashes in it (llvm/llvm-project#142197). So instead I've moved the meat of our `.lldbinit` file to `misctools/lldb/init.lldb`, which can import the Python modules with relative paths containing no slashes, and then the `.lldbinit` file can source `init.lldb` using a relative path with `command source -C`.

I also made it not echo the commands that are sourced from `init.lldb` so that starting the debugger is a little quieter.

### How did you verify your code works?

No code changes. I tested the attach configuration and some of the normal run configurations and they all still work.