### PR TITLE
Add support for catalogs in `bun outdated`

### DIFF
--- a/src/cli/outdated_command.zig
+++ b/src/cli/outdated_command.zig
@@ -21,6 +21,17 @@ const WorkspaceFilter = PackageManager.WorkspaceFilter;
 const OOM = bun.OOM;
 
 pub const OutdatedCommand = struct {
+    fn resolveCatalogDependency(manager: *PackageManager, dep: Install.Dependency) ?Install.Dependency.Version {
+        return if (dep.version.tag == .catalog) blk: {
+            const catalog_dep = manager.lockfile.catalogs.get(
+                manager.lockfile,
+                dep.version.value.catalog,
+                dep.name,
+            ) orelse return null;
+            break :blk catalog_dep.version;
+        } else dep.version;
+    }
+
     pub fn exec(ctx: Command.Context) !void {
         Output.prettyln("<r><b>bun outdated <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>", .{});
         Output.flush();
@@ -281,7 +292,8 @@ pub const OutdatedCommand = struct {
                 const package_id = lockfile.buffers.resolutions.items[dep_id];
                 if (package_id == invalid_package_id) continue;
                 const dep = lockfile.buffers.dependencies.items[dep_id];
-                if (dep.version.tag != .npm and dep.version.tag != .dist_tag) continue;
+                const resolved_version = resolveCatalogDependency(manager, dep) orelse continue;
+                if (resolved_version.tag != .npm and resolved_version.tag != .dist_tag) continue;
                 const resolution = pkg_resolutions[package_id];
                 if (resolution.tag != .npm) continue;
 
@@ -320,10 +332,10 @@ pub const OutdatedCommand = struct {
 
                 const latest = manifest.findByDistTag("latest") orelse continue;
 
-                const update_version = if (dep.version.tag == .npm)
-                    manifest.findBestVersion(dep.version.value.npm.version, string_buf) orelse continue
+                const update_version = if (resolved_version.tag == .npm)
+                    manifest.findBestVersion(resolved_version.value.npm.version, string_buf) orelse continue
                 else
-                    manifest.findByDistTag(dep.version.value.dist_tag.tag.slice(string_buf)) orelse continue;
+                    manifest.findByDistTag(resolved_version.value.dist_tag.tag.slice(string_buf)) orelse continue;
 
                 if (resolution.value.npm.version.order(latest.version, string_buf, manifest.string_buf) != .lt) continue;
 
@@ -440,10 +452,11 @@ pub const OutdatedCommand = struct {
                     ) orelse continue;
 
                     const latest = manifest.findByDistTag("latest") orelse continue;
-                    const update = if (dep.version.tag == .npm)
-                        manifest.findBestVersion(dep.version.value.npm.version, string_buf) orelse continue
+                    const resolved_version = resolveCatalogDependency(manager, dep) orelse continue;
+                    const update = if (resolved_version.tag == .npm)
+                        manifest.findBestVersion(resolved_version.value.npm.version, string_buf) orelse continue
                     else
-                        manifest.findByDistTag(dep.version.value.dist_tag.tag.slice(string_buf)) orelse continue;
+                        manifest.findByDistTag(resolved_version.value.dist_tag.tag.slice(string_buf)) orelse continue;
 
                     table.printLineSeparator();
 
@@ -537,7 +550,8 @@ pub const OutdatedCommand = struct {
                 const package_id = resolutions[dep_id];
                 if (package_id == invalid_package_id) continue;
                 const dep = dependencies[dep_id];
-                if (dep.version.tag != .npm and dep.version.tag != .dist_tag) continue;
+                const resolved_version = resolveCatalogDependency(manager, dep) orelse continue;
+                if (resolved_version.tag != .npm and resolved_version.tag != .dist_tag) continue;
                 const resolution: Install.Resolution = pkg_resolutions[package_id];
                 if (resolution.tag != .npm) continue;
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8411,7 +8411,7 @@ describe("outdated", () => {
     expect(out).toContain("prereleases-1");
   });
 
-  test.only("scoped workspace names", async () => {
+  test("scoped workspace names", async () => {
     await Promise.all([
       write(
         packageJson,


### PR DESCRIPTION
### What does this PR do?

This adds support for catalogs in `bun outdated`, fixing https://github.com/oven-sh/bun/issues/19844

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

I wrote automated tests

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test bun-install-registry.test.ts`)

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
