### PR TITLE
fix `NapiHandleScopeImpl` race condition

### DIFF
--- a/src/bun.js/bindings/napi_handle_scope.cpp
+++ b/src/bun.js/bindings/napi_handle_scope.cpp
@@ -44,10 +44,6 @@ void NapiHandleScopeImpl::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    if (thisObject->vm().isCollectorBusyOnCurrentThread()) {
-        return;
-    }
-
     WTF::Locker locker { thisObject->cellLock() };
 
     for (auto& handle : thisObject->m_storage) {
@@ -63,6 +59,7 @@ DEFINE_VISIT_CHILDREN(NapiHandleScopeImpl);
 
 void NapiHandleScopeImpl::append(JSC::JSValue val)
 {
+    WTF::Locker locker { cellLock() };
     m_storage.append(Slot(vm(), this, val));
 }
 
@@ -79,6 +76,7 @@ bool NapiHandleScopeImpl::escape(JSC::JSValue val)
 
 NapiHandleScopeImpl::Slot* NapiHandleScopeImpl::reserveSlot()
 {
+    WTF::Locker locker { cellLock() };
     m_storage.append(Slot());
     return &m_storage.last();
 }

--- a/src/bun.js/bindings/napi_handle_scope.cpp
+++ b/src/bun.js/bindings/napi_handle_scope.cpp
@@ -44,6 +44,10 @@ void NapiHandleScopeImpl::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
+    if (thisObject->vm().isCollectorBusyOnCurrentThread()) {
+        return;
+    }
+
     WTF::Locker locker { thisObject->cellLock() };
 
     for (auto& handle : thisObject->m_storage) {


### PR DESCRIPTION
### What does this PR do?
fixes #16146,

`NapiHandleScopeImpl` functions can be accessed from multiple threads (e.g., during GC sweeping), which makes m_storage prone to race conditions.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
ran test_handle_scope.c

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
