### PR TITLE
Fix memory leak in Bun.spawn

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -517,8 +517,7 @@ const Readable = union(enum) {
                 const own = buffer.takeSlice(bun.default_allocator) catch {
                     globalThis.throwOutOfMemory() catch return .zero;
                 };
-                const blob = JSC.WebCore.Blob.init(own, bun.default_allocator, globalThis);
-                return JSC.WebCore.ReadableStream.fromBlob(globalThis, &blob, 0);
+                return JSC.WebCore.ReadableStream.fromOwnedSlice(globalThis, own, 0);
             },
             else => {
                 return JSValue.jsUndefined();
@@ -1118,9 +1117,8 @@ pub const PipeReader = struct {
                 return stream;
             },
             .done => |bytes| {
-                const blob = JSC.WebCore.Blob.init(bytes, bun.default_allocator, globalObject);
                 this.state = .{ .done = &.{} };
-                return JSC.WebCore.ReadableStream.fromBlob(globalObject, &blob, 0);
+                return JSC.WebCore.ReadableStream.fromOwnedSlice(globalObject, bytes, 0);
             },
             .err => |err| {
                 _ = err; // autofix

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -486,7 +486,7 @@ const Readable = union(enum) {
                 defer pipe.detach();
                 this.* = .{ .closed = {} };
             },
-            .buffer => |buf| {
+            .buffer => |*buf| {
                 buf.deinit(bun.default_allocator);
             },
             else => {},
@@ -1095,6 +1095,12 @@ pub const PipeReader = struct {
         const out = this.reader._buffer;
         this.reader._buffer.items = &.{};
         this.reader._buffer.capacity = 0;
+
+        if (out.capacity > 0 and out.items.len == 0) {
+            out.deinit();
+            return &.{};
+        }
+
         return out.items;
     }
 

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -252,7 +252,7 @@ pub fn shouldRequestBePending(this: *const NodeHTTPResponse) bool {
 }
 
 pub fn dumpRequestBody(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame, thisValue: JSC.JSValue) bun.JSError!JSC.JSValue {
-    if (this.buffered_request_body_data_during_pause.len > 0) {
+    if (this.buffered_request_body_data_during_pause.cap > 0) {
         this.buffered_request_body_data_during_pause.deinitWithAllocator(bun.default_allocator);
     }
     if (!this.flags.request_has_completed) {

--- a/src/bun.js/bindings/Uint8Array.cpp
+++ b/src/bun.js/bindings/Uint8Array.cpp
@@ -26,18 +26,17 @@ extern "C" JSC::EncodedJSValue JSUint8Array__fromDefaultAllocator(JSC::JSGlobalO
 extern "C" JSC::EncodedJSValue JSArrayBuffer__fromDefaultAllocator(JSC::JSGlobalObject* lexicalGlobalObject, uint8_t* ptr, size_t length)
 {
 
-    JSC::JSArrayBuffer* arrayBuffer;
+    RefPtr<ArrayBuffer> buffer;
 
     if (length > 0) [[likely]] {
-        RefPtr<ArrayBuffer> buffer = ArrayBuffer::createFromBytes({ ptr, length }, createSharedTask<void(void*)>([](void* p) {
+        buffer = ArrayBuffer::createFromBytes({ ptr, length }, createSharedTask<void(void*)>([](void* p) {
             mi_free(p);
         }));
-
-        arrayBuffer = JSC::JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(), WTFMove(buffer));
     } else {
-        arrayBuffer = JSC::JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(), nullptr);
+        buffer = ArrayBuffer::create(0, 1);
     }
 
+    auto arrayBuffer = JSC::JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(), WTFMove(buffer));
     return JSC::JSValue::encode(arrayBuffer);
 }
 

--- a/src/bun.js/bindings/ZigString.zig
+++ b/src/bun.js/bindings/ZigString.zig
@@ -270,6 +270,11 @@ pub const ZigString = extern struct {
             list.items.ptr[list.items.len] = 0;
         }
 
+        if (list.capacity > 0 and list.items.len == 0) {
+            list.deinit();
+            return &.{};
+        }
+
         return list.items;
     }
 

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -4250,10 +4250,6 @@ pub const Any = union(enum) {
             //     return value;
             // },
             .InternalBlob => {
-                if (this.InternalBlob.bytes.items.len == 0) {
-                    return JSC.ArrayBuffer.create(global, "", TypedArrayView);
-                }
-
                 const bytes = this.InternalBlob.toOwnedSlice();
                 this.* = .{ .Blob = .{} };
 

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1040,7 +1040,7 @@ pub fn writeFileWithSourceDestination(
         return file_copier.promise.value();
     } else if (destination_type == .file and source_type == .s3) {
         const s3 = &source_store.data.s3;
-        if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlob(
+        if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlobCopyRef(
             ctx,
             source_blob,
             @truncate(s3.options.partSize),
@@ -1077,7 +1077,7 @@ pub fn writeFileWithSourceDestination(
         switch (source_store.data) {
             .bytes => |bytes| {
                 if (bytes.len > S3.MultiPartUploadOptions.MAX_SINGLE_UPLOAD_SIZE) {
-                    if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlob(
+                    if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlobCopyRef(
                         ctx,
                         source_blob,
                         @truncate(s3.options.partSize),
@@ -1144,7 +1144,7 @@ pub fn writeFileWithSourceDestination(
             },
             .file, .s3 => {
                 // stream
-                if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlob(
+                if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlobCopyRef(
                     ctx,
                     source_blob,
                     @truncate(s3.options.partSize),
@@ -1970,7 +1970,7 @@ pub fn getStream(
 
         recommended_chunk_size = @as(SizeType, @intCast(@max(0, @as(i52, @truncate(arguments[0].toInt64())))));
     }
-    const stream = JSC.WebCore.ReadableStream.fromBlob(
+    const stream = JSC.WebCore.ReadableStream.fromBlobCopyRef(
         globalThis,
         this,
         recommended_chunk_size,

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -4413,8 +4413,15 @@ pub const Internal = struct {
 
     pub fn toOwnedSlice(this: *@This()) []u8 {
         const bytes = this.bytes.items;
+        const capacity = this.bytes.capacity;
+        if (bytes.len == 0 and capacity > 0) {
+            this.bytes.clearAndFree();
+            return &.{};
+        }
+
         this.bytes.items = &.{};
         this.bytes.capacity = 0;
+
         return bytes;
     }
 

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -460,7 +460,7 @@ pub const Value = union(Tag) {
                 var blob = this.use();
                 defer blob.detach();
                 blob.resolveSize();
-                const value = JSC.WebCore.ReadableStream.fromBlob(globalThis, &blob, blob.size);
+                const value = JSC.WebCore.ReadableStream.fromBlobCopyRef(globalThis, &blob, blob.size);
 
                 this.* = .{
                     .Locked = .{

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -290,7 +290,13 @@ pub fn fromNative(globalThis: *JSGlobalObject, native: JSC.JSValue) JSC.JSValue 
     return ZigGlobalObject__createNativeReadableStream(globalThis, native);
 }
 
-pub fn fromBlob(globalThis: *JSGlobalObject, blob: *const Blob, recommended_chunk_size: Blob.SizeType) JSC.JSValue {
+pub fn fromOwnedSlice(globalThis: *JSGlobalObject, bytes: []u8, recommended_chunk_size: Blob.SizeType) JSC.JSValue {
+    var blob = Blob.init(bytes, bun.default_allocator, globalThis);
+    defer blob.deinit();
+    return fromBlobCopyRef(globalThis, &blob, recommended_chunk_size);
+}
+
+pub fn fromBlobCopyRef(globalThis: *JSGlobalObject, blob: *const Blob, recommended_chunk_size: Blob.SizeType) JSC.JSValue {
     JSC.markBinding(@src());
     var store = blob.store orelse {
         return ReadableStream.empty(globalThis);

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1,4 +1,3 @@
-
 const JSType = JSC.C.JSType;
 
 pub const fetch_error_no_args = "fetch() expects a string but received no arguments.";
@@ -2386,7 +2385,7 @@ pub fn Bun__fetch_(
         prepare_body: {
             // is a S3 file we can use chunked here
 
-            if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlob(globalThis, &body.AnyBlob.Blob, s3.MultiPartUploadOptions.DefaultPartSize), globalThis)) |stream| {
+            if (JSC.WebCore.ReadableStream.fromJS(JSC.WebCore.ReadableStream.fromBlobCopyRef(globalThis, &body.AnyBlob.Blob, s3.MultiPartUploadOptions.DefaultPartSize), globalThis)) |stream| {
                 var old = body;
                 defer old.detach();
                 body = .{ .ReadableStream = JSC.WebCore.ReadableStream.Strong.init(stream, globalThis) };

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2302,7 +2302,7 @@ pub const PackCommand = struct {
     };
 
     pub const IgnorePatterns = struct {
-        list: []const Pattern,
+        list: []Pattern,
         kind: Kind,
         depth: usize,
 
@@ -2411,7 +2411,7 @@ pub const PackCommand = struct {
         }
 
         pub fn deinit(this: *const IgnorePatterns, allocator: std.mem.Allocator) void {
-            for (this.list) |pattern_info| {
+            for (this.list) |*pattern_info| {
                 pattern_info.glob.deinit(allocator);
             }
             allocator.free(this.list);

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2302,7 +2302,7 @@ pub const PackCommand = struct {
     };
 
     pub const IgnorePatterns = struct {
-        list: []Pattern,
+        list: []const Pattern,
         kind: Kind,
         depth: usize,
 

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -387,8 +387,6 @@ const PosixBufferedReader = struct {
         }
     }
 
-    const stack_buffer_len = 64 * 1024;
-
     inline fn drainChunk(parent: *PosixBufferedReader, chunk: []const u8, hasMore: ReadState) bool {
         if (parent.vtable.isStreamingEnabled()) {
             if (chunk.len > 0) {

--- a/src/ptr/CowSlice.zig
+++ b/src/ptr/CowSlice.zig
@@ -229,7 +229,7 @@ pub fn CowSliceZ(T: type, comptime sentinel: ?T) type {
         ///
         /// In debug builds, deinitializing borrowed strings performs debug
         /// checks. In release builds it is a no-op.
-        pub fn deinit(str: Self, allocator: Allocator) void {
+        pub fn deinit(str: *Self, allocator: Allocator) void {
             if (comptime cow_str_assertions) if (str.debug) |debug| {
                 debug.mutex.lock();
                 bun.assertf(

--- a/src/ptr/CowSlice.zig
+++ b/src/ptr/CowSlice.zig
@@ -229,7 +229,7 @@ pub fn CowSliceZ(T: type, comptime sentinel: ?T) type {
         ///
         /// In debug builds, deinitializing borrowed strings performs debug
         /// checks. In release builds it is a no-op.
-        pub fn deinit(str: *Self, allocator: Allocator) void {
+        pub fn deinit(str: *const Self, allocator: Allocator) void {
             if (comptime cow_str_assertions) if (str.debug) |debug| {
                 debug.mutex.lock();
                 bun.assertf(

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -12,7 +12,6 @@ const JSGlobalObject = JSC.JSGlobalObject;
 const uws = bun.uws;
 const sh = bun.shell;
 
-
 const util = @import("./util.zig");
 
 pub const Stdio = util.Stdio;
@@ -943,7 +942,6 @@ pub const ShellSubprocess = struct {
     }
 };
 
-
 pub const PipeReader = struct {
     const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});
     pub const ref = RefCount.ref;
@@ -1273,9 +1271,8 @@ pub const PipeReader = struct {
                 return stream;
             },
             .done => |bytes| {
-                const blob = JSC.WebCore.Blob.init(bytes, bun.default_allocator, globalObject);
                 this.state = .{ .done = &.{} };
-                return JSC.WebCore.ReadableStream.fromBlob(globalObject, &blob, 0);
+                return JSC.WebCore.ReadableStream.fromOwnedSlice(globalObject, bytes, 0);
             },
             .err => |err| {
                 _ = err; // autofix

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -1249,6 +1249,11 @@ pub const PipeReader = struct {
         const out = this.reader._buffer;
         this.reader._buffer.items = &.{};
         this.reader._buffer.capacity = 0;
+
+        if (out.capacity > 0 and out.items.len == 0) {
+            out.deinit();
+            return &.{};
+        }
         return out.items;
     }
 

--- a/src/string/MutableString.zig
+++ b/src/string/MutableString.zig
@@ -276,7 +276,7 @@ pub fn sliceWithSentinel(self: *MutableString) [:0]u8 {
 }
 
 pub fn toOwnedSliceLength(self: *MutableString, length: usize) string {
-    self.list.shrinkAndFree(self.allocator, length);
+    self.list.items.len = length;
     return self.list.toOwnedSlice(self.allocator) catch bun.outOfMemory(); // TODO
 }
 

--- a/test/js/bun/spawn/spawn-pipe-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-leak.test.ts
@@ -5,7 +5,7 @@
  * and then exits. We only await the `process.exited` promise without reading
  * any of the output data to test for potential memory leaks.
  */
-import { bunExe } from "harness";
+import { bunExe, isWindows } from "harness";
 
 describe("Bun.spawn", () => {
   const DEBUG_LOGS = true; // turn this on to see debug logs
@@ -123,7 +123,11 @@ describe("Bun.spawn", () => {
     await run(dontRead);
   }, 30_000);
 
-  test("'pipe' stdout if read before exit should not leak memory", async () => {
-    await run(readPipeBeforeExit);
-  }, 30_000);
+  test.todoIf(isWindows)(
+    "'pipe' stdout if read before exit should not leak memory",
+    async () => {
+      await run(readPipeBeforeExit);
+    },
+    30_000,
+  );
 });

--- a/test/js/bun/spawn/spawn-pipe-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-leak.test.ts
@@ -8,39 +8,70 @@
 import { bunExe } from "harness";
 
 describe("Bun.spawn", () => {
-  const DEBUG_LOGS = false; // turn this on to see debug logs
+  const DEBUG_LOGS = true; // turn this on to see debug logs
   const log = (...args: any[]) => DEBUG_LOGS && console.log(...args);
 
   const MB = 1024 * 1024;
 
-  test("'pipe' stdout should not leak memory", async () => {
+  // Create a command that will generate ~512 KB of output
+  const cmd = [
+    bunExe(),
+    "-e",
+    `for (let buffer = Buffer.alloc(1024 * 1024 * 10, 'X'); buffer.length > 0;) {
+    const written = require('fs').writeSync(1, buffer);
+    buffer = buffer.slice(written);
+}`,
+  ];
+
+  const cmd10 = [
+    bunExe(),
+    "-e",
+    `for (let buffer = Buffer.alloc(10, 'X'); buffer.length > 0;) {
+    const written = require('fs').writeSync(1, buffer);
+    buffer = buffer.slice(written);
+}`,
+  ];
+
+  async function readPipeAfterExit() {
+    const process = Bun.spawn({
+      cmd,
+      stdout: "pipe", // We pipe stdout but never read from it
+      stderr: "ignore",
+      stdin: "ignore",
+    });
+    await process.exited;
+    await Bun.readableStreamToBlob(process.stdout);
+  }
+
+  async function dontRead() {
+    const process = Bun.spawn({
+      cmd: cmd10,
+      stdout: "pipe",
+      stderr: "ignore",
+      stdin: "ignore",
+    });
+    await process.exited;
+  }
+
+  async function readPipeBeforeExit() {
+    const process = Bun.spawn({
+      cmd,
+      stdout: "pipe", // We pipe stdout but never read from it
+      stderr: "ignore",
+      stdin: "ignore",
+    });
+    await process.exited;
+    await Bun.readableStreamToBlob(process.stdout);
+  }
+
+  async function run(iterate: () => Promise<void>) {
     /**
      * @param batchSize # of processes to spawn in parallel in each batch
      * @param totalBatches # of batches to run
      */
     async function testSpawnMemoryLeak(batchSize: number, totalBatches: number) {
-      // Create a command that will generate ~512 KB of output
-      const cmd = [
-        bunExe(),
-        "-e",
-        `for (let buffer = Buffer.alloc(10, 'X'); buffer.length > 0;) {
-            const written = require('fs').writeSync(1, buffer);
-            buffer = buffer.slice(written);
-        }`,
-      ];
-
       log("Starting memory leak test...");
       log(`Initial memory usage: ${Math.round(process.memoryUsage.rss() / MB)} MB`);
-
-      async function iterate() {
-        const process = Bun.spawn({
-          cmd,
-          stdout: "ignore", // We pipe stdout but never read from it
-          stderr: "pipe",
-          stdin: "ignore",
-        });
-        await process.exited;
-      }
 
       for (let batch = 0; batch < totalBatches; batch++) {
         const batchPromises: Promise<void>[] = [];
@@ -80,5 +111,17 @@ describe("Bun.spawn", () => {
     const pct = delta / memBefore.rss;
     console.log(`RSS delta: ${delta / MB}MB (${Math.round(100 * pct)}%)`);
     expect(pct).toBeLessThan(0.5);
-  }, 10_000); // NOTE: this test doesn't actually take this long, but keeping the limit high will help avoid flakyness
+  }
+
+  test("'pipe' stdout if read after exit should not leak memory", async () => {
+    await run(readPipeAfterExit);
+  }, 30_000);
+
+  test("'pipe' stdout if not read should not leak memory", async () => {
+    await run(dontRead);
+  }, 30_000);
+
+  test("'pipe' stdout if read before exit should not leak memory", async () => {
+    await run(readPipeBeforeExit);
+  }, 30_000);
 });

--- a/test/js/bun/spawn/spawn-pipe-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-leak.test.ts
@@ -94,7 +94,7 @@ describe("Bun.spawn", () => {
       Bun.gc(true);
     }
 
-    const batchSize = process.platform === "win32" ? 10 : 100;
+    const batchSize = process.platform === "win32" ? 10 : 50;
 
     // Warmup
     await testSpawnMemoryLeak(batchSize, 5);

--- a/test/js/bun/spawn/spawn-pipe-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-leak.test.ts
@@ -35,7 +35,7 @@ describe("Bun.spawn", () => {
   async function readPipeAfterExit() {
     const process = Bun.spawn({
       cmd,
-      stdout: "pipe", // We pipe stdout but never read from it
+      stdout: "pipe",
       stderr: "ignore",
       stdin: "ignore",
     });
@@ -56,11 +56,11 @@ describe("Bun.spawn", () => {
   async function readPipeBeforeExit() {
     const process = Bun.spawn({
       cmd,
-      stdout: "pipe", // We pipe stdout but never read from it
+      stdout: "pipe",
       stderr: "ignore",
       stdin: "ignore",
     });
-    Bun.readableStreamToBlob(process.stdout);
+    await Bun.readableStreamToBlob(process.stdout);
     await process.exited;
   }
 


### PR DESCRIPTION
### What does this PR do?

- Adds `ReadableStream.fromOwnedSlice` to clarify ownership
- Renames `ReadableStream.fromBlob` to `ReadableStream.fromBlobCopyRef` to clarify it is increments a reference count.
- Fixes a few cases where we assumed a 0-length slice was a 0-capacity slice and did not free the slice.

### How did you verify your code works?

Updated an existing memory leak test to work properly

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
