### PR TITLE
Run mi_collect after releasing heap access

### DIFF
--- a/src/bun.js/bindings/BunJSCEventLoop.cpp
+++ b/src/bun.js/bindings/BunJSCEventLoop.cpp
@@ -3,6 +3,7 @@
 
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/Heap.h>
+#include <mimalloc.h>
 
 // It would be nicer to construct a DropAllLocks in us_loop_run_bun_tick (the only function that
 // uses onBeforeWait and onAfterWait), but that code is in C. We use an optional as that lets us
@@ -20,6 +21,7 @@ extern "C" void Bun__JSC_onBeforeWait(JSC::VM* vm)
         drop_all_locks.emplace(*vm);
         if (previouslyHadAccess) {
             vm->heap.releaseAccess();
+            mi_collect(false);
         }
     }
 }

--- a/test/js/bun/spawn/spawn-pipe-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-leak.test.ts
@@ -75,5 +75,5 @@ describe("Bun.spawn", () => {
     const pct = delta / memBefore.rss;
     console.log(`RSS delta: ${delta / MB}MB (${Math.round(100 * pct)}%)`);
     expect(pct).toBeLessThan(0.5);
-  }, 10_000); // NOTE: this test doesn't actually take this long, but keeping the limit high will help avoid flakyness
+  }, 30_000); // NOTE: this test doesn't actually take this long, but keeping the limit high will help avoid flakyness
 });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
