### PR TITLE
Avoid allocating 16 KB to read a potentially empty buffer

### DIFF
--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -538,6 +538,70 @@ const PosixBufferedReader = struct {
 
                 if (!parent.vtable.isStreamingEnabled()) break;
             }
+        } else if (resizable_buffer.capacity == 0 and parent._offset == 0) {
+            // Avoid a 16 KB dynamic memory allocation when the buffer might very well be empty.
+            const stack_buffer = parent.vtable.eventLoop().pipeReadBuffer();
+
+            // Unlike the block of code following this one, only handle the non-streaming case.
+            bun.debugAssert(!streaming);
+
+            switch (sys_fn(fd, stack_buffer, 0)) {
+                .result => |bytes_read| {
+                    if (bytes_read > 0) {
+                        resizable_buffer.appendSlice(stack_buffer[0..bytes_read]) catch bun.outOfMemory();
+                    }
+                    if (parent.maxbuf) |l| l.onReadBytes(bytes_read);
+                    parent._offset += bytes_read;
+
+                    if (bytes_read == 0) {
+                        parent.closeWithoutReporting();
+                        _ = drainChunk(parent, resizable_buffer.items, .eof);
+                        parent.done();
+                        return;
+                    }
+
+                    if (comptime file_type == .pipe) {
+                        if (bun.Environment.isMac or !bun.linux.RWFFlagSupport.isMaybeSupported()) {
+                            switch (bun.isReadable(fd)) {
+                                .ready => {},
+                                .hup => {
+                                    received_hup = true;
+                                },
+                                .not_ready => {
+                                    if (received_hup) {
+                                        parent.closeWithoutReporting();
+                                    }
+                                    defer {
+                                        if (received_hup) {
+                                            parent.done();
+                                        }
+                                    }
+
+                                    if (!received_hup) {
+                                        parent.registerPoll();
+                                    }
+
+                                    return;
+                                },
+                            }
+                        }
+                    }
+                },
+                .err => |err| {
+                    if (err.isRetry()) {
+                        if (comptime file_type == .file) {
+                            bun.Output.debugWarn("Received EAGAIN while reading from a file. This is a bug.", .{});
+                        } else {
+                            parent.registerPoll();
+                        }
+                        return;
+                    }
+                    parent.onError(err);
+                    return;
+                },
+            }
+
+            // Allow falling through
         }
 
         while (true) {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
