### PR TITLE
fix memory leak when pipe Bun.spawn stdio is never read repeatedly

### DIFF
--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -226,7 +226,7 @@ const PosixBufferedReader = struct {
 
         bun.assert(!this.flags.is_done);
         this.flags.is_done = true;
-        this._buffer.clearAndFree();
+        this._buffer.shrinkAndFree(this._buffer.items.len);
     }
 
     fn closeHandle(this: *PosixBufferedReader) void {
@@ -802,7 +802,7 @@ pub const WindowsBufferedReader = struct {
     fn finish(this: *WindowsBufferedReader) void {
         this.flags.has_inflight_read = false;
         this.flags.is_done = true;
-        this._buffer.clearAndFree();
+        this._buffer.shrinkAndFree(this._buffer.items.len);
     }
 
     pub fn done(this: *WindowsBufferedReader) void {

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -226,6 +226,7 @@ const PosixBufferedReader = struct {
 
         bun.assert(!this.flags.is_done);
         this.flags.is_done = true;
+        this._buffer.clearAndFree();
     }
 
     fn closeHandle(this: *PosixBufferedReader) void {
@@ -801,6 +802,7 @@ pub const WindowsBufferedReader = struct {
     fn finish(this: *WindowsBufferedReader) void {
         this.flags.has_inflight_read = false;
         this.flags.is_done = true;
+        this._buffer.clearAndFree();
     }
 
     pub fn done(this: *WindowsBufferedReader) void {

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -12,7 +12,6 @@ const JSGlobalObject = JSC.JSGlobalObject;
 const uws = bun.uws;
 const sh = bun.shell;
 
-
 const util = @import("./util.zig");
 
 pub const Stdio = util.Stdio;
@@ -942,7 +941,6 @@ pub const ShellSubprocess = struct {
         }
     }
 };
-
 
 pub const PipeReader = struct {
     const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});

--- a/test/js/bun/spawn/spawn-noread-leak.test.ts
+++ b/test/js/bun/spawn/spawn-noread-leak.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 async function spawn() {
   const proc = Bun.spawn(["cat", import.meta.path], {

--- a/test/js/bun/spawn/spawn-noread-leak.test.ts
+++ b/test/js/bun/spawn/spawn-noread-leak.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+
+async function spawn() {
+  const proc = Bun.spawn(["cat", import.meta.path], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  await proc.exited;
+}
+
+async function spawn100() {
+  return Promise.all(new Array(100).fill(0).map(v => spawn()));
+}
+
+test("does not leak", async () => {
+  const before = process.memoryUsage().rss;
+  console.log("before", (before / 1024 / 1024).toFixed(3), "MB");
+  for (let index = 0; index < 200; index++) {
+    await spawn100();
+    Bun.gc(true);
+  }
+  const after = process.memoryUsage().rss;
+  console.log("after", (after / 1024 / 1024).toFixed(3), "MB");
+  expect(before + after).toBeLessThan(before * 3);
+}, 0);


### PR DESCRIPTION
calls to `.ensureUnusedCapacity()` elsewhere were not previously accounted for upon the closing of the PipeReader.

Closes: https://github.com/oven-sh/bun/issues/18265

----

results of the new test:

before:

```
test/js/bun/spawn/spawn-noread-leak.test.ts:
before 36.266 MB
after 369.531 MB
```

after:

```
test/js/bun/spawn/spawn-noread-leak.test.ts:
before 35.344 MB
after 58.313 MB
```

----

additionally using the `spawn` function from the linked issue:

```js
async function spawn() {
  const proc = Bun.spawn(["sed", "20q", "/etc/passwd"], {
    stdio: ["ignore", "pipe", "pipe"],
  });
  await proc.exited;
}

setTimeout(() => process.exit(0), 30_000);

while (true) {
  Bun.gc(true);
  console.clear();
  console.log(`RSS: ${(process.memoryUsage().rss / 1024 / 1024).toFixed(3)} MB`);
  await spawn();
}
```

before:
`RSS: 310.938 MB`
after:
`RSS: 38.328 MB`

and increasing the simulation to 2 mins:

before:
`RSS: 1090.328 MB`
after:
`RSS: 38.266 MB`
