### PR TITLE
Clean up help text for package manager commands

### DIFF
--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -139,7 +139,7 @@ pub const PackageManagerCommand = struct {
             \\  <d>└<r>  <cyan>--all<r>                    trust all untrusted dependencies
             \\  <b><green>bun pm<r> <blue>default-trusted<r>      print the default trusted dependencies list
             \\
-            \\Learn more about these at <magenta>https://bun.sh/docs/cli/pm<r>
+            \\Learn more about these at <magenta>https://bun.sh/docs/cli/pm<r>.
             \\
         ;
 

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -108,7 +108,7 @@ pub const PackageManagerCommand = struct {
             \\
             \\<b>Usage<r>: <b><green>bun pm<r> <cyan>[flags]<r> <blue>[\<command\>]<r>
             \\
-            \\  Run package manager utilities
+            \\  Run package manager utilities.
         ;
         const outro_text =
             \\

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -105,43 +105,45 @@ pub const PackageManagerCommand = struct {
         // use <bar> to emphasize 'bar'
 
         const intro_text =
+            \\
             \\<b>Usage<r>: <b><green>bun pm<r> <cyan>[flags]<r> <blue>[\<command\>]<r>
+            \\
             \\  Run package manager utilities
         ;
         const outro_text =
-            \\<b>Examples:<r>
             \\
-            \\  <b><green>bun pm<r> <blue>pack<r>               create a tarball of the current workspace
-            \\  <d>├<r> <cyan>--dry-run<r>               do everything except for writing the tarball to disk
-            \\  <d>├<r> <cyan>--destination<r>           the directory the tarball will be saved in
-            \\  <d>├<r> <cyan>--filename<r>              the name of the tarball
-            \\  <d>├<r> <cyan>--ignore-scripts<r>        don't run pre/postpack and prepare scripts
-            \\  <d>└<r> <cyan>--gzip-level<r>            specify a custom compression level for gzip (0-9, default is 9)
-            \\  <b><green>bun pm<r> <blue>bin<r>                print the path to bin folder
-            \\  <d>└<r> <cyan>-g<r>                      print the <b>global<r> path to bin folder
-            \\  <b><green>bun pm<r> <blue>ls<r>                 list the dependency tree according to the current lockfile
-            \\  <d>└<r> <cyan>--all<r>                   list the entire dependency tree according to the current lockfile
-            \\  <b><green>bun pm<r> <blue>whoami<r>             print the current npm username
+            \\
+            \\<b>Commands:<r>
+            \\
+            \\  <b><green>bun pm<r> <blue>pack<r>                 create a tarball of the current workspace
+            \\  <d>├<r> <cyan>--dry-run<r>                 do everything except for writing the tarball to disk
+            \\  <d>├<r> <cyan>--destination<r>             the directory the tarball will be saved in
+            \\  <d>├<r> <cyan>--filename<r>                the name of the tarball
+            \\  <d>├<r> <cyan>--ignore-scripts<r>          don't run pre/postpack and prepare scripts
+            \\  <d>└<r> <cyan>--gzip-level<r>              specify a custom compression level for gzip (0-9, default is 9)
+            \\  <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
+            \\  <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
+            \\  <b><green>bun pm<r> <blue>ls<r>                   list the dependency tree according to the current lockfile
+            \\  <d>└<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
+            \\  <b><green>bun pm<r> <blue>whoami<r>               print the current npm username
             \\  <b><green>bun pm<r> <blue>view<r> <d>name[@version]<r>  view package metadata from the registry
-            \\  <b><green>bun pm<r> <blue>hash<r>               generate & print the hash of the current lockfile
-            \\  <b><green>bun pm<r> <blue>hash-string<r>        print the string used to hash the lockfile
-            \\  <b><green>bun pm<r> <blue>hash-print<r>         print the hash stored in the current lockfile
-            \\  <b><green>bun pm<r> <blue>audit<r>              check installed packages for vulnerabilities
-            \\  <b><green>bun pm<r> <blue>cache<r>              print the path to the cache folder
-            \\  <b><green>bun pm<r> <blue>cache rm<r>           clear the cache
-            \\  <b><green>bun pm<r> <blue>migrate<r>            migrate another package manager's lockfile without installing anything
-            \\  <b><green>bun pm<r> <blue>untrusted<r>          print current untrusted dependencies with scripts
-            \\  <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>    run scripts for untrusted dependencies and add to `trustedDependencies`
-            \\  <d>└<r>  <cyan>--all<r>                  trust all untrusted dependencies
-            \\  <b><green>bun pm<r> <blue>default-trusted<r>    print the default trusted dependencies list
+            \\  <b><green>bun pm<r> <blue>hash<r>                 generate & print the hash of the current lockfile
+            \\  <b><green>bun pm<r> <blue>hash-string<r>          print the string used to hash the lockfile
+            \\  <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile
+            \\  <b><green>bun pm<r> <blue>audit<r>                check installed packages for vulnerabilities
+            \\  <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder
+            \\  <b><green>bun pm<r> <blue>cache rm<r>             clear the cache
+            \\  <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything
+            \\  <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts
+            \\  <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`
+            \\  <d>└<r>  <cyan>--all<r>                    trust all untrusted dependencies
+            \\  <b><green>bun pm<r> <blue>default-trusted<r>      print the default trusted dependencies list
             \\
             \\Learn more about these at <magenta>https://bun.sh/docs/cli/pm<r>
             \\
         ;
 
         Output.pretty(intro_text, .{});
-        Output.flush();
-        Output.pretty("\n\n", .{});
         Output.pretty(outro_text, .{});
         Output.flush();
     }

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -220,11 +220,17 @@ pub fn printHelp(subcommand: Subcommand) void {
         // fall back to HelpCommand.printWithReason
         Subcommand.install => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun install<r> <cyan>[flags]<r> <blue>\<name\><r><d>@\<version\><r>
-                \\<b>Alias: <b><green>bun i<r>
-                \\  Install the dependencies listed in package.json
+                \\<b>Alias<r>: <b><green>bun i<r>
+                \\
+                \\  Install the dependencies listed in package.json.
+                \\
+                \\<b>Flags:<r>
             ;
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Install the dependencies for the current project<r>
                 \\  <b><green>bun install<r>
@@ -233,22 +239,25 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun install<r> <cyan>--production<r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.sh/docs/cli/install<r>
+                \\
             ;
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(install_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.update => {
             const intro_text =
-                \\<b>Usage<r>: <b><green>bun update<r> <cyan>[flags]<r> <blue>\<name\><r><d>@\<version\><r>
-                \\  Update all dependencies to most recent versions within the version range in package.json
                 \\
+                \\<b>Usage<r>: <b><green>bun update<r> <cyan>[flags]<r> <blue>\<name\><r><d>@\<version\><r>
+                \\
+                \\  Update dependencies to their most recent versions within the version range in package.json.
+                \\
+                \\<b>Flags:<r>
             ;
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Update all dependencies:<r>
                 \\  <b><green>bun update<r>
@@ -260,56 +269,70 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun update<r> <blue>zod jquery@3<r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.sh/docs/cli/update<r>
+                \\
             ;
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(update_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.patch => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun patch<r> <cyan>[flags or options]<r> <blue>\<package\><r><d>@\<version\><r>
                 \\
-                \\Prepare a package for patching.
+                \\  Prepare a package for patching, or generate and save a patch.
+                \\
+                \\<b>Flags:<r>
+            ;
+
+            const outro_text =
+                \\
+                \\
+                \\<b>Examples:<r>
+                \\  <d>Prepare jquery for patching<r>
+                \\  <b><green>bun patch jquery<r>
+                \\
+                \\  <d>Generate a patch file for changes made to jquery<r>
+                \\  <b><green>bun patch --commit 'node_modules/jquery'<r>
+                \\
+                \\  <d>Generate a patch file in a custom directory for changes made to jquery<r>
+                \\  <b><green>bun patch --patches-dir 'my-patches' 'node_modules/jquery'<r>
+                \\
+                \\Full documentation is available at <magenta>https://bun.sh/docs/install/patch<r>
                 \\
             ;
 
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(patch_params);
-            // Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
-            Output.pretty("\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.@"patch-commit" => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun patch-commit<r> <cyan>[flags or options]<r> <blue>\<directory\><r>
                 \\
-                \\Generate a patc out of a directory and save it.
+                \\  Generate a patch out of a directory and save it. This is equivalent to <b><green>bun patch --commit<r>.
                 \\
-                \\<b>Options:<r>
-                \\  <cyan>--patches-dir<r>               <d>The directory to save the patch file<r>
+                \\<b>Flags:<r>
+            ;
+            const outro_text =
+                \\
+                \\
+                \\<b>Examples:<r>
+                \\  <d>Generate a patch in the default "./patches" directory for changes in "./node_modules/jquery"<r>
+                \\  <b><green>bun patch-commit 'node_modules/jquery'<r>
+                \\
+                \\  <d>Generate a patch in a custom directory ("./my-patches")<r>
+                \\  <b><green>bun patch-commit --patches-dir 'my-patches' 'node_modules/jquery'<r>
+                \\
+                \\Full documentation is available at <magenta>https://bun.sh/docs/install/patch<r>
                 \\
             ;
-            // const outro_text =
-            //     \\<b>Options:<r>
-            //     \\  <d>--edit-dir<r>
-            //     \\  <b><green>bun update<r>
-            //     \\
-            //     \\Full documentation is available at <magenta>https://bun.sh/docs/cli/update<r>
-            // ;
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(patch_params);
-            // Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
-            Output.pretty("\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.pm => {
@@ -317,10 +340,17 @@ pub fn printHelp(subcommand: Subcommand) void {
         },
         Subcommand.add => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun add<r> <cyan>[flags]<r> <blue>\<package\><r><d>\<@version\><r>
-                \\<b>Alias: <b><green>bun a<r>
+                \\<b>Alias<r>: <b><green>bun a<r>
+                \\
+                \\  Add a new dependency to package.json and install it.
+                \\
+                \\<b>Flags:<r>
             ;
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Add a dependency from the npm registry<r>
                 \\  <b><green>bun add<r> <blue>zod<r>
@@ -333,43 +363,50 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun add<r> <cyan>--peer<r> <blue>esbuild<r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.sh/docs/cli/add<r>
+                \\
             ;
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(add_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.remove => {
             const intro_text =
-                \\<b>Usage<r>: <b><green>bun remove<r> <cyan>[flags]<r> <blue>[\<packages\>]<r>
-                \\<b>Alias: <b>bun r<r>
-                \\  Remove a package from package.json and uninstall from node_modules
                 \\
+                \\<b>Usage<r>: <b><green>bun remove<r> <cyan>[flags]<r> <blue>[\<packages\>]<r>
+                \\<b>Alias<r>: <b><green>bun r<r>
+                \\
+                \\  Remove a package from package.json and uninstall from node_modules.
+                \\
+                \\<b>Flags:<r>
             ;
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Remove a dependency<r>
                 \\  <b><green>bun remove<r> <blue>ts-node<r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.sh/docs/cli/remove<r>
+                \\
             ;
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(remove_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.link => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun link<r> <cyan>[flags]<r> <blue>[\<packages\>]<r>
                 \\
+                \\  Register a local directory as a "linkable" package, or link a "linkable" package to the current project.
+                \\
+                \\<b>Flags:<r>
             ;
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Register the current directory as a linkable package.<r>
                 \\  <d>Directory should contain a package.json.<r>
@@ -379,42 +416,52 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun link<r> <blue>\<package\><r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.sh/docs/cli/link<r>
+                \\
             ;
-            Output.pretty("\n" ++ intro_text, .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(link_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         Subcommand.unlink => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun unlink<r> <cyan>[flags]<r>
+                \\
+                \\  Unregister the current directory as a "linkable" package.
+                \\
+                \\<b>Flags:<r>
             ;
 
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Unregister the current directory as a linkable package.<r>
                 \\  <b><green>bun unlink<r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.sh/docs/cli/unlink<r>
+                \\
             ;
 
-            Output.pretty("\n" ++ intro_text ++ "\n", .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(unlink_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         .outdated => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun outdated<r> <cyan>[flags]<r> <blue>[filter]<r>
+                \\
+                \\  Display outdated dependencies for each matching workspace.
+                \\
+                \\<b>Flags:<r>
             ;
 
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Display outdated dependencies in the current workspace.<r>
                 \\  <b><green>bun outdated<r>
@@ -429,39 +476,53 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun outdated<r> <blue>"is-*"<r>
                 \\  <b><green>bun outdated<r> <blue>"!is-even"<r>
                 \\
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/outdated<r>
+                \\
             ;
 
-            Output.pretty("\n" ++ intro_text ++ "\n", .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(outdated_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         .pack => {
             const intro_text =
-                \\<b>Usage<r>: <b><green>bun pack<r> <cyan>[flags]<r>
+                \\
+                \\<b>Usage<r>: <b><green>bun pm pack<r> <cyan>[flags]<r>
+                \\
+                \\  Create a tarball for the current project.
+                \\
+                \\<b>Flags:<r>
             ;
 
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
-                \\  <b><green>bun pack<r>
+                \\  <b><green>bun pm pack<r>
+                \\
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/pm#pack<r>
                 \\
             ;
 
-            Output.pretty("\n" ++ intro_text ++ "\n", .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(pack_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         .publish => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun publish<r> <cyan>[flags]<r> <blue>[dist]<r>
+                \\
+                \\  Publish a package to the npm registry.
+                \\
+                \\<b>Flags:<r>
             ;
 
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Display files that would be published, without publishing to the registry.<r>
                 \\  <b><green>bun publish<r> <cyan>--dry-run<r>
@@ -472,21 +533,28 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Publish a pre-existing package tarball with tag 'next'.<r>
                 \\  <b><green>bun publish<r> <cyan>--tag next<r> <blue>./path/to/tarball.tgz<r>
                 \\
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/publish<r>
+                \\
             ;
 
-            Output.pretty("\n" ++ intro_text ++ "\n", .{});
-            Output.flush();
-            Output.pretty("\n<b>Flags:<r>", .{});
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(publish_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
         .audit => {
             const intro_text =
+                \\
                 \\<b>Usage<r>: <b><green>bun audit<r> <cyan>[flags]<r>
+                \\
+                \\  Check installed packages for vulnerabilities.
+                \\
+                \\<b>Flags:<r>
             ;
 
             const outro_text =
+                \\
+                \\
                 \\<b>Examples:<r>
                 \\  <d>Check installed packages for vulnerabilities.<r>
                 \\  <b><green>bun audit<r>
@@ -494,13 +562,13 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Output package vulnerabilities in JSON format.<r>
                 \\  <b><green>bun audit --json<r>
                 \\
+                \\Full documentation is available at <magenta>https://bun.sh/docs/install/audit<r>
+                \\
             ;
 
-            Output.pretty("\n" ++ intro_text ++ "\n", .{});
-            Output.pretty("\n<b>Flags:<r>", .{});
-            Output.flush();
+            Output.pretty(intro_text, .{});
             clap.simpleHelp(audit_params);
-            Output.pretty("\n\n" ++ outro_text ++ "\n", .{});
+            Output.pretty(outro_text, .{});
             Output.flush();
         },
     }
@@ -792,7 +860,6 @@ const JSON = bun.JSON;
 const Path = bun.path;
 
 const URL = bun.URL;
-
 
 const clap = bun.clap;
 const PackageManagerCommand = @import("../../cli/package_manager_command.zig").PackageManagerCommand;

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -238,7 +238,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Skip devDependencies<r>
                 \\  <b><green>bun install<r> <cyan>--production<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/install<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/install<r>.
                 \\
             ;
             Output.pretty(intro_text, .{});
@@ -268,7 +268,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Update specific packages:<r>
                 \\  <b><green>bun update<r> <blue>zod jquery@3<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/update<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/update<r>.
                 \\
             ;
             Output.pretty(intro_text, .{});
@@ -299,7 +299,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Generate a patch file in a custom directory for changes made to jquery<r>
                 \\  <b><green>bun patch --patches-dir 'my-patches' 'node_modules/jquery'<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/install/patch<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/install/patch<r>.
                 \\
             ;
 
@@ -327,7 +327,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Generate a patch in a custom directory ("./my-patches")<r>
                 \\  <b><green>bun patch-commit --patches-dir 'my-patches' 'node_modules/jquery'<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/install/patch<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/install/patch<r>.
                 \\
             ;
             Output.pretty(intro_text, .{});
@@ -362,7 +362,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun add<r> <cyan>--optional<r> <blue>lodash<r>
                 \\  <b><green>bun add<r> <cyan>--peer<r> <blue>esbuild<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/add<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/add<r>.
                 \\
             ;
             Output.pretty(intro_text, .{});
@@ -387,7 +387,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Remove a dependency<r>
                 \\  <b><green>bun remove<r> <blue>ts-node<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/remove<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/remove<r>.
                 \\
             ;
             Output.pretty(intro_text, .{});
@@ -415,7 +415,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Add a previously-registered linkable package as a dependency of the current project.<r>
                 \\  <b><green>bun link<r> <blue>\<package\><r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/link<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/link<r>.
                 \\
             ;
             Output.pretty(intro_text, .{});
@@ -440,7 +440,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Unregister the current directory as a linkable package.<r>
                 \\  <b><green>bun unlink<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/unlink<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/unlink<r>.
                 \\
             ;
 
@@ -476,7 +476,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun outdated<r> <blue>"is-*"<r>
                 \\  <b><green>bun outdated<r> <blue>"!is-even"<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/outdated<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/outdated<r>.
                 \\
             ;
 
@@ -501,7 +501,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\<b>Examples:<r>
                 \\  <b><green>bun pm pack<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/pm#pack<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/pm#pack<r>.
                 \\
             ;
 
@@ -533,7 +533,7 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Publish a pre-existing package tarball with tag 'next'.<r>
                 \\  <b><green>bun publish<r> <cyan>--tag next<r> <blue>./path/to/tarball.tgz<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/publish<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/cli/publish<r>.
                 \\
             ;
 
@@ -556,13 +556,13 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\
                 \\
                 \\<b>Examples:<r>
-                \\  <d>Check installed packages for vulnerabilities.<r>
+                \\  <d>Check the current project's packages for vulnerabilities.<r>
                 \\  <b><green>bun audit<r>
                 \\
                 \\  <d>Output package vulnerabilities in JSON format.<r>
                 \\  <b><green>bun audit --json<r>
                 \\
-                \\Full documentation is available at <magenta>https://bun.sh/docs/install/audit<r>
+                \\Full documentation is available at <magenta>https://bun.sh/docs/install/audit<r>.
                 \\
             ;
 


### PR DESCRIPTION
### What does this PR do?
- adds documentation links for `bun outdated`, `bun patch`, `bun patch-commit`, `bun audit`, and `bun publish`
- makes spacing and newlines consistent for each command
- adds examples for `bun patch/patch-commit`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually. `bun audit` before:

<img width="369" alt="Screenshot 2025-05-31 at 5 52 39 PM" src="https://github.com/user-attachments/assets/78fb41dd-7e34-41f8-9551-55054a82fad6" />

And after:
<img width="516" alt="Screenshot 2025-05-31 at 5 59 52 PM" src="https://github.com/user-attachments/assets/97917e78-7a9f-400b-8e60-b9162a38ebf5" />



<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
