### PR TITLE
fixed SharedArrayBuffer crashing on transfer

### DIFF
--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -5095,7 +5095,9 @@ private:
             }
 
             RELEASE_ASSERT(m_sharedBuffers->at(index));
-            auto buffer = ArrayBuffer::create(WTFMove(m_sharedBuffers->at(index)));
+            ArrayBufferContents arrayBufferContents;
+            m_sharedBuffers->at(index).shareWith(arrayBufferContents);
+            auto buffer = ArrayBuffer::create(WTFMove(arrayBufferContents));
             JSValue result = getJSValue(buffer.get());
             m_gcBuffer.appendWithCrashOnOverflow(result);
             return result;

--- a/test/js/node/worker_threads/15787.fixture.ts
+++ b/test/js/node/worker_threads/15787.fixture.ts
@@ -1,0 +1,46 @@
+const { isMainThread, Worker, BroadcastChannel } = require("node:worker_threads");
+
+if (isMainThread) {
+  // create a shared buffer with dummy value
+  const sharedBuffer = new SharedArrayBuffer(4);
+  const uint32Array = new Uint32Array(sharedBuffer);
+  uint32Array[0] = 12345;
+
+  // create broadcast channel
+  const mainChannel = new BroadcastChannel("shared-array-buffer");
+
+  // answer to workers
+  mainChannel.onmessage = event => {
+    if (event.data === "request-buffer") {
+      mainChannel.postMessage(sharedBuffer);
+    }
+  };
+
+  // The first worker works!
+  new Worker(__filename);
+
+  // A delayed worker works as well
+  setTimeout(() => {
+    new Worker(__filename);
+  }, 1);
+
+  // Immediately starting another crashes bun - comment next line to make bun 'work'
+  new Worker(__filename);
+
+  setTimeout(() => process.exit(0), 500);
+} else {
+  // Worker thread logic
+  const workerChannel = new BroadcastChannel("shared-array-buffer");
+
+  // Request the SharedArrayBuffer from the main thread
+  workerChannel.postMessage("request-buffer");
+
+  // get the buffer and print it
+  workerChannel.onmessage = event => {
+    if (event.data instanceof SharedArrayBuffer) {
+      const uint32Array = new Uint32Array(event.data);
+      console.log("SharedArrayBuffer bytes:", uint32Array[0]);
+      workerChannel.close();
+    }
+  };
+}

--- a/test/js/node/worker_threads/15787.test.ts
+++ b/test/js/node/worker_threads/15787.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "bun:test";
+import path from "path";
+
+test("SharedArrayBuffer with workers doesn't crash", async () => {
+  expect([path.join(import.meta.dir, "15787.fixture.ts")]).toRun();
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
share `ArrayBufferContents` instead of moving the actual `ArrayBufferContents`
fixes [15787](https://github.com/oven-sh/bun/issues/15787)
<!--


This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
