### PR TITLE
Support Optional Message Argument in RedisClient.ping()

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -609,8 +609,6 @@ declare module "bun" {
      *  @returns Promise that resolves with the message if the server is reachable, or throws an error if the server is not reachable
      */
     ping(message: string | ArrayBufferView | Blob): Promise<string>;
-
-    /** */
   }
 
   /**

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -599,14 +599,14 @@ declare module "bun" {
 
     /**
      *  Ping the server
-     *  @returns Promise that resolves with "PONG" if the server is reachable, or an error if the server is not reachable
+     *  @returns Promise that resolves with "PONG" if the server is reachable, or throws an error if the server is not reachable
      */
-    ping(): Promise<string>;
+    ping(): Promise<"PONG">;
 
     /**
      *  Ping the server with a message
      *  @param message The message to send to the server
-     *  @returns Promise that resolves with the message if the server is reachable, or an error if the server is not reachable
+     *  @returns Promise that resolves with the message if the server is reachable, or throws an error if the server is not reachable
      */
     ping(message: string | ArrayBufferView | Blob): Promise<string>;
 

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -596,6 +596,21 @@ declare module "bun" {
      * @returns Promise that resolves with the value of the key, or null if the key doesn't exist
      */
     getex(key: string | ArrayBufferView | Blob): Promise<string | null>;
+
+    /**
+     *  Ping the server
+     *  @returns Promise that resolves with "PONG" if the server is reachable, or an error if the server is not reachable
+     */
+    ping(): Promise<string>;
+
+    /**
+     *  Ping the server with a message
+     *  @param message The message to send to the server
+     *  @returns Promise that resolves with the message if the server is reachable, or an error if the server is not reachable
+     */
+    ping(message: string | ArrayBufferView | Blob): Promise<string>;
+
+    /** */
   }
 
   /**

--- a/src/valkey/js_valkey_functions.zig
+++ b/src/valkey/js_valkey_functions.zig
@@ -546,6 +546,38 @@ pub fn hmset(this: *JSValkeyClient, globalObject: *JSC.JSGlobalObject, callframe
     return promise.toJS();
 }
 
+// Implement ping (send a PING command with an optional message)
+pub fn ping(this: *JSValkeyClient, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
+    var message_buf: [1]JSArgument = undefined;
+    var args_slice: []JSArgument = &.{};
+
+    if (!callframe.argument(0).isUndefinedOrNull()) {
+        // Only use the first argument if provided, ignore any additional arguments
+        const message = (try fromJS(globalObject, callframe.argument(0))) orelse {
+            return globalObject.throwInvalidArgumentType("ping", "message", "string or buffer");
+        };
+        message_buf[0] = message;
+        args_slice = message_buf[0..1];
+    }
+    defer {
+        for (args_slice) |*item| {
+            item.deinit();
+        }
+    }
+
+    const promise = this.send(
+        globalObject,
+        callframe.this(),
+        &.{
+            .command = "PING",
+            .args = .{ .args = args_slice },
+        },
+    ) catch |err| {
+        return protocol.valkeyErrorToJS(globalObject, "Failed to send PING command", err);
+    };
+    return promise.toJS();
+}
+
 pub const bitcount = compile.@"(key: RedisKey)"("bitcount", "BITCOUNT", "key").call;
 pub const dump = compile.@"(key: RedisKey)"("dump", "DUMP", "key").call;
 pub const expiretime = compile.@"(key: RedisKey)"("expiretime", "EXPIRETIME", "key").call;
@@ -569,7 +601,6 @@ pub const zcard = compile.@"(key: RedisKey)"("zcard", "ZCARD", "key").call;
 pub const zpopmax = compile.@"(key: RedisKey)"("zpopmax", "ZPOPMAX", "key").call;
 pub const zpopmin = compile.@"(key: RedisKey)"("zpopmin", "ZPOPMIN", "key").call;
 pub const zrandmember = compile.@"(key: RedisKey)"("zrandmember", "ZRANDMEMBER", "key").call;
-pub const ping = compile.@"(key: RedisKey)"("ping", "PING", "message").call;
 
 pub const append = compile.@"(key: RedisKey, value: RedisValue)"("append", "APPEND", "key", "value").call;
 pub const getset = compile.@"(key: RedisKey, value: RedisValue)"("getset", "GETSET", "key", "value").call;

--- a/test/js/valkey/unit/ping.test.ts
+++ b/test/js/valkey/unit/ping.test.ts
@@ -26,5 +26,16 @@ describe.skipIf(!isEnabled)("Valkey: PING Command", () => {
       const result = await redis.ping(message);
       expect(result).toBe(message);
     });
+
+    test("should send PING with message as array buffer and return the message", async () => {
+      const redis = ctx.redis;
+
+      const message = new Uint8Array([98, 117, 110]);
+      const result = await redis.ping(message);
+
+      // redis ping always returns a string
+      expect(result).toBeTypeOf("string");
+      expect(result).toBe("bun");
+    });
   });
 });

--- a/test/js/valkey/unit/ping.test.ts
+++ b/test/js/valkey/unit/ping.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { createClient, ctx, isEnabled, ConnectionType } from "../test-utils";
+
+describe.skipIf(!isEnabled)("Valkey: PING Command", () => {
+  beforeEach(() => {
+    if (ctx.redis?.connected) {
+      ctx.redis.close?.();
+    }
+    ctx.redis = createClient(ConnectionType.TCP);
+  });
+
+  describe("Basic PING Operations", () => {
+    test("should send PING without message and return PONG", async () => {
+      const redis = ctx.redis;
+
+      // Test ping without arguments
+      const result = await redis.ping();
+      expect(result).toBe("PONG");
+    });
+
+    test("should send PING with message and return the message", async () => {
+      const redis = ctx.redis;
+
+      // Test ping with message
+      const message = "Hello World";
+      const result = await redis.ping(message);
+      expect(result).toBe(message);
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes the `PING` command implementation to properly handle optional string arguments. With this change:

- `RedisClient.ping()` returns `PONG` when called with no arguments
- `RedisClient.ping(<message>)` returns `<message>` as expected

This aligns the behavior with standard Redis protocol and improves client compatibility.

- [x] Documentation or TypeScript types
- [x] Code changes

### How did you verify your code works?

- [x] I wrote automated tests
- [x] I ran my tests locally and they pass (`bun bd test js/valkey/unit/ping.test.ts`)

<!-- If applicable, update these below based on your actual stack -->

- [x] I included a test for the new code, or existing tests cover it
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be *(if working in Zig)*
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed *(if working with JSValue in Zig)*
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun bd test js/valkey/unit/ping.test.ts`)
- [x] I added TypeScript types for the new methods, getters, or setters *(if applicable)*