### PR TITLE
Added rapidhash algorithm

### DIFF
--- a/bench/snippets/hash.mjs
+++ b/bench/snippets/hash.mjs
@@ -50,6 +50,10 @@ bench("murmur64v2 (short)", () => {
   Bun.hash.murmur64v2(shortStr);
 });
 
+bench("rapidhash (short)", () => {
+  Bun.hash.rapidhash(shortStr);
+});
+
 bench("wyhash (128 KB)", () => {
   Bun.hash.wyhash(longStr);
 });
@@ -92,6 +96,10 @@ bench("murmur32v2 (128 KB)", () => {
 
 bench("murmur64v2 (128 KB)", () => {
   Bun.hash.murmur64v2(longStr);
+});
+
+bench("rapidhash (128 KB)", () => {
+  Bun.hash.rapidhash(longStr);
 });
 
 run();

--- a/docs/api/hashing.md
+++ b/docs/api/hashing.md
@@ -175,6 +175,7 @@ Bun.hash.xxHash3("data", 1234);
 Bun.hash.murmur32v3("data", 1234);
 Bun.hash.murmur32v2("data", 1234);
 Bun.hash.murmur64v2("data", 1234);
+Bun.hash.rapidhash("data", 1234);
 ```
 
 ## `Bun.CryptoHasher`

--- a/examples/hashing.js
+++ b/examples/hashing.js
@@ -17,6 +17,7 @@ console.log(Bun.hash.xxHash3(input)); // bigint
 console.log(Bun.hash.murmur32v3(input)); // number
 console.log(Bun.hash.murmur32v2(input)); // number
 console.log(Bun.hash.murmur64v2(input)); // bigint
+console.log(Bun.hash.rapidhash(input)); // bigint
 
 // Second argument accepts a seed where relevant
 console.log(Bun.hash(input, 12345));

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1865,6 +1865,7 @@ declare module "bun" {
     murmur32v3: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur32v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur64v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
+    rapidhash: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
   }
 
   type JavaScriptLoader = "jsx" | "js" | "ts" | "tsx";

--- a/src/bun.js/api/HashObject.zig
+++ b/src/bun.js/api/HashObject.zig
@@ -27,6 +27,7 @@ pub const xxHash3 = hashWrap(struct {
 pub const murmur32v2 = hashWrap(std.hash.murmur.Murmur2_32);
 pub const murmur32v3 = hashWrap(std.hash.murmur.Murmur3_32);
 pub const murmur64v2 = hashWrap(std.hash.murmur.Murmur2_64);
+pub const rapidhash = hashWrap(std.hash.RapidHash);
 
 pub fn create(globalThis: *JSC.JSGlobalObject) JSC.JSValue {
     const function = JSC.createCallback(globalThis, ZigString.static("hash"), 1, wyhash);
@@ -42,6 +43,7 @@ pub fn create(globalThis: *JSC.JSGlobalObject) JSC.JSValue {
         "murmur32v2",
         "murmur32v3",
         "murmur64v2",
+        "rapidhash",
     };
     inline for (fns) |name| {
         const value = JSC.createCallback(

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -66,3 +66,8 @@ it(`Bun.hash.murmur64v2()`, () => {
   gcTick();
   expect(Bun.hash.murmur64v2(new TextEncoder().encode("hello world"))).toBe(0xd3ba2368a832afcen);
 });
+it(`Bun.hash.rapidhash()`, () => {
+  expect(Bun.hash.rapidhash("hello world")).toBe(0x58a89bdcee89c08cn);
+  gcTick();
+  expect(Bun.hash.rapidhash(new TextEncoder().encode("hello world"))).toBe(0x58a89bdcee89c08cn);
+});


### PR DESCRIPTION
### What does this PR do?

This adds wyhash's successor algorithm[1], rapidhash, to Bun.hash.

You could make a case whether it should be named `rapidHash` or `rapidhash`.
Zig's standard library has the object under `RapidHash`, but the algorithm's
author seems to always refer to it as `rapidhash`, so I went with that. Easy to
change though.

Fixes https://github.com/oven-sh/bun/issues/19770


Benchmark:

```
cpu: AMD Ryzen 7 9700X 8-Core Processor
runtime: bun 1.2.16 (x64-linux)

benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
wyhash (short)        13.75 ns/iter     (13.06 ns … 139 ns)  13.36 ns  19.29 ns    103 ns
adler32 (short)       10.88 ns/iter    (10.7 ns … 28.58 ns)  10.85 ns  11.82 ns  19.93 ns
crc32 (short)         16.08 ns/iter   (15.76 ns … 43.04 ns)  15.96 ns   18.5 ns  32.12 ns
cityHash32 (short)    11.34 ns/iter   (10.99 ns … 25.96 ns)  11.37 ns  13.63 ns  17.91 ns
cityHash64 (short)    16.74 ns/iter     (16.05 ns … 132 ns)  16.31 ns  28.34 ns    106 ns
xxHash32 (short)      13.42 ns/iter    (13.21 ns … 27.9 ns)  13.38 ns   14.3 ns  22.27 ns
xxHash64 (short)      16.76 ns/iter      (15.9 ns … 182 ns)   16.3 ns  28.05 ns    121 ns
xxHash3 (short)          17 ns/iter     (16.35 ns … 120 ns)  16.85 ns  18.14 ns    108 ns
murmur32v3 (short)    12.32 ns/iter    (11.5 ns … 25.24 ns)  12.29 ns  13.88 ns  22.31 ns
murmur32v2 (short)     11.2 ns/iter   (11.09 ns … 21.34 ns)  11.19 ns  12.06 ns  16.61 ns
murmur64v2 (short)    15.45 ns/iter     (14.78 ns … 141 ns)  15.09 ns  22.09 ns    111 ns
rapidhash (short)     15.53 ns/iter     (14.88 ns … 132 ns)  15.17 ns  20.38 ns    109 ns
wyhash (128 KB)       3'200 ns/iter   (3'189 ns … 3'307 ns)  3'200 ns  3'307 ns  3'307 ns
adler32 (128 KB)     23'813 ns/iter (23'574 ns … 34'094 ns) 23'765 ns 25'729 ns 27'211 ns
crc32 (128 KB)          190 µs/iter       (189 µs … 200 µs)    189 µs    192 µs    198 µs
cityHash32 (128 KB)  10'669 ns/iter (10'659 ns … 10'696 ns) 10'671 ns 10'696 ns 10'696 ns
cityHash64 (128 KB)   3'945 ns/iter   (3'934 ns … 3'985 ns)  3'947 ns  3'985 ns  3'985 ns
xxHash32 (128 KB)    13'928 ns/iter (13'920 ns … 13'950 ns) 13'927 ns 13'950 ns 13'950 ns
xxHash64 (128 KB)     4'290 ns/iter   (4'273 ns … 4'329 ns)  4'293 ns  4'329 ns  4'329 ns
xxHash3 (128 KB)      1'960 ns/iter   (1'956 ns … 1'995 ns)  1'960 ns  1'977 ns  1'995 ns
murmur32v3 (128 KB)  24'157 ns/iter (23'925 ns … 33'173 ns) 24'106 ns 25'959 ns 26'610 ns
murmur32v2 (128 KB)  23'889 ns/iter (23'555 ns … 32'802 ns) 24'075 ns 25'708 ns 26'360 ns
murmur64v2 (128 KB)  11'972 ns/iter (11'953 ns … 12'052 ns) 11'979 ns 12'052 ns 12'052 ns
rapidhash (128 KB)    3'173 ns/iter   (3'164 ns … 3'196 ns)  3'174 ns  3'196 ns  3'196 ns
```

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)
- [x] I ran the hash benchmarks too
- [x] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
- [x] I added TypeScript types for the new methods, getters, or setters

The zig code is only glue between `wrapHash` and the zig std library, so unsure if these apply:
- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

[1]: https://github.com/wangyi-fudan/wyhash