### PR TITLE
remove `audit` from `bun pm` help

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -260,7 +260,6 @@ _bun_pm_completion() {
             'hash\:"generate & print the hash of the current lockfile" '
             'hash-string\:"print the string used to hash the lockfile" '
             'hash-print\:"print the hash stored in the current lockfile" '
-            'audit\:"run a security audit of dependencies in Bun'\''s lockfile"'
             'cache\:"print the path to the cache folder" '
         )
 
@@ -573,7 +572,7 @@ _bun_outdated_completion() {
         '--no-progress[Disable the progress bar]' \
         '--help[Print this help menu]' &&
         ret=0
-    
+
     case $state in
     config)
         _bun_list_bunfig_toml

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -130,7 +130,6 @@ pub const PackageManagerCommand = struct {
             \\  <b><green>bun pm<r> <blue>hash<r>                 generate & print the hash of the current lockfile
             \\  <b><green>bun pm<r> <blue>hash-string<r>          print the string used to hash the lockfile
             \\  <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile
-            \\  <b><green>bun pm<r> <blue>audit<r>                check installed packages for vulnerabilities
             \\  <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder
             \\  <b><green>bun pm<r> <blue>cache rm<r>             clear the cache
             \\  <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -7519,10 +7519,6 @@ pub const PackageManager = struct {
             break :brk loader;
         };
 
-        if (subcommand == .pm and cli.positionals.len >= 2 and strings.eqlComptime(cli.positionals[1], "audit")) {
-            env.quiet = true;
-        }
-
         env.loadProcess();
         try env.load(entries_option.entries, &[_][]u8{}, .production, false);
 

--- a/test/cli/install/registry/fixtures/audit/generate-audit-fixtures.ts
+++ b/test/cli/install/registry/fixtures/audit/generate-audit-fixtures.ts
@@ -39,7 +39,7 @@ for (const packageJsonPath of absolutes) {
   await $`bun i`.cwd(tmp);
 
   await spawn({
-    cmd: [bunExe(), "pm", "audit"],
+    cmd: [bunExe(), "audit"],
     cwd: tmp,
     env: {
       ...bunEnv,
@@ -50,7 +50,7 @@ for (const packageJsonPath of absolutes) {
   const body = await requestBodyPromise;
 
   const { stdout, exited } = spawn({
-    cmd: [bunExe(), "pm", "audit", "--json"],
+    cmd: [bunExe(), "audit", "--json"],
     cwd: tmp,
     stdout: "pipe",
     stderr: "ignore",


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

Remove `audit` from `bun pm` help & completion

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
