### PR TITLE
Fix calc bug

### DIFF
--- a/src/css/values/length.zig
+++ b/src/css/values/length.zig
@@ -639,28 +639,10 @@ pub const Length = union(enum) {
             std.mem.swap(Length, &a, &b);
         }
 
-        if (a == .calc and b == .calc) {
-            return Length{ .calc = bun.create(allocator, Calc(Length), a.calc.add(allocator, b.calc.*)) };
-        } else if (a == .calc) {
-            switch (a.calc.*) {
-                .value => |v| return v.add__(allocator, b),
-                else => return Length{ .calc = bun.create(allocator, Calc(Length), Calc(Length){
-                    .sum = .{
-                        .left = bun.create(allocator, Calc(Length), a.calc.*),
-                        .right = bun.create(allocator, Calc(Length), b.intoCalc(allocator)),
-                    },
-                }) },
-            }
-        } else if (b == .calc) {
-            switch (b.calc.*) {
-                .value => |v| return a.add__(allocator, v.*),
-                else => return Length{ .calc = bun.create(allocator, Calc(Length), Calc(Length){
-                    .sum = .{
-                        .left = bun.create(allocator, Calc(Length), a.intoCalc(allocator)),
-                        .right = bun.create(allocator, Calc(Length), b.calc.*),
-                    },
-                }) },
-            }
+        if (a == .calc and a.calc.* == .value and b != .calc) {
+            return a.calc.value.add__(allocator, b);
+        } else if (b == .calc and b.calc.* == .value and a != .calc) {
+            return a.add__(allocator, b.calc.value.*);
         } else {
             return Length{ .calc = bun.create(allocator, Calc(Length), Calc(Length){
                 .sum = .{

--- a/src/css/values/percentage.zig
+++ b/src/css/values/percentage.zig
@@ -331,38 +331,10 @@ pub fn DimensionPercentage(comptime D: type) type {
                 std.mem.swap(This, &a, &b);
             }
 
-            if (a == .calc and b == .calc) {
-                return .{ .calc = bun.create(allocator, Calc(DimensionPercentage(D)), a.calc.add(allocator, b.calc.*)) };
-            } else if (a == .calc) {
-                if (a.calc.* == .value) {
-                    return a.calc.value.addImpl(allocator, b);
-                } else {
-                    return .{
-                        .calc = bun.create(
-                            allocator,
-                            Calc(DimensionPercentage(D)),
-                            .{ .sum = .{
-                                .left = bun.create(allocator, Calc(DimensionPercentage(D)), a.calc.*),
-                                .right = bun.create(allocator, Calc(DimensionPercentage(D)), b.intoCalc(allocator)),
-                            } },
-                        ),
-                    };
-                }
-            } else if (b == .calc) {
-                if (b.calc.* == .value) {
-                    return a.addImpl(allocator, b.calc.value.*);
-                } else {
-                    return .{
-                        .calc = bun.create(
-                            allocator,
-                            Calc(DimensionPercentage(D)),
-                            .{ .sum = .{
-                                .left = bun.create(allocator, Calc(DimensionPercentage(D)), a.intoCalc(allocator)),
-                                .right = bun.create(allocator, Calc(DimensionPercentage(D)), b.calc.*),
-                            } },
-                        ),
-                    };
-                }
+            if (a == .calc and a.calc.* == .value and b != .calc) {
+                return a.calc.value.addImpl(allocator, b);
+            } else if (b == .calc and b.calc.* == .value and a != .calc) {
+                return a.addImpl(allocator, b.calc.value.*);
             } else {
                 return .{
                     .calc = bun.create(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -147,6 +147,7 @@ describe("css tests", () => {
       `a { width: calc(10 - 4 - 100% - 2 - 4 - 300% - 8vh + 3ic) }`,
       `a{width:calc(6 - 400% - 2 - 4 - 8vh + 3ic)}`,
     ); // ideally -400% - 8vh + 3ic
+    minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
   describe("border_spacing", () => {
     minify_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -139,6 +139,15 @@ describe("css tests", () => {
       indoc`.rounded-full{height:infinity;border-radius:3.40282e38px;width:-3.40282e38px}`,
     );
   });
+  describe("calc stack overflow", () => {
+    // https://github.com/oven-sh/bun/issues/20128
+    minify_test(`a { width: calc(100% - 2 - 1) }`, `a{width:calc(100% - 2 - 1)}`); // ideally 100% - 3
+    minify_test(`a { width: calc(100% - 2 - 1 + 5vh - 10vh) }`, `a{width:calc(100% - 2 - 1 - 5vh)}`); // ideally 100% - 3 + 5vh
+    minify_test(
+      `a { width: calc(10 - 4 - 100% - 2 - 4 - 300% - 8vh + 3ic) }`,
+      `a{width:calc(6 - 400% - 2 - 4 - 8vh + 3ic)}`,
+    ); // ideally -400% - 8vh + 3ic
+  });
   describe("border_spacing", () => {
     minify_test(
       `


### PR DESCRIPTION
Fixes #20128

Given `calc(calc, calc)`, it would calculate `a.calc.add(b.calc)` which would add `a.calc.add(b.calc)` which would add `a.calc.add(b.calc)` ...

`a { top: calc(100% - 1 * 2 - 8 * 2); }`:
- before: (crash)
- this PR: `a{top:calc(100% - 2 - 16)}`
- ideal: `a{top:calc(100% - 18)}`
