### PR TITLE
Ensure we set the socket flag in LifecycleScriptSubprocess

### DIFF
--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -103,6 +103,7 @@ pub const LifecycleScriptSubprocess = struct {
         output.flags.memfd = false;
         output.flags.received_eof = false;
         output.flags.closed_without_reporting = false;
+
         if (comptime Environment.allow_assert) {
             const flags = bun.sys.getFcntlFlags(fd).unwrap() catch @panic("Failed to get fcntl flags");
             bun.assertWithLocation(flags & bun.O.NONBLOCK == 0, @src());
@@ -237,6 +238,9 @@ pub const LifecycleScriptSubprocess = struct {
 
                     resetOutputFlags(&this.stdout, stdout);
                     try this.stdout.start(stdout, true).unwrap();
+                    if (this.stdout.handle.getPoll()) |poll| {
+                        poll.flags.insert(.socket);
+                    }
                 } else {
                     this.stdout.setParent(this);
                     this.stdout.startMemfd(stdout);
@@ -250,6 +254,9 @@ pub const LifecycleScriptSubprocess = struct {
 
                     resetOutputFlags(&this.stderr, stderr);
                     try this.stderr.start(stderr, true).unwrap();
+                    if (this.stderr.handle.getPoll()) |poll| {
+                        poll.flags.insert(.socket);
+                    }
                 } else {
                     this.stderr.setParent(this);
                     this.stderr.startMemfd(stderr);

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -108,7 +108,7 @@ pub const LifecycleScriptSubprocess = struct {
             bun.assertWithLocation(flags & bun.O.NONBLOCK == 0, @src());
 
             const stat = bun.sys.fstat(fd).unwrap() catch @panic("Failed to fstat");
-            bun.assertWithLocation(std.posix.S.ISSOCK(stat.st_mode), @src());
+            bun.assertWithLocation(std.posix.S.ISSOCK(stat.mode), @src());
         }
     }
 

--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -106,7 +106,7 @@ pub const LifecycleScriptSubprocess = struct {
 
         if (comptime Environment.allow_assert) {
             const flags = bun.sys.getFcntlFlags(fd).unwrap() catch @panic("Failed to get fcntl flags");
-            bun.assertWithLocation(flags & bun.O.NONBLOCK == 0, @src());
+            bun.assertWithLocation(flags & bun.O.NONBLOCK != 0, @src());
 
             const stat = bun.sys.fstat(fd).unwrap() catch @panic("Failed to fstat");
             bun.assertWithLocation(std.posix.S.ISSOCK(stat.mode), @src());


### PR DESCRIPTION
### What does this PR do?

This might make lifecycle scripts run a little bit faster

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
