### PR TITLE
Add ci-ec2.sh

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -341,6 +341,8 @@ function getZigAgent(platform, options) {
 }
 
 /**
+ * Get the instance type to use for running tests. Keep synced with ci-ec2.sh.
+ *
  * @param {Platform} platform
  * @param {PipelineOptions} options
  * @returns {Agent}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -251,6 +251,14 @@ check_features() {
 			gcc_version="13"
 			print "GCC 13: enabled"
 			;;
+		*--clone*)
+			clone_bun=1
+			print "Clone Bun: enabled"
+			;;
+		*--xterm-256color*)
+			xterm_256color=1
+			print "Set TERM=xterm-256color: enabled"
+			;;
 		esac
 	done
 }
@@ -1345,6 +1353,24 @@ clean_system() {
 	done
 }
 
+clone_bun() {
+	if ! [ "$clone_bun" = "1" ]; then
+		return
+	fi
+
+	print "Cloning Bun..."
+	execute_as_user sh -c "cd && git clone https://github.com/oven-sh/bun.git"
+}
+
+set_term() {
+	if ! [ "$xterm_256color" = "1" ]; then
+		return
+	fi
+
+	print "Setting TERM=xterm-256color..."
+	append_to_profile "export TERM=xterm-256color"
+}
+
 main() {
 	check_features "$@"
 	check_operating_system
@@ -1357,6 +1383,8 @@ main() {
 	install_build_essentials
 	install_chromium
 	install_fuse_python
+	clone_bun
+	set_term
 	clean_system
 }
 

--- a/scripts/ci-ec2.sh
+++ b/scripts/ci-ec2.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# wrapper for machine.mjs that makes it easier to create an EC2 box matching our CI test runners
+# usage: ./scripts/ci-ec2.sh <distro> <release> <x64|aarch64>
+
+distro="$1"
+release="$2"
+arch="$3"
+shift 3
+extra="$@"
+
+if [ "$distro" = windows ]; then
+  os=windows
+else
+  os=linux
+fi
+
+if [ "$arch" = x64 ]; then
+  if [ "$os" = windows ]; then
+    instance_type=c7i.2xlarge
+  else
+    instance_type=c7i.xlarge
+  fi
+else
+  instance_type=c8g.xlarge
+fi
+
+if [ "$TERM" = "xterm-ghostty" ]; then
+  ghostty_flag="--feature=xterm-256color"
+else
+  ghostty_flag=""
+fi
+
+# TODO this should be able to use a published image instead of running bootstrap
+exec bun scripts/machine.mjs ssh --cloud=aws --os=$os --distro=$distro --release=$release --arch=$arch --instance-type=$instance_type --feature=clone $ghostty_flag

--- a/scripts/ci-ec2.sh
+++ b/scripts/ci-ec2.sh
@@ -6,7 +6,6 @@ distro="$1"
 release="$2"
 arch="$3"
 shift 3
-extra="$@"
 
 if [ "$distro" = windows ]; then
   os=windows
@@ -31,4 +30,4 @@ else
 fi
 
 # TODO this should be able to use a published image instead of running bootstrap
-exec bun scripts/machine.mjs ssh --cloud=aws --os=$os --distro=$distro --release=$release --arch=$arch --instance-type=$instance_type --feature=clone $ghostty_flag
+exec bun scripts/machine.mjs ssh --cloud=aws --os=$os --distro=$distro --release=$release --arch=$arch --instance-type=$instance_type --feature=clone $ghostty_flag $@


### PR DESCRIPTION
### What does this PR do?

This is a simplified wrapper around machine.mjs which:

- Lets you pass fewer arguments
- Picks the instance type automatically to match CI
- Automatically clones Bun in your home directory
- Automatically sets `TERM=xterm-256color` if you use Ghostty, since the instance won't have Ghostty's terminfo (this makes stuff like pressing delete fail)

Even though I changed `bootstrap.sh`, I don't _think_ this needs to rebuild the CI images or bump the version because the new parts of bootstrap.sh aren't used by test runners. @Electroid will know for sure.

It would be nice if this could use one of our published images instead of running bootstrap.sh, but I'm not sure how to do this (specifically I'm not sure how to find the image IDs or names).

### How did you verify your code works?

I've already used this script a couple times.