### PR TITLE
Add Response HTML bundle support

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -115,7 +115,7 @@ pub const AnyRoute = union(enum) {
         if (argument.as(HTMLBundle)) |html_bundle| {
             const entry = init_ctx.dedupe_html_bundle_map.getOrPut(html_bundle) catch bun.outOfMemory();
             if (!entry.found_existing) {
-                entry.value_ptr.* = HTMLBundle.Route.init(html_bundle);
+                entry.value_ptr.* = HTMLBundle.Route.init(html_bundle, true);
                 return .{ .html = entry.value_ptr.* };
             } else {
                 return .{ .html = entry.value_ptr.dupeRef() };

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1698,6 +1698,23 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     this.renderWithBlobFromBodyValue();
                     return;
                 },
+                .HTMLBundle => |route| {
+                    if (this.isAbortedOrEnded()) {
+                        return;
+                    }
+                    if (this.resp) |resp| {
+                        value.* = .{ .Used = {} };
+                        this.setAbortHandler();
+                        resp.timeout(this.server.?.config.idleTimeout);
+                        route.data.server = this.server.?;
+                        if (this.method == .HEAD) {
+                            route.data.onHEADRequest(this.req.?, resp);
+                        } else {
+                            route.data.onRequest(this.req.?, resp);
+                        }
+                    }
+                    return;
+                },
                 .Locked => |*lock| {
                     if (this.isAbortedOrEnded()) {
                         return;
@@ -2537,3 +2554,4 @@ const AnyRequestContext = JSC.API.AnyRequestContext;
 const VirtualMachine = JSC.VirtualMachine;
 const writeStatus = @import("../server.zig").writeStatus;
 const Fallback = @import("../../../runtime.zig").Fallback;
+const HTMLBundle = JSC.API.HTMLBundle;

--- a/test/js/bun/http/bun-serve-response-htmlbundle.test.ts
+++ b/test/js/bun/http/bun-serve-response-htmlbundle.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { tempDirWithFiles } from "harness";
 import { join } from "path";
 

--- a/test/js/bun/http/bun-serve-response-htmlbundle.test.ts
+++ b/test/js/bun/http/bun-serve-response-htmlbundle.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test";
+import { tempDirWithFiles } from "harness";
+import { join } from "path";
+
+test("Response(htmlImport)", async () => {
+  const dir = tempDirWithFiles("response-htmlbundle", {
+    "index.html": "<!DOCTYPE html><html><body>Hello HTML</body></html>",
+  });
+  const { default: html } = await import(join(dir, "index.html"));
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(html);
+    },
+  });
+  const res = await fetch(server.url);
+  expect(await res.text()).toContain("Hello HTML");
+  const missing = await fetch(server.url + "/index.html");
+  expect(missing.status).toBe(404);
+});


### PR DESCRIPTION
## Summary
- add HTMLBundle variant to `Body.Value`
- route HTML bundle responses in RequestContext
- test `Response(htmlImport)` with Bun.serve
- handle abort/timeout events when serving HTML bundles

## Testing
- `bun bd test test/js/bun/http/bun-serve-response-htmlbundle.test.ts` *(fails: file RENAME failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce43d0948328a4a9c79d32293f92