### PR TITLE
A couple small zig cleanup things

### DIFF
--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -52,7 +52,7 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
         .macos, .ios, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris => struct {
             dir: Dir,
             seek: i64,
-            buf: [8192]u8, // TODO align(@alignOf(os.system.dirent)),
+            buf: [8192]u8 align(@alignOf(std.posix.system.dirent)),
             index: usize,
             end_index: usize,
             received_eof: bool = false,

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -43,7 +43,7 @@ pub fn NewResponse(ssl_flag: i32) type {
         }
 
         pub fn prepareForSendfile(res: *Response) void {
-            return c.uws_res_prepare_for_sendfile(ssl_flag, res.downcast());
+            c.uws_res_prepare_for_sendfile(ssl_flag, res.downcast());
         }
 
         pub fn uncork(_: *Response) void {
@@ -315,9 +315,9 @@ pub const AnyResponse = union(enum) {
         };
     }
     pub fn flushHeaders(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.flushHeaders(),
-        };
+        }
     }
     pub fn getWriteOffset(this: AnyResponse) u64 {
         return switch (this) {
@@ -332,9 +332,9 @@ pub const AnyResponse = union(enum) {
     }
 
     pub fn writeContinue(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.writeContinue(),
-        };
+        }
     }
 
     pub fn state(this: AnyResponse) State {
@@ -358,25 +358,25 @@ pub const AnyResponse = union(enum) {
     }
 
     pub fn onData(this: AnyResponse, comptime UserDataType: type, comptime handler: fn (UserDataType, []const u8, bool) void, optional_data: UserDataType) void {
-        return switch (this) {
+        switch (this) {
             inline .SSL, .TCP => |resp, ssl| resp.onData(UserDataType, struct {
                 pub fn onDataCallback(user_data: UserDataType, _: *uws.NewApp(ssl == .SSL).Response, data: []const u8, last: bool) void {
                     @call(.always_inline, handler, .{ user_data, data, last });
                 }
             }.onDataCallback, optional_data),
-        };
+        }
     }
 
     pub fn writeStatus(this: AnyResponse, status: []const u8) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.writeStatus(status),
-        };
+        }
     }
 
     pub fn writeHeader(this: AnyResponse, key: []const u8, value: []const u8) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.writeHeader(key, value),
-        };
+        }
     }
 
     pub fn write(this: AnyResponse, data: []const u8) WriteResult {
@@ -386,9 +386,9 @@ pub const AnyResponse = union(enum) {
     }
 
     pub fn end(this: AnyResponse, data: []const u8, close_connection: bool) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.end(data, close_connection),
-        };
+        }
     }
 
     pub fn shouldCloseConnection(this: AnyResponse) bool {
@@ -404,27 +404,27 @@ pub const AnyResponse = union(enum) {
     }
 
     pub fn pause(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.pause(),
-        };
+        }
     }
 
     pub fn @"resume"(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.@"resume"(),
-        };
+        }
     }
 
     pub fn writeHeaderInt(this: AnyResponse, key: []const u8, value: u64) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.writeHeaderInt(key, value),
-        };
+        }
     }
 
     pub fn endWithoutBody(this: AnyResponse, close_connection: bool) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.endWithoutBody(close_connection),
-        };
+        }
     }
 
     pub fn onWritable(this: AnyResponse, comptime UserDataType: type, comptime handler: fn (UserDataType, u64, AnyResponse) bool, optional_data: UserDataType) void {
@@ -437,10 +437,10 @@ pub const AnyResponse = union(enum) {
                 return handler(user_data, offset, .{ .TCP = resp });
             }
         };
-        return switch (this) {
+        switch (this) {
             .SSL => |resp| resp.onWritable(UserDataType, wrapper.ssl_handler, optional_data),
             .TCP => |resp| resp.onWritable(UserDataType, wrapper.tcp_handler, optional_data),
-        };
+        }
     }
 
     pub fn onTimeout(this: AnyResponse, comptime UserDataType: type, comptime handler: fn (UserDataType, AnyResponse) void, optional_data: UserDataType) void {
@@ -453,10 +453,10 @@ pub const AnyResponse = union(enum) {
             }
         };
 
-        return switch (this) {
+        switch (this) {
             .SSL => |resp| resp.onTimeout(UserDataType, wrapper.ssl_handler, optional_data),
             .TCP => |resp| resp.onTimeout(UserDataType, wrapper.tcp_handler, optional_data),
-        };
+        }
     }
 
     pub fn onAborted(this: AnyResponse, comptime UserDataType: type, comptime handler: fn (UserDataType, AnyResponse) void, optional_data: UserDataType) void {
@@ -468,51 +468,51 @@ pub const AnyResponse = union(enum) {
                 handler(user_data, .{ .TCP = resp });
             }
         };
-        return switch (this) {
+        switch (this) {
             .SSL => |resp| resp.onAborted(UserDataType, wrapper.ssl_handler, optional_data),
             .TCP => |resp| resp.onAborted(UserDataType, wrapper.tcp_handler, optional_data),
-        };
+        }
     }
 
     pub fn clearAborted(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.clearAborted(),
-        };
+        }
     }
     pub fn clearTimeout(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.clearTimeout(),
-        };
+        }
     }
 
     pub fn clearOnWritable(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.clearOnWritable(),
-        };
+        }
     }
 
     pub fn clearOnData(this: AnyResponse) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.clearOnData(),
-        };
+        }
     }
 
     pub fn endStream(this: AnyResponse, close_connection: bool) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.endStream(close_connection),
-        };
+        }
     }
 
     pub fn corked(this: AnyResponse, comptime handler: anytype, args_tuple: anytype) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.corked(handler, args_tuple),
-        };
+        }
     }
 
     pub fn runCorkedWithType(this: AnyResponse, comptime UserDataType: type, comptime handler: fn (UserDataType) void, optional_data: UserDataType) void {
-        return switch (this) {
+        switch (this) {
             inline else => |resp| resp.runCorkedWithType(UserDataType, handler, optional_data),
-        };
+        }
     }
 
     pub fn upgrade(


### PR DESCRIPTION
### What does this PR do?

- Avoids unnecessary `return` in a `void` fn
- Set the alignment for the dirent struct, similar to https://github.com/ziglang/zig/pull/24078

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
