### PR TITLE
Work around compiler crash in uws.WebSocket

### DIFF
--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -11,6 +11,7 @@
 /// - Maintains zero-cost abstractions over the underlying µWebSockets API
 pub fn NewResponse(ssl_flag: i32) type {
     // making this opaque crashes Zig 0.14.0 when built in Debug or ReleaseSafe
+    // TODO: change to opaque when we have https://github.com/ziglang/zig/pull/23197
     return struct {
         const Response = @This();
         const ssl = ssl_flag == 1;

--- a/src/deps/uws/WebSocket.zig
+++ b/src/deps/uws/WebSocket.zig
@@ -1,5 +1,6 @@
 pub fn NewWebSocket(comptime ssl_flag: c_int) type {
-    return opaque {
+    // TODO: change to opaque when we have https://github.com/ziglang/zig/pull/23197
+    return struct {
         const WebSocket = @This();
 
         pub fn raw(this: *WebSocket) *RawWebSocket {


### PR DESCRIPTION
### What does this PR do?

Restores the other workaround for ziglang/zig#22869 (which is fixed upstream but not yet in the Zig version that we use) that was lost in #20138

### How did you verify your code works?

`bun run build -DZIG_COMPILER_SAFE=ON` doesn't crash