### PR TITLE
Make DebugData.magic enum nonexhaustive

### DIFF
--- a/src/ptr/ref_count.zig
+++ b/src/ptr/ref_count.zig
@@ -428,7 +428,7 @@ pub fn DebugData(thread_safe: bool) type {
         const Debug = @This();
         const Count = if (thread_safe) std.atomic.Value(u32) else u32;
 
-        magic: enum(u128) { valid = 0x2f84e51d } align(@alignOf(u32)),
+        magic: enum(u128) { valid = 0x2f84e51d, _ } align(@alignOf(u32)),
         lock: if (thread_safe) std.debug.SafetyLock else bun.Mutex,
         next_id: u32,
         map: std.AutoHashMapUnmanaged(TrackedRef.Id, TrackedRef),


### PR DESCRIPTION
### What does this PR do?

Guards against a theoretical compiler optimization. Previously, since the enum only had a single legal value, it would have been legal for Zig to optimize comparisons against that value (like the one in `assertValid`) to always be true (though this optimization doesn't occur now). Now we say that any u128 is a legal value to ensure that the comparison is done.

### How did you verify your code works?

It compiles