### PR TITLE
`*anyopaque` -> `mach_port_t`

### DIFF
--- a/src/async/posix_event_loop.zig
+++ b/src/async/posix_event_loop.zig
@@ -1132,7 +1132,7 @@ pub const LinuxWaker = struct {
 
 pub const KEventWaker = struct {
     kq: std.posix.fd_t,
-    machport: std.c.mach_port_t = undefined,
+    machport: bun.mach_port = undefined,
     machport_buf: []u8 = &.{},
     has_pending_wake: bool = false,
 
@@ -1173,15 +1173,15 @@ pub const KEventWaker = struct {
         );
     }
 
-    extern fn io_darwin_close_machport(std.c.mach_port_t) void;
+    extern fn io_darwin_close_machport(bun.mach_port) void;
 
     extern fn io_darwin_create_machport(
         std.posix.fd_t,
         *anyopaque,
         usize,
-    ) std.c.mach_port_t;
+    ) bun.mach_port;
 
-    extern fn io_darwin_schedule_wakeup(std.c.mach_port_t) bool;
+    extern fn io_darwin_schedule_wakeup(bun.mach_port) bool;
 
     pub fn init() !Waker {
         return initWithFileDescriptor(bun.default_allocator, try std.posix.kqueue());

--- a/src/async/posix_event_loop.zig
+++ b/src/async/posix_event_loop.zig
@@ -1132,7 +1132,7 @@ pub const LinuxWaker = struct {
 
 pub const KEventWaker = struct {
     kq: std.posix.fd_t,
-    machport: *anyopaque = undefined,
+    machport: std.c.mach_port_t = undefined,
     machport_buf: []u8 = &.{},
     has_pending_wake: bool = false,
 
@@ -1155,6 +1155,10 @@ pub const KEventWaker = struct {
     }
 
     pub fn wait(this: Waker) void {
+        if (!bun.FD.fromNative(this.kq).isValid()) {
+            return;
+        }
+
         bun.JSC.markBinding(@src());
         var events = zeroed;
 
@@ -1169,14 +1173,15 @@ pub const KEventWaker = struct {
         );
     }
 
+    extern fn io_darwin_close_machport(std.c.mach_port_t) void;
+
     extern fn io_darwin_create_machport(
-        *anyopaque,
         std.posix.fd_t,
         *anyopaque,
         usize,
-    ) ?*anyopaque;
+    ) std.c.mach_port_t;
 
-    extern fn io_darwin_schedule_wakeup(*anyopaque) bool;
+    extern fn io_darwin_schedule_wakeup(std.c.mach_port_t) bool;
 
     pub fn init() !Waker {
         return initWithFileDescriptor(bun.default_allocator, try std.posix.kqueue());
@@ -1187,11 +1192,13 @@ pub const KEventWaker = struct {
         bun.assert(kq > -1);
         const machport_buf = try allocator.alloc(u8, 1024);
         const machport = io_darwin_create_machport(
-            machport_buf.ptr,
             kq,
             machport_buf.ptr,
             1024,
-        ) orelse return error.MachportCreationFailed;
+        );
+        if (machport == 0) {
+            return error.MachportCreationFailed;
+        }
 
         return Waker{
             .kq = kq,

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -29,9 +29,9 @@ const LibInfo = struct {
     // static int32_t (*getaddrinfo_async_handle_reply)(void*);
     // static void (*getaddrinfo_async_cancel)(mach_port_t);
     // typedef void getaddrinfo_async_callback(int32_t, struct addrinfo*, void*)
-    const GetaddrinfoAsyncStart = fn (*?*anyopaque, noalias node: ?[*:0]const u8, noalias service: ?[*:0]const u8, noalias hints: ?*const std.c.addrinfo, callback: *const GetAddrInfoAsyncCallback, noalias context: ?*anyopaque) callconv(.C) i32;
-    const GetaddrinfoAsyncHandleReply = fn (?**anyopaque) callconv(.C) i32;
-    const GetaddrinfoAsyncCancel = fn (?**anyopaque) callconv(.C) void;
+    const GetaddrinfoAsyncStart = fn (*std.c.mach_port_t, noalias node: ?[*:0]const u8, noalias service: ?[*:0]const u8, noalias hints: ?*const std.c.addrinfo, callback: *const GetAddrInfoAsyncCallback, noalias context: ?*anyopaque) callconv(.C) i32;
+    const GetaddrinfoAsyncHandleReply = fn (?*std.c.mach_port_t) callconv(.C) i32;
+    const GetaddrinfoAsyncCancel = fn (?*std.c.mach_port_t) callconv(.C) void;
 
     var handle: ?*anyopaque = null;
     var loaded = false;
@@ -117,7 +117,7 @@ const LibInfo = struct {
             return promise_value;
         }
 
-        bun.assert(request.backend.libinfo.machport != null);
+        bun.assert(request.backend.libinfo.machport != 0);
         var poll = bun.Async.FilePoll.init(
             this.vm,
             // TODO: WHAT?????????
@@ -131,7 +131,7 @@ const LibInfo = struct {
             this.vm.event_loop_handle.?,
             .machport,
             .one_shot,
-            .fromNative(@intCast(@intFromPtr(request.backend.libinfo.machport))),
+            .fromNative(@bitCast(request.backend.libinfo.machport)),
         );
         bun.assert(rc == .result);
 
@@ -805,15 +805,15 @@ pub const GetAddrInfoRequest = struct {
 
         pub const LibInfo = struct {
             file_poll: ?*bun.Async.FilePoll = null,
-            machport: ?*anyopaque = null,
+            machport: std.c.mach_port_t = 0,
 
-            extern fn getaddrinfo_send_reply(*anyopaque, *const bun.api.DNS.LibInfo.GetaddrinfoAsyncHandleReply) bool;
+            extern fn getaddrinfo_send_reply(std.c.mach_port_t, *const bun.api.DNS.LibInfo.GetaddrinfoAsyncHandleReply) bool;
             pub fn onMachportChange(this: *GetAddrInfoRequest) void {
                 if (comptime !Environment.isMac)
                     unreachable;
                 bun.JSC.markBinding(@src());
 
-                if (!getaddrinfo_send_reply(this.backend.libinfo.machport.?, bun.api.DNS.LibInfo.getaddrinfo_async_handle_reply().?)) {
+                if (!getaddrinfo_send_reply(this.backend.libinfo.machport, bun.api.DNS.LibInfo.getaddrinfo_async_handle_reply().?)) {
                     log("onMachportChange: getaddrinfo_send_reply failed", .{});
                     getAddrInfoAsyncCallback(-1, null, this);
                 }
@@ -1232,11 +1232,11 @@ pub const InternalDNS = struct {
 
         pub const MacAsyncDNS = struct {
             file_poll: ?*bun.Async.FilePoll = null,
-            machport: ?*anyopaque = null,
+            machport: std.c.mach_port_t = 0,
 
-            extern fn getaddrinfo_send_reply(*anyopaque, *const bun.api.DNS.LibInfo.GetaddrinfoAsyncHandleReply) bool;
+            extern fn getaddrinfo_send_reply(std.c.mach_port_t, *const bun.api.DNS.LibInfo.GetaddrinfoAsyncHandleReply) bool;
             pub fn onMachportChange(this: *Request) void {
-                if (!getaddrinfo_send_reply(this.libinfo.machport.?, LibInfo.getaddrinfo_async_handle_reply().?)) {
+                if (!getaddrinfo_send_reply(this.libinfo.machport, LibInfo.getaddrinfo_async_handle_reply().?)) {
                     libinfoCallback(@intFromEnum(std.c.E.NOSYS), null, this);
                 }
             }
@@ -1603,7 +1603,7 @@ pub const InternalDNS = struct {
     pub fn lookupLibinfo(req: *Request, loop: JSC.EventLoopHandle) bool {
         const getaddrinfo_async_start_ = LibInfo.getaddrinfo_async_start() orelse return false;
 
-        var machport: ?*anyopaque = null;
+        var machport: std.c.mach_port_t = 0;
         var service_buf: [bun.fmt.fastDigitCount(std.math.maxInt(u16)) + 2]u8 = undefined;
         const service: ?[*:0]const u8 = if (req.key.port > 0)
             (std.fmt.bufPrintZ(&service_buf, "{d}", .{req.key.port}) catch unreachable).ptr
@@ -1621,12 +1621,11 @@ pub const InternalDNS = struct {
             req,
         );
 
-        if (errno != 0 or machport == null) {
+        if (errno != 0 or machport == 0) {
             return false;
         }
 
-        const fake_fd: i32 = @intCast(@intFromPtr(machport));
-        var poll = bun.Async.FilePoll.init(loop, .fromNative(fake_fd), .{}, InternalDNSRequest, req);
+        var poll = bun.Async.FilePoll.init(loop, .fromNative(@bitCast(machport)), .{}, InternalDNSRequest, req);
         const rc = poll.register(loop.loop(), .machport, true);
 
         if (rc == .err) {
@@ -1657,7 +1656,7 @@ pub const InternalDNS = struct {
             else
                 null;
             const getaddrinfo_async_start_ = LibInfo.getaddrinfo_async_start() orelse return;
-            var machport: ?*anyopaque = null;
+            var machport: std.c.mach_port_t = 0;
             var hints = getHints();
             hints.flags.ADDRCONFIG = false;
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3770,3 +3770,5 @@ pub fn move(dest: []u8, src: []const u8) void {
     }
     _ = bun.c.memmove(dest.ptr, src.ptr, src.len);
 }
+
+pub const mach_port = if (Environment.isMac) std.c.mach_port_t else u32;

--- a/src/darwin.zig
+++ b/src/darwin.zig
@@ -25,6 +25,8 @@ pub const nocancel = struct {
     pub extern "c" fn @"write$NOCANCEL"(fd: c.fd_t, buf: [*]const u8, nbyte: usize) isize;
     pub extern "c" fn @"writev$NOCANCEL"(fd: c.fd_t, buf: [*]const std.posix.iovec_const, count: i32) isize;
     pub extern "c" fn @"pwritev$NOCANCEL"(fd: c.fd_t, buf: [*]const std.posix.iovec_const, count: i32, offset: c.off_t) isize;
+    pub extern "c" fn @"poll$NOCANCEL"(fds: [*]std.posix.pollfd, nfds: c_int, timeout: c_int) isize;
+    pub extern "c" fn @"ppoll$NOCANCEL"(fds: [*]std.posix.pollfd, nfds: c_int, timeout: ?*const std.posix.timespec, sigmask: ?*const std.posix.sigset_t) isize;
 };
 
 pub const OSLog = opaque {

--- a/src/io/io_darwin.cpp
+++ b/src/io/io_darwin.cpp
@@ -9,7 +9,7 @@
 
 #include "wtf/Assertions.h"
 
-extern "C" mach_port_t io_darwin_create_machport(uint64_t wakeup, int32_t fd,
+extern "C" mach_port_t io_darwin_create_machport(int32_t fd,
     void* wakeup_buffer_,
     size_t nbytes)
 {
@@ -117,10 +117,15 @@ extern "C" bool io_darwin_schedule_wakeup(mach_port_t waker)
     }
 }
 
+extern "C" void io_darwin_close_machport(mach_port_t port)
+{
+    mach_port_deallocate(mach_task_self(), port);
+}
+
 #else
 
 // stub out these symbols
-extern "C" int io_darwin_create_machport(unsigned long long wakeup, int fd,
+extern "C" int io_darwin_create_machport(int fd,
     void* wakeup_buffer_,
     unsigned long long nbytes)
 {
@@ -129,5 +134,7 @@ extern "C" int io_darwin_create_machport(unsigned long long wakeup, int fd,
 
 // stub out these symbols
 extern "C" bool io_darwin_schedule_wakeup(void* waker) { return false; }
+
+extern "C" void io_darwin_close_machport(unsigned port) {}
 
 #endif

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -271,6 +271,7 @@ pub const Tag = enum(u8) {
     futime,
     pidfd_open,
     poll,
+    ppoll,
     watch,
     scandir,
 


### PR DESCRIPTION
### What does this PR do?

The zig extern didn't match the C++ extern "C"

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
