### PR TITLE
Fix `dest` field in sys.Error

### DIFF
--- a/src/bun.js/webcore/blob/copy_file.zig
+++ b/src/bun.js/webcore/blob/copy_file.zig
@@ -998,6 +998,7 @@ pub const CopyFileWindows = struct {
         const globalThis = this.event_loop.global;
         const promise = this.promise.swap();
         const err_instance = err.toJSC(globalThis);
+
         var event_loop = this.event_loop;
         event_loop.enter();
         defer event_loop.exit();
@@ -1109,9 +1110,10 @@ pub const CopyFileWindows = struct {
     fn onMkdirpComplete(this: *CopyFileWindows) void {
         this.event_loop.unrefConcurrently();
 
-        if (this.err) |err| {
+        if (bun.take(&this.err)) |err| {
             this.throw(err);
-            bun.default_allocator.free(err.path);
+            var err2 = err;
+            err2.deinit();
             return;
         }
 

--- a/src/shell/builtin/mv.zig
+++ b/src/shell/builtin/mv.zig
@@ -352,12 +352,12 @@ pub fn batchedMoveTaskDone(this: *Mv, task: *ShellMvBatchedTask) void {
 
     var exec = &this.state.executing;
 
-    if (task.err) |err| {
+    if (task.err) |*err| {
         exec.error_signal.store(true, .seq_cst);
         if (exec.err == null) {
-            exec.err = err;
+            exec.err = err.*;
         } else {
-            bun.default_allocator.free(err.path);
+            err.deinit();
         }
     }
 

--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -581,7 +581,8 @@ pub const ShellRmTask = struct {
                         this.task_manager.err = err;
                         this.task_manager.error_signal.store(true, .seq_cst);
                     } else {
-                        bun.default_allocator.free(err.path);
+                        var err2 = err;
+                        err2.deinit();
                     }
                 },
                 .result => {},
@@ -596,7 +597,7 @@ pub const ShellRmTask = struct {
                 this.task_manager.err = err;
                 this.task_manager.error_signal.store(true, .seq_cst);
             } else {
-                bun.default_allocator.free(err.path);
+                this.task_manager.err.?.deinit();
             }
         }
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -423,6 +423,18 @@ pub const Error = struct {
         };
     }
 
+    /// Only call this after it's been .clone()'d
+    pub fn deinit(this: *Error) void {
+        if (this.path.len > 0) {
+            bun.default_allocator.free(this.path);
+            this.path = "";
+        }
+        if (this.dest.len > 0) {
+            bun.default_allocator.free(this.dest);
+            this.dest = "";
+        }
+    }
+
     pub inline fn withPathDest(this: Error, path: anytype, dest: anytype) Error {
         if (std.meta.Child(@TypeOf(path)) == u16) {
             @compileError("Do not pass WString path to withPathDest, it needs the path encoded as utf8 (path)");


### PR DESCRIPTION
### What does this PR do?

This is the original fix from #19275 extracted into a smaller PR

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
