### PR TITLE
Wait for FSEvents thread to exit before exiting the process

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -219,6 +219,8 @@ comptime {
 }
 
 pub export fn Bun__onExit() void {
+    bun.JSC.Node.FSEvents.closeAndWait();
+
     runExitCallbacks();
     Output.flush();
     std.mem.doNotOptimizeAway(&Bun__atexit);

--- a/src/bun.js/node.zig
+++ b/src/bun.js/node.zig
@@ -36,6 +36,7 @@ pub const Encoding = types.Encoding;
 pub const StringOrBuffer = types.StringOrBuffer;
 pub const BlobOrStringOrBuffer = types.BlobOrStringOrBuffer;
 
+pub const FSEvents = @import("node/fs_events.zig");
 const stat = @import("node/Stat.zig");
 pub const Stats = stat.Stats;
 pub const StatsBig = stat.StatsBig;

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -619,3 +619,16 @@ pub fn watch(path: string, recursive: bool, callback: FSEventsWatcher.Callback, 
         return FSEventsWatcher.init(fsevents_default_loop.?, path, recursive, callback, updateEnd, ctx);
     }
 }
+
+pub fn closeAndWait() void {
+    if (!bun.Environment.isMac) {
+        return;
+    }
+
+    if (fsevents_default_loop) |loop| {
+        fsevents_default_loop_mutex.lock();
+        defer fsevents_default_loop_mutex.unlock();
+        loop.deinit();
+        fsevents_default_loop = null;
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a rare crash that could occur on macOS when the main thread already exited

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
