### PR TITLE
Display symlink target path when failing to open one

### DIFF
--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -41,3 +41,61 @@ test("writer.end() should not close the fd if it does not own the fd", async () 
     expect(await Bun.file(filename).text()).toBe("");
   }
 });
+
+test("Bun.file() should show symlink target in error when symlink points to non-existent file", async () => {
+  const dir = tempDirWithFiles("broken-symlink-test", {});
+  const target = join(dir, "non-existent-target.txt");
+  const symlink = join(dir, "broken-symlink.txt");
+
+  await fsPromises.symlink(target, symlink);
+
+  const symlinkStats = await fsPromises.lstat(symlink);
+  expect(symlinkStats.isSymbolicLink()).toBe(true);
+
+  try {
+    await fsPromises.stat(target);
+    throw new Error("Target should not exist");
+  } catch {
+    // Expected - target doesn't exist
+  }
+
+  // Test various file operations that should trigger the enhanced error
+  const operations = [
+    { name: "text()", fn: () => Bun.file(symlink).text() },
+    { name: "arrayBuffer()", fn: () => Bun.file(symlink).arrayBuffer() },
+    { name: "stream()", fn: () => Bun.file(symlink).stream() },
+    { name: "bytes()", fn: () => Bun.file(symlink).bytes() },
+  ];
+
+  for (const { name, fn } of operations) {
+    try {
+      await fn();
+    } catch (err: any) {
+      expect(err.message).toContain(symlink);
+      expect(err.message).toContain(target);
+      expect(err.message).toContain("->");
+      expect(err.code).toBe("ENOENT");
+      expect(err.errno).toBe(-2);
+      expect(err.dest).toBe(target);
+    }
+  }
+});
+
+test("Bun.file() should show relative symlink target correctly", async () => {
+  const dir = tempDirWithFiles("relative-symlink-test", {});
+  const subdir = join(dir, "subdir");
+  await fsPromises.mkdir(subdir);
+
+  const target = "../non-existent.txt";
+  const symlink = join(subdir, "relative-link.txt");
+
+  await fsPromises.symlink(target, symlink);
+
+  try {
+    await Bun.file(symlink).text();
+  } catch (err: any) {
+    expect(err.message).toContain(symlink);
+    expect(err.message).toContain(target);
+    expect(err.dest).toBe(target);
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Extends the error message when failing to read a symlink with the target path as well as sets the `dest` field to the target path.

This helps with debugging as it makes it clear to the user the target is ENOENT and not the actual path they are passing to `Bun.file`. This is borne out of my own confusion at seeing the path exists with `ls` and seeing the entry in my VS Code Explorer pane, but not realizing the symlink target has been deleted or the path was even a symlink to begin with.

Fixes #17557

- [x] Code changes

### How did you verify your code works?

```typescript
import { writeFileSync, symlinkSync, unlinkSync } from "fs";
import { join } from "path";

// Create a target file
const targetPath = join(import.meta.dir, "target.txt");
const symlinkPath = join(import.meta.dir, "symlink.txt");

console.log("1. Creating target file:", targetPath);
writeFileSync(targetPath, "Hello from target file");

console.log("2. Creating symlink:", symlinkPath, "->", targetPath);
symlinkSync(targetPath, symlinkPath);

console.log("3. Deleting target file:", targetPath);
unlinkSync(targetPath);

console.log("4. Attempting to open symlink with Bun.file()...");
try {
  const file = Bun.file(symlinkPath);
  console.log("File path:", file.name);
  const content = await file.text();
  console.log("Content:", content);
} catch (error) {
  console.error("Error:", error);
  console.error("Error message:", error.message);
  console.error("Symlink path exists?", await Bun.file(symlinkPath).exists());
}

// Cleanup
try {
  unlinkSync(symlinkPath);
} catch {}
```

Run using `bun bd demo.ts`

Before:

```
1. Creating target file: /Users/tom/Desktop/bun/target.txt
2. Creating symlink: /Users/tom/Desktop/bun/symlink.txt -> /Users/tom/Desktop/bun/target.txt
3. Deleting target file: /Users/tom/Desktop/bun/target.txt
4. Attempting to open symlink with Bun.file()...
File path: /Users/tom/Desktop/bun/symlink.txt
Error: ENOENT: no such file or directory, open '/Users/tom/Desktop/bun/symlink.txt'
    path: "/Users/tom/Desktop/bun/symlink.txt",
 syscall: "open",
   errno: -2,
    code: "ENOENT"
```

After:

```
1. Creating target file: /Users/tom/Desktop/bun/target.txt
2. Creating symlink: /Users/tom/Desktop/bun/symlink.txt -> /Users/tom/Desktop/bun/target.txt
3. Deleting target file: /Users/tom/Desktop/bun/target.txt
4. Attempting to open symlink with Bun.file()...
File path: /Users/tom/Desktop/bun/symlink.txt
Error: ENOENT: no such file or directory, open '/Users/tom/Desktop/bun/symlink.txt' -> '/Users/tom/Desktop/bun/target.txt'
    path: "/Users/tom/Desktop/bun/symlink.txt",
    dest: "/Users/tom/Desktop/bun/target.txt",
 syscall: "open",
   errno: -2,
    code: "ENOENT"
```

I am not skilled in Zig and am a first-time contributor to Bun so I haven't authored the tests yet. I will figure out how to do it but I figured I'd open the pull request first in case there was feedback about a better way to do this or it was immediately clear to the maintainers this is not a fit to go in.

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be

     Not sure how to do that

- [ ] I included a test for the new code, or an existing test covers it

     Not yet but I will figure out how to do this

- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed

     Not dealing with `JSValue` in this change