### PR TITLE
For debug builds on macOS, add heap allocation counter for Zig

### DIFF
--- a/src/heap_breakdown.zig
+++ b/src/heap_breakdown.zig
@@ -4,7 +4,7 @@ const Environment = bun.Environment;
 const Allocator = std.mem.Allocator;
 const vm_size_t = usize;
 
-pub const enabled = Environment.allow_assert and Environment.isMac;
+pub const enabled = Environment.allow_assert and (Environment.isMac or Environment.isLinux);
 
 fn heapLabel(comptime T: type) [:0]const u8 {
     const base_name = if (@hasDecl(T, "heap_label"))
@@ -25,9 +25,10 @@ fn getAllocationCounter(comptime T: type) *std.atomic.Value(usize) {
 
     // Export the counter with the specific naming convention and section
     comptime {
+        const section_name = if (Environment.isMac) "__DATA,BUNHEAPCNT" else ".bunheapcnt";
         @export(&static.active_allocation_counter, .{
             .name = std.fmt.comptimePrint("Bun__allocationCounter__{s}", .{full_name}),
-            .section = "__DATA,BUNHEAPCNT",
+            .section = section_name,
         });
     }
 


### PR DESCRIPTION
This adds a "zig" object to `heapStats` in `bun:jsc` that reports a counter for how many of what types are allocated for tracking in debug builds. 

It does this without allocating memory itself (allowing it to be threadsafe, without needing locks and without making debug builds meaningfully slower) by exporting a u64 for each type to a section to the output binary named `__DATA,BUNHEAPCNT` and then at runtime, we loop through all the symbol from the current macho executable in that section and derefence the pointers to get the active count.

The current malloc heap breakdown implementation reports a single "asan" zone which makes it not useful for seeing the counts. Also, malloc zones keep some extra bytes around which makes it hard to know if those bytes are for malloc_zone's own state or for our types.

Unlike the JSC mechanism for this it will report non-GC memory.