### PR TITLE
node:net: fix crash calling getsockname on native server handle

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1294,6 +1294,7 @@ pub const Listener = struct {
         }
 
         const out = callFrame.argumentsAsArray(1)[0];
+        if (!out.isObject()) return .jsUndefined();
         const socket = this.listener.uws;
 
         var buf: [64]u8 = [_]u8{0} ** 64;

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -689,13 +689,19 @@ it("connectionListener should emit the right amount of times, and with alpnProto
 
 describe("should fuzz the native handle and not crash", () => {
   const handle = require("tls").Server().listen().unref()._handle;
-  for (const k in Object.getOwnPropertyDescriptors(Object.getPrototypeOf(handle))) {
+  const proto = Object.getPrototypeOf(handle);
+  const descs = Object.getOwnPropertyDescriptors(proto);
+  for (const k in descs) {
     for (const v of [undefined, null, "", "a", 24, -3.4, {}, [], Symbol("b")]) {
       it(`${k}(${String(v)})`, () => {
         try {
           handle[k];
+          descs[k].get?.call(handle);
           if (typeof handle[k] != "function") return;
           handle[k].call(handle, v);
+          handle[k].call(undefined, v);
+          handle[k].call(null, v);
+          descs[k].set?.call(handle, v);
         } catch (e) {
           //
         }

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -686,3 +686,20 @@ it("connectionListener should emit the right amount of times, and with alpnProto
   await Promise.all(promises);
   expect(count).toBe(50);
 });
+
+describe("should fuzz the native handle and not crash", () => {
+  const handle = require("tls").Server().listen().unref()._handle;
+  for (const k in Object.getPrototypeOf(handle)) {
+    for (const v of [undefined, null, "", "a", 24, -3.4, {}, [], Symbol("b")]) {
+      it(`${k}(${String(v)})`, () => {
+        try {
+          handle[k];
+          if (typeof handle[k] != "function") return;
+          handle[k].call(handle, v);
+        } catch (e) {
+          //
+        }
+      });
+    }
+  }
+});

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -689,7 +689,7 @@ it("connectionListener should emit the right amount of times, and with alpnProto
 
 describe("should fuzz the native handle and not crash", () => {
   const handle = require("tls").Server().listen().unref()._handle;
-  for (const k in Object.getPrototypeOf(handle)) {
+  for (const k in Object.getOwnPropertyDescriptors(Object.getPrototypeOf(handle))) {
     for (const v of [undefined, null, "", "a", 24, -3.4, {}, [], Symbol("b")]) {
       it(`${k}(${String(v)})`, () => {
         try {


### PR DESCRIPTION
fix crash doing `require("tls").Server().listen().unref()._handle.getsockname()`