### PR TITLE
Fix TOML parser to handle inline tables and table arrays correctly

### DIFF
--- a/src/toml/toml_parser.zig
+++ b/src/toml/toml_parser.zig
@@ -326,6 +326,7 @@ pub const TOML = struct {
                 if (p.lexer.has_newline_before) {
                     is_single_line = false;
                 }
+                p.lexer.allow_double_bracket = true;
                 try p.lexer.expect(.t_close_brace);
                 return expr;
             },
@@ -363,8 +364,8 @@ pub const TOML = struct {
                 if (p.lexer.has_newline_before) {
                     is_single_line = false;
                 }
-                try p.lexer.expect(.t_close_bracket);
                 p.lexer.allow_double_bracket = true;
+                try p.lexer.expect(.t_close_bracket);
                 return array_;
             },
             else => {

--- a/test-toml-fix.toml
+++ b/test-toml-fix.toml
@@ -1,0 +1,10 @@
+[global]
+inline_table = { q1 = 1 }
+
+[[items]]
+q1 = 1
+q2 = 2
+
+[[items]]
+q1 = 3
+q2 = 4

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -40,3 +40,66 @@ it("via dynamic import with type attribute", async () => {
 it("empty via import statement", () => {
   expect(emptyToml).toEqual({});
 });
+
+it("inline table followed by table array", () => {
+  const tomlContent = `
+[global]
+inline_table = { q1 = 1 }
+
+[[items]]
+q1 = 1
+q2 = 2
+
+[[items]]
+q1 = 3
+q2 = 4
+`;
+
+  // Test via Bun's internal TOML parser
+  const Bun = globalThis.Bun;
+  const parsed = Bun.TOML.parse(tomlContent);
+
+  expect(parsed.global).toEqual({
+    inline_table: { q1: 1 },
+  });
+  expect(parsed.items).toEqual([
+    { q1: 1, q2: 2 },
+    { q1: 3, q2: 4 },
+  ]);
+});
+
+it("array followed by table array", () => {
+  const tomlContent = `
+[global]
+array = [1, 2, 3]
+
+[[items]]
+q1 = 1
+`;
+
+  const Bun = globalThis.Bun;
+  const parsed = Bun.TOML.parse(tomlContent);
+
+  expect(parsed.global).toEqual({
+    array: [1, 2, 3],
+  });
+  expect(parsed.items).toEqual([{ q1: 1 }]);
+});
+
+it("nested inline tables", () => {
+  const tomlContent = `
+[global]
+nested = { outer = { inner = 1 } }
+
+[[items]]
+q1 = 1
+`;
+
+  const Bun = globalThis.Bun;
+  const parsed = Bun.TOML.parse(tomlContent);
+
+  expect(parsed.global).toEqual({
+    nested: { outer: { inner: 1 } },
+  });
+  expect(parsed.items).toEqual([{ q1: 1 }]);
+});


### PR DESCRIPTION

AI PR don't trust until CI passes

---


The TOML parser was failing to correctly interpret table array headers (`[[...]]`) when they immediately followed an inline table or array. The `allow_double_bracket` flag in the lexer was not being reset to `true` after parsing these structures, causing `[[` to be lexed as a single `[` and resulting in an "Expected key but found [" error.

To address this:
*   In `src/toml/toml_parser.zig`, `p.lexer.allow_double_bracket = true