### PR TITLE
Fix proxy handling in bun audit

### DIFF
--- a/src/cli/audit_command.zig
+++ b/src/cli/audit_command.zig
@@ -334,6 +334,8 @@ fn sendAuditRequest(allocator: std.mem.Allocator, pm: *PackageManager, body: []c
     defer allocator.free(url_str);
     const url = URL.parse(url_str);
 
+    const http_proxy = pm.env.getHttpProxyFor(url);
+
     var response_buf = try MutableString.init(allocator, 1024);
     var req = http.AsyncHTTP.initSync(
         allocator,
@@ -343,7 +345,7 @@ fn sendAuditRequest(allocator: std.mem.Allocator, pm: *PackageManager, body: []c
         headers.content.ptr.?[0..headers.content.len],
         &response_buf,
         final_compressed_body,
-        null,
+        http_proxy,
         null,
         .follow,
     );

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1,8 +1,7 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers } from "bun:internal-for-testing";
-import { afterAll, beforeAll, beforeEach, describe, expect, test, afterEach } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
-import { readlink } from "fs/promises";
 import { cp, exists, mkdir, rm } from "fs/promises";
 import {
   assertManifestsPopulated,


### PR DESCRIPTION
The `audit` command was not respecting proxy environment variables.

The `sendAuditRequest` function in `src/cli/audit_command.zig` was updated to correctly utilize proxy settings.

*   Previously, `AsyncHTTP.initSync` was called with `null` for the `http_proxy` parameter.
*   A new line was added: `const http_proxy = pm.env.getHttpProxyFor(url)

Fixes #20229