### PR TITLE
some tls tests

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -14,9 +14,9 @@ declare module "bun" {
 }
 
 /** $debug is a preprocessor macro that works like a templated console.log, and only runs in debug mode if you pass
- * BUN_DEBUG_JS=<module>
+ * BUN_DEBUG_JS=1 or BUN_DEBUG_<MODULE>=1
  *
- * So to get node stream to log, you pass BUN_DEBUG_JS=stream or BUN_DEBUG_JS=node:stream
+ * So to get node stream to log, you pass BUN_DEBUG_STREAM=1 or BUN_DEBUG_NODE_STREAM=1
  *
  * This only works in debug builds, the log fn is completely removed in release builds.
  */

--- a/test/js/node/test/parallel/test-tls-server-capture-rejection.js
+++ b/test/js/node/test/parallel/test-tls-server-capture-rejection.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const events = require('events');
+const fixtures = require('../common/fixtures');
+const { createServer, connect } = require('tls');
+const cert = fixtures.readKey('rsa_cert.crt');
+const key = fixtures.readKey('rsa_private.pem');
+
+events.captureRejections = true;
+
+const server = createServer({ cert, key }, common.mustCall(async (sock) => {
+  server.close();
+
+  const _err = new Error('kaboom');
+  sock.on('error', common.mustCall((err) => {
+    assert.strictEqual(err, _err);
+  }));
+  throw _err;
+}));
+
+server.listen(0, common.mustCall(() => {
+  const sock = connect({
+    port: server.address().port,
+    host: server.address().host,
+    rejectUnauthorized: false
+  });
+
+  sock.on('close', common.mustCall());
+}));

--- a/test/js/node/test/parallel/test-tls-server-parent-constructor-options.js
+++ b/test/js/node/test/parallel/test-tls-server-parent-constructor-options.js
@@ -1,0 +1,68 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Test that `tls.Server` constructor options are passed to the parent
+// constructor.
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+};
+
+{
+  const server = tls.createServer(options, common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, false);
+    assert.strictEqual(socket.isPaused(), false);
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, false);
+  assert.strictEqual(server.pauseOnConnect, false);
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      socket.end();
+    }));
+
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
+}
+
+{
+  const server = tls.createServer({
+    allowHalfOpen: true,
+    pauseOnConnect: true,
+    ...options
+  }, common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, true);
+    assert.strictEqual(socket.isPaused(), true);
+    socket.on('end', socket.end);
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, true);
+  assert.strictEqual(server.pauseOnConnect, true);
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      socket.end();
+    }));
+
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
+}


### PR DESCRIPTION
Modify tls to add its callback by listening for 'connection' / 'secureConnection' rather than calling the handler directly. To get two more tests, would have to allow calling .emit("connection") on a tls server with a net socket to create the tls socket

Issues:

- [ ] An error thrown in the tls.createServer() socket callback gets discarded