### PR TITLE
fix(FileRoute) fix eof handling, fix max size handling, fix onReaderError behavior

### DIFF
--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -475,7 +475,7 @@ const StreamTransfer = struct {
         defer scope.exit();
 
         if (!this.state.has_ended_response) {
-            // we need to signal to the client that somethig went wrong, so close the connection
+            // we need to signal to the client that something went wrong, so close the connection
             // sending the end chunk would be a lie and could cause issues
             this.state.has_ended_response = true;
             this.state.waiting_for_writable = false;

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -403,6 +403,7 @@ const StreamTransfer = struct {
                 const chunk = chunk_[0..@min(chunk_.len, max_size.*)];
                 max_size.* -|= chunk.len;
                 if (state_ != .eof and max_size.* == 0) {
+                    this.reader.pause();
                     break :brk .{ chunk, .eof };
                 }
 
@@ -431,7 +432,6 @@ const StreamTransfer = struct {
             .backpressure => {
                 this.resp.onWritable(*StreamTransfer, onWritable, this);
                 this.reader.pause();
-                this.resp.markNeedsMore();
                 this.state.waiting_for_writable = true;
                 this.state.waiting_for_readable = false;
                 return false;

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -303,7 +303,7 @@ const StreamTransfer = struct {
     defer_deinit: ?*bool = null,
     max_size: ?u64 = null,
 
-    delay_eof: ?JSC.AnyTask = null,
+    eof_task: ?JSC.AnyTask = null,
 
     state: packed struct(u8) {
         waiting_for_readable: bool = false,
@@ -410,8 +410,8 @@ const StreamTransfer = struct {
                     if (this.route.server) |server| {
                         this.reader.pause();
                         // we cannot end inside onReadChunk so we schedule it to be done in the next event loop tick
-                        this.delay_eof = JSC.AnyTask.New(StreamTransfer, StreamTransfer.onReaderDone).init(this);
-                        server.vm().enqueueTask(JSC.Task.init(&this.delay_eof.?));
+                        this.eof_task = JSC.AnyTask.New(StreamTransfer, StreamTransfer.onReaderDone).init(this);
+                        server.vm().enqueueTask(JSC.Task.init(&this.eof_task.?));
                     }
                     break :brk .{ chunk, .eof };
                 }

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -468,6 +468,16 @@ const StreamTransfer = struct {
         scope.enter(this);
         defer scope.exit();
 
+        if (!this.state.has_ended_response) {
+            // we need to signal to the client that somethig went wrong, so close the connection
+            // sending the end chunk would be a lie and could cause issues
+            this.state.has_ended_response = true;
+            this.state.waiting_for_writable = false;
+            const resp = this.resp;
+            const route = this.route;
+            route.onResponseComplete(resp);
+            this.resp.forceClose();
+        }
         this.finish();
     }
 

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -449,9 +449,6 @@ const StreamTransfer = struct {
                 this.state.waiting_for_readable = true;
                 this.state.waiting_for_writable = false;
 
-                if (bun.Environment.isWindows)
-                    this.reader.unpause();
-
                 return true;
             },
         }

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -417,7 +417,7 @@ const StreamTransfer = struct {
                     if (this.route.server) |server| {
                         // dont need to ref because we are already holding a ref and will be derefed in onReaderDone
                         this.reader.pause();
-                        // we cannot free inside onReadChunk other would be UAF so we schedule it to be done in the next event loop tick
+                        // we cannot free inside onReadChunk this would be UAF so we schedule it to be done in the next event loop tick
                         this.eof_task = JSC.AnyTask.New(StreamTransfer, StreamTransfer.onReaderDone).init(this);
                         server.vm().enqueueTask(JSC.Task.init(&this.eof_task.?));
                     }
@@ -447,7 +447,7 @@ const StreamTransfer = struct {
 
         switch (this.resp.write(chunk)) {
             .backpressure => {
-                // pause the reader so deref the ref
+                // pause the reader so deref until onWritable
                 defer this.deref();
                 this.resp.onWritable(*StreamTransfer, onWritable, this);
                 this.reader.pause();

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -407,7 +407,7 @@ const StreamTransfer = struct {
                     break :brk .{ chunk, .eof };
                 }
 
-                break :brk .{ chunk_, state_ };
+                break :brk .{ chunk, state_ };
             }
 
             break :brk .{ chunk_, state_ };

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -470,6 +470,15 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             }
         }
 
+        pub fn forceClose(this: *RequestContext) void {
+            if (this.resp) |resp| {
+                defer this.deref();
+                this.detachResponse();
+                this.endRequestStreamingAndDrain();
+                resp.forceClose();
+            }
+        }
+
         pub fn onWritableResponseBuffer(this: *RequestContext, _: u64, resp: *App.Response) bool {
             ctxLog("onWritableResponseBuffer", .{});
 

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -24,6 +24,10 @@ pub fn NewResponse(ssl_flag: i32) type {
             return @as(*c.uws_res, @ptrCast(@alignCast(res)));
         }
 
+        pub inline fn downcastSocket(res: *Response) *bun.uws.us_socket_t {
+            return @as(*bun.uws.us_socket_t, @ptrCast(@alignCast(res)));
+        }
+
         pub fn end(res: *Response, data: []const u8, close_connection: bool) void {
             c.uws_res_end(ssl_flag, res.downcast(), data.ptr, data.len, close_connection);
         }
@@ -458,6 +462,13 @@ pub const AnyResponse = union(enum) {
     pub fn endWithoutBody(this: AnyResponse, close_connection: bool) void {
         switch (this) {
             inline else => |resp| resp.endWithoutBody(close_connection),
+        }
+    }
+
+    pub fn forceClose(this: AnyResponse) void {
+        switch (this) {
+            .SSL => |resp| resp.downcastSocket().close(true, .failure),
+            .TCP => |resp| resp.downcastSocket().close(false, .failure),
         }
     }
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -397,7 +397,6 @@ describe("Bun.file in serve routes", () => {
         for (let i = 0; i < iterations; i++) {
           await iterate();
           Bun.gc();
-         
         }
       },
       60000,

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -397,7 +397,7 @@ describe("Bun.file in serve routes", () => {
         for (let i = 0; i < iterations; i++) {
           await iterate();
           Bun.gc();
-          console.log("Completed iteration", i + 1);
+         
         }
       },
       60000,

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -388,9 +388,10 @@ describe("Bun.file in serve routes", () => {
 
           // Verify all responses are identical
           const expected = results[0];
-          results.forEach(result => {
+          for (const result of results) {
+            expect(result?.length).toBe(expected.length);
             expect(result).toBe(expected);
-          });
+          }
         }
 
         for (let i = 0; i < iterations; i++) {
@@ -398,7 +399,7 @@ describe("Bun.file in serve routes", () => {
           Bun.gc();
         }
       },
-      30000,
+      60000,
     );
 
     it("memory usage stays reasonable", async () => {

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,6 +1,6 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { isWindows, rmScope, tempDirWithFiles } from "harness";
+import { rmScope, tempDirWithFiles } from "harness";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -373,8 +373,8 @@ describe("Bun.file in serve routes", () => {
     test.each(["hello.txt", "large.txt"])(
       "concurrent requests for %s",
       async filename => {
-        const batchSize = isWindows ? 8 : 32;
-        const iterations = isWindows ? 2 : 5;
+        const batchSize = 16;
+        const iterations = 10;
 
         async function iterate() {
           const promises = Array.from({ length: batchSize }, () =>
@@ -397,6 +397,7 @@ describe("Bun.file in serve routes", () => {
         for (let i = 0; i < iterations; i++) {
           await iterate();
           Bun.gc();
+          console.log("Completed iteration", i + 1);
         }
       },
       60000,


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
