### PR TITLE
WIP: fix flaky `bun-serve-file.test.ts`

### DIFF
--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -403,7 +403,7 @@ const StreamTransfer = struct {
                 const chunk = chunk_[0..@min(chunk_.len, max_size.*)];
                 max_size.* -|= chunk.len;
                 if (state_ != .eof and max_size.* == 0) {
-                    break :brk .{ chunk, state_ };
+                    break :brk .{ chunk, .eof };
                 }
 
                 break :brk .{ chunk, state_ };

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -403,7 +403,7 @@ const StreamTransfer = struct {
                 const chunk = chunk_[0..@min(chunk_.len, max_size.*)];
                 max_size.* -|= chunk.len;
                 if (state_ != .eof and max_size.* == 0) {
-                    break :brk .{ chunk, .eof };
+                    break :brk .{ chunk, state_ };
                 }
 
                 break :brk .{ chunk, state_ };

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -406,7 +406,7 @@ const StreamTransfer = struct {
                     break :brk .{ chunk, .eof };
                 }
 
-                break :brk .{ chunk_, state_ };
+                break :brk .{ chunk, state_ };
             }
 
             break :brk .{ chunk_, state_ };

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -373,8 +373,8 @@ describe("Bun.file in serve routes", () => {
     test.each(["hello.txt", "large.txt"])(
       "concurrent requests for %s",
       async filename => {
-        const batchSize = isWindows ? 8 : 32;
-        const iterations = isWindows ? 2 : 5;
+        const batchSize = isWindows ? 8 : 16;
+        const iterations = 2;
 
         async function iterate() {
           const promises = Array.from({ length: batchSize }, () =>
@@ -389,6 +389,7 @@ describe("Bun.file in serve routes", () => {
           // Verify all responses are identical
           const expected = results[0];
           results.forEach(result => {
+            expect(result.length).toBe(expected.length);
             expect(result).toBe(expected);
           });
         }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -373,7 +373,7 @@ describe("Bun.file in serve routes", () => {
     test.each(["hello.txt", "large.txt"])(
       "concurrent requests for %s",
       async filename => {
-        const batchSize = isWindows ? 8 : 16;
+        const batchSize = 16;
         const iterations = 2;
 
         async function iterate() {
@@ -391,7 +391,7 @@ describe("Bun.file in serve routes", () => {
           results.forEach(result => {
             expect(result.length).toBe(expected.length);
             expect(result).toBe(expected);
-          }
+          });
         }
 
         for (let i = 0; i < iterations; i++) {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
