### PR TITLE
Fix --windows-hide-console flag

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -730,20 +730,20 @@ pub const StandaloneModuleGraph = struct {
                     _ = bun.c.fchmod(cloned_executable_fd.native(), 0o777);
                 }
 
+                if (Environment.isWindows and inject_options.windows_hide_console) {
+                    bun.windows.editWin32BinarySubsystem(.{ .handle = cloned_executable_fd }, .windows_gui) catch |err| {
+                        Output.err(err, "failed to disable console on executable", .{});
+                        cleanup(zname, cloned_executable_fd);
+
+                        Global.exit(1);
+                    };
+                }
+
                 return cloned_executable_fd;
             },
         }
 
-        if (Environment.isWindows and inject_options.windows_hide_console) {
-            bun.windows.editWin32BinarySubsystem(.{ .handle = cloned_executable_fd }, .windows_gui) catch |err| {
-                Output.err(err, "failed to disable console on executable", .{});
-                cleanup(zname, cloned_executable_fd);
-
-                Global.exit(1);
-            };
-        }
-
-        return cloned_executable_fd;
+        unreachable;
     }
 
     pub const CompileTarget = @import("./compile_target.zig");

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -542,12 +542,10 @@ extern "C" void bun_initialize_process()
                 }
                 case 1: {
                     SetStdHandle(STD_OUTPUT_HANDLE, uv_get_osfhandle(fd));
-                    ASSERT(GetStdHandle(STD_OUTPUT_HANDLE) == uv_get_osfhandle(fd));
                     break;
                 }
                 case 2: {
                     SetStdHandle(STD_ERROR_HANDLE, uv_get_osfhandle(fd));
-                    ASSERT(GetStdHandle(STD_ERROR_HANDLE) == uv_get_osfhandle(fd));
                     break;
                 }
                 default: {

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3678,6 +3678,7 @@ pub extern "kernel32" fn GetCommandLineW() callconv(.winapi) LPWSTR;
 pub extern "kernel32" fn CreateDirectoryW(lpPathName: [*:0]const u16, lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES) callconv(.winapi) BOOL;
 pub extern "kernel32" fn SetEndOfFile(hFile: HANDLE) callconv(.winapi) BOOL;
 pub extern "kernel32" fn GetProcessTimes(in_hProcess: HANDLE, out_lpCreationTime: *FILETIME, out_lpExitTime: *FILETIME, out_lpKernelTime: *FILETIME, out_lpUserTime: *FILETIME) callconv(.winapi) BOOL;
+pub extern "kernel32" fn SetFilePointerEx(hFile: HANDLE, liDistanceToMove: LARGE_INTEGER, lpNewFilePointer: ?*LARGE_INTEGER, dwMoveMethod: DWORD) callconv(.winapi) BOOL;
 
 /// Returns the original mode, or null on failure
 pub fn updateStdioModeFlags(i: bun.FD.Stdio, opts: struct { set: DWORD = 0, unset: DWORD = 0 }) !DWORD {


### PR DESCRIPTION
### What does this PR do?
As described by #19916, the --windows-hide-console flag didnt work. This was because the code to actually set the subsystem to windows was in an unreachable path and not where it belonged to.

Also, it removes two assertions that wouldnt make sense with /subsystem:windows (and also fail).

### How did you verify your code works?

I tested it locally with a the bun init template and compiled it to a single file executable with `bun-debug build --compile --target=bun-windows-x64 --minify --bytecode --windows-hide-console  ./index.ts --outfile test.exe`