### PR TITLE
[bun build] in cjs node, dont convert `module` to `require.module`

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -2111,12 +2111,12 @@ fn NewPrinter(
 
                         if (p.options.target == .node) {
                             // "__require.module"
-                            if (p.options.require_ref) |require|
-                                p.printSymbol(require)
-                            else
-                                p.print("require");
-
-                            p.print(".module");
+                            if (p.options.require_ref) |require| {
+                                p.printSymbol(require);
+                                p.print(".module");
+                            } else {
+                                p.print("module");
+                            }
                         } else if (p.options.commonjs_module_ref.isValid()) {
                             p.printSymbol(p.options.commonjs_module_ref);
                         } else {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1805,7 +1805,7 @@ describe("bundler", () => {
         import {other} from './other';
         console.log(capture(import.meta.main), capture(require.main === module), ...other);
       `,
-      "/other.ts": /* js */`
+      "/other.ts": /* js */ `
         globalThis['ca' + 'pture'] = x => x;
 
         export const other = [capture(require.main === module), capture(import.meta.main)];

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1799,6 +1799,28 @@ describe("bundler", () => {
       api.expectFile("/out.js").not.toMatch(/[^\.:]module/); // `.module` and `node:module` are ok.
     },
   });
+  itBundled("edgecase/build-cjs-module#20308", {
+    files: {
+      "/entry.ts": /* js */ `
+        import {other} from './other';
+        console.log(capture(import.meta.main), capture(require.main === module), ...other);
+      `,
+      "/other.ts": /* js */`
+        globalThis['ca' + 'pture'] = x => x;
+
+        export const other = [capture(require.main === module), capture(import.meta.main)];
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    capture: ["false", "false", "require.main == module", "require.main == module"],
+    onAfterBundle(api) {
+      console.log(api.readFile("/out.js"));
+      // This should be marked as a CommonJS module
+      api.expectFile("/out.js").toMatch(/\brequire\b/); // __require is not ok
+      api.expectFile("/out.js").toMatch(/[^\.:]module/); // `.module` and `node:module` are not ok.
+    },
+  });
   itBundled("edgecase/IdentifierInEnum#13081", {
     files: {
       "/entry.ts": `


### PR DESCRIPTION
### What does this PR do?

fixes #20308

Context: `module` gets converted to `require.module` in `--format=cjs --target=node`, unfortunately that isn't actually a thing in node/bun so this pr lets it stay to the base module. I'm not sure if this is the right way of going about it and if it effects esm outputs.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

modified existing test to fit cjs mode, and ran it
