### PR TITLE
fix(types): make the RedisClient.del accept spread keys by default

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -220,12 +220,11 @@ declare module "bun" {
     set(key: RedisClient.KeyLike, value: RedisClient.KeyLike, ...options: string[]): Promise<"OK" | string | null>;
 
     /**
-     * Delete a key
-     * @param key The key to delete
-     * @param keys Additional keys to delete
+     * Delete a key(s)
+     * @param keys The keys to delete
      * @returns Promise that resolves with the number of keys removed
      */
-    del(key: RedisClient.KeyLike, ...keys: RedisClient.KeyLike[]): Promise<number>;
+    del(...keys: RedisClient.KeyLike[]): Promise<number>;
 
     /**
      * Increment the integer value of a key by one


### PR DESCRIPTION
### What does this PR do?

- ✅ TypeScript types

This updates the `RedisClient.del` type definition to accept a spread of keys (`...keys`) instead of a required first key followed by optional rest. This change simplifies usage by aligning the type with typical `del(...keys)` usage patterns and improves type safety when deleting multiple keys.

### How did you verify your code works?

- [x] Type definition updated in `redis.d.ts`
- [x] Confirmed the new type supports variadic deletion syntax like `client.del("a", "b", "c")`


Basically it makes it so I can just `client.del(...keysToDel)` instead of hacking something like `client.del("keyThatDoesntExist", ...keysToDel)` for TypeScript not to complain. Also the [Zig code is just defined as `(...keys)`](https://github.com/oven-sh/bun/blob/d6590c4bfa7627f376bdfedd318658dab98d6c38/src/valkey/js_valkey_functions.zig#L615)
