### PR TITLE
only allow numbers in asNumber

### DIFF
--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -2012,7 +2012,7 @@ pub const JSValue = enum(i64) {
     }
 
     pub fn asNumber(this: JSValue) f64 {
-        bun.assert(this.isNumber());
+        bun.debugAssert(this.isNumber());
         if (this.isInt32()) {
             return @floatFromInt(this.asInt32());
         } else {

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -2011,24 +2011,14 @@ pub const JSValue = enum(i64) {
         return null;
     }
 
-    extern fn JSC__JSValue__asNumber(this: JSValue) f64;
     pub fn asNumber(this: JSValue) f64 {
+        bun.assert(this.isNumber());
         if (this.isInt32()) {
-            return @as(f64, @floatFromInt(this.asInt32()));
-        }
-
-        if (isNumber(this)) {
+            return @floatFromInt(this.asInt32());
+        } else {
             // Don't need to check for !isInt32() because above
-            return asDouble(this);
+            return this.asDouble();
         }
-
-        if (this.isUndefinedOrNull()) {
-            return 0.0;
-        } else if (this.isBoolean()) {
-            return if (asBoolean(this)) 1.0 else 0.0;
-        }
-
-        return JSC__JSValue__asNumber(this);
     }
 
     pub fn asDouble(this: JSValue) f64 {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3554,11 +3554,6 @@ JSC::JSCell* JSC__JSValue__asCell(JSC::EncodedJSValue JSValue0)
     auto value = JSC::JSValue::decode(JSValue0);
     return value.asCell();
 }
-double JSC__JSValue__asNumber(JSC::EncodedJSValue JSValue0)
-{
-    auto value = JSC::JSValue::decode(JSValue0);
-    return value.asNumber();
-};
 
 JSC::JSString* JSC__JSValue__asString(JSC::EncodedJSValue JSValue0)
 {

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -197,7 +197,6 @@ CPP_DECL bool JSC__JSValue__asArrayBuffer_(JSC::EncodedJSValue JSValue0, JSC::JS
 CPP_DECL unsigned char JSC__JSValue__asBigIntCompare(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL JSC::JSCell* JSC__JSValue__asCell(JSC::EncodedJSValue JSValue0);
 CPP_DECL JSC::JSInternalPromise* JSC__JSValue__asInternalPromise(JSC::EncodedJSValue JSValue0);
-CPP_DECL double JSC__JSValue__asNumber(JSC::EncodedJSValue JSValue0);
 CPP_DECL JSC::JSPromise* JSC__JSValue__asPromise(JSC::EncodedJSValue JSValue0);
 CPP_DECL JSC::JSString* JSC__JSValue__asString(JSC::EncodedJSValue JSValue0);
 CPP_DECL double JSC__JSValue__coerceToDouble(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2998,7 +2998,7 @@ noinline fn assertionFailureWithMsg(comptime msg: []const u8, args: anytype) nor
 /// }
 /// ```
 pub fn debugAssert(cheap_value_only_plz: bool) callconv(callconv_inline) void {
-    if (comptime !Environment.isDebug) {
+    if (comptime !(Environment.isDebug or Environment.enable_asan)) {
         return;
     }
 


### PR DESCRIPTION
### What does this PR do?

Bans undefined, null, and booleans which should never have been permitted by this function

### How did you verify your code works?

CI only shows the usual failures. This would have broken windows or asan tests if we relied on the old behavior.
