### PR TITLE
zig: make uws Response and WebSocket opaque again

### DIFF
--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -10,10 +10,8 @@
 /// - Offers safe casting between Zig and C representations
 /// - Maintains zero-cost abstractions over the underlying µWebSockets API
 pub fn NewResponse(ssl_flag: i32) type {
-    // making this opaque crashes Zig 0.14.0 when built in Debug or ReleaseSafe
-    // TODO: change to opaque when we have https://github.com/ziglang/zig/pull/23197
-    return struct {
-        const Response = @This();
+    return opaque {
+        const Response = NewResponse(ssl_flag);
         const ssl = ssl_flag == 1;
 
         pub inline fn castRes(res: *c.uws_res) *Response {

--- a/src/deps/uws/WebSocket.zig
+++ b/src/deps/uws/WebSocket.zig
@@ -1,7 +1,6 @@
 pub fn NewWebSocket(comptime ssl_flag: c_int) type {
-    // TODO: change to opaque when we have https://github.com/ziglang/zig/pull/23197
-    return struct {
-        const WebSocket = @This();
+    return opaque {
+        const WebSocket = NewWebSocket(ssl_flag);
 
         pub fn raw(this: *WebSocket) *RawWebSocket {
             return @as(*RawWebSocket, @ptrCast(this));


### PR DESCRIPTION
this wouldve worked before since it avoids the `@This()` but we also upgraded our Zig to 0.14.1 so the bug is fixed now