### PR TITLE
Fix TypeScript non-null assertion with new operator

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -14180,7 +14180,6 @@ fn NewParser_(
                             return error.SyntaxError;
                         }
 
-                        // Non-null assertions should be transparent - no precedence check
                         try p.lexer.next();
                         optional_chain = old_optional_chain;
                     },

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -14180,10 +14180,7 @@ fn NewParser_(
                             return error.SyntaxError;
                         }
 
-                        if (level.gte(.postfix)) {
-                            return left;
-                        }
-
+                        // Non-null assertions should be transparent - no precedence check
                         try p.lexer.next();
                         optional_chain = old_optional_chain;
                     },
@@ -15052,11 +15049,6 @@ fn NewParser_(
                     var args = ExprNodeList{};
 
                     if (comptime is_typescript_enabled) {
-                        // Skip over TypeScript non-null assertions
-                        if (p.lexer.token == .t_exclamation and !p.lexer.has_newline_before) {
-                            try p.lexer.next();
-                        }
-
                         // Skip over TypeScript type arguments here if there are any
                         if (p.lexer.token == .t_less_than) {
                             _ = p.trySkipTypeScriptTypeArgumentsWithBacktracking();

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -729,22 +729,30 @@ describe("Bun.Transpiler", () => {
 
     it("non-null assertion with new operator", () => {
       const exp = ts.expectPrinted_;
-      
+
       // Basic non-null assertion with new operator on nested class
-      exp("const obj = { a: class Abc {} }; const instance = new obj!.a();", 
-          "const obj = {\n  a: class Abc {\n  }\n};\nconst instance = new obj.a");
-      
+      exp(
+        "const obj = { a: class Abc {} }; const instance = new obj!.a();",
+        "const obj = {\n  a: class Abc {\n  }\n};\nconst instance = new obj.a",
+      );
+
       // Non-null assertion with new operator on nested property
-      exp("const obj = { nested: { Class: class NestedClass {} } }; const instance = new obj!.nested.Class();",
-          "const obj = {\n  nested: {\n    Class: class NestedClass {\n    }\n  }\n};\nconst instance = new obj.nested.Class");
-      
+      exp(
+        "const obj = { nested: { Class: class NestedClass {} } }; const instance = new obj!.nested.Class();",
+        "const obj = {\n  nested: {\n    Class: class NestedClass {\n    }\n  }\n};\nconst instance = new obj.nested.Class",
+      );
+
       // Multiple non-null assertions in new expression
-      exp("const obj = { a: { b: class DeepClass {} } }; const instance = new obj!.a!.b();",
-          "const obj = {\n  a: {\n    b: class DeepClass {\n    }\n  }\n};\nconst instance = new obj.a.b");
-      
+      exp(
+        "const obj = { a: { b: class DeepClass {} } }; const instance = new obj!.a!.b();",
+        "const obj = {\n  a: {\n    b: class DeepClass {\n    }\n  }\n};\nconst instance = new obj.a.b",
+      );
+
       // Non-null assertion with new operator and method call
-      exp("const obj = { getClass() { return class MyClass {}; } }; const C = obj!.getClass(); const instance = new C();",
-          "const obj = {\n  getClass() {\n    return class MyClass {\n    };\n  }\n};\nconst C = obj.getClass();\nconst instance = new C");
+      exp(
+        "const obj = { getClass() { return class MyClass {}; } }; const C = obj!.getClass(); const instance = new C();",
+        "const obj = {\n  getClass() {\n    return class MyClass {\n    };\n  }\n};\nconst C = obj.getClass();\nconst instance = new C",
+      );
     });
 
     it("modifiers", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -727,6 +727,26 @@ describe("Bun.Transpiler", () => {
       // err("async <const const T extends X>() => {}", "Unexpected const");
     });
 
+    it("non-null assertion with new operator", () => {
+      const exp = ts.expectPrinted_;
+      
+      // Basic non-null assertion with new operator on nested class
+      exp("const obj = { a: class Abc {} }; const instance = new obj!.a();", 
+          "const obj = {\n  a: class Abc {\n  }\n};\nconst instance = new obj.a");
+      
+      // Non-null assertion with new operator on nested property
+      exp("const obj = { nested: { Class: class NestedClass {} } }; const instance = new obj!.nested.Class();",
+          "const obj = {\n  nested: {\n    Class: class NestedClass {\n    }\n  }\n};\nconst instance = new obj.nested.Class");
+      
+      // Multiple non-null assertions in new expression
+      exp("const obj = { a: { b: class DeepClass {} } }; const instance = new obj!.a!.b();",
+          "const obj = {\n  a: {\n    b: class DeepClass {\n    }\n  }\n};\nconst instance = new obj.a.b");
+      
+      // Non-null assertion with new operator and method call
+      exp("const obj = { getClass() { return class MyClass {}; } }; const C = obj!.getClass(); const instance = new C();",
+          "const obj = {\n  getClass() {\n    return class MyClass {\n    };\n  }\n};\nconst C = obj.getClass();\nconst instance = new C");
+    });
+
     it("modifiers", () => {
       const exp = ts.expectPrinted_;
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -733,25 +733,31 @@ describe("Bun.Transpiler", () => {
       // Basic non-null assertion with new operator on nested class
       exp(
         "const obj = { a: class Abc {} }; const instance = new obj!.a();",
-        "const obj = {\n  a: class Abc {\n  }\n};\nconst instance = new obj.a();",
+        "const obj = { a: class Abc {\n} };\nconst instance = new obj.a",
+      );
+
+      // with constructor
+      exp(
+        "const obj = { a: class Abc { constructor(x) { this.x = x; }} }; const instance = new obj!.a(1);",
+        "const obj = { a: class Abc {\n  constructor(x) {\n    this.x = x;\n  }\n} };\nconst instance = new obj.a(1)",
       );
 
       // Non-null assertion with new operator on nested property
       exp(
         "const obj = { nested: { Class: class NestedClass {} } }; const instance = new obj!.nested.Class();",
-        "const obj = {\n  nested: {\n    Class: class NestedClass {\n    }\n  }\n};\nconst instance = new obj.nested.Class();",
+        "const obj = { nested: { Class: class NestedClass {\n} } };\nconst instance = new obj.nested.Class",
       );
 
       // Multiple non-null assertions in new expression
       exp(
         "const obj = { a: { b: class DeepClass {} } }; const instance = new obj!.a!.b();",
-        "const obj = {\n  a: {\n    b: class DeepClass {\n    }\n  }\n};\nconst instance = new obj.a.b();",
+        "const obj = { a: { b: class DeepClass {\n} } };\nconst instance = new obj.a.b",
       );
 
       // Non-null assertion with new operator and method call
       exp(
         "const obj = { getClass() { return class MyClass {}; } }; const C = obj!.getClass(); const instance = new C();",
-        "const obj = {\n  getClass() {\n    return class MyClass {\n    };\n  }\n};\nconst C = obj.getClass();\nconst instance = new C();",
+        "const obj = { getClass() {\n  return class MyClass {\n  };\n} };\nconst C = obj.getClass();\nconst instance = new C",
       );
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -733,25 +733,25 @@ describe("Bun.Transpiler", () => {
       // Basic non-null assertion with new operator on nested class
       exp(
         "const obj = { a: class Abc {} }; const instance = new obj!.a();",
-        "const obj = {\n  a: class Abc {\n  }\n};\nconst instance = new obj.a",
+        "const obj = {\n  a: class Abc {\n  }\n};\nconst instance = new obj.a();",
       );
 
       // Non-null assertion with new operator on nested property
       exp(
         "const obj = { nested: { Class: class NestedClass {} } }; const instance = new obj!.nested.Class();",
-        "const obj = {\n  nested: {\n    Class: class NestedClass {\n    }\n  }\n};\nconst instance = new obj.nested.Class",
+        "const obj = {\n  nested: {\n    Class: class NestedClass {\n    }\n  }\n};\nconst instance = new obj.nested.Class();",
       );
 
       // Multiple non-null assertions in new expression
       exp(
         "const obj = { a: { b: class DeepClass {} } }; const instance = new obj!.a!.b();",
-        "const obj = {\n  a: {\n    b: class DeepClass {\n    }\n  }\n};\nconst instance = new obj.a.b",
+        "const obj = {\n  a: {\n    b: class DeepClass {\n    }\n  }\n};\nconst instance = new obj.a.b();",
       );
 
       // Non-null assertion with new operator and method call
       exp(
         "const obj = { getClass() { return class MyClass {}; } }; const C = obj!.getClass(); const instance = new C();",
-        "const obj = {\n  getClass() {\n    return class MyClass {\n    };\n  }\n};\nconst C = obj.getClass();\nconst instance = new C",
+        "const obj = {\n  getClass() {\n    return class MyClass {\n    };\n  }\n};\nconst C = obj.getClass();\nconst instance = new C();",
       );
     });
 


### PR DESCRIPTION
## Summary
- Fixes #20106
- Allows TypeScript non-null assertions (\!) to work correctly with the new operator

## Test plan
- Added tests in `test/bundler/transpiler/transpiler.test.js` to verify the fix:
  - Basic non-null assertion with new operator on nested class
  - Non-null assertion with new operator on nested property  
  - Multiple non-null assertions in new expression
  - Non-null assertion with new operator and method call

🤖 Generated with [Claude Code](https://claude.ai/code)