### PR TITLE
`fetch()` block some ports according to whatwg spec

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1712,6 +1712,19 @@ pub fn Bun__fetch_(
             err,
         );
     };
+
+    if (url.isBadPort()) {
+        const err = globalThis.createTypeErrorInstance("fetch failed", .{});
+        // const cause = bun.String.createUTF8ForJS(globalThis, "bad port");
+        const cause = globalThis.createError("bad port", .{});
+        _ = err.put(globalThis, "cause", cause);
+        is_error = true;
+        return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(
+            globalThis,
+            err,
+        );
+    }
+
     if (url.isFile()) {
         url_type = URLType.file;
     } else if (url.isBlob()) {

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1715,7 +1715,6 @@ pub fn Bun__fetch_(
 
     if (url.isBadPort()) {
         const err = globalThis.createTypeErrorInstance("fetch failed", .{});
-        // const cause = bun.String.createUTF8ForJS(globalThis, "bad port");
         const cause = globalThis.createError("bad port", .{});
         _ = err.put(globalThis, "cause", cause);
         is_error = true;

--- a/src/url.zig
+++ b/src/url.zig
@@ -158,6 +158,27 @@ pub const URL = struct {
         return (this.getPort() orelse 0) > 0;
     }
 
+    pub fn isBadPort(this: *const URL) bool {
+        if (this.port.len == 0 or !this.hasHTTPLikeProtocol()) {
+            return false;
+        }
+
+        const port_num = this.getPort() orelse {
+            return false;
+        };
+
+        // https://fetch.spec.whatwg.org/#port-blocking
+        const bad_ports = [_]u16{ 1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6697, 10080 };
+
+        for (bad_ports) |bad_port| {
+            if (port_num == bad_port) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     pub fn isEmpty(this: *const URL) bool {
         return this.href.len == 0;
     }

--- a/test/js/web/fetch/fetch-bad-port.test.ts
+++ b/test/js/web/fetch/fetch-bad-port.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+
+test("fetch should block bad ports", async () => {
+  // Test a few known bad ports
+  const badPorts = [1, 7, 9, 21, 22, 23, 25, 6000];
+
+  for (const port of badPorts) {
+    try {
+      await fetch(`http://localhost:${port}/`);
+      throw new Error(`Expected fetch to localhost:${port} to fail, but it succeeded`);
+    } catch (error) {
+      expect(error).toBeInstanceOf(TypeError);
+      expect(error.message).toBe("fetch failed");
+      expect(error.cause).toBeDefined();
+      expect(error.cause.message).toBe("bad port");
+    }
+  }
+});
+
+test("fetch should allow good ports", async () => {
+  // These ports should be allowed (but might fail to connect)
+  const goodPorts = [80, 443, 8080, 3000];
+
+  for (const port of goodPorts) {
+    try {
+      await fetch(`http://localhost:${port}/`, {
+        signal: AbortSignal.timeout(100),
+      });
+    } catch (error) {
+      // We expect connection errors, but not "bad port" errors
+      expect(error.cause?.message).not.toBe("bad port");
+    }
+  }
+});

--- a/test/js/web/fetch/fetch-bad-port.test.ts
+++ b/test/js/web/fetch/fetch-bad-port.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("fetch should block bad ports", async () => {
   // Test a few known bad ports


### PR DESCRIPTION
### What does this PR do?

fixes #20352 by blocking the ports like undici. the perf impact of this shouldn't be much as only compares the list when manually port is manually set

https://fetch.spec.whatwg.org/#port-blocking

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

made test & manual test