### PR TITLE
zig: .jsUndefined -> .js_undefined

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -767,36 +767,36 @@ declare module "bun:sqlite" {
     /**
      * The actual SQLite column types from the first row of the result set.
      * Useful for expressions and computed columns, which are not covered by `declaredTypes`
-     * 
+     *
      * Returns an array of SQLite type constants as uppercase strings:
      * - `"INTEGER"` for integer values
-     * - `"FLOAT"` for floating-point values  
+     * - `"FLOAT"` for floating-point values
      * - `"TEXT"` for text values
      * - `"BLOB"` for binary data
      * - `"NULL"` for null values
      * - `null` for unknown/unsupported types
-     * 
+     *
      * **Requirements:**
      * - Only available for read-only statements (SELECT queries)
      * - For non-read-only statements, throws an error
-     * 
+     *
      * **Behavior:**
      * - Uses `sqlite3_column_type()` to get actual data types from the first row
      * - Returns `null` for columns with unknown SQLite type constants
-     * 
+     *
      * @example
      * ```ts
      * const stmt = db.prepare("SELECT id, name, age FROM users WHERE id = 1");
-     * 
+     *
      * console.log(stmt.columnTypes);
      * // => ["INTEGER", "TEXT", "INTEGER"]
-     * 
+     *
      * // For expressions:
      * const exprStmt = db.prepare("SELECT length('bun') AS str_length");
      * console.log(exprStmt.columnTypes);
      * // => ["INTEGER"]
      * ```
-     * 
+     *
      * @throws Error if statement is not read-only (INSERT, UPDATE, DELETE, etc.)
      * @since Bun v1.2.13
      */
@@ -804,19 +804,19 @@ declare module "bun:sqlite" {
 
     /**
      * The declared column types from the table schema.
-     * 
+     *
      * Returns an array of declared type strings from `sqlite3_column_decltype()`:
      * - Raw type strings as declared in the CREATE TABLE statement
      * - `null` for columns without declared types (e.g., expressions, computed columns)
-     * 
+     *
      * **Requirements:**
      * - Statement must be executed at least once before accessing this property
      * - Available for both read-only and read-write statements
-     * 
+     *
      * **Behavior:**
      * - Uses `sqlite3_column_decltype()` to get schema-declared types
      * - Returns the exact type string from the table definition
-     * 
+     *
      * @example
      * ```ts
      * // For table columns:
@@ -824,14 +824,14 @@ declare module "bun:sqlite" {
      * stmt.get();
      * console.log(stmt.declaredTypes);
      * // => ["INTEGER", "TEXT", "REAL"]
-     * 
+     *
      * // For expressions (no declared types):
      * const exprStmt = db.prepare("SELECT length('bun') AS str_length");
      * exprStmt.get();
      * console.log(exprStmt.declaredTypes);
      * // => [null]
      * ```
-     * 
+     *
      * @throws Error if statement hasn't been executed
      * @since Bun v1.2.13
      */
@@ -913,10 +913,10 @@ declare module "bun:sqlite" {
      * Native object representing the underlying `sqlite3_stmt`
      *
      * This is left untyped because the ABI of the native bindings may change at any time.
-     * 
+     *
      * For stable, typed access to statement metadata, use the typed properties on the Statement class:
      * - {@link columnNames} for column names
-     * - {@link paramsCount} for parameter count  
+     * - {@link paramsCount} for parameter count
      * - {@link columnTypes} for actual data types from the first row
      * - {@link declaredTypes} for schema-declared column types
      */

--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -321,7 +321,7 @@ pub fn toJS(
 ) bun.JSC.JSValue {
     return switch (this.value) {
         .move, .pending => @panic("Unexpected pending output file"),
-        .noop => .jsUndefined(),
+        .noop => .js_undefined,
         .copy => |copy| brk: {
             const file_blob = JSC.WebCore.Blob.Store.initFile(
                 if (copy.fd.isValid())

--- a/src/bake/FrameworkRouter.zig
+++ b/src/bake/FrameworkRouter.zig
@@ -1110,7 +1110,7 @@ pub const JSFrameworkRouter = struct {
             return global.throwInvalidArguments("Missing options.root", .{});
         defer root.deinit();
 
-        var style = try Style.fromJS(try opts.getOptional(global, "style", JSValue) orelse .jsUndefined(), global);
+        var style = try Style.fromJS(try opts.getOptional(global, "style", JSValue) orelse .js_undefined, global);
         errdefer style.deinit();
 
         const abs_root = try bun.default_allocator.dupe(u8, bun.strings.withoutTrailingSlash(

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -184,7 +184,7 @@ fn messageWithTypeAndLevel_(
         // if value is not an object/array/iterable, don't print a table and just print it
         var tabular_data = vals[0];
         if (tabular_data.isObject()) {
-            const properties: JSValue = if (len >= 2 and vals[1].jsType().isArray()) vals[1] else .jsUndefined();
+            const properties: JSValue = if (len >= 2 and vals[1].jsType().isArray()) vals[1] else .js_undefined;
             var table_printer = TablePrinter.init(
                 global,
                 level,
@@ -2606,7 +2606,7 @@ pub const Formatter = struct {
                     }
 
                     // this case should never happen
-                    return try this.printAs(.Undefined, Writer, writer_, .jsUndefined(), .Cell, enable_ansi_colors);
+                    return try this.printAs(.Undefined, Writer, writer_, .js_undefined, .Cell, enable_ansi_colors);
                 } else if (value.as(bun.api.Timer.TimeoutObject)) |timer| {
                     this.addForNewLine("Timeout(# ) ".len + bun.fmt.fastDigitCount(@as(u64, @intCast(@max(timer.internals.id, 0)))));
                     if (timer.internals.flags.kind == .setInterval) {
@@ -2896,12 +2896,12 @@ pub const Formatter = struct {
             },
             .Event => {
                 const event_type_value: JSValue = brk: {
-                    const value_ = value.get_unsafe(this.globalThis, "type") orelse break :brk .jsUndefined();
+                    const value_ = value.get_unsafe(this.globalThis, "type") orelse break :brk .js_undefined;
                     if (value_.isString()) {
                         break :brk value_;
                     }
 
-                    break :brk .jsUndefined();
+                    break :brk .js_undefined;
                 };
 
                 const event_type = switch (try EventType.map.fromJS(this.globalThis, event_type_value) orelse .unknown) {
@@ -2972,7 +2972,7 @@ pub const Formatter = struct {
                                 comptime Output.prettyFmt("<r><blue>data<d>:<r> ", enable_ansi_colors),
                                 .{},
                             );
-                            const data: JSValue = (try value.fastGet(this.globalThis, .data)) orelse .jsUndefined();
+                            const data: JSValue = (try value.fastGet(this.globalThis, .data)) orelse .js_undefined;
                             const tag = Tag.getAdvanced(data, this.globalThis, .{
                                 .hide_global = true,
                                 .disable_inspect_custom = this.disable_inspect_custom,

--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -61,7 +61,7 @@ pub const ResolveMessage = struct {
                 defer atom.deref();
                 return atom.toJS(globalObject);
             },
-            else => return .jsUndefined(),
+            else => return .js_undefined,
         }
     }
 

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1686,7 +1686,7 @@ pub const main_file_name: string = "bun:main";
 pub export fn Bun__drainMicrotasksFromJS(globalObject: *JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) JSValue {
     _ = callframe; // autofix
     globalObject.bunVM().drainMicrotasks();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn drainMicrotasks(this: *VirtualMachine) void {
@@ -2345,7 +2345,7 @@ fn printErrorFromMaybePrivateData(
 pub fn reportUncaughtException(globalObject: *JSGlobalObject, exception: *Exception) JSValue {
     var jsc_vm = globalObject.bunVM();
     _ = jsc_vm.uncaughtException(globalObject, exception.value(), false);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn printStackTrace(comptime Writer: type, writer: Writer, trace: ZigStackTrace, comptime allow_ansi_colors: bool) !void {

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -356,7 +356,7 @@ pub fn inspectTable(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) 
 
     if (!arguments[1].isArray()) {
         arguments[2] = arguments[1];
-        arguments[1] = .jsUndefined();
+        arguments[1] = .js_undefined;
     }
 
     var formatOptions = ConsoleObject.FormatOptions{
@@ -380,7 +380,7 @@ pub fn inspectTable(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) 
 
     const writer = buffered_writer.writer();
     const Writer = @TypeOf(writer);
-    const properties: JSValue = if (arguments[1].jsType().isArray()) arguments[1] else .jsUndefined();
+    const properties: JSValue = if (arguments[1].jsType().isArray()) arguments[1] else .js_undefined;
     var table_printer = ConsoleObject.TablePrinter.init(
         globalThis,
         .Log,
@@ -527,7 +527,7 @@ pub fn registerMacro(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFram
     arguments[1].protect();
     get_or_put_result.value_ptr.* = arguments[1].asObjectRef();
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn getCWD(globalThis: *JSC.JSGlobalObject, _: *JSC.JSObject) JSC.JSValue {
@@ -694,7 +694,7 @@ pub fn openInEditor(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) 
         return globalThis.throw("Opening editor failed {s}", .{@errorName(err)});
     };
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn getPublicPath(to: string, origin: URL, comptime Writer: type, writer: Writer) void {
@@ -768,7 +768,7 @@ pub fn sleepSync(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) b
     }
 
     std.time.sleep(@as(u64, @intCast(milliseconds)) * std.time.ns_per_ms);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn gc(vm: *JSC.VirtualMachine, sync: bool) usize {
@@ -780,7 +780,7 @@ export fn Bun__gc(vm: *JSC.VirtualMachine, sync: bool) callconv(.C) usize {
 
 pub fn shrink(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     globalObject.vm().shrinkFootprint();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn doResolve(globalThis: *JSC.JSGlobalObject, arguments: []const JSValue) bun.JSError!JSC.JSValue {
@@ -1043,22 +1043,22 @@ pub fn serve(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.J
                     @field(@TypeOf(entry.tag()), @typeName(JSC.API.HTTPServer)) => {
                         var server: *JSC.API.HTTPServer = entry.as(JSC.API.HTTPServer);
                         server.onReloadFromZig(&config, globalObject);
-                        return server.js_value.get() orelse .jsUndefined();
+                        return server.js_value.get() orelse .js_undefined;
                     },
                     @field(@TypeOf(entry.tag()), @typeName(JSC.API.DebugHTTPServer)) => {
                         var server: *JSC.API.DebugHTTPServer = entry.as(JSC.API.DebugHTTPServer);
                         server.onReloadFromZig(&config, globalObject);
-                        return server.js_value.get() orelse .jsUndefined();
+                        return server.js_value.get() orelse .js_undefined;
                     },
                     @field(@TypeOf(entry.tag()), @typeName(JSC.API.DebugHTTPSServer)) => {
                         var server: *JSC.API.DebugHTTPSServer = entry.as(JSC.API.DebugHTTPSServer);
                         server.onReloadFromZig(&config, globalObject);
-                        return server.js_value.get() orelse .jsUndefined();
+                        return server.js_value.get() orelse .js_undefined;
                     },
                     @field(@TypeOf(entry.tag()), @typeName(JSC.API.HTTPSServer)) => {
                         var server: *JSC.API.HTTPSServer = entry.as(JSC.API.HTTPSServer);
                         server.onReloadFromZig(&config, globalObject);
-                        return server.js_value.get() orelse .jsUndefined();
+                        return server.js_value.get() orelse .js_undefined;
                     },
                     else => {},
                 }
@@ -1288,7 +1288,7 @@ pub fn getS3DefaultClient(globalThis: *JSC.JSGlobalObject, _: *JSC.JSObject) JSC
 }
 
 pub fn getValkeyDefaultClient(globalThis: *JSC.JSGlobalObject, _: *JSC.JSObject) JSC.JSValue {
-    const valkey = JSC.API.Valkey.create(globalThis, &.{.jsUndefined()}) catch |err| {
+    const valkey = JSC.API.Valkey.create(globalThis, &.{.js_undefined}) catch |err| {
         if (err != error.JSError) {
             _ = globalThis.throwError(err, "Failed to create Redis client") catch {};
             return .zero;
@@ -1459,7 +1459,7 @@ pub const JSZlib = struct {
     // This has to be `inline` due to the callframe.
     inline fn getOptions(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!struct { JSC.Node.StringOrBuffer, ?JSValue } {
         const arguments = callframe.arguments_old(2).slice();
-        const buffer_value: JSValue = if (arguments.len > 0) arguments[0] else .jsUndefined();
+        const buffer_value: JSValue = if (arguments.len > 0) arguments[0] else .js_undefined;
         const options_val: ?JSValue =
             if (arguments.len > 1 and arguments[1].isObject())
                 arguments[1]
@@ -1731,7 +1731,7 @@ pub const JSZstd = struct {
 
     inline fn getOptions(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!struct { JSC.Node.StringOrBuffer, ?JSValue } {
         const arguments = callframe.arguments();
-        const buffer_value: JSValue = if (arguments.len > 0) arguments[0] else .jsUndefined();
+        const buffer_value: JSValue = if (arguments.len > 0) arguments[0] else .js_undefined;
         const options_val: ?JSValue =
             if (arguments.len > 1 and arguments[1].isObject())
                 arguments[1]
@@ -1765,7 +1765,7 @@ pub const JSZstd = struct {
 
     inline fn getOptionsAsync(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!struct { JSC.Node.StringOrBuffer, ?JSValue, i32 } {
         const arguments = callframe.arguments();
-        const buffer_value: JSValue = if (arguments.len > 0) arguments[0] else .jsUndefined();
+        const buffer_value: JSValue = if (arguments.len > 0) arguments[0] else .js_undefined;
         const options_val: ?JSValue =
             if (arguments.len > 1 and arguments[1].isObject())
                 arguments[1]

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -88,7 +88,7 @@ pub const JSBundler = struct {
             if (try config.getArray(globalThis, "plugins")) |array| {
                 const length = array.getLength(globalThis);
                 var iter = array.arrayIterator(globalThis);
-                var onstart_promise_array: JSValue = .jsUndefined();
+                var onstart_promise_array: JSValue = .js_undefined;
                 var i: usize = 0;
                 while (iter.next()) |plugin| : (i += 1) {
                     if (!plugin.isObject()) {

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -330,8 +330,8 @@ pub const All = struct {
         globalThis.emitWarning(
             warning_string.transferToJS(globalThis),
             warning_type_string.transferToJS(globalThis),
-            .jsUndefined(),
-            .jsUndefined(),
+            .js_undefined,
+            .js_undefined,
         ) catch unreachable;
     }
 
@@ -390,7 +390,7 @@ pub const All = struct {
 
         const countdown_int = try vm.timer.jsValueToCountdown(global, countdown, .clamp, true);
         const wrapped_promise = promise.withAsyncContextIfNeeded(global);
-        return TimeoutObject.init(global, id, .setTimeout, countdown_int, wrapped_promise, .jsUndefined());
+        return TimeoutObject.init(global, id, .setTimeout, countdown_int, wrapped_promise, .js_undefined);
     }
 
     pub fn setImmediate(
@@ -517,7 +517,7 @@ pub const All = struct {
     ) JSError!JSValue {
         JSC.markBinding(@src());
         try clearTimer(id, globalThis, .setImmediate);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
     pub fn clearTimeout(
         globalThis: *JSGlobalObject,
@@ -525,7 +525,7 @@ pub const All = struct {
     ) JSError!JSValue {
         JSC.markBinding(@src());
         try clearTimer(id, globalThis, .setTimeout);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
     pub fn clearInterval(
         globalThis: *JSGlobalObject,
@@ -533,7 +533,7 @@ pub const All = struct {
     ) JSError!JSValue {
         JSC.markBinding(@src());
         try clearTimer(id, globalThis, .setInterval);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     comptime {
@@ -671,7 +671,7 @@ pub const TimeoutObject = struct {
 
     pub fn dispose(this: *TimeoutObject, globalThis: *JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         this.internals.cancel(globalThis.bunVM());
-        return .jsUndefined();
+        return .js_undefined;
     }
 };
 
@@ -766,7 +766,7 @@ pub const ImmediateObject = struct {
 
     pub fn dispose(this: *ImmediateObject, globalThis: *JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         this.internals.cancel(globalThis.bunVM());
-        return .jsUndefined();
+        return .js_undefined;
     }
 };
 
@@ -891,8 +891,8 @@ pub const TimerObjectInternals = struct {
             .setImmediate => .{
                 ImmediateObject.js.callbackGetCached(this_object).?,
                 ImmediateObject.js.argumentsGetCached(this_object).?,
-                .jsUndefined(),
-                .jsUndefined(),
+                .js_undefined,
+                .js_undefined,
             },
             .setTimeout, .setInterval => .{
                 TimeoutObject.js.callbackGetCached(this_object).?,

--- a/src/bun.js/api/UnsafeObject.zig
+++ b/src/bun.js/api/UnsafeObject.zig
@@ -64,7 +64,7 @@ fn dump_mimalloc(globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSErr
     if (bun.heap_breakdown.enabled) {
         dump_zone_malloc_stats();
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 const JSC = bun.JSC;

--- a/src/bun.js/api/bun/dns_resolver.zig
+++ b/src/bun.js/api/bun/dns_resolver.zig
@@ -1787,7 +1787,7 @@ pub const InternalDNS = struct {
         };
 
         prefetch(JSC.VirtualMachine.get().uwsLoop(), hostname_z, port);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn prefetch(loop: *bun.uws.Loop, hostname: ?[:0]const u8, port: u16) void {
@@ -2762,7 +2762,7 @@ pub const DNSResolver = struct {
 
             options = GetAddrInfo.Options.fromJS(optionsObject, globalThis) catch |err| {
                 return switch (err) {
-                    error.InvalidFlags => globalThis.throwInvalidArgumentValue("flags", try optionsObject.getTruthy(globalThis, "flags") orelse .jsUndefined()),
+                    error.InvalidFlags => globalThis.throwInvalidArgumentValue("flags", try optionsObject.getTruthy(globalThis, "flags") orelse .js_undefined),
                     error.JSError => |exception| exception,
                     error.OutOfMemory => |oom| oom,
 
@@ -3245,13 +3245,13 @@ pub const DNSResolver = struct {
         const first_af = try setChannelLocalAddress(channel, globalThis, arguments[0]);
 
         if (arguments.len < 2 or arguments[1].isUndefined()) {
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         const second_af = try setChannelLocalAddress(channel, globalThis, arguments[1]);
 
         if (first_af != second_af) {
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         switch (first_af) {
@@ -3311,7 +3311,7 @@ pub const DNSResolver = struct {
                 const err = c_ares.Error.get(r).?;
                 return globalThis.throwValue(globalThis.createErrorInstance("ares_set_servers_ports error: {s}", .{err.label()}));
             }
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         const allocator = bun.default_allocator;
@@ -3370,7 +3370,7 @@ pub const DNSResolver = struct {
             return globalThis.throwValue(globalThis.createErrorInstance("ares_set_servers_ports error: {s}", .{err.label()}));
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setGlobalServers(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -3402,7 +3402,7 @@ pub const DNSResolver = struct {
         _ = callframe;
         const channel = try this.getChannelOrError(globalThis);
         c_ares.ares_cancel(channel);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     // Resolves the given address and port into a host name and service using the operating system's underlying getnameinfo implementation.

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -419,7 +419,7 @@ pub fn jsAssertSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallF
             }
         }
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn jsGetPackedSettings(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -556,7 +556,7 @@ const Handlers = struct {
 
     pub fn callWriteCallback(this: *Handlers, callback: JSC.JSValue, data: []const JSValue) bool {
         if (!callback.isCallable()) return false;
-        this.vm.eventLoop().runCallback(callback, this.globalObject, .jsUndefined(), data);
+        this.vm.eventLoop().runCallback(callback, this.globalObject, .js_undefined, data);
         return true;
     }
 
@@ -1888,7 +1888,7 @@ pub const H2FrameParser = struct {
         const headers = try JSC.JSValue.createEmptyArray(globalObject, 0);
         headers.ensureStillAlive();
 
-        var sensitiveHeaders = JSC.JSValue.jsUndefined();
+        var sensitiveHeaders: JSValue = .js_undefined;
         var count: usize = 0;
 
         while (true) {
@@ -2075,7 +2075,7 @@ pub const H2FrameParser = struct {
         }
         if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
             var payload = content.data;
-            var originValue = JSC.JSValue.jsUndefined();
+            var originValue: JSValue = .js_undefined;
             var count: usize = 0;
             this.readBuffer.reset();
 
@@ -2609,7 +2609,7 @@ pub const H2FrameParser = struct {
             return globalObject.throwValue(err);
         };
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn loadSettingsFromJSValue(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, options: JSC.JSValue) bun.JSError!void {
@@ -2739,7 +2739,7 @@ pub const H2FrameParser = struct {
             }
             stream.windowSize = windowSizeValue;
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn getCurrentState(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2794,14 +2794,14 @@ pub const H2FrameParser = struct {
                     if (opaque_data_arg.asArrayBuffer(globalObject)) |array_buffer| {
                         const slice = array_buffer.byteSlice();
                         this.sendGoAway(0, @enumFromInt(errorCode), slice, lastStreamID, false);
-                        return .jsUndefined();
+                        return .js_undefined;
                     }
                 }
             }
         }
 
         this.sendGoAway(0, @enumFromInt(errorCode), "", lastStreamID, false);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn ping(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2819,7 +2819,7 @@ pub const H2FrameParser = struct {
         if (args_list.ptr[0].asArrayBuffer(globalObject)) |array_buffer| {
             const slice = array_buffer.slice();
             this.sendPing(false, slice);
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         return globalObject.throw("Expected payload to be a Buffer", .{});
@@ -2843,7 +2843,7 @@ pub const H2FrameParser = struct {
             };
             _ = frame.write(@TypeOf(writer), writer);
             _ = this.write(&buffer);
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         if (origin_arg.isString()) {
@@ -2909,7 +2909,7 @@ pub const H2FrameParser = struct {
             _ = frame.write(@TypeOf(writer), writer);
             _ = this.write(buffer[0..total_length]);
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn altsvc(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2957,11 +2957,11 @@ pub const H2FrameParser = struct {
         if (stream_id > 0) {
             // dont error but dont send frame to invalid stream id
             _ = this.streams.getPtr(stream_id) orelse {
-                return .jsUndefined();
+                return .js_undefined;
             };
         }
         this.sendAltSvc(stream_id, origin_str, value_str);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn getEndAfterHeaders(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -3271,7 +3271,7 @@ pub const H2FrameParser = struct {
                     enqueued = true;
                     // write the full frame in memory and queue the frame
                     // the callback will only be called after the last frame is sended
-                    stream.queueFrame(this, slice, if (offset >= payload.len) callback else JSC.JSValue.jsUndefined(), offset >= payload.len and close);
+                    stream.queueFrame(this, slice, if (offset >= payload.len) callback else .js_undefined, offset >= payload.len and close);
                 } else {
                     const padding = stream.getPadding(size, max_size - 1);
                     const payload_size = size + (if (padding != 0) padding + 1 else 0);
@@ -3321,7 +3321,7 @@ pub const H2FrameParser = struct {
         };
 
         stream.waitForTrailers = false;
-        this.sendData(stream, "", true, JSC.JSValue.jsUndefined());
+        this.sendData(stream, "", true, .js_undefined);
 
         const identifier = stream.getIdentifier();
         identifier.ensureStillAlive();
@@ -3332,7 +3332,7 @@ pub const H2FrameParser = struct {
             stream.state = .HALF_CLOSED_LOCAL;
         }
         this.dispatchWithExtra(.onStreamEnd, identifier, JSC.JSValue.jsNumber(@intFromEnum(stream.state)));
-        return .jsUndefined();
+        return .js_undefined;
     }
     /// validate header name and convert to lowecase if needed
     fn toValidHeaderName(in: []const u8, out: []u8) ![]const u8 {
@@ -3488,7 +3488,7 @@ pub const H2FrameParser = struct {
                             JSC.JSValue.jsNumber(@intFromEnum(ErrorCode.FRAME_SIZE_ERROR)),
                         );
                         this.dispatchWithExtra(.onStreamError, identifier, JSC.JSValue.jsNumber(stream.rstCode));
-                        return .jsUndefined();
+                        return .js_undefined;
                     };
                 }
             } else {
@@ -3527,7 +3527,7 @@ pub const H2FrameParser = struct {
 
                     this.dispatchWithExtra(.onStreamError, identifier, JSC.JSValue.jsNumber(stream.rstCode));
 
-                    return .jsUndefined();
+                    return .js_undefined;
                 };
             }
         }
@@ -3552,7 +3552,7 @@ pub const H2FrameParser = struct {
             stream.state = .HALF_CLOSED_LOCAL;
         }
         this.dispatchWithExtra(.onStreamEnd, identifier, JSC.JSValue.jsNumber(@intFromEnum(stream.state)));
-        return .jsUndefined();
+        return .js_undefined;
     }
     pub fn writeStream(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         JSC.markBinding(@src());
@@ -3649,7 +3649,7 @@ pub const H2FrameParser = struct {
                 this.lastStreamID -= 2;
             }
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn hasNativeRead(this: *H2FrameParser, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
@@ -3686,7 +3686,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         };
 
-        return stream.jsContext.get() orelse .jsUndefined();
+        return stream.jsContext.get() orelse .js_undefined;
     }
 
     pub fn setStreamContext(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -3709,17 +3709,17 @@ pub const H2FrameParser = struct {
         }
 
         stream.setContext(context_arg, globalObject);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn forEachStream(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         JSC.markBinding(@src());
         const args = callframe.arguments();
         if (args.len < 1 or !args[0].isCallable()) {
-            return .jsUndefined();
+            return .js_undefined;
         }
         const callback = args[0];
-        const thisValue: JSValue = if (args.len > 1) args[1] else .jsUndefined();
+        const thisValue: JSValue = if (args.len > 1) args[1] else .js_undefined;
         var count: u32 = 0;
         var it = this.streams.valueIterator();
         while (it.next()) |stream| {
@@ -3727,7 +3727,7 @@ pub const H2FrameParser = struct {
             this.handlers.vm.eventLoop().runCallback(callback, globalObject, thisValue, &[_]JSC.JSValue{value});
             count += 1;
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn emitAbortToAllStreams(this: *H2FrameParser, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -3746,10 +3746,10 @@ pub const H2FrameParser = struct {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
                 stream.freeResources(this, false);
-                this.dispatchWith2Extra(.onAborted, identifier, .jsUndefined(), JSC.JSValue.jsNumber(@intFromEnum(old_state)));
+                this.dispatchWith2Extra(.onAborted, identifier, .js_undefined, JSC.JSValue.jsNumber(@intFromEnum(old_state)));
             }
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn emitErrorToAllStreams(this: *H2FrameParser, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -3774,7 +3774,7 @@ pub const H2FrameParser = struct {
                 this.dispatchWithExtra(.onStreamError, identifier, args_list.ptr[0]);
             }
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn flushFromJS(this: *H2FrameParser, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
@@ -3932,7 +3932,7 @@ pub const H2FrameParser = struct {
                             stream.state = .CLOSED;
                             stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                             this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), JSC.JSValue.jsNumber(stream.rstCode));
-                            return .jsUndefined();
+                            return .js_undefined;
                         };
                     }
                 } else if (!js_value.isEmptyOrUndefinedOrNull()) {
@@ -4205,7 +4205,7 @@ pub const H2FrameParser = struct {
                 const result = try this.readBytes(bytes);
                 bytes = bytes[result..];
             }
-            return .jsUndefined();
+            return .js_undefined;
         }
         return globalObject.throw("Expected data to be a Buffer or ArrayBuffer", .{});
     }
@@ -4266,7 +4266,7 @@ pub const H2FrameParser = struct {
             // if we started with non native and go to native we now control the backpressure internally
             this.has_nonnative_backpressure = false;
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn detachNativeSocket(this: *H2FrameParser) void {
@@ -4441,7 +4441,7 @@ pub const H2FrameParser = struct {
             stream.freeResources(this, false);
         }
         this.detach();
-        return .jsUndefined();
+        return .js_undefined;
     }
     /// be careful when calling detach be sure that the socket is closed and the parser not accesible anymore
     /// this function can be called multiple times, it will erase stream info

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -538,7 +538,7 @@ pub const Listener = struct {
 
     pub fn getData(this: *Listener, _: *JSC.JSGlobalObject) JSValue {
         log("getData()", .{});
-        return this.strong_data.get() orelse JSValue.jsUndefined();
+        return this.strong_data.get() orelse .js_undefined;
     }
 
     pub fn setData(this: *Listener, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) void {
@@ -609,7 +609,7 @@ pub const Listener = struct {
         this.handlers = handlers; // TODO: this is a memory leak
         this.handlers.protect();
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn listen(globalObject: *JSC.JSGlobalObject, opts: JSValue) bun.JSError!JSValue {
@@ -921,12 +921,12 @@ pub const Listener = struct {
             this.socket_context.?.addServerName(true, server_name, ssl_config.asUSockets());
         }
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn dispose(this: *Listener, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         this.doStop(true);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn stop(this: *Listener, _: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -935,7 +935,7 @@ pub const Listener = struct {
 
         this.doStop(if (arguments.len > 0 and arguments.ptr[0].isBoolean()) arguments.ptr[0].toBoolean() else false);
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     fn doStop(this: *Listener, force_close: bool) void {
@@ -1015,7 +1015,7 @@ pub const Listener = struct {
 
     pub fn getUnix(this: *Listener, globalObject: *JSC.JSGlobalObject) JSValue {
         if (this.connection != .unix) {
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         return ZigString.init(this.connection.unix).withEncoding().toJS(globalObject);
@@ -1023,24 +1023,24 @@ pub const Listener = struct {
 
     pub fn getHostname(this: *Listener, globalObject: *JSC.JSGlobalObject) JSValue {
         if (this.connection != .host) {
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
         return ZigString.init(this.connection.host.host).withEncoding().toJS(globalObject);
     }
 
     pub fn getPort(this: *Listener, _: *JSC.JSGlobalObject) JSValue {
         if (this.connection != .host) {
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
         return JSValue.jsNumber(this.connection.host.port);
     }
 
     pub fn ref(this: *Listener, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         const this_value = callframe.this();
-        if (this.listener == .none) return JSValue.jsUndefined();
+        if (this.listener == .none) return .js_undefined;
         this.poll_ref.ref(globalObject.bunVM());
         this.strong_self.set(globalObject, this_value);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn unref(this: *Listener, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
@@ -1048,7 +1048,7 @@ pub const Listener = struct {
         if (this.handlers.active_connections == 0) {
             this.strong_self.clearWithoutDeallocation();
         }
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn connect(globalObject: *JSC.JSGlobalObject, opts: JSValue) bun.JSError!JSValue {
@@ -1290,7 +1290,7 @@ pub const Listener = struct {
 
     pub fn getsockname(this: *Listener, globalThis: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSValue {
         if (this.listener != .uws) {
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         const out = callFrame.argumentsAsArray(1)[0];
@@ -1298,16 +1298,16 @@ pub const Listener = struct {
 
         var buf: [64]u8 = [_]u8{0} ** 64;
         var text_buf: [512]u8 = undefined;
-        const address_bytes: []const u8 = socket.getLocalAddress(this.ssl, &buf) catch return .jsUndefined();
+        const address_bytes: []const u8 = socket.getLocalAddress(this.ssl, &buf) catch return .js_undefined;
         const address_zig: std.net.Address = switch (address_bytes.len) {
             4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
             16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),
-            else => return .jsUndefined(),
+            else => return .js_undefined,
         };
         const family_js = switch (address_bytes.len) {
             4 => bun.String.static("IPv4").toJS(globalThis),
             16 => bun.String.static("IPv6").toJS(globalThis),
-            else => return .jsUndefined(),
+            else => return .js_undefined,
         };
         const address_js = ZigString.init(bun.fmt.formatIp(address_zig, &text_buf) catch unreachable).toJS(globalThis);
         const port_js: JSValue = .jsNumber(socket.getLocalPort(this.ssl));
@@ -1315,7 +1315,7 @@ pub const Listener = struct {
         out.put(globalThis, bun.String.static("family"), family_js);
         out.put(globalThis, bun.String.static("address"), address_js);
         out.put(globalThis, bun.String.static("port"), port_js);
-        return .jsUndefined();
+        return .js_undefined;
     }
 };
 
@@ -1501,19 +1501,19 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn resumeFromJS(this: *This, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
-            if (this.socket.isDetached()) return .jsUndefined();
+            if (this.socket.isDetached()) return .js_undefined;
 
             log("resume", .{});
             // we should not allow pausing/resuming a wrapped socket because a wrapped socket is 2 sockets and this can cause issues
             if (this.wrapped == .none and this.flags.is_paused) {
                 this.flags.is_paused = !this.socket.resumeStream();
             }
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         pub fn pauseFromJS(this: *This, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
-            if (this.socket.isDetached()) return .jsUndefined();
+            if (this.socket.isDetached()) return .js_undefined;
 
             log("pause", .{});
             // we should not allow pausing/resuming a wrapped socket because a wrapped socket is 2 sockets and this can cause issues
@@ -1521,7 +1521,7 @@ fn NewSocket(comptime ssl: bool) type {
                 this.flags.is_paused = this.socket.pauseStream();
             }
 
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         pub fn setKeepAlive(this: *This, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -1972,7 +1972,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             const globalObject = handlers.globalObject;
             const this_value = this.getThisValue(globalObject);
-            var js_error: JSValue = .jsUndefined();
+            var js_error: JSValue = .js_undefined;
             if (err != 0) {
                 // errors here are always a read error
                 js_error = bun.sys.Error.fromCodeInt(err, .read).toJSC(globalObject);
@@ -2019,7 +2019,7 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getData(_: *This, _: *JSC.JSGlobalObject) JSValue {
             log("getData()", .{});
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn setData(this: *This, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) void {
@@ -2029,11 +2029,11 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getListener(this: *This, _: *JSC.JSGlobalObject) JSValue {
             if (!this.handlers.is_server or this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const l: *Listener = @fieldParentPtr("handlers", this.handlers);
-            return l.strong_self.get() orelse JSValue.jsUndefined();
+            return l.strong_self.get() orelse .js_undefined;
         }
 
         pub fn getReadyState(this: *This, _: *JSC.JSGlobalObject) JSValue {
@@ -2058,7 +2058,7 @@ fn NewSocket(comptime ssl: bool) type {
         pub fn timeout(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
             const args = callframe.arguments_old(1);
-            if (this.socket.isDetached()) return JSValue.jsUndefined();
+            if (this.socket.isDetached()) return .js_undefined;
             if (args.len == 0) {
                 return globalObject.throw("Expected 1 argument, got 0", .{});
             }
@@ -2070,7 +2070,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             this.socket.setTimeout(@as(c_uint, @intCast(t)));
 
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getAuthorizationError(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2116,31 +2116,31 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getLocalFamily(this: *This, globalThis: *JSC.JSGlobalObject) JSValue {
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             var buf: [64]u8 = [_]u8{0} ** 64;
-            const address_bytes: []const u8 = this.socket.localAddress(&buf) orelse return JSValue.jsUndefined();
+            const address_bytes: []const u8 = this.socket.localAddress(&buf) orelse return .js_undefined;
             return switch (address_bytes.len) {
                 4 => bun.String.static("IPv4").toJS(globalThis),
                 16 => bun.String.static("IPv6").toJS(globalThis),
-                else => return JSValue.jsUndefined(),
+                else => return .js_undefined,
             };
         }
 
         pub fn getLocalAddress(this: *This, globalThis: *JSC.JSGlobalObject) JSValue {
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             var buf: [64]u8 = [_]u8{0} ** 64;
             var text_buf: [512]u8 = undefined;
 
-            const address_bytes: []const u8 = this.socket.localAddress(&buf) orelse return JSValue.jsUndefined();
+            const address_bytes: []const u8 = this.socket.localAddress(&buf) orelse return .js_undefined;
             const address: std.net.Address = switch (address_bytes.len) {
                 4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
                 16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),
-                else => return JSValue.jsUndefined(),
+                else => return .js_undefined,
             };
 
             const text = bun.fmt.formatIp(address, &text_buf) catch unreachable;
@@ -2149,7 +2149,7 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getLocalPort(this: *This, _: *JSC.JSGlobalObject) JSValue {
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             return JSValue.jsNumber(this.socket.localPort());
@@ -2157,31 +2157,31 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getRemoteFamily(this: *This, globalThis: *JSC.JSGlobalObject) JSValue {
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             var buf: [64]u8 = [_]u8{0} ** 64;
-            const address_bytes: []const u8 = this.socket.remoteAddress(&buf) orelse return JSValue.jsUndefined();
+            const address_bytes: []const u8 = this.socket.remoteAddress(&buf) orelse return .js_undefined;
             return switch (address_bytes.len) {
                 4 => bun.String.static("IPv4").toJS(globalThis),
                 16 => bun.String.static("IPv6").toJS(globalThis),
-                else => return JSValue.jsUndefined(),
+                else => return .js_undefined,
             };
         }
 
         pub fn getRemoteAddress(this: *This, globalThis: *JSC.JSGlobalObject) JSValue {
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             var buf: [64]u8 = [_]u8{0} ** 64;
             var text_buf: [512]u8 = undefined;
 
-            const address_bytes: []const u8 = this.socket.remoteAddress(&buf) orelse return JSValue.jsUndefined();
+            const address_bytes: []const u8 = this.socket.remoteAddress(&buf) orelse return .js_undefined;
             const address: std.net.Address = switch (address_bytes.len) {
                 4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
                 16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),
-                else => return JSValue.jsUndefined(),
+                else => return .js_undefined,
             };
 
             const text = bun.fmt.formatIp(address, &text_buf) catch unreachable;
@@ -2190,7 +2190,7 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getRemotePort(this: *This, _: *JSC.JSGlobalObject) JSValue {
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             return JSValue.jsNumber(this.socket.remotePort());
@@ -2257,7 +2257,7 @@ fn NewSocket(comptime ssl: bool) type {
 
         fn writeOrEndBuffered(this: *This, globalObject: *JSC.JSGlobalObject, data_value: JSC.JSValue, encoding_value: JSC.JSValue, comptime is_end: bool) WriteResult {
             if (this.buffered_data_for_node_net.len == 0) {
-                var values = [4]JSC.JSValue{ data_value, .jsUndefined(), .jsUndefined(), encoding_value };
+                var values = [4]JSC.JSValue{ data_value, .js_undefined, .js_undefined, encoding_value };
                 return this.writeOrEnd(globalObject, &values, true, is_end);
             }
 
@@ -2387,10 +2387,10 @@ fn NewSocket(comptime ssl: bool) type {
             var encoding_value: JSC.JSValue = args[3];
             if (args[2].isString()) {
                 encoding_value = args[2];
-                args[2] = .jsUndefined();
+                args[2] = .js_undefined;
             } else if (args[1].isString()) {
                 encoding_value = args[1];
-                args[1] = .jsUndefined();
+                args[1] = .js_undefined;
             }
 
             const offset_value = args[1];
@@ -2552,13 +2552,13 @@ fn NewSocket(comptime ssl: bool) type {
         pub fn flush(this: *This, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
             this.internalFlush();
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn terminate(this: *This, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
             this.closeAndDetach(.failure);
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn shutdown(this: *This, _: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2570,7 +2570,7 @@ fn NewSocket(comptime ssl: bool) type {
                 this.socket.shutdown();
             }
 
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn close(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2579,7 +2579,7 @@ fn NewSocket(comptime ssl: bool) type {
             this.socket.close(.normal);
             this.socket.detach();
             this.poll_ref.unref(globalObject.bunVM());
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         pub fn end(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -2609,16 +2609,16 @@ fn NewSocket(comptime ssl: bool) type {
         pub fn jsRef(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
             if (this.socket.isDetached()) this.ref_pollref_on_connect = true;
-            if (this.socket.isDetached()) return JSValue.jsUndefined();
+            if (this.socket.isDetached()) return .js_undefined;
             this.poll_ref.ref(globalObject.bunVM());
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn jsUnref(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
             if (this.socket.isDetached()) this.ref_pollref_on_connect = false;
             this.poll_ref.unref(globalObject.bunVM());
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn deinit(this: *This) void {
@@ -2670,7 +2670,7 @@ fn NewSocket(comptime ssl: bool) type {
             }
 
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const opts = args.ptr[0];
@@ -2689,24 +2689,24 @@ fn NewSocket(comptime ssl: bool) type {
             this.handlers.* = handlers; // TODO: this is a memory leak
             this.handlers.protect();
 
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn disableRenegotiation(this: *This, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             BoringSSL.SSL_set_renegotiate_mode(ssl_ptr, BoringSSL.ssl_renegotiate_never);
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn setVerifyMode(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const args = callframe.arguments_old(2);
@@ -2733,36 +2733,36 @@ fn NewSocket(comptime ssl: bool) type {
             const ssl_ptr = this.socket.ssl();
             // we always allow and check the SSL certificate after the handshake or renegotiation
             BoringSSL.SSL_set_verify(ssl_ptr, verify_mode, alwaysAllowSSLVerifyCallback);
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn renegotiate(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             BoringSSL.ERR_clear_error();
             if (BoringSSL.SSL_renegotiate(ssl_ptr) != 1) {
                 return globalObject.throwValue(getSSLException(globalObject, "SSL_renegotiate error"));
             }
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getTLSTicket(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
-            const session = BoringSSL.SSL_get_session(ssl_ptr) orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
+            const session = BoringSSL.SSL_get_session(ssl_ptr) orelse return .js_undefined;
             var ticket: [*c]const u8 = undefined;
             var length: usize = 0;
             //The pointer is only valid while the connection is in use so we need to copy it
             BoringSSL.SSL_SESSION_get0_ticket(session, @as([*c][*c]const u8, @ptrCast(&ticket)), &length);
 
             if (ticket == null or length == 0) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             return JSC.ArrayBuffer.createBuffer(globalObject, ticket[0..length]);
@@ -2770,11 +2770,11 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn setSession(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const args = callframe.arguments_old(1);
@@ -2792,11 +2792,11 @@ fn NewSocket(comptime ssl: bool) type {
                 const session_slice = sb.slice();
                 const ssl_ptr = this.socket.ssl();
                 var tmp = @as([*c]const u8, @ptrCast(session_slice.ptr));
-                const session = BoringSSL.d2i_SSL_SESSION(null, &tmp, @as(c_long, @intCast(session_slice.len))) orelse return JSValue.jsUndefined();
+                const session = BoringSSL.d2i_SSL_SESSION(null, &tmp, @as(c_long, @intCast(session_slice.len))) orelse return .js_undefined;
                 if (BoringSSL.SSL_set_session(ssl_ptr, session) != 1) {
                     return globalObject.throwValue(getSSLException(globalObject, "SSL_set_session error"));
                 }
-                return JSValue.jsUndefined();
+                return .js_undefined;
             } else {
                 return globalObject.throw("Expected session to be a string, Buffer or TypedArray", .{});
             }
@@ -2804,14 +2804,14 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getSession(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
-            const session = BoringSSL.SSL_get_session(ssl_ptr) orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
+            const session = BoringSSL.SSL_get_session(ssl_ptr) orelse return .js_undefined;
             const size = BoringSSL.i2d_SSL_SESSION(session, null);
             if (size <= 0) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const buffer_size = @as(usize, @intCast(size));
@@ -2854,11 +2854,11 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn exportKeyingMaterial(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             if (this.socket.isDetached()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const args = callframe.arguments_old(3);
@@ -2884,7 +2884,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             defer label.deinit();
             const label_slice = label.slice();
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
 
             if (args.len > 2) {
                 const context_arg = args.ptr[2];
@@ -2985,10 +2985,10 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getCipher(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             const cipher = BoringSSL.SSL_get_current_cipher(ssl_ptr);
             var result = JSValue.createEmptyObject(globalObject, 3);
 
@@ -3025,10 +3025,10 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getTLSPeerFinishedMessage(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             // We cannot just pass nullptr to SSL_get_peer_finished()
             // because it would further be propagated to memcpy(),
             // where the standard requirements as described in ISO/IEC 9899:2011
@@ -3036,7 +3036,7 @@ fn NewSocket(comptime ssl: bool) type {
             // Thus, we use a dummy byte.
             var dummy: [1]u8 = undefined;
             const size = BoringSSL.SSL_get_peer_finished(ssl_ptr, @as(*anyopaque, @ptrCast(&dummy)), @sizeOf(@TypeOf(dummy)));
-            if (size == 0) return JSValue.jsUndefined();
+            if (size == 0) return .js_undefined;
 
             const buffer_size = @as(usize, @intCast(size));
             var buffer = JSValue.createBufferFromLength(globalObject, buffer_size);
@@ -3049,10 +3049,10 @@ fn NewSocket(comptime ssl: bool) type {
 
         pub fn getTLSFinishedMessage(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             // We cannot just pass nullptr to SSL_get_finished()
             // because it would further be propagated to memcpy(),
             // where the standard requirements as described in ISO/IEC 9899:2011
@@ -3060,7 +3060,7 @@ fn NewSocket(comptime ssl: bool) type {
             // Thus, we use a dummy byte.
             var dummy: [1]u8 = undefined;
             const size = BoringSSL.SSL_get_finished(ssl_ptr, @as(*anyopaque, @ptrCast(&dummy)), @sizeOf(@TypeOf(dummy)));
-            if (size == 0) return JSValue.jsUndefined();
+            if (size == 0) return .js_undefined;
 
             const buffer_size = @as(usize, @intCast(size));
             var buffer = JSValue.createBufferFromLength(globalObject, buffer_size);
@@ -3201,7 +3201,7 @@ fn NewSocket(comptime ssl: bool) type {
         pub fn getPeerCertificate(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             JSC.markBinding(@src());
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             const args = callframe.arguments_old(1);
@@ -3214,7 +3214,7 @@ fn NewSocket(comptime ssl: bool) type {
                 abbreviated = arg.toBoolean();
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
 
             if (abbreviated) {
                 if (this.handlers.is_server) {
@@ -3224,8 +3224,8 @@ fn NewSocket(comptime ssl: bool) type {
                     }
                 }
 
-                const cert_chain = BoringSSL.SSL_get_peer_cert_chain(ssl_ptr) orelse return JSValue.jsUndefined();
-                const cert = BoringSSL.sk_X509_value(cert_chain, 0) orelse return JSValue.jsUndefined();
+                const cert_chain = BoringSSL.SSL_get_peer_cert_chain(ssl_ptr) orelse return .js_undefined;
+                const cert = BoringSSL.sk_X509_value(cert_chain, 0) orelse return .js_undefined;
                 return X509.toJS(cert, globalObject);
             }
             var cert: ?*BoringSSL.X509 = null;
@@ -3237,67 +3237,67 @@ fn NewSocket(comptime ssl: bool) type {
             const first_cert = if (cert) |c| c else if (cert_chain) |cc| BoringSSL.sk_X509_value(cc, 0) else null;
 
             if (first_cert == null) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             // TODO: we need to support the non abbreviated version of this
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getCertificate(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             const cert = BoringSSL.SSL_get_certificate(ssl_ptr);
 
             if (cert) |x509| {
                 return X509.toJS(x509, globalObject);
             }
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getPeerX509Certificate(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             const cert = BoringSSL.SSL_get_peer_certificate(ssl_ptr);
             if (cert) |x509| {
                 return X509.toJSObject(x509, globalObject);
             }
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getX509Certificate(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
-            const ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+            const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
             const cert = BoringSSL.SSL_get_certificate(ssl_ptr);
             if (cert) |x509| {
                 return X509.toJSObject(x509.ref(), globalObject);
             }
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getServername(this: *This, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
             const ssl_ptr = this.socket.ssl();
 
             const servername = BoringSSL.SSL_get_servername(ssl_ptr, BoringSSL.TLSEXT_NAMETYPE_host_name);
             if (servername == null) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
             return ZigString.fromUTF8(servername[0..bun.len(servername)]).toJS(globalObject);
         }
 
         pub fn setServername(this: *This, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
             if (comptime ssl == false) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             if (this.handlers.is_server) {
@@ -3324,7 +3324,7 @@ fn NewSocket(comptime ssl: bool) type {
 
             const host = normalizeHost(@as([]const u8, slice));
             if (host.len > 0) {
-                var ssl_ptr = this.socket.ssl() orelse return JSValue.jsUndefined();
+                var ssl_ptr = this.socket.ssl() orelse return .js_undefined;
 
                 if (ssl_ptr.isInitFinished()) {
                     // match node.js exceptions
@@ -3335,7 +3335,7 @@ fn NewSocket(comptime ssl: bool) type {
                 ssl_ptr.setHostname(host__);
             }
 
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         // this invalidates the current socket returning 2 new sockets
@@ -3346,10 +3346,10 @@ fn NewSocket(comptime ssl: bool) type {
             const this_js = callframe.this();
 
             if (comptime ssl) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
             if (this.socket.isDetached() or this.socket.isNamedPipe()) {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
             const args = callframe.arguments_old(1);
 
@@ -3485,7 +3485,7 @@ fn NewSocket(comptime ssl: bool) type {
                     return globalObject.throw("Failed to upgrade socket from TCP -> TLS. Is the TLS config correct?", .{});
                 }
 
-                return JSValue.jsUndefined();
+                return .js_undefined;
             };
 
             // Do not create the JS Wrapper object until _after_ we've validated the TLS config.
@@ -4404,5 +4404,5 @@ pub fn jsSetSocketOptions(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame
         }
     }
 
-    return JSC.JSValue.jsUndefined();
+    return .js_undefined;
 }

--- a/src/bun.js/api/bun/socket/SocketAddress.zig
+++ b/src/bun.js/api/bun/socket/SocketAddress.zig
@@ -114,7 +114,7 @@ pub fn parse(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError
     };
     defer url_str.deref();
 
-    const url = JSC.URL.fromString(url_str) orelse return JSValue.jsUndefined();
+    const url = JSC.URL.fromString(url_str) orelse return .js_undefined;
     defer url.deinit();
     const host = url.host();
     const port_: u16 = blk: {
@@ -129,10 +129,10 @@ pub fn parse(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError
     // - "0x.0x.0" -> "0.0.0.0"
     const paddr = host.latin1(); // presentation address
     const addr = if (paddr[0] == '[' and paddr[paddr.len - 1] == ']') v6: {
-        const v6 = net.Ip6Address.parse(paddr[1 .. paddr.len - 1], port_) catch return JSValue.jsUndefined();
+        const v6 = net.Ip6Address.parse(paddr[1 .. paddr.len - 1], port_) catch return .js_undefined;
         break :v6 SocketAddress{ ._addr = .{ .sin6 = v6.sa } };
     } else v4: {
-        const v4 = net.Ip4Address.parse(paddr, port_) catch return JSValue.jsUndefined();
+        const v4 = net.Ip4Address.parse(paddr, port_) catch return .js_undefined;
         break :v4 SocketAddress{ ._addr = .{ .sin = v4.sa } };
     };
 

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -237,7 +237,7 @@ pub fn createResourceUsageObject(this: *Subprocess, globalObject: *JSGlobalObjec
             }
         }
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     };
 
     const resource_usage = ResourceUsage{
@@ -520,7 +520,7 @@ const Readable = union(enum) {
                 return JSC.WebCore.ReadableStream.fromOwnedSlice(globalThis, own, 0);
             },
             else => {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             },
         }
     }
@@ -551,7 +551,7 @@ const Readable = union(enum) {
                 return JSC.MarkedArrayBuffer.fromBytes(own, bun.default_allocator, .Uint8Array).toNodeBuffer(globalThis);
             },
             else => {
-                return JSValue.jsUndefined();
+                return .js_undefined;
             },
         }
     }
@@ -591,7 +591,7 @@ pub fn asyncDispose(
 ) bun.JSError!JSValue {
     if (this.process.hasExited()) {
         // rely on GC to clean everything up in this case
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const this_jsvalue = callframe.this();
@@ -699,7 +699,7 @@ pub fn kill(
         },
     }
 
-    return JSValue.jsUndefined();
+    return .js_undefined;
 }
 
 pub fn hasKilled(this: *const Subprocess) bool {
@@ -726,12 +726,12 @@ fn closeProcess(this: *Subprocess) void {
 
 pub fn doRef(this: *Subprocess, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
     this.jsRef();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn doUnref(this: *Subprocess, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
     this.jsUnref();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn onStdinDestroyed(this: *Subprocess) void {
@@ -761,7 +761,7 @@ pub fn disconnect(this: *Subprocess, globalThis: *JSGlobalObject, callframe: *JS
     _ = globalThis;
     _ = callframe;
     this.disconnectIPC(true);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn getConnected(this: *Subprocess, globalThis: *JSGlobalObject) JSValue {
@@ -1133,7 +1133,7 @@ pub const PipeReader = struct {
                 return JSC.MarkedArrayBuffer.fromBytes(bytes, bun.default_allocator, .Uint8Array).toNodeBuffer(globalThis);
             },
             else => {
-                return .jsUndefined();
+                return .js_undefined;
             },
         }
     }
@@ -1391,8 +1391,8 @@ const Writable = union(enum) {
     pub fn toJS(this: *Writable, globalThis: *JSC.JSGlobalObject, subprocess: *Subprocess) JSValue {
         return switch (this.*) {
             .fd => |fd| fd.toJS(globalThis),
-            .memfd, .ignore => JSValue.jsUndefined(),
-            .buffer, .inherit => JSValue.jsUndefined(),
+            .memfd, .ignore => .js_undefined,
+            .buffer, .inherit => .js_undefined,
             .pipe => |pipe| {
                 this.* = .{ .ignore = {} };
                 if (subprocess.process.hasExited() and !subprocess.flags.has_stdin_destructor_called) {
@@ -1597,9 +1597,9 @@ pub fn onProcessExit(this: *Subprocess, process: *Process, status: bun.spawn.Sta
                     if (status == .err)
                         status.err.toJSC(globalThis)
                     else
-                        .jsUndefined();
+                        .js_undefined;
 
-                const this_value: JSValue = if (this_jsvalue.isEmptyOrUndefinedOrNull()) .jsUndefined() else this_jsvalue;
+                const this_value: JSValue = if (this_jsvalue.isEmptyOrUndefinedOrNull()) .js_undefined else this_jsvalue;
                 this_value.ensureStillAlive();
 
                 const args = [_]JSValue{

--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -801,13 +801,13 @@ pub const UDPSocket = struct {
             this.poll_ref.ref(globalThis.bunVM());
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn unref(this: *This, globalThis: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         this.poll_ref.unref(globalThis.bunVM());
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn close(
@@ -817,7 +817,7 @@ pub const UDPSocket = struct {
     ) bun.JSError!JSValue {
         if (!this.closed) this.socket.close();
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn reload(this: *This, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
@@ -835,7 +835,7 @@ pub const UDPSocket = struct {
         previous_config.unprotect();
         this.config = config;
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn getClosed(this: *This, _: *JSGlobalObject) JSValue {
@@ -848,17 +848,17 @@ pub const UDPSocket = struct {
     }
 
     pub fn getPort(this: *This, _: *JSGlobalObject) JSValue {
-        if (this.closed) return .jsUndefined();
+        if (this.closed) return .js_undefined;
         return JSValue.jsNumber(this.socket.boundPort());
     }
 
     fn createSockAddr(globalThis: *JSGlobalObject, address_bytes: []const u8, port: u16) JSValue {
-        var sockaddr = SocketAddress.init(address_bytes, port) catch return .jsUndefined();
+        var sockaddr = SocketAddress.init(address_bytes, port) catch return .js_undefined;
         return sockaddr.intoDTO(globalThis);
     }
 
     pub fn getAddress(this: *This, globalThis: *JSGlobalObject) JSValue {
-        if (this.closed) return .jsUndefined();
+        if (this.closed) return .js_undefined;
         var buf: [64]u8 = [_]u8{0} ** 64;
         var length: i32 = 64;
         this.socket.boundIp(&buf, &length);
@@ -869,8 +869,8 @@ pub const UDPSocket = struct {
     }
 
     pub fn getRemoteAddress(this: *This, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
-        if (this.closed) return .jsUndefined();
-        const connect_info = this.connect_info orelse return .jsUndefined();
+        if (this.closed) return .js_undefined;
+        const connect_info = this.connect_info orelse return .js_undefined;
         var buf: [64]u8 = [_]u8{0} ** 64;
         var length: i32 = 64;
         this.socket.remoteIp(&buf, &length);
@@ -948,7 +948,7 @@ pub const UDPSocket = struct {
         js.addressSetCached(callFrame.this(), globalThis, .zero);
         js.remoteAddressSetCached(callFrame.this(), globalThis, .zero);
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn jsDisconnect(globalObject: *JSC.JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -969,6 +969,6 @@ pub const UDPSocket = struct {
         }
         this.connect_info = null;
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 };

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -595,7 +595,7 @@ pub const FFI = struct {
             }
         }
 
-        const symbols_object: JSValue = object.getOwn(globalThis, "symbols") orelse .jsUndefined();
+        const symbols_object: JSValue = object.getOwn(globalThis, "symbols") orelse .js_undefined;
         if (!globalThis.hasException() and (symbols_object == .zero or !symbols_object.isObject())) {
             return globalThis.throwInvalidArgumentTypeValue("symbols", "object", symbols_object);
         }
@@ -807,7 +807,7 @@ pub const FFI = struct {
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
         var function: *Function = @ptrFromInt(ctx.asPtrAddress());
         function.deinit(globalThis);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn callback(globalThis: *JSGlobalObject, interface: JSC.JSValue, js_callback: JSC.JSValue) JSValue {
@@ -866,7 +866,7 @@ pub const FFI = struct {
     ) bun.JSError!JSValue {
         JSC.markBinding(@src());
         if (this.closed) {
-            return .jsUndefined();
+            return .js_undefined;
         }
         this.closed = true;
         if (this.dylib) |*dylib| {
@@ -894,7 +894,7 @@ pub const FFI = struct {
         //     bun.default_allocator.free(relocated_bytes_to_free);
         // }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn printCallback(global: *JSGlobalObject, object: JSC.JSValue) JSValue {
@@ -1143,7 +1143,7 @@ pub const FFI = struct {
 
     pub fn getSymbols(_: *FFI, _: *JSC.JSGlobalObject) JSC.JSValue {
         // This shouldn't be called. The cachedValue is what should be called.
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn linkSymbols(global: *JSGlobalObject, object_value: JSC.JSValue) JSC.JSValue {

--- a/src/bun.js/api/glob.zig
+++ b/src/bun.js/api/glob.zig
@@ -331,7 +331,7 @@ pub fn __scan(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.CallFram
     var arena = std.heap.ArenaAllocator.init(alloc);
     const globWalker = try this.makeGlobWalker(globalThis, &arguments, "scan", alloc, &arena) orelse {
         arena.deinit();
-        return .jsUndefined();
+        return .js_undefined;
     };
 
     incrPendingActivityFlag(&this.has_pending_activity);
@@ -354,7 +354,7 @@ pub fn __scanSync(this: *Glob, globalThis: *JSGlobalObject, callframe: *JSC.Call
     var arena = std.heap.ArenaAllocator.init(alloc);
     var globWalker = try this.makeGlobWalker(globalThis, &arguments, "scanSync", alloc, &arena) orelse {
         arena.deinit();
-        return .jsUndefined();
+        return .js_undefined;
     };
     defer globWalker.deinit(true);
 

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -1093,7 +1093,7 @@ pub const TextChunk = struct {
 
     fn contentHandler(this: *TextChunk, comptime Callback: (fn (*LOLHTML.TextChunk, []const u8, bool) LOLHTML.Error!void), thisObject: JSValue, globalObject: *JSGlobalObject, content: ZigString, contentOptions: ?ContentOptions) JSValue {
         if (this.text_chunk == null)
-            return .jsUndefined();
+            return .js_undefined;
         var content_slice = content.toSlice(bun.default_allocator);
         defer content_slice.deinit();
 
@@ -1146,7 +1146,7 @@ pub const TextChunk = struct {
         callFrame: *JSC.CallFrame,
     ) bun.JSError!JSValue {
         if (this.text_chunk == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         this.text_chunk.?.remove();
         return callFrame.this();
     }
@@ -1156,7 +1156,7 @@ pub const TextChunk = struct {
         global: *JSGlobalObject,
     ) JSValue {
         if (this.text_chunk == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return ZigString.init(this.text_chunk.?.getContent().slice()).withEncoding().toJS(global);
     }
 
@@ -1213,7 +1213,7 @@ pub const DocType = struct {
         globalObject: *JSGlobalObject,
     ) JSValue {
         if (this.doctype == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         const str = this.doctype.?.getName().slice();
         if (str.len == 0)
             return JSValue.jsNull();
@@ -1225,7 +1225,7 @@ pub const DocType = struct {
         globalObject: *JSGlobalObject,
     ) JSValue {
         if (this.doctype == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         const str = this.doctype.?.getSystemId().slice();
         if (str.len == 0)
@@ -1238,7 +1238,7 @@ pub const DocType = struct {
         globalObject: *JSGlobalObject,
     ) JSValue {
         if (this.doctype == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         const str = this.doctype.?.getPublicId().slice();
         if (str.len == 0)
@@ -1252,7 +1252,7 @@ pub const DocType = struct {
         callFrame: *JSC.CallFrame,
     ) bun.JSError!JSValue {
         if (this.doctype == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         this.doctype.?.remove();
         return callFrame.this();
     }
@@ -1262,7 +1262,7 @@ pub const DocType = struct {
         _: *JSGlobalObject,
     ) JSValue {
         if (this.doctype == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return JSValue.jsBoolean(this.doctype.?.isRemoved());
     }
 };
@@ -1433,7 +1433,7 @@ pub const Comment = struct {
         _: *JSGlobalObject,
     ) JSValue {
         if (this.comment == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return JSValue.jsBoolean(this.comment.?.isRemoved());
     }
 
@@ -1547,7 +1547,7 @@ pub const EndTag = struct {
         callFrame: *JSC.CallFrame,
     ) bun.JSError!JSValue {
         if (this.end_tag == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         this.end_tag.?.remove();
         return callFrame.this();
@@ -1558,7 +1558,7 @@ pub const EndTag = struct {
         globalObject: *JSGlobalObject,
     ) JSValue {
         if (this.end_tag == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         return this.end_tag.?.getName().toJS(globalObject);
     }
@@ -1620,13 +1620,13 @@ pub const AttributeIterator = struct {
         const value_label = JSC.ZigString.static("value");
 
         if (this.iterator == null) {
-            return JSValue.createObject2(globalObject, done_label, value_label, JSValue.jsBoolean(true), JSValue.jsUndefined());
+            return JSValue.createObject2(globalObject, done_label, value_label, JSValue.jsBoolean(true), .js_undefined);
         }
 
         var attribute = this.iterator.?.next() orelse {
             this.iterator.?.deinit();
             this.iterator = null;
-            return JSValue.createObject2(globalObject, done_label, value_label, JSValue.jsBoolean(true), JSValue.jsUndefined());
+            return JSValue.createObject2(globalObject, done_label, value_label, JSValue.jsBoolean(true), .js_undefined);
         };
 
         const value = attribute.value();
@@ -1729,7 +1729,7 @@ pub const Element = struct {
     /// Sets an attribute to a provided value, creating the attribute if it does not exist.
     pub fn setAttribute_(this: *Element, callFrame: *JSC.CallFrame, globalObject: *JSGlobalObject, name_: ZigString, value_: ZigString) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         var name_slice = name_.toSlice(bun.default_allocator);
         defer name_slice.deinit();
@@ -1743,7 +1743,7 @@ pub const Element = struct {
     ///  Removes the attribute.
     pub fn removeAttribute_(this: *Element, callFrame: *JSC.CallFrame, globalObject: *JSGlobalObject, name: ZigString) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         var name_slice = name.toSlice(bun.default_allocator);
         defer name_slice.deinit();
@@ -1762,7 +1762,7 @@ pub const Element = struct {
 
     fn contentHandler(this: *Element, comptime Callback: (fn (*LOLHTML.Element, []const u8, bool) LOLHTML.Error!void), thisObject: JSValue, globalObject: *JSGlobalObject, content: ZigString, contentOptions: ?ContentOptions) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         var content_slice = content.toSlice(bun.default_allocator);
         defer content_slice.deinit();
@@ -1862,7 +1862,7 @@ pub const Element = struct {
         callFrame: *JSC.CallFrame,
     ) bun.JSError!JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         this.element.?.remove();
         return callFrame.this();
@@ -1875,14 +1875,14 @@ pub const Element = struct {
         callFrame: *JSC.CallFrame,
     ) bun.JSError!JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         this.element.?.removeAndKeepContent();
         return callFrame.this();
     }
     pub fn getTagName(this: *Element, globalObject: *JSGlobalObject) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         return htmlStringValue(this.element.?.tagName(), globalObject);
     }
@@ -1907,7 +1907,7 @@ pub const Element = struct {
         _: *JSGlobalObject,
     ) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return JSValue.jsBoolean(this.element.?.isRemoved());
     }
 
@@ -1916,7 +1916,7 @@ pub const Element = struct {
         _: *JSGlobalObject,
     ) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return JSValue.jsBoolean(this.element.?.isSelfClosing());
     }
 
@@ -1925,7 +1925,7 @@ pub const Element = struct {
         _: *JSGlobalObject,
     ) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return JSValue.jsBoolean(this.element.?.canHaveContent());
     }
 
@@ -1934,7 +1934,7 @@ pub const Element = struct {
         globalObject: *JSGlobalObject,
     ) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
         return bun.String.createUTF8ForJS(globalObject, std.mem.span(this.element.?.namespaceURI()));
     }
 
@@ -1943,7 +1943,7 @@ pub const Element = struct {
         globalObject: *JSGlobalObject,
     ) JSValue {
         if (this.element == null)
-            return JSValue.jsUndefined();
+            return .js_undefined;
 
         const iter = this.element.?.attributes() orelse return createLOLHTMLError(globalObject);
         var attr_iter = bun.new(AttributeIterator, .{

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -361,7 +361,7 @@ const ServePlugins = struct {
 
         handleOnResolve(plugins);
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn handleOnResolve(this: *ServePlugins) void {
@@ -392,7 +392,7 @@ const ServePlugins = struct {
         const plugins = plugin_js.asPromisePtr(ServePlugins);
         handleOnReject(plugins, globalThis, error_js);
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn handleOnReject(this: *ServePlugins, global: *JSC.JSGlobalObject, err: JSValue) void {
@@ -552,7 +552,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             bun.debugAssert(server.listener != null); // this assertion is only valid while listening
             return server.js_value.get() orelse brk: {
                 bun.debugAssert(false);
-                break :brk .jsUndefined(); // safe-ish
+                break :brk .js_undefined; // safe-ish
             };
         }
 
@@ -594,7 +594,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 return this.globalThis.throwInvalidArguments("timeout() requires a Request object", .{});
             }
 
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn setIdleTimeout(this: *ThisServer, seconds: c_uint) void {
@@ -1048,7 +1048,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             this.onReloadFromZig(&new_config, globalThis);
 
-            return this.js_value.get() orelse .jsUndefined();
+            return this.js_value.get() orelse .js_undefined;
         }
 
         pub fn onFetch(
@@ -1196,7 +1196,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 this.stop(true);
             }
 
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         pub fn getPort(
@@ -1204,7 +1204,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             _: *JSC.JSGlobalObject,
         ) JSC.JSValue {
             switch (this.config.address) {
-                .unix => return .jsUndefined(),
+                .unix => return .js_undefined,
                 else => {},
             }
 
@@ -1303,7 +1303,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
         pub fn getHostname(this: *ThisServer, globalThis: *JSGlobalObject) JSC.JSValue {
             switch (this.config.address) {
-                .unix => return .jsUndefined(),
+                .unix => return .js_undefined,
                 else => {},
             }
 
@@ -1376,7 +1376,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
         pub fn getAllClosedPromise(this: *ThisServer, globalThis: *JSC.JSGlobalObject) JSC.JSValue {
             if (this.listener == null and this.pending_requests == 0) {
-                return JSC.JSPromise.resolvedPromise(globalThis, .jsUndefined()).toJS();
+                return JSC.JSPromise.resolvedPromise(globalThis, .js_undefined).toJS();
             }
             const prom = &this.all_closed_promise;
             if (prom.strong.has()) {
@@ -1789,7 +1789,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             resp.timeout(this.config.idleTimeout);
 
             const globalThis = this.globalThis;
-            const thisObject: JSValue = this.js_value.get() orelse .jsUndefined();
+            const thisObject: JSValue = this.js_value.get() orelse .js_undefined;
             const vm = this.vm;
 
             var node_http_response: ?*NodeHTTPResponse = null;
@@ -1810,7 +1810,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 if (bun.http.Method.find(req.method())) |method|
                     method.toJS(globalThis)
                 else
-                    .jsUndefined(),
+                    .js_undefined,
                 req,
                 resp,
                 upgrade_ctx,
@@ -2795,7 +2795,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 const loop = this.globalThis.bunVM().eventLoop();
                 loop.enter();
                 defer loop.exit();
-                _ = callback.call(this.globalThis, .jsUndefined(), &.{ JSValue.jsBoolean(is_ssl), node_socket, error_code_value, raw_packet_value }) catch |err| {
+                _ = callback.call(this.globalThis, .js_undefined, &.{ JSValue.jsBoolean(is_ssl), node_socket, error_code_value, raw_packet_value }) catch |err| {
                     this.globalThis.reportActiveExceptionAsUnhandled(err);
                 };
             }
@@ -2843,7 +2843,7 @@ pub const ServerAllConnectionsClosedTask = struct {
         bun.destroy(this);
 
         if (!vm.isShuttingDown()) {
-            promise.resolve(globalObject, .jsUndefined());
+            promise.resolve(globalObject, .js_undefined);
         }
     }
 };
@@ -3215,7 +3215,7 @@ pub fn Server__setOnClientError_(globalThis: *JSC.JSGlobalObject, server: JSC.JS
     } else {
         bun.debugAssert(false);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn Server__setAppFlags_(globalThis: *JSC.JSGlobalObject, server: JSC.JSValue, require_host_header: bool, use_strict_method_validation: bool) bun.JSError!JSC.JSValue {
@@ -3234,7 +3234,7 @@ pub fn Server__setAppFlags_(globalThis: *JSC.JSGlobalObject, server: JSC.JSValue
     } else {
         return globalThis.throw("Failed to set timeout: The 'this' value is not a Server.", .{});
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn Server__setMaxHTTPHeaderSize_(globalThis: *JSC.JSGlobalObject, server: JSC.JSValue, max_header_size: u64) bun.JSError!JSC.JSValue {
@@ -3253,7 +3253,7 @@ pub fn Server__setMaxHTTPHeaderSize_(globalThis: *JSC.JSGlobalObject, server: JS
     } else {
         return globalThis.throw("Failed to set maxHeaderSize: The 'this' value is not a Server.", .{});
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 comptime {
     _ = Server__setIdleTimeout;

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -259,7 +259,7 @@ pub fn dumpRequestBody(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObjec
         this.clearOnDataCallback(thisValue, globalObject);
     }
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn markRequestAsDone(this: *NodeHTTPResponse) void {
@@ -394,14 +394,14 @@ pub fn jsRef(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, _: *JSC
     if (!this.isDone()) {
         this.js_ref.ref(globalObject.bunVM());
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn jsUnref(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     if (!this.isDone()) {
         this.js_ref.unref(globalObject.bunVM());
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn handleEndedIfNecessary(state: uws.State, globalObject: *JSC.JSGlobalObject) bun.JSError!void {
@@ -436,9 +436,9 @@ pub fn writeHead(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, cal
     const state = this.raw_response.state();
     try handleEndedIfNecessary(state, globalObject);
 
-    const status_code_value: JSValue = if (arguments.len > 0) arguments[0] else .jsUndefined();
-    const status_message_value: JSValue = if (arguments.len > 1 and arguments[1] != .null) arguments[1] else .jsUndefined();
-    const headers_object_value: JSValue = if (arguments.len > 2 and arguments[2] != .null) arguments[2] else .jsUndefined();
+    const status_code_value: JSValue = if (arguments.len > 0) arguments[0] else .js_undefined;
+    const status_message_value: JSValue = if (arguments.len > 1 and arguments[1] != .null) arguments[1] else .js_undefined;
+    const headers_object_value: JSValue = if (arguments.len > 2 and arguments[2] != .null) arguments[2] else .js_undefined;
 
     const status_code: i32 = brk: {
         if (!status_code_value.isUndefined()) {
@@ -483,7 +483,7 @@ pub fn writeHead(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, cal
         break :do_it;
     }
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn writeHeadInternal(response: uws.AnyResponse, globalObject: *JSC.JSGlobalObject, status_message: []const u8, headers: JSC.JSValue) void {
@@ -496,14 +496,14 @@ fn writeHeadInternal(response: uws.AnyResponse, globalObject: *JSC.JSGlobalObjec
 
 pub fn writeContinue(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     if (this.isDone()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const state = this.raw_response.state();
     try handleEndedIfNecessary(state, globalObject);
 
     this.raw_response.writeContinue();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub const AbortEvent = enum(u8) {
@@ -575,7 +575,7 @@ pub fn doPause(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.CallFram
 }
 
 pub fn drainRequestBody(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    return this.drainBufferedRequestBodyFromPause(globalObject) orelse .jsUndefined();
+    return this.drainBufferedRequestBodyFromPause(globalObject) orelse .js_undefined;
 }
 
 fn drainBufferedRequestBodyFromPause(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject) ?JSC.JSValue {
@@ -640,7 +640,7 @@ pub export fn Bun__NodeHTTPRequest__onResolve(globalObject: *JSC.JSGlobalObject,
         this.onRequestComplete();
     }
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub export fn Bun__NodeHTTPRequest__onReject(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) JSC.JSValue {
@@ -668,18 +668,18 @@ pub export fn Bun__NodeHTTPRequest__onReject(globalObject: *JSC.JSGlobalObject, 
     }
 
     _ = globalObject.bunVM().uncaughtException(globalObject, err, true);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn abort(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     if (this.isDone()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     this.flags.socket_closed = true;
     const state = this.raw_response.state();
     if (state.isHttpEndCalled()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
     resumeSocket(this);
     this.raw_response.clearOnData();
@@ -687,7 +687,7 @@ pub fn abort(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.CallFrame)
     this.raw_response.clearTimeout();
     this.raw_response.endWithoutBody(true);
     this.onRequestComplete();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn onBufferRequestBodyWhilePaused(this: *NodeHTTPResponse, chunk: []const u8, last: bool) void {
@@ -746,10 +746,10 @@ fn onDataOrAborted(this: *NodeHTTPResponse, chunk: []const u8, last: bool, event
             if (chunk.len > 0) {
                 break :brk JSC.ArrayBuffer.createBuffer(globalThis, chunk);
             }
-            break :brk .jsUndefined();
+            break :brk .js_undefined;
         };
 
-        event_loop.runCallback(callback, globalThis, .jsUndefined(), &.{
+        event_loop.runCallback(callback, globalThis, .js_undefined, &.{
             bytes,
             JSC.JSValue.jsBoolean(last),
             JSC.JSValue.jsNumber(@intFromEnum(event)),
@@ -775,10 +775,10 @@ fn onDrain(this: *NodeHTTPResponse, offset: u64, response: uws.AnyResponse) bool
     const thisValue = this.getThisValue();
     const on_writable = js.onWritableGetCached(thisValue) orelse return false;
     const globalThis = JSC.VirtualMachine.get().global;
-    js.onWritableSetCached(thisValue, globalThis, .jsUndefined()); // TODO(@heimskr): is this necessary?
+    js.onWritableSetCached(thisValue, globalThis, .js_undefined); // TODO(@heimskr): is this necessary?
     const vm = globalThis.bunVM();
 
-    response.corked(JSC.EventLoop.runCallback, .{ vm.eventLoop(), on_writable, globalThis, .jsUndefined(), &.{JSC.JSValue.jsNumberFromUint64(offset)} });
+    response.corked(JSC.EventLoop.runCallback, .{ vm.eventLoop(), on_writable, globalThis, .js_undefined, &.{JSC.JSValue.jsNumberFromUint64(offset)} });
     // return true means we may have something to drain
     return true;
 }
@@ -799,11 +799,11 @@ fn writeOrEnd(
         return globalObject.ERR(.STREAM_WRITE_AFTER_END, "Stream already ended", .{}).throw();
     }
 
-    const input_value: JSValue = if (arguments.len > 0) arguments[0] else .jsUndefined();
-    var encoding_value: JSValue = if (arguments.len > 1) arguments[1] else .jsUndefined();
+    const input_value: JSValue = if (arguments.len > 0) arguments[0] else .js_undefined;
+    var encoding_value: JSValue = if (arguments.len > 1) arguments[1] else .js_undefined;
     const callback_value: JSValue = brk: {
         if (!encoding_value.isUndefinedOrNull() and encoding_value.isCallable()) {
-            encoding_value = .jsUndefined();
+            encoding_value = .js_undefined;
             break :brk arguments[1];
         }
 
@@ -815,7 +815,7 @@ fn writeOrEnd(
             break :brk arguments[2];
         }
 
-        break :brk .jsUndefined();
+        break :brk .js_undefined;
     };
 
     const strict_content_length: ?u64 = brk: {
@@ -903,7 +903,7 @@ fn writeOrEnd(
         switch (this.raw_response.write(bytes)) {
             .want_more => |written| {
                 this.raw_response.clearOnWritable();
-                js.onWritableSetCached(js_this, globalObject, .jsUndefined());
+                js.onWritableSetCached(js_this, globalObject, .js_undefined);
                 return JSC.JSValue.jsNumberFromUint64(written);
             },
             .backpressure => |written| {
@@ -920,21 +920,21 @@ fn writeOrEnd(
 
 pub fn setOnWritable(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalObject: *JSC.JSGlobalObject, value: JSValue) void {
     if (this.isDone() or value.isUndefined()) {
-        js.onWritableSetCached(thisValue, globalObject, .jsUndefined());
+        js.onWritableSetCached(thisValue, globalObject, .js_undefined);
     } else {
         js.onWritableSetCached(thisValue, globalObject, value.withAsyncContextIfNeeded(globalObject));
     }
 }
 
 pub fn getOnWritable(_: *NodeHTTPResponse, thisValue: JSC.JSValue, _: *JSC.JSGlobalObject) JSC.JSValue {
-    return js.onWritableGetCached(thisValue) orelse .jsUndefined();
+    return js.onWritableGetCached(thisValue) orelse .js_undefined;
 }
 
 pub fn getOnAbort(this: *NodeHTTPResponse, thisValue: JSC.JSValue, _: *JSC.JSGlobalObject) JSC.JSValue {
     if (this.flags.socket_closed) {
-        return .jsUndefined();
+        return .js_undefined;
     }
-    return js.onAbortedGetCached(thisValue) orelse .jsUndefined();
+    return js.onAbortedGetCached(thisValue) orelse .js_undefined;
 }
 
 pub fn setOnAbort(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalObject: *JSC.JSGlobalObject, value: JSValue) void {
@@ -950,7 +950,7 @@ pub fn setOnAbort(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalObject:
 }
 
 pub fn getOnData(_: *NodeHTTPResponse, thisValue: JSC.JSValue, _: *JSC.JSGlobalObject) JSC.JSValue {
-    return js.onDataGetCached(thisValue) orelse .jsUndefined();
+    return js.onDataGetCached(thisValue) orelse .js_undefined;
 }
 
 pub fn getHasCustomOnData(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject) JSC.JSValue {
@@ -968,7 +968,7 @@ pub fn setHasCustomOnData(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, value
 fn clearOnDataCallback(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalObject: *JSC.JSGlobalObject) void {
     if (this.body_read_state != .none) {
         if (thisValue != .zero) {
-            js.onDataSetCached(thisValue, globalObject, .jsUndefined());
+            js.onDataSetCached(thisValue, globalObject, .js_undefined);
         }
         if (!this.flags.socket_closed)
             this.raw_response.clearOnData();
@@ -980,7 +980,7 @@ fn clearOnDataCallback(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalOb
 
 pub fn setOnData(this: *NodeHTTPResponse, thisValue: JSC.JSValue, globalObject: *JSC.JSGlobalObject, value: JSValue) void {
     if (value.isUndefined() or this.flags.ended or this.flags.socket_closed or this.body_read_state == .none or this.flags.is_data_buffered_during_pause_last) {
-        js.onDataSetCached(thisValue, globalObject, .jsUndefined());
+        js.onDataSetCached(thisValue, globalObject, .js_undefined);
         defer {
             if (this.body_read_ref.has) {
                 this.body_read_ref.unref(globalObject.bunVM());
@@ -1017,7 +1017,7 @@ pub fn write(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, callfra
 
 pub fn flushHeaders(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     this.raw_response.flushHeaders();
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn end(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -1032,7 +1032,7 @@ pub fn getBytesWritten(this: *NodeHTTPResponse, _: *JSC.JSGlobalObject, _: *JSC.
 }
 
 fn handleCorked(globalObject: *JSC.JSGlobalObject, function: JSC.JSValue, result: *JSValue, is_exception: *bool) void {
-    result.* = function.call(globalObject, .jsUndefined(), &.{}) catch |err| {
+    result.* = function.call(globalObject, .js_undefined, &.{}) catch |err| {
         result.* = globalObject.takeException(err);
         is_exception.* = true;
         return;
@@ -1091,7 +1091,7 @@ pub fn cork(this: *NodeHTTPResponse, globalObject: *JSC.JSGlobalObject, callfram
     }
 
     if (result == .zero) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     return result;

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -105,7 +105,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             result.ensureStillAlive();
 
             handleResolve(ctx, result);
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         fn renderMissingInvalidResponse(ctx: *RequestContext, value: JSC.JSValue) void {
@@ -254,8 +254,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             const ctx = arguments.ptr[1].asPromisePtr(@This());
             const err = arguments.ptr[0];
             defer ctx.deref();
-            handleReject(ctx, if (!err.isEmptyOrUndefinedOrNull()) err else .jsUndefined());
-            return JSValue.jsUndefined();
+            handleReject(ctx, if (!err.isEmptyOrUndefinedOrNull()) err else .js_undefined);
+            return .js_undefined;
         }
 
         fn handleReject(ctx: *RequestContext, value: JSC.JSValue) void {
@@ -1622,7 +1622,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             var req: *@This() = args.ptr[args.len - 1].asPromisePtr(@This());
             defer req.deref();
             req.handleResolveStream();
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
         pub fn onRejectStream(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             streamLog("onRejectStream", .{});
@@ -1632,7 +1632,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             defer req.deref();
 
             req.handleRejectStream(globalThis, err);
-            return JSValue.jsUndefined();
+            return .js_undefined;
         }
 
         pub fn handleRejectStream(req: *@This(), globalThis: *JSC.JSGlobalObject, err: JSValue) void {
@@ -1978,7 +1978,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     this.flags.has_called_error_handler = true;
                     const result = server.config.onError.call(
                         server.globalThis,
-                        server.js_value.get() orelse .jsUndefined(),
+                        server.js_value.get() orelse .js_undefined,
                         &.{value},
                     ) catch |err| server.globalThis.takeException(err);
                     defer result.ensureStillAlive();

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -243,7 +243,7 @@ pub fn onPing(this: *ServerWebSocket, _: uws.AnyWebSocket, data: []const u8) voi
 
     _ = cb.call(
         globalThis,
-        .jsUndefined(),
+        .js_undefined,
         &[_]JSC.JSValue{ this.getThisValue(), this.binaryToJS(globalThis, data) },
     ) catch |e| {
         const err = globalThis.takeException(e);
@@ -271,7 +271,7 @@ pub fn onPong(this: *ServerWebSocket, _: uws.AnyWebSocket, data: []const u8) voi
 
     _ = cb.call(
         globalThis,
-        .jsUndefined(),
+        .js_undefined,
         &[_]JSC.JSValue{ this.getThisValue(), this.binaryToJS(globalThis, data) },
     ) catch |e| {
         const err = globalThis.takeException(e);
@@ -324,7 +324,7 @@ pub fn onClose(this: *ServerWebSocket, _: uws.AnyWebSocket, code: i32, message: 
 
         _ = handler.onClose.call(
             globalObject,
-            .jsUndefined(),
+            .js_undefined,
             &[_]JSC.JSValue{ this.getThisValue(), JSValue.jsNumber(code), bun.String.createUTF8ForJS(globalObject, message) },
         ) catch |e| {
             const err = globalObject.takeException(e);
@@ -674,7 +674,7 @@ pub fn cork(
     }
 
     if (this.isClosed()) {
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     var corker = Corker{
@@ -1027,7 +1027,7 @@ pub fn getData(
     _: *JSC.JSGlobalObject,
 ) JSValue {
     log("getData()", .{});
-    return JSValue.jsUndefined();
+    return .js_undefined;
 }
 
 pub fn setData(
@@ -1064,7 +1064,7 @@ pub fn close(
     this.this_value = this_value;
 
     if (this.isClosed()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const code = brk: {
@@ -1089,7 +1089,7 @@ pub fn close(
 
     this.flags.closed = true;
     this.websocket().end(code, message_value.slice());
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn terminate(
@@ -1107,14 +1107,14 @@ pub fn terminate(
     this.this_value = this_value;
 
     if (this.isClosed()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     this.flags.closed = true;
     this.this_value.unprotect();
     this.websocket().close();
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn getBinaryType(
@@ -1244,7 +1244,7 @@ pub fn getRemoteAddress(
     globalThis: *JSC.JSGlobalObject,
 ) JSValue {
     if (this.isClosed()) {
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -1254,7 +1254,7 @@ pub fn getRemoteAddress(
     const address: std.net.Address = switch (address_bytes.len) {
         4 => std.net.Address.initIp4(address_bytes[0..4].*, 0),
         16 => std.net.Address.initIp6(address_bytes[0..16].*, 0, 0, 0),
-        else => return JSValue.jsUndefined(),
+        else => return .js_undefined,
     };
 
     const text = bun.fmt.formatIp(address, &text_buf) catch unreachable;
@@ -1272,7 +1272,7 @@ const Corker = struct {
         const this_value = this.this_value;
         this.result = this.callback.call(
             this.globalObject,
-            if (this_value == .zero) .jsUndefined() else this_value,
+            if (this_value == .zero) .js_undefined else this_value,
             this.args,
         ) catch |err| this.globalObject.takeException(err);
     }

--- a/src/bun.js/api/server/WebSocketServerContext.zig
+++ b/src/bun.js/api/server/WebSocketServerContext.zig
@@ -37,7 +37,7 @@ pub const Handler = struct {
     pub fn runErrorCallback(this: *const Handler, vm: *JSC.VirtualMachine, globalObject: *JSC.JSGlobalObject, error_value: JSC.JSValue) void {
         const onError = this.onError;
         if (!onError.isEmptyOrUndefinedOrNull()) {
-            _ = onError.call(globalObject, .jsUndefined(), &.{error_value}) catch |err|
+            _ = onError.call(globalObject, .js_undefined, &.{error_value}) catch |err|
                 this.globalObject.reportActiveExceptionAsUnhandled(err);
             return;
         }

--- a/src/bun.js/bindings/CallFrame.zig
+++ b/src/bun.js/bindings/CallFrame.zig
@@ -17,7 +17,7 @@ pub const CallFrame = opaque {
     /// Usage: `const arg1, const arg2 = call_frame.argumentsAsArray(2);`
     pub fn argumentsAsArray(call_frame: *const CallFrame, comptime count: usize) [count]JSValue {
         const slice = call_frame.arguments();
-        var value: [count]JSValue = @splat(.jsUndefined());
+        var value: [count]JSValue = @splat(.js_undefined);
         const n = @min(call_frame.argumentsCount(), count);
         @memcpy(value[0..n], slice[0..n]);
         return value;
@@ -25,7 +25,7 @@ pub const CallFrame = opaque {
 
     /// This function protects out-of-bounds access by returning undefined
     pub fn argument(self: *const CallFrame, i: usize) JSC.JSValue {
-        return if (self.argumentsCount() > i) self.arguments()[i] else .jsUndefined();
+        return if (self.argumentsCount() > i) self.arguments()[i] else .js_undefined;
     }
 
     pub fn argumentsCount(self: *const CallFrame) u32 {
@@ -134,7 +134,7 @@ pub const CallFrame = opaque {
             }
 
             pub inline fn initUndef(comptime i: usize, ptr: [*]const JSC.JSValue) @This() {
-                var args: [max]JSC.JSValue = @splat(.jsUndefined());
+                var args: [max]JSC.JSValue = @splat(.js_undefined);
                 args[0..i].* = ptr[0..i].*;
                 return @This(){ .ptr = args, .len = i };
             }
@@ -168,7 +168,7 @@ pub const CallFrame = opaque {
         const slice = self.arguments();
         comptime bun.assert(max <= 9);
         return switch (@as(u4, @min(slice.len, max))) {
-            0 => .{ .ptr = @splat(.jsUndefined()), .len = 0 },
+            0 => .{ .ptr = @splat(.js_undefined), .len = 0 },
             inline 1...9 => |count| Arguments(max).initUndef(@min(count, max), slice.ptr),
             else => unreachable,
         };

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -482,7 +482,7 @@ pub const JSGlobalObject = opaque {
         error_array: JSValue,
     ) JSValue {
         if (bun.Environment.allow_assert) bun.assert(error_array.isArray());
-        return JSC__JSGlobalObject__createAggregateErrorWithArray(globalObject, error_array, message, .jsUndefined());
+        return JSC__JSGlobalObject__createAggregateErrorWithArray(globalObject, error_array, message, .js_undefined);
     }
 
     extern fn JSC__JSGlobalObject__generateHeapSnapshot(*JSGlobalObject) JSValue;

--- a/src/bun.js/bindings/JSPromise.zig
+++ b/src/bun.js/bindings/JSPromise.zig
@@ -199,7 +199,7 @@ pub const JSPromise = opaque {
 
     pub fn wrapValue(globalObject: *JSGlobalObject, value: JSValue) JSValue {
         if (value == .zero) {
-            return resolvedPromiseValue(globalObject, JSValue.jsUndefined());
+            return resolvedPromiseValue(globalObject, .js_undefined);
         } else if (value.isEmptyOrUndefinedOrNull() or !value.isCell()) {
             return resolvedPromiseValue(globalObject, value);
         }

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -1,6 +1,8 @@
 /// ABI-compatible with EncodedJSValue
 /// In the future, this type will exclude `zero`, encoding it as `error.JSError` instead.
 pub const JSValue = enum(i64) {
+    // fields here are prefixed so they're not accidentally mixed up with Zig's undefined/null/etc.
+    js_undefined = 0xa,
     null = 0x2,
     true = FFI.TrueI64,
     false = 0x6,
@@ -19,10 +21,6 @@ pub const JSValue = enum(i64) {
     /// in `JSC__JSValue__getIfPropertyExistsImpl`
     property_does_not_exist_on_object = 0x4,
     _,
-
-    /// not `pub` on purpose.
-    /// use .jsUndefined() so as to not be accidentally confused/typo'd with Zig undefined.
-    const @"undefined": JSValue = @enumFromInt(0xa);
 
     /// When JavaScriptCore throws something, it returns a null cell (0). The
     /// exception is set on the global object. ABI-compatible with EncodedJSValue.
@@ -700,10 +698,6 @@ pub const JSValue = enum(i64) {
         return JSC__JSValue__jsTDZValue();
     }
 
-    pub inline fn jsUndefined() JSValue {
-        return @enumFromInt(0xa);
-    }
-
     pub fn className(this: JSValue, globalThis: *JSGlobalObject) ZigString {
         var str = ZigString.init("");
         this.getClassName(globalThis, &str);
@@ -1095,7 +1089,7 @@ pub const JSValue = enum(i64) {
 
     pub inline fn isCell(this: JSValue) bool {
         return switch (this) {
-            .zero, JSValue.undefined, .null, .true, .false => false,
+            .zero, .js_undefined, .null, .true, .false => false,
             else => (@as(u64, @bitCast(@intFromEnum(this))) & FFI.NotCellMask) == 0,
         };
     }
@@ -1371,7 +1365,7 @@ pub const JSValue = enum(i64) {
 
         return switch (JSC__JSValue__fastGet(this, global, @intFromEnum(builtin_name))) {
             .zero => error.JSError,
-            JSValue.undefined, .property_does_not_exist_on_object => null,
+            .js_undefined, .property_does_not_exist_on_object => null,
             else => |val| val,
         };
     }
@@ -1454,7 +1448,7 @@ pub const JSValue = enum(i64) {
         }
 
         return switch (JSC__JSValue__getIfPropertyExistsImpl(this, global, property.ptr, @intCast(property.len))) {
-            JSValue.undefined, .zero, .property_does_not_exist_on_object => null,
+            .js_undefined, .zero, .property_does_not_exist_on_object => null,
             else => |val| val,
         };
     }
@@ -1490,7 +1484,7 @@ pub const JSValue = enum(i64) {
             // since there are false positives, the better path is to make them
             // negatives, as the number of places that desire throwing on
             // existing undefined is extremely small, but non-zero.
-            JSValue.undefined => null,
+            .js_undefined => null,
             else => |val| val,
         };
     }
@@ -1510,7 +1504,7 @@ pub const JSValue = enum(i64) {
         return switch (JSC__JSValue__getPropertyValue(target, global, property_name.ptr, @intCast(property_name.len))) {
             .zero => error.JSError,
             .property_does_not_exist_on_object => null,
-            JSValue.undefined => null,
+            .js_undefined => null,
             else => |val| val,
         };
     }
@@ -1563,7 +1557,7 @@ pub const JSValue = enum(i64) {
             .zero => unreachable,
 
             // Treat undefined and null as unspecified
-            .null, JSValue.undefined => null,
+            .null, .js_undefined => null,
 
             // false, 0, are deliberately not included in this list.
             // That would prevent you from passing `0` or `false` to various Bun APIs.
@@ -1613,7 +1607,7 @@ pub const JSValue = enum(i64) {
     /// Returns null when the value is:
     /// - JSValue.null
     /// - JSValue.false
-    /// - JSValue.undefined
+    /// - .js_undefined
     /// - an empty string
     pub fn getStringish(this: JSValue, global: *JSGlobalObject, property: []const u8) bun.JSError!?bun.String {
         const prop = try get(this, global, property) orelse return null;
@@ -1809,7 +1803,7 @@ pub const JSValue = enum(i64) {
         const prop = try this.get(global, property_name) orelse return null;
 
         return switch (prop) {
-            JSValue.undefined => null,
+            .js_undefined => null,
             .false, .true => prop == .true,
             else => {
                 return JSC.Node.validators.throwErrInvalidArgType(global, property_name, .{}, "boolean", prop);
@@ -2336,7 +2330,7 @@ pub const JSValue = enum(i64) {
         }
 
         switch (comptime Type) {
-            void => return .jsUndefined(),
+            void => return .js_undefined,
             bool => return JSC.JSValue.jsBoolean(if (comptime Type != T) value.* else value),
             *JSC.JSGlobalObject => return value.toJSValue(),
             []const u8, [:0]const u8, [*:0]const u8, []u8, [:0]u8, [*:0]u8 => {

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -2375,22 +2375,22 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
     CHECK_PREPARED
 
     int count = sqlite3_column_count(castedThis->stmt);
-    
+
     // We need to reset and step the statement to get fresh types,
     // but only do this for read-only statements to avoid side effects
     bool isReadOnly = sqlite3_stmt_readonly(castedThis->stmt) != 0;
 
-    if (! isReadOnly) {
-      // For non-read-only statements, throw an error since column types don't make sense
-      throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "columnTypes is not available for non-read-only statements (INSERT, UPDATE, DELETE, etc.)"_s));
-      return { };
+    if (!isReadOnly) {
+        // For non-read-only statements, throw an error since column types don't make sense
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "columnTypes is not available for non-read-only statements (INSERT, UPDATE, DELETE, etc.)"_s));
+        return {};
     }
 
     // Reset the statement (safe for read-only statements)
     int resetStatus = sqlite3_reset(castedThis->stmt);
     if (resetStatus != SQLITE_OK) {
         throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
-        return { };
+        return {};
     }
 
     MarkedArgumentBuffer args;
@@ -2439,7 +2439,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnTypes, (JSGlobalObject * lexical
         // If there was an error stepping, throw it
         throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, castedThis->version_db->db));
         sqlite3_reset(castedThis->stmt);
-        return { };
+        return {};
     }
 
     // Reset the statement back to its original state
@@ -2462,7 +2462,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnDeclaredTypes, (JSGlobalObject *
     // Ensure the statement has been executed at least once
     if (!castedThis->hasExecuted) {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Statement must be executed before accessing declaredTypes"_s));
-        return { };
+        return {};
     }
 
     int count = sqlite3_column_count(castedThis->stmt);
@@ -2472,7 +2472,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnDeclaredTypes, (JSGlobalObject *
     for (int i = 0; i < count; i++) {
         const char* declType = sqlite3_column_decltype(castedThis->stmt, i);
         JSC::JSValue typeValue;
-        
+
         if (declType != nullptr) {
             String typeStr = String::fromUTF8(declType);
             typeValue = JSC::jsNontrivialString(vm, typeStr);
@@ -2480,10 +2480,10 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnDeclaredTypes, (JSGlobalObject *
             // If no declared type (e.g., for expressions or results of functions)
             typeValue = JSC::jsNull();
         }
-        
+
         array->putDirectIndex(lexicalGlobalObject, i, typeValue);
     }
-    
+
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(array));
 }
 

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -644,8 +644,8 @@ pub const SendQueue = struct {
             global.emitWarning(
                 warning.transferToJS(global),
                 warning_name.transferToJS(global),
-                .jsUndefined(),
-                .jsUndefined(),
+                .js_undefined,
+                .js_undefined,
             ) catch |e| {
                 _ = global.takeException(e);
             };
@@ -927,7 +927,7 @@ const MAX_HANDLE_RETRANSMISSIONS = 3;
 fn emitProcessErrorEvent(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     const ex = callframe.argumentsAsArray(1)[0];
     JSC.VirtualMachine.Process__emitErrorEvent(globalThis, ex);
-    return .jsUndefined();
+    return .js_undefined;
 }
 const FromEnum = enum { subprocess_exited, subprocess, process };
 fn doSendErr(globalObject: *JSC.JSGlobalObject, callback: JSC.JSValue, ex: JSC.JSValue, from: FromEnum) bun.JSError!JSC.JSValue {
@@ -948,11 +948,11 @@ pub fn doSend(ipc: ?*SendQueue, globalObject: *JSC.JSGlobalObject, callFrame: *J
 
     if (handle.isCallable()) {
         callback = handle;
-        handle = .jsUndefined();
-        options_ = .jsUndefined();
+        handle = .js_undefined;
+        options_ = .js_undefined;
     } else if (options_.isCallable()) {
         callback = options_;
-        options_ = .jsUndefined();
+        options_ = .js_undefined;
     } else if (!options_.isUndefined()) {
         try globalObject.validateObject("options", options_, .{});
     }
@@ -979,7 +979,7 @@ pub fn doSend(ipc: ?*SendQueue, globalObject: *JSC.JSGlobalObject, callFrame: *J
     if (!handle.isUndefinedOrNull()) {
         const serialized_array: JSC.JSValue = try ipcSerialize(globalObject, message, handle);
         if (serialized_array.isUndefinedOrNull()) {
-            handle = .jsUndefined();
+            handle = .js_undefined;
         } else {
             const serialized_handle = serialized_array.getIndex(globalObject, 0);
             const serialized_message = serialized_array.getIndex(globalObject, 1);
@@ -1023,14 +1023,14 @@ pub fn doSend(ipc: ?*SendQueue, globalObject: *JSC.JSGlobalObject, callFrame: *J
 pub fn emitHandleIPCMessage(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     const target, const message, const handle = callframe.argumentsAsArray(3);
     if (target.isNull()) {
-        const ipc = globalThis.bunVM().getIPCInstance() orelse return .jsUndefined();
+        const ipc = globalThis.bunVM().getIPCInstance() orelse return .js_undefined;
         ipc.handleIPCMessage(.{ .data = message }, handle);
     } else {
-        if (!target.isCell()) return .jsUndefined();
-        const subprocess = bun.JSC.Subprocess.fromJSDirect(target) orelse return .jsUndefined();
+        if (!target.isCell()) return .js_undefined;
+        const subprocess = bun.JSC.Subprocess.fromJSDirect(target) orelse return .js_undefined;
         subprocess.handleIPCMessage(.{ .data = message }, handle);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 const IPCCommand = union(enum) {
@@ -1131,7 +1131,7 @@ fn handleIPCMessage(send_queue: *SendQueue, message: DecodedIPCMessage, globalTh
     } else {
         switch (send_queue.owner) {
             inline else => |owner| {
-                owner.handleIPCMessage(message, .jsUndefined());
+                owner.handleIPCMessage(message, .js_undefined);
             },
         }
     }

--- a/src/bun.js/node.zig
+++ b/src/bun.js/node.zig
@@ -198,7 +198,7 @@ pub fn Maybe(comptime ReturnTypeT: type, comptime ErrorTypeT: type) type {
                 .result => |r| switch (ReturnType) {
                     JSC.JSValue => r,
 
-                    void => .jsUndefined(),
+                    void => .js_undefined,
                     bool => JSC.JSValue.jsBoolean(r),
 
                     JSC.ArrayBuffer => r.toJS(globalObject, null),

--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -61,7 +61,7 @@ pub fn addAddress(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *J
         break :blk (try SocketAddress.initFromAddrFamily(globalThis, address_js, family_js))._addr;
     };
     try this.da_rules.insert(0, .{ .addr = address });
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn addRange(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -86,7 +86,7 @@ pub fn addRange(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC
         }
     }
     try this.da_rules.insert(0, .{ .range = .{ .start = start, .end = end } });
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn addSubnet(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -107,7 +107,7 @@ pub fn addSubnet(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JS
         else => {},
     }
     try this.da_rules.insert(0, .{ .subnet = .{ .network = network, .prefix = prefix } });
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn check(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {

--- a/src/bun.js/node/node_cluster_binding.zig
+++ b/src/bun.js/node/node_cluster_binding.zig
@@ -60,7 +60,7 @@ pub fn sendHelperChild(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFram
             const arguments_ = callframe_.arguments_old(1).slice();
             const ex = arguments_[0];
             Process__emitErrorEvent(globalThis_, ex.toError() orelse ex);
-            return .jsUndefined();
+            return .js_undefined;
         }
     };
 
@@ -84,7 +84,7 @@ pub fn onInternalMessageChild(globalThis: *JSC.JSGlobalObject, callframe: *JSC.C
     child_singleton.worker = .create(arguments[0], globalThis);
     child_singleton.cb = .create(arguments[1], globalThis);
     try child_singleton.flush(globalThis);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn handleInternalMessageChild(globalThis: *JSC.JSGlobalObject, message: JSC.JSValue) bun.JSError!void {
@@ -216,11 +216,11 @@ pub fn sendHelperPrimary(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFr
 pub fn onInternalMessagePrimary(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     const arguments = callframe.arguments_old(3).ptr;
     const subprocess = arguments[0].as(bun.JSC.Subprocess).?;
-    const ipc_data = subprocess.ipc() orelse return .jsUndefined();
+    const ipc_data = subprocess.ipc() orelse return .js_undefined;
     // TODO: remove these strongs.
     ipc_data.internal_msg_queue.worker = .create(arguments[1], globalThis);
     ipc_data.internal_msg_queue.cb = .create(arguments[2], globalThis);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn handleInternalMessagePrimary(globalThis: *JSC.JSGlobalObject, subprocess: *JSC.Subprocess, message: JSC.JSValue) bun.JSError!void {
@@ -275,7 +275,7 @@ pub fn setRef(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.
     } else {
         vm.channel_ref.unref(vm);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 export fn Bun__refChannelUnlessOverridden(globalObject: *JSC.JSGlobalObject) void {

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -211,7 +211,7 @@ const random = struct {
 
         fn runFromJS(this: *JobCtx, global: *JSGlobalObject, callback: JSValue) void {
             const vm = global.bunVM();
-            vm.eventLoop().runCallback(callback, global, .jsUndefined(), &.{ .null, this.value });
+            vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .null, this.value });
         }
 
         fn deinit(this: *JobCtx) void {
@@ -266,8 +266,8 @@ const random = struct {
         const res = std.crypto.random.intRangeLessThan(i64, min, max);
 
         if (!callback.isUndefined()) {
-            callback.callNextTick(global, [2]JSValue{ .jsUndefined(), JSValue.jsNumber(res) });
-            return JSValue.jsUndefined();
+            callback.callNextTick(global, [2]JSValue{ .js_undefined, JSValue.jsNumber(res) });
+            return .js_undefined;
         }
 
         return JSValue.jsNumber(res);
@@ -351,7 +351,7 @@ const random = struct {
         };
         try Job.initAndSchedule(global, callback, &ctx);
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     fn randomFillSync(global: *JSGlobalObject, callFrame: *JSC.CallFrame) JSError!JSValue {
@@ -414,8 +414,8 @@ const random = struct {
             try assertSize(global, size_value, element_size, offset, buf.byte_len);
 
         if (size == 0) {
-            _ = try callback.call(global, .jsUndefined(), &.{ .null, JSValue.jsNumber(0) });
-            return .jsUndefined();
+            _ = try callback.call(global, .js_undefined, &.{ .null, JSValue.jsNumber(0) });
+            return .js_undefined;
         }
 
         const ctx: JobCtx = .{
@@ -426,7 +426,7 @@ const random = struct {
         };
         try Job.initAndSchedule(global, callback, &ctx);
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 };
 
@@ -481,7 +481,7 @@ pub fn timingSafeEqual(global: *JSGlobalObject, callFrame: *JSC.CallFrame) JSErr
 }
 
 pub fn secureHeapUsed(_: *JSGlobalObject, _: *JSC.CallFrame) JSError!JSValue {
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn getFips(_: *JSGlobalObject, _: *JSC.CallFrame) JSError!JSValue {
@@ -489,7 +489,7 @@ pub fn getFips(_: *JSGlobalObject, _: *JSC.CallFrame) JSError!JSValue {
 }
 
 pub fn setFips(_: *JSGlobalObject, _: *JSC.CallFrame) JSError!JSValue {
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn setEngine(global: *JSGlobalObject, _: *JSC.CallFrame) JSError!JSValue {
@@ -718,17 +718,17 @@ const Scrypt = struct {
                 var buf: [256]u8 = undefined;
                 const msg = BoringSSL.ERR_error_string_n(err, &buf, buf.len);
                 const exception = global.ERR(.CRYPTO_OPERATION_FAILED, "Scrypt failed: {s}", .{msg}).toJS();
-                vm.eventLoop().runCallback(callback, global, .jsUndefined(), &.{exception});
+                vm.eventLoop().runCallback(callback, global, .js_undefined, &.{exception});
                 return;
             }
 
             const exception = global.ERR(.CRYPTO_OPERATION_FAILED, "Scrypt failed", .{}).toJS();
-            vm.eventLoop().runCallback(callback, global, .jsUndefined(), &.{exception});
+            vm.eventLoop().runCallback(callback, global, .js_undefined, &.{exception});
             return;
         }
 
         const buf = this.buf.swap();
-        vm.eventLoop().runCallback(callback, global, .jsUndefined(), &.{ .jsUndefined(), buf });
+        vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .js_undefined, buf });
     }
 
     fn deinit(this: *Scrypt) void {
@@ -739,7 +739,7 @@ const Scrypt = struct {
 fn scrypt(global: *JSGlobalObject, callFrame: *JSC.CallFrame) JSError!JSValue {
     const ctx, const callback = try Scrypt.fromJS(global, callFrame, true);
     try Scrypt.Job.initAndSchedule(global, callback, &ctx);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn scryptSync(global: *JSGlobalObject, callFrame: *JSC.CallFrame) JSError!JSValue {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -1286,11 +1286,11 @@ pub const Arguments = struct {
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Rename {
             const old_path = try PathLike.fromJS(ctx, arguments) orelse {
-                return ctx.throwInvalidArgumentTypeValue("oldPath", "string or an instance of Buffer or URL", arguments.next() orelse .jsUndefined());
+                return ctx.throwInvalidArgumentTypeValue("oldPath", "string or an instance of Buffer or URL", arguments.next() orelse .js_undefined);
             };
 
             const new_path = try PathLike.fromJS(ctx, arguments) orelse {
-                return ctx.throwInvalidArgumentTypeValue("newPath", "string or an instance of Buffer or URL", arguments.next() orelse .jsUndefined());
+                return ctx.throwInvalidArgumentTypeValue("newPath", "string or an instance of Buffer or URL", arguments.next() orelse .js_undefined);
             };
 
             return Rename{ .old_path = old_path, .new_path = new_path };
@@ -1350,7 +1350,7 @@ pub const Arguments = struct {
         }
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Writev {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -1404,7 +1404,7 @@ pub const Arguments = struct {
         }
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Readv {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -1450,7 +1450,7 @@ pub const Arguments = struct {
         }
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!FTruncate {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -1521,7 +1521,7 @@ pub const Arguments = struct {
         pub fn toThreadSafe(_: *const @This()) void {}
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Fchown {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -1619,7 +1619,7 @@ pub const Arguments = struct {
             };
             errdefer path.deinit();
 
-            const mode_arg: JSC.JSValue = arguments.next() orelse .jsUndefined();
+            const mode_arg: JSC.JSValue = arguments.next() orelse .js_undefined;
             const mode: Mode = try JSC.Node.modeFromJS(ctx, mode_arg) orelse {
                 return JSC.Node.validators.throwErrInvalidArgType(ctx, "mode", .{}, "number", mode_arg);
             };
@@ -1639,12 +1639,12 @@ pub const Arguments = struct {
         pub fn toThreadSafe(_: *const @This()) void {}
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!FChmod {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
 
-            const mode_arg: JSC.JSValue = arguments.next() orelse .jsUndefined();
+            const mode_arg: JSC.JSValue = arguments.next() orelse .js_undefined;
             const mode: Mode = try JSC.Node.modeFromJS(ctx, mode_arg) orelse {
                 return JSC.Node.validators.throwErrInvalidArgType(ctx, "mode", .{}, "number", mode_arg);
             };
@@ -1753,7 +1753,7 @@ pub const Arguments = struct {
         pub fn toThreadSafe(_: *@This()) void {}
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Fstat {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -2160,7 +2160,7 @@ pub const Arguments = struct {
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!MkdirTemp {
             const prefix = try PathLike.fromJS(ctx, arguments) orelse {
-                return ctx.throwInvalidArgumentTypeValue("prefix", "string, Buffer, or URL", arguments.next() orelse .jsUndefined());
+                return ctx.throwInvalidArgumentTypeValue("prefix", "string, Buffer, or URL", arguments.next() orelse .js_undefined);
             };
             errdefer prefix.deinit();
 
@@ -2268,7 +2268,7 @@ pub const Arguments = struct {
         pub fn toThreadSafe(_: Close) void {}
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Close {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -2355,7 +2355,7 @@ pub const Arguments = struct {
         }
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Futimes {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -2427,7 +2427,7 @@ pub const Arguments = struct {
         }
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Write {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -2532,7 +2532,7 @@ pub const Arguments = struct {
             // fs_binding.read(fd, buffer, offset, length, position)
 
             // fd = getValidatedFd(fd);
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -2977,7 +2977,7 @@ pub const Arguments = struct {
         }
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!FdataSync {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -3127,7 +3127,7 @@ pub const Arguments = struct {
         pub fn toThreadSafe(_: *const @This()) void {}
 
         pub fn fromJS(ctx: *JSC.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Fsync {
-            const fd_value: JSC.JSValue = arguments.nextEat() orelse .jsUndefined();
+            const fd_value: JSC.JSValue = arguments.nextEat() orelse .js_undefined;
             const fd = try bun.FD.fromJSValidated(fd_value, ctx) orelse {
                 return throwInvalidFdError(ctx, fd_value);
             };
@@ -3144,14 +3144,14 @@ pub const StatOrNotFound = union(enum) {
     pub fn toJS(this: *StatOrNotFound, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         return switch (this.*) {
             .stats => this.stats.toJS(globalObject),
-            .not_found => .jsUndefined(),
+            .not_found => .js_undefined,
         };
     }
 
     pub fn toJSNewlyCreated(this: *const StatOrNotFound, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         return switch (this.*) {
             .stats => this.stats.toJSNewlyCreated(globalObject),
-            .not_found => .jsUndefined(),
+            .not_found => .js_undefined,
         };
     }
 };
@@ -3163,7 +3163,7 @@ pub const StringOrUndefined = union(enum) {
     pub fn toJS(this: *const StringOrUndefined, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
         return switch (this.*) {
             .string => this.string.toJS(globalObject),
-            .none => .jsUndefined(),
+            .none => .js_undefined,
         };
     }
 };
@@ -5876,7 +5876,7 @@ pub const NodeFS = struct {
                 .code = bun.String.init(@errorName(err)),
                 .path = bun.String.init(args.path.slice()),
             }).toErrorInstance(args.global_this)) catch {};
-            return Maybe(Return.Watch){ .result = .jsUndefined() };
+            return Maybe(Return.Watch){ .result = .js_undefined };
         };
         return Maybe(Return.Watch){ .result = watcher };
     }

--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -218,7 +218,7 @@ pub fn createMemfdForTesting(globalObject: *JSC.JSGlobalObject, callFrame: *JSC.
     const arguments = callFrame.arguments_old(1);
 
     if (arguments.len < 1) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     if (comptime !bun.Environment.isLinux) {

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -309,7 +309,7 @@ pub const StatWatcher = struct {
             if (obj.js_this != .zero) {
                 return obj.js_this;
             }
-            return .jsUndefined();
+            return .js_undefined;
         }
     };
 
@@ -318,7 +318,7 @@ pub const StatWatcher = struct {
             this.persistent = true;
             this.poll_ref.ref(this.ctx);
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn doUnref(this: *StatWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -326,7 +326,7 @@ pub const StatWatcher = struct {
             this.persistent = false;
             this.poll_ref.unref(this.ctx);
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     /// Stops file watching but does not free the instance.
@@ -341,7 +341,7 @@ pub const StatWatcher = struct {
 
     pub fn doClose(this: *StatWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         this.close();
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     /// If the scheduler is not using this, free instantly, otherwise mark for being freed.
@@ -408,7 +408,7 @@ pub const StatWatcher = struct {
 
         _ = js.listenerGetCached(this.js_this).?.call(
             this.globalThis,
-            .jsUndefined(),
+            .js_undefined,
             &[2]JSC.JSValue{
                 jsvalue,
                 jsvalue,
@@ -444,7 +444,7 @@ pub const StatWatcher = struct {
 
         _ = js.listenerGetCached(this.js_this).?.call(
             this.globalThis,
-            .jsUndefined(),
+            .js_undefined,
             &[2]JSC.JSValue{
                 current_jsvalue,
                 prev_jsvalue,

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -524,7 +524,7 @@ pub const FSWatcher = struct {
         if (js_this == .zero) return;
         const listener = js.listenerGetCached(js_this) orelse return;
         const globalObject = this.globalThis;
-        var filename: JSC.JSValue = .jsUndefined();
+        var filename: JSC.JSValue = .js_undefined;
         if (file_name.len > 0) {
             if (this.encoding == .buffer)
                 filename = JSC.ArrayBuffer.createBuffer(globalObject, file_name)
@@ -556,7 +556,7 @@ pub const FSWatcher = struct {
             this.persistent = true;
             this.poll_ref.ref(this.ctx);
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn doUnref(this: *FSWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -564,7 +564,7 @@ pub const FSWatcher = struct {
             this.persistent = false;
             this.poll_ref.unref(this.ctx);
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn hasRef(this: *FSWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -604,7 +604,7 @@ pub const FSWatcher = struct {
                 if (FSWatcher.js.listenerGetCached(js_this)) |listener| {
                     _ = this.refTask();
                     log("emit('close')", .{});
-                    emitJS(listener, this.globalThis, .jsUndefined(), .close);
+                    emitJS(listener, this.globalThis, .js_undefined, .close);
                     this.unrefTask();
                 }
             }
@@ -637,7 +637,7 @@ pub const FSWatcher = struct {
 
     pub fn doClose(this: *FSWatcher, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         this.close();
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn init(args: Arguments) bun.JSC.Maybe(*FSWatcher) {

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -135,7 +135,7 @@ pub fn extractedSplitNewLinesFastPathStringsOnly(globalThis: *JSC.JSGlobalObject
         .utf8 => if (bun.strings.isAllASCII(str.byteSlice()))
             return split(.utf8, globalThis, bun.default_allocator, &str)
         else
-            return JSC.JSValue.jsUndefined(),
+            return .js_undefined,
     };
 }
 
@@ -209,7 +209,7 @@ pub fn normalizeEncoding(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFr
     defer str.deref();
     if (str.length() == 0) return JSC.Node.Encoding.utf8.toJS(globalThis);
     if (str.inMapCaseInsensitive(JSC.Node.Encoding.map)) |enc| return enc.toJS(globalThis);
-    return JSC.JSValue.jsUndefined();
+    return .js_undefined;
 }
 
 pub fn parseEnv(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {

--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -14,7 +14,7 @@ pub fn crc32(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
         const data: JSC.JSValue = arguments[0];
 
         if (data == .zero) {
-            return globalThis.throwInvalidArgumentTypeValue("data", "string or an instance of Buffer, TypedArray, or DataView", .jsUndefined());
+            return globalThis.throwInvalidArgumentTypeValue("data", "string or an instance of Buffer, TypedArray, or DataView", .js_undefined);
         }
         if (data.isString()) {
             break :blk data.asString().toSlice(globalThis, bun.default_allocator);
@@ -113,7 +113,7 @@ pub fn CompressionStream(comptime T: type) type {
             this.poll_ref.ref(vm);
             JSC.WorkPool.schedule(&this.task);
 
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         const AsyncJob = struct {
@@ -216,7 +216,7 @@ pub fn CompressionStream(comptime T: type) type {
             }
             this.deref();
 
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         pub fn reset(this: *T, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -224,14 +224,14 @@ pub fn CompressionStream(comptime T: type) type {
             if (err.isError()) {
                 try emitError(this, globalThis, callframe.this(), err);
             }
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         pub fn close(this: *T, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             _ = globalThis;
             _ = callframe;
             closeInternal(this);
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         fn closeInternal(this: *T) void {
@@ -252,7 +252,7 @@ pub fn CompressionStream(comptime T: type) type {
         }
 
         pub fn getOnError(_: *T, this_value: JSC.JSValue, _: *JSC.JSGlobalObject) JSC.JSValue {
-            return T.js.errorCallbackGetCached(this_value) orelse .jsUndefined();
+            return T.js.errorCallbackGetCached(this_value) orelse .js_undefined;
         }
 
         /// returns true if no error was detected/emitted

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -443,7 +443,7 @@ pub fn basename(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*
         };
     }
 
-    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         return .zero;
@@ -634,7 +634,7 @@ pub inline fn dirnameJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, i
 }
 
 pub fn dirname(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -833,7 +833,7 @@ pub inline fn extnameJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, i
 }
 
 pub fn extname(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -947,7 +947,7 @@ pub fn formatJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, allocator
 }
 
 pub fn format(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) bun.JSError!JSC.JSValue {
-    const pathObject_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const pathObject_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateObject(globalObject, pathObject_ptr, "pathObject", .{}, .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -1040,7 +1040,7 @@ pub fn isAbsoluteWindowsZigString(pathZStr: JSC.ZigString) bool {
 }
 
 pub fn isAbsolute(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -1664,7 +1664,7 @@ pub fn normalizeJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, alloca
 }
 
 pub fn normalize(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -1987,7 +1987,7 @@ pub inline fn parseJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, isW
 }
 
 pub fn parse(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const path_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, path_ptr, "path", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
@@ -2348,13 +2348,13 @@ pub fn relativeJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject, allocat
 }
 
 pub fn relative(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    const from_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .jsUndefined();
+    const from_ptr: JSC.JSValue = if (args_len > 0) args_ptr[0] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, from_ptr, "from", .{}) catch {
         // Returning .zero translates to a nullprt JSC.JSValue.
         return .zero;
     };
-    const to_ptr: JSC.JSValue = if (args_len > 1) args_ptr[1] else .jsUndefined();
+    const to_ptr: JSC.JSValue = if (args_len > 1) args_ptr[1] else .js_undefined;
     // Supress exeption in zig. It does globalThis.vm().throwError() in JS land.
     validateString(globalObject, to_ptr, "to", .{}) catch {
         return .zero;
@@ -2940,7 +2940,7 @@ pub fn toNamespacedPathJS_T(comptime T: type, globalObject: *JSC.JSGlobalObject,
 }
 
 pub fn toNamespacedPath(globalObject: *JSC.JSGlobalObject, isWindows: bool, args_ptr: [*]JSC.JSValue, args_len: u16) callconv(JSC.conv) JSC.JSValue {
-    if (args_len == 0) return .jsUndefined();
+    if (args_len == 0) return .js_undefined;
     var path_ptr = args_ptr[0];
 
     // Based on Node v21.6.1 path.win32.toNamespacedPath and path.posix.toNamespacedPath:

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -477,7 +477,7 @@ pub const Encoding = enum(u8) {
 pub fn jsAssertEncodingValid(global: *JSC.JSGlobalObject, call_frame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     const value = call_frame.argument(0);
     _ = try Encoding.assert(value, global, .utf8);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 const PathOrBuffer = union(Tag) {
@@ -1174,7 +1174,7 @@ pub const PathOrBlob = union(enum) {
         }
 
         const arg = args.nextEat() orelse {
-            return ctx.throwInvalidArgumentTypeValue("destination", "path, file descriptor, or Blob", .jsUndefined());
+            return ctx.throwInvalidArgumentTypeValue("destination", "path, file descriptor, or Blob", .js_undefined);
         };
         if (arg.as(Blob)) |blob| {
             return PathOrBlob{

--- a/src/bun.js/node/util/parse_args.zig
+++ b/src/bun.js/node/util/parse_args.zig
@@ -175,7 +175,7 @@ fn getDefaultArgs(globalThis: *JSGlobalObject) !ArgsSlice {
     }
 
     return .{
-        .array = .jsUndefined(),
+        .array = .js_undefined,
         .start = 0,
         .end = 0,
     };
@@ -316,7 +316,7 @@ fn parseOptionDefinitions(globalThis: *JSGlobalObject, options_obj: JSValue, opt
         try validators.validateObject(globalThis, obj, "options.{s}", .{option.long_name}, .{});
 
         // type field is required
-        const option_type: JSValue = obj.getOwn(globalThis, "type") orelse .jsUndefined();
+        const option_type: JSValue = obj.getOwn(globalThis, "type") orelse .js_undefined;
         option.type = try validators.validateStringEnum(OptionValueType, globalThis, option_type, "options.{s}.type", .{option.long_name});
 
         if (obj.getOwn(globalThis, "short")) |short_option| {
@@ -413,7 +413,7 @@ fn tokenizeArgs(
                 const short_option = arg.substringWithLen(1, 2);
                 const option_idx = findOptionByShortName(short_option, options);
                 const option_type: OptionValueType = if (option_idx) |idx| options[idx].type else .boolean;
-                var value = ValueRef{ .jsvalue = .jsUndefined() };
+                var value = ValueRef{ .jsvalue = .js_undefined };
                 var has_inline_value = true;
                 if (option_type == .string and index + 1 < num_args) {
                     // e.g. '-f', "bar"
@@ -447,7 +447,7 @@ fn tokenizeArgs(
                         // Boolean option, or last short in group. Well formed.
 
                         // Immediately process as a lone_short_option (e.g. from input -abc, process -a -b -c)
-                        var value = ValueRef{ .jsvalue = .jsUndefined() };
+                        var value = ValueRef{ .jsvalue = .js_undefined };
                         var has_inline_value = true;
                         if (option_type == .string and index + 1 < num_args) {
                             // e.g. '-f', "bar"
@@ -526,7 +526,7 @@ fn tokenizeArgs(
 
                 try ctx.handleToken(.{ .option = .{
                     .index = index,
-                    .value = ValueRef{ .jsvalue = value orelse JSValue.jsUndefined() },
+                    .value = ValueRef{ .jsvalue = value orelse .js_undefined },
                     .inline_value = (value == null),
                     .name = ValueRef{ .bunstr = long_option },
                     .parse_type = .lone_long_option,
@@ -635,7 +635,7 @@ const ParseArgsState = struct {
                     // value exists only for string options, otherwise the property exists with "undefined" as value
                     var value = token.value.asJSValue(globalThis);
                     obj.put(globalThis, ZigString.static("value"), value);
-                    obj.put(globalThis, ZigString.static("inlineValue"), if (value.isUndefined()) .jsUndefined() else JSValue.jsBoolean(token.inline_value));
+                    obj.put(globalThis, ZigString.static("inlineValue"), if (value.isUndefined()) .js_undefined else JSValue.jsBoolean(token.inline_value));
                 },
                 .positional => |token| {
                     obj.put(globalThis, ZigString.static("index"), JSValue.jsNumber(token.index));
@@ -665,7 +665,7 @@ pub fn parseArgs(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
     const config = if (config_value.isUndefined()) null else config_value;
 
     // Phase 0.A: Get and validate type of input args
-    const config_args: JSValue = if (config) |c| c.getOwn(globalThis, "args") orelse .jsUndefined() else .jsUndefined();
+    const config_args: JSValue = if (config) |c| c.getOwn(globalThis, "args") orelse .js_undefined else .js_undefined;
     const args: ArgsSlice = if (!config_args.isUndefinedOrNull()) args: {
         try validators.validateArray(globalThis, config_args, "args", .{}, null);
         break :args .{
@@ -681,7 +681,7 @@ pub fn parseArgs(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
     var config_allow_positionals: JSValue = if (config) |c| c.getOwn(globalThis, "allowPositionals") orelse JSC.jsBoolean(!config_strict.toBoolean()) else JSC.jsBoolean(!config_strict.toBoolean());
     const config_return_tokens: JSValue = (if (config) |c| c.getOwn(globalThis, "tokens") else null) orelse JSValue.jsBoolean(false);
     const config_allow_negative: JSValue = if (config) |c| c.getOwn(globalThis, "allowNegative") orelse .false else .false;
-    const config_options: JSValue = if (config) |c| c.getOwn(globalThis, "options") orelse .jsUndefined() else .jsUndefined();
+    const config_options: JSValue = if (config) |c| c.getOwn(globalThis, "options") orelse .js_undefined else .js_undefined;
 
     const strict = try validators.validateBoolean(globalThis, config_strict, "strict", .{});
 
@@ -714,7 +714,7 @@ pub fn parseArgs(globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSE
     // note that "values" needs to have a null prototype instead of Object, to avoid issues such as "values.toString"` being defined
     const values = JSValue.createEmptyObjectWithNullPrototype(globalThis);
     const positionals = try JSC.JSValue.createEmptyArray(globalThis, 0);
-    const tokens: JSValue = if (return_tokens) try JSC.JSValue.createEmptyArray(globalThis, 0) else .jsUndefined();
+    const tokens: JSValue = if (return_tokens) try JSC.JSValue.createEmptyArray(globalThis, 0) else .js_undefined;
 
     var state = ParseArgsState{
         .globalThis = globalThis,

--- a/src/bun.js/node/zlib/NativeBrotli.zig
+++ b/src/bun.js/node/zlib/NativeBrotli.zig
@@ -112,7 +112,7 @@ pub fn params(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.C
     _ = globalThis;
     _ = callframe;
     // intentionally left empty
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn deinit(this: *@This()) void {

--- a/src/bun.js/node/zlib/NativeZlib.zig
+++ b/src/bun.js/node/zlib/NativeZlib.zig
@@ -93,7 +93,7 @@ pub fn init(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.Cal
 
     this.stream.init(level, windowBits, memLevel, strategy, dictionary);
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn params(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -110,7 +110,7 @@ pub fn params(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.C
     if (err.isError()) {
         try impl.emitError(this, globalThis, callframe.this(), err);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn deinit(this: *@This()) void {

--- a/src/bun.js/node/zlib/NativeZstd.zig
+++ b/src/bun.js/node/zlib/NativeZstd.zig
@@ -112,7 +112,7 @@ pub fn params(this: *@This(), globalThis: *JSC.JSGlobalObject, callframe: *JSC.C
     _ = globalThis;
     _ = callframe;
     // intentionally left empty
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn deinit(this: *@This()) void {

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -356,7 +356,7 @@ pub const Expect = struct {
 
     pub fn call(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(2).slice();
-        const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
+        const value = if (arguments.len < 1) .js_undefined else arguments[0];
 
         var custom_label = bun.String.empty;
         if (arguments.len > 1) {
@@ -438,7 +438,7 @@ pub const Expect = struct {
         var pass = true;
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var msg = _msg.toSlice(default_allocator);
         defer msg.deinit();
@@ -483,7 +483,7 @@ pub const Expect = struct {
         var pass = false;
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var msg = _msg.toSlice(default_allocator);
         defer msg.deinit();
@@ -516,7 +516,7 @@ pub const Expect = struct {
         var pass = right.isSameValue(left, globalThis);
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -608,7 +608,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         if (not) {
@@ -686,7 +686,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -781,7 +781,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1424,7 +1424,7 @@ pub const Expect = struct {
         if (truthy) pass = true;
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1453,7 +1453,7 @@ pub const Expect = struct {
         if (value.isUndefined()) pass = true;
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1486,7 +1486,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1514,7 +1514,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         var pass = value.isNull();
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1542,7 +1542,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         var pass = !value.isUndefined();
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1575,7 +1575,7 @@ pub const Expect = struct {
         if (!truthy) pass = true;
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1612,7 +1612,7 @@ pub const Expect = struct {
         var pass = try value.jestDeepEquals(expected, globalThis);
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         const diff_formatter = DiffFormatter{
@@ -1651,7 +1651,7 @@ pub const Expect = struct {
         var pass = try value.jestStrictDeepEquals(expected, globalThis);
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         const diff_formatter = DiffFormatter{ .received = value, .expected = expected, .globalThis = globalThis, .not = not };
@@ -1706,7 +1706,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1790,7 +1790,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1847,7 +1847,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1907,7 +1907,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -1967,7 +1967,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -2027,7 +2027,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -2090,7 +2090,7 @@ pub const Expect = struct {
         }
 
         if (std.math.isPositiveInf(expected) and std.math.isPositiveInf(received)) {
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         const expected_diff = bun.pow(10, -precision) / 2;
@@ -2100,7 +2100,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -2159,7 +2159,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -2217,7 +2217,7 @@ pub const Expect = struct {
         if (not) {
             const signature = comptime getSignature("toThrow", "<green>expected<r>", true);
 
-            if (!did_throw) return .jsUndefined();
+            if (!did_throw) return .js_undefined;
 
             const result: JSValue = result_.?;
             var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -2226,8 +2226,8 @@ pub const Expect = struct {
             if (expected_value == .zero or expected_value.isUndefined()) {
                 const signature_no_args = comptime getSignature("toThrow", "", true);
                 if (result.toError()) |err| {
-                    const name: JSValue = try err.getTruthyComptime(globalThis, "name") orelse .jsUndefined();
-                    const message: JSValue = try err.getTruthyComptime(globalThis, "message") orelse .jsUndefined();
+                    const name: JSValue = try err.getTruthyComptime(globalThis, "name") orelse .js_undefined;
+                    const message: JSValue = try err.getTruthyComptime(globalThis, "message") orelse .js_undefined;
                     const fmt = signature_no_args ++ "\n\nError name: <red>{any}<r>\nError message: <red>{any}<r>\n";
                     return globalThis.throwPretty(fmt, .{
                         name.toFmt(&formatter),
@@ -2244,7 +2244,7 @@ pub const Expect = struct {
                 const received_message: JSValue = (if (result.isObject())
                     try result.fastGet(globalThis, .message)
                 else
-                    JSValue.fromCell(try result.toJSString(globalThis))) orelse .jsUndefined();
+                    JSValue.fromCell(try result.toJSString(globalThis))) orelse .js_undefined;
                 if (globalThis.hasException()) return .zero;
 
                 // TODO: remove this allocation
@@ -2254,7 +2254,7 @@ pub const Expect = struct {
                     defer expected_slice.deinit();
                     const received_slice = try received_message.toSliceOrNull(globalThis);
                     defer received_slice.deinit();
-                    if (!strings.contains(received_slice.slice(), expected_slice.slice())) return .jsUndefined();
+                    if (!strings.contains(received_slice.slice(), expected_slice.slice())) return .js_undefined;
                 }
 
                 return this.throw(globalThis, signature, "\n\nExpected substring: not <green>{any}<r>\nReceived message: <red>{any}<r>\n", .{
@@ -2267,13 +2267,13 @@ pub const Expect = struct {
                 const received_message: JSValue = (if (result.isObject())
                     try result.fastGet(globalThis, .message)
                 else
-                    JSValue.fromCell(try result.toJSString(globalThis))) orelse .jsUndefined();
+                    JSValue.fromCell(try result.toJSString(globalThis))) orelse .js_undefined;
 
                 if (globalThis.hasException()) return .zero;
                 // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
                 if (try expected_value.get(globalThis, "test")) |test_fn| {
                     const matches = test_fn.call(globalThis, expected_value, &.{received_message}) catch |err| globalThis.takeException(err);
-                    if (!matches.toBoolean()) return .jsUndefined();
+                    if (!matches.toBoolean()) return .js_undefined;
                 }
 
                 return this.throw(globalThis, signature, "\n\nExpected pattern: not <green>{any}<r>\nReceived message: <red>{any}<r>\n", .{
@@ -2286,25 +2286,25 @@ pub const Expect = struct {
                 const received_message: JSValue = (if (result.isObject())
                     try result.fastGet(globalThis, .message)
                 else
-                    JSValue.fromCell(try result.toJSString(globalThis))) orelse .jsUndefined();
+                    JSValue.fromCell(try result.toJSString(globalThis))) orelse .js_undefined;
                 if (globalThis.hasException()) return .zero;
 
                 // no partial match for this case
-                if (!expected_message.isSameValue(received_message, globalThis)) return .jsUndefined();
+                if (!expected_message.isSameValue(received_message, globalThis)) return .js_undefined;
 
                 return this.throw(globalThis, signature, "\n\nExpected message: not <green>{any}<r>\n", .{expected_message.toFmt(&formatter)});
             }
 
-            if (!result.isInstanceOf(globalThis, expected_value)) return .jsUndefined();
+            if (!result.isInstanceOf(globalThis, expected_value)) return .js_undefined;
 
             var expected_class = ZigString.Empty;
             expected_value.getClassName(globalThis, &expected_class);
-            const received_message: JSValue = (try result.fastGet(globalThis, .message)) orelse .jsUndefined();
+            const received_message: JSValue = (try result.fastGet(globalThis, .message)) orelse .js_undefined;
             return this.throw(globalThis, signature, "\n\nExpected constructor: not <green>{s}<r>\n\nReceived message: <red>{any}<r>\n", .{ expected_class, received_message.toFmt(&formatter) });
         }
 
         if (did_throw) {
-            if (expected_value == .zero or expected_value.isUndefined()) return .jsUndefined();
+            if (expected_value == .zero or expected_value.isUndefined()) return .js_undefined;
 
             const result: JSValue = if (result_.?.toError()) |r|
                 r
@@ -2324,7 +2324,7 @@ pub const Expect = struct {
                     defer expected_slice.deinit();
                     const received_slice = try received_message.toSlice(globalThis, globalThis.allocator());
                     defer received_slice.deinit();
-                    if (strings.contains(received_slice.slice(), expected_slice.slice())) return .jsUndefined();
+                    if (strings.contains(received_slice.slice(), expected_slice.slice())) return .js_undefined;
                 }
 
                 // error: message from received error does not match expected string
@@ -2349,7 +2349,7 @@ pub const Expect = struct {
                     // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
                     if (try expected_value.get(globalThis, "test")) |test_fn| {
                         const matches = test_fn.call(globalThis, expected_value, &.{received_message}) catch |err| globalThis.takeException(err);
-                        if (matches.toBoolean()) return .jsUndefined();
+                        if (matches.toBoolean()) return .js_undefined;
                     }
                 }
 
@@ -2380,7 +2380,7 @@ pub const Expect = struct {
                 }
 
                 if (is_equal) {
-                    return .jsUndefined();
+                    return .js_undefined;
                 }
 
                 var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -2397,7 +2397,7 @@ pub const Expect = struct {
                 const signature = comptime getSignature("toThrow", "<green>expected<r>", false);
 
                 if (_received_message) |received_message| {
-                    if (received_message.isSameValue(expected_message, globalThis)) return .jsUndefined();
+                    if (received_message.isSameValue(expected_message, globalThis)) return .js_undefined;
                 }
 
                 // error: message from received error does not match expected error message.
@@ -2415,7 +2415,7 @@ pub const Expect = struct {
                 return this.throw(globalThis, signature, "\n\nExpected message: <green>{any}<r>\nReceived value: <red>{any}<r>\n", .{ expected_fmt, received_fmt });
             }
 
-            if (result.isInstanceOf(globalThis, expected_value)) return .jsUndefined();
+            if (result.isInstanceOf(globalThis, expected_value)) return .js_undefined;
 
             // error: received error not instance of received error constructor
             var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -2503,7 +2503,7 @@ pub const Expect = struct {
         const prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
         vm.unhandled_pending_rejection_to_capture = &return_value;
         vm.onUnhandledRejection = &VirtualMachine.onQuietUnhandledRejectionHandlerCaptureValue;
-        return_value_from_function = value.call(globalThis, .jsUndefined(), &.{}) catch |err| globalThis.takeException(err);
+        return_value_from_function = value.call(globalThis, .js_undefined, &.{}) catch |err| globalThis.takeException(err);
         vm.unhandled_pending_rejection_to_capture = prev_unhandled_pending_rejection_to_capture;
 
         vm.global.handleRejectedPromises();
@@ -2584,10 +2584,10 @@ pub const Expect = struct {
 
         var err_value_res = err_value orelse return null;
         if (err_value_res.isAnyError()) {
-            const message: JSValue = try err_value_res.getTruthyComptime(globalThis, "message") orelse .jsUndefined();
+            const message: JSValue = try err_value_res.getTruthyComptime(globalThis, "message") orelse .js_undefined;
             err_value_res = message;
         } else {
-            err_value_res = .jsUndefined();
+            err_value_res = .js_undefined;
         }
         return err_value_res;
     }
@@ -2787,7 +2787,7 @@ pub const Expect = struct {
 
             if (strings.eqlLong(pretty_value.slice(), trim_res.trimmed, true)) {
                 Jest.runner.?.snapshots.passed += 1;
-                return .jsUndefined();
+                return .js_undefined;
             } else if (update) {
                 Jest.runner.?.snapshots.passed += 1;
                 needs_write = true;
@@ -2850,7 +2850,7 @@ pub const Expect = struct {
             });
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
     pub fn toMatchSnapshot(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
         defer this.postMatch(globalThis);
@@ -2955,7 +2955,7 @@ pub const Expect = struct {
         if (existing_value) |saved_value| {
             if (strings.eqlLong(pretty_value.slice(), saved_value, true)) {
                 Jest.runner.?.snapshots.passed += 1;
-                return .jsUndefined();
+                return .js_undefined;
             }
 
             Jest.runner.?.snapshots.failed += 1;
@@ -2970,7 +2970,7 @@ pub const Expect = struct {
             return globalThis.throwPretty(fmt, .{diff_format});
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn toBeEmpty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
@@ -3036,7 +3036,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         if (not) {
             const signature = comptime getSignature("toBeEmpty", "", true);
@@ -3089,7 +3089,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isUndefinedOrNull() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3115,7 +3115,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.jsType().isArray() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3156,7 +3156,7 @@ pub const Expect = struct {
         var pass = value.jsType().isArray() and @as(i32, @intCast(value.getLength(globalThis))) == size.toInt32();
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3182,7 +3182,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isBoolean() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3253,7 +3253,7 @@ pub const Expect = struct {
         pass = strings.eql(typeof, whatIsTheType);
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3280,7 +3280,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = (value.isBoolean() and value.toBoolean()) != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3306,7 +3306,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = (value.isBoolean() and !value.toBoolean()) != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3332,7 +3332,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isNumber() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3358,7 +3358,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isAnyInt() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3416,7 +3416,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3448,7 +3448,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3480,7 +3480,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3533,7 +3533,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3616,7 +3616,7 @@ pub const Expect = struct {
         }
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -3644,7 +3644,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isSymbol() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3670,7 +3670,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isCallable() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3696,7 +3696,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isDate() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3749,7 +3749,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = value.isString() != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3798,7 +3798,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3879,7 +3879,7 @@ pub const Expect = struct {
             pass = std.mem.containsAtLeast(u8, expectStringAsStr, countAsNum, subStringAsStr);
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -3945,7 +3945,7 @@ pub const Expect = struct {
         };
         value.ensureStillAlive();
 
-        const result = predicate.call(globalThis, .jsUndefined(), &.{value}) catch |e| {
+        const result = predicate.call(globalThis, .js_undefined, &.{value}) catch |e| {
             const err = globalThis.takeException(e);
             const fmt = ZigString.init("toSatisfy() predicate threw an exception");
             return globalThis.throwValue(globalThis.createAggregateError(&.{err}, &fmt));
@@ -3954,7 +3954,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         const pass = (result.isBoolean() and result.toBoolean()) != not;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -4006,7 +4006,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -4060,7 +4060,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         if (not) pass = !pass;
 
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
@@ -4106,7 +4106,7 @@ pub const Expect = struct {
         const not = this.flags.not;
         var pass = value.isInstanceOf(globalThis, expected_value);
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         const expected_fmt = expected_value.toFmt(&formatter);
@@ -4165,7 +4165,7 @@ pub const Expect = struct {
         };
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         const expected_fmt = expected_value.toFmt(&formatter);
@@ -4202,7 +4202,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         if (not) {
@@ -4233,7 +4233,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         if (not) {
@@ -4272,7 +4272,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         if (not) {
@@ -4323,7 +4323,7 @@ pub const Expect = struct {
         var pass = received_object.jestDeepMatch(property_matchers, globalThis, true);
 
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         const diff_formatter = DiffFormatter{
@@ -4389,7 +4389,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         if (not) {
@@ -4444,7 +4444,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -4508,7 +4508,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         // handle failure
         var formatter = JSC.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
@@ -4593,7 +4593,7 @@ pub const Expect = struct {
 
         const not = this.flags.not;
         if (not) pass = !pass;
-        if (pass) return .jsUndefined();
+        if (pass) return .js_undefined;
 
         if (!pass and return_status == ReturnStatus.throw) {
             const signature = comptime getSignature(name, "<green>expected<r>", false);
@@ -4707,7 +4707,7 @@ pub const Expect = struct {
 
         globalThis.bunVM().autoGarbageCollect();
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const CustomMatcherParamsFormatter = struct {
@@ -4823,7 +4823,7 @@ pub const Expect = struct {
                         }
                         message = message_value;
                     } else {
-                        message = .jsUndefined();
+                        message = .js_undefined;
                     }
 
                     break :valid true;
@@ -4868,7 +4868,7 @@ pub const Expect = struct {
 
         // retrieve the user-provided matcher function (matcher_fn)
         const func: JSValue = callFrame.callee();
-        var matcher_fn: JSValue = getCustomMatcherFn(func, globalThis) orelse .jsUndefined();
+        var matcher_fn: JSValue = getCustomMatcherFn(func, globalThis) orelse .js_undefined;
         if (!matcher_fn.jsType().isFunction()) {
             return globalThis.throw("Internal consistency error: failed to retrieve the matcher function for a custom matcher!", .{});
         }
@@ -4922,7 +4922,7 @@ pub const Expect = struct {
 
         is_expecting_assertions = true;
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn assertions(globalThis: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
@@ -4953,7 +4953,7 @@ pub const Expect = struct {
         is_expecting_assertions_count = true;
         active_test_expectation_counter.expected = unsigned_expected_assertions;
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn notImplementedJSCFn(_: *Expect, globalThis: *JSGlobalObject, _: *CallFrame) bun.JSError!JSValue {
@@ -5178,7 +5178,7 @@ pub const ExpectCloseTo = struct {
         }
         const number_value = args[0];
 
-        var precision_value: JSValue = if (args.len > 1) args[1] else .jsUndefined();
+        var precision_value: JSValue = if (args.len > 1) args[1] else .js_undefined;
         if (precision_value.isUndefined()) {
             precision_value = JSValue.jsNumberFromInt32(2); // default value from jest
         }
@@ -5461,7 +5461,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
 
     pub fn asymmetricMatch(this: *ExpectCustomAsymmetricMatcher, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(1).slice();
-        const received_value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
+        const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
         return JSValue.jsBoolean(matched);
     }
@@ -5616,19 +5616,19 @@ pub const ExpectMatcherUtils = struct {
 
     pub fn stringify(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(1).slice();
-        const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
+        const value = if (arguments.len < 1) .js_undefined else arguments[0];
         return printValueCatched(globalThis, value, null);
     }
 
     pub fn printExpected(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(1).slice();
-        const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
+        const value = if (arguments.len < 1) .js_undefined else arguments[0];
         return printValueCatched(globalThis, value, "<green>");
     }
 
     pub fn printReceived(_: *ExpectMatcherUtils, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(1).slice();
-        const value = if (arguments.len < 1) JSValue.jsUndefined() else arguments[0];
+        const value = if (arguments.len < 1) .js_undefined else arguments[0];
         return printValueCatched(globalThis, value, "<red>");
     }
 
@@ -5643,7 +5643,7 @@ pub const ExpectMatcherUtils = struct {
 
         const received = if (arguments.len > 1) arguments[1] else bun.String.static("received").toJS(globalThis);
         const expected = if (arguments.len > 2) arguments[2] else bun.String.static("expected").toJS(globalThis);
-        const options = if (arguments.len > 3) arguments[3] else JSValue.jsUndefined();
+        const options = if (arguments.len > 3) arguments[3] else .js_undefined;
 
         var is_not = false;
         var comment: ?*JSC.JSString = null; // TODO support

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -285,7 +285,7 @@ pub const Jest = struct {
 
                 function.protect();
                 @field(the_runner.global_callbacks, name).append(bun.default_allocator, function) catch unreachable;
-                return .jsUndefined();
+                return .js_undefined;
             }
         }.appendGlobalFunctionCallback;
     }
@@ -505,7 +505,7 @@ pub const Jest = struct {
             test_runner.default_timeout_override = timeout_ms;
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     comptime {
@@ -592,7 +592,7 @@ pub const TestScope = struct {
         var task: *TestRunnerTask = arguments.ptr[1].asPromisePtr(TestRunnerTask);
         task.handleResult(.{ .fail = expect.active_test_expectation_counter.actual }, .promise);
         globalThis.bunVM().autoGarbageCollect();
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
     const jsOnReject = JSC.toJSHostFn(onReject);
 
@@ -602,7 +602,7 @@ pub const TestScope = struct {
         var task: *TestRunnerTask = arguments.ptr[1].asPromisePtr(TestRunnerTask);
         task.handleResult(.{ .pass = expect.active_test_expectation_counter.actual }, .promise);
         globalThis.bunVM().autoGarbageCollect();
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
     const jsOnResolve = JSC.toJSHostFn(onResolve);
 
@@ -648,7 +648,7 @@ pub const TestScope = struct {
             }
         }
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn run(
@@ -905,7 +905,7 @@ pub const DescribeScope = struct {
             scope.done = true;
         }
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub const afterAll = createCallback(.afterAll);
@@ -1083,7 +1083,7 @@ pub const DescribeScope = struct {
 
         if (callback == .zero) {
             this.runTests(globalObject);
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         {
@@ -1096,17 +1096,17 @@ pub const DescribeScope = struct {
                     .fulfilled => {},
                     else => {
                         _ = globalObject.bunVM().unhandledRejection(globalObject, prom.result(globalObject.vm()), prom.asValue());
-                        return .jsUndefined();
+                        return .js_undefined;
                     },
                 }
             } else if (result.toError()) |err| {
                 _ = globalObject.bunVM().uncaughtException(globalObject, err, true);
-                return .jsUndefined();
+                return .js_undefined;
             }
         }
 
         this.runTests(globalObject);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn runTests(this: *DescribeScope, globalObject: *JSGlobalObject) void {
@@ -1805,7 +1805,7 @@ inline fn createScope(
         Jest.runner.?.setOnly();
         tag_to_use = .only;
     } else if (is_test and Jest.runner.?.only and parent.tag != .only) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     var is_skip = tag == .skip or
@@ -2052,14 +2052,14 @@ fn eachBind(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSVa
         const allocator = bun.default_allocator;
         const each_data = bun.cast(*EachData, data);
         JSC.host_fn.setFunctionData(callee, null);
-        const array = each_data.*.strong.get() orelse return .jsUndefined();
+        const array = each_data.*.strong.get() orelse return .js_undefined;
         defer {
             each_data.*.strong.deinit();
             allocator.destroy(each_data);
         }
 
         if (array.isUndefinedOrNull() or !array.jsType().isArray()) {
-            return .jsUndefined();
+            return .js_undefined;
         }
 
         var iter = array.arrayIterator(globalThis);
@@ -2138,7 +2138,7 @@ fn eachBind(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSVa
                 allocator.free(formattedLabel);
             } else if (each_data.is_test) {
                 if (Jest.runner.?.only and tag != .only) {
-                    return .jsUndefined();
+                    return .js_undefined;
                 } else {
                     function.protect();
                     parent.tests.append(allocator, TestScope{
@@ -2168,7 +2168,7 @@ fn eachBind(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSVa
         }
     }
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 inline fn createEach(
@@ -2207,7 +2207,7 @@ fn callJSFunctionForTestRunner(vm: *JSC.VirtualMachine, globalObject: *JSGlobalO
     defer vm.eventLoop().exit();
 
     globalObject.clearTerminationException();
-    return function.call(globalObject, .jsUndefined(), args) catch |err| globalObject.takeException(err);
+    return function.call(globalObject, .js_undefined, args) catch |err| globalObject.takeException(err);
 }
 
 const assert = bun.assert;

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1421,12 +1421,12 @@ pub const JestPrettyFormat = struct {
                 },
                 .Event => {
                     const event_type_value: JSValue = brk: {
-                        const value_: JSValue = value.get_unsafe(this.globalThis, "type") orelse break :brk .jsUndefined();
+                        const value_: JSValue = value.get_unsafe(this.globalThis, "type") orelse break :brk .js_undefined;
                         if (value_.isString()) {
                             break :brk value_;
                         }
 
-                        break :brk .jsUndefined();
+                        break :brk .js_undefined;
                     };
 
                     const event_type = switch (try EventType.map.fromJS(this.globalThis, event_type_value) orelse .unknown) {
@@ -1478,7 +1478,7 @@ pub const JestPrettyFormat = struct {
                                     comptime Output.prettyFmt("<r><blue>data<d>:<r> ", enable_ansi_colors),
                                     .{},
                                 );
-                                const data: JSValue = (try value.fastGet(this.globalThis, .data)) orelse .jsUndefined();
+                                const data: JSValue = (try value.fastGet(this.globalThis, .data)) orelse .js_undefined;
                                 const tag = Tag.get(data, this.globalThis);
 
                                 if (tag.cell.isStringLike()) {

--- a/src/bun.js/virtual_machine_exports.zig
+++ b/src/bun.js/virtual_machine_exports.zig
@@ -91,7 +91,7 @@ pub export fn Bun__reportUnhandledError(globalObject: *JSGlobalObject, value: JS
     if (!value.isTerminationException(vm.jsc)) {
         _ = vm.uncaughtException(globalObject, value, false);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 /// This function is called on another thread

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -2329,7 +2329,7 @@ pub fn onFileStreamResolveRequestStream(globalThis: *JSC.JSGlobalObject, callfra
         stream.done(globalThis);
     }
     this.promise.resolve(globalThis, JSC.JSValue.jsNumber(0));
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn onFileStreamRejectRequestStream(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -2347,7 +2347,7 @@ pub fn onFileStreamRejectRequestStream(globalThis: *JSC.JSGlobalObject, callfram
     if (strong.get(globalThis)) |stream| {
         stream.cancel(globalThis);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 comptime {
     const jsonResolveRequestStream = JSC.toJSHostFn(onFileStreamResolveRequestStream);
@@ -2911,7 +2911,7 @@ pub fn getName(
     _: JSC.JSValue,
     globalThis: *JSC.JSGlobalObject,
 ) JSValue {
-    return if (this.getNameString()) |name| name.toJS(globalThis) else .jsUndefined();
+    return if (this.getNameString()) |name| name.toJS(globalThis) else .js_undefined;
 }
 
 pub fn setName(
@@ -3017,7 +3017,7 @@ export fn Bun__Blob__getSizeForBindings(this: *Blob) callconv(.C) u64 {
 }
 
 pub fn getStat(this: *Blob, globalThis: *JSC.JSGlobalObject, callback: *JSC.CallFrame) bun.JSError!JSC.JSValue {
-    const store = this.store orelse return JSC.JSValue.jsUndefined();
+    const store = this.store orelse return .js_undefined;
     // TODO: make this async for files
     return switch (store.data) {
         .file => |*file| {
@@ -3037,7 +3037,7 @@ pub fn getStat(this: *Blob, globalThis: *JSC.JSGlobalObject, callback: *JSC.Call
             };
         },
         .s3 => S3File.getStat(this, globalThis, callback),
-        else => JSC.JSValue.jsUndefined(),
+        else => .js_undefined,
     };
 }
 pub fn getSize(this: *Blob, _: *JSC.JSGlobalObject) JSValue {

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -175,7 +175,7 @@ pub const PendingValue = struct {
 
                             break :brk globalThis.readableStreamToFormData(readable.value, switch (form_data.?.encoding) {
                                 .Multipart => |multipart| bun.String.init(multipart).toJS(globalThis),
-                                .URLEncoded => .jsUndefined(),
+                                .URLEncoded => .js_undefined,
                             });
                         },
                         else => unreachable,
@@ -306,7 +306,7 @@ pub const Value = union(Tag) {
                 .SystemError => |system_error| system_error.toErrorInstance(globalObject),
                 .Message => |message| message.toErrorInstance(globalObject),
                 // do a early return in this case we don't need to create a new Strong
-                .JSValue => |js_value| return js_value.get() orelse JSC.JSValue.jsUndefined(),
+                .JSValue => |js_value| return js_value.get() orelse .js_undefined,
             };
             this.* = .{ .JSValue = .create(js_value, globalObject) };
             return js_value;
@@ -1503,7 +1503,7 @@ pub const ValueBufferer = struct {
         var args = callframe.arguments_old(2);
         var sink: *@This() = args.ptr[args.len - 1].asPromisePtr(@This());
         sink.handleResolveStream(true);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn onRejectStream(_: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -1511,7 +1511,7 @@ pub const ValueBufferer = struct {
         var sink = args.ptr[args.len - 1].asPromisePtr(@This());
         const err = args.ptr[0];
         sink.handleRejectStream(err, true);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     fn handleRejectStream(sink: *@This(), err: JSValue, is_async: bool) void {

--- a/src/bun.js/webcore/Crypto.zig
+++ b/src/bun.js/webcore/Crypto.zig
@@ -114,7 +114,7 @@ comptime {
 pub fn Bun__randomUUIDv7_(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     const arguments = callframe.argumentsUndef(2).slice();
 
-    var encoding_value: JSC.JSValue = .jsUndefined();
+    var encoding_value: JSC.JSValue = .js_undefined;
 
     const encoding: JSC.Node.Encoding = brk: {
         if (arguments.len > 0) {
@@ -137,7 +137,7 @@ pub fn Bun__randomUUIDv7_(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallF
         else if (arguments.len == 1 and encoding_value.isUndefined())
             arguments[0]
         else
-            .jsUndefined();
+            .js_undefined;
 
         if (!timestamp_value.isUndefined()) {
             if (timestamp_value.isDate()) {

--- a/src/bun.js/webcore/FileReader.zig
+++ b/src/bun.js/webcore/FileReader.zig
@@ -611,7 +611,7 @@ pub fn onReaderDone(this: *FileReader) void {
                     this.eventLoop().js.runCallback(
                         cb,
                         globalThis,
-                        .jsUndefined(),
+                        .js_undefined,
                         &.{
                             JSC.ArrayBuffer.fromBytes(
                                 buffered.items,

--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -434,7 +434,7 @@ pub fn flushFromJS(this: *FileSink, globalThis: *JSGlobalObject, wait: bool) JSC
     }
 
     if (this.done) {
-        return .initResult(.jsUndefined());
+        return .initResult(.js_undefined);
     }
 
     const rc = this.writer.flush();

--- a/src/bun.js/webcore/ObjectURLRegistry.zig
+++ b/src/bun.js/webcore/ObjectURLRegistry.zig
@@ -120,7 +120,7 @@ fn Bun__revokeObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JSC.Call
     }
     const str = arguments.ptr[0].toBunString(globalObject) catch @panic("unreachable");
     if (!str.hasPrefixComptime("blob:")) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const slice = str.toUTF8WithoutRef(bun.default_allocator);
@@ -129,10 +129,10 @@ fn Bun__revokeObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JSC.Call
 
     const sliced = slice.slice();
     if (sliced.len < "blob:".len + UUID.stringLength) {
-        return .jsUndefined();
+        return .js_undefined;
     }
     ObjectURLRegistry.singleton().revoke(sliced["blob:".len..]);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 comptime {
@@ -146,7 +146,7 @@ fn jsFunctionResolveObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JS
     // Not thrown.
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/blob.js#L441
     if (arguments.len < 1) {
-        return .jsUndefined();
+        return .js_undefined;
     }
     const str = try arguments.ptr[0].toBunString(globalObject);
     defer str.deref();
@@ -156,7 +156,7 @@ fn jsFunctionResolveObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JS
     }
 
     if (!str.hasPrefixComptime("blob:") or str.length() < specifier_len) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const slice = str.toUTF8WithoutRef(bun.default_allocator);
@@ -165,7 +165,7 @@ fn jsFunctionResolveObjectURL_(globalObject: *JSC.JSGlobalObject, callframe: *JS
 
     const registry = ObjectURLRegistry.singleton();
     const blob = registry.resolveAndDupeToJS(sliced["blob:".len..], globalObject);
-    return blob orelse .jsUndefined();
+    return blob orelse .js_undefined;
 }
 
 pub const specifier_len = "blob:".len + UUID.stringLength;

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -570,7 +570,7 @@ pub fn NewSource(
                     bun.assert(flag.isBoolean());
                 }
                 return switch (this.context.setRawMode(flag == .true)) {
-                    .result => .jsUndefined(),
+                    .result => .js_undefined,
                     .err => |e| e.toJSC(global),
                 };
             }
@@ -618,7 +618,7 @@ pub fn NewSource(
                 const view = arguments.ptr[0];
                 view.ensureStillAlive();
                 this.this_jsvalue = this_jsvalue;
-                var buffer = view.asArrayBuffer(globalThis) orelse return .jsUndefined();
+                var buffer = view.asArrayBuffer(globalThis) orelse return .js_undefined;
                 return processResult(
                     this_jsvalue,
                     globalThis,
@@ -679,7 +679,7 @@ pub fn NewSource(
                 JSC.markBinding(@src());
                 this.this_jsvalue = callFrame.this();
                 this.cancel();
-                return .jsUndefined();
+                return .js_undefined;
             }
 
             pub fn setOnCloseFromJS(this: *ReadableStreamSourceType, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) bun.JSError!void {
@@ -704,7 +704,7 @@ pub fn NewSource(
                 this.globalThis = globalObject;
 
                 if (value.isUndefined()) {
-                    js.onDrainCallbackSetCached(this.this_jsvalue, globalObject, .jsUndefined());
+                    js.onDrainCallbackSetCached(this.this_jsvalue, globalObject, .js_undefined);
                     return;
                 }
 
@@ -720,7 +720,7 @@ pub fn NewSource(
 
                 JSC.markBinding(@src());
 
-                return this.close_jsvalue.get() orelse .jsUndefined();
+                return this.close_jsvalue.get() orelse .js_undefined;
             }
 
             pub fn getOnDrainFromJS(this: *ReadableStreamSourceType, globalObject: *JSC.JSGlobalObject) JSC.JSValue {
@@ -732,7 +732,7 @@ pub fn NewSource(
                     return val;
                 }
 
-                return .jsUndefined();
+                return .js_undefined;
             }
 
             pub fn updateRef(this: *ReadableStreamSourceType, globalObject: *JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -742,7 +742,7 @@ pub fn NewSource(
                 const ref_or_unref = callFrame.argument(0).toBoolean();
                 this.setRef(ref_or_unref);
 
-                return .jsUndefined();
+                return .js_undefined;
             }
 
             fn onClose(ptr: ?*anyopaque) void {
@@ -768,7 +768,7 @@ pub fn NewSource(
                 if (list.len > 0) {
                     return JSC.ArrayBuffer.fromBytes(list.slice(), .Uint8Array).toJS(globalThis, null);
                 }
-                return JSValue.jsUndefined();
+                return .js_undefined;
             }
 
             pub fn text(this: *ReadableStreamSourceType, globalThis: *JSGlobalObject, callFrame: *JSC.CallFrame) bun.JSError!JSC.JSValue {

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -94,7 +94,7 @@ pub const InternalJSEventCallback = struct {
 
     pub fn trigger(this: *InternalJSEventCallback, eventType: EventType, globalThis: *JSC.JSGlobalObject) bool {
         if (this.function.get()) |callback| {
-            _ = callback.call(globalThis, JSC.JSValue.jsUndefined(), &.{JSC.JSValue.jsNumber(
+            _ = callback.call(globalThis, .js_undefined, &.{JSC.JSValue.jsNumber(
                 @intFromEnum(eventType),
             )}) catch |err| globalThis.reportActiveExceptionAsUnhandled(err);
             return true;
@@ -555,10 +555,10 @@ pub fn constructInto(globalThis: *JSC.JSGlobalObject, arguments: []const JSC.JSV
         if (arguments.len > 1 and arguments[1].isObject())
             arguments[1]
         else if (is_first_argument_a_url)
-            .jsUndefined()
+            .js_undefined
         else
             url_or_object,
-        if (is_first_argument_a_url) .jsUndefined() else url_or_object,
+        if (is_first_argument_a_url) .js_undefined else url_or_object,
     };
     const values_to_try = values_to_try_[0 .. @as(usize, @intFromBool(!is_first_argument_a_url)) +
         @as(usize, @intFromBool(arguments.len > 1 and arguments[1].isObject()))];

--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -77,7 +77,7 @@ pub export fn jsFunctionGetCompleteRequestOrResponseBodyValueAsArrayBuffer(globa
     const arguments = callframe.arguments_old(1);
     const this_value = arguments.ptr[0];
     if (this_value.isEmptyOrUndefinedOrNull()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     const body: *Body.Value = brk: {
@@ -87,15 +87,15 @@ pub export fn jsFunctionGetCompleteRequestOrResponseBodyValueAsArrayBuffer(globa
             break :brk &request.body.value;
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     };
 
     // Get the body if it's available synchronously.
     switch (body.*) {
-        .Used, .Empty, .Null => return .jsUndefined(),
+        .Used, .Empty, .Null => return .js_undefined,
         .Blob => |*blob| {
             if (blob.isBunFile()) {
-                return .jsUndefined();
+                return .js_undefined;
             }
             defer body.* = .{ .Used = {} };
             return blob.toArrayBuffer(globalObject, .transfer) catch return .zero;
@@ -104,7 +104,7 @@ pub export fn jsFunctionGetCompleteRequestOrResponseBodyValueAsArrayBuffer(globa
             var any_blob = body.useAsAnyBlob();
             return any_blob.toArrayBufferTransfer(globalObject) catch return .zero;
         },
-        .Error, .Locked => return .jsUndefined(),
+        .Error, .Locked => return .js_undefined,
     }
 }
 

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -542,7 +542,7 @@ pub fn getBucket(this: *Blob, globalThis: *JSC.JSGlobalObject) callconv(JSC.conv
     if (getBucketName(this)) |name| {
         return bun.String.createUTF8ForJS(globalThis, name);
     }
-    return .jsUndefined();
+    return .js_undefined;
 }
 pub fn getPresignUrl(this: *Blob, globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
     const args = callframe.arguments_old(1);

--- a/src/bun.js/webcore/Sink.zig
+++ b/src/bun.js/webcore/Sink.zig
@@ -228,11 +228,11 @@ pub fn JSSink(comptime SinkType: type, comptime abi_name: []const u8) type {
             }
 
             pub fn close(this: *@This(), _: ?Syscall.Error) void {
-                onClose(@as(SinkSignal, @bitCast(@intFromPtr(this))).cpp, JSValue.jsUndefined());
+                onClose(@as(SinkSignal, @bitCast(@intFromPtr(this))).cpp, .js_undefined);
             }
 
             pub fn ready(this: *@This(), _: ?Blob.SizeType, _: ?Blob.SizeType) void {
-                onReady(@as(SinkSignal, @bitCast(@intFromPtr(this))).cpp, JSValue.jsUndefined(), JSValue.jsUndefined());
+                onReady(@as(SinkSignal, @bitCast(@intFromPtr(this))).cpp, .js_undefined, .js_undefined);
             }
 
             pub fn start(_: *@This()) void {}
@@ -463,7 +463,7 @@ pub fn JSSink(comptime SinkType: type, comptime abi_name: []const u8) type {
 
         pub fn close(globalThis: *JSGlobalObject, sink_ptr: ?*anyopaque) callconv(.C) JSValue {
             JSC.markBinding(@src());
-            const this: *ThisSink = @ptrCast(@alignCast(sink_ptr orelse return .jsUndefined()));
+            const this: *ThisSink = @ptrCast(@alignCast(sink_ptr orelse return .js_undefined));
 
             if (comptime @hasDecl(SinkType, "getPendingError")) {
                 if (this.sink.getPendingError()) |err| {

--- a/src/bun.js/webcore/TextEncoder.zig
+++ b/src/bun.js/webcore/TextEncoder.zig
@@ -200,7 +200,7 @@ pub export fn TextEncoder__encodeRopeString(
     array.ensureStillAlive();
 
     if (encoder.any_non_ascii) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     if (array == .zero) {

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -353,7 +353,7 @@ pub const FetchTasklet = struct {
             }
         }
 
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
 
     pub fn onRejectRequestStream(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -372,7 +372,7 @@ pub const FetchTasklet = struct {
         }
 
         this.abortListener(err);
-        return JSValue.jsUndefined();
+        return .js_undefined;
     }
     comptime {
         const jsonResolveRequestStream = JSC.toJSHostFn(onResolveRequestStream);
@@ -794,7 +794,7 @@ pub const FetchTasklet = struct {
                     const js_hostname = hostname.toJS(globalObject);
                     js_hostname.ensureStillAlive();
                     js_cert.ensureStillAlive();
-                    const check_result = check_server_identity.call(globalObject, .jsUndefined(), &.{ js_hostname, js_cert }) catch |err| globalObject.takeException(err);
+                    const check_result = check_server_identity.call(globalObject, .js_undefined, &.{ js_hostname, js_cert }) catch |err| globalObject.takeException(err);
 
                     // > Returns <Error> object [...] on failure
                     if (check_result.isAnyError()) {
@@ -1499,7 +1499,7 @@ pub fn Bun__fetchPreconnect_(
     }
 
     bun.http.AsyncHTTP.preconnect(url, true);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 const StringOrURL = struct {

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -31,14 +31,14 @@ fn alert(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSErr
             // 5. Show message to the user, treating U+000A LF as a line break.
             output.writeAll(message.slice()) catch {
                 // 1. If we cannot show simple dialogs for this, then return.
-                return .jsUndefined();
+                return .js_undefined;
             };
         }
     }
 
     output.writeAll(if (has_message) " [Enter] " else "Alert [Enter] ") catch {
         // 1. If we cannot show simple dialogs for this, then return.
-        return .jsUndefined();
+        return .js_undefined;
     };
 
     // 6. Invoke WebDriver BiDi user prompt opened with this, "alert", and message.
@@ -56,7 +56,7 @@ fn alert(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSErr
     // 8. Invoke WebDriver BiDi user prompt closed with this and true.
     // *  Again, not necessary in a server context.
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 fn confirm(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -32,7 +32,7 @@ pub const Start = union(Tag) {
     pub fn toJS(this: Start, globalThis: *JSGlobalObject) JSC.JSValue {
         switch (this) {
             .empty, .ready => {
-                return .jsUndefined();
+                return .js_undefined;
             },
             .chunk_size => |chunk| {
                 return JSC.JSValue.jsNumber(@as(Blob.SizeType, @intCast(chunk)));
@@ -47,7 +47,7 @@ pub const Start = union(Tag) {
                 return JSC.ArrayBuffer.create(globalThis, list.slice(), .Uint8Array);
             },
             else => {
-                return .jsUndefined();
+                return .js_undefined;
             },
         }
     }

--- a/src/bun_js.zig
+++ b/src/bun_js.zig
@@ -413,11 +413,11 @@ pub const Run = struct {
 
                 if (this.ctx.runtime_options.eval.eval_and_print) {
                     const to_print = brk: {
-                        const result: JSC.JSValue = vm.entry_point_result.value.get() orelse .jsUndefined();
+                        const result: JSC.JSValue = vm.entry_point_result.value.get() orelse .js_undefined;
                         if (result.asAnyPromise()) |promise| {
                             switch (promise.status(vm.jsc)) {
                                 .pending => {
-                                    result._then2(vm.global, .jsUndefined(), Bun__onResolveEntryPointResult, Bun__onRejectEntryPointResult);
+                                    result._then2(vm.global, .js_undefined, Bun__onResolveEntryPointResult, Bun__onRejectEntryPointResult);
 
                                     vm.tick();
                                     vm.eventLoop().autoTickActive();
@@ -490,7 +490,7 @@ pub export fn Bun__onResolveEntryPointResult(global: *JSC.JSGlobalObject, callfr
     const result = arguments[0];
     result.print(global, .Log, .Log);
     Global.exit(global.bunVM().exit_handler.exit_code);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub export fn Bun__onRejectEntryPointResult(global: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) callconv(JSC.conv) noreturn {
@@ -498,7 +498,7 @@ pub export fn Bun__onRejectEntryPointResult(global: *JSC.JSGlobalObject, callfra
     const result = arguments[0];
     result.print(global, .Log, .Log);
     Global.exit(global.bunVM().exit_handler.exit_code);
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 noinline fn dumpBuildError(vm: *JSC.VirtualMachine) void {

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -939,13 +939,13 @@ pub const upgrade_js_bindings = struct {
     /// For testing upgrades when the temp directory has an open handle without FILE_SHARE_DELETE.
     /// Windows only
     pub fn jsOpenTempDirWithoutSharingDelete(_: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!bun.JSC.JSValue {
-        if (comptime !Environment.isWindows) return .jsUndefined();
+        if (comptime !Environment.isWindows) return .js_undefined;
         const w = std.os.windows;
 
         var buf: bun.WPathBuffer = undefined;
         const tmpdir_path = fs.FileSystem.RealFS.getDefaultTempDir();
         const path = switch (bun.sys.normalizePathWindows(u8, bun.invalid_fd, tmpdir_path, &buf, .{})) {
-            .err => return .jsUndefined(),
+            .err => return .js_undefined,
             .result => |norm| norm,
         };
 
@@ -989,17 +989,17 @@ pub const upgrade_js_bindings = struct {
             else => {},
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn jsCloseTempDirHandle(_: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
-        if (comptime !Environment.isWindows) return .jsUndefined();
+        if (comptime !Environment.isWindows) return .js_undefined;
 
         if (tempdir_fd) |fd| {
             fd.close();
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 };
 

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -1779,9 +1779,9 @@ pub const js_bindings = struct {
     }
 
     pub fn jsGetMachOImageZeroOffset(_: *bun.JSC.JSGlobalObject, _: *bun.JSC.CallFrame) bun.JSError!JSValue {
-        if (!bun.Environment.isMac) return .jsUndefined();
+        if (!bun.Environment.isMac) return .js_undefined;
 
-        const header = std.c._dyld_get_image_header(0) orelse return .jsUndefined();
+        const header = std.c._dyld_get_image_header(0) orelse return .js_undefined;
         const base_address = @intFromPtr(header);
         const vmaddr_slide = std.c._dyld_get_image_vmaddr_slide(0);
 
@@ -1793,7 +1793,7 @@ pub const js_bindings = struct {
         const ptr: [*]align(1) u64 = @ptrFromInt(0xDEADBEEF);
         ptr[0] = 0xDEADBEEF;
         std.mem.doNotOptimizeAway(&ptr);
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn jsPanic(_: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {

--- a/src/css/css_internals.zig
+++ b/src/css/css_internals.zig
@@ -320,7 +320,7 @@ pub fn attrTest(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.
                 .initOutsideOfBundler(&import_records),
             ) catch |e| {
                 bun.handleErrorReturnTrace(e, @errorReturnTrace());
-                return .jsUndefined();
+                return .js_undefined;
             };
 
             return bun.String.fromBytes(result.code).toJS(globalThis);

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -332,7 +332,7 @@ pub const hostent_with_ttls = struct {
                     bun.dns.addressToJS(&std.net.Address.initIp4(addr[0..4].*, 0), globalThis)) catch return globalThis.throwOutOfMemoryValue();
 
                 const ttl: ?c_int = if (count < this.ttls.len) this.ttls[count] else null;
-                const resultObject = JSC.JSValue.createObject2(globalThis, &addressKey, &ttlKey, addrString, if (ttl) |val| JSC.jsNumber(val) else .jsUndefined());
+                const resultObject = JSC.JSValue.createObject2(globalThis, &addressKey, &ttlKey, addrString, if (ttl) |val| JSC.jsNumber(val) else .js_undefined);
                 array.putIndex(globalThis, count, resultObject);
             }
 
@@ -439,7 +439,7 @@ pub const struct_nameinfo = extern struct {
             const node_slice = this.node[0..node_len];
             array.putIndex(globalThis, 0, JSC.ZigString.fromUTF8(node_slice).toJS(globalThis));
         } else {
-            array.putIndex(globalThis, 0, .jsUndefined());
+            array.putIndex(globalThis, 0, .js_undefined);
         }
 
         if (this.service != null) {
@@ -447,7 +447,7 @@ pub const struct_nameinfo = extern struct {
             const service_slice = this.service[0..service_len];
             array.putIndex(globalThis, 1, JSC.ZigString.fromUTF8(service_slice).toJS(globalThis));
         } else {
-            array.putIndex(globalThis, 1, .jsUndefined());
+            array.putIndex(globalThis, 1, .js_undefined);
         }
 
         return array;
@@ -2021,9 +2021,9 @@ pub fn Bun__canonicalizeIP_(globalThis: *JSC.JSGlobalObject, callframe: *JSC.Cal
         const addr_slice = addr.toSlice(bun.default_allocator);
         const addr_str = addr_slice.slice();
         if (addr_str.len >= INET6_ADDRSTRLEN) {
-            return .jsUndefined();
+            return .js_undefined;
         }
-        for (addr_str) |char| if (char == '/') return .jsUndefined(); // CIDR not allowed
+        for (addr_str) |char| if (char == '/') return .js_undefined; // CIDR not allowed
 
         var ip_std_text: [INET6_ADDRSTRLEN + 1]u8 = undefined;
         // we need a null terminated string as input
@@ -2036,12 +2036,12 @@ pub fn Bun__canonicalizeIP_(globalThis: *JSC.JSGlobalObject, callframe: *JSC.Cal
         if (ares_inet_pton(af, &ip_addr, &ip_std_text) != 1) {
             af = AF.INET6;
             if (ares_inet_pton(af, &ip_addr, &ip_std_text) != 1) {
-                return .jsUndefined();
+                return .js_undefined;
             }
         }
         // ip_addr will contain the null-terminated string of the cannonicalized IP
         if (ares_inet_ntop(af, &ip_std_text, &ip_addr, @sizeOf(@TypeOf(ip_addr))) == null) {
-            return .jsUndefined();
+            return .js_undefined;
         }
         // use the null-terminated size to return the string
         const size = bun.len(bun.cast([*:0]u8, &ip_addr));

--- a/src/deps/uws/UpgradedDuplex.zig
+++ b/src/deps/uws/UpgradedDuplex.zig
@@ -149,7 +149,7 @@ fn onReceivedData(
             const data_arg = args.ptr[0];
             if (this.origin.has()) {
                 if (data_arg.isEmptyOrUndefinedOrNull()) {
-                    return JSC.JSValue.jsUndefined();
+                    return .js_undefined;
                 }
                 if (data_arg.asArrayBuffer(globalObject)) |array_buffer| {
                     // yay we can read the data
@@ -164,7 +164,7 @@ fn onReceivedData(
             }
         }
     }
-    return JSC.JSValue.jsUndefined();
+    return .js_undefined;
 }
 
 fn onEnd(
@@ -203,7 +203,7 @@ fn onWritable(
         this.handlers.onWritable(this.handlers.ctx);
     }
 
-    return JSC.JSValue.jsUndefined();
+    return .js_undefined;
 }
 
 fn onCloseJS(
@@ -223,7 +223,7 @@ fn onCloseJS(
         }
     }
 
-    return JSC.JSValue.jsUndefined();
+    return .js_undefined;
 }
 
 pub fn onTimeout(this: *UpgradedDuplex) EventLoopTimer.Arm {

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -783,10 +783,10 @@ pub const Version = struct {
         pub fn inferFromJS(globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
             const arguments = callframe.arguments_old(1).slice();
             if (arguments.len == 0 or !arguments[0].isString()) {
-                return .jsUndefined();
+                return .js_undefined;
             }
 
-            const tag = try Tag.fromJS(globalObject, arguments[0]) orelse return .jsUndefined();
+            const tag = try Tag.fromJS(globalObject, arguments[0]) orelse return .js_undefined;
             var str = bun.String.init(@tagName(tag));
             return str.transferToJS(globalObject);
         }
@@ -1284,19 +1284,19 @@ pub fn fromJS(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JS
     var stack = std.heap.stackFallback(1024, arena.allocator());
     const allocator = stack.get();
 
-    const alias_value: JSC.JSValue = if (arguments.len > 0) arguments[0] else .jsUndefined();
+    const alias_value: JSC.JSValue = if (arguments.len > 0) arguments[0] else .js_undefined;
 
     if (!alias_value.isString()) {
-        return .jsUndefined();
+        return .js_undefined;
     }
     const alias_slice = try alias_value.toSlice(globalThis, allocator);
     defer alias_slice.deinit();
 
     if (alias_slice.len == 0) {
-        return .jsUndefined();
+        return .js_undefined;
     }
 
-    const name_value: JSC.JSValue = if (arguments.len > 1) arguments[1] else .jsUndefined();
+    const name_value: JSC.JSValue = if (arguments.len > 1) arguments[1] else .js_undefined;
     const name_slice = try name_value.toSlice(globalThis, allocator);
     defer name_slice.deinit();
 
@@ -1320,7 +1320,7 @@ pub fn fromJS(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JS
             return globalThis.throwValue(try log.toJS(globalThis, bun.default_allocator, "Failed to parse dependency"));
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     };
 
     if (log.msgs.items.len > 0) {

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -8267,11 +8267,11 @@ pub const PackageManager = struct {
                 }
                 if (globalThis.hasException()) return .zero;
             } else {
-                return .jsUndefined();
+                return .js_undefined;
             }
 
             if (all_positionals.items.len == 0) {
-                return .jsUndefined();
+                return .js_undefined;
             }
 
             var array = Array{};
@@ -8279,7 +8279,7 @@ pub const PackageManager = struct {
             const update_requests = parseWithError(allocator, null, &log, all_positionals.items, &array, .add, false) catch {
                 return globalThis.throwValue(try log.toJS(globalThis, bun.default_allocator, "Failed to parse dependencies"));
             };
-            if (update_requests.len == 0) return .jsUndefined();
+            if (update_requests.len == 0) return .js_undefined;
 
             if (log.msgs.items.len > 0) {
                 return globalThis.throwValue(try log.toJS(globalThis, bun.default_allocator, "Failed to parse dependencies"));

--- a/src/js_ast.zig
+++ b/src/js_ast.zig
@@ -6342,7 +6342,7 @@ pub const Expr = struct {
                 .e_object => |e| e.toJS(allocator, globalObject),
                 .e_string => |e| e.toJS(allocator, globalObject),
                 .e_null => JSC.JSValue.null,
-                .e_undefined => .jsUndefined(),
+                .e_undefined => .js_undefined,
                 .e_boolean => |boolean| if (boolean.value)
                     JSC.JSValue.true
                 else

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -748,7 +748,7 @@ pub const Log = struct {
 
         const count = @as(u16, @intCast(@min(msgs.len, errors_stack.len)));
         switch (count) {
-            0 => return .jsUndefined(),
+            0 => return .js_undefined,
             1 => {
                 const msg = msgs[0];
                 return switch (msg.metadata) {

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -270,7 +270,7 @@ pub export fn napi_get_undefined(env_: napi_env, result_: ?*napi_value) napi_sta
     const result = result_ orelse {
         return env.invalidArg();
     };
-    result.set(env, JSValue.jsUndefined());
+    result.set(env, .js_undefined);
     return env.ok();
 }
 pub export fn napi_get_null(env_: napi_env, result_: ?*napi_value) napi_status {
@@ -674,7 +674,7 @@ pub export fn napi_make_callback(env_: napi_env, _: *anyopaque, recv_: napi_valu
         if (recv != .zero)
             recv
         else
-            .jsUndefined(),
+            .js_undefined,
         if (arg_count > 0 and args != null)
             @as([*]const JSC.JSValue, @ptrCast(args.?))[0..arg_count]
         else
@@ -1616,16 +1616,16 @@ pub const ThreadSafeFunction = struct {
 
         switch (this.callback) {
             .js => |strong| {
-                const js: JSValue = strong.get() orelse .jsUndefined();
+                const js: JSValue = strong.get() orelse .js_undefined;
                 if (js.isEmptyOrUndefinedOrNull()) {
                     return;
                 }
 
-                _ = js.call(globalObject, .jsUndefined(), &.{}) catch |err|
+                _ = js.call(globalObject, .js_undefined, &.{}) catch |err|
                     globalObject.reportActiveExceptionAsUnhandled(err);
             },
             .c => |cb| {
-                const js: JSValue = cb.js.get() orelse .jsUndefined();
+                const js: JSValue = cb.js.get() orelse .js_undefined;
 
                 const handle_scope = NapiHandleScope.open(env, false);
                 defer if (handle_scope) |scope| scope.close(env);

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -1168,11 +1168,11 @@ pub const TestingAPIs = struct {
 
         const patchfile_js = arguments.nextEat() orelse {
             globalThis.throw("apply: expected at least 1 argument, got 0", .{}) catch {};
-            return .initErr(.jsUndefined());
+            return .initErr(.js_undefined);
         };
 
         const dir_fd = if (arguments.nextEat()) |dir_js| brk: {
-            var bunstr = dir_js.toBunString(globalThis) catch return .initErr(.jsUndefined());
+            var bunstr = dir_js.toBunString(globalThis) catch return .initErr(.js_undefined);
             defer bunstr.deref();
             const path = bunstr.toOwnedSliceZ(bun.default_allocator) catch unreachable;
             defer bun.default_allocator.free(path);
@@ -1180,13 +1180,13 @@ pub const TestingAPIs = struct {
             break :brk switch (bun.sys.open(path, bun.O.DIRECTORY | bun.O.RDONLY, 0)) {
                 .err => |e| {
                     globalThis.throwValue(e.withPath(path).toJSC(globalThis)) catch {};
-                    return .initErr(.jsUndefined());
+                    return .initErr(.js_undefined);
                 },
                 .result => |fd| fd,
             };
         } else bun.FileDescriptor.cwd();
 
-        const patchfile_bunstr = patchfile_js.toBunString(globalThis) catch return .initErr(.jsUndefined());
+        const patchfile_bunstr = patchfile_js.toBunString(globalThis) catch return .initErr(.js_undefined);
         defer patchfile_bunstr.deref();
         const patchfile_src = patchfile_bunstr.toUTF8(bun.default_allocator);
 
@@ -1198,7 +1198,7 @@ pub const TestingAPIs = struct {
 
             patchfile_src.deinit();
             globalThis.throwError(e, "failed to parse patchfile") catch {};
-            return .initErr(.jsUndefined());
+            return .initErr(.js_undefined);
         };
 
         return .{

--- a/src/s3/client.zig
+++ b/src/s3/client.zig
@@ -376,7 +376,7 @@ pub fn onUploadStreamResolveRequestStream(globalThis: *JSC.JSGlobalObject, callf
     this.readable_stream_ref.deinit();
     this.task.continueStream();
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn onUploadStreamRejectRequestStream(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -403,7 +403,7 @@ pub fn onUploadStreamRejectRequestStream(globalThis: *JSC.JSGlobalObject, callfr
     }
     this.task.continueStream();
 
-    return .jsUndefined();
+    return .js_undefined;
 }
 comptime {
     const jsonResolveRequestStream = JSC.toJSHostFn(onUploadStreamResolveRequestStream);

--- a/src/shell/ParsedShellScript.zig
+++ b/src/shell/ParsedShellScript.zig
@@ -54,12 +54,12 @@ pub fn setCwd(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: 
     };
     const str = try bun.String.fromJS(str_js, globalThis);
     this.cwd = str;
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn setQuiet(this: *ParsedShellScript, _: *JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
     this.quiet = true;
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn setEnv(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -97,7 +97,7 @@ pub fn setEnv(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: 
         previous.deinit();
     }
     this.export_env = env;
-    return .jsUndefined();
+    return .js_undefined;
 }
 
 pub fn createParsedShellScript(globalThis: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -1137,7 +1137,7 @@ pub const Interpreter = struct {
         root.start();
         if (globalThis.hasException()) return error.JSError;
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     fn ioToJSValue(globalThis: *JSGlobalObject, buf: *bun.ByteList) JSValue {
@@ -1185,13 +1185,13 @@ pub const Interpreter = struct {
                     const loop = this.event_loop.js;
                     this.keep_alive.disable();
                     loop.enter();
-                    _ = resolve.call(globalThis, .jsUndefined(), &.{
+                    _ = resolve.call(globalThis, .js_undefined, &.{
                         JSValue.jsNumberFromU16(exit_code),
                         this.getBufferedStdout(globalThis),
                         this.getBufferedStderr(globalThis),
                     }) catch |err| globalThis.reportActiveExceptionAsUnhandled(err);
-                    JSC.Codegen.JSShellInterpreter.resolveSetCached(this_jsvalue, globalThis, .jsUndefined());
-                    JSC.Codegen.JSShellInterpreter.rejectSetCached(this_jsvalue, globalThis, .jsUndefined());
+                    JSC.Codegen.JSShellInterpreter.resolveSetCached(this_jsvalue, globalThis, .js_undefined);
+                    JSC.Codegen.JSShellInterpreter.rejectSetCached(this_jsvalue, globalThis, .js_undefined);
                     loop.exit();
                 }
             }
@@ -1220,8 +1220,8 @@ pub const Interpreter = struct {
                         this.getBufferedStdout(globalThis),
                         this.getBufferedStderr(globalThis),
                     }) catch |err| globalThis.reportActiveExceptionAsUnhandled(err);
-                    JSC.Codegen.JSShellInterpreter.resolveSetCached(this_jsvalue, globalThis, .jsUndefined());
-                    JSC.Codegen.JSShellInterpreter.rejectSetCached(this_jsvalue, globalThis, .jsUndefined());
+                    JSC.Codegen.JSShellInterpreter.resolveSetCached(this_jsvalue, globalThis, .js_undefined);
+                    JSC.Codegen.JSShellInterpreter.rejectSetCached(this_jsvalue, globalThis, .js_undefined);
 
                     loop.exit();
                 }
@@ -1269,7 +1269,7 @@ pub const Interpreter = struct {
     pub fn setQuiet(this: *ThisInterpreter, _: *JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         log("Interpreter(0x{x}) setQuiet()", .{@intFromPtr(this)});
         this.flags.quiet = true;
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setCwd(this: *ThisInterpreter, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -1284,7 +1284,7 @@ pub const Interpreter = struct {
             },
             .result => {},
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setEnv(this: *ThisInterpreter, globalThis: *JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSC.JSValue {
@@ -1320,7 +1320,7 @@ pub const Interpreter = struct {
             this.root_shell.export_env.insert(keyref, valueref);
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn isRunning(

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -241,8 +241,8 @@ pub const ShellSubprocess = struct {
         pub fn toJS(this: *Writable, globalThis: *JSC.JSGlobalObject, subprocess: *Subprocess) JSValue {
             return switch (this.*) {
                 .fd => |fd| JSValue.jsNumber(fd),
-                .memfd, .ignore => JSValue.jsUndefined(),
-                .buffer, .inherit => JSValue.jsUndefined(),
+                .memfd, .ignore => .js_undefined,
+                .buffer, .inherit => .js_undefined,
                 .pipe => |pipe| {
                     this.* = .{ .ignore = {} };
                     if (subprocess.process.hasExited() and !subprocess.flags.has_stdin_destructor_called) {
@@ -1295,7 +1295,7 @@ pub const PipeReader = struct {
                 return JSC.MarkedArrayBuffer.fromBytes(bytes, bun.default_allocator, .Uint8Array).toNodeBuffer(globalThis);
             },
             else => {
-                return .jsUndefined();
+                return .js_undefined;
             },
         }
     }

--- a/src/sql/postgres.zig
+++ b/src/sql/postgres.zig
@@ -245,7 +245,7 @@ pub const PostgresSQLContext = struct {
         ctx.onQueryResolveFn.set(globalObject, callframe.argument(0));
         ctx.onQueryRejectFn.set(globalObject, callframe.argument(1));
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     comptime {
@@ -541,10 +541,10 @@ pub const PostgresSQLQuery = struct {
 
         event_loop.runCallback(function, globalObject, thisValue, &.{
             targetValue,
-            consumePendingValue(thisValue, globalObject) orelse .jsUndefined(),
+            consumePendingValue(thisValue, globalObject) orelse .js_undefined,
             tag.toJSTag(globalObject),
             tag.toJSNumber(),
-            if (connection == .zero) .jsUndefined() else PostgresSQLConnection.js.queriesGetCached(connection) orelse .jsUndefined(),
+            if (connection == .zero) .js_undefined else PostgresSQLConnection.js.queriesGetCached(connection) orelse .js_undefined,
             JSValue.jsBoolean(is_last),
         });
     }
@@ -578,8 +578,8 @@ pub const PostgresSQLQuery = struct {
             return globalThis.throw("values must be an array", .{});
         }
 
-        const pending_value: JSValue = args.nextEat() orelse .jsUndefined();
-        const columns: JSValue = args.nextEat() orelse .jsUndefined();
+        const pending_value: JSValue = args.nextEat() orelse .js_undefined;
+        const columns: JSValue = args.nextEat() orelse .js_undefined;
         const js_bigint: JSValue = args.nextEat() orelse .false;
         const js_simple: JSValue = args.nextEat() orelse .false;
 
@@ -628,12 +628,12 @@ pub const PostgresSQLQuery = struct {
     pub fn doDone(this: *@This(), globalObject: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         _ = globalObject;
         this.flags.is_done = true;
-        return .jsUndefined();
+        return .js_undefined;
     }
     pub fn setPendingValue(this: *PostgresSQLQuery, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         const result = callframe.argument(0);
         js.pendingValueSetCached(this.thisValue.get(), globalObject, result);
-        return .jsUndefined();
+        return .js_undefined;
     }
     pub fn setMode(this: *PostgresSQLQuery, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
         const js_mode = callframe.argument(0);
@@ -645,7 +645,7 @@ pub const PostgresSQLQuery = struct {
         this.flags.result_mode = std.meta.intToEnum(PostgresSQLQueryResultMode, mode) catch {
             return globalObject.throwInvalidArgumentTypeValue("mode", "Number", js_mode);
         };
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn doRun(this: *PostgresSQLQuery, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -704,10 +704,10 @@ pub const PostgresSQLQuery = struct {
             } else {
                 connection.resetConnectionTimeout();
             }
-            return .jsUndefined();
+            return .js_undefined;
         }
 
-        const columns_value: JSValue = js.columnsGetCached(this_value) orelse .jsUndefined();
+        const columns_value: JSValue = js.columnsGetCached(this_value) orelse .js_undefined;
 
         var signature = Signature.generate(globalObject, query_str.slice(), binding_value, columns_value, connection.prepared_statement_id, connection.flags.use_unnamed_prepared_statements) catch |err| {
             if (!globalObject.hasException())
@@ -821,7 +821,7 @@ pub const PostgresSQLQuery = struct {
         } else {
             connection.resetConnectionTimeout();
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn doCancel(this: *PostgresSQLQuery, globalObject: *JSC.JSGlobalObject, callframe: *JSC.CallFrame) bun.JSError!JSValue {
@@ -829,7 +829,7 @@ pub const PostgresSQLQuery = struct {
         _ = globalObject;
         _ = this;
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     comptime {
@@ -1182,7 +1182,7 @@ pub const PostgresSQLConnection = struct {
     statements: PreparedStatementsMap,
     prepared_statement_id: u64 = 0,
     pending_activity_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
-    js_value: JSValue = .jsUndefined(),
+    js_value: JSValue = .js_undefined,
 
     backend_parameters: bun.StringMap = bun.StringMap.init(bun.default_allocator, true),
     backend_key_data: protocol.BackendKeyData = .{},
@@ -1410,7 +1410,7 @@ pub const PostgresSQLConnection = struct {
             return value;
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setOnConnect(_: *PostgresSQLConnection, thisValue: JSC.JSValue, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) void {
@@ -1422,7 +1422,7 @@ pub const PostgresSQLConnection = struct {
             return value;
         }
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setOnClose(_: *PostgresSQLConnection, thisValue: JSC.JSValue, globalObject: *JSC.JSGlobalObject, value: JSC.JSValue) void {
@@ -2046,17 +2046,17 @@ pub const PostgresSQLConnection = struct {
     pub fn doRef(this: *@This(), _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         this.poll_ref.ref(this.globalObject.bunVM());
         this.updateHasPendingActivity();
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn doUnref(this: *@This(), _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         this.poll_ref.unref(this.globalObject.bunVM());
         this.updateHasPendingActivity();
-        return .jsUndefined();
+        return .js_undefined;
     }
     pub fn doFlush(this: *PostgresSQLConnection, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSC.JSValue {
         this.flushData();
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn deref(this: *@This()) void {
@@ -2074,7 +2074,7 @@ pub const PostgresSQLConnection = struct {
         this.disconnect();
         this.write_buffer.deinit(bun.default_allocator);
 
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn stopTimers(this: *PostgresSQLConnection) void {
@@ -2378,13 +2378,13 @@ pub const PostgresSQLConnection = struct {
             .DataRow => {
                 const request = this.current() orelse return error.ExpectedRequest;
                 var statement = request.statement orelse return error.ExpectedStatement;
-                var structure: JSValue = .jsUndefined();
+                var structure: JSValue = .js_undefined;
                 var cached_structure: ?PostgresCachedStructure = null;
                 // explicit use switch without else so if new modes are added, we don't forget to check for duplicate fields
                 switch (request.flags.result_mode) {
                     .objects => {
                         cached_structure = statement.structure(this.js_value, this.globalObject);
-                        structure = cached_structure.?.jsValue() orelse .jsUndefined();
+                        structure = cached_structure.?.jsValue() orelse .js_undefined;
                     },
                     .raw, .values => {
                         // no need to check for duplicate fields or structure

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -165,7 +165,7 @@ pub const JSValkeyClient = struct {
 
         // If already connected, resolve immediately
         if (this.client.status == .connected) {
-            return JSC.JSPromise.resolvedPromiseValue(globalObject, js.helloGetCached(this_value) orelse .jsUndefined());
+            return JSC.JSPromise.resolvedPromiseValue(globalObject, js.helloGetCached(this_value) orelse .js_undefined);
         }
 
         if (js.connectionPromiseGetCached(this_value)) |promise| {
@@ -219,17 +219,17 @@ pub const JSValkeyClient = struct {
 
     pub fn jsDisconnect(this: *JSValkeyClient, _: *JSC.JSGlobalObject, _: *JSC.CallFrame) bun.JSError!JSValue {
         if (this.client.status == .disconnected) {
-            return .jsUndefined();
+            return .js_undefined;
         }
         this.client.disconnect();
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn getOnConnect(_: *JSValkeyClient, thisValue: JSValue, _: *JSC.JSGlobalObject) JSValue {
         if (js.onconnectGetCached(thisValue)) |value| {
             return value;
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *JSC.JSGlobalObject, value: JSValue) void {
@@ -240,7 +240,7 @@ pub const JSValkeyClient = struct {
         if (js.oncloseGetCached(thisValue)) |value| {
             return value;
         }
-        return .jsUndefined();
+        return .js_undefined;
     }
 
     pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *JSC.JSGlobalObject, value: JSValue) void {
@@ -406,7 +406,7 @@ pub const JSValkeyClient = struct {
         defer event_loop.exit();
 
         if (this.this_value.tryGet()) |this_value| {
-            const hello_value: JSValue = value.toJS(globalObject) catch .jsUndefined();
+            const hello_value: JSValue = value.toJS(globalObject) catch .js_undefined;
             js.helloSetCached(this_value, globalObject, hello_value);
             // Call onConnect callback if defined by the user
             if (js.onconnectGetCached(this_value)) |on_connect| {

--- a/test/js/bun/sqlite/column-types.test.js
+++ b/test/js/bun/sqlite/column-types.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "bun:test";
 import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
 
 describe("SQLite Statement column types", () => {
   it("reports correct column types for a variety of data types", () => {
@@ -25,25 +25,25 @@ describe("SQLite Statement column types", () => {
 
     // Prepare a statement that selects all columns
     const stmt = db.prepare("SELECT * FROM test_types");
-    
+
     // Execute the statement to get column types
     const row = stmt.get();
 
     // Verify column metadata
     expect(stmt.native.columns).toEqual(["id", "name", "weight", "image", "is_active"]);
     expect(stmt.native.columnsCount).toBe(5);
-    
+
     // Test the columnTypes property (uses actual data types from sqlite3_column_type)
     expect(stmt.columnTypes).toBeDefined();
     expect(Array.isArray(stmt.columnTypes)).toBe(true);
     expect(stmt.columnTypes.length).toBe(5);
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'TEXT', 'FLOAT', 'BLOB', 'INTEGER']);
-    
+    expect(stmt.columnTypes).toEqual(["INTEGER", "TEXT", "FLOAT", "BLOB", "INTEGER"]);
+
     // Test the declaredTypes property (uses declared types from sqlite3_column_decltype)
     expect(stmt.declaredTypes).toBeDefined();
     expect(Array.isArray(stmt.declaredTypes)).toBe(true);
     expect(stmt.declaredTypes.length).toBe(5);
-    expect(stmt.declaredTypes).toEqual(['INTEGER', 'TEXT', 'REAL', 'BLOB', 'INTEGER']);
+    expect(stmt.declaredTypes).toEqual(["INTEGER", "TEXT", "REAL", "BLOB", "INTEGER"]);
   });
 
   it("handles NULL values correctly", () => {
@@ -59,15 +59,15 @@ describe("SQLite Statement column types", () => {
     db.run(`INSERT INTO nulls_test (id, nullable) VALUES (1, NULL)`);
 
     const stmt = db.prepare("SELECT * FROM nulls_test");
-    
+
     // Execute the statement to get column types
     const row = stmt.get();
 
     // columnTypes now returns actual data types - NULL values are reported as 'NULL'
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'NULL']);
-    
+    expect(stmt.columnTypes).toEqual(["INTEGER", "NULL"]);
+
     // declaredTypes still shows the declared table schema
-    expect(stmt.declaredTypes).toEqual(['INTEGER', 'TEXT']);
+    expect(stmt.declaredTypes).toEqual(["INTEGER", "TEXT"]);
   });
 
   it("reports actual column types based on data values", () => {
@@ -82,24 +82,24 @@ describe("SQLite Statement column types", () => {
 
     // SQLite can store various types in the same column
     db.run(`INSERT INTO dynamic_types VALUES (1, 42)`);
-    
+
     let stmt = db.prepare("SELECT * FROM dynamic_types");
-    
+
     // Execute the statement to get column types
     let row = stmt.get();
-    
+
     // We should get the actual type of the value (integer)
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'INTEGER']);
-    
+    expect(stmt.columnTypes).toEqual(["INTEGER", "INTEGER"]);
+
     // Update to a text value
     db.run(`UPDATE dynamic_types SET value = 'text' WHERE id = 1`);
-    
+
     // Re-prepare to get fresh column type information
     stmt = db.prepare("SELECT * FROM dynamic_types");
     row = stmt.get();
-    
+
     // We should get the actual type of the value (text)
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'TEXT']);
+    expect(stmt.columnTypes).toEqual(["INTEGER", "TEXT"]);
 
     // Update to a float value
     db.run(`UPDATE dynamic_types SET value = 3.14 WHERE id = 1`);
@@ -109,7 +109,7 @@ describe("SQLite Statement column types", () => {
     row = stmt.get();
 
     // We should get the actual type of the value (float)
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'FLOAT']);
+    expect(stmt.columnTypes).toEqual(["INTEGER", "FLOAT"]);
   });
 
   it("reports actual types for columns from expressions", () => {
@@ -124,14 +124,14 @@ describe("SQLite Statement column types", () => {
     expect(row).toEqual({
       str_length: 3,
       magic_number: 42,
-      greeting: "hello"
+      greeting: "hello",
     });
 
     // Check columns are correctly identified
-    expect(stmt.native.columns).toEqual(['str_length', 'magic_number', 'greeting']);
-    
+    expect(stmt.native.columns).toEqual(["str_length", "magic_number", "greeting"]);
+
     // For expressions, expect the actual data types
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'INTEGER', 'TEXT']);
+    expect(stmt.columnTypes).toEqual(["INTEGER", "INTEGER", "TEXT"]);
   });
 
   it("handles multiple different expressions and functions", () => {
@@ -148,33 +148,31 @@ describe("SQLite Statement column types", () => {
         length('bun') AS func_result,
         CURRENT_TIMESTAMP AS timestamp
     `);
-    
+
     const row = stmt.get();
 
     // Verify we have the expected columns
     expect(stmt.native.columns).toEqual([
-      'int_val', 
-      'float_val', 
-      'text_val', 
-      'blob_val', 
-      'null_val', 
-      'func_result', 
-      'timestamp'
+      "int_val",
+      "float_val",
+      "text_val",
+      "blob_val",
+      "null_val",
+      "func_result",
+      "timestamp",
     ]);
 
     // Expression columns should be reported with their actual types
-    expect(stmt.columnTypes).toEqual([
-      'INTEGER', 'FLOAT', 'TEXT', 'BLOB', 'NULL', 'INTEGER', 'TEXT'
-    ]);
+    expect(stmt.columnTypes).toEqual(["INTEGER", "FLOAT", "TEXT", "BLOB", "NULL", "INTEGER", "TEXT"]);
 
     // Verify data types were correctly identified at runtime
-    expect(typeof row.int_val).toBe('number');
-    expect(typeof row.float_val).toBe('number');
-    expect(typeof row.text_val).toBe('string');
+    expect(typeof row.int_val).toBe("number");
+    expect(typeof row.float_val).toBe("number");
+    expect(typeof row.text_val).toBe("string");
     expect(row.blob_val instanceof Uint8Array).toBe(true);
     expect(row.null_val).toBe(null);
-    expect(typeof row.func_result).toBe('number');
-    expect(typeof row.timestamp).toBe('string');
+    expect(typeof row.func_result).toBe("number");
+    expect(typeof row.timestamp).toBe("string");
   });
 
   it("shows difference between columnTypes and declaredTypes for expressions", () => {
@@ -185,8 +183,8 @@ describe("SQLite Statement column types", () => {
     const row = stmt.get();
 
     // columnTypes shows actual data types based on the values
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'INTEGER', 'TEXT']);
-    
+    expect(stmt.columnTypes).toEqual(["INTEGER", "INTEGER", "TEXT"]);
+
     // declaredTypes shows declared types (which are null for expressions without explicit declarations)
     expect(stmt.declaredTypes).toEqual([null, null, null]);
   });
@@ -203,27 +201,27 @@ describe("SQLite Statement column types", () => {
 
     // Insert an integer value
     db.run(`INSERT INTO dynamic_types VALUES (1, 42)`);
-    
+
     let stmt = db.prepare("SELECT * FROM dynamic_types");
     let row = stmt.get();
-    
+
     // columnTypes shows actual type (integer) for the current value
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'INTEGER']);
-    
+    expect(stmt.columnTypes).toEqual(["INTEGER", "INTEGER"]);
+
     // declaredTypes shows the declared table schema
-    expect(stmt.declaredTypes).toEqual(['INTEGER', 'ANY']);
-    
+    expect(stmt.declaredTypes).toEqual(["INTEGER", "ANY"]);
+
     // Update to a text value
     db.run(`UPDATE dynamic_types SET value = 'text' WHERE id = 1`);
-    
+
     stmt = db.prepare("SELECT * FROM dynamic_types");
     row = stmt.get();
-    
+
     // columnTypes now shows text for the current value
-    expect(stmt.columnTypes).toEqual(['INTEGER', 'TEXT']);
-    
+    expect(stmt.columnTypes).toEqual(["INTEGER", "TEXT"]);
+
     // declaredTypes still shows the declared table schema
-    expect(stmt.declaredTypes).toEqual(['INTEGER', 'ANY']);
+    expect(stmt.declaredTypes).toEqual(["INTEGER", "ANY"]);
   });
 
   it("throws an error when accessing columnTypes before statement execution", () => {
@@ -235,7 +233,7 @@ describe("SQLite Statement column types", () => {
 
     // Accessing columnTypes before executing is fine (implicitly executes the statement)
     expect(stmt.columnTypes).toBeArray();
-    
+
     // Accessing declaredTypes before executing should throw
     expect(() => {
       stmt.declaredTypes;


### PR DESCRIPTION
post the merge of https://github.com/oven-sh/bun/pull/20332 and a discussion with the team it was decided that a prefixed enum tag would be more idiomatic for Zig and achieve the same goal as using the decl literal. as the function was only an inline fn returning `@enumFromInt(0xa)` this has no observable change in behavior.
