### PR TITLE
Add Bun.loadExtraCACerts(string) that works like $NODE_EXTRA_CA_CERTS does at startup

### DIFF
--- a/docs/runtime/bun-apis.md
+++ b/docs/runtime/bun-apis.md
@@ -79,6 +79,11 @@ Click the link in the right column to jump to the associated documentation.
 
 ---
 
+- Cryptography
+- `Bun.loadExtraCACerts`
+
+---
+
 - SQLite
 - [`bun:sqlite`](https://bun.com/docs/api/sqlite)
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -957,6 +957,21 @@ declare module "bun" {
   ): Promise<FormData>;
 
   /**
+   * Load CA certificates from the given path and add them to the global certificate store.
+   *
+   * This works equivalently to setting $NODE_EXTRA_CA_CERTS except at run-time:
+   * `path` must be a valid PEM certificate chain, otherwise this is a no-op.
+   *
+   * @param path The CA certificates.
+   *
+   * @example
+   * ```ts
+   * Bun.loadExtraCACerts("/etc/certs/ca.pem");
+   * ```
+   */
+  function loadExtraCACerts(path: string): void;
+
+  /**
    * Consume all data from a {@link ReadableStream} until it closes or errors.
    *
    * @param stream The stream to consume

--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -35,7 +35,7 @@ static bool us_should_use_system_ca() {
   if (Bun__Node__UseSystemCA) {
     return true;
   }
-  
+
   // Check environment variable
   const char *use_system_ca = getenv("NODE_USE_SYSTEM_CA");
   return use_system_ca && strcmp(use_system_ca, "1") == 0;
@@ -191,12 +191,14 @@ struct us_default_ca_certificates {
 us_default_ca_certificates* us_get_default_ca_certificates() {
   static us_default_ca_certificates default_ca_certificates = {{NULL}, NULL, NULL};
 
-  us_internal_init_root_certs(default_ca_certificates.root_cert_instances, 
+  us_internal_init_root_certs(default_ca_certificates.root_cert_instances,
                               default_ca_certificates.root_extra_cert_instances,
                               default_ca_certificates.root_system_cert_instances);
 
   return &default_ca_certificates;
 }
+
+std::mutex us_get_root_extra_cert_instances_mutex;
 
 STACK_OF(X509) *us_get_root_extra_cert_instances() {
   return us_get_default_ca_certificates()->root_extra_cert_instances;
@@ -210,8 +212,34 @@ STACK_OF(X509) *us_get_root_system_cert_instances() {
   return certs->root_system_cert_instances;
 }
 
+static X509_STORE *store;
+
+void us_load_extra_ca_certs(const char *extra_certs) {
+  if (store == NULL || !extra_certs || !extra_certs[0])
+    return;
+
+  STACK_OF(X509)* loaded = us_ssl_ctx_load_all_certs_from_file(extra_certs);
+  if (loaded) {
+    for (int i = 0; i < sk_X509_num(loaded); i++) {
+      X509 *cert = sk_X509_value(loaded, i);
+      X509_up_ref(cert);
+      X509_STORE_add_cert(store, cert);
+    }
+
+    std::unique_lock current_lock{us_get_root_extra_cert_instances_mutex};
+    auto* current = us_get_default_ca_certificates();
+    if (current->root_extra_cert_instances == NULL)
+      current->root_extra_cert_instances = loaded;
+    else {
+      for (X509 *cert; (cert = sk_X509_pop(loaded)) != NULL;)
+        sk_X509_push(current->root_extra_cert_instances, cert);
+      sk_X509_free(loaded);
+    }
+  }
+}
+
 extern "C" X509_STORE *us_get_default_ca_store() {
-  X509_STORE *store = X509_STORE_new();
+  store = X509_STORE_new();
   if (store == NULL) {
     return NULL;
   }
@@ -284,11 +312,11 @@ void us_load_system_certificates_windows(STACK_OF(X509) **system_certs) {
   if (*system_certs == NULL) {
     return;
   }
-  
+
   // Load raw certificates from Windows stores
   std::vector<RawCertificate> raw_certs;
   us_load_system_certificates_windows_raw(raw_certs);
-  
+
   // Convert each raw certificate to X509
   for (const auto& raw_cert : raw_certs) {
     const unsigned char* data = raw_cert.data.data();

--- a/packages/bun-usockets/src/crypto/root_certs_header.h
+++ b/packages/bun-usockets/src/crypto/root_certs_header.h
@@ -3,7 +3,10 @@
 
 #ifdef __cplusplus
 #define CPPDECL extern "C"
+#include <mutex>
 
+extern std::mutex us_get_root_extra_cert_instances_mutex;
+void us_load_extra_ca_certs(const char *extra_certs);
 STACK_OF(X509) *us_get_root_extra_cert_instances();
 STACK_OF(X509) *us_get_root_system_cert_instances();
 

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -41,6 +41,7 @@
 #include "JSCookie.h"
 #include "JSCookieMap.h"
 #include "Secrets.h"
+#include "../../../packages/bun-usockets/src/crypto/root_certs_header.h"
 
 #ifdef WIN32
 #include <ws2def.h>
@@ -567,6 +568,24 @@ JSC_DEFINE_HOST_FUNCTION(functionBunNanoseconds, (JSGlobalObject * globalObject,
     return JSValue::encode(jsNumber(time));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionBunLoadExtraCACerts, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& globalObject = *defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = globalObject.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto pathValue = callFrame->argument(0);
+
+    {
+        WTF::String pathString = pathValue.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(throwScope, JSC::JSValue::encode({}));
+        pathString = pathResolveWTFString(lexicalGlobalObject, pathString);
+
+        us_load_extra_ca_certs(pathString.utf8().data());
+    }
+
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::jsUndefined()));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionPathToFileURL, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     auto& globalObject = *defaultGlobalObject(lexicalGlobalObject);
@@ -756,6 +775,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     isMainThread                                   constructIsMainThread                                               ReadOnly|DontDelete|PropertyCallback
     jest                                           BunObject_callback_jest                                             DontEnum|DontDelete|Function 1
     listen                                         BunObject_callback_listen                                           DontDelete|Function 1
+    loadExtraCACerts                               functionBunLoadExtraCACerts                                         DontDelete|Function 1
     udpSocket                                      BunObject_callback_udpSocket                                        DontDelete|Function 1
     main                                           bunObjectMain                                                       DontDelete|CustomAccessor
     mmap                                           BunObject_callback_mmap                                             DontDelete|Function 1

--- a/src/bun.js/bindings/NodeTLS.cpp
+++ b/src/bun.js/bindings/NodeTLS.cpp
@@ -40,6 +40,7 @@ JSC_DEFINE_HOST_FUNCTION(getExtraCACertificates, (JSC::JSGlobalObject * globalOb
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     VM& vm = globalObject->vm();
 
+    std::unique_lock root_extra_cert_instances_lock { us_get_root_extra_cert_instances_mutex };
     STACK_OF(X509)* root_extra_cert_instances = us_get_root_extra_cert_instances();
 
     auto size = sk_X509_num(root_extra_cert_instances);


### PR DESCRIPTION
### What does this PR do?

Add `Bun.loadExtraCACerts(string)` to load additional certificates into the current certificate store, like `$NODE_EXTRA_CA_CERTS` does on start-up.

This is the first and only way to change them dynamically.

This implements/closes #13868

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

Auto-testing this would involve generating TLS certificates and making HTTP servers. I've tested this manually thusly:
```typescript
// http --ssl ~/uwu/tls/ca/server.p12  -p 8000
// http --ssl ~/uwu/tls/ca2/server.p12 -p 8001
// NODE_EXTRA_CA_CERTS=/srv/tls/ca/ca.crt bun ./repro.ts
// 0. /srv/tls/ca/ca.crt is loaded from $NODE_EXTRA_CA_CERTS
// 1. request to :8000 succeeds
// 2. request to :8001 fails
// 3. /srv/tls/ca2/ca.crt is loaded from loadExtraCACerts()
// 4. request to :8001 succeeds now
async function one(port) {
	try {
		const response = await fetch(`https://tarta:${port}/util.diff`, {method: 'GET', verbose: false});
		const html = await response.text();
		console.log(html)
	} catch(e) {
		console.log(e)
	}
}

await one(8000);
await one(8001);
Bun.loadExtraCACerts("/srv/tls/ca2/ca.crt");
await one(8001);
```
where tls is [tls.tar.gz](https://github.com/user-attachments/files/20735080/tls.tar.gz)
