### PR TITLE
chore: trim trailing space in uws

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs.h
+++ b/packages/bun-usockets/src/crypto/root_certs.h
@@ -1,4 +1,4 @@
-// Maintaining the root certificates 
+// Maintaining the root certificates
 //
 // `src/crypto/root_certs.h` contains a compiled-in set of root certificates used as trust anchors
 // for TLS certificate validation.
@@ -23,7 +23,7 @@
 //    `src/crypto/root_certs.h`.
 //  * Using `git diff-files` to determine which certificate have been added and/or
 //    removed.
-//  
+//
 #include "libusockets.h"
 static struct us_cert_string_t root_certs[] = {
 

--- a/packages/bun-usockets/src/crypto/root_certs_header.h
+++ b/packages/bun-usockets/src/crypto/root_certs_header.h
@@ -11,4 +11,3 @@ STACK_OF(X509) *us_get_root_extra_cert_instances();
 #endif
 
 CPPDECL X509_STORE *us_get_default_ca_store();
-

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -110,7 +110,7 @@ struct us_loop_t *us_timer_loop(struct us_timer_t *t) {
 }
 
 
-#if defined(LIBUS_USE_EPOLL) 
+#if defined(LIBUS_USE_EPOLL)
 
 #include <sys/syscall.h>
 #include <signal.h>
@@ -131,9 +131,9 @@ extern ssize_t sys_epoll_pwait2(int epfd, struct epoll_event* events, int maxeve
 
 static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents, const struct timespec *timeout) {
     int ret;
-    sigset_t mask;  
+    sigset_t mask;
     sigemptyset(&mask);
-  
+
     if (has_epoll_pwait2 != 0) {
         do {
             ret = sys_epoll_pwait2(epfd, events, maxevents, timeout, &mask);
@@ -146,7 +146,7 @@ static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
         has_epoll_pwait2 = 0;
     }
 
-    int timeoutMs = -1; 
+    int timeoutMs = -1;
     if (timeout) {
         timeoutMs = timeout->tv_sec * 1000 + timeout->tv_nsec / 1000000;
     }
@@ -178,7 +178,7 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
     if (has_epoll_pwait2 == -1) {
         if (Bun__isEpollPwait2SupportedOnLinuxKernel() == 0) {
             has_epoll_pwait2 = 0;
-        } 
+        }
     }
 
 #else
@@ -358,16 +358,16 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
     if ((new_events & LIBUS_SOCKET_READABLE) != (old_events & LIBUS_SOCKET_READABLE)) {
         EV_SET64(&change_list[change_length++], fd, EVFILT_READ, is_readable ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
     }
-    
+
     if(!is_readable && !is_writable) {
         if(!(old_events & LIBUS_SOCKET_WRITABLE)) {
             // if we are not reading or writing, we need to add writable to receive FIN
             EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, EV_ADD, 0, 0, (uint64_t)(void*)user_data, 0, 0);
         }
     } else if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
-        /* Do they differ in writable? */    
+        /* Do they differ in writable? */
         EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
-    } 
+    }
     int ret;
     do {
         ret = kevent64(kqfd, change_list, change_length, change_list, change_length, KEVENT_FLAG_ERROR_EVENTS, NULL);
@@ -673,7 +673,7 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
     // using it for notifications and not for any other purpose.
     mach_port_limits_t limits = { .mpl_qlimit = 1 };
     kr = mach_port_set_attributes(self, cb->port, MACH_PORT_LIMITS_INFO, (mach_port_info_t)&limits, MACH_PORT_LIMITS_INFO_COUNT);
-    
+
     if (UNLIKELY(kr != KERN_SUCCESS)) {
         return NULL;
     }
@@ -688,7 +688,7 @@ void us_internal_async_close(struct us_internal_async *a) {
     struct kevent64_s event;
     uint64_t ptr = (uint64_t)(void*)internal_cb;
     EV_SET64(&event, ptr, EVFILT_MACHPORT, EV_DELETE, 0, 0, (uint64_t)(void*)internal_cb, 0,0);
-    
+
     int ret;
     do {
         ret = kevent64(internal_cb->loop->fd, &event, 1, &event, 1, KEVENT_FLAG_ERROR_EVENTS, NULL);
@@ -720,7 +720,7 @@ void us_internal_async_set(struct us_internal_async *a, void (*cb)(struct us_int
     event.ext[1] = MACHPORT_BUF_LEN;
     event.udata = (uint64_t)(void*)internal_cb;
 
-    int ret; 
+    int ret;
     do {
         ret = kevent64(internal_cb->loop->fd, &event, 1, &event, 1, KEVENT_FLAG_ERROR_EVENTS, NULL);
     } while (IS_EINTR(ret));
@@ -750,12 +750,12 @@ void us_internal_async_wakeup(struct us_internal_async *a) {
         0, // Fail instantly if the port is full
         MACH_PORT_NULL
     );
-    
+
     switch (kr) {
         case KERN_SUCCESS: {
             break;
         }
-        
+
         // This means that the send would've blocked because the
         // queue is full. We assume success because the port is full.
         case MACH_SEND_TIMED_OUT: {

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -108,7 +108,7 @@ struct addrinfo_result {
 #define us_internal_ssl_socket_r struct us_internal_ssl_socket_t *nonnull_arg
 
 extern int Bun__addrinfo_get(struct us_loop_t* loop, const char* host, uint16_t port,  struct addrinfo_request** ptr);
-extern int Bun__addrinfo_set(struct addrinfo_request* ptr, struct us_connecting_socket_t* socket); 
+extern int Bun__addrinfo_set(struct addrinfo_request* ptr, struct us_connecting_socket_t* socket);
 extern void Bun__addrinfo_freeRequest(struct addrinfo_request* addrinfo_req, int error);
 extern struct addrinfo_result *Bun__addrinfo_getRequestResult(struct addrinfo_request* addrinfo_req);
 
@@ -158,7 +158,7 @@ void us_internal_socket_after_open(us_socket_r s, int error);
 struct us_internal_ssl_socket_t *
 us_internal_ssl_socket_close(us_internal_ssl_socket_r s, int code,
                              void *reason);
-                             
+
 int us_internal_handle_dns_results(us_loop_r loop);
 
 /* Sockets are polls */
@@ -167,9 +167,9 @@ struct us_socket_flags {
     /* If true, the readable side is paused */
     bool is_paused: 1;
     /* Allow to stay alive after FIN/EOF */
-    bool allow_half_open: 1; 
+    bool allow_half_open: 1;
     /* 0 = not in low-prio queue, 1 = is in low-prio queue, 2 = was in low-prio queue in this iteration */
-    unsigned char low_prio_state: 2; 
+    unsigned char low_prio_state: 2;
     /* If true, the socket should be read using readmsg to support receiving file descriptors */
     bool is_ipc: 1;
 
@@ -299,7 +299,7 @@ struct us_socket_context_t {
   struct us_connecting_socket_t *(*on_connect_error)(struct us_connecting_socket_t *, int code);
   struct us_socket_t *(*on_socket_connect_error)(struct us_socket_t *, int code);
   int (*is_low_prio)(struct us_socket_t *);
-  
+
 };
 
 /* Internal SSL interface */
@@ -310,7 +310,7 @@ struct us_internal_ssl_socket_t;
 typedef void (*us_internal_on_handshake_t)(
     struct us_internal_ssl_socket_t *, int success,
     struct us_bun_verify_error_t verify_error, void *custom_data);
-    
+
 void us_internal_socket_context_free(int ssl, struct us_socket_context_t *context);
 /* SNI functions */
 void us_internal_ssl_socket_context_add_server_name(

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -128,7 +128,7 @@ void us_internal_timer_sweep(struct us_loop_t *loop) {
             if (context->iterator == s && long_ticks == s->long_timeout) {
                 s->long_timeout = 255;
                 if (context->on_socket_long_timeout != NULL) context->on_socket_long_timeout(s);
-            }   
+            }
 
             /* Check for unlink / link (if the event handler did not modify the chain, we step 1) */
             if (s == context->iterator) {
@@ -398,20 +398,20 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         struct msghdr msg = {0};
                         struct iovec iov = {0};
                         char cmsg_buf[CMSG_SPACE(sizeof(int))];
-                        
+
                         iov.iov_base = loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING;
                         iov.iov_len = LIBUS_RECV_BUFFER_LENGTH;
 
-                        msg.msg_flags = 0;                        
+                        msg.msg_flags = 0;
                         msg.msg_iov = &iov;
                         msg.msg_iovlen = 1;
                         msg.msg_name = NULL;
                         msg.msg_namelen = 0;
                         msg.msg_controllen = CMSG_LEN(sizeof(int));
                         msg.msg_control = cmsg_buf;
-                        
+
                         length = bsd_recvmsg(us_poll_fd(&s->p), &msg, recv_flags);
-                        
+
                         // Extract file descriptor if present
                         if (length > 0 && msg.msg_controllen > 0) {
                             struct cmsghdr *cmsg_ptr = CMSG_FIRSTHDR(&msg);
@@ -439,14 +439,14 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         // - the event loop isn't very busy, so we can read multiple times in a row
                         #define LOOP_ISNT_VERY_BUSY_THRESHOLD 25
                         if (
-                            s && length >= (LIBUS_RECV_BUFFER_LENGTH - 24 * 1024) && length <= LIBUS_RECV_BUFFER_LENGTH && 
-                            (error || loop->num_ready_polls < LOOP_ISNT_VERY_BUSY_THRESHOLD) && 
+                            s && length >= (LIBUS_RECV_BUFFER_LENGTH - 24 * 1024) && length <= LIBUS_RECV_BUFFER_LENGTH &&
+                            (error || loop->num_ready_polls < LOOP_ISNT_VERY_BUSY_THRESHOLD) &&
                             !us_socket_is_closed(0, s)
                         ) {
                             repeat_recv_count += error == 0;
 
                             // When not hung up, read a maximum of 10 times to avoid starving other sockets
-                            // We don't bother with ioctl(FIONREAD) because we've set MSG_DONTWAIT 
+                            // We don't bother with ioctl(FIONREAD) because we've set MSG_DONTWAIT
                             if (!(repeat_recv_count > 10 && loop->num_ready_polls > 2)) {
                                 continue;
                             }
@@ -486,7 +486,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     s = us_socket_close(0, s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                     return;
                 }
-            } 
+            }
             /* Such as epollerr or EV_ERROR */
             if (error && s) {
                 /* Todo: decide what code we give here */

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -387,29 +387,29 @@ int us_socket_ipc_write_fd(struct us_socket_t *s, const char* data, int length, 
     struct msghdr msg = {0};
     struct iovec iov = {0};
     char cmsgbuf[CMSG_SPACE(sizeof(int))];
-    
+
     iov.iov_base = (void*)data;
     iov.iov_len = length;
-    
+
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
     msg.msg_control = cmsgbuf;
     msg.msg_controllen = CMSG_SPACE(sizeof(int));
-    
+
     struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
     cmsg->cmsg_level = SOL_SOCKET;
     cmsg->cmsg_type = SCM_RIGHTS;
     cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-    
+
     *(int *)CMSG_DATA(cmsg) = fd;
-    
+
     int sent = bsd_sendmsg(us_poll_fd(&s->p), &msg, 0);
-    
+
     if (sent != length) {
         s->context->loop->data.last_write_failed = 1;
         us_poll_change(&s->p, s->context->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
     }
-    
+
     return sent < 0 ? 0 : sent;
 }
 #endif

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -249,7 +249,7 @@ public:
     }
 
     static TemplatedApp<SSL>* create(SocketContextOptions options = {}) {
-        
+
         auto* httpContext = HttpContext<SSL>::create(Loop::get(), options);
         if (!httpContext) {
             return nullptr;
@@ -646,4 +646,3 @@ typedef TemplatedApp<false> App;
 typedef TemplatedApp<true> SSLApp;
 
 }
-

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -224,7 +224,7 @@ public:
 
     /**
     * Flushes the socket buffer by writing as much data as possible to the underlying socket.
-    * 
+    *
     * @return The total number of bytes successfully written to the socket
     */
     size_t flush() {
@@ -237,24 +237,24 @@ public:
         /* Get the associated asynchronous socket data structure */
         AsyncSocketData<SSL> *asyncSocketData = getAsyncSocketData();
         size_t total_written = 0;
-        
+
         /* Continue flushing as long as we have data in the buffer */
         while (asyncSocketData->buffer.length()) {
             /* Get current buffer size */
             size_t buffer_len = asyncSocketData->buffer.length();
-            
+
             /* Limit write size to INT_MAX as the underlying socket API uses int for length */
             int max_flush_len = std::min(buffer_len, (size_t)INT_MAX);
 
             /* Attempt to write data to the socket */
             int written = us_socket_write(SSL, (us_socket_t *) this, asyncSocketData->buffer.data(), max_flush_len, 0);
             total_written += written;
-            
+
             /* Check if we couldn't write the entire buffer */
             if ((unsigned int) written < buffer_len) {
                 /* Remove the successfully written data from the buffer */
                 asyncSocketData->buffer.erase((unsigned int) written);
-                
+
                 /* If we wrote less than we attempted, the socket buffer is likely full
                 * likely is used as an optimization hint to the compiler
                 * since written < buffer_len is very likely to be true
@@ -317,7 +317,7 @@ public:
             asyncSocketData->buffer.clear();
         }
 
-        if (length) {          
+        if (length) {
             if (loopData->isCorkedWith(this)) {
                 /* We are corked */
                 if (LoopData::CORK_BUFFER_SIZE - loopData->getCorkOffset() >= (unsigned int) length) {

--- a/packages/bun-uws/src/BloomFilter.h
+++ b/packages/bun-uws/src/BloomFilter.h
@@ -52,7 +52,7 @@ public:
         if (key.length() < 2) {
             return true;
         }
-    
+
         ScrambleArea s = getFeatures(key);
         s.val = perfectHash(s.val);
         return filter[s.p[0]] &&

--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -76,7 +76,7 @@ namespace uWS {
                 data.remove_prefix(1);
             }
         }
-        
+
         auto len = data.length();
         if(len) {
             // consume extension
@@ -93,20 +93,20 @@ namespace uWS {
                     /* RFC 9110: Token format (TLDR; anything bellow 32 is not allowed)
                     * TODO: add support for quoted-strings values (RFC 9110: 3.2.6. Quoted-String)
                     * Example of chunked encoding with extensions:
-                    * 
+                    *
                     * 4;key=value\r\n
                     * Wiki\r\n
                     * 5;foo=bar;baz=quux\r\n
                     * pedia\r\n
                     * 0\r\n
                     * \r\n
-                    * 
+                    *
                     * The chunk size is in hex (4, 5, 0), followed by optional
                     * semicolon-separated extensions. Extensions consist of a key
                     * (token) and optional value. The value may be a token or a
                     * quoted string. The chunk data follows the CRLF after the
                     * extensions and must be exactly the size specified.
-                    * 
+                    *
                     * RFC 7230 Section 4.1.1 defines chunk extensions as:
                     * chunk-ext = *( ";" chunk-ext-name [ "=" chunk-ext-val ] )
                     * chunk-ext-name = token
@@ -116,7 +116,7 @@ namespace uWS {
                         state = STATE_IS_ERROR;
                         return;
                     }
-                    
+
                     data.remove_prefix(1);
                 }
             }

--- a/packages/bun-uws/src/Http3ContextData.h
+++ b/packages/bun-uws/src/Http3ContextData.h
@@ -17,5 +17,5 @@ namespace uWS {
             //printf("Constructing http3contextdata: %p\n", this);
         }
     };
-    
+
 }

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -77,7 +77,7 @@ namespace uWS {
 
             /* If not already written */
             writeStatus("200 OK");
-            
+
             // has body is determined by the ending so this is perfect here
             us_quic_socket_context_send_headers(nullptr, (us_quic_stream_t *) this, responseData->headerOffset, data.length() > 0);
 

--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -14,7 +14,7 @@ namespace uWS {
 
         /* Status is always first header just like for h1 */
         unsigned int headerOffset = 0;
-        
+
         /* Write offset */
         uint64_t offset = 0;
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -90,7 +90,7 @@ private:
         MACRO("UNLINK") \
         MACRO("UNLOCK") \
         MACRO("UNSUBSCRIBE") \
-    
+
 
 #ifndef _WIN32
     static constexpr std::array<const std::string, 35> HTTP_METHODS = {
@@ -108,12 +108,12 @@ private:
         FOR_EACH_HTTP_METHOD(MACRO)
         #undef MACRO
     };
-    
+
     static std::span<const std::string> getAllHttpMethods() {
         static std::once_flag flag;
         static std::array<std::string, 35> methods;
         std::call_once(flag, []() {
-            methods = { 
+            methods = {
                 #define MACRO(name) std::string {name},
                 FOR_EACH_HTTP_METHOD(MACRO)
                 #undef MACRO
@@ -201,7 +201,7 @@ private:
             /* Call filter */
             HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
 
-            
+
             for (auto &f : httpContextData->filterHandlers) {
                 f((HttpResponse<SSL> *) s, -1);
             }
@@ -276,7 +276,7 @@ private:
 
                 /* Mark pending request and emit it */
                 httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
-                
+
 
                 /* Mark this response as connectionClose if ancient or connection: close */
                 if (httpRequest->isAncient() || httpRequest->getHeader("connection").length() == 5) {
@@ -336,7 +336,7 @@ private:
             }, [httpResponseData](void *user, std::string_view data, bool fin) -> void * {
                 /* We always get an empty chunk even if there is no data */
                 if (httpResponseData->inStream) {
-                    
+
                     /* Todo: can this handle timeout for non-post as well? */
                     if (fin) {
                         /* If we just got the last chunk (or empty chunk), disable timeout */
@@ -374,7 +374,7 @@ private:
             });
 
             auto httpErrorStatusCode = result.httpErrorStatusCode();
-            
+
             /* Mark that we are no longer parsing Http */
             httpContextData->flags.isParsingHttp = false;
             /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
@@ -388,7 +388,7 @@ private:
                 /* Close any socket on HTTP errors */
                 us_socket_close(SSL, s, 0, nullptr);
             }
-        
+
             auto returnedData = result.returnedData;
             /* We need to uncork in all cases, except for nullptr (closed socket, or upgraded socket) */
             if (returnedData != nullptr) {
@@ -471,12 +471,12 @@ private:
                 * and will fall through to the next section of code
                 */
             }
-            
+
             /* Ask the developer to write data and return success (true) or failure (false), OR skip sending anything and return success (true). */
             if (httpResponseData->onWritable) {
                 /* We are now writable, so hang timeout again, the user does not have to do anything so we should hang until end or tryEnd rearms timeout */
                 us_socket_timeout(SSL, s, 0);
-                
+
                 /* We expect the developer to return whether or not write was successful (true).
                  * If write was never called, the developer should still return true so that we may drain. */
                 bool success = httpResponseData->callOnWritable(reinterpret_cast<HttpResponse<SSL> *>(asyncSocket), httpResponseData->offset);
@@ -497,7 +497,7 @@ private:
             if (httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) {
                 if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
                     if (asyncSocket->getBufferedAmount() == 0) {
-                        
+
                         asyncSocket->shutdown();
                         /* We need to force close after sending FIN since we want to hinder
                          * clients from keeping to send their huge data */
@@ -588,7 +588,7 @@ public:
             methods = getAllHttpMethods();
         } else {
             methods_buffer[0] = std::string(method);
-            methods = {methods_buffer.data(), 1};   
+            methods = {methods_buffer.data(), 1};
         }
 
         uint32_t priority = method == "*" ? httpContextData->currentRouter->LOW_PRIORITY : (upgrade ? httpContextData->currentRouter->HIGH_PRIORITY : httpContextData->currentRouter->MEDIUM_PRIORITY);
@@ -616,7 +616,7 @@ public:
             }
         }
 
-        
+
 
         httpContextData->currentRouter->add(methods, pattern, [handler = std::move(handler), parameterOffsets = std::move(parameterOffsets), httpContextData](auto *r) mutable {
             auto user = r->getUserData();
@@ -667,5 +667,3 @@ public:
 };
 
 }
-
-

--- a/packages/bun-uws/src/HttpErrors.h
+++ b/packages/bun-uws/src/HttpErrors.h
@@ -39,4 +39,3 @@ static const std::string_view httpErrorResponses[] = {
 
 
 }
-

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -108,7 +108,7 @@ namespace uWS
         }
 
 
-        /* Returns true if there was an error */    
+        /* Returns true if there was an error */
         bool isError() {
             return parserError != HTTP_PARSER_ERROR_NONE;
         }
@@ -403,7 +403,7 @@ namespace uWS
 
         static bool isValidMethod(std::string_view str, bool useStrictMethodValidation) {
             if (str.empty()) return false;
-             
+
             if (useStrictMethodValidation) {
                 return Bun__HTTPMethod__from(str.data(), str.length()) != -1;
             }
@@ -613,13 +613,13 @@ namespace uWS
                 return HttpParserResult::shortRead();
             }
             postPaddedBuffer = requestLineResult.position;
-            
+
             if(requestLineResult.isAncientHTTP) {
                 isAncientHTTP = true;
             }
             /* No request headers found */
             const char * headerStart = (headers[0].key.length() > 0) ? headers[0].key.data() : end;
-                
+
             /* Check if we can see if headers follow or not */
             if (postPaddedBuffer + 2 > end) {
                 /* Not enough data to check for \r\n */
@@ -711,7 +711,7 @@ namespace uWS
                         }
                     }
                 } else {
-                 
+
                     if(postPaddedBuffer[0] == '\r') {
                         // invalid char after \r
                         return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_REQUEST);
@@ -757,7 +757,7 @@ namespace uWS
 
             /* Add all headers to bloom filter */
             req->bf.reset();
-            
+
             for (HttpRequest::Header *h = req->headers; (++h)->key.length(); ) {
                 req->bf.add(h->key);
             }
@@ -864,7 +864,7 @@ namespace uWS
                 break;
             }
         }
-        
+
         return HttpParserResult::success(consumedTotal, user);
     }
 
@@ -1000,4 +1000,3 @@ public:
 };
 
 }
-

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -106,7 +106,7 @@ public:
         if (closeConnection) {
             /* We can only write the header once */
             if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
-                    
+
                 /* HTTP 1.1 must send this back unless the client already sent it to us.
                 * It is a connection close when either of the two parties say so but the
                 * one party must tell the other one so.
@@ -125,10 +125,10 @@ public:
 
             /* We do not have tryWrite-like functionalities, so ignore optional in this path */
 
-            
+
             /* Write the chunked data if there is any (this will not send zero chunks) */
             this->write(data, nullptr);
-            
+
 
             /* Terminating 0 chunk */
             Super::write("0\r\n\r\n", 5);
@@ -470,7 +470,7 @@ public:
         writeStatus(HTTP_200_OK);
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-        
+
         if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_CONTENT_LENGTH_HEADER) && !httpResponseData->fromAncientRequest) {
             if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
                 /* Write mark on first call to write */
@@ -532,7 +532,7 @@ public:
             }
             return !has_failed;
         }
-        
+
 
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
@@ -545,7 +545,7 @@ public:
                 Super::write("\r\n", 2);
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
             }
-            
+
             writeUnsignedHex((unsigned int) data.length());
             Super::write("\r\n", 2);
         } else if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
@@ -578,7 +578,7 @@ public:
             // Write End of Chunked Encoding after data has been written
             Super::write("\r\n", 2);
         }
-        
+
         /* Reset timeout on each sended chunk */
         this->resetTimeout();
 

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -109,5 +109,3 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
 };
 
 }
-
-

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -87,7 +87,7 @@ private:
         LoopData *loopData = (LoopData *) us_loop_ext((struct us_loop_t *) loop);
         loopData->dateTimer = us_create_timer((struct us_loop_t *) loop, 1, sizeof(LoopData *));
         loopData->updateDate();
-        
+
         memcpy(us_timer_ext(loopData->dateTimer), &loopData, sizeof(LoopData *));
         us_timer_set(loopData->dateTimer, [](struct us_timer_t *t) {
             LoopData *loopData;
@@ -103,7 +103,7 @@ private:
         ~LoopCleaner() {
             // There's no need to call this destructor if Bun is in the process of exiting.
             // This is both a performance thing, and also to prevent freeing some things which are not meant to be freed
-            // such as uv_tty_t 
+            // such as uv_tty_t
             if(loop && cleanMe && !bun_is_exiting()) {
                 cleanMe = false;
                 loop->free();

--- a/packages/bun-uws/src/LoopData.h
+++ b/packages/bun-uws/src/LoopData.h
@@ -97,11 +97,11 @@ public:
         this->corkedSocket = nullptr;
         this->corkOffset = 0;
     }
-        
+
     unsigned int getCorkOffset() {
         return this->corkOffset;
     }
-    
+
     void setCorkOffset(unsigned int offset) {
         this->corkOffset = offset;
     }
@@ -109,7 +109,7 @@ public:
     void incrementCorkedOffset(unsigned int offset) {
         this->corkOffset += offset;
     }
-    
+
     char* getCorkBuffer() {
         return this->corkBuffer;
     }

--- a/packages/bun-uws/src/TopicTree.h
+++ b/packages/bun-uws/src/TopicTree.h
@@ -260,7 +260,7 @@ public:
             /* This one always resets needsDrainage before it calls any cb's.
              * Otherwise we would stackoverflow when sending after publish but before drain. */
             drainImpl(s);
-            
+
             /* If we drained last subscriber, also clear outgoingMessages */
             if (!drainableSubscribers) {
                 outgoingMessages.clear();
@@ -363,5 +363,3 @@ public:
 };
 
 }
-
-


### PR DESCRIPTION
we skip clang-format in these files so the diffs here show up when editing and then i have to remove the hunks manually
we might change that in the future but this was easy to submit now