### PR TITLE
Added a devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,34 @@
+FROM fedora:41
+
+# Install packages
+RUN dnf install -y \
+    cargo \
+    ccache \
+    cmake \
+    git \
+    golang \
+    libtool \
+    ninja-build \
+    pkg-config \
+    rustc \
+    ruby \
+    libatomic-static \
+    libstdc++-static \
+    sed \
+    unzip \
+    which \
+    libicu-devel \
+    'perl(Math::BigInt)' \
+    llvm \
+    clang \
+    lld-devel \
+    sudo
+
+# Create vscode user
+RUN useradd -m -s /bin/bash vscode && echo 'vscode ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Install bun as vscode user
+USER vscode
+RUN curl -fsSL https://bun.sh/install | bash && sudo ln -s ~/.bun/bin/* /usr/local/bin/
+
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Custom",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {},
+  "containerEnv": {},
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@ Configuring a development environment for Bun can take 10-30 minutes depending o
 
 If you are using Windows, please refer to [this guide](https://bun.sh/docs/project/building-windows)
 
+By using [Dev Containers](https://containers.dev/) you can skip the next two sections, and instead just open the project folder in a supported IDE *or* run `devpod up .`. This is especially convenient as manually getting the dependencies right can be finicky.
+
 ## Install Dependencies
 
 Using your system's package manager, install Bun's dependencies:
@@ -110,6 +112,8 @@ $ export PATH="$PATH:/usr/lib/llvm19/bin"
 ## Building Bun
 
 After cloning the repository, run the following command to build. This may take a while as it will clone submodules and build dependencies.
+
+Note that this will require about 8 GB of RAM, so you may want to close a few apps first if your system is tight on memory.
 
 ```bash
 $ bun run build

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -88,7 +88,7 @@ endif()
 if(UNIX)
   register_compiler_flags(
     DESCRIPTION "Enable debug symbols"
-    -g3 -gz=zstd ${DEBUG}
+    -g3 -gz=zlib ${DEBUG}
     -g1 ${RELEASE}
   )
 


### PR DESCRIPTION
I know similar efforts have been rejected earlier, but given how much time it took me to get Bun to compile, I think it's worth reconsidering, if you want to welcome external developers. I imagine maintenance by core developers would be minimal, as external developers using this configuration would likely create pull requests whenever the build breaks.

Eventually, CI/CD based on this container may be something to aim for?

### What does this PR do?

In this initial version, the container environment successfully builds the project, though many of the tests fail. This seems to be a larger/unrelated problem?

The container workspace mounts at the same path as the actual project directory, so that the resulting bun-debug can be run from outside the container as well (it accesses bundled js at a compiled-in path). The container runs as the actual user, so the project directory won't get littered with build files owned by root.

I've needed to switch from compressing debug symbols with zlib instead of zstd, as in the few base image distro's I've tried, I couldn't find one that has support for this compiled into clang, while also providing a libstdc++ that doesn't clash with the clang version (regarding constexpr std::string).

### How did you verify your code works?

`bun run build` just works in a newly created devcontainer.
