### PR TITLE
Update WebKit

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 014cad89f528483e3fc431ff5ca6e2095d92e7bd)
+  set(WEBKIT_VERSION 397dafc9721b8f8046f9448abb6dbc14efe096d3)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)

--- a/src/bun.js/bindings/AsymmetricKeyValue.cpp
+++ b/src/bun.js/bindings/AsymmetricKeyValue.cpp
@@ -106,11 +106,11 @@ AsymmetricKeyValue::AsymmetricKeyValue(WebCore::CryptoKey& cryptoKey)
         const auto& okpKey = downcast<WebCore::CryptoKeyOKP>(cryptoKey);
         auto keyData = okpKey.exportKey();
         if (okpKey.type() == CryptoKeyType::Private) {
-            key = EVP_PKEY_new_raw_private_key(okpKey.namedCurve() == CryptoKeyOKP::NamedCurve::X25519 ? EVP_PKEY_X25519 : EVP_PKEY_ED25519, nullptr, keyData.data(), keyData.size());
+            key = EVP_PKEY_new_raw_private_key(okpKey.namedCurve() == CryptoKeyOKP::NamedCurve::X25519 ? EVP_PKEY_X25519 : EVP_PKEY_ED25519, nullptr, keyData.begin(), keyData.size());
             owned = true;
             break;
         } else {
-            auto* evp_key = EVP_PKEY_new_raw_public_key(okpKey.namedCurve() == CryptoKeyOKP::NamedCurve::X25519 ? EVP_PKEY_X25519 : EVP_PKEY_ED25519, nullptr, keyData.data(), keyData.size());
+            auto* evp_key = EVP_PKEY_new_raw_public_key(okpKey.namedCurve() == CryptoKeyOKP::NamedCurve::X25519 ? EVP_PKEY_X25519 : EVP_PKEY_ED25519, nullptr, keyData.begin(), keyData.size());
             key = evp_key;
             owned = true;
             break;

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2491,7 +2491,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functiongetgroups, (JSGlobalObject * globalObje
     JSArray* groups = constructEmptyArray(globalObject, nullptr, ngroups);
     RETURN_IF_EXCEPTION(throwScope, {});
     Vector<gid_t> groupVector(ngroups);
-    getgroups(ngroups, groupVector.data());
+    getgroups(ngroups, groupVector.begin());
     for (unsigned i = 0; i < ngroups; i++) {
         groups->putDirectIndex(globalObject, i, jsNumber(groupVector[i]));
     }

--- a/src/bun.js/bindings/CodeCoverage.cpp
+++ b/src/bun.js/bindings/CodeCoverage.cpp
@@ -39,6 +39,6 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
         basicBlocks.append(range);
     }
 
-    blockCallback(ctx, basicBlocks.data(), basicBlocks.size(), functionStartOffset, ignoreSourceMap);
+    blockCallback(ctx, basicBlocks.begin(), basicBlocks.size(), functionStartOffset, ignoreSourceMap);
     return true;
 }

--- a/src/bun.js/bindings/ImportMetaObject.cpp
+++ b/src/bun.js/bindings/ImportMetaObject.cpp
@@ -358,7 +358,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                     paths.append(Bun::toStringRef(pathStr));
                 }
 
-                result = Bun__resolveSyncWithPaths(lexicalGlobalObject, JSC::JSValue::encode(moduleName), JSValue::encode(from), isESM, isRequireDotResolve, paths.data(), paths.size());
+                result = Bun__resolveSyncWithPaths(lexicalGlobalObject, JSC::JSValue::encode(moduleName), JSValue::encode(from), isESM, isRequireDotResolve, paths.begin(), paths.size());
                 if (scope.exception()) goto cleanup;
 
                 if (!JSC::JSValue::decode(result).isString()) {

--- a/src/bun.js/bindings/InternalModuleRegistry.cpp
+++ b/src/bun.js/bindings/InternalModuleRegistry.cpp
@@ -71,7 +71,7 @@ JSC::JSValue generateModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, cons
     ASSERT(
         result && result.isCell() && jsDynamicCast<JSObject*>(result),
         "Expected \"%s\" to export a JSObject. Bun is going to crash.",
-        moduleName.utf8().data());
+        moduleName.utf8().span().data());
     return result;
 }
 
@@ -114,7 +114,7 @@ JSValue initializeInternalModuleFromDisk(
     } else {
         printf("\nFATAL: bun-debug failed to load bundled version of \"%s\" at \"%s\" (was it deleted?)\n"
                "Please re-compile Bun to continue.\n\n",
-            moduleName.utf8().data(), file.utf8().data());
+            moduleName.utf8().span().data(), file.utf8().span().data());
         CRASH();
     }
 }

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -442,7 +442,7 @@ JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const 
 
 JSC::JSUint8Array* createBuffer(JSC::JSGlobalObject* lexicalGlobalObject, const Vector<uint8_t>& data)
 {
-    return createBuffer(lexicalGlobalObject, data.data(), data.size());
+    return createBuffer(lexicalGlobalObject, data.begin(), data.size());
 }
 
 JSC::JSUint8Array* createEmptyBuffer(JSC::JSGlobalObject* lexicalGlobalObject)

--- a/src/bun.js/bindings/JSCommonJSModule.cpp
+++ b/src/bun.js/bindings/JSCommonJSModule.cpp
@@ -1156,7 +1156,7 @@ void JSCommonJSModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.appendHidden(thisObject->m_paths);
     visitor.appendHidden(thisObject->m_overriddenParent);
     visitor.appendHidden(thisObject->m_childrenValue);
-    visitor.appendValues(thisObject->m_children.data(), thisObject->m_children.size());
+    visitor.appendValues(thisObject->m_children.begin(), thisObject->m_children.size());
 }
 
 DEFINE_VISIT_CHILDREN(JSCommonJSModule);

--- a/src/bun.js/bindings/Serialization.cpp
+++ b/src/bun.js/bindings/Serialization.cpp
@@ -41,7 +41,7 @@ extern "C" SerializedValueSlice Bun__serializeJSValue(JSGlobalObject* globalObje
     const Vector<uint8_t>& bytes = serializedValue->wireBytes();
 
     return {
-        bytes.data(),
+        bytes.begin(),
         bytes.size(),
         &serializedValue.leakRef(),
     };

--- a/src/bun.js/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/bun.js/bindings/node/crypto/CryptoHkdf.cpp
@@ -50,11 +50,11 @@ void HkdfJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
         .len = key.size(),
     };
     auto infoBuf = ncrypto::Buffer<const unsigned char> {
-        .data = m_info.data(),
+        .data = m_info.begin(),
         .len = m_info.size(),
     };
     auto saltBuf = ncrypto::Buffer<const unsigned char> {
-        .data = m_salt.data(),
+        .data = m_salt.begin(),
         .len = m_salt.size(),
     };
     auto dp = ncrypto::hkdf(m_digest, keyBuf, infoBuf, saltBuf, m_length);

--- a/src/bun.js/bindings/node/crypto/CryptoKeygen.cpp
+++ b/src/bun.js/bindings/node/crypto/CryptoKeygen.cpp
@@ -28,7 +28,7 @@ void SecretKeyJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     Vector<uint8_t> key;
     key.grow(m_length);
 
-    if (!ncrypto::CSPRNG(key.data(), key.size())) {
+    if (!ncrypto::CSPRNG(key.begin(), key.size())) {
         return;
     }
 

--- a/src/bun.js/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/bun.js/bindings/node/crypto/CryptoSignJob.cpp
@@ -121,7 +121,7 @@ void SignJobCtx::runTask(JSGlobalObject* globalObject)
     switch (m_mode) {
     case Mode::Sign: {
         auto dataBuf = ncrypto::Buffer<const uint8_t> {
-            .data = m_data.data(),
+            .data = m_data.begin(),
             .len = m_data.size(),
         };
 
@@ -176,11 +176,11 @@ void SignJobCtx::runTask(JSGlobalObject* globalObject)
     }
     case Mode::Verify: {
         auto dataBuf = ncrypto::Buffer<const uint8_t> {
-            .data = m_data.data(),
+            .data = m_data.begin(),
             .len = m_data.size(),
         };
         auto sigBuf = ncrypto::Buffer<const uint8_t> {
-            .data = m_signature.data(),
+            .data = m_signature.begin(),
             .len = m_signature.size(),
         };
         m_verifyResult = context.verify(dataBuf, sigBuf);

--- a/src/bun.js/bindings/node/crypto/JSECDHConstructor.cpp
+++ b/src/bun.js/bindings/node/crypto/JSECDHConstructor.cpp
@@ -128,7 +128,7 @@ JSC_DEFINE_HOST_FUNCTION(jsECDHConvertKey, (JSC::JSGlobalObject * lexicalGlobalO
         return JSValue::encode({});
     }
 
-    if (!EC_POINT_point2oct(group, point, form, buf.data(), buf.size(), nullptr)) {
+    if (!EC_POINT_point2oct(group, point, form, buf.begin(), buf.size(), nullptr)) {
         return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "Failed to get public key"_s);
     }
 

--- a/src/bun.js/bindings/node/crypto/JSECDHPrototype.cpp
+++ b/src/bun.js/bindings/node/crypto/JSECDHPrototype.cpp
@@ -127,7 +127,7 @@ JSC_DEFINE_HOST_FUNCTION(jsECDHProtoFuncComputeSecret, (JSC::JSGlobalObject * gl
     }
 
     // Compute the shared secret
-    if (!ECDH_compute_key(secret.data(), secret.size(), pubPoint, ecdh->m_key.get(), nullptr)) {
+    if (!ECDH_compute_key(secret.begin(), secret.size(), pubPoint, ecdh->m_key.get(), nullptr)) {
         return Bun::ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "Failed to compute ECDH key"_s);
     }
 

--- a/src/bun.js/bindings/node/crypto/JSVerify.cpp
+++ b/src/bun.js/bindings/node/crypto/JSVerify.cpp
@@ -414,7 +414,7 @@ JSC_DEFINE_HOST_FUNCTION(jsVerifyProtoFuncVerify, (JSGlobalObject * globalObject
         if (convertP1363ToDER(sigBuf, keyPtr, derBuffer)) {
             // Conversion succeeded, perform verification with the converted signature
             ncrypto::Buffer<const uint8_t> derSigBuf {
-                .data = derBuffer.data(),
+                .data = derBuffer.begin(),
                 .len = derBuffer.size(),
             };
 

--- a/src/bun.js/bindings/node/crypto/KeyObject.cpp
+++ b/src/bun.js/bindings/node/crypto/KeyObject.cpp
@@ -419,7 +419,7 @@ JSValue KeyObject::exportSecret(JSGlobalObject* lexicalGlobalObject, ThrowScope&
             throwOutOfMemoryError(lexicalGlobalObject, scope);
             return {};
         }
-        memcpy(buf->data(), key.data(), key.size());
+        memcpy(buf->data(), key.begin(), key.size());
         return JSUint8Array::create(lexicalGlobalObject, globalObject->JSBufferSubclassStructure(), WTFMove(buf), 0, key.size());
     };
 

--- a/src/bun.js/bindings/node/crypto/node_crypto_binding.cpp
+++ b/src/bun.js/bindings/node/crypto/node_crypto_binding.cpp
@@ -68,7 +68,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGetCurves, (JSC::JSGlobalObject * lexicalGlobalObject
 
     const size_t numCurves = EC_get_builtin_curves(nullptr, 0);
     Vector<EC_builtin_curve> curves(numCurves);
-    EC_get_builtin_curves(curves.data(), numCurves);
+    EC_get_builtin_curves(curves.begin(), numCurves);
 
     JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, numCurves);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/bun.js/bindings/v8/shim/FunctionTemplate.cpp
+++ b/src/bun.js/bindings/v8/shim/FunctionTemplate.cpp
@@ -95,7 +95,7 @@ JSC::EncodedJSValue FunctionTemplate::functionCall(JSC::JSGlobalObject* globalOb
         .new_target = nullptr,
     };
 
-    FunctionCallbackInfo<Value> info(&implicit_args, args.data() + 1, callFrame->argumentCount());
+    FunctionCallbackInfo<Value> info(&implicit_args, args.begin() + 1, callFrame->argumentCount());
 
     functionTemplate->m_callback(info);
 

--- a/src/bun.js/bindings/webcore/HTTPParsers.cpp
+++ b/src/bun.js/bindings/webcore/HTTPParsers.cpp
@@ -742,10 +742,10 @@ size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReaso
                 failureReason = makeString("CR doesn't follow LF in header name at "_s, trimInputSample(p, end - p));
                 return 0;
             }
-            failureReason = makeString("Unexpected CR in header name at "_s, trimInputSample(name.data(), name.size()));
+            failureReason = makeString("Unexpected CR in header name at "_s, trimInputSample(name.begin(), name.size()));
             return 0;
         case '\n':
-            failureReason = makeString("Unexpected LF in header name at "_s, trimInputSample(name.data(), name.size()));
+            failureReason = makeString("Unexpected LF in header name at "_s, trimInputSample(name.begin(), name.size()));
             return 0;
         case ':':
             break;
@@ -754,7 +754,7 @@ size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReaso
                 if (name.size() < 1)
                     failureReason = "Unexpected start character in header name"_s;
                 else
-                    failureReason = makeString("Unexpected character in header name at "_s, trimInputSample(name.data(), name.size()));
+                    failureReason = makeString("Unexpected character in header name at "_s, trimInputSample(name.begin(), name.size()));
                 return 0;
             }
             name.append(*p);
@@ -782,7 +782,7 @@ size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReaso
             break;
         case '\n':
             if (strict) {
-                failureReason = makeString("Unexpected LF in header value at "_s, trimInputSample(value.data(), value.size()));
+                failureReason = makeString("Unexpected LF in header value at "_s, trimInputSample(value.begin(), value.size()));
                 return 0;
             }
             break;
@@ -798,7 +798,7 @@ size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReaso
         failureReason = makeString("CR doesn't follow LF after header value at "_s, trimInputSample(p, end - p));
         return 0;
     }
-    valueStr = String::fromUTF8({ value.data(), value.size() });
+    valueStr = String::fromUTF8({ value.begin(), value.size() });
     if (valueStr.isNull()) {
         failureReason = "Invalid UTF-8 sequence in header value"_s;
         return 0;

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -2228,7 +2228,7 @@ private:
     {
         uint32_t size = vector.size();
         write(size);
-        writeLittleEndian(m_buffer, vector.data(), size);
+        writeLittleEndian(m_buffer, vector.begin(), size);
     }
 
     // void write(const File& file)
@@ -4542,7 +4542,7 @@ private:
         }
         ncrypto::ClearErrorOnReturn clear_error_on_return;
         X509* ptr = nullptr;
-        const uint8_t* data = buffer.data();
+        const uint8_t* data = buffer.begin();
 
         auto cert = d2i_X509(&ptr, &data, buffer.size());
         if (!cert) {
@@ -5992,7 +5992,7 @@ Ref<JSC::ArrayBuffer> SerializedScriptValue::toArrayBuffer()
 
     this->ref();
     auto arrayBuffer = ArrayBuffer::createFromBytes(
-        { this->m_data.data(), this->m_data.size() }, createSharedTask<void(void*)>([protectedThis = Ref { *this }](void* p) {
+        { this->m_data.begin(), this->m_data.size() }, createSharedTask<void(void*)>([protectedThis = Ref { *this }](void* p) {
             protectedThis->deref();
         }));
 

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -441,11 +441,11 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     if (is_secure) {
         us_socket_context_t* ctx = scriptExecutionContext()->webSocketContext<true>();
         RELEASE_ASSERT(ctx);
-        this->m_upgradeClient = Bun__WebSocketHTTPSClient__connect(scriptExecutionContext()->jsGlobalObject(), ctx, reinterpret_cast<CppWebSocket*>(this), &host, port, &path, &clientProtocolString, headerNames.data(), headerValues.data(), headerNames.size());
+        this->m_upgradeClient = Bun__WebSocketHTTPSClient__connect(scriptExecutionContext()->jsGlobalObject(), ctx, reinterpret_cast<CppWebSocket*>(this), &host, port, &path, &clientProtocolString, headerNames.begin(), headerValues.begin(), headerNames.size());
     } else {
         us_socket_context_t* ctx = scriptExecutionContext()->webSocketContext<false>();
         RELEASE_ASSERT(ctx);
-        this->m_upgradeClient = Bun__WebSocketHTTPClient__connect(scriptExecutionContext()->jsGlobalObject(), ctx, reinterpret_cast<CppWebSocket*>(this), &host, port, &path, &clientProtocolString, headerNames.data(), headerValues.data(), headerNames.size());
+        this->m_upgradeClient = Bun__WebSocketHTTPClient__connect(scriptExecutionContext()->jsGlobalObject(), ctx, reinterpret_cast<CppWebSocket*>(this), &host, port, &path, &clientProtocolString, headerNames.begin(), headerValues.begin(), headerNames.size());
     }
 
     headerValues.clear();

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -186,7 +186,7 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
     static_assert(sizeof(WTF::String) == sizeof(WTF::StringImpl*));
     std::span<WTF::StringImpl*> execArgv = worker->m_options.execArgv
                                                .transform([](Vector<String>& vec) -> std::span<WTF::StringImpl*> {
-                                                   return { reinterpret_cast<WTF::StringImpl**>(vec.data()), vec.size() };
+                                                   return { reinterpret_cast<WTF::StringImpl**>(vec.begin()), vec.size() };
                                                })
                                                .value_or(std::span<WTF::StringImpl*> {});
     void* impl = WebWorker__create(
@@ -200,12 +200,12 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
         worker->m_options.mini,
         worker->m_options.unref,
         worker->m_options.evalMode,
-        reinterpret_cast<WTF::StringImpl**>(worker->m_options.argv.data()),
+        reinterpret_cast<WTF::StringImpl**>(worker->m_options.argv.begin()),
         worker->m_options.argv.size(),
         !worker->m_options.execArgv.has_value(),
         execArgv.data(),
         execArgv.size(),
-        preloadModules.data(),
+        preloadModules.begin(),
         preloadModules.size());
     // now referenced by Zig
     worker->ref();

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CBCOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CBCOpenSSL.cpp
@@ -67,15 +67,15 @@ static std::optional<Vector<uint8_t>> cryptEncrypt(const Vector<uint8_t>& key, c
     Vector<uint8_t> cipherText(cipherTextLen);
 
     // Initialize the encryption operation
-    if (1 != EVP_EncryptInit_ex(ctx.get(), algorithm, nullptr, key.data(), iv.data()))
+    if (1 != EVP_EncryptInit_ex(ctx.get(), algorithm, nullptr, key.begin(), iv.begin()))
         return std::nullopt;
 
     // Provide the message to be encrypted, and obtain the encrypted output
-    if (1 != EVP_EncryptUpdate(ctx.get(), cipherText.data(), &len, plainText.data(), plainSize))
+    if (1 != EVP_EncryptUpdate(ctx.get(), cipherText.begin(), &len, plainText.begin(), plainSize))
         return std::nullopt;
 
     // Finalize the encryption. Further ciphertext bytes may be written at this stage
-    if (1 != EVP_EncryptFinal_ex(ctx.get(), cipherText.data() + len, &len))
+    if (1 != EVP_EncryptFinal_ex(ctx.get(), cipherText.begin() + len, &len))
         return std::nullopt;
 
     return cipherText;
@@ -99,16 +99,16 @@ static std::optional<Vector<uint8_t>> cryptDecrypt(const Vector<uint8_t>& key, c
         return std::nullopt;
 
     // Initialize the decryption operation
-    if (1 != EVP_DecryptInit_ex(ctx.get(), algorithm, nullptr, key.data(), iv.data()))
+    if (1 != EVP_DecryptInit_ex(ctx.get(), algorithm, nullptr, key.begin(), iv.begin()))
         return std::nullopt;
 
     // Provide the message to be decrypted, and obtain the plaintext output
-    if (1 != EVP_DecryptUpdate(ctx.get(), plainText.data(), &len, cipherText.data(), cipherSize))
+    if (1 != EVP_DecryptUpdate(ctx.get(), plainText.begin(), &len, cipherText.begin(), cipherSize))
         return std::nullopt;
     plainTextLen = len;
 
     // Finalize the decryption. Further plaintext bytes may be written at this stage
-    if (1 != EVP_DecryptFinal_ex(ctx.get(), plainText.data() + len, &len))
+    if (1 != EVP_DecryptFinal_ex(ctx.get(), plainText.begin() + len, &len))
         return std::nullopt;
     plainTextLen += len;
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CFBOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CFBOpenSSL.cpp
@@ -48,7 +48,7 @@ static std::optional<Vector<uint8_t>> cfb8(const Vector<uint8_t>& key, const Vec
     // (shiftRegister + shift + AES_BLOCK_SIZE) until the feedback position reaches
     // the end of the buffer.
     uint8_t shiftRegister[AES_BLOCK_SIZE * 2];
-    memcpy(shiftRegister, iv.data(), AES_BLOCK_SIZE);
+    memcpy(shiftRegister, iv.begin(), AES_BLOCK_SIZE);
     size_t shift = 0;
 
     Vector<uint8_t> output(input.size());

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
@@ -211,9 +211,9 @@ CryptoAlgorithmAES_CTR::CounterBlockHelper::CounterBlockHelper(const Vector<uint
     ASSERT(counterVector.size() == CounterSize);
     ASSERT(counterLength <= CounterSize * 8);
     bool littleEndian = false; // counterVector is stored in big-endian.
-    memcpy(&m_bits.m_hi, counterVector.data(), 8);
+    memcpy(&m_bits.m_hi, counterVector.begin(), 8);
     m_bits.m_hi = flipBytesIfLittleEndian(m_bits.m_hi, littleEndian);
-    memcpy(&m_bits.m_lo, counterVector.data() + 8, 8);
+    memcpy(&m_bits.m_lo, counterVector.begin() + 8, 8);
     m_bits.m_lo = flipBytesIfLittleEndian(m_bits.m_lo, littleEndian);
 }
 
@@ -257,9 +257,9 @@ Vector<uint8_t> CryptoAlgorithmAES_CTR::CounterBlockHelper::counterVectorAfterOv
     bool littleEndian = false; // counterVector is stored in big-endian.
     Vector<uint8_t> counterVector(CounterSize);
     uint64_t hi = flipBytesIfLittleEndian(bits.m_hi, littleEndian);
-    memcpy(counterVector.data(), &hi, 8);
+    memcpy(counterVector.begin(), &hi, 8);
     uint64_t lo = flipBytesIfLittleEndian(bits.m_lo, littleEndian);
-    memcpy(counterVector.data() + 8, &lo, 8);
+    memcpy(counterVector.begin() + 8, &lo, 8);
 
     return counterVector;
 }

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CTROpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CTROpenSSL.cpp
@@ -82,7 +82,7 @@ static std::optional<Vector<uint8_t>> crypt(int operation, const Vector<uint8_t>
     // First part
     {
         // Initialize the encryption(decryption) operation
-        if (1 != EVP_CipherInit_ex(ctx.get(), algorithm, nullptr, key.data(), counter.data(), operation))
+        if (1 != EVP_CipherInit_ex(ctx.get(), algorithm, nullptr, key.begin(), counter.begin(), operation))
             return std::nullopt;
 
         // Disable padding
@@ -90,11 +90,11 @@ static std::optional<Vector<uint8_t>> crypt(int operation, const Vector<uint8_t>
             return std::nullopt;
 
         // Provide the message to be encrypted(decrypted), and obtain the encrypted(decrypted) output
-        if (1 != EVP_CipherUpdate(ctx.get(), outputText.data(), &len, inputText.data(), headSize))
+        if (1 != EVP_CipherUpdate(ctx.get(), outputText.begin(), &len, inputText.begin(), headSize))
             return std::nullopt;
 
         // Finalize the encryption(decryption)
-        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.data() + len, &len))
+        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.begin() + len, &len))
             return std::nullopt;
     }
 
@@ -105,7 +105,7 @@ static std::optional<Vector<uint8_t>> crypt(int operation, const Vector<uint8_t>
         Vector<uint8_t> remainingCounter = counterBlockHelper.counterVectorAfterOverflow();
 
         // Initialize the encryption(decryption) operation
-        if (1 != EVP_CipherInit_ex(ctx.get(), algorithm, nullptr, key.data(), remainingCounter.data(), operation))
+        if (1 != EVP_CipherInit_ex(ctx.get(), algorithm, nullptr, key.begin(), remainingCounter.begin(), operation))
             return std::nullopt;
 
         // Disable padding
@@ -113,11 +113,11 @@ static std::optional<Vector<uint8_t>> crypt(int operation, const Vector<uint8_t>
             return std::nullopt;
 
         // Provide the message to be encrypted(decrypted), and obtain the encrypted(decrypted) output
-        if (1 != EVP_CipherUpdate(ctx.get(), outputText.data() + headSize, &len, inputText.data() + headSize, tailSize))
+        if (1 != EVP_CipherUpdate(ctx.get(), outputText.begin() + headSize, &len, inputText.begin() + headSize, tailSize))
             return std::nullopt;
 
         // Finalize the encryption(decryption)
-        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.data() + headSize + len, &len))
+        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.begin() + headSize + len, &len))
             return std::nullopt;
     }
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_KWOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_KWOpenSSL.cpp
@@ -43,7 +43,7 @@ static std::optional<Vector<uint8_t>> cryptWrapKey(const Vector<uint8_t>& key, c
         return std::nullopt;
 
     Vector<uint8_t> cipherText(data.size() + 8);
-    if (AES_wrap_key(aesKey.key(), nullptr, cipherText.data(), data.data(), data.size()) < 0)
+    if (AES_wrap_key(aesKey.key(), nullptr, cipherText.begin(), data.begin(), data.size()) < 0)
         return std::nullopt;
 
     return cipherText;
@@ -59,7 +59,7 @@ static std::optional<Vector<uint8_t>> cryptUnwrapKey(const Vector<uint8_t>& key,
         return std::nullopt;
 
     Vector<uint8_t> plainText(data.size() - 8);
-    if (AES_unwrap_key(aesKey.key(), nullptr, plainText.data(), data.data(), data.size()) < 0)
+    if (AES_unwrap_key(aesKey.key(), nullptr, plainText.begin(), data.begin(), data.size()) < 0)
         return std::nullopt;
 
     return plainText;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmECDHOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmECDHOpenSSL.cpp
@@ -51,7 +51,7 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const Cry
         return std::nullopt;
 
     Vector<uint8_t> key(keyLen);
-    if (EVP_PKEY_derive(ctx.get(), key.data(), &keyLen) <= 0)
+    if (EVP_PKEY_derive(ctx.get(), key.begin(), &keyLen) <= 0)
         return std::nullopt;
 
     // Shrink the buffer since the new keyLen may differ from the buffer size.

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmEd25519.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmEd25519.cpp
@@ -41,7 +41,7 @@ static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, size_
 {
     uint8_t newSignature[64];
 
-    ED25519_sign(newSignature, data.data(), data.size(), sk.data());
+    ED25519_sign(newSignature, data.begin(), data.size(), sk.begin());
     return Vector<uint8_t>(std::span { newSignature, 64 });
 }
 
@@ -55,7 +55,7 @@ static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLen
     if (signature.size() != keyLengthInBytes * 2)
         return false;
 
-    return ED25519_verify(data.data(), data.size(), signature.data(), key.data()) == 1;
+    return ED25519_verify(data.begin(), data.size(), signature.begin(), key.begin()) == 1;
 }
 
 ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHKDFOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHKDFOpenSSL.cpp
@@ -42,7 +42,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const Crypt
         return Exception { NotSupportedError };
 
     Vector<uint8_t> output(length / 8);
-    if (HKDF(output.data(), output.size(), algorithm, key.key().data(), key.key().size(), parameters.saltVector().data(), parameters.saltVector().size(), parameters.infoVector().data(), parameters.infoVector().size()) <= 0)
+    if (HKDF(output.begin(), output.size(), algorithm, key.key().begin(), key.key().size(), parameters.saltVector().begin(), parameters.saltVector().size(), parameters.infoVector().begin(), parameters.infoVector().size()) <= 0)
         return Exception { OperationError };
 
     return output;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmHMACOpenSSL.cpp
@@ -42,7 +42,7 @@ static std::optional<Vector<uint8_t>> calculateSignature(const EVP_MD* algorithm
     if (!(ctx = HMACCtxPtr(HMAC_CTX_new())))
         return std::nullopt;
 
-    if (1 != HMAC_Init_ex(ctx.get(), key.data(), key.size(), algorithm, nullptr))
+    if (1 != HMAC_Init_ex(ctx.get(), key.begin(), key.size(), algorithm, nullptr))
         return std::nullopt;
 
     // Call update with the message
@@ -52,7 +52,7 @@ static std::optional<Vector<uint8_t>> calculateSignature(const EVP_MD* algorithm
     // Finalize the DigestSign operation
     Vector<uint8_t> cipherText(EVP_MAX_MD_SIZE);
     unsigned len = 0;
-    if (1 != HMAC_Final(ctx.get(), cipherText.data(), &len))
+    if (1 != HMAC_Final(ctx.get(), cipherText.begin(), &len))
         return std::nullopt;
 
     cipherText.shrink(len);
@@ -66,7 +66,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSignWithAlgorithm(cons
     if (!algorithm)
         return Exception { OperationError };
 
-    auto result = calculateSignature(algorithm, key.key(), data.data(), data.size());
+    auto result = calculateSignature(algorithm, key.key(), data.begin(), data.size());
     if (!result)
         return Exception { OperationError };
     return WTFMove(*result);
@@ -78,7 +78,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     if (!algorithm)
         return Exception { OperationError };
 
-    auto result = calculateSignature(algorithm, key.key(), data.data(), data.size());
+    auto result = calculateSignature(algorithm, key.key(), data.begin(), data.size());
     if (!result)
         return Exception { OperationError };
     return WTFMove(*result);
@@ -91,7 +91,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerifyWithAlgorithm(const CryptoK
     if (!algorithm)
         return Exception { OperationError };
 
-    auto expectedSignature = calculateSignature(algorithm, key.key(), data.data(), data.size());
+    auto expectedSignature = calculateSignature(algorithm, key.key(), data.begin(), data.size());
     if (!expectedSignature)
         return Exception { OperationError };
     // Using a constant time comparison to prevent timing attacks.
@@ -104,7 +104,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, 
     if (!algorithm)
         return Exception { OperationError };
 
-    auto expectedSignature = calculateSignature(algorithm, key.key(), data.data(), data.size());
+    auto expectedSignature = calculateSignature(algorithm, key.key(), data.begin(), data.size());
     if (!expectedSignature)
         return Exception { OperationError };
     // Using a constant time comparison to prevent timing attacks.

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmPBKDF2OpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmPBKDF2OpenSSL.cpp
@@ -46,7 +46,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmPBKDF2::platformDeriveBits(const Cry
         return Exception { OperationError };
 
     Vector<uint8_t> output(length / 8);
-    if (PKCS5_PBKDF2_HMAC(reinterpret_cast<const char*>(key.key().data()), key.key().size(), parameters.saltVector().data(), parameters.saltVector().size(), parameters.iterations, algorithm, output.size(), output.data()) <= 0)
+    if (PKCS5_PBKDF2_HMAC(reinterpret_cast<const char*>(key.key().begin()), key.key().size(), parameters.saltVector().begin(), parameters.saltVector().size(), parameters.iterations, algorithm, output.size(), output.begin()) <= 0)
         return Exception { OperationError };
 
     return output;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSAES_PKCS1_v1_5OpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSAES_PKCS1_v1_5OpenSSL.cpp
@@ -46,11 +46,11 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSAES_PKCS1_v1_5::platformEncrypt(co
         return Exception { OperationError };
 
     size_t cipherTextLen;
-    if (EVP_PKEY_encrypt(ctx.get(), nullptr, &cipherTextLen, plainText.data(), plainText.size()) <= 0)
+    if (EVP_PKEY_encrypt(ctx.get(), nullptr, &cipherTextLen, plainText.begin(), plainText.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> cipherText(cipherTextLen);
-    if (EVP_PKEY_encrypt(ctx.get(), cipherText.data(), &cipherTextLen, plainText.data(), plainText.size()) <= 0)
+    if (EVP_PKEY_encrypt(ctx.get(), cipherText.begin(), &cipherTextLen, plainText.begin(), plainText.size()) <= 0)
         return Exception { OperationError };
     cipherText.shrink(cipherTextLen);
 
@@ -70,11 +70,11 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSAES_PKCS1_v1_5::platformDecrypt(co
         return Exception { OperationError };
 
     size_t plainTextLen;
-    if (EVP_PKEY_decrypt(ctx.get(), nullptr, &plainTextLen, cipherText.data(), cipherText.size()) <= 0)
+    if (EVP_PKEY_decrypt(ctx.get(), nullptr, &plainTextLen, cipherText.begin(), cipherText.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> plainText(plainTextLen);
-    if (EVP_PKEY_decrypt(ctx.get(), plainText.data(), &plainTextLen, cipherText.data(), cipherText.size()) <= 0)
+    if (EVP_PKEY_decrypt(ctx.get(), plainText.begin(), &plainTextLen, cipherText.begin(), cipherText.size()) <= 0)
         return Exception { OperationError };
     plainText.shrink(plainTextLen);
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
@@ -56,11 +56,11 @@ static ExceptionOr<Vector<uint8_t>> signWithEVP_MD(const CryptoKeyRSA& key, cons
     }
 
     size_t signatureLen;
-    if (EVP_PKEY_sign(ctx.get(), nullptr, &signatureLen, toSign.data(), toSign.size()) <= 0)
+    if (EVP_PKEY_sign(ctx.get(), nullptr, &signatureLen, toSign.begin(), toSign.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> signature(signatureLen);
-    if (EVP_PKEY_sign(ctx.get(), signature.data(), &signatureLen, toSign.data(), toSign.size()) <= 0)
+    if (EVP_PKEY_sign(ctx.get(), signature.begin(), &signatureLen, toSign.begin(), toSign.size()) <= 0)
         return Exception { OperationError };
     signature.shrink(signatureLen);
 
@@ -109,7 +109,7 @@ static ExceptionOr<bool> verifyWithEVP_MD(const CryptoKeyRSA& key, const EVP_MD*
     if (EVP_PKEY_CTX_set_signature_md(ctx.get(), md) <= 0)
         return Exception { OperationError };
 
-    int ret = EVP_PKEY_verify(ctx.get(), signature.data(), signature.size(), digest->data(), digest->size());
+    int ret = EVP_PKEY_verify(ctx.get(), signature.begin(), signature.size(), digest->begin(), digest->size());
 
     return ret == 1;
 }
@@ -145,11 +145,11 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSASSA_PKCS1_v1_5::platformVerifyRec
         return Exception { OperationError };
 
     size_t plaintextLen;
-    if (EVP_PKEY_verify_recover(ctx.get(), nullptr, &plaintextLen, signature.data(), signature.size()) <= 0)
+    if (EVP_PKEY_verify_recover(ctx.get(), nullptr, &plaintextLen, signature.begin(), signature.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> plaintext(plaintextLen);
-    if (EVP_PKEY_verify_recover(ctx.get(), plaintext.data(), &plaintextLen, signature.data(), signature.size()) <= 0)
+    if (EVP_PKEY_verify_recover(ctx.get(), plaintext.begin(), &plaintextLen, signature.begin(), signature.size()) <= 0)
         return Exception { OperationError };
     plaintext.shrink(plaintextLen);
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
@@ -74,7 +74,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformEncryptWithHash(co
         size_t labelSize = parameters.labelVector().size();
         // The library takes ownership of the label so the caller should not free the original memory pointed to by label.
         auto label = OPENSSL_malloc(labelSize);
-        memcpy(label, parameters.labelVector().data(), labelSize);
+        memcpy(label, parameters.labelVector().begin(), labelSize);
         if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), reinterpret_cast<uint8_t*>(label), labelSize) <= 0) {
             OPENSSL_free(label);
             return Exception { OperationError };
@@ -82,11 +82,11 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformEncryptWithHash(co
     }
 
     size_t cipherTextLen;
-    if (EVP_PKEY_encrypt(ctx.get(), nullptr, &cipherTextLen, plainText.data(), plainText.size()) <= 0)
+    if (EVP_PKEY_encrypt(ctx.get(), nullptr, &cipherTextLen, plainText.begin(), plainText.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> cipherText(cipherTextLen);
-    if (EVP_PKEY_encrypt(ctx.get(), cipherText.data(), &cipherTextLen, plainText.data(), plainText.size()) <= 0)
+    if (EVP_PKEY_encrypt(ctx.get(), cipherText.begin(), &cipherTextLen, plainText.begin(), plainText.size()) <= 0)
         return Exception { OperationError };
     cipherText.shrink(cipherTextLen);
 
@@ -131,7 +131,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformDecryptWithHash(co
         size_t labelSize = parameters.labelVector().size();
         // The library takes ownership of the label so the caller should not free the original memory pointed to by label.
         auto label = OPENSSL_malloc(labelSize);
-        memcpy(label, parameters.labelVector().data(), labelSize);
+        memcpy(label, parameters.labelVector().begin(), labelSize);
         if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), reinterpret_cast<uint8_t*>(label), labelSize) <= 0) {
             OPENSSL_free(label);
             return Exception { OperationError };
@@ -139,11 +139,11 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmRSA_OAEP::platformDecryptWithHash(co
     }
 
     size_t plainTextLen;
-    if (EVP_PKEY_decrypt(ctx.get(), nullptr, &plainTextLen, cipherText.data(), cipherText.size()) <= 0)
+    if (EVP_PKEY_decrypt(ctx.get(), nullptr, &plainTextLen, cipherText.begin(), cipherText.size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> plainText(plainTextLen);
-    if (EVP_PKEY_decrypt(ctx.get(), plainText.data(), &plainTextLen, cipherText.data(), cipherText.size()) <= 0)
+    if (EVP_PKEY_decrypt(ctx.get(), plainText.begin(), &plainTextLen, cipherText.begin(), cipherText.size()) <= 0)
         return Exception { OperationError };
     plainText.shrink(plainTextLen);
 

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSSOpenSSL.cpp
@@ -66,11 +66,11 @@ static ExceptionOr<Vector<uint8_t>> signWithMD(const CryptoAlgorithmRsaPssParams
         return Exception { OperationError };
 
     size_t signatureLen;
-    if (EVP_PKEY_sign(ctx.get(), nullptr, &signatureLen, digest->data(), digest->size()) <= 0)
+    if (EVP_PKEY_sign(ctx.get(), nullptr, &signatureLen, digest->begin(), digest->size()) <= 0)
         return Exception { OperationError };
 
     Vector<uint8_t> signature(signatureLen);
-    if (EVP_PKEY_sign(ctx.get(), signature.data(), &signatureLen, digest->data(), digest->size()) <= 0)
+    if (EVP_PKEY_sign(ctx.get(), signature.begin(), &signatureLen, digest->begin(), digest->size()) <= 0)
         return Exception { OperationError };
     signature.shrink(signatureLen);
 
@@ -134,7 +134,7 @@ static ExceptionOr<bool> verifyWithMD(const CryptoAlgorithmRsaPssParams& paramet
     if (!digest)
         return Exception { OperationError };
 
-    int ret = EVP_PKEY_verify(ctx.get(), signature.data(), signature.size(), digest->data(), digest->size());
+    int ret = EVP_PKEY_verify(ctx.get(), signature.begin(), signature.size(), digest->begin(), digest->size());
 
     return ret == 1;
 }

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA1.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA1.cpp
@@ -53,7 +53,7 @@ void CryptoAlgorithmSHA1::digest(Vector<uint8_t>&& message, VectorCallback&& cal
 
     if (message.size() < 64) {
         auto moved = WTFMove(message);
-        digest->addBytes(moved.data(), moved.size());
+        digest->addBytes(moved.begin(), moved.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(context.identifier(), [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);
@@ -62,7 +62,7 @@ void CryptoAlgorithmSHA1::digest(Vector<uint8_t>&& message, VectorCallback&& cal
     }
 
     workQueue.dispatch(context.globalObject(), [digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.data(), message.size());
+        digest->addBytes(message.begin(), message.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA224.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA224.cpp
@@ -53,7 +53,7 @@ void CryptoAlgorithmSHA224::digest(Vector<uint8_t>&& message, VectorCallback&& c
 
     if (message.size() < 64) {
         auto moved = WTFMove(message);
-        digest->addBytes(moved.data(), moved.size());
+        digest->addBytes(moved.begin(), moved.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(context.identifier(), [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);
@@ -62,7 +62,7 @@ void CryptoAlgorithmSHA224::digest(Vector<uint8_t>&& message, VectorCallback&& c
     }
 
     workQueue.dispatch(context.globalObject(), [digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.data(), message.size());
+        digest->addBytes(message.begin(), message.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA256.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA256.cpp
@@ -53,7 +53,7 @@ void CryptoAlgorithmSHA256::digest(Vector<uint8_t>&& message, VectorCallback&& c
 
     if (message.size() < 64) {
         auto moved = WTFMove(message);
-        digest->addBytes(moved.data(), moved.size());
+        digest->addBytes(moved.begin(), moved.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(context.identifier(), [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);
@@ -62,7 +62,7 @@ void CryptoAlgorithmSHA256::digest(Vector<uint8_t>&& message, VectorCallback&& c
     }
 
     workQueue.dispatch(context.globalObject(), [digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.data(), message.size());
+        digest->addBytes(message.begin(), message.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA384.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA384.cpp
@@ -53,7 +53,7 @@ void CryptoAlgorithmSHA384::digest(Vector<uint8_t>&& message, VectorCallback&& c
 
     if (message.size() < 64) {
         auto moved = WTFMove(message);
-        digest->addBytes(moved.data(), moved.size());
+        digest->addBytes(moved.begin(), moved.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(context.identifier(), [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);
@@ -62,7 +62,7 @@ void CryptoAlgorithmSHA384::digest(Vector<uint8_t>&& message, VectorCallback&& c
     }
 
     workQueue.dispatch(context.globalObject(), [digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.data(), message.size());
+        digest->addBytes(message.begin(), message.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA512.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmSHA512.cpp
@@ -53,7 +53,7 @@ void CryptoAlgorithmSHA512::digest(Vector<uint8_t>&& message, VectorCallback&& c
 
     if (message.size() < 64) {
         auto moved = WTFMove(message);
-        digest->addBytes(moved.data(), moved.size());
+        digest->addBytes(moved.begin(), moved.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(context.identifier(), [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);
@@ -62,7 +62,7 @@ void CryptoAlgorithmSHA512::digest(Vector<uint8_t>&& message, VectorCallback&& c
     }
 
     workQueue.dispatch(context.globalObject(), [digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.data(), message.size());
+        digest->addBytes(message.begin(), message.size());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);

--- a/src/bun.js/bindings/webcrypto/CryptoDigest.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoDigest.cpp
@@ -95,7 +95,7 @@ struct CryptoDigestContextImpl : public CryptoDigestContext {
     Vector<uint8_t> computeHash() override
     {
         Vector<uint8_t> result(SHAFunctions::digestLength);
-        SHAFunctions::final(result.data(), &m_context);
+        SHAFunctions::final(result.begin(), &m_context);
         return result;
     }
 

--- a/src/bun.js/bindings/webcrypto/CryptoKey.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoKey.cpp
@@ -79,7 +79,7 @@ WebCoreOpaqueRoot root(CryptoKey* key)
 Vector<uint8_t> CryptoKey::randomData(size_t size)
 {
     Vector<uint8_t> result(size);
-    RAND_bytes(result.data(), result.size());
+    RAND_bytes(result.begin(), result.size());
     return result;
 }
 

--- a/src/bun.js/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -79,7 +79,7 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::create(CryptoAlgorithmIdentifier identifier, 
         // Internal format is private key + public key suffix
         if (platformKey.size() == bytesExpectedExternal) {
             auto&& privateKey = ed25519PrivateFromSeed(WTFMove(platformKey));
-            if (!privateKey.data())
+            if (privateKey.size() == 0)
                 return nullptr;
 
             return adoptRef(*new CryptoKeyOKP(identifier, curve, type, WTFMove(privateKey), extractable, usages));
@@ -95,7 +95,7 @@ CryptoKeyOKP::CryptoKeyOKP(CryptoAlgorithmIdentifier identifier, NamedCurve curv
     : CryptoKey(identifier, type, extractable, usages)
     , m_curve(curve)
     , m_data(data)
-    , m_exportKey(curve == NamedCurve::Ed25519 && type == CryptoKeyType::Private ? std::optional<Vector<uint8_t>>(Vector<uint8_t>(std::span { data.data(), 32 })) : std::nullopt)
+    , m_exportKey(curve == NamedCurve::Ed25519 && type == CryptoKeyType::Private ? std::optional<Vector<uint8_t>>(Vector<uint8_t>(std::span { data.begin(), 32 })) : std::nullopt)
 {
 }
 

--- a/src/bun.js/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -231,7 +231,7 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
 RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifier, std::optional<CryptoAlgorithmIdentifier> hash, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // We need a local pointer variable to pass to d2i (DER to internal) functions().
-    const uint8_t* ptr = keyData.data();
+    const uint8_t* ptr = keyData.begin();
 
     // We use d2i_PUBKEY() to import a public key.
     auto pkey = EvpPKeyPtr(d2i_PUBKEY(nullptr, &ptr, keyData.size()));
@@ -244,7 +244,7 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifi
 RefPtr<CryptoKeyRSA> CryptoKeyRSA::importPkcs8(CryptoAlgorithmIdentifier identifier, std::optional<CryptoAlgorithmIdentifier> hash, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
     // We need a local pointer variable to pass to d2i (DER to internal) functions().
-    const uint8_t* ptr = keyData.data();
+    const uint8_t* ptr = keyData.begin();
 
     // We use d2i_PKCS8_PRIV_KEY_INFO() to import a private key.
     auto p8inf = PKCS8PrivKeyInfoPtr(d2i_PKCS8_PRIV_KEY_INFO(nullptr, &ptr, keyData.size()));
@@ -268,7 +268,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyRSA::exportSpki() const
         return Exception { OperationError };
 
     Vector<uint8_t> keyData(len);
-    auto ptr = keyData.data();
+    auto ptr = keyData.begin();
     if (i2d_PUBKEY(platformKey(), &ptr) < 0)
         return Exception { OperationError };
 
@@ -289,7 +289,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyRSA::exportPkcs8() const
         return Exception { OperationError };
 
     Vector<uint8_t> keyData(len);
-    auto ptr = keyData.data();
+    auto ptr = keyData.begin();
     if (i2d_PKCS8_PRIV_KEY_INFO(p8inf.get(), &ptr) < 0)
         return Exception { OperationError };
 
@@ -313,7 +313,7 @@ auto CryptoKeyRSA::algorithm() const -> KeyAlgorithm
         CryptoRsaHashedKeyAlgorithm result;
         result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
         result.modulusLength = modulusLength;
-        result.publicExponent = Uint8Array::tryCreate(publicExponent.data(), publicExponent.size());
+        result.publicExponent = Uint8Array::tryCreate(publicExponent.begin(), publicExponent.size());
         result.hash.name = CryptoAlgorithmRegistry::singleton().name(m_hash);
         return result;
     }
@@ -321,7 +321,7 @@ auto CryptoKeyRSA::algorithm() const -> KeyAlgorithm
     CryptoRsaKeyAlgorithm result;
     result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
     result.modulusLength = modulusLength;
-    result.publicExponent = Uint8Array::tryCreate(publicExponent.data(), publicExponent.size());
+    result.publicExponent = Uint8Array::tryCreate(publicExponent.begin(), publicExponent.size());
     return result;
 }
 

--- a/src/bun.js/bindings/webcrypto/OpenSSLUtilities.cpp
+++ b/src/bun.js/bindings/webcrypto/OpenSSLUtilities.cpp
@@ -64,10 +64,10 @@ std::optional<Vector<uint8_t>> calculateDigest(const EVP_MD* algorithm, const Ve
     if (EVP_DigestInit_ex(ctx.get(), algorithm, nullptr) != 1)
         return std::nullopt;
 
-    if (EVP_DigestUpdate(ctx.get(), message.data(), message.size()) != 1)
+    if (EVP_DigestUpdate(ctx.get(), message.begin(), message.size()) != 1)
         return std::nullopt;
 
-    if (EVP_DigestFinal_ex(ctx.get(), digest.data(), nullptr) != 1)
+    if (EVP_DigestFinal_ex(ctx.get(), digest.begin(), nullptr) != 1)
         return std::nullopt;
 
     return digest;
@@ -76,7 +76,7 @@ std::optional<Vector<uint8_t>> calculateDigest(const EVP_MD* algorithm, const Ve
 Vector<uint8_t> convertToBytes(const BIGNUM* bignum)
 {
     Vector<uint8_t> bytes(BN_num_bytes(bignum));
-    BN_bn2bin(bignum, bytes.data());
+    BN_bn2bin(bignum, bytes.begin());
     return bytes;
 }
 
@@ -96,13 +96,13 @@ Vector<uint8_t> convertToBytesExpand(const BIGNUM* bignum, size_t minimumBufferS
         for (size_t i = 0; i < paddingLength; i++)
             bytes[i] = padding;
     }
-    BN_bn2bin(bignum, bytes.data() + paddingLength);
+    BN_bn2bin(bignum, bytes.begin() + paddingLength);
     return bytes;
 }
 
 BIGNUMPtr convertToBigNumber(const Vector<uint8_t>& bytes)
 {
-    return BIGNUMPtr(BN_bin2bn(bytes.data(), bytes.size(), nullptr));
+    return BIGNUMPtr(BN_bin2bn(bytes.begin(), bytes.size(), nullptr));
 }
 
 bool AESKey::setKey(const Vector<uint8_t>& key, int enc)
@@ -112,13 +112,13 @@ bool AESKey::setKey(const Vector<uint8_t>& key, int enc)
         return false;
 
     if (enc == AES_ENCRYPT) {
-        if (AES_set_encrypt_key(key.data(), keySize, &m_key) < 0)
+        if (AES_set_encrypt_key(key.begin(), keySize, &m_key) < 0)
             return false;
         return true;
     }
 
     if (enc == AES_DECRYPT) {
-        if (AES_set_decrypt_key(key.data(), keySize, &m_key) < 0)
+        if (AES_set_decrypt_key(key.begin(), keySize, &m_key) < 0)
             return false;
         return true;
     }

--- a/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
@@ -635,7 +635,7 @@ void SubtleCrypto::encrypt(JSC::JSGlobalObject& state, AlgorithmIdentifier&& alg
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis](const Vector<uint8_t>& cipherText) mutable {
         if (auto promise = getPromise(index, weakThis))
-            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), cipherText.data(), cipherText.size());
+            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), cipherText.begin(), cipherText.size());
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec, const String& msg) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -675,7 +675,7 @@ void SubtleCrypto::decrypt(JSC::JSGlobalObject& state, AlgorithmIdentifier&& alg
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis](const Vector<uint8_t>& plainText) mutable {
         if (auto promise = getPromise(index, weakThis))
-            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), plainText.data(), plainText.size());
+            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), plainText.begin(), plainText.size());
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec, const String& msg) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -713,7 +713,7 @@ void SubtleCrypto::sign(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algori
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis](const Vector<uint8_t>& signature) mutable {
         if (auto promise = getPromise(index, weakThis))
-            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), signature.data(), signature.size());
+            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), signature.begin(), signature.size());
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec, const String& msg) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -780,7 +780,7 @@ void SubtleCrypto::digest(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algo
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis](const Vector<uint8_t>& digest) mutable {
         if (auto promise = getPromise(index, weakThis))
-            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), digest.data(), digest.size());
+            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), digest.begin(), digest.size());
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec, const String& msg) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -940,7 +940,7 @@ void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& 
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis](const Vector<uint8_t>& derivedKey) mutable {
         if (auto promise = getPromise(index, weakThis))
-            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), derivedKey.data(), derivedKey.size());
+            fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), derivedKey.begin(), derivedKey.size());
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec, const String& msg) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -1017,7 +1017,7 @@ void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromi
             case SubtleCrypto::KeyFormat::Pkcs8:
             case SubtleCrypto::KeyFormat::Raw: {
                 Vector<uint8_t>& rawKey = std::get<Vector<uint8_t>>(key);
-                fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), rawKey.data(), rawKey.size());
+                fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), rawKey.begin(), rawKey.size());
                 return;
             }
             case SubtleCrypto::KeyFormat::Jwk:
@@ -1099,13 +1099,13 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
                     auto jwk = toJS<IDLDictionary<JsonWebKey>>(*(promise->globalObject()), *(promise->globalObject()), WTFMove(std::get<JsonWebKey>(key)));
                     String jwkString = JSONStringify(promise->globalObject(), jwk, 0);
                     CString jwkUTF8String = jwkString.utf8(StrictConversion);
-                    bytes.append(std::span { jwkUTF8String.data(), jwkUTF8String.length() });
+                    bytes.append(jwkUTF8String.span());
                 }
                 }
 
                 auto callback = [index, weakThis](const Vector<uint8_t>& wrappedKey) mutable {
                     if (auto promise = getPromise(index, weakThis))
-                        fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), wrappedKey.data(), wrappedKey.size());
+                        fulfillPromiseWithArrayBuffer(promise.releaseNonNull(), wrappedKey.begin(), wrappedKey.size());
                 };
                 auto exceptionCallback = [index, weakThis](ExceptionCode ec, const String& msg) mutable {
                     if (auto promise = getPromise(index, weakThis))
@@ -1200,7 +1200,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
                     auto& vm = state.vm();
                     auto scope = DECLARE_THROW_SCOPE(vm);
 
-                    String jwkString(std::span { bytes.data(), bytes.size() });
+                    String jwkString(bytes.span());
                     JSLockHolder locker(vm);
                     auto jwkObject = JSONParse(&state, jwkString);
                     if (!jwkObject) {

--- a/src/bun.js/bindings/wtf-bindings.cpp
+++ b/src/bun.js/bindings/wtf-bindings.cpp
@@ -194,7 +194,7 @@ String base64URLEncodeToString(Vector<uint8_t> data)
     std::span<LChar> ptr;
     auto result = String::createUninitialized(encodedLength, ptr);
 
-    encodedLength = WTF__base64URLEncode(reinterpret_cast<const char*>(data.data()), data.size(), reinterpret_cast<char*>(ptr.data()), encodedLength);
+    encodedLength = WTF__base64URLEncode(reinterpret_cast<const char*>(data.begin()), data.size(), reinterpret_cast<char*>(ptr.data()), encodedLength);
     if (result.length() != encodedLength) {
         return result.substringSharingImpl(0, encodedLength);
     }

--- a/src/bun.js/modules/BunJSCModule.h
+++ b/src/bun.js/modules/BunJSCModule.h
@@ -81,7 +81,7 @@ JSC_DEFINE_HOST_FUNCTION(functionStartRemoteDebugger,
 
         auto str = hostValue.toWTFString(globalObject);
         if (!str.isEmpty())
-            host = toCString(str).data();
+            host = toCString(str).span().data();
     } else if (!hostValue.isUndefined()) {
         throwVMError(globalObject, scope,
             createTypeError(globalObject, "host must be a string"_s));
@@ -415,14 +415,14 @@ JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
         if (!path.isEmpty()) {
             StringPrintStream pathOut;
             auto pathCString = toCString(String(path));
-            if (!Bun__mkdirp(globalObject, pathCString.data())) {
+            if (!Bun__mkdirp(globalObject, pathCString.span().data())) {
                 throwVMError(
                     globalObject, scope,
                     createTypeError(globalObject, "directory couldn't be created"_s));
                 return {};
             }
 
-            Options::samplingProfilerPath() = pathCString.data();
+            Options::samplingProfilerPath() = pathCString.span().data();
             samplingProfiler.registerForReportAtExit();
         }
     }
@@ -617,7 +617,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
     vm.dateCache.resetIfNecessarySlow();
     WTF::Vector<UChar, 32> buffer;
     WTF::getTimeZoneOverride(buffer);
-    WTF::String timeZoneString({ buffer.data(), buffer.size() });
+    WTF::String timeZoneString(buffer.span());
     return JSValue::encode(jsString(vm, timeZoneString));
 }
 
@@ -884,7 +884,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCodeCoverageForFile,
     }
 
     return ByteRangeMapping__findExecutedLines(
-        globalObject, Bun::toString(fileName), basicBlocks.data(),
+        globalObject, Bun::toString(fileName), basicBlocks.begin(),
         basicBlocks.size(), functionStartOffset, ignoreSourceMap);
 }
 

--- a/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-format.test.js
@@ -317,17 +317,17 @@ test("no assertion failures", () => {
       "  foo: 'bar',\n" +
       "  foobar: 1,\n" +
       "  func: <ref *1> [Function: func] {\n" +
-      "    [prototype]: { [constructor]: [Circular *1] },\n" +
+      "    [length]: 0,\n" +
       "    [name]: 'func',\n" +
-      "    [length]: 0\n" +
+      "    [prototype]: { [constructor]: [Circular *1] }\n" +
       "  }\n" +
       "} {\n" +
       "  foo: 'bar',\n" +
       "  foobar: 1,\n" +
       "  func: <ref *1> [Function: func] {\n" +
-      "    [prototype]: { [constructor]: [Circular *1] },\n" +
+      "    [length]: 0,\n" +
       "    [name]: 'func',\n" +
-      "    [length]: 0\n" +
+      "    [prototype]: { [constructor]: [Circular *1] }\n" +
       "  }\n" +
       "}",
   );
@@ -338,9 +338,9 @@ test("no assertion failures", () => {
       "  foo: 'bar',\n" +
       "  foobar: 1,\n" +
       "  func: <ref *1> [Function: func] {\n" +
-      "    [prototype]: { [constructor]: [Circular *1] },\n" +
+      "    [length]: 0,\n" +
       "    [name]: 'func',\n" +
-      "    [length]: 0\n" +
+      "    [prototype]: { [constructor]: [Circular *1] }\n" +
       "  }\n" +
       "} %o",
   );

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -3088,8 +3088,8 @@ test("no assertion failures 3", () => {
       "Fhqwhgads {\n" +
         "  constructor: <ref *1> [Function: Fhqwhgads] {\n" +
         "    [length]: 0,\n" +
-        "    [prototype]: { [constructor]: [Circular *1] },\n" +
-        "    [name]: 'Fhqwhgads'\n" +
+        "    [name]: 'Fhqwhgads',\n" +
+        "    [prototype]: { [constructor]: [Circular *1] }\n" +
         "  }\n" +
         "}",
     );

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -2914,8 +2914,8 @@ test("no assertion failures 3", () => {
       inspect(Object.getPrototypeOf(bar), { showHidden: true, getters: true }),
       "<ref *1> Foo [Map] {\n" +
         "    [constructor]: [class Bar extends Foo] {\n" +
-        `      [prototype]: [Circular *1],\n      [name]: 'Bar',\n` +
         "      [length]: 0,\n" +
+        `      [name]: 'Bar',\n      [prototype]: [Circular *1],\n` +
         "      [Symbol(Symbol.species)]: [Getter: <Inspection threw " +
         "(Symbol.prototype.toString requires that |this| be a symbol or a symbol object)>]\n" +
         "    },\n" +


### PR DESCRIPTION


### What does this PR do?

WebKit made data() a private member of WTF::Vector. This commit updates all uses to use the appropriate public APIs:

- Replace .data() with .begin() for most Vector uses
- Replace .data() with .span() when constructing std::span
- Use .span().data() for CString objects
- Replace null checks like !vector.data() with vector.size() == 0

This ensures compatibility with the latest WebKit builds.

🤖 Generated with [Claude Code](https://claude.ai/code)

### How did you verify your code works?

It compiled