### PR TITLE
Unhandled rejections: remove "bun" option

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -1626,7 +1626,6 @@ pub const Api = struct {
             .{ "warn", .warn },
             .{ "none", .none },
             .{ "warn-with-error-code", .warn_with_error_code },
-            .{ "bun", .bun },
         });
     };
 

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -201,7 +201,10 @@ pub fn allowRejectionHandledWarning(this: *VirtualMachine) callconv(.C) bool {
     return this.unhandledRejectionsMode() != .bun;
 }
 pub fn unhandledRejectionsMode(this: *VirtualMachine) Api.UnhandledRejections {
-    return this.transpiler.options.transform_options.unhandled_rejections orelse .bun;
+    return this.transpiler.options.transform_options.unhandled_rejections orelse switch (bun.FeatureFlags.breaking_changes_1_3) {
+        false => .bun,
+        true => .throw,
+    };
 }
 
 pub fn initRequestBodyValue(this: *VirtualMachine, body: JSC.WebCore.Body.Value) !*Body.Value.HiveRef {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -237,7 +237,7 @@ pub const Arguments = struct {
         clap.parseParam("--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled.") catch unreachable,
         clap.parseParam("--redis-preconnect                Preconnect to $REDIS_URL at startup") catch unreachable,
         clap.parseParam("--no-addons                       Throw an error if process.dlopen is called, and disable export condition \"node-addons\"") catch unreachable,
-        clap.parseParam("--unhandled-rejections <STR>      One of \"strict\", \"throw\", \"warn\", \"none\", \"warn-with-error-code\", or \"bun\" (default)") catch unreachable,
+        clap.parseParam("--unhandled-rejections <STR>      One of \"strict\", \"throw\", \"warn\", \"none\", \"warn-with-error-code\"") catch unreachable,
     };
 
     const auto_or_run_params = [_]ParamType{
@@ -715,7 +715,7 @@ pub const Arguments = struct {
 
             if (args.option("--unhandled-rejections")) |unhandled_rejections| {
                 const resolved = Api.UnhandledRejections.map.get(unhandled_rejections) orelse {
-                    Output.errGeneric("Invalid value for --unhandled-rejections: \"{s}\". Must be one of \"strict\", \"throw\", \"warn\", \"none\", \"warn-with-error-code\", or \"bun\"\n", .{unhandled_rejections});
+                    Output.errGeneric("Invalid value for --unhandled-rejections: \"{s}\". Must be one of \"strict\", \"throw\", \"warn\", \"none\", \"warn-with-error-code\"\n", .{unhandled_rejections});
                     Global.exit(1);
                 };
                 opts.unhandled_rejections = resolved;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -237,7 +237,7 @@ pub const Arguments = struct {
         clap.parseParam("--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled.") catch unreachable,
         clap.parseParam("--redis-preconnect                Preconnect to $REDIS_URL at startup") catch unreachable,
         clap.parseParam("--no-addons                       Throw an error if process.dlopen is called, and disable export condition \"node-addons\"") catch unreachable,
-        clap.parseParam("--unhandled-rejections <STR>      One of \"strict\", \"throw\", \"warn\", \"none\", \"warn-with-error-code\"") catch unreachable,
+        clap.parseParam("--unhandled-rejections <STR>      One of \"strict\", \"throw\", \"warn\", \"none\", or \"warn-with-error-code\"") catch unreachable,
     };
 
     const auto_or_run_params = [_]ParamType{


### PR DESCRIPTION
Removes `--unhandled-rejections=bun`, instead that is the default option but it is not mentioned. Add a switch on the bun_1_3 feature flag to change it to throw for bun 1.3. Draft while waiting for CI.