### PR TITLE
zig: RefCount: fix assertion found by windows app verifier

### DIFF
--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -21,7 +21,6 @@ const Global = bun.Global;
 const invalid_package_id = install.invalid_package_id;
 const strings = bun.strings;
 const string = bun.string;
-const stringZ = bun.stringZ;
 const FileSystem = bun.fs.FileSystem;
 const LifecycleScriptSubprocess = install.LifecycleScriptSubprocess;
 const PackageID = install.PackageID;
@@ -30,11 +29,9 @@ const ExtractData = install.ExtractData;
 const Task = install.Task;
 const TaskCallbackContext = install.TaskCallbackContext;
 const PatchTask = install.PatchTask;
-const NetworkTask = install.NetworkTask;
 const Package = Lockfile.Package;
 const Path = bun.path;
 const Syscall = bun.sys;
-const ThreadPool = bun.ThreadPool;
 
 pub const PackageInstaller = struct {
     manager: *PackageManager,

--- a/src/install/hoisted_install.zig
+++ b/src/install/hoisted_install.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const bun = @import("bun");
 const strings = bun.strings;
-const string = bun.string;
 const FileSystem = bun.fs.FileSystem;
 const install = bun.install;
 const PackageManager = install.PackageManager;

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -45,11 +45,9 @@ const HeaderBuilder = HTTP.HeaderBuilder;
 
 const ExtractTarball = @import("./extract_tarball.zig");
 pub const Npm = @import("./npm.zig");
-const Bitset = bun.bit_set.DynamicBitSetUnmanaged;
 const Syscall = bun.sys;
 const RunCommand = @import("../cli/run_command.zig").RunCommand;
 threadlocal var initialized_store = false;
-const Futex = @import("../futex.zig");
 
 pub const Lockfile = @import("./lockfile.zig");
 pub const TextLockfile = @import("./lockfile/bun.lock.zig");

--- a/src/ptr/ref_count.zig
+++ b/src/ptr/ref_count.zig
@@ -494,6 +494,7 @@ pub fn DebugData(thread_safe: bool) type {
             assertValid(debug);
             debug.magic = undefined;
             debug.lock.lock();
+            defer debug.lock.unlock();
             debug.map.clearAndFree(bun.default_allocator);
             debug.frees.clearAndFree(bun.default_allocator);
             if (debug.allocation_scope) |scope| {


### PR DESCRIPTION
before:

```
=======================================
VERIFIER STOP 0000000000000253: pid 0x3B9C: The SRW lock is being acquired recursively by the same thread. 

	00000200006113A8 : SRW Lock
	000001C4DAEF53A0 : Address of the first acquire stack trace. Use dps <address> to see where the SRW lock was acquired.
	0000000000000000 : Not used
	0000000000000000 : Not used


=======================================
This verifier stop is continuable.
After debugging it use `go' to continue.

=======================================
```

after:

clean run

reproduction:

`bun-debug test .\test\js\node\net\node-net.test.ts`
