### PR TITLE
Fix BUN-D93

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3708,24 +3708,16 @@ const StackOverflow = error{StackOverflow};
 // We keep up to 4 path buffers alive per thread at a time.
 pub fn PathBufferPoolT(comptime T: type) type {
     return struct {
-        const Pool = ObjectPool(PathBuf, null, true, 4);
-        pub const PathBuf = struct {
-            bytes: T,
-
-            pub fn deinit(this: *PathBuf) void {
-                var node: *Pool.Node = @alignCast(@fieldParentPtr("data", this));
-                node.release();
-            }
-        };
+        const Pool = ObjectPool(T, null, true, 4);
 
         pub fn get() *T {
             // use a threadlocal allocator so mimalloc deletes it on thread deinit.
-            return &Pool.get(bun.threadlocalAllocator()).data.bytes;
+            return &Pool.get(bun.threadlocalAllocator()).data;
         }
 
         pub fn put(buffer: *T) void {
-            var path_buf: *PathBuf = @alignCast(@fieldParentPtr("bytes", buffer));
-            path_buf.deinit();
+            var node: *Pool.Node = @alignCast(@fieldParentPtr("data", buffer));
+            node.release();
         }
 
         pub fn deleteAll() void {


### PR DESCRIPTION
### What does this PR do?
Filling the path buffer pool, then having a node free it's data would cause an infinite loop.

PathBufferPool.put -> PathBuf.deinit -> Node.release -> (loop) -> PathBuf.deinit

repro:
```zig
const buf1 = bun.PathBufferPool.get();
const buf2 = bun.PathBufferPool.get();
const buf3 = bun.PathBufferPool.get();
const buf4 = bun.PathBufferPool.get();
const buf5 = bun.PathBufferPool.get();

// fill the pool
bun.PathBufferPool.put(buf1);
bun.PathBufferPool.put(buf2);
bun.PathBufferPool.put(buf3);
bun.PathBufferPool.put(buf4);

// this one can't fit, deinit will be called if it
// exists on the struct
bun.PathBufferPool.put(buf5);
```

fixes #16765

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
