### PR TITLE
Make `bunx` work with `npm i -g bun` on windows 

### DIFF
--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -221,7 +221,6 @@ function bundle(src: string, dst: string, options: BuildOptions = {}): void {
     outfile: dst,
     ...options,
   });
-  console.log(errors)
   if (errors?.length) {
     const messages = formatMessagesSync(errors, { kind: "error" });
     throw new Error(messages.join("\n"));

--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -72,6 +72,7 @@ async function buildRootModule(dryRun?: boolean) {
     },
   });
   write(join(cwd, "bin", "bun.exe"), "");
+  write(join(cwd, "bin", "bunx.exe"), "");
   write(
     join(cwd, "bin", "README.txt"),
     `The 'bun.exe' file is a placeholder for the binary file, which
@@ -105,7 +106,7 @@ without *requiring* a postinstall script.
     ),
     bin: {
       bun: "bin/bun.exe",
-      bunx: "bin/bun.exe",
+      bunx: "bin/bunx.exe",
     },
     os,
     cpu,
@@ -220,6 +221,7 @@ function bundle(src: string, dst: string, options: BuildOptions = {}): void {
     outfile: dst,
     ...options,
   });
+  console.log(errors)
   if (errors?.length) {
     const messages = formatMessagesSync(errors, { kind: "error" });
     throw new Error(messages.join("\n"));

--- a/packages/bun-release/src/fs.ts
+++ b/packages/bun-release/src/fs.ts
@@ -157,3 +157,15 @@ export function exists(path: string): boolean {
   }
   return false;
 }
+
+export function link(path: string, newPath: string): void {
+  debug("link", path, newPath);
+  try {
+    fs.unlinkSync(newPath);
+    fs.linkSync(path, newPath);
+    return;
+  } catch (error) {
+    copy(path, newPath);
+    debug("fs.linkSync failed, reverting to copy", error);
+  }
+}

--- a/packages/bun-release/src/npm/install.ts
+++ b/packages/bun-release/src/npm/install.ts
@@ -1,7 +1,7 @@
 import { unzipSync } from "zlib";
 import { debug, error } from "../console";
 import { fetch } from "../fetch";
-import { chmod, join, rename, rm, tmp, write } from "../fs";
+import { chmod, join, link, rename, rm, tmp, write } from "../fs";
 import type { Platform } from "../platform";
 import { abi, arch, os, supportedPlatforms } from "../platform";
 import { spawn } from "../spawn";
@@ -125,6 +125,7 @@ export function optimizeBun(path: string): void {
     os === "win32" ? 'powershell -c "irm bun.sh/install.ps1 | iex"' : "curl -fsSL https://bun.sh/install | bash";
   try {
     rename(path, join(__dirname, "bin", "bun.exe"));
+    link(join(__dirname, "bin", "bun.exe"), join(__dirname, "bin", "bunx.exe"));
     return;
   } catch (error) {
     debug("optimizeBun failed", error);


### PR DESCRIPTION
### What does this PR do?

Currently npm on windows installs the bin items with proxy .cmd file. This causes bun's `bunx` determination to think its the actual bun instead. My solution tries to do a hardlink like the powershell script does.

Ideally it would be nice if it didn't need to have the proxy .cmd file as it means anyone installing with it gets the "terminate batch job" which is annoying noise, however this is just trying to be a simple quick fix. On posix, npm actually just links to the binary file which is nice. **update** this annoying extra msg seems to only be for `cmd` invocations, but still its decent performance penalty. 

Once this merges, I'll try the published canary version and if it has any regressions, I'll revert

### How did you verify your code works?

build & tested locally on windows `npm i -g C:/.../bun-1.2.16.tgz`
