### PR TITLE
make options argument not required for `fs.promises.glob`

### DIFF
--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -17,9 +17,9 @@ interface ExtendedGlobOptions extends GlobScanOptions {
   exclude(ent: string): boolean;
 }
 
-async function* glob(pattern: string | string[], options: GlobOptions): AsyncGenerator<string> {
+async function* glob(pattern: string | string[], options?: GlobOptions): AsyncGenerator<string> {
   pattern = validatePattern(pattern);
-  const globOptions = mapOptions(options);
+  const globOptions = mapOptions(options || {});
   let it = new Bun.Glob(pattern).scan(globOptions);
   const exclude = globOptions.exclude;
 
@@ -29,9 +29,9 @@ async function* glob(pattern: string | string[], options: GlobOptions): AsyncGen
   }
 }
 
-function* globSync(pattern: string | string[], options: GlobOptions): Generator<string> {
+function* globSync(pattern: string | string[], options?: GlobOptions): Generator<string> {
   pattern = validatePattern(pattern);
-  const globOptions = mapOptions(options);
+  const globOptions = mapOptions(options || {});
   const g = new Bun.Glob(pattern);
   const exclude = globOptions.exclude;
   for (const ent of g.scanSync(globOptions)) {

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -102,6 +102,18 @@ describe("fs.globSync", () => {
     expect(fs.globSync("a/*", { cwd: tmp, exclude })).toStrictEqual(expected);
   });
 
+  it("works without providing options", () => {
+    const oldProcessCwd = process.cwd;
+    try {
+      process.cwd = () => tmp;
+
+      const paths = fs.globSync("*.txt");
+      expect(paths).toContain("foo.txt");
+    } finally {
+      process.cwd = oldProcessCwd;
+    }
+  });
+
   describe("invalid arguments", () => {
     // TODO: GlobSet
     it("does not support arrays of patterns yet", () => {
@@ -127,6 +139,25 @@ describe("fs.promises.glob", () => {
     expect(iter[Symbol.asyncIterator]).toBeDefined();
     for await (const path of iter) {
       expect(path).toMatch(/\.txt$/);
+    }
+  });
+
+  it("works without providing options", async () => {
+    const oldProcessCwd = process.cwd;
+    try {
+      process.cwd = () => tmp;
+
+      const iter = fs.promises.glob("*.txt");
+      expect(iter[Symbol.asyncIterator]).toBeDefined();
+
+      const paths = [];
+      for await (const path of iter) {
+        paths.push(path);
+      }
+
+      expect(paths).toContain("foo.txt");
+    } finally {
+      process.cwd = oldProcessCwd;
     }
   });
 }); // </fs.promises.glob>


### PR DESCRIPTION
### What does this PR do?

fixes #20432

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

made test & verified behavior with node.js
