### PR TITLE
feat(semver): add `gt`, `lt`, `eq`, `gte`, `lte`, `neq`, `valid`

### DIFF
--- a/src/semver/SemverObject.zig
+++ b/src/semver/SemverObject.zig
@@ -115,8 +115,8 @@ pub fn order(
     const left = argumentStrings.left.slice();
     const right = argumentStrings.right.slice();
 
-    const left_result = Version.parse(SlicedString.init(left, left));
-    const right_result = Version.parse(SlicedString.init(right, right));
+    const left_result = Version.parseStrict(SlicedString.init(left, left));
+    const right_result = Version.parseStrict(SlicedString.init(right, right));
 
     if (!left_result.valid) {
         return globalThis.throw("Invalid SemVer: {s}\n", .{left});
@@ -150,7 +150,7 @@ pub fn satisfies(
     const left = argumentStrings.left.slice();
     const right = argumentStrings.right.slice();
 
-    const left_result = Version.parse(SlicedString.init(left, left));
+    const left_result = Version.parseStrict(SlicedString.init(left, left));
     if (left_result.wildcard != .none) {
         return .false;
     }

--- a/src/semver/Version.zig
+++ b/src/semver/Version.zig
@@ -675,7 +675,7 @@ pub const Version = extern struct {
                         }
                     },
                     '-' => {
-                        if (state != .pre) {
+                        if (state == .none) {
                             state = .pre;
                             start = i + 1;
                         }

--- a/src/semver/Version.zig
+++ b/src/semver/Version.zig
@@ -740,6 +740,129 @@ pub const Version = extern struct {
         len: u32 = 0,
     };
 
+    pub fn parseStrict(sliced_string: SlicedString) ParseResult {
+        var input = sliced_string.slice;
+        var result = ParseResult{};
+
+        var part_i: u8 = 0;
+        var part_start_i: usize = 0;
+        var last_char_i: usize = 0;
+
+        if (input.len == 0) {
+            result.valid = false;
+            return result;
+        }
+        var is_done = false;
+
+        var i: usize = 0;
+
+        // Only skip a single leading 'v' if present
+        if (input.len > 0 and input[0] == 'v') {
+            i = 1;
+        }
+
+        if (i == input.len) {
+            result.valid = false;
+            return result;
+        }
+
+        // two passes :(
+        while (i < input.len) {
+            if (is_done) {
+                break;
+            }
+
+            switch (input[i]) {
+                '0'...'9' => {
+                    part_start_i = i;
+                    i += 1;
+
+                    while (i < input.len and switch (input[i]) {
+                        '0'...'9' => true,
+                        else => false,
+                    }) {
+                        i += 1;
+                    }
+
+                    last_char_i = i;
+
+                    switch (part_i) {
+                        0 => {
+                            result.version.major = parseVersionNumber(input[part_start_i..last_char_i]);
+                            part_i = 1;
+                        },
+                        1 => {
+                            result.version.minor = parseVersionNumber(input[part_start_i..last_char_i]);
+                            part_i = 2;
+                        },
+                        2 => {
+                            result.version.patch = parseVersionNumber(input[part_start_i..last_char_i]);
+                            part_i = 3;
+                        },
+                        else => {},
+                    }
+
+                    if (i < input.len and switch (input[i]) {
+                        // `.` is expected only if there are remaining core version numbers
+                        '.' => part_i != 3,
+                        else => false,
+                    }) {
+                        i += 1;
+                    }
+                },
+                '.' => {
+                    result.valid = false;
+                    is_done = true;
+                    break;
+                },
+                '-', '+' => {
+                    // Just a plain tag with no version is invalid.
+                    if (part_i < 3) {
+                        result.valid = false;
+                        is_done = true;
+                        break;
+                    }
+
+                    part_start_i = i;
+                    const tag_result = Tag.parse(sliced_string.sub(input[part_start_i..]));
+
+                    // dirty
+                    const tag_input = input[part_start_i .. part_start_i + tag_result.len];
+                    const build_marker_index = std.mem.indexOfScalar(u8, tag_input, '+');
+                    const pre_marker_index = std.mem.indexOfScalar(u8, tag_input, '-');
+                    if ((tag_result.tag.pre.isEmpty() and tag_result.tag.build.isEmpty()) or
+                        // disallow `1.0.0-a+`
+                        ((build_marker_index != null) and tag_result.tag.build.isEmpty()) or
+                        // disallow `1.0.0-+a`, but not `1.0.0+a-`
+                        ((pre_marker_index != null) and tag_result.tag.pre.isEmpty() and pre_marker_index.? < build_marker_index.?))
+                    {
+                        result.valid = false;
+                        is_done = true;
+                        break;
+                    }
+
+                    result.version.tag = tag_result.tag;
+                    i += tag_result.len;
+                    break;
+                },
+                else => {
+                    last_char_i = 0;
+                    result.valid = false;
+                    is_done = true;
+                    break;
+                },
+            }
+        }
+
+        if (part_i < 2) {
+            result.valid = false;
+        }
+
+        result.len = @as(u32, @intCast(i));
+
+        return result;
+    }
+
     pub fn parse(sliced_string: SlicedString) ParseResult {
         var input = sliced_string.slice;
         var result = ParseResult{};


### PR DESCRIPTION
### What does this PR do?

#### Changes:

- `order` throws when the input strings are non-ascii as per the semver spec
- two arguments parsing logic was extracted into a separate function, so it can be reused
- `arguments_old(x).slice` was replaced with `arguments()`
- bun now correctly handles versions with `-` in build metadata, such as `1.0.0+21A--14C`

resolves #7698
partially (maybe not, haven't decided yet) resolves_ #13996

#### To do:

- add `semver.coerce` function
- deduplicate version parsing code
- adapt tests from [node-semver](https://github.com/npm/node-semver)

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
