### PR TITLE
`fs.glob` set `onlyFiles: false` so it can match folders

### DIFF
--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -65,6 +65,8 @@ function mapOptions(options: GlobOptions): ExtendedGlobOptions {
     cwd: options?.cwd ?? process.cwd(),
     // https://github.com/nodejs/node/blob/a9546024975d0bfb0a8ae47da323b10fb5cbb88b/lib/internal/fs/glob.js#L655
     followSymlinks: true,
+    // https://github.com/oven-sh/bun/issues/20507
+    onlyFiles: false,
     exclude,
   };
 }

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -14,6 +14,10 @@ beforeAll(() => {
       "bar.txt": "bar",
       "baz.js": "baz",
     },
+    "folder.test": {
+      "file.txt": "content",
+      "another-folder": {},
+    },
   });
 });
 
@@ -60,6 +64,11 @@ describe("fs.glob", () => {
       expect(() => fs.glob("*.txt", { cwd: tmp })).toThrow(TypeError);
       expect(() => fs.glob("*.txt", { cwd: tmp }, undefined)).toThrow(TypeError);
     });
+  });
+
+  it("matches directories", () => {
+    const paths = fs.globSync("*.test", { cwd: tmp });
+    expect(paths).toContain("folder.test");
   });
 }); // </fs.glob>
 
@@ -120,6 +129,11 @@ describe("fs.globSync", () => {
       expect(() => fs.globSync(["*.txt"])).toThrow(TypeError);
     });
   });
+
+  it("matches directories", () => {
+    const paths = fs.globSync("*.test", { cwd: tmp });
+    expect(paths).toContain("folder.test");
+  });
 }); // </fs.globSync>
 
 describe("fs.promises.glob", () => {
@@ -159,5 +173,16 @@ describe("fs.promises.glob", () => {
     } finally {
       process.cwd = oldProcessCwd;
     }
+  });
+
+  it("matches directories", async () => {
+    const iter = fs.promises.glob("*.test", { cwd: tmp });
+    expect(iter[Symbol.asyncIterator]).toBeDefined();
+    let count = 0;
+    for await (const path of iter) {
+      expect(path).toBe("folder.test");
+      count++;
+    }
+    expect(count).toBe(1);
   });
 }); // </fs.promises.glob>


### PR DESCRIPTION
### What does this PR do?

Node glob matches folders but Bun.Glob doesn't by default, so this pr fixes #20507 by disabling the onlyFiles option which by default is on. I couldn't find any similar node option, so I made it hardcoded to be disabled.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

added a test & manually tested node's behaviour
