### PR TITLE
Fix : Matches Node.js behavior by prefixing "Assertion failed" in `console.assert` messages 

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -590,7 +590,11 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
 
     assert(expression, ...args) {
       if (!expression) {
-        args[0] = `Assertion failed${args.length === 0 ? "" : `: ${args[0]}`}`;
+        if (args.length && typeof args[0] === "string") {
+            args[0] = `Assertion failed: ${args[0]}`;
+        } else {
+            args.unshift("Assertion failed");
+        }
         // The arguments will be formatted in warn() again
         this.warn.$apply(this, args);
       }

--- a/test/js/bun/console/console-assert-run.ts
+++ b/test/js/bun/console/console-assert-run.ts
@@ -1,0 +1,1 @@
+console.assert(false, process.argv[2]);

--- a/test/js/bun/console/console-assert.test.ts
+++ b/test/js/bun/console/console-assert.test.ts
@@ -1,0 +1,13 @@
+import { spawnSync } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("console.assert", () => {
+  test("prints Assertion failed prefix", () => {
+    const { stderr } = spawnSync({
+      cmd: [bunExe(), import.meta.dir + "/console-assert-run.ts", "message"],
+      env: bunEnv,
+    });
+    expect(stderr.toString().trim()).toBe("Assertion failed: message");
+  });
+});


### PR DESCRIPTION
## Fixes - 
 - #19953 
## What does this PR do?
- [x] Code changes

This fixes the behavior of `console.assert()` so that it includes the "Assertion failed" prefix in output messages when a custom message is provided.


### Example:
```
console.assert(false, "message");
```
#### Before:
```
message
```
#### After:
```
Assertion failed: message
```
### How did you verify your code works?
- [x] I included a test for the new code, or existing tests cover it 
<!---  
(In progress ⚒️)
- [ ] I ran my tests locally, and they pass (`bun-debug test test-file-name.test`)  (In progress ⚒️) --->



