### PR TITLE
Fix crash with garbage environment variables

### DIFF
--- a/test/cli/run/garbage-env-fixtures.ts
+++ b/test/cli/run/garbage-env-fixtures.ts
@@ -1,0 +1,1 @@
+console.log(process.env);

--- a/test/cli/run/garbage-env-fixtures.ts
+++ b/test/cli/run/garbage-env-fixtures.ts
@@ -1,1 +1,0 @@
-console.log(process.env);

--- a/test/cli/run/garbage-env.c
+++ b/test/cli/run/garbage-env.c
@@ -1,0 +1,141 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int exec_garbage_env() {
+  int stdout_pipe[2], stderr_pipe[2];
+  pid_t pid;
+  int status;
+  char stdout_buffer[4096] = {0};
+  char stderr_buffer[4096] = {0};
+
+  // Create pipes for stdout and stderr
+  if (pipe(stdout_pipe) == -1 || pipe(stderr_pipe) == -1) {
+    perror("pipe");
+    return 1;
+  }
+
+  // Create garbage environment variables with stack buffers containing
+  // arbitrary bytes
+  char garbage1[64];
+  char garbage2[64];
+  char garbage3[64];
+  char garbage4[64];
+  char garbage5[64];
+
+  // Fill with arbitrary non-ASCII/UTF-8 bytes
+  for (int i = 0; i < 63; i++) {
+    garbage1[i] = (char)(0x80 + (i % 128));  // Invalid UTF-8 start bytes
+    garbage2[i] = (char)(0xFF - (i % 256));  // High bytes
+    garbage3[i] = (char)(i * 3 + 128);       // Mixed garbage
+    garbage4[i] = (char)(0xC0 | (i & 0x1F)); // Invalid UTF-8 sequences
+  }
+  garbage1[63] = '\0';
+  garbage2[63] = '\0';
+  garbage3[63] = '\0';
+  garbage4[63] = '\0';
+
+  for (int i = 0; i < 10; i++) {
+    garbage5[i] = (char)(0x80 + (i % 128));
+  }
+  garbage5[10] = '=';
+  garbage5[11] = 0x81;
+  garbage5[12] = 0xF5;
+  garbage5[13] = 0xC1;
+  garbage5[14] = 0xC2;
+  garbage5[15] = '\0';
+
+  char *garbage_env[] = {
+      garbage5,     garbage1,           garbage2,
+      garbage3,     garbage4,           "BUN_DEBUG_QUIET_LOGS=1",
+      "OOGA=booga", "OOGA=laskdjflsdf", NULL};
+
+  pid = fork();
+
+  if (pid == -1) {
+    perror("fork");
+    return 1;
+  }
+
+  if (pid == 0) {
+    // Child process
+    close(stdout_pipe[0]); // Close read end
+    close(stderr_pipe[0]); // Close read end
+
+    // Redirect stdout and stderr to pipes
+    dup2(stdout_pipe[1], STDOUT_FILENO);
+    dup2(stderr_pipe[1], STDERR_FILENO);
+
+    close(stdout_pipe[1]);
+    close(stderr_pipe[1]);
+
+    const char *path = getenv("BUN_PATH");
+    if (path == NULL) {
+      printf("MISSING BUN_PATH\n");
+      fflush(stdout);
+      exit(1);
+    }
+    const char *fixturesPath = getenv("FIXTURE_PATH");
+    if (fixturesPath == NULL) {
+      printf("MISSING FIXTURE_PATH\n");
+      fflush(stdout);
+      exit(1);
+    }
+    char *bun = "bun";
+
+    char *args[] = {bun, (char *)fixturesPath, NULL};
+    execve(path, args, garbage_env);
+
+    // If execve fails, try with /bin/env
+    // execve("/bin/env", (char *[]){"env", NULL}, garbage_env);
+
+    // If both fail, exit with error
+    perror("execve");
+    exit(127);
+  } else {
+    // Parent process
+    close(stdout_pipe[1]); // Close write end
+    close(stderr_pipe[1]); // Close write end
+
+    // Read from stdout pipe
+    ssize_t stdout_bytes =
+        read(stdout_pipe[0], stdout_buffer, sizeof(stdout_buffer) - 1);
+    if (stdout_bytes > 0) {
+      stdout_buffer[stdout_bytes] = '\0';
+    }
+
+    // Read from stderr pipe
+    ssize_t stderr_bytes =
+        read(stderr_pipe[0], stderr_buffer, sizeof(stderr_buffer) - 1);
+    if (stderr_bytes > 0) {
+      stderr_buffer[stderr_bytes] = '\0';
+    }
+
+    close(stdout_pipe[0]);
+    close(stderr_pipe[0]);
+
+    // Wait for child process
+    waitpid(pid, &status, 0);
+
+    // Print results
+    printf("=== PROCESS OUTPUT ===\n");
+    printf("Exit code: %d\n", WEXITSTATUS(status));
+
+    printf("\n=== STDOUT ===\n");
+    printf("%s", stdout_buffer);
+    fflush(stdout);
+
+    if (stderr_bytes > 0) {
+      fprintf(stderr, "\n=== STDERR ===\n");
+      fprintf(stderr, "%s", stderr_buffer);
+      fflush(stderr);
+      exit(status);
+    }
+    exit(status);
+  }
+
+  return 0;
+}

--- a/test/cli/run/garbage-env.c
+++ b/test/cli/run/garbage-env.c
@@ -86,7 +86,7 @@ int exec_garbage_env() {
     }
     char *bun = "bun";
 
-    char *args[] = {bun, (char *)fixturesPath, NULL};
+    char *args[] = {bun, "-e", "console.log(process.env)", NULL};
     execve(path, args, garbage_env);
 
     // If execve fails, try with /bin/env

--- a/test/cli/run/garbage-env.c
+++ b/test/cli/run/garbage-env.c
@@ -122,8 +122,9 @@ int main() {
     fflush(stdout);
 
     if (stderr_bytes > 0) {
-      printf("\n=== STDERR ===\n");
-      printf("%s", stderr_buffer);
+      fprintf(stderr, "\n=== STDERR ===\n");
+      fprintf(stderr, "%s", stderr_buffer);
+      fflush(stderr);
     }
     exit(status);
   }

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunExe } from "harness";
 import path from "path";
 
 describe("garbage env", () => {

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -16,7 +16,10 @@ describe.if(isPosix)("garbage env", () => {
     }
 
     const { exitCode, stderr } = await Bun.$`./garbage-env`.env({ BUN_PATH: bunExe() });
-    expect(stderr.toString()).toBe("");
+    const stderrText = stderr.toString();
+    if (stderrText.length > 0) {
+      console.error(stderrText);
+    }
     expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { bunExe } from "harness";
+import { bunExe, isPosix } from "harness";
 import path from "path";
 
-describe("garbage env", () => {
+describe.if(isPosix)("garbage env", () => {
   test("garbage env", async () => {
     const cfile = path.join(import.meta.dirname, "garbage-env.c");
     {

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -1,7 +1,5 @@
-import { expect } from "bun:test";
-import { describe, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
-import { cc } from "bun:ffi";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 describe("garbage env", () => {

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -6,7 +6,8 @@ describe("garbage env", () => {
   test("garbage env", async () => {
     const cfile = path.join(import.meta.dirname, "garbage-env.c");
     {
-      const { exitCode, stderr } = await Bun.$`clang -o garbage-env ${cfile}`;
+      const cc = Bun.which("clang") || Bun.which("gcc") || Bun.which("cc");
+      const { exitCode, stderr } = await Bun.$`${cc} -o garbage-env ${cfile}`;
       const stderrText = stderr.toString();
       if (stderrText.length > 0) {
         console.error(stderrText);

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -25,7 +25,7 @@ describe("garbage env", () => {
 
     const proc = Bun.spawn({
       cmd: [bunExe(), "-e", bunScript()],
-      env: { ...bunEnv, BUN_PATH: bunExe(), FIXTURE_PATH: fixturesPath },
+      env: { ...bunEnv, BUN_PATH: bunExe() },
       cwd: import.meta.dirname,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/run/garbage-env.test.ts
+++ b/test/cli/run/garbage-env.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "bun:test";
+import { describe, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { cc } from "bun:ffi";
+import path from "path";
+
+describe("garbage env", () => {
+  test("garbage env", async () => {
+    const fixturesPath = path.join(import.meta.dirname, "garbage-env-fixtures.ts");
+
+    const bunScript = () => /* ts */ `
+      import { cc } from "bun:ffi";
+      import path from "path"
+      const program = cc({
+        source: path.join(import.meta.dirname, "garbage-env.c"),
+        symbols: {
+          exec_garbage_env: {
+            args: [],
+            returns: "int",
+          },
+        },
+      });
+      program.symbols.exec_garbage_env();
+    `;
+
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", bunScript()],
+      env: { ...bunEnv, BUN_PATH: bunExe(), FIXTURE_PATH: fixturesPath },
+      cwd: import.meta.dirname,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -69,6 +69,7 @@ test/cli/install/catalogs.test.ts
 test/cli/install/npmrc.test.ts
 test/cli/install/overrides.test.ts
 test/cli/run/env.test.ts
+test/cli/run/garbage-env.test.ts
 test/cli/run/esm-defineProperty.test.ts
 test/cli/run/jsx-namespaced-attributes.test.ts
 test/cli/run/log-test.test.ts


### PR DESCRIPTION
### What does this PR do?

This fixes a crash in Bun when invalid UTF-8 bytes are passed to the Bun process as environment variables. We can't rely on the OS giving us valid UTF-8 for environment variable strings and instead to use `String::fromUTF8ReplacingInvalidSequences`