### PR TITLE
build(windows/resources): specify company name

### DIFF
--- a/src/windows-app-info.rc
+++ b/src/windows-app-info.rc
@@ -18,7 +18,8 @@ BEGIN
             VALUE "InternalName", "bun\0"
             VALUE "OriginalFilename", "bun.exe\0"
             VALUE "ProductName", "Bun\0"
-            VALUE "ProductVersion", "@Bun_VERSION_WITH_TAG@\0"
+            VALUE "ProductVersion", "@Bun_VERSION_WITH_TAG@\0",
+            VALUE "CompanyName", "Oven\0"
             VALUE "LegalCopyright", "https://bun.sh/docs/project/licensing\0"
         END
     END


### PR DESCRIPTION
### What does this PR do?

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/d521d1be-c1c8-4b37-8064-4836405d4c94) | ![image](https://github.com/user-attachments/assets/53e3343a-6434-4d47-882c-2c96f8a03752) |

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
- [x] Windows resources

### How did you verify your code works?

manually

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
