### PR TITLE
Fix crash in napi_remove_env_cleanup_hook during worker finalization

### DIFF
--- a/src/bun.js/bindings/NodeVMScript.cpp
+++ b/src/bun.js/bindings/NodeVMScript.cpp
@@ -252,10 +252,8 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSGlobalObject* globalObject, ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
+static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
 {
-    VM& vm = JSC::getVM(globalObject);
-
     if (vm.hasTerminationRequest()) {
         vm.clearHasTerminationRequest();
         if (script->getSigintReceived()) {
@@ -337,7 +335,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
     }
 
-    if (checkForTermination(globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
         return {};
     }
 
@@ -399,7 +397,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
     }
 
-    if (checkForTermination(globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
         return {};
     }
 

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2739,7 +2739,7 @@ extern "C" JS_EXPORT napi_status napi_remove_env_cleanup_hook(napi_env env,
 {
     NAPI_PREAMBLE(env);
 
-    if (function != nullptr && !env->globalObject()->vm().hasTerminationRequest()) [[likely]] {
+    if (function != nullptr && !env->isVMTerminating()) [[likely]] {
         env->removeCleanupHook(function, data);
     }
 
@@ -2753,7 +2753,7 @@ extern "C" JS_EXPORT napi_status napi_remove_async_cleanup_hook(napi_async_clean
 
     NAPI_PREAMBLE(env);
 
-    if (!env->globalObject()->vm().hasTerminationRequest()) {
+    if (!env->isVMTerminating()) {
         env->removeAsyncCleanupHook(handle);
     }
 


### PR DESCRIPTION
### What does this PR do?

We cannot use the global object to access the JSC::VM to check if the VM has a termination request, since the global object may have already been finalized due to the termination request.

Fixes https://github.com/oven-sh/bun/issues/19849

instead, we can rely on the ScriptExecutionContext being a nullptr.

### How did you verify your code works?

Speculative. This needs a test somehow.