### PR TITLE
Fix asan failure in napi_async_work caused by accessing napi_async_work after freed

### DIFF
--- a/src/bun.js/event_loop/Task.zig
+++ b/src/bun.js/event_loop/Task.zig
@@ -223,7 +223,7 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine) u3
             },
             @field(Task.Tag, @typeName(bun.api.napi.napi_async_work)) => {
                 const transform_task: *bun.api.napi.napi_async_work = task.get(bun.api.napi.napi_async_work).?;
-                transform_task.*.runFromJS();
+                transform_task.runFromJS(virtual_machine, global);
             },
             @field(Task.Tag, @typeName(ThreadSafeFunction)) => {
                 var transform_task: *ThreadSafeFunction = task.as(ThreadSafeFunction);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -294,8 +294,9 @@ describe("napi", () => {
       checkSameOutput("test_get_exception", [5]);
       checkSameOutput("test_get_exception", [{ foo: "bar" }]);
     });
-    it("can throw an exception from an async_complete_callback", () => {
-      checkSameOutput("create_promise", [true]);
+    it("can throw an exception from an async_complete_callback", async () => {
+      const count = 10;
+      await Promise.all(Array.from({ length: count }, () => checkSameOutput("create_promise", [true])));
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

This was an asan failure that was unlikely to lead to a crash. 

```js
rror: =================================================================
==39118==ERROR: AddressSanitizer: use-after-poison on address 0x00011c6b0290 at pc 0x000103cfbab8 bp 0x00016fdec470 sp 0x00016fdec468
READ of size 8 at 0x00011c6b0290 thread T0
    #0 0x000103cfbab4 in napi.napi.napi_async_work.runFromJS napi.zig:1144
    #1 0x00010348d0f8 in bun.js.event_loop.Task.tickQueueWithCount Task.zig:226
    #2 0x000102edc28c in bun.js.event_loop.tickWithCount event_loop.zig:194
    #3 0x0001029cfd34 in bun.js.event_loop.tick event_loop.zig:469
    #4 0x000102c1ee9c in bun.js.event_loop.waitForPromise event_loop.zig:492
    #5 0x0001025d9158 in bun.js.VirtualMachine.waitForPromise VirtualMachine.zig:868
    #6 0x0001031077c8 in bun.js.VirtualMachine.loadEntryPoint VirtualMachine.zig:2225
    #7 0x000102b8b574 in bun_js.Run.start bun_js.zig:323
    #8 0x0001025034ec in bun.js.jsc.OpaqueWrap__anon_31412__struct_241566.callback jsc.zig:241
    #9 0x000100150130 in JSC__VM__holdAPILock bindings.cpp:5329
    #10 0x000101ee6078 in bun.js.bindings.VM.VM.holdAPILock VM.zig:41
    #11 0x00010243c640 in bun_js.Run.boot bun_js.zig:274
    #12 0x00010244349c in cli.run_command.RunCommand._bootAndHandleError run_command.zig:1248
    #13 0x000102442818 in cli.run_command.RunCommand.maybeOpenWithBunJS run_command.zig:1332
    #14 0x00010243d4c0 in cli.run_command.RunCommand.exec run_command.zig:1377
    #15 0x000102461df0 in cli.Command.start cli.zig:1181
    #16 0x000101dfb974 in cli.Cli.start cli.zig:48
    #17 0x000101df7c54 in main.main main.zig:66
    #18 0x000101df7a20 in main start.zig:635
    #19 0x000188b64270  (<unknown module>)

Address 0x00011c6b0290 is a wild pointer inside of access range of size 0x000000000008.
SUMMARY: AddressSanitizer: use-after-poison napi.zig:1144 in napi.napi.napi_async_work.runFromJS
Shadow bytes around the buggy address:
  0x00011c6b0000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00011c6b0080: 00 00 00 00 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0100: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0180: 00 00 00 00 00 00 00 00 00 00 00 00 00 f7 f7 f7
  0x00011c6b0200: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
=>0x00011c6b0280: f7 f7[f7]f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0300: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0380: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0400: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0480: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x00011c6b0500: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
2025-06-22 04:32:02.207613+0000 bun-debug[39118:383766414] =================================================================
2025-06-22 04:32:02.208603+0000 bun-debug[39118:383766414] ==39118==ERROR: AddressSanitizer: use-after-poison on address 0x00011c6b0290 at pc 0x000103cfbab8 bp 0x00016fdec470 sp 0x00016fdec468
2025-06-22 04:32:02.208616+0000 bun-debug[39118:383766414] READ of size 8 at 0x00011c6b0290 thread T0
2025-06-22 04:32:02.208619+0000 bun-debug[39118:383766414]     #0 0x000103cfbab4 in napi.napi.napi_async_work.runFromJS napi.zig:1144
2025-06-22 04:32:02.208622+0000 bun-debug[39118:383766414]     #1 0x00010348d0f8 in bun.js.event_loop.Task.tickQueueWithCount Task.zig:226
2025-06-22 04:32:02.208625+0000 bun-debug[39118:383766414]     #2 0x000102edc28c in bun.js.event_loop.tickWithCount event_loop.zig:194
2025-06-22 04:32:02.208628+0000 bun-debug[39118:383766414]     #3 0x0001029cfd34 in bun.js.event_loop.tick event_loop.zig:469
2025-06-22 04:32:02.208630+0000 bun-debug[39118:383766414]     #4 0x000102c1ee9c in bun.js.event_loop.waitForPromise event_loop.zig:492
2025-06-22 04:32:02.208633+0000 bun-debug[39118:383766414]     #5 0x0001025d9158 in bun.js.VirtualMachine.waitForPromise VirtualMachine.zig:868
2025-06-22 04:32:02.208636+0000 bun-debug[39118:383766414]     #6 0x0001031077c8 in bun.js.VirtualMachine.loadEntryPoint VirtualMachine.zig:2225
2025-06-22 04:32:02.208638+0000 bun-debug[39118:383766414]     #7 0x000102b8b574 in bun_js.Run.start bun_js.zig:323
2025-06-22 04:32:02.208641+0000 bun-debug[39118:383766414]     #8 0x0001025034ec in bun.js.jsc.OpaqueWrap__anon_31412__struct_241566.callback jsc.zig:241
2025-06-22 04:32:02.208643+0000 bun-debug[39118:383766414]     #9 0x000100150130 in JSC__VM__holdAPILock bindings.cpp:5329
2025-06-22 04:32:02.208646+0000 bun-debug[39118:383766414]     #10 0x000101ee6078 in bun.js.bindings.VM.VM.holdAPILock VM.zig:41
2025-06-22 04:32:02.208648+0000 bun-debug[39118:383766414]     #11 0x00010243c640 in bun_js.Run.boot bun_js.zig:274
2025-06-22 04:32:02.208650+0000 bun-debug[39118:383766414]     #12 0x00010244349c in cli.run_command.RunCommand._bootAndHandleError run_command.zig:1248
2025-06-22 04:32:02.208653+0000 bun-debug[39118:383766414]     #13 0x000102442818 in cli.run_command.RunCommand.maybeOpenWithBunJS run_command.zig:1332
2025-06-22 04:32:02.208655+0000 bun-debug[39118:383766414]     #14 0x00010243d4c0 in cli.run_command.RunCommand.exec run_command.zig:1377
2025-06-22 04:32:02.208658+0000 bun-debug[39118:383766414]     #15 0x000102461df0 in cli.Command.start cli.zig:1181
2025-06-22 04:32:02.208660+0000 bun-debug[39118:383766414]     #16 0x000101dfb974 in cli.Cli.start cli.zig:48
2025-06-22 04:32:02.208662+0000 bun-debug[39118:383766414]     #17 0x000101df7c54 in main.main main.zig:66
2025-06-22 04:32:02.208664+0000 bun-debug[39118:383766414]     #18 0x000101df7a20 in main start.zig:635
2025-06-22 04:32:02.208665+0000 bun-debug[39118:383766414]     #19 0x000188b64270  (<unknown module>)
2025-06-22 04:32:02.208667+0000 bun-debug[39118:383766414] 
2025-06-22 04:32:02.208669+0000 bun-debug[39118:383766414] Address 0x00011c6b0290 is a wild pointer inside of access range of size 0x000000000008.
2025-06-22 04:32:02.208672+0000 bun-debug[39118:383766414] SUMMARY: AddressSanitizer: use-after-poison napi.zig:1144 in napi.napi.napi_async_work.runFromJS
2025-06-22 04:32:02.208674+0000 bun-debug[39118:383766414] Shadow bytes around the buggy address:
2025-06-22 04:32:02.208677+0000 bun-debug[39118:383766414]   0x00011c6b0000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
2025-06-22 04:32:02.208679+0000 bun-debug[39118:383766414]   0x00011c6b0080: 00 00 00 00 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208682+0000 bun-debug[39118:383766414]   0x00011c6b0100: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208684+0000 bun-debug[39118:383766414]   0x00011c6b0180: 00 00 00 00 00 00 00 00 00 00 00 00 00 f7 f7 f7
2025-06-22 04:32:02.208686+0000 bun-debug[39118:383766414]   0x00011c6b0200: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208689+0000 bun-debug[39118:383766414] =>0x00011c6b0280: f7 f7[f7]f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208691+0000 bun-debug[39118:383766414]   0x00011c6b0300: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208693+0000 bun-debug[39118:383766414]   0x00011c6b0380: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208695+0000 bun-debug[39118:383766414]   0x00011c6b0400: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208697+0000 bun-debug[39118:383766414]   0x00011c6b0480: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208699+0000 bun-debug[39118:383766414]   0x00011c6b0500: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
2025-06-22 04:32:02.208705+0000 bun-debug[39118:383766414] Shadow byte legend (one shadow byte represents 8 application bytes):
2025-06-22 04:32:02.208707+0000 bun-debug[39118:383766414]   Addressable:           00
2025-06-22 04:32:02.208710+0000 bun-debug[39118:383766414]   Partially addressable: 01 02 03 04 05 06 07
2025-06-22 04:32:02.208712+0000 bun-debug[39118:383766414]   Heap left redzone:       fa
2025-06-22 04:32:02.208714+0000 bun-debug[39118:383766414]   Freed heap region:       fd
... (15 lines left)
```

### How did you verify your code works?

Run the same test 10 times more