### PR TITLE
Make the napi/v8 tests compile faster

### DIFF
--- a/test/napi/napi-app/package.json
+++ b/test/napi/napi-app/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "gypfile": true,
   "scripts": {
-    "install": "node-gyp rebuild --debug",
-    "build": "node-gyp rebuild --debug",
+    "install": "node-gyp rebuild --debug -j max",
+    "build": "node-gyp rebuild --debug -j max",
     "clean": "node-gyp clean"
   },
   "devDependencies": {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -7,6 +7,7 @@ import { join } from "path";
 describe("napi", () => {
   beforeAll(() => {
     // build gyp
+    console.time("Building node-gyp");
     const install = spawnSync({
       cmd: [bunExe(), "install", "--verbose"],
       cwd: join(__dirname, "napi-app"),
@@ -19,6 +20,7 @@ describe("napi", () => {
       console.error("build failed, bailing out!");
       process.exit(1);
     }
+    console.timeEnd("Building node-gyp");
   });
 
   describe.each(["esm", "cjs"])("bundle .node files to %s via", format => {

--- a/test/napi/node-napi.test.ts
+++ b/test/napi/node-napi.test.ts
@@ -98,7 +98,7 @@ beforeAll(async () => {
 
   async function buildOne(dir: string) {
     const child = spawn({
-      cmd: [bunExe(), "x", "node-gyp", "rebuild", "--debug"],
+      cmd: [bunExe(), "x", "node-gyp", "rebuild", "--debug", "-j", "max"],
       cwd: dir,
       stderr: "pipe",
       stdout: "ignore",

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -62,8 +62,17 @@ async function build(
   const build = spawn({
     cmd:
       runtime == Runtime.bun
-        ? [bunExe(), "x", "--bun", "node-gyp", "rebuild", buildMode == BuildMode.debug ? "--debug" : "--release"]
-        : [bunExe(), "x", "node-gyp", "rebuild", "--release"], // for node.js we don't bother with debug mode
+        ? [
+            bunExe(),
+            "x",
+            "--bun",
+            "node-gyp",
+            "rebuild",
+            buildMode == BuildMode.debug ? "--debug" : "--release",
+            "-j",
+            "max",
+          ]
+        : [bunExe(), "x", "node-gyp", "rebuild", "--release", "-j", "max"], // for node.js we don't bother with debug mode
     cwd: tmpDir,
     env: bunEnv,
     stdin: "inherit",


### PR DESCRIPTION
### What does this PR do?

Make the napi/v8 tests compile faster

`-j max` is like `-j8` where 8 is the number of CPUs. Using `-j8` confusingly doesn't work, it has to be `-j 8`. The altenrative is the `JOBS` env var but that doesn't work in Windows apparently.

### How did you verify your code works?

Ran the napi.test.ts locally