### PR TITLE
Make node-gyp faster

### DIFF
--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -34,7 +34,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
 
   [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 242, regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
-  "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1859 },
+  "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1861 },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 179 },
   "std.fs.cwd": { reason: "Prefer bun.FD.cwd()", limit: 102 },


### PR DESCRIPTION
### What does this PR do?

Make node-gyp faster by automatically settings the `JOBS` environment variable if not already set. By default, like GNU `make`, `node-gyp` compiles one file at a time. This partially explains why it's slow. We can tell it to use all available cores with the `JOBS` environment variable.

### How did you verify your code works?

