### PR TITLE
Fix Yes command panic in EventLoop

### DIFF
--- a/src/bun.js/event_loop/Task.zig
+++ b/src/bun.js/event_loop/Task.zig
@@ -489,8 +489,11 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine) u3
                 var any: *FlushPendingFileSinkTask = task.get(FlushPendingFileSinkTask).?;
                 any.runFromJSThread();
             },
-
-            .@"shell.builtin.yes.YesTask", .@"bun.js.api.Timer.ImmediateObject", .@"bun.js.api.Timer.TimeoutObject" => {
+            @field(Task.Tag, @typeName(shell.Interpreter.Builtin.Yes.YesTask)) => {
+                var yes_task: *shell.Interpreter.Builtin.Yes.YesTask = task.get(shell.Interpreter.Builtin.Yes.YesTask).?;
+                yes_task.runFromMainThread();
+            },
+            .@"bun.js.api.Timer.ImmediateObject", .@"bun.js.api.Timer.TimeoutObject" => {
                 bun.Output.panic("Unexpected tag: {s}", .{@tagName(task.tag())});
             },
             _ => {

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -1,5 +1,8 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+
+const TestBuilder = createTestBuilder(import.meta.path);
 
 $.throws(false);
 
@@ -21,4 +24,33 @@ describe("yes", async () => {
     await $`yes ab cd ef > ${buffer}`;
     expect(buffer.toString()).toEqual("ab\nab\nab\nab\nab\nab");
   });
+});
+
+describe("yes - event loop task processing", async () => {
+  TestBuilder.command`yes | head -3`
+    .exitCode(0)
+    .stdout("y\ny\ny\n")
+    .stderr("")
+    .runAsTest("basic yes with head - tests YesTask event loop processing");
+
+  TestBuilder.command`yes hello | head -2`
+    .exitCode(0)
+    .stdout("hello\nhello\n")
+    .stderr("")
+    .runAsTest("custom string yes with head - tests YesTask with custom output");
+
+  TestBuilder.command`timeout 0.1 yes`
+    .exitCode(124)
+    .stdout((stdout) => {
+      expect(stdout.length).toBeGreaterThan(0);
+      expect(stdout.split('\n').filter(line => line === 'y').length).toBeGreaterThan(0);
+    })
+    .stderr("")
+    .runAsTest("yes with timeout - tests YesTask cancellation in event loop");
+
+  TestBuilder.command`yes test | head -1000 | wc -l`
+    .exitCode(0)
+    .stdout("1000\n")
+    .stderr("")
+    .runAsTest("high volume yes output - tests YesTask event loop stability");
 });

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -41,9 +41,9 @@ describe("yes - event loop task processing", async () => {
 
   TestBuilder.command`timeout 0.1 yes`
     .exitCode(124)
-    .stdout((stdout) => {
+    .stdout(stdout => {
       expect(stdout.length).toBeGreaterThan(0);
-      expect(stdout.split('\n').filter(line => line === 'y').length).toBeGreaterThan(0);
+      expect(stdout.split("\n").filter(line => line === "y").length).toBeGreaterThan(0);
     })
     .stderr("")
     .runAsTest("yes with timeout - tests YesTask cancellation in event loop");


### PR DESCRIPTION
A crash in the `Yes` command was resolved by correcting its handling within the event loop's task processing.

Previously:
*   `shell.builtin.yes.YesTask` was incorrectly grouped with `bun.js.api.Timer.ImmediateObject` and `bun.js.api.Timer.TimeoutObject` in a `panic` case within the `switch` statement in `src/bun.js/event_loop/Task.zig`.
*   This caused a crash whenever a `YesTask` was processed, as it triggered the `panic` function.

The fix involved:
*   Removing `shell.builtin.yes.YesTask` from the `panic` case.
*   Adding a dedicated `case` for `@field(Task.Tag, @typeName(shell.Interpreter.Builtin.Yes.YesTask))` in the `tickQueueWithCount` function.
*   This new case now correctly retrieves the `YesTask` and calls its `runFromMainThread()` method, ensuring proper asynchronous I/O operation without crashing.