### PR TITLE
Enable Math.sumPrecise

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -295,6 +295,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         JSC::Options::useJITCage() = false;
         JSC::Options::useShadowRealm() = true;
         JSC::Options::useV8DateParser() = true;
+        JSC::Options::useMathSumPreciseMethod() = true;
         JSC::Options::evalMode() = evalMode;
         JSC::Options::heapGrowthSteepnessFactor() = 1.0;
         JSC::Options::heapGrowthMaxIncrease() = 2.0;

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -30,6 +30,7 @@ test("exists", () => {
   expect(typeof PerformanceResourceTiming !== "undefined").toBe(true);
   expect(typeof PerformanceServerTiming !== "undefined").toBe(true);
   expect(typeof PerformanceTiming !== "undefined").toBe(true);
+  expect(typeof Math.sumPrecise !== "undefined").toBe(true);
 });
 
 const globalSetters = [


### PR DESCRIPTION
## Summary
- enable JSC option `useMathSumPreciseMethod`
- test that `Math.sumPrecise` is defined

Fixes #20565


------
https://chatgpt.com/codex/tasks/task_e_685885f6d5cc8328b93e8ab1320d18d0