### PR TITLE
Fix YesTask execution

### DIFF
--- a/src/bun.js/event_loop/Task.zig
+++ b/src/bun.js/event_loop/Task.zig
@@ -490,7 +490,11 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine) u3
                 any.runFromJSThread();
             },
 
-            .@"shell.builtin.yes.YesTask", .@"bun.js.api.Timer.ImmediateObject", .@"bun.js.api.Timer.TimeoutObject" => {
+            .@"shell.builtin.yes.YesTask" => {
+                var yes_task: *YesTask = task.get(YesTask).?;
+                yes_task.runFromMainThread();
+            },
+            .@"bun.js.api.Timer.ImmediateObject", .@"bun.js.api.Timer.TimeoutObject" => {
                 bun.Output.panic("Unexpected tag: {s}", .{@tagName(task.tag())});
             },
             _ => {
@@ -582,6 +586,7 @@ const ShellMvCheckTargetTask = shell.Interpreter.Builtin.Mv.ShellMvCheckTargetTa
 const ShellMvBatchedTask = shell.Interpreter.Builtin.Mv.ShellMvBatchedTask;
 const ShellMkdirTask = shell.Interpreter.Builtin.Mkdir.ShellMkdirTask;
 const ShellTouchTask = shell.Interpreter.Builtin.Touch.ShellTouchTask;
+const YesTask = shell.Interpreter.Builtin.Yes.YesTask;
 const ShellCpTask = shell.Interpreter.Builtin.Cp.ShellCpTask;
 const ShellCondExprStatTask = shell.Interpreter.CondExpr.ShellCondExprStatTask;
 const ShellAsync = shell.Interpreter.Async;

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -26,15 +26,9 @@ describe("yes", async () => {
 });
 
 describe("yes command", async () => {
-  TestBuilder.command`yes | head -n 5`
-    .stdout("y\ny\ny\ny\ny\n")
-    .runAsTest("default output");
+  TestBuilder.command`yes | head -n 5`.stdout("y\ny\ny\ny\ny\n").runAsTest("default output");
 
-  TestBuilder.command`yes xy | head -n 6`
-    .stdout("xy\nxy\nxy\nxy\nxy\nxy\n")
-    .runAsTest("custom expletive");
+  TestBuilder.command`yes xy | head -n 6`.stdout("xy\nxy\nxy\nxy\nxy\nxy\n").runAsTest("custom expletive");
 
-  TestBuilder.command`yes ab cd ef | head -n 6`
-    .stdout("ab\nab\nab\nab\nab\nab\n")
-    .runAsTest("ignores extra args");
+  TestBuilder.command`yes ab cd ef | head -n 6`.stdout("ab\nab\nab\nab\nab\nab\n").runAsTest("ignores extra args");
 });

--- a/test/js/bun/shell/commands/yes.test.ts
+++ b/test/js/bun/shell/commands/yes.test.ts
@@ -1,5 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
 
 $.throws(false);
 
@@ -21,4 +23,18 @@ describe("yes", async () => {
     await $`yes ab cd ef > ${buffer}`;
     expect(buffer.toString()).toEqual("ab\nab\nab\nab\nab\nab");
   });
+});
+
+describe("yes command", async () => {
+  TestBuilder.command`yes | head -n 5`
+    .stdout("y\ny\ny\ny\ny\n")
+    .runAsTest("default output");
+
+  TestBuilder.command`yes xy | head -n 6`
+    .stdout("xy\nxy\nxy\nxy\nxy\nxy\n")
+    .runAsTest("custom expletive");
+
+  TestBuilder.command`yes ab cd ef | head -n 6`
+    .stdout("ab\nab\nab\nab\nab\nab\n")
+    .runAsTest("ignores extra args");
 });


### PR DESCRIPTION
## Summary
- allow `YesTask` to run from the main thread instead of panicking
- expose `YesTask` alias in `Task.zig`
- add bun shell test for `yes` using TestBuilder

## Testing
- `bun bd test test/js/bun/shell/commands/yes.test.ts` *(fails: WebKit download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6858849743ec8328878335caea994223