### PR TITLE
Fix bundler not removing leading layer statements

### DIFF
--- a/src/bundler/linker_context/prepareCssAstsForChunk.zig
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.zig
@@ -159,7 +159,7 @@ fn prepareCssAstsForChunkImpl(c: *LinkerContext, chunk: *Chunk, allocator: std.m
                         // TODO: we are doing simple version rn, only @import
                         for (ast.rules.v.items, 0..) |*rule, ruleidx| {
                             // if ((rule.* == .import and import_records[source_index.get()].at(rule.import.import_record_idx).is_internal) or rule.* == .ignored) {} else {
-                            if (rule.* == .import or rule.* == .ignored) {} else {
+                            if (rule.* == .import or rule.* == .layer_statement or rule.* == .ignored) {} else {
                                 // It's okay to do this because AST is allocated into arena
                                 const reslice = ast.rules.v.items[ruleidx..];
                                 ast.rules.v = .{

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -177,6 +177,47 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("css/CSSTrimLeadingLayerStatements", {
+    files: {
+      "/main.css": /* css */ `
+        @layer one;
+        @layer two;
+        @layer three;
+
+        @import url("./a.css") layer(one);
+        @import url("./b.css") layer(two);
+        @import url("./c.css") layer(three);
+      `,
+      "/a.css": `body { margin: 0; }`,
+      "/b.css": `h1 { font-family: sans-serif; }`,
+      "/c.css": `.text-centered { text-align: center; }`,
+    },
+    outfile: "/out.css",
+    onAfterBundle(api) {
+      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
+  /* a.css */
+  @layer one {
+    body {
+      margin: 0;
+    }
+  }
+  /* b.css */
+  @layer two {
+    h1 {
+      font-family: sans-serif;
+    }
+  }
+  /* c.css */
+  @layer three {
+    .text-centered {
+      text-align: center;
+    }
+  }
+  /* main.css */
+  `);
+    },
+  });
+
   // TODO: re-enable these tests when we do minify local css identifiers
   // itBundled("css/TestImportLocalCSSFromJSMinifyIdentifiersAvoidGlobalNames", {
   //   files: {


### PR DESCRIPTION
## Summary
- trim `@layer` statements when filtering leading directives in the CSS bundler
- add regression test to ensure leading layer statements aren't kept

## Testing
- `bun bd test test/bundler/esbuild/css.test.ts` *(fails: CMake configuration requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6858866c841c83289b128ad07b163e73