### PR TITLE
Fix fs.watchFile ignoring atime

### DIFF
--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -430,7 +430,17 @@ pub const StatWatcher = struct {
             .err => std.mem.zeroes(bun.Stat),
         };
 
-        if (std.mem.eql(u8, std.mem.asBytes(&res), std.mem.asBytes(&this.last_stat))) return;
+        var compare = res;
+        const StatT = @TypeOf(compare);
+        if (@hasField(StatT, "st_atim")) {
+            compare.st_atim = this.last_stat.st_atim;
+        } else if (@hasField(StatT, "st_atimespec")) {
+            compare.st_atimespec = this.last_stat.st_atimespec;
+        } else if (@hasField(StatT, "atim")) {
+            compare.atim = this.last_stat.atim;
+        }
+
+        if (std.mem.eql(u8, std.mem.asBytes(&compare), std.mem.asBytes(&this.last_stat))) return;
 
         this.last_stat = res;
         this.enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, swapAndCallListenerOnMainThread));


### PR DESCRIPTION
## Summary
- avoid triggering fs.watchFile on atime updates

## Testing
- `bun bd test test/js/node/watch/fs.watchFile.test.ts` *(fails: could not download webkit)*

------
https://chatgpt.com/codex/tasks/task_e_685888b3842c832899982d4de44b8017