### PR TITLE
Fix fs.watchFile ignoring atime

### DIFF
--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -430,7 +430,17 @@ pub const StatWatcher = struct {
             .err => std.mem.zeroes(bun.Stat),
         };
 
-        if (std.mem.eql(u8, std.mem.asBytes(&res), std.mem.asBytes(&this.last_stat))) return;
+        var compare = res;
+        const StatT = @TypeOf(compare);
+        if (@hasField(StatT, "st_atim")) {
+            compare.st_atim = this.last_stat.st_atim;
+        } else if (@hasField(StatT, "st_atimespec")) {
+            compare.st_atimespec = this.last_stat.st_atimespec;
+        } else if (@hasField(StatT, "atim")) {
+            compare.atim = this.last_stat.atim;
+        }
+
+        if (std.mem.eql(u8, std.mem.asBytes(&compare), std.mem.asBytes(&this.last_stat))) return;
 
         this.last_stat = res;
         this.enqueueTaskConcurrent(JSC.ConcurrentTask.fromCallback(this, swapAndCallListenerOnMainThread));

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,4 +1,4 @@
-import { tempDirWithFiles, isWindows } from "harness";
+import { isWindows, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "path";
 

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,4 +1,4 @@
-import { tempDirWithFiles } from "harness";
+import { tempDirWithFiles, isWindows } from "harness";
 import fs from "node:fs";
 import path from "path";
 
@@ -111,6 +111,18 @@ describe("fs.watchFile", () => {
     expect(entries.length).toBeGreaterThan(0);
 
     expect(typeof entries[0][0].mtimeMs === "bigint").toBe(true);
+  });
+
+  test.if(isWindows)("does not fire on atime-only update", async () => {
+    let called = false;
+    const file = path.join(testDir, "watch.txt");
+    fs.watchFile(file, { interval: 50 }, () => {
+      called = true;
+    });
+    fs.readFileSync(file);
+    await Bun.sleep(100);
+    fs.unwatchFile(file);
+    expect(called).toBe(false);
   });
 
   test("StatWatcherScheduler stress test (1000 watchers with random times)", async () => {


### PR DESCRIPTION
## Summary
- avoid triggering fs.watchFile on atime updates
- add regression test

Fixes https://github.com/oven-sh/bun/issues/20542

## Testing
- `bun bd test test/js/node/watch/fs.watchFile.test.ts` *(fails: could not download webkit)*

------
https://chatgpt.com/codex/tasks/task_e_685888b3842c832899982d4de44b8017