### PR TITLE
Fix NODE_PATH for bun build

### DIFF
--- a/docs/bundler/fullstack.md
+++ b/docs/bundler/fullstack.md
@@ -381,7 +381,6 @@ Note: this is currently in `bunfig.toml` to make it possible to know statically 
 Bun uses [`HTMLRewriter`](/docs/api/html-rewriter) to scan for `<script>` and `<link>` tags in HTML files, uses them as entrypoints for [Bun's bundler](/docs/bundler), generates an optimized bundle for the JavaScript/TypeScript/TSX/JSX and CSS files, and serves the result.
 
 1. **`<script>` processing**
-
    - Transpiles TypeScript, JSX, and TSX in `<script>` tags
    - Bundles imported dependencies
    - Generates sourcemaps for debugging
@@ -392,7 +391,6 @@ Bun uses [`HTMLRewriter`](/docs/api/html-rewriter) to scan for `<script>` and `<
    ```
 
 2. **`<link>` processing**
-
    - Processes CSS imports and `<link>` tags
    - Concatenates CSS files
    - Rewrites `url` and asset paths to include content-addressable hashes in URLs
@@ -402,18 +400,15 @@ Bun uses [`HTMLRewriter`](/docs/api/html-rewriter) to scan for `<script>` and `<
    ```
 
 3. **`<img>` & asset processing**
-
    - Links to assets are rewritten to include content-addressable hashes in URLs
    - Small assets in CSS files are inlined into `data:` URLs, reducing the total number of HTTP requests sent over the wire
 
 4. **Rewrite HTML**
-
    - Combines all `<script>` tags into a single `<script>` tag with a content-addressable hash in the URL
    - Combines all `<link>` tags into a single `<link>` tag with a content-addressable hash in the URL
    - Outputs a new HTML file
 
 5. **Serve**
-
    - All the output files from the bundler are exposed as static routes, using the same mechanism internally as when you pass a `Response` object to [`static` in `Bun.serve()`](/docs/api/http#static-routes).
 
 This works similarly to how [`Bun.build` processes HTML files](/docs/bundler/html).

--- a/docs/cli/bun-create.md
+++ b/docs/cli/bun-create.md
@@ -308,14 +308,12 @@ IF remote template
 1. GET `registry.npmjs.org/@bun-examples/${template}/latest` and parse it
 2. GET `registry.npmjs.org/@bun-examples/${template}/-/${template}-${latestVersion}.tgz`
 3. Decompress & extract `${template}-${latestVersion}.tgz` into `${destination}`
-
    - If there are files that would overwrite, warn and exit unless `--force` is passed
 
 IF GitHub repo
 
 1. Download the tarball from GitHub’s API
 2. Decompress & extract into `${destination}`
-
    - If there are files that would overwrite, warn and exit unless `--force` is passed
 
 ELSE IF local template
@@ -333,7 +331,6 @@ ELSE IF local template
 7. Run `${npmClient} install` unless `--no-install` is passed OR no dependencies are in package.json
 8. Run any tasks defined in `"bun-create": { "postinstall" }` with the npm client
 9. Run `git init; git add -A .; git commit -am "Initial Commit";`
-
    - Rename `gitignore` to `.gitignore`. NPM automatically removes `.gitignore` files from appearing in packages.
    - If there are dependencies, this runs in a separate thread concurrently while node_modules are being installed
    - Using libgit2 if available was tested and performed 3x slower in microbenchmarks

--- a/docs/test/mocks.md
+++ b/docs/test/mocks.md
@@ -206,13 +206,11 @@ Understanding how `mock.module()` works helps you use it more effectively:
 2. **Lazy Evaluation**: The mock factory callback is only evaluated when the module is actually imported or required.
 
 3. **Path Resolution**: Bun automatically resolves the module specifier as though you were doing an import, supporting:
-
    - Relative paths (`'./module'`)
    - Absolute paths (`'/path/to/module'`)
    - Package names (`'lodash'`)
 
 4. **Import Timing Effects**:
-
    - When mocking before first import: No side effects from the original module occur
    - When mocking after import: The original module's side effects have already happened
    - For this reason, using `--preload` is recommended for mocks that need to prevent side effects

--- a/packages/bun-types/authoring.md
+++ b/packages/bun-types/authoring.md
@@ -65,13 +65,11 @@ Note: The order of references in `index.d.ts` is important - `bun.ns.d.ts` must 
 ### Best Practices
 
 1. **Type Safety**
-
    - Please use strict types instead of `any` where possible
    - Leverage TypeScript's type system features (generics, unions, etc.)
    - Document complex types with JSDoc comments
 
 2. **Compatibility**
-
    - Use `Bun.__internal.UseLibDomIfAvailable<LibDomName extends string, OurType>` for types that might conflict with lib.dom.d.ts (see [`./fetch.d.ts`](./fetch.d.ts) for a real example)
    - `@types/node` often expects variables to always be defined (this was the biggest cause of most of the conflicts in the past!), so we use the `UseLibDomIfAvailable` type to make sure we don't overwrite `lib.dom.d.ts` but still provide Bun types while simultaneously declaring the variable exists (for Node to work) in the cases that we can.
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -206,7 +206,7 @@ pub const BundleV2 = struct {
 
         try client_transpiler.configureDefines();
         client_transpiler.resolver.opts = client_transpiler.options;
-
+        client_transpiler.resolver.env_loader = client_transpiler.env;
         this.client_transpiler = client_transpiler;
         return client_transpiler;
     }
@@ -1752,7 +1752,7 @@ pub const BundleV2 = struct {
             if (!transpiler.options.production) {
                 try transpiler.options.conditions.appendSlice(&.{"development"});
             }
-
+            transpiler.resolver.env_loader = transpiler.env;
             transpiler.resolver.opts = transpiler.options;
         }
 

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -557,13 +557,11 @@ For production builds, the function uses frequency-based minification for optima
 _Algorithm steps_:
 
 1. **Character Frequency Analysis**:
-
    - Analyzes character usage across all files in the chunk
    - Builds frequency map to generate shortest possible identifiers
    - Common patterns get shorter names (e.g., `a`, `b`, `c` for most used symbols)
 
 2. **Symbol Usage Counting**:
-
    - Counts how often each symbol is used throughout the chunk
    - Prioritizes frequently-used symbols for shortest names
    - Includes special handling for `exports` and `module` references
@@ -879,7 +877,6 @@ When bundling modules, Bun often needs to wrap module code in runtime functions 
 1. **Module Wrapper Management**: Determines which statements can be placed inside wrapper functions vs. which must remain at the top level
 
 2. **Import/Export Statement Processing**: Transforms import/export syntax based on output format and bundling context
-
    - Converts `export * from 'path'` to import statements when needed
    - Strips export keywords when bundling (since internal modules don't need exports)
    - Handles re-export runtime function calls

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -225,6 +225,7 @@ pub const BuildCommand = struct {
         }
 
         this_transpiler.resolver.opts = this_transpiler.options;
+        this_transpiler.resolver.env_loader = this_transpiler.env;
         this_transpiler.options.jsx.development = !this_transpiler.options.production;
         this_transpiler.resolver.opts.jsx.development = this_transpiler.options.jsx.development;
 
@@ -268,7 +269,9 @@ pub const BuildCommand = struct {
             try bun.bake.addImportMetaDefines(allocator, client_transpiler.options.define, .development, .client);
 
             this_transpiler.resolver.opts = this_transpiler.options;
+            this_transpiler.resolver.env_loader = this_transpiler.env;
             client_transpiler.resolver.opts = client_transpiler.options;
+            client_transpiler.resolver.env_loader = client_transpiler.env;
         }
 
         // var env_loader = this_transpiler.env;

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -19,7 +19,8 @@ const kRemainingChunk = Symbol("remainingChunk");
 
 const MIN_BUFFER_SIZE = 512;
 let dynamicallyAdjustChunkSize = (_?) => (
-  (_ = process.env.BUN_DISABLE_DYNAMIC_CHUNK_SIZE !== "1"), (dynamicallyAdjustChunkSize = () => _)
+  (_ = process.env.BUN_DISABLE_DYNAMIC_CHUNK_SIZE !== "1"),
+  (dynamicallyAdjustChunkSize = () => _)
 );
 
 type NativeReadable = typeof import("node:stream").Readable &

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -12,7 +12,7 @@ var __getOwnPropNames = Object.getOwnPropertyNames;
 
 var __commonJS = (cb, mod: typeof module | undefined = undefined) =>
   function __require2() {
-    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    return (mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports);
   };
 
 // node_modules/wasi-js/dist/types.js

--- a/src/node-fallbacks/util.js
+++ b/src/node-fallbacks/util.js
@@ -123,8 +123,8 @@ export const debuglog = /* @__PURE__ */ ((debugs = {}, debugEnvRegex = {}, debug
  */
 /* legacy: obj, showHidden, depth, colors*/
 export const inspect = /* @__PURE__ */ (i =>
+  // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
   (
-    // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
     (i.colors = {
       "bold": [1, 22],
       "italic": [3, 23],

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -160,7 +160,7 @@ export var __legacyDecorateClassTS = function (decorators, target, key, desc) {
   else
     for (var i = decorators.length - 1; i >= 0; i--)
       if ((d = decorators[i])) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-  return c > 3 && r && Object.defineProperty(target, key, r), r;
+  return (c > 3 && r && Object.defineProperty(target, key, r), r);
 };
 
 export var __legacyDecorateParamTS = (index, decorator) => (target, key) => decorator(target, key, index);

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -663,3 +663,67 @@ export function testMacro(val: any) {
     `var t={borderRadius:{"1":"4px","2":"8px"}};export{t as testConfig};\n`,
   );
 });
+
+// Since NODE_PATH has to be set, we need to run this test outside the bundler tests.
+test("regression/NODE_PATHBuild api", async () => {
+  const dir = tempDirWithFiles("node-path-build", {
+    "entry.js": `
+      import MyClass from 'MyClass';
+      console.log(new MyClass().constructor.name);
+    `,
+    "src/MyClass.js": `
+      export default class MyClass {}
+    `,
+    "build.js": `
+      import { join } from "path";
+      
+      const build = await Bun.build({
+        entrypoints: [join(import.meta.dir, "entry.js")],
+        outdir: join(import.meta.dir, "out"),
+      });
+      
+      if (!build.success) {
+        console.error("Build failed:", build.logs);
+        process.exit(1);
+      }
+      
+      // Run the built file
+      const runProc = Bun.spawn({
+        cmd: [process.argv[0], join(import.meta.dir, "out", "entry.js")],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      
+      await runProc.exited;
+      const runOutput = await new Response(runProc.stdout).text();
+      const runError = await new Response(runProc.stderr).text();
+      
+      if (runError) {
+        console.error("Run error:", runError);
+        process.exit(1);
+      }
+      
+      console.log(runOutput.trim());
+      
+    `,
+  });
+
+  // Run the build script with NODE_PATH set
+  const proc = Bun.spawn({
+    cmd: [bunExe(), join(dir, "build.js")],
+    env: {
+      ...bunEnv,
+      NODE_PATH: join(dir, "src"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: dir,
+  });
+
+  await proc.exited;
+  const output = await new Response(proc.stdout).text();
+  const error = await new Response(proc.stderr).text();
+
+  expect(error).toBe("");
+  expect(output.trim()).toBe("MyClass");
+});

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -225,27 +225,25 @@ describe("bundler", () => {
     entryPointsRaw: ["test/entry.ts", "--external", "*"],
   });
 
-  for (let backend of ["cli", "api"] as const) {
-    itBundled(`regression/NODE_PATHBuild ${backend}`, {
-      files: {
-        "/entry.js": `
+  itBundled(`regression/NODE_PATHBuild cli`, {
+    files: {
+      "/entry.js": `
         import MyClass from 'MyClass';
         console.log(new MyClass().constructor.name);
       `,
-        "/src/MyClass.js": `
+      "/src/MyClass.js": `
         export default class MyClass {}
       `,
-      },
-      entryPoints: ["/entry.js"],
-      backend,
-      env: {
-        NODE_PATH: "{{root}}/src",
-      },
-      run: {
-        stdout: "MyClass",
-      },
-    });
-  }
+    },
+    entryPoints: ["/entry.js"],
+    backend: "cli",
+    env: {
+      NODE_PATH: "{{root}}/src",
+    },
+    run: {
+      stdout: "MyClass",
+    },
+  });
 
   itBundled("regression/NamespaceTracking#12337", {
     files: {

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -225,24 +225,27 @@ describe("bundler", () => {
     entryPointsRaw: ["test/entry.ts", "--external", "*"],
   });
 
-  itBundled("regression/NODE_PATHBuild", {
-    files: {
-      "/entry.js": `
+  for (let backend of ["cli", "api"] as const) {
+    itBundled(`regression/NODE_PATHBuild ${backend}`, {
+      files: {
+        "/entry.js": `
         import MyClass from 'MyClass';
         console.log(new MyClass().constructor.name);
       `,
-      "/src/MyClass.js": `
+        "/src/MyClass.js": `
         export default class MyClass {}
       `,
-    },
-    entryPoints: ["/entry.js"],
-    env: {
-      NODE_PATH: "{{root}}/src",
-    },
-    run: {
-      stdout: "MyClass",
-    },
-  });
+      },
+      entryPoints: ["/entry.js"],
+      backend,
+      env: {
+        NODE_PATH: "{{root}}/src",
+      },
+      run: {
+        stdout: "MyClass",
+      },
+    });
+  }
 
   itBundled("regression/NamespaceTracking#12337", {
     files: {

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -225,6 +225,25 @@ describe("bundler", () => {
     entryPointsRaw: ["test/entry.ts", "--external", "*"],
   });
 
+  itBundled("regression/NODE_PATHBuild", {
+    files: {
+      "/entry.js": `
+        import MyClass from 'MyClass';
+        console.log(new MyClass().constructor.name);
+      `,
+      "/src/MyClass.js": `
+        export default class MyClass {}
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    env: {
+      NODE_PATH: "{{root}}/src",
+    },
+    run: {
+      stdout: "MyClass",
+    },
+  });
+
   itBundled("regression/NamespaceTracking#12337", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -63,7 +63,7 @@ describe("bun build", () => {
     const tmpdir = tmpdirSync();
     const baseDir = `${tmpdir}/bun-build-dirname-filename-${Date.now()}`;
     fs.mkdirSync(baseDir, { recursive: true });
-    fs.mkdirSync(path.join(baseDir, "我")), { recursive: true };
+    (fs.mkdirSync(path.join(baseDir, "我")), { recursive: true });
     fs.writeFileSync(path.join(baseDir, "我", "我.ts"), "console.log(__dirname); console.log(__filename);");
     const { exitCode } = Bun.spawnSync({
       cmd: [bunExe(), "build", path.join(baseDir, "我/我.ts"), "--compile", "--outfile", path.join(baseDir, "exe.exe")],

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -198,7 +198,7 @@ describe("bundler", () => {
     onAfterBundle(api) {
       api.appendFile(
         "/out.js",
-        dedent/* js */ `
+        dedent /* js */ `
           import { strictEqual } from "node:assert";
           strictEqual(globalName.default, 123, ".default");
           strictEqual(globalName.v, 234, ".v");
@@ -299,7 +299,7 @@ describe("bundler", () => {
         export default 3;
         export const a2 = 4;
       `,
-      "/test.js": String.raw/* js */ `
+      "/test.js": String.raw /* js */ `
         import { deepEqual } from 'node:assert';
         globalThis.deepEqual = deepEqual;
         await import ('./out.js');

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -832,7 +832,7 @@ function expectBundled(
         if (value === undefined) {
           delete bundlerEnv[key];
         } else if (typeof value === "string") {
-          bundlerEnv[key] = value.replaceAll("{{root}}", root.replaceAll("\\", "\\\\"));
+          bundlerEnv[key] = value.replaceAll("{{root}}", root);
         }
       }
 

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -826,10 +826,13 @@ function expectBundled(
       }
 
       const bundlerEnv = { ...bunEnv, ...env };
-      // remove undefined keys instead of passing "undefined"
+      // remove undefined keys instead of passing "undefined" and resolve {{root}}
       for (const key in bundlerEnv) {
-        if (bundlerEnv[key] === undefined) {
+        const value = bundlerEnv[key];
+        if (value === undefined) {
           delete bundlerEnv[key];
+        } else if (typeof value === "string") {
+          bundlerEnv[key] = value.replaceAll("{{root}}", root.replaceAll("\\", "\\\\"));
         }
       }
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2266,6 +2266,6 @@ it("should add local tarball dependency", async () => {
   const package_json = await file(join(package_dir, "node_modules", "baz", "package.json")).json();
   expect(package_json.name).toBe("baz");
   expect(package_json.version).toBe("0.0.3");
-  expect(await file(join(package_dir, "package.json")).text()).toInclude('"baz-0.0.3.tgz"'),
-    await access(join(package_dir, "bun.lockb"));
+  (expect(await file(join(package_dir, "package.json")).text()).toInclude('"baz-0.0.3.tgz"'),
+    await access(join(package_dir, "bun.lockb")));
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -486,7 +486,7 @@ it("should work when moving workspace packages", async () => {
 
   await Bun.$`${bunExe()} i`.env(bunEnv).cwd(package_dir);
 
-  await Bun.$/* sh */ `
+  await Bun.$ /* sh */ `
   mkdir config
 
   # change workspaces from "packages/*" to "config/*"
@@ -558,7 +558,7 @@ it("should work when renaming a single workspace package", async () => {
 
   await Bun.$`${bunExe()} i`.env(bunEnv).cwd(package_dir);
 
-  await Bun.$/* sh */ `
+  await Bun.$ /* sh */ `
   echo ${JSON.stringify({
     "name": "my-workspace",
     version: "0.0.1",

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -582,7 +582,7 @@ bar\n`,
   describe("escaped_newline", () => {
     const printArgs = /* ts */ `console.log(JSON.stringify(process.argv))`;
 
-    TestBuilder.command/* sh */ `${BUN} run ./code.ts hi hello \
+    TestBuilder.command /* sh */ `${BUN} run ./code.ts hi hello \
     on a newline!
   `
       .ensureTempDir()
@@ -590,7 +590,7 @@ bar\n`,
       .stdout(out => expect(JSON.parse(out).slice(2)).toEqual(["hi", "hello", "on", "a", "newline!"]))
       .runAsTest("single");
 
-    TestBuilder.command/* sh */ `${BUN} run ./code.ts hi hello \
+    TestBuilder.command /* sh */ `${BUN} run ./code.ts hi hello \
     on a newline! \
     and \
     a few \
@@ -603,7 +603,7 @@ bar\n`,
       )
       .runAsTest("many");
 
-    TestBuilder.command/* sh */ `${BUN} run ./code.ts hi hello \
+    TestBuilder.command /* sh */ `${BUN} run ./code.ts hi hello \
     on a newline! \
     ooga"
 booga"
@@ -1340,7 +1340,7 @@ describe("deno_task", () => {
 });
 
 describe("if_clause", () => {
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
 # The name of the package we're interested in
 package_name=react
 
@@ -2199,7 +2199,7 @@ describe("subshell", () => {
     }
   }`;
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   mkdir sharp-test
   cd sharp-test
   echo ${sharppkgjson} > package.json
@@ -2212,16 +2212,16 @@ describe("subshell", () => {
     .env(bunEnv)
     .runAsTest("sharp");
 
-  TestBuilder.command/* sh */ `( ( ( ( echo HI! ) ) ) )`.stdout("HI!\n").runAsTest("multiple levels");
-  TestBuilder.command/* sh */ `(
+  TestBuilder.command /* sh */ `( ( ( ( echo HI! ) ) ) )`.stdout("HI!\n").runAsTest("multiple levels");
+  TestBuilder.command /* sh */ `(
     echo HELLO! ;
     echo HELLO AGAIN!
     )`
     .stdout("HELLO!\nHELLO AGAIN!\n")
     .runAsTest("multiline");
-  TestBuilder.command/* sh */ `(exit 42)`.exitCode(42).runAsTest("exit code");
-  TestBuilder.command/* sh */ `(exit 42); echo hi`.exitCode(0).stdout("hi\n").runAsTest("exit code 2");
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `(exit 42)`.exitCode(42).runAsTest("exit code");
+  TestBuilder.command /* sh */ `(exit 42); echo hi`.exitCode(0).stdout("hi\n").runAsTest("exit code 2");
+  TestBuilder.command /* sh */ `
   VAR1=VALUE1
   VAR2=VALUE2
   VAR3=VALUE3
@@ -2237,7 +2237,7 @@ describe("subshell", () => {
     .stdout("VALUE1 VALUE2 VALUE3\nyou cant see me my time is now\nVALUE1 VALUE2 VALUE3\n")
     .runAsTest("copy of environment");
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   mkdir foo
   (
     echo $PWD
@@ -2267,7 +2267,7 @@ describe("subshell", () => {
   TestBuilder.command`\(echo hi \)`.stderr("bun: command not found: (echo\n").exitCode(1).runAsTest("escaped subshell");
   TestBuilder.command`echo \\\(hi\\\)`.stdout("\\(hi\\)\n").runAsTest("escaped subshell 2");
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   mkdir dir
   (
     cd dir
@@ -2279,7 +2279,7 @@ describe("subshell", () => {
     .stdout(`$TEMP_DIR${sep}dir\n$TEMP_DIR\n`)
     .runAsTest("pipeline in subshell");
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   mkdir dir
   (pwd) | cat
   (cd dir; pwd) | cat
@@ -2289,7 +2289,7 @@ describe("subshell", () => {
     .stdout(`$TEMP_DIR\n$TEMP_DIR${sep}dir\n$TEMP_DIR\n`)
     .runAsTest("subshell in pipeline");
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   mkdir dir
   (pwd) | cat
   (cd dir; pwd) | cat
@@ -2299,7 +2299,7 @@ describe("subshell", () => {
     .stdout(`$TEMP_DIR\n$TEMP_DIR${sep}dir\n$TEMP_DIR\n`)
     .runAsTest("subshell in pipeline");
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   mkdir foo
   ( ( (cd foo ; pwd) | cat) ) | ( ( (cat) ) | cat )
 
@@ -2308,7 +2308,7 @@ describe("subshell", () => {
     .stdout(`$TEMP_DIR${sep}foo\n`)
     .runAsTest("imbricated subshells and pipelines");
 
-  TestBuilder.command/* sh */ `
+  TestBuilder.command /* sh */ `
   echo (echo)
   `
     .error("Unexpected token: `(`")
@@ -2316,7 +2316,7 @@ describe("subshell", () => {
 
   describe("ported", () => {
     // test_oE 'effect of subshell'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
   a=1
   # (a=2; echo $a; exit; echo not reached)
   # NOTE: We actually implemented exit wrong so changing this for now until we fix it
@@ -2327,14 +2327,14 @@ describe("subshell", () => {
       .runAsTest("effect of subshell");
 
     // test_x -e 23 'exit status of subshell'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
   (true; exit 23)
   `
       .exitCode(23)
       .runAsTest("exit status of subshell");
 
     // test_oE 'redirection on subshell'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
   (echo 1; echo 2; echo 3; echo 4) >sub_out
   # (tail -n 2) <sub_out
   cat sub_out
@@ -2344,14 +2344,14 @@ describe("subshell", () => {
       .runAsTest("redirection on subshell");
 
     // test_oE 'subshell ending with semicolon'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 (echo foo;)
 `
       .stdout("foo\n")
       .runAsTest("subshell ending with semicolon");
 
     // test_oE 'subshell ending with asynchronous list'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 mkfifo fifo1
 (echo foo >fifo1&)
 cat fifo1
@@ -2361,7 +2361,7 @@ cat fifo1
       .runAsTest("subshell ending with asynchronous list");
 
     // test_oE 'newlines in subshell'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 (
 echo foo
 )
@@ -2370,7 +2370,7 @@ echo foo
       .runAsTest("newlines in subshell");
 
     // test_oE 'effect of brace grouping'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 a=1
 { a=2; echo $a; exit; echo not reached; }
 echo $a
@@ -2380,7 +2380,7 @@ echo $a
       .runAsTest("effect of brace grouping");
 
     // test_x -e 29 'exit status of brace grouping'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 { true; sh -c 'exit 29'; }
 `
       .exitCode(29)
@@ -2388,7 +2388,7 @@ echo $a
       .runAsTest("exit status of brace grouping");
 
     // test_oE 'redirection on brace grouping'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 { echo 1; echo 2; echo 3; echo 4; } >brace_out
 { tail -n 2; } <brace_out
 `
@@ -2397,7 +2397,7 @@ echo $a
       .runAsTest("redirection on brace grouping");
 
     // test_oE 'brace grouping ending with semicolon'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 { echo foo; }
 `
       .stdout("foo\n")
@@ -2405,7 +2405,7 @@ echo $a
       .runAsTest("brace grouping ending with semicolon");
 
     // test_oE 'brace grouping ending with asynchronous list'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 mkfifo fifo1
 { echo foo >fifo1& }
 cat fifo1
@@ -2415,7 +2415,7 @@ cat fifo1
       .runAsTest("brace grouping ending with asynchronous list");
 
     // test_oE 'newlines in brace grouping'
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
 {
 echo foo
 }

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -61,7 +61,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
     .runAsTest("dir -> ? fails without -R");
 
   describe("EBUSY windows", () => {
-    TestBuilder.command/* sh */ `
+    TestBuilder.command /* sh */ `
     echo hi! > hello.txt
     mkdir somedir 
     cp ${{ raw: Array(50).fill("hello.txt").join(" ") }} somedir 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4157,13 +4157,13 @@ describe("expect()", () => {
       expect(expect.objectContaining({ first: { second: {} } })).not.toEqual({
         first: { second: {}, third: {} },
       });
-      expect(
+      (expect(
         expect.objectContaining({
           answer: 42,
           foo: { bar: "baz", foobar: "qux" },
         }),
       ).not.toEqual({ foo: { bar: "baz" } }),
-        expect(expect.objectContaining({ [foo]: "foo" })).not.toEqual({ [bar]: "bar" });
+        expect(expect.objectContaining({ [foo]: "foo" })).not.toEqual({ [bar]: "bar" }));
     });
 
     test("ObjectContaining matches defined properties", () => {

--- a/test/js/bun/util/fuzzy-wuzzy.test.ts
+++ b/test/js/bun/util/fuzzy-wuzzy.test.ts
@@ -210,11 +210,11 @@ function callAllMethods(object) {
           object?.on?.("error", () => {});
         }
         const returnValue = wrap(Reflect.apply(object?.[methodName], object, []));
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         calls++;
       } catch (e) {
         const returnValue = wrap(Reflect.apply(object.constructor?.[methodName], object?.constructor, []));
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         calls++;
       }
     } catch (e) {
@@ -244,7 +244,7 @@ function callAllMethods(object) {
           if (returnValue?.then) {
             continue;
           }
-          Bun.inspect?.(returnValue), queue.push(returnValue);
+          (Bun.inspect?.(returnValue), queue.push(returnValue));
           calls++;
         } catch (e) {}
       }
@@ -261,17 +261,17 @@ function constructAllConstructors(object) {
     try {
       try {
         const returnValue = Reflect.construct(object, [], method);
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         constructs++;
       } catch (e) {
         const returnValue = Reflect.construct(object?.constructor, [], method);
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         constructs++;
       }
     } catch (e) {
       try {
         const returnValue = Reflect.construct(object?.prototype?.constructor, [], method);
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         constructs++;
       } catch (e) {
         Error.captureStackTrace(e);
@@ -293,7 +293,7 @@ function constructAllConstructors(object) {
           continue;
         }
 
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         seen.add(returnValue);
         constructs++;
       } catch (e) {}
@@ -312,21 +312,21 @@ function constructAllConstructorsWithSubclassing(object) {
         // Create a subclass of the constructor
         class Subclass extends object {}
         const returnValue = Reflect.construct(object, [], Subclass);
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         subclasses++;
       } catch (e) {
         try {
           // Try with the constructor property
           class Subclass extends object?.constructor {}
           const returnValue = Reflect.construct(object?.constructor, [], Subclass);
-          Bun.inspect?.(returnValue), queue.push(returnValue);
+          (Bun.inspect?.(returnValue), queue.push(returnValue));
           subclasses++;
         } catch (e) {
           // Fallback to a more generic approach
           const Subclass = function () {};
           Object.setPrototypeOf(Subclass.prototype, object);
           const returnValue = Reflect.construct(object, [], Subclass);
-          Bun.inspect?.(returnValue), queue.push(returnValue);
+          (Bun.inspect?.(returnValue), queue.push(returnValue));
           subclasses++;
         }
       }
@@ -335,7 +335,7 @@ function constructAllConstructorsWithSubclassing(object) {
         // Try with prototype constructor
         class Subclass extends object?.prototype?.constructor {}
         const returnValue = Reflect.construct(object?.prototype?.constructor, [], Subclass);
-        Bun.inspect?.(returnValue), queue.push(returnValue);
+        (Bun.inspect?.(returnValue), queue.push(returnValue));
         subclasses++;
       } catch (e) {
         Error.captureStackTrace(e);
@@ -360,7 +360,7 @@ function constructAllConstructorsWithSubclassing(object) {
             continue;
           }
 
-          Bun.inspect?.(returnValue), queue.push(returnValue);
+          (Bun.inspect?.(returnValue), queue.push(returnValue));
           seen.add(returnValue);
           subclasses++;
         } catch (e) {
@@ -372,7 +372,7 @@ function constructAllConstructorsWithSubclassing(object) {
             continue;
           }
 
-          Bun.inspect?.(returnValue), queue.push(returnValue);
+          (Bun.inspect?.(returnValue), queue.push(returnValue));
           seen.add(returnValue);
           subclasses++;
         }


### PR DESCRIPTION
## Summary
- pass the env loader to BuildCommand resolver so NODE_PATH works
- test NODE_PATH resolution with bun build
- support `{{root}}` in env vars for bundler tests

Fixes https://github.com/oven-sh/bun/issues/20537

## Testing
- `bun bd test test/bundler/bundler_regressions.test.ts` *(fails: file rename error)*

------
https://chatgpt.com/codex/tasks/task_e_6858899c74848328b364e622629a4b7a