### PR TITLE
Improve Headers construction

### DIFF
--- a/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
@@ -131,6 +131,14 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSFetchHeadersDOMConstru
     ASSERT(castedThis);
     EnsureStillAliveScope argument0 = callFrame->argument(0);
 
+    if (!argument0.value() || argument0.value().isUndefined()) {
+        auto object = FetchHeaders::create();
+        auto jsValue = toJSNewlyConstructed(*lexicalGlobalObject, *castedThis->globalObject(), WTFMove(object));
+        setSubclassStructureIfNeeded<FetchHeaders>(lexicalGlobalObject, callFrame, asObject(jsValue));
+        RETURN_IF_EXCEPTION(throwScope, {});
+        return JSValue::encode(jsValue);
+    }
+
     auto init = std::optional<Converter<IDLUnion<IDLSequence<IDLSequence<IDLDOMString>>, IDLRecord<IDLDOMString, IDLDOMString>>>::ReturnType>();
 
     if (argument0.value() && !argument0.value().isUndefined()) {
@@ -760,6 +768,11 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObj
         // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
 #endif
     }
+    return createWrapper<FetchHeaders>(globalObject, WTFMove(impl));
+}
+
+JSC::JSValue toJSNewlyConstructed(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<FetchHeaders>&& impl)
+{
     return createWrapper<FetchHeaders>(globalObject, WTFMove(impl));
 }
 

--- a/src/bun.js/bindings/webcore/JSFetchHeaders.h
+++ b/src/bun.js/bindings/webcore/JSFetchHeaders.h
@@ -92,6 +92,8 @@ JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, FetchHeaders&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, FetchHeaders* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<FetchHeaders>&&);
 inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<FetchHeaders>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
+JSC::JSValue toJSNewlyConstructed(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<FetchHeaders>&&);
+inline JSC::JSValue toJSNewlyConstructed(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<FetchHeaders>&& impl) { return impl ? toJSNewlyConstructed(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<FetchHeaders> {
     using WrapperClass = JSFetchHeaders;


### PR DESCRIPTION
## Summary
- optimize Headers constructor when called without arguments
- expose and use `toJSNewlyConstructed`

## Testing
- `bun bd test test/js/bun/http/bun-serve-headers.test.ts` *(fails: unable to download WebKit build)*

------
https://chatgpt.com/codex/tasks/task_e_6858904715488328921daf5016807c78