### PR TITLE
Fix bundler crash when CSS entry is imported

### DIFF
--- a/src/bundler/linker_context/computeChunks.zig
+++ b/src/bundler/linker_context/computeChunks.zig
@@ -70,7 +70,8 @@ pub noinline fn computeChunks(
         }
 
         if (css_asts[source_index] != null) {
-            const order = this.findImportedFilesInCSSOrder(temp_allocator, &.{Index.init(source_index)});
+            const order_temp = this.findImportedFilesInCSSOrder(temp_allocator, &.{Index.init(source_index)});
+            const order = order_temp.clone(this.allocator) catch bun.outOfMemory();
             // Create a chunk for the entry point here to ensure that the chunk is
             // always generated even if the resulting file is empty
             const hash_to_use = if (!this.options.css_chunking)
@@ -133,7 +134,8 @@ pub noinline fn computeChunks(
             // algorithm to determine the final CSS file order for the chunk.
             const css_source_indices = this.findImportedCSSFilesInJSOrder(temp_allocator, Index.init(source_index));
             if (css_source_indices.len > 0) {
-                const order = this.findImportedFilesInCSSOrder(temp_allocator, css_source_indices.slice());
+                const order_temp = this.findImportedFilesInCSSOrder(temp_allocator, css_source_indices.slice());
+                const order = order_temp.clone(this.allocator) catch bun.outOfMemory();
 
                 const use_content_based_key = css_chunking or has_server_html_imports;
                 const hash_to_use = if (!use_content_based_key)

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -274,4 +274,15 @@ describe("bundler", () => {
     run: true,
     capture: ["1 /* Value */", "1 /* Value */", "1 /* Value */"],
   });
+
+  // https://github.com/oven-sh/bun/issues/20278
+  itBundled("regression/EntryPointAlsoImported#20278", {
+    files: {
+      "/style.css": `body { color: red }`,
+      "/main.ts": `import './style.css';\nconsole.log('done');`,
+    },
+    entryPoints: ["/style.css", "/main.ts"],
+    outdir: "/out",
+    run: { file: "/out/main.js" },
+  });
 });


### PR DESCRIPTION
## Summary
- fix computeChunks to copy CSS order list
- add regression test for imported entrypoints

## Testing
- `bun bd test test/bundler/bundler_regressions.test.ts` *(fails: CMake cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685892dd9da08328bc18ade9cb4ee734