### PR TITLE
remove ref count from `napi_async_work`

### DIFF
--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1048,11 +1048,6 @@ pub const napi_async_work = struct {
     status: std.atomic.Value(Status) = .init(.pending),
     scheduled: bool = false,
     poll_ref: Async.KeepAlive = .{},
-    ref_count: RefCount,
-
-    const RefCount = bun.ptr.ThreadSafeRefCount(@This(), "ref_count", destroy, .{});
-    pub const ref = RefCount.ref;
-    pub const deref = RefCount.deref;
 
     pub const Status = enum(u32) {
         pending = 0,
@@ -1061,7 +1056,7 @@ pub const napi_async_work = struct {
         cancelled = 3,
     };
 
-    pub fn new(env: *NapiEnv, execute: napi_async_execute_callback, complete: ?napi_async_complete_callback, data: ?*anyopaque) !*napi_async_work {
+    pub fn new(env: *NapiEnv, execute: napi_async_execute_callback, complete: ?napi_async_complete_callback, data: ?*anyopaque) *napi_async_work {
         const global = env.toJS();
 
         const work = bun.new(napi_async_work, .{
@@ -1071,13 +1066,11 @@ pub const napi_async_work = struct {
             .event_loop = global.bunVM().eventLoop(),
             .complete = complete,
             .data = data,
-            .ref_count = .initExactRefs(1),
         });
         return work;
     }
 
     pub fn destroy(this: *napi_async_work) void {
-        bun.debugAssert(!this.poll_ref.isActive()); // we must always have unref'd it.
         bun.destroy(this);
     }
 
@@ -1109,12 +1102,10 @@ pub const napi_async_work = struct {
         return this.status.cmpxchgStrong(.pending, .cancelled, .seq_cst, .seq_cst) == null;
     }
 
-    fn runFromJSWithError(this: *napi_async_work, vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject) bun.JSError!void {
-        this.ref();
-        defer {
-            this.poll_ref.unref(vm);
-            this.deref();
-        }
+    pub fn runFromJS(this: *napi_async_work, vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject) void {
+        // Note: the "this" value here may already be freed by the user in `complete`
+        var poll_ref = this.poll_ref;
+        defer poll_ref.unref(vm);
 
         // https://github.com/nodejs/node/blob/a2de5b9150da60c77144bb5333371eaca3fab936/src/node_api.cc#L1201
         const complete = this.complete orelse {
@@ -1137,15 +1128,8 @@ pub const napi_async_work = struct {
         );
 
         if (global.hasException()) {
-            return error.JSError;
+            global.reportActiveExceptionAsUnhandled(error.JSError);
         }
-    }
-
-    pub fn runFromJS(this: *napi_async_work, vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject) void {
-        this.runFromJSWithError(vm, global) catch |e| {
-            // Note: the "this" value here may already be freed.
-            global.reportActiveExceptionAsUnhandled(e);
-        };
     }
 };
 pub const napi_threadsafe_function = *ThreadSafeFunction;
@@ -1296,9 +1280,7 @@ pub export fn napi_create_async_work(
     const execute = execute_ orelse {
         return env.invalidArg();
     };
-    result.* = napi_async_work.new(env, execute, complete, data) catch {
-        return env.genericFailure();
-    };
+    result.* = napi_async_work.new(env, execute, complete, data);
     return env.ok();
 }
 pub export fn napi_delete_async_work(env_: napi_env, work_: ?*napi_async_work) napi_status {
@@ -1310,7 +1292,7 @@ pub export fn napi_delete_async_work(env_: napi_env, work_: ?*napi_async_work) n
         return env.invalidArg();
     };
     if (comptime bun.Environment.allow_assert) bun.assert(env.toJS() == work.global);
-    work.deref();
+    work.destroy();
     return env.ok();
 }
 pub export fn napi_queue_async_work(env_: napi_env, work_: ?*napi_async_work) napi_status {


### PR DESCRIPTION
### What does this PR do?
The debug assertion could be hit if the user called `napi_delete_async_work` twice in the complete callback. To keep this closer to node, changed `napi_delete_async_work` to free the pointer instead of deref.
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
