### PR TITLE
Optimize `napi_create_buffer`

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1893,6 +1893,28 @@ extern "C" napi_status napi_get_property_names(napi_env env, napi_value object,
     NAPI_RETURN_SUCCESS(env);
 }
 
+extern "C" napi_status napi_create_buffer(napi_env env, size_t length,
+    void** data,
+    napi_value* result)
+{
+    NAPI_PREAMBLE(env);
+    NAPI_CHECK_ARG(env, result);
+
+    Zig::GlobalObject* globalObject = toJS(env);
+    auto* subclassStructure = globalObject->JSBufferSubclassStructure();
+
+    // In Node.js, napi_create_buffer is uninitialized memory.
+    auto* uint8Array = JSC::JSUint8Array::createUninitialized(globalObject, subclassStructure, length);
+    NAPI_RETURN_IF_EXCEPTION(env);
+
+    if (data != nullptr) {
+        *data = length > 0 ? uint8Array->typedVector() : nullptr;
+    }
+
+    *result = toNapi(uint8Array, globalObject);
+    NAPI_RETURN_SUCCESS(env);
+}
+
 extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     void* data,
     napi_finalize finalize_cb,

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1908,6 +1908,9 @@ extern "C" napi_status napi_create_buffer(napi_env env, size_t length,
     NAPI_RETURN_IF_EXCEPTION(env);
 
     if (data != nullptr) {
+        // Node.js' code looks like this:
+        //    *data = node::Buffer::Data(buffer);
+        // That means they unconditionally update the data pointer.
         *data = length > 0 ? uint8Array->typedVector() : nullptr;
     }
 

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1175,20 +1175,7 @@ pub export fn napi_fatal_error(location_ptr: ?[*:0]const u8, location_len: usize
 
     bun.Output.panic("napi: {s}", .{message});
 }
-pub export fn napi_create_buffer(env_: napi_env, length: usize, data: ?**anyopaque, result: *napi_value) napi_status {
-    log("napi_create_buffer: {d}", .{length});
-    const env = env_ orelse {
-        return envIsNull();
-    };
-    var buffer = JSC.JSValue.createBufferFromLength(env.toJS(), length);
-    if (length > 0) {
-        if (data) |ptr| {
-            ptr.* = buffer.asArrayBuffer(env.toJS()).?.ptr;
-        }
-    }
-    result.set(env, buffer);
-    return env.ok();
-}
+pub extern fn napi_create_buffer(env: napi_env, length: usize, data: ?**anyopaque, result: *napi_value) napi_status;
 pub extern fn napi_create_external_buffer(env: napi_env, length: usize, data: ?*anyopaque, finalize_cb: napi_finalize, finalize_hint: ?*anyopaque, result: *napi_value) napi_status;
 pub export fn napi_create_buffer_copy(env_: napi_env, length: usize, data: [*]u8, result_data: ?*?*anyopaque, result_: ?*napi_value) napi_status {
     log("napi_create_buffer_copy: {d}", .{length});


### PR DESCRIPTION
### What does this PR do?

Use uninitialized memory when creating buffers via `napi_create_buffer`.


<details>
<summary>In Node.js, <code>napi_create_buffer</code> uses uninitialized memory. In Bun, it uses zero-initialized memory and that makes us slower than Node in a method that really is performance sensitive.</summary>

```js
❯ node test_buffer_init.js
Testing if napi_create_buffer creates initialized or uninitialized memory...

Test run 1:
First 32 bytes of buffer created by napi_create_buffer: 00 00 00 00 00 00 00 00 5c 65 6e 69 6e 67 6b 49 00 00 00 00 00 00 00 00 5c 7d 5c 2e 29 65 34 02 Buffer is initialized (all zeros): false
Buffer has non-zero bytes: true
Found 676 non-zero bytes out of 1024 total bytes
First 32 bytes (hex): 00000000000000005c656e696e676b4900000000000000005c7d5c2e29653402

Test run 2:
First 32 bytes of buffer created by napi_create_buffer: 00 00 00 00 00 00 00 00 5c e6 85 1d 01 00 00 00 00 00 00 00 00 00 00 00 5c e6 85 1d 01 00 00 00 Buffer is initialized (all zeros): false
Buffer has non-zero bytes: true
Found 500 non-zero bytes out of 1024 total bytes
First 32 bytes (hex): 00000000000000005ce6851d0100000000000000000000005ce6851d01000000

Test run 3:
First 32 bytes of buffer created by napi_create_buffer: 00 00 00 00 00 00 00 00 5c 00 6b 00 20 00 77 00 00 00 00 00 00 00 00 00 5c 00 61 00 76 00 65 00 Buffer is initialized (all zeros): false
Buffer has non-zero bytes: true
Found 511 non-zero bytes out of 1024 total bytes
First 32 bytes (hex): 00000000000000005c006b002000770000000000000000005c00610076006500

Test run 4:
First 32 bytes of buffer created by napi_create_buffer: 00 00 00 00 00 00 00 00 5c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 5c 00 00 00 07 00 00 00 Buffer is initialized (all zeros): false
Buffer has non-zero bytes: true
Found 524 non-zero bytes out of 1024 total bytes
First 32 bytes (hex): 00000000000000005c0000000000000000000000000000005c00000007000000

Test run 5:
First 32 bytes of buffer created by napi_create_buffer: 00 00 00 00 00 00 00 00 5c 1d 61 e6 d3 34 00 00 00 00 00 00 00 00 00 00 5c 30 c1 9f a4 37 00 00 Buffer is initialized (all zeros): false
Buffer has non-zero bytes: true
Found 696 non-zero bytes out of 1024 total bytes
First 32 bytes (hex): 00000000000000005c1d61e6d334000000000000000000005c30c19fa4370000

Conclusion:
If you see non-zero bytes, napi_create_buffer creates UNINITIALIZED memory. If all bytes are zero, napi_create_buffer creates INITIALIZED (zeroed) memory.
```

```js
const addon = require('./build/Release/test_buffer_init');

console.log('Testing if napi_create_buffer creates initialized or uninitialized memory...\n');

// Run the test multiple times to check consistency
for (let i = 0; i < 5; i++) {
    console.log(`\nTest run ${i + 1}:`);
    const result = addon.testBufferInit();

    console.log(`Buffer is initialized (all zeros): ${result.isInitialized}`);
    console.log(`Buffer has non-zero bytes: ${result.hasNonZeroBytes}`);

    // Also check the buffer in JavaScript
    const buffer = result.buffer;
    let nonZeroCount = 0;
    for (let j = 0; j < buffer.length; j++) {
        if (buffer[j] !== 0) {
            nonZeroCount++;
        }
    }

    if (nonZeroCount > 0) {
        console.log(`Found ${nonZeroCount} non-zero bytes out of ${buffer.length} total bytes`);
        console.log(`First 32 bytes (hex): ${buffer.slice(0, 32).toString('hex')}`);
    } else {
        console.log('All bytes are zero - buffer is initialized to zero');
    }
}

console.log('\nConclusion:');
console.log('If you see non-zero bytes, napi_create_buffer creates UNINITIALIZED memory.');
console.log('If all bytes are zero, napi_create_buffer creates INITIALIZED (zeroed) memory.');
```

```c
#include <node_api.h>
#include <stdio.h>
#include <string.h>
#include <stdbool.h>

static napi_value TestBufferInit(napi_env env, napi_callback_info info) {
    napi_status status;
    napi_value result;
    void* data;
    size_t buffer_size = 1024;  // 1KB buffer

    // Create a buffer using napi_create_buffer
    status = napi_create_buffer(env, buffer_size, &data, &result);
    if (status != napi_ok) {
        napi_throw_error(env, NULL, "Failed to create buffer");
        return NULL;
    }

    // Check if the buffer contains all zeros (initialized) or random data (uninitialized)
    unsigned char* byte_data = (unsigned char*)data;
    bool all_zeros = true;
    bool has_non_zero = false;

    // Print first 32 bytes for inspection
    printf("First 32 bytes of buffer created by napi_create_buffer:\n");
    for (size_t i = 0; i < 32 && i < buffer_size; i++) {
        printf("%02x ", byte_data[i]);
        if (byte_data[i] != 0) {
            all_zeros = false;
            has_non_zero = true;
        }
    }
    printf("\n");

    // Check entire buffer
    for (size_t i = 0; i < buffer_size; i++) {
        if (byte_data[i] != 0) {
            all_zeros = false;
            has_non_zero = true;
            break;
        }
    }

    // Create result object
    napi_value result_obj;
    napi_create_object(env, &result_obj);

    napi_value is_initialized;
    napi_get_boolean(env, all_zeros, &is_initialized);
    napi_set_named_property(env, result_obj, "isInitialized", is_initialized);

    napi_value has_garbage;
    napi_get_boolean(env, has_non_zero, &has_garbage);
    napi_set_named_property(env, result_obj, "hasNonZeroBytes", has_garbage);

    // Also return the buffer itself for further inspection
    napi_set_named_property(env, result_obj, "buffer", result);

    return result_obj;
}

static napi_value Init(napi_env env, napi_value exports) {
    napi_status status;
    napi_value fn;

    status = napi_create_function(env, NULL, 0, TestBufferInit, NULL, &fn);
    if (status != napi_ok) return NULL;

    status = napi_set_named_property(env, exports, "testBufferInit", fn);
    if (status != napi_ok) return NULL;

    return exports;
}

NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
```

</details>


### How did you verify your code works?

Existing tests