### PR TITLE
Fixes #20615

### DIFF
--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -380,7 +380,7 @@ pub const UDPSocket = struct {
         const globalThis = this.globalThis;
         const vm = globalThis.bunVM();
 
-        if (err.isTerminationException(vm.jsc)) {
+        if (err.isTerminationException()) {
             return;
         }
         if (callback == .zero) {

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -553,7 +553,7 @@ pub const JSGlobalObject = opaque {
     ///
     pub fn reportActiveExceptionAsUnhandled(this: *JSGlobalObject, err: bun.JSError) void {
         const exception = this.takeException(err);
-        if (!exception.isTerminationException(this.vm())) {
+        if (!exception.isTerminationException()) {
             _ = this.bunVM().uncaughtException(this, exception, false);
         }
     }

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -1150,9 +1150,9 @@ pub const JSValue = enum(i64) {
             null;
     }
 
-    extern fn JSC__JSValue__isTerminationException(this: JSValue, vm: *VM) bool;
-    pub fn isTerminationException(this: JSValue, vm: *VM) bool {
-        return JSC__JSValue__isTerminationException(this, vm);
+    extern fn JSC__JSValue__isTerminationException(this: JSValue) bool;
+    pub fn isTerminationException(this: JSValue) bool {
+        return JSC__JSValue__isTerminationException(this);
     }
 
     extern fn JSC__JSValue__toZigException(this: JSValue, global: *JSGlobalObject, exception: *ZigException) void;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5309,10 +5309,13 @@ void JSC__VM__setExecutionTimeLimit(JSC::VM* vm, double limit)
     watchdog.setTimeLimit(WTF::Seconds { limit });
 }
 
-bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0, JSC::VM* arg1)
+bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0)
 {
     JSC::Exception* exception = JSC::jsDynamicCast<JSC::Exception*>(JSC::JSValue::decode(JSValue0));
-    return exception != NULL && arg1->isTerminationException(exception);
+    if (exception == nullptr)
+        return false;
+
+    return exception->vm().isTerminationException(exception);
 }
 
 extern "C" void JSC__Exception__getStackTrace(JSC::Exception* arg0, JSC::JSGlobalObject* global, ZigStackTrace* trace)

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -256,7 +256,7 @@ CPP_DECL bool JSC__JSValue__isObject(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isPrimitive(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isSameValue(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
 CPP_DECL bool JSC__JSValue__isSymbol(JSC::EncodedJSValue JSValue0);
-CPP_DECL bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0, JSC::VM* arg1);
+CPP_DECL bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isUInt32AsAnyInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__jestDeepEquals(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
 CPP_DECL bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2, bool arg3);

--- a/src/bun.js/virtual_machine_exports.zig
+++ b/src/bun.js/virtual_machine_exports.zig
@@ -86,11 +86,9 @@ pub export fn Bun__queueTaskWithTimeout(global: *JSGlobalObject, task: *JSC.CppT
 
 pub export fn Bun__reportUnhandledError(globalObject: *JSGlobalObject, value: JSValue) callconv(.C) JSValue {
     JSC.markBinding(@src());
-    // This JSGlobalObject might not be the main script execution context
-    // See the crash in https://github.com/oven-sh/bun/issues/9778
-    const vm = JSC.VirtualMachine.get();
-    if (!value.isTerminationException(vm.jsc)) {
-        _ = vm.uncaughtException(globalObject, value, false);
+
+    if (!value.isTerminationException()) {
+        _ = globalObject.bunVM().uncaughtException(globalObject, value, false);
     }
     return .js_undefined;
 }

--- a/src/env.zig
+++ b/src/env.zig
@@ -26,6 +26,7 @@ pub const isX86 = @import("builtin").target.cpu.arch.isX86();
 pub const isX64 = @import("builtin").target.cpu.arch == .x86_64;
 pub const isMusl = builtin.target.abi.isMusl();
 pub const allow_assert = isDebug or isTest or std.builtin.Mode.ReleaseSafe == @import("builtin").mode;
+pub const ci_assert = isDebug or isTest or enable_asan or (std.builtin.Mode.ReleaseSafe == @import("builtin").mode and is_canary);
 pub const show_crash_trace = isDebug or isTest or enable_asan;
 /// All calls to `@export` should be gated behind this check, so that code
 /// generators that compile Zig code know not to reference and compile a ton of


### PR DESCRIPTION
### What does this PR do?

- Prevent exception scope verification code leaking into release builds
- Every `JSCell` has a JSC::VM. We don't need to store a JSGlobalObject.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
