### PR TITLE
fix(http2) fix remoteSettings not emitting on default settings

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2370,8 +2370,6 @@ pub const H2FrameParser = struct {
             }
         } else {
             if (isACK) {
-                defer _ = this.flush();
-                defer this.incrementWindowSizeIfNeeded();
                 // we received an ACK
                 log("settings frame ACK", .{});
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -214,6 +214,31 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(parsed.url).toBe(`${HTTPS_SERVER}/get`);
         }
       });
+      it("http2 should receive remoteSettings when receiving default settings frame", async () => {
+        const { promise, resolve, reject } = Promise.withResolvers();
+        const session = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
+
+        session.once("remoteSettings", resolve);
+        session.once("close", () => {
+          reject(new Error("Failed to receive remoteSettings"));
+        });
+        try {
+          const settings = await promise;
+          expect(settings).toBeDefined();
+          expect(settings).toEqual({
+            headerTableSize: 4096,
+            enablePush: false,
+            maxConcurrentStreams: 4294967295,
+            initialWindowSize: 65535,
+            maxFrameSize: 16384,
+            maxHeaderListSize: 65535,
+            maxHeaderSize: 65535,
+            enableConnectProtocol: false,
+          });
+        } finally {
+          session.close();
+        }
+      });
       it("should be able to mutiplex POST requests", async () => {
         const results = await doMultiplexHttp2Request(HTTPS_SERVER, [
           { headers: { ":path": "/post", ":method": "POST" }, payload: JSON.stringify({ "request": 1 }) },


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/oven-sh/bun/issues/20284 new versions of grpcjs may wait remoteSettings for default settings
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
