### PR TITLE
feat(bun-lambda): expose API Gateway Authorizer Context through `x-amzn-authorizer` header

### DIFF
--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -299,6 +299,7 @@ type HttpEventV1 = {
     readonly domainName: string;
     readonly httpMethod: string;
     readonly path: string;
+    readonly authorizer?: Record<string, unknown>;
   };
   readonly headers: Record<string, string>;
   readonly multiValueHeaders?: Record<string, string[]>;
@@ -329,10 +330,6 @@ function formatHttpEventV1(event: HttpEventV1): Request {
     }
   }
 
-  if (event.requestContext.authorizer != null) {
-    headers.set("x-amzn-authorizer", JSON.stringify(event.requestContext.authorizer));
-  }
-
   return new Request(url.toString(), {
     method: request.httpMethod,
     headers,
@@ -349,6 +346,7 @@ type HttpEventV2 = {
       readonly method: string;
       readonly path: string;
     };
+    readonly authorizer?: Record<string, unknown>;
   };
   readonly headers: Record<string, string>;
   readonly queryStringParameters?: Record<string, string>;
@@ -377,10 +375,6 @@ function formatHttpEventV2(event: HttpEventV2): Request {
   const url = new URL(request.http.path, `${proto}://${hostname}/`);
   for (const [name, values] of Object.entries(event.queryStringParameters ?? {})) {
     url.searchParams.append(name, values);
-  }
-
-  if (event.requestContext.authorizer != null) {
-    headers.set("x-amzn-authorizer", JSON.stringify(event.requestContext.authorizer));
   }
 
   return new Request(url.toString(), {
@@ -480,6 +474,11 @@ function formatRequest(input: LambdaRequest): Request | undefined {
   request.headers.set("x-amzn-function-arn", functionArn);
   if (deadlineMs !== null) {
     request.headers.set("x-amzn-deadline-ms", `${deadlineMs}`);
+  }
+  // Include API Gateway Authorizer context for HTTP events
+  const rc = (event as any)?.requestContext;
+  if (rc?.authorizer != null) {
+    request.headers.set("x-amzn-authorizer", JSON.stringify(rc.authorizer));
   }
   // @ts-ignore: Attach the original event to the Request
   request.aws = event;

--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -328,6 +328,11 @@ function formatHttpEventV1(event: HttpEventV1): Request {
       url.searchParams.append(name, value);
     }
   }
+
+  if (event.requestContext.authorizer != null) {
+    headers.set("x-amzn-authorizer", JSON.stringify(event.requestContext.authorizer));
+  }
+
   return new Request(url.toString(), {
     method: request.httpMethod,
     headers,
@@ -373,6 +378,11 @@ function formatHttpEventV2(event: HttpEventV2): Request {
   for (const [name, values] of Object.entries(event.queryStringParameters ?? {})) {
     url.searchParams.append(name, values);
   }
+
+  if (event.requestContext.authorizer != null) {
+    headers.set("x-amzn-authorizer", JSON.stringify(event.requestContext.authorizer));
+  }
+
   return new Request(url.toString(), {
     method: request.http.method,
     headers,


### PR DESCRIPTION
### What does this PR do?

Expose API Gateway Authorizer Context through `x-amzn-authorizer` header for bun-lambda runtime.

- [x] Code changes

### How did you verify your code works?

- [x] I deploy it to AWS with custom runtime build and test it - worked as expected

