### PR TITLE
fix(sockets) some fixes and improvements

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -782,6 +782,7 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
         /* This properly updates the iterator if in on_timeout */
         us_internal_socket_context_unlink_socket(ssl, old_context, s);
     } else {
+        /* Remove old socket from low-priority queue */
         if (loop->data.low_prio_head == s) {
             loop->data.low_prio_head = s->next;
             if (s->next) s->next->prev = NULL;
@@ -803,7 +804,6 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
     
     if (ext_size != -1) {
         struct us_poll_t *pool_ref = &s->p;
-        /* Remove old socket from low-priority queue */
        
         new_s = (struct us_socket_t *) us_poll_resize(pool_ref, loop, sizeof(struct us_socket_t) + ext_size);
         if (c) {

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -385,14 +385,14 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, un
     struct us_poll_t *new_p = us_realloc(p, sizeof(struct us_poll_t) + ext_size);
     if (p != new_p) {
 #ifdef LIBUS_USE_EPOLL
-            /* Hack: forcefully update poll by stripping away already set events */
-            new_p->state.poll_type = us_internal_poll_type(new_p);
-            us_poll_change(new_p, loop, events);
+        /* Hack: forcefully update poll by stripping away already set events */
+        new_p->state.poll_type = us_internal_poll_type(new_p);
+        us_poll_change(new_p, loop, events);
 #else
-            /* Forcefully update poll by resetting them with new_p as user data */
-            kqueue_change(loop->fd, new_p->state.fd, 0, LIBUS_SOCKET_WRITABLE | LIBUS_SOCKET_READABLE, new_p);
+        /* Forcefully update poll by resetting them with new_p as user data */
+        kqueue_change(loop->fd, new_p->state.fd, 0, LIBUS_SOCKET_WRITABLE | LIBUS_SOCKET_READABLE, new_p);
 #endif      /* This is needed for epoll also (us_change_poll doesn't update the old poll) */
-            us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
+        us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
     }
 
     return new_p;

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -380,20 +380,25 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
 
 struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, unsigned int ext_size) {
     int events = us_poll_events(p);
+    
 
     struct us_poll_t *new_p = us_realloc(p, sizeof(struct us_poll_t) + ext_size);
-    if (p != new_p && events) {
+    if (p != new_p) {
+        if (events) {
 #ifdef LIBUS_USE_EPOLL
-        /* Hack: forcefully update poll by stripping away already set events */
-        new_p->state.poll_type = us_internal_poll_type(new_p);
-        us_poll_change(new_p, loop, events);
+            /* Hack: forcefully update poll by stripping away already set events */
+            new_p->state.poll_type = us_internal_poll_type(new_p);
+            us_poll_change(new_p, loop, events);
 #else
-        /* Forcefully update poll by resetting them with new_p as user data */
-        kqueue_change(loop->fd, new_p->state.fd, 0, events, new_p);
-#endif
-
-        /* This is needed for epoll also (us_change_poll doesn't update the old poll) */
-        us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
+            /* Forcefully update poll by resetting them with new_p as user data */
+            kqueue_change(loop->fd, new_p->state.fd, 0, events, new_p);
+#endif      /* This is needed for epoll also (us_change_poll doesn't update the old poll) */
+            us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
+        } else {
+            /* If we dont have events just make sure that the poll is removed from pending ready polls */
+            us_internal_loop_update_pending_ready_polls(loop, p, 0, events, events);
+        }
+      
     }
 
     return new_p;

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -19,7 +19,6 @@
 #include "internal/internal.h"
 #include <stdlib.h>
 #include <time.h>
-
 #if defined(LIBUS_USE_EPOLL) || defined(LIBUS_USE_KQUEUE)
 
 void Bun__internal_dispatch_ready_poll(void* loop, void* poll);
@@ -338,7 +337,7 @@ void us_internal_loop_update_pending_ready_polls(struct us_loop_t *loop, struct 
 
             // if new events does not contain the ready events of this poll then remove (no we filter that out later on)
             SET_READY_POLL(loop, i, new_poll);
-
+            
             num_entries_possibly_remaining--;
         }
     }
@@ -447,7 +446,7 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
         kqueue_change(loop->fd, p->state.fd, old_events, events, p);
 #endif
         /* Set all removed events to null-polls in pending ready poll list */
-        //us_internal_loop_update_pending_ready_polls(loop, p, p, old_events, events);
+        // us_internal_loop_update_pending_ready_polls(loop, p, p, old_events, events);
     }
 }
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -336,6 +336,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
     case POLL_TYPE_SOCKET: {
             /* We should only use s, no p after this point */
             struct us_socket_t *s = (struct us_socket_t *) p;
+            /* The context can change after calling a callback but the loop is always the same */
             struct us_loop_t* loop = s->context->loop;
             if (events & LIBUS_SOCKET_WRITABLE && !error) {
                 /* Note: if we failed a write as a socket of one loop then adopted
@@ -480,7 +481,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 }
                 if(s->flags.allow_half_open) {
                     /* We got a Error but is EOF and we allow half open so stop polling for readable and keep going*/
-                    us_poll_change(&s->p, us_socket_context(0, s)->loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
+                    us_poll_change(&s->p, loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
                     s = s->context->on_end(s);
                 } else {
                     /* We dont allow half open just emit end and close the socket */


### PR DESCRIPTION
### What does this PR do?
Fixes `us_socket_context_adopt_socket` context memory management.
Fixes `kqueue` bug possible having an invalid ptr in a inflight event after a resize of the pool
Did some more cleanups
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Run websockets test with debug mode using macos + CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

