### PR TITLE
Update the AUTH_TOKEN for publishing to the correct environment variable.

### DIFF
--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -108,5 +108,5 @@ $ bun publish --otp 123456
 ```
 
 {% callout %}
-**Note** - `bun publish` respects the `NPM_CONFIG_TOKEN` environment variable which can be used when publishing in github actions or automated workflows.
+**Note** - `bun publish` respects the `BUN_AUTH_TOKEN` environment variable which can be used when publishing in github actions or automated workflows.
 {% /callout %}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

I ran into the issue of not being able to publishing after swapping from `yarn` to `bun` and I found the following issue (closed for reason)

https://github.com/oven-sh/bun/issues/14824#issuecomment-2888616557


Which gave me the hint, and since updating to `BUN_AUTH_TOKEN` I'm able to publish without problems.