### PR TITLE
remove yarn from default-trusted-dependencies.txt

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -359,7 +359,6 @@ wordpos
 workerd
 wrtc
 xxhash
-yarn
 yo
 yorkie
 zeromq


### PR DESCRIPTION
### What does this PR do?

Yarn has a postinstall script but its not needed when using bun. The script is about corepack stuff and ensuring its not conflicting, however the way it is checking means it should never be affected by `bun i -g yarn` or `bunx yarn`. As such bun is just slowing down trying to check for it.

https://app.unpkg.com/yarn@1.22.22/files/preinstall.js

As a sideresult this should make it work on windows, even though the actual fix for it is to make bun shell understand `:; (node ./preinstall.js > /dev/null 2>&1 || true)`

```js
bunx yarn@latest

  ⚙️  yarn [1/1] error: Failed to run script C:\Users\...\AppData\Local\Temp\bunx-3645674270-yarn@latest\node_modules\yarn\[eval] due to error expected a command or assignment but got: "Redirect"
```

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
