### PR TITLE
Implement gid & uid in Bun.spawn

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6963,6 +6963,40 @@ declare module "bun" {
        * @default undefined (no limit)
        */
       maxBuffer?: number;
+
+      /**
+       * The user ID to run the subprocess as (Linux only).
+       * 
+       * On macOS and Windows, this option is silently ignored.
+       * 
+       * @platform Linux
+       * @example
+       * ```ts
+       * // Run as user with UID 1000
+       * const subprocess = Bun.spawn({
+       *   cmd: ["id"],
+       *   uid: 1000,
+       * });
+       * ```
+       */
+      uid?: number;
+
+      /**
+       * The group ID to run the subprocess as (Linux only).
+       * 
+       * On macOS and Windows, this option is silently ignored.
+       * 
+       * @platform Linux
+       * @example
+       * ```ts
+       * // Run as group with GID 1000
+       * const subprocess = Bun.spawn({
+       *   cmd: ["id"],
+       *   gid: 1000,
+       * });
+       * ```
+       */
+      gid?: number;
     }
 
     type ReadableIO = ReadableStream<Uint8Array> | number | undefined;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6966,9 +6966,9 @@ declare module "bun" {
 
       /**
        * The user ID to run the subprocess as (Linux only).
-       * 
+       *
        * On macOS and Windows, this option is silently ignored.
-       * 
+       *
        * @platform Linux
        * @example
        * ```ts
@@ -6983,9 +6983,9 @@ declare module "bun" {
 
       /**
        * The group ID to run the subprocess as (Linux only).
-       * 
+       *
        * On macOS and Windows, this option is silently ignored.
-       * 
+       *
        * @platform Linux
        * @example
        * ```ts

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1234,7 +1234,7 @@ pub fn spawnProcessPosix(
 
     var attr = try PosixSpawn.Attr.init();
     defer attr.deinit();
-    
+
     // On Linux, set uid/gid in the attr struct
     if (comptime Environment.isLinux) {
         if (options.uid) |uid| {

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -971,6 +971,8 @@ pub const PosixSpawnOptions = struct {
     detached: bool = false,
     windows: void = {},
     argv0: ?[*:0]const u8 = null,
+    uid: ?std.posix.uid_t = null,
+    gid: ?std.posix.gid_t = null,
     stream: bool = true,
     sync: bool = false,
     can_block_entire_thread_to_reduce_cpu_usage_in_fast_path: bool = false,
@@ -1051,6 +1053,8 @@ pub const WindowsSpawnOptions = struct {
     detached: bool = false,
     windows: WindowsOptions = .{},
     argv0: ?[*:0]const u8 = null,
+    uid: void = {},
+    gid: void = {},
     stream: bool = true,
     use_execve_on_macos: bool = false,
     can_block_entire_thread_to_reduce_cpu_usage_in_fast_path: bool = false,
@@ -1230,6 +1234,16 @@ pub fn spawnProcessPosix(
 
     var attr = try PosixSpawn.Attr.init();
     defer attr.deinit();
+    
+    // On Linux, set uid/gid in the attr struct
+    if (comptime Environment.isLinux) {
+        if (options.uid) |uid| {
+            attr.uid = uid;
+        }
+        if (options.gid) |gid| {
+            attr.gid = gid;
+        }
+    }
 
     var flags: i32 = bun.c.POSIX_SPAWN_SETSIGDEF | bun.c.POSIX_SPAWN_SETSIGMASK;
 
@@ -1282,6 +1296,8 @@ pub fn spawnProcessPosix(
 
     attr.set(@intCast(flags)) catch {};
     attr.resetSignals() catch {};
+
+    // uid/gid is only supported on Linux, silently ignored on other platforms
 
     if (options.ipc) |ipc| {
         try actions.inherit(ipc);

--- a/test/js/bun/spawn/spawn-uid-gid.test.ts
+++ b/test/js/bun/spawn/spawn-uid-gid.test.ts
@@ -1,96 +1,96 @@
-import { test, expect, describe } from "bun:test";
-import { bunExe, bunEnv, isPosix, isLinux, isMacOS } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isMacOS } from "harness";
 
 // uid/gid support is Linux-only due to macOS security restrictions
 describe.if(isLinux)("Bun.spawn with uid and gid (Linux only)", () => {
-    // This test can only run as root, as only root can change user/group
-    test.if(process.getuid() === 0)("should spawn process with different uid and gid", async () => {
-        // 'nobody' user usually has a high UID, a safe non-root user.
-        // On macOS it's often -2 (65534), on Linux 65534.
-        const nobodyUser = await Bun.spawn({ cmd: ["id", "-u", "nobody"] });
-        const nobodyUid = parseInt(await new Response(nobodyUser.stdout).text());
-        
-        const nobodyGroup = await Bun.spawn({ cmd: ["id", "-g", "nobody"] });
-        const nobodyGid = parseInt(await new Response(nobodyGroup.stdout).text());
+  // This test can only run as root, as only root can change user/group
+  test.if(process.getuid() === 0)("should spawn process with different uid and gid", async () => {
+    // 'nobody' user usually has a high UID, a safe non-root user.
+    // On macOS it's often -2 (65534), on Linux 65534.
+    const nobodyUser = await Bun.spawn({ cmd: ["id", "-u", "nobody"] });
+    const nobodyUid = parseInt(await new Response(nobodyUser.stdout).text());
 
-        // Test with spawn (async)
-        const procUid = Bun.spawn({
-            cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
-            env: bunEnv,
-            uid: nobodyUid,
-        });
-        const uidOutput = await new Response(procUid.stdout).text();
-        expect(parseInt(uidOutput)).toBe(nobodyUid);
-        expect(await procUid.exited).toBe(0);
-        
-        const procGid = Bun.spawn({
-            cmd: [bunExe(), "-e", "console.write(String(process.getgid()))"],
-            env: bunEnv,
-            gid: nobodyGid,
-        });
-        const gidOutput = await new Response(procGid.stdout).text();
-        expect(parseInt(gidOutput)).toBe(nobodyGid);
-        expect(await procGid.exited).toBe(0);
-        
-        // Test with spawnSync
-        const { stdout: syncUidOut } = Bun.spawnSync({
-            cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
-            env: bunEnv,
-            uid: nobodyUid,
-        });
-        expect(parseInt(syncUidOut.toString())).toBe(nobodyUid);
-    });
+    const nobodyGroup = await Bun.spawn({ cmd: ["id", "-g", "nobody"] });
+    const nobodyGid = parseInt(await new Response(nobodyGroup.stdout).text());
 
-    test("should fail with EPERM when not running as root", async () => {
-        // Skip if running as root, as this test would pass.
-        if (process.getuid() === 0) {
-            return;
-        }
+    // Test with spawn (async)
+    const procUid = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
+      env: bunEnv,
+      uid: nobodyUid,
+    });
+    const uidOutput = await new Response(procUid.stdout).text();
+    expect(parseInt(uidOutput)).toBe(nobodyUid);
+    expect(await procUid.exited).toBe(0);
 
-        const targetUid = process.getuid() + 1; // Any other UID
-        
-        // Bun.spawn throws a system error on failure
-        expect(() => {
-            Bun.spawnSync({
-                cmd: ["echo", "hello"],
-                uid: targetUid,
-            });
-        }).toThrow("operation not permitted");
+    const procGid = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.write(String(process.getgid()))"],
+      env: bunEnv,
+      gid: nobodyGid,
     });
-    
-    test("should throw for invalid uid/gid arguments", () => {
-        expect(() => {
-            Bun.spawnSync({ cmd: ["echo", "hello"], uid: "not-a-number" });
-        }).toThrow("Invalid value for option \"uid\"");
-        
-        expect(() => {
-            Bun.spawnSync({ cmd: ["echo", "hello"], gid: -1 });
-        }).toThrow("Invalid value for option \"gid\"");
+    const gidOutput = await new Response(procGid.stdout).text();
+    expect(parseInt(gidOutput)).toBe(nobodyGid);
+    expect(await procGid.exited).toBe(0);
+
+    // Test with spawnSync
+    const { stdout: syncUidOut } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
+      env: bunEnv,
+      uid: nobodyUid,
     });
+    expect(parseInt(syncUidOut.toString())).toBe(nobodyUid);
+  });
+
+  test("should fail with EPERM when not running as root", async () => {
+    // Skip if running as root, as this test would pass.
+    if (process.getuid() === 0) {
+      return;
+    }
+
+    const targetUid = process.getuid() + 1; // Any other UID
+
+    // Bun.spawn throws a system error on failure
+    expect(() => {
+      Bun.spawnSync({
+        cmd: ["echo", "hello"],
+        uid: targetUid,
+      });
+    }).toThrow("operation not permitted");
+  });
+
+  test("should throw for invalid uid/gid arguments", () => {
+    expect(() => {
+      Bun.spawnSync({ cmd: ["echo", "hello"], uid: "not-a-number" });
+    }).toThrow('Invalid value for option "uid"');
+
+    expect(() => {
+      Bun.spawnSync({ cmd: ["echo", "hello"], gid: -1 });
+    }).toThrow('Invalid value for option "gid"');
+  });
 });
 
 // Test that uid/gid is silently ignored on macOS
 describe.if(isMacOS)("Bun.spawn with uid and gid (macOS)", () => {
-    test("should silently ignore uid/gid on macOS", async () => {
-        const currentUid = process.getuid();
-        const currentGid = process.getgid();
-        
-        // Test with spawn (async) - should ignore uid/gid and run as current user
-        const procUid = Bun.spawn({
-            cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
-            env: bunEnv,
-            uid: 9999, // Some arbitrary uid that would fail if actually used
-        });
-        const uidOutput = await new Response(procUid.stdout).text();
-        expect(parseInt(uidOutput)).toBe(currentUid);
-        expect(await procUid.exited).toBe(0);
-        
-        // Test with spawnSync - should ignore gid and run as current group
-        const { stdout: gidOut } = Bun.spawnSync({
-            cmd: [bunExe(), "-e", "console.write(String(process.getgid()))"],
-            env: bunEnv,
-            gid: 9999, // Some arbitrary gid that would fail if actually used
-        });
-        expect(parseInt(gidOut.toString())).toBe(currentGid);
+  test("should silently ignore uid/gid on macOS", async () => {
+    const currentUid = process.getuid();
+    const currentGid = process.getgid();
+
+    // Test with spawn (async) - should ignore uid/gid and run as current user
+    const procUid = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
+      env: bunEnv,
+      uid: 9999, // Some arbitrary uid that would fail if actually used
     });
+    const uidOutput = await new Response(procUid.stdout).text();
+    expect(parseInt(uidOutput)).toBe(currentUid);
+    expect(await procUid.exited).toBe(0);
+
+    // Test with spawnSync - should ignore gid and run as current group
+    const { stdout: gidOut } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.write(String(process.getgid()))"],
+      env: bunEnv,
+      gid: 9999, // Some arbitrary gid that would fail if actually used
+    });
+    expect(parseInt(gidOut.toString())).toBe(currentGid);
+  });
 });

--- a/test/js/bun/spawn/spawn-uid-gid.test.ts
+++ b/test/js/bun/spawn/spawn-uid-gid.test.ts
@@ -1,0 +1,96 @@
+import { test, expect, describe } from "bun:test";
+import { bunExe, bunEnv, isPosix, isLinux, isMacOS } from "harness";
+
+// uid/gid support is Linux-only due to macOS security restrictions
+describe.if(isLinux)("Bun.spawn with uid and gid (Linux only)", () => {
+    // This test can only run as root, as only root can change user/group
+    test.if(process.getuid() === 0)("should spawn process with different uid and gid", async () => {
+        // 'nobody' user usually has a high UID, a safe non-root user.
+        // On macOS it's often -2 (65534), on Linux 65534.
+        const nobodyUser = await Bun.spawn({ cmd: ["id", "-u", "nobody"] });
+        const nobodyUid = parseInt(await new Response(nobodyUser.stdout).text());
+        
+        const nobodyGroup = await Bun.spawn({ cmd: ["id", "-g", "nobody"] });
+        const nobodyGid = parseInt(await new Response(nobodyGroup.stdout).text());
+
+        // Test with spawn (async)
+        const procUid = Bun.spawn({
+            cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
+            env: bunEnv,
+            uid: nobodyUid,
+        });
+        const uidOutput = await new Response(procUid.stdout).text();
+        expect(parseInt(uidOutput)).toBe(nobodyUid);
+        expect(await procUid.exited).toBe(0);
+        
+        const procGid = Bun.spawn({
+            cmd: [bunExe(), "-e", "console.write(String(process.getgid()))"],
+            env: bunEnv,
+            gid: nobodyGid,
+        });
+        const gidOutput = await new Response(procGid.stdout).text();
+        expect(parseInt(gidOutput)).toBe(nobodyGid);
+        expect(await procGid.exited).toBe(0);
+        
+        // Test with spawnSync
+        const { stdout: syncUidOut } = Bun.spawnSync({
+            cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
+            env: bunEnv,
+            uid: nobodyUid,
+        });
+        expect(parseInt(syncUidOut.toString())).toBe(nobodyUid);
+    });
+
+    test("should fail with EPERM when not running as root", async () => {
+        // Skip if running as root, as this test would pass.
+        if (process.getuid() === 0) {
+            return;
+        }
+
+        const targetUid = process.getuid() + 1; // Any other UID
+        
+        // Bun.spawn throws a system error on failure
+        expect(() => {
+            Bun.spawnSync({
+                cmd: ["echo", "hello"],
+                uid: targetUid,
+            });
+        }).toThrow("operation not permitted");
+    });
+    
+    test("should throw for invalid uid/gid arguments", () => {
+        expect(() => {
+            Bun.spawnSync({ cmd: ["echo", "hello"], uid: "not-a-number" });
+        }).toThrow("Invalid value for option \"uid\"");
+        
+        expect(() => {
+            Bun.spawnSync({ cmd: ["echo", "hello"], gid: -1 });
+        }).toThrow("Invalid value for option \"gid\"");
+    });
+});
+
+// Test that uid/gid is silently ignored on macOS
+describe.if(isMacOS)("Bun.spawn with uid and gid (macOS)", () => {
+    test("should silently ignore uid/gid on macOS", async () => {
+        const currentUid = process.getuid();
+        const currentGid = process.getgid();
+        
+        // Test with spawn (async) - should ignore uid/gid and run as current user
+        const procUid = Bun.spawn({
+            cmd: [bunExe(), "-e", "console.write(String(process.getuid()))"],
+            env: bunEnv,
+            uid: 9999, // Some arbitrary uid that would fail if actually used
+        });
+        const uidOutput = await new Response(procUid.stdout).text();
+        expect(parseInt(uidOutput)).toBe(currentUid);
+        expect(await procUid.exited).toBe(0);
+        
+        // Test with spawnSync - should ignore gid and run as current group
+        const { stdout: gidOut } = Bun.spawnSync({
+            cmd: [bunExe(), "-e", "console.write(String(process.getgid()))"],
+            env: bunEnv,
+            gid: 9999, // Some arbitrary gid that would fail if actually used
+        });
+        expect(parseInt(gidOut.toString())).toBe(currentGid);
+    });
+});

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -275,18 +275,23 @@ describe("napi", () => {
         runOn("node", "test_napi_async_work_complete_null_check", []),
         runOn(bunExe(), "test_napi_async_work_complete_null_check", []),
       ]);
-      
+
       // Filter out debug logs and normalize
-      const cleanBunResult = bunResult
-        .replaceAll(/^\[\w+\].+$/gm, "")
-        .trim();
-      
+      const cleanBunResult = bunResult.replaceAll(/^\[\w+\].+$/gm, "").trim();
+
       // Both should contain these two lines, but order may vary
       const expectedLines = ["execute called!", "resolved to undefined"];
-      
-      const nodeLines = nodeResult.trim().split('\n').filter(line => line).sort();
-      const bunLines = cleanBunResult.split('\n').filter(line => line).sort();
-      
+
+      const nodeLines = nodeResult
+        .trim()
+        .split("\n")
+        .filter(line => line)
+        .sort();
+      const bunLines = cleanBunResult
+        .split("\n")
+        .filter(line => line)
+        .sort();
+
       expect(bunLines).toEqual(nodeLines);
       expect(bunLines).toEqual(expectedLines.sort());
     });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
