### PR TITLE
update to http docs

### DIFF
--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -38,7 +38,7 @@ Bun.serve({
     "/blog/hello": Response.redirect("/blog/hello/world"),
 
     // Serve a file by buffering it in memory
-    "/favicon.ico": new Response(await Bun.file("./favicon.ico").bytes(), {
+    "/favicon.ico": new Response(Bun.file("./favicon.ico"), {
       headers: {
         "Content-Type": "image/x-icon",
       },

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -166,7 +166,7 @@ Static route responses are cached for the lifetime of the server object. To relo
 
 ```ts
 const server = Bun.serve({
-  static: {
+  routes: {
     "/api/time": new Response(new Date().toISOString()),
   },
 
@@ -178,7 +178,7 @@ const server = Bun.serve({
 // Update the time every second.
 setInterval(() => {
   server.reload({
-    static: {
+    routes: {
       "/api/time": new Response(new Date().toISOString()),
     },
 

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -37,7 +37,7 @@ Bun.serve({
     // Redirect from /blog/hello to /blog/hello/world
     "/blog/hello": Response.redirect("/blog/hello/world"),
 
-    // Serve a file by buffering it in memory
+    // Serve files directly (Bun v1.2.16+)
     "/favicon.ico": new Response(Bun.file("./favicon.ico"), {
       headers: {
         "Content-Type": "image/x-icon",


### PR DESCRIPTION
### What does this PR do?

updated the http docs, by removing static: for routes: in the examples and removing the old buffering pattern for the new
direct file serving introduced in bun v.1.2.16