### PR TITLE
Fix assertions_only usage in fromJSHostCallGeneric

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -473,7 +473,7 @@ pub const AsyncModule = struct {
         var specifier = specifier_;
         var referrer = referrer_;
         var scope: JSC.CatchScope = undefined;
-        scope.init(globalThis, @src(), .enabled);
+        scope.init(globalThis, @src());
         defer {
             specifier.deref();
             referrer.deref();

--- a/src/bun.js/bindings/AnyPromise.zig
+++ b/src/bun.js/bindings/AnyPromise.zig
@@ -81,7 +81,7 @@ pub const AnyPromise = union(enum) {
         };
 
         var scope: JSC.CatchScope = undefined;
-        scope.init(globalObject, @src(), .enabled);
+        scope.init(globalObject, @src());
         defer scope.deinit();
         var ctx = Wrapper{ .args = args };
         JSC__AnyPromise__wrap(globalObject, this.asValue(), &ctx, @ptrCast(&Wrapper.call));

--- a/src/bun.js/bindings/CatchScope.zig
+++ b/src/bun.js/bindings/CatchScope.zig
@@ -51,7 +51,7 @@ pub fn init(
 ) void {
     const enabled = comptime switch (enable_condition) {
         .enabled => true,
-        .assertions_only => Environment.ci_assert,
+        .assertions_only => Environment.allow_assert,
     };
     if (comptime enabled) {
         CatchScope__construct(

--- a/src/bun.js/bindings/CatchScope.zig
+++ b/src/bun.js/bindings/CatchScope.zig
@@ -1,5 +1,6 @@
 //! Binding for JSC::CatchScope. This should be used rarely, only at translation boundaries between
-//! JSC's exception checking and Zig's. Make sure not to move it after creation. For instance:
+//! JSC's exception checking and Zig's. Make sure not to move it after creation. For instance, for
+//! a function which returns an empty JSValue for exceptions:
 //!
 //! ```zig
 //! // Declare a CatchScope surrounding the call that may throw an exception
@@ -42,9 +43,10 @@ pub fn init(
     global: *jsc.JSGlobalObject,
     src: std.builtin.SourceLocation,
     /// If not enabled, the scope does nothing (it never has an exception).
-    /// If you need to do something different when there is an exception, leave enabled.
-    /// If you are only using the scope to prove you handle exceptions correctly, you can pass
-    /// `Environment.allow_assert` as `enabled`.
+    /// If you need to use the CatchScope to check for exceptions, leave enabled.
+    /// If you are only using the scope to prove you handle exceptions correctly, because you have
+    /// a different way (like a return value) to check for exceptions, pass `.assertions_only` and
+    /// call `assertExceptionPresenceMatches`
     comptime enable_condition: Enable,
 ) void {
     const enabled = comptime switch (enable_condition) {

--- a/src/bun.js/bindings/CatchScopeBinding.cpp
+++ b/src/bun.js/bindings/CatchScopeBinding.cpp
@@ -53,5 +53,7 @@ extern "C" void CatchScope__destruct(void* ptr)
 extern "C" void CatchScope__assertNoException(void* ptr)
 {
     ASSERT((uintptr_t)ptr % alignof(CatchScope) == 0);
-    static_cast<CatchScope*>(ptr)->assertNoException();
+    // this function assumes it should assert in all build modes, anything else would be confusing.
+    // Zig should only call CatchScope__assertNoException if it wants the assertion.
+    static_cast<CatchScope*>(ptr)->releaseAssertNoException();
 }

--- a/src/bun.js/bindings/JSBigInt.zig
+++ b/src/bun.js/bindings/JSBigInt.zig
@@ -38,7 +38,7 @@ pub const JSBigInt = opaque {
     extern fn JSC__JSBigInt__toString(*JSBigInt, *JSGlobalObject) bun.String;
     pub fn toString(this: *JSBigInt, global: *JSGlobalObject) JSError!bun.String {
         var scope: jsc.CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const str = JSC__JSBigInt__toString(this, global);
         try scope.returnIfException();

--- a/src/bun.js/bindings/JSObject.zig
+++ b/src/bun.js/bindings/JSObject.zig
@@ -150,7 +150,7 @@ pub const JSObject = opaque {
         // with an exception:
         // https://github.com/oven-sh/WebKit/blob/397dafc9721b8f8046f9448abb6dbc14efe096d3/Source/JavaScriptCore/runtime/JSObjectInlines.h#L112
         var scope: JSC.CatchScope = undefined;
-        scope.init(globalThis, @src(), .enabled);
+        scope.init(globalThis, @src());
         defer scope.deinit();
         const value = JSC__JSObject__getIndex(this, globalThis, i);
         try scope.returnIfException();

--- a/src/bun.js/bindings/JSPromise.zig
+++ b/src/bun.js/bindings/JSPromise.zig
@@ -194,7 +194,7 @@ pub const JSPromise = opaque {
         };
 
         var scope: JSC.CatchScope = undefined;
-        scope.init(globalObject, @src(), .enabled);
+        scope.init(globalObject, @src());
         defer scope.deinit();
         var ctx = Wrapper{ .args = args };
         const promise = JSC__JSPromise__wrap(globalObject, &ctx, @ptrCast(&Wrapper.call));

--- a/src/bun.js/bindings/JSPropertyIterator.zig
+++ b/src/bun.js/bindings/JSPropertyIterator.zig
@@ -117,7 +117,7 @@ const JSPropertyIteratorImpl = opaque {
         only_non_index_properties: bool,
     ) bun.JSError!?*JSPropertyIteratorImpl {
         var scope: JSC.CatchScope = undefined;
-        scope.init(globalObject, @src(), .enabled);
+        scope.init(globalObject, @src());
         defer scope.deinit();
         const iter = Bun__JSPropertyIterator__create(globalObject, object.toJS(), count, own_properties_only, only_non_index_properties);
         try scope.returnIfException();
@@ -128,7 +128,7 @@ const JSPropertyIteratorImpl = opaque {
 
     pub fn getNameAndValue(iter: *JSPropertyIteratorImpl, globalObject: *JSC.JSGlobalObject, object: *JSC.JSObject, propertyName: *bun.String, i: usize) bun.JSError!JSC.JSValue {
         var scope: bun.jsc.CatchScope = undefined;
-        scope.init(globalObject, @src(), .enabled);
+        scope.init(globalObject, @src());
         defer scope.deinit();
         const value = Bun__JSPropertyIterator__getNameAndValue(iter, globalObject, object, propertyName, i);
         try scope.returnIfException();
@@ -137,7 +137,7 @@ const JSPropertyIteratorImpl = opaque {
 
     pub fn getNameAndValueNonObservable(iter: *JSPropertyIteratorImpl, globalObject: *JSC.JSGlobalObject, object: *JSC.JSObject, propertyName: *bun.String, i: usize) bun.JSError!JSC.JSValue {
         var scope: bun.jsc.CatchScope = undefined;
-        scope.init(globalObject, @src(), .enabled);
+        scope.init(globalObject, @src());
         defer scope.deinit();
         const value = Bun__JSPropertyIterator__getNameAndValueNonObservable(iter, globalObject, object, propertyName, i);
         try scope.returnIfException();

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -91,7 +91,7 @@ pub const JSValue = enum(i64) {
         callback: PropertyIteratorFn,
     ) JSError!void {
         var scope: CatchScope = undefined;
-        scope.init(globalThis, @src(), .enabled);
+        scope.init(globalThis, @src());
         defer scope.deinit();
         JSC__JSValue__forEachPropertyNonIndexed(this, globalThis, ctx, callback);
         try scope.returnIfException();
@@ -104,7 +104,7 @@ pub const JSValue = enum(i64) {
         callback: PropertyIteratorFn,
     ) JSError!void {
         var scope: CatchScope = undefined;
-        scope.init(globalThis, @src(), .enabled);
+        scope.init(globalThis, @src());
         defer scope.deinit();
         JSC__JSValue__forEachProperty(this, globalThis, ctx, callback);
         try scope.returnIfException();
@@ -117,7 +117,7 @@ pub const JSValue = enum(i64) {
         callback: PropertyIteratorFn,
     ) JSError!void {
         var scope: CatchScope = undefined;
-        scope.init(globalThis, @src(), .enabled);
+        scope.init(globalThis, @src());
         defer scope.deinit();
         JSC__JSValue__forEachPropertyOrdered(this, globalThis, ctx, callback);
         try scope.returnIfException();
@@ -130,7 +130,7 @@ pub const JSValue = enum(i64) {
     /// https://tc39.es/ecma262/#sec-tonumber
     pub fn toNumber(this: JSValue, global: *JSGlobalObject) bun.JSError!f64 {
         var scope: bun.jsc.CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = Bun__JSValue__toNumber(this, global);
         try scope.returnIfException();
@@ -790,7 +790,7 @@ pub const JSValue = enum(i64) {
     /// If the object is not an object, it will crash. **You must check if the object is an object before calling this function.**
     pub fn hasOwnPropertyValue(this: JSValue, global: *JSGlobalObject, key: JSValue) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__hasOwnPropertyValue(this, global, key);
         try scope.returnIfException();
@@ -1251,8 +1251,8 @@ pub const JSValue = enum(i64) {
     extern fn JSC__JSValue__toStringOrNull(this: JSValue, globalThis: *JSGlobalObject) ?*JSString;
     // Calls JSValue::toStringOrNull. Returns error on exception.
     pub fn toJSString(this: JSValue, globalThis: *JSGlobalObject) bun.JSError!*JSString {
-        var scope: CatchScope = undefined;
-        scope.init(globalThis, @src(), .assertions_only);
+        var scope: ExceptionValidationScope = undefined;
+        scope.init(globalThis, @src());
         defer scope.deinit();
         const maybe_string = JSC__JSValue__toStringOrNull(this, globalThis);
         scope.assertExceptionPresenceMatches(maybe_string == null);
@@ -1429,7 +1429,7 @@ pub const JSValue = enum(i64) {
     extern fn JSC__JSValue__getIfPropertyExistsFromPath(this: JSValue, global: *JSGlobalObject, path: JSValue) JSValue;
     pub fn getIfPropertyExistsFromPath(this: JSValue, global: *JSGlobalObject, path: JSValue) JSError!JSValue {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__getIfPropertyExistsFromPath(this, global, path);
         try scope.returnIfException();
@@ -1458,7 +1458,7 @@ pub const JSValue = enum(i64) {
 
     pub fn _then2(this: JSValue, global: *JSGlobalObject, ctx: JSValue, resolve: *const JSC.JSHostFn, reject: *const JSC.JSHostFn) void {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         JSC__JSValue___then(this, global, ctx, resolve, reject);
         bun.debugAssert(!scope.hasException()); // TODO: properly propagate exception upwards
@@ -1466,7 +1466,7 @@ pub const JSValue = enum(i64) {
 
     pub fn then(this: JSValue, global: *JSGlobalObject, ctx: ?*anyopaque, resolve: JSC.JSHostFnZig, reject: JSC.JSHostFnZig) void {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         this._then(global, JSValue.fromPtrAddress(@intFromPtr(ctx)), resolve, reject);
         bun.debugAssert(!scope.hasException()); // TODO: properly propagate exception upwards
@@ -1545,7 +1545,7 @@ pub const JSValue = enum(i64) {
     pub fn getOwn(this: JSValue, global: *JSGlobalObject, property_name: anytype) bun.JSError!?JSValue {
         var property_name_str = bun.String.init(property_name);
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const value = JSC__JSValue__getOwn(this, global, &property_name_str);
         try scope.returnIfException();
@@ -1648,7 +1648,7 @@ pub const JSValue = enum(i64) {
     /// - an empty string
     pub fn getStringish(this: JSValue, global: *JSGlobalObject, property: []const u8) bun.JSError!?bun.String {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const prop = try get(this, global, property) orelse return null;
         if (prop.isNull() or prop == .false) {
@@ -1910,7 +1910,7 @@ pub const JSValue = enum(i64) {
     pub fn isSameValue(this: JSValue, other: JSValue, global: *JSGlobalObject) JSError!bool {
         if (@intFromEnum(this) == @intFromEnum(other)) return true;
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const same = JSC__JSValue__isSameValue(this, other, global);
         try scope.returnIfException();
@@ -1920,7 +1920,7 @@ pub const JSValue = enum(i64) {
     extern fn JSC__JSValue__deepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) bool;
     pub fn deepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__deepEquals(this, other, global);
         try scope.returnIfException();
@@ -1930,7 +1930,7 @@ pub const JSValue = enum(i64) {
     /// same as `JSValue.deepEquals`, but with jest asymmetric matchers enabled
     pub fn jestDeepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__jestDeepEquals(this, other, global);
         try scope.returnIfException();
@@ -1940,7 +1940,7 @@ pub const JSValue = enum(i64) {
     extern fn JSC__JSValue__strictDeepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) bool;
     pub fn strictDeepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__strictDeepEquals(this, other, global);
         try scope.returnIfException();
@@ -1950,7 +1950,7 @@ pub const JSValue = enum(i64) {
     /// same as `JSValue.strictDeepEquals`, but with jest asymmetric matchers enabled
     pub fn jestStrictDeepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__jestStrictDeepEquals(this, other, global);
         try scope.returnIfException();
@@ -1960,7 +1960,7 @@ pub const JSValue = enum(i64) {
     /// same as `JSValue.deepMatch`, but with jest asymmetric matchers enabled
     pub fn jestDeepMatch(this: JSValue, subset: JSValue, global: *JSGlobalObject, replace_props_with_asymmetric_matchers: bool) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(global, @src(), .enabled);
+        scope.init(global, @src());
         defer scope.deinit();
         const result = JSC__JSValue__jestDeepMatch(this, subset, global, replace_props_with_asymmetric_matchers);
         try scope.returnIfException();
@@ -2181,7 +2181,7 @@ pub const JSValue = enum(i64) {
     /// TODO this should probably just return an optional
     pub fn getLengthIfPropertyExistsInternal(this: JSValue, globalThis: *JSGlobalObject) JSError!f64 {
         var scope: CatchScope = undefined;
-        scope.init(globalThis, @src(), .enabled);
+        scope.init(globalThis, @src());
         defer scope.deinit();
         const length = JSC__JSValue__getLengthIfPropertyExistsInternal(this, globalThis);
         try scope.returnIfException();
@@ -2217,7 +2217,7 @@ pub const JSValue = enum(i64) {
     extern fn JSC__JSValue__isIterable(this: JSValue, globalObject: *JSGlobalObject) bool;
     pub fn isIterable(this: JSValue, globalObject: *JSGlobalObject) JSError!bool {
         var scope: CatchScope = undefined;
-        scope.init(globalObject, @src(), .enabled);
+        scope.init(globalObject, @src());
         defer scope.deinit();
         const is_iterable = JSC__JSValue__isIterable(this, globalObject);
         try scope.returnIfException();
@@ -2487,6 +2487,7 @@ const JSArrayIterator = JSC.JSArrayIterator;
 const JSCell = JSC.JSCell;
 const fromJSHostCall = JSC.fromJSHostCall;
 const CatchScope = JSC.CatchScope;
+const ExceptionValidationScope = JSC.ExceptionValidationScope;
 
 const AnyPromise = JSC.AnyPromise;
 const DOMURL = JSC.DOMURL;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -110,7 +110,7 @@ extern fn JSC__JSGlobalObject__drainMicrotasks(*JSC.JSGlobalObject) void;
 pub fn drainMicrotasksWithGlobal(this: *EventLoop, globalObject: *JSC.JSGlobalObject, jsc_vm: *JSC.VM) bun.JSExecutionTerminated!void {
     JSC.markBinding(@src());
     var scope: JSC.CatchScope = undefined;
-    scope.init(globalObject, @src(), .enabled);
+    scope.init(globalObject, @src());
     defer scope.deinit();
 
     jsc_vm.releaseWeakRefs();
@@ -449,7 +449,7 @@ pub fn processGCTimer(this: *EventLoop) void {
 pub fn tick(this: *EventLoop) void {
     JSC.markBinding(@src());
     var scope: JSC.CatchScope = undefined;
-    scope.init(this.global, @src(), .enabled);
+    scope.init(this.global, @src());
     defer scope.deinit();
     this.entered_event_loop_count += 1;
     this.debug.enter();

--- a/src/bun.js/event_loop/JSCScheduler.zig
+++ b/src/bun.js/event_loop/JSCScheduler.zig
@@ -4,8 +4,8 @@ pub const JSCDeferredWorkTask = opaque {
     extern fn Bun__runDeferredWork(task: *JSCScheduler.JSCDeferredWorkTask) void;
     pub fn run(task: *JSCScheduler.JSCDeferredWorkTask) void {
         const globalThis = bun.jsc.VirtualMachine.get().global;
-        var scope: bun.jsc.CatchScope = undefined;
-        scope.init(globalThis, @src(), .assertions_only);
+        var scope: bun.jsc.ExceptionValidationScope = undefined;
+        scope.init(globalThis, @src());
         defer scope.deinit();
         Bun__runDeferredWork(task);
         scope.assertNoExceptionExceptTermination() catch return;

--- a/src/bun.js/jsc.zig
+++ b/src/bun.js/jsc.zig
@@ -80,7 +80,8 @@ pub const Weak = @import("Weak.zig").Weak;
 pub const WeakRefType = @import("Weak.zig").WeakRefType;
 pub const Exception = @import("bindings/Exception.zig").Exception;
 pub const SourceProvider = @import("bindings/SourceProvider.zig").SourceProvider;
-pub const CatchScope = @import("bindings/CatchScope.zig");
+pub const CatchScope = @import("bindings/CatchScope.zig").CatchScope;
+pub const ExceptionValidationScope = @import("bindings/CatchScope.zig").ExceptionValidationScope;
 
 // JavaScript-related
 pub const Errorable = @import("bindings/Errorable.zig").Errorable;

--- a/src/bun.js/jsc/host_fn.zig
+++ b/src/bun.js/jsc/host_fn.zig
@@ -136,6 +136,16 @@ pub fn fromJSHostCallGeneric(
     defer scope.deinit();
 
     const result = @call(.auto, function, args);
+    // supporting JSValue would make it too easy to mix up this function with fromJSHostCall
+    // fromJSHostCall has the benefit of checking that the function is correctly returning an empty
+    // value if and only if it has thrown.
+    // fromJSHostCallGeneric is only for functions where the return value tells you nothing about
+    // whether an exception was thrown.
+    //
+    // alternatively, we could consider something like `comptime exception_sentinel: ?T`
+    // to generically support using a value of any type to signal exceptions (INT_MAX, infinity,
+    // nullptr...?) but it's unclear how often that would be useful
+    if (@TypeOf(result) == JSValue) @compileError("fromJSHostCallGeneric does not support JSValue");
     try scope.returnIfException();
     return result;
 }

--- a/src/bun.js/jsc/host_fn.zig
+++ b/src/bun.js/jsc/host_fn.zig
@@ -129,7 +129,7 @@ pub fn fromJSHostCallGeneric(
     args: std.meta.ArgsTuple(@TypeOf(function)),
 ) bun.JSError!@typeInfo(@TypeOf(function)).@"fn".return_type.? {
     var scope: jsc.CatchScope = undefined;
-    scope.init(globalThis, src, .assertions_only);
+    scope.init(globalThis, src, .enabled);
     defer scope.deinit();
 
     const result = @call(.auto, function, args);

--- a/src/bun.js/jsc/host_fn.zig
+++ b/src/bun.js/jsc/host_fn.zig
@@ -105,6 +105,9 @@ pub fn toJSHostCall(
 
 /// Convert the return value of a function returning a maybe-empty JSValue into an error union.
 /// The wrapped function must return an empty JSValue if and only if it has thrown an exception.
+/// If your function does not follow this pattern (if it can return empty without an exception, or
+/// throw an exception and return non-empty), either fix the function or write a custom wrapper with
+/// CatchScope.
 pub fn fromJSHostCall(
     globalThis: *JSGlobalObject,
     /// For attributing thrown exceptions

--- a/src/bun.js/jsc/host_fn.zig
+++ b/src/bun.js/jsc/host_fn.zig
@@ -90,8 +90,8 @@ pub fn toJSHostCall(
     // runtime tuple values
     args: anytype,
 ) JSValue {
-    var scope: jsc.CatchScope = undefined;
-    scope.init(globalThis, src, .assertions_only);
+    var scope: jsc.ExceptionValidationScope = undefined;
+    scope.init(globalThis, src);
     defer scope.deinit();
 
     const returned: error{ OutOfMemory, JSError }!JSValue = @call(.auto, function, args);
@@ -115,8 +115,8 @@ pub fn fromJSHostCall(
     comptime function: anytype,
     args: std.meta.ArgsTuple(@TypeOf(function)),
 ) bun.JSError!JSValue {
-    var scope: jsc.CatchScope = undefined;
-    scope.init(globalThis, src, .assertions_only);
+    var scope: jsc.ExceptionValidationScope = undefined;
+    scope.init(globalThis, src);
     defer scope.deinit();
 
     const value = @call(.auto, function, args);
@@ -132,7 +132,7 @@ pub fn fromJSHostCallGeneric(
     args: std.meta.ArgsTuple(@TypeOf(function)),
 ) bun.JSError!@typeInfo(@TypeOf(function)).@"fn".return_type.? {
     var scope: jsc.CatchScope = undefined;
-    scope.init(globalThis, src, .enabled);
+    scope.init(globalThis, src);
     defer scope.deinit();
 
     const result = @call(.auto, function, args);

--- a/src/string.zig
+++ b/src/string.zig
@@ -514,15 +514,15 @@ pub const String = extern struct {
     }
 
     pub fn fromJS(value: bun.JSC.JSValue, globalObject: *JSC.JSGlobalObject) bun.JSError!String {
-        var scope: JSC.CatchScope = undefined;
-        scope.init(globalObject, @src(), .assertions_only);
+        var scope: JSC.ExceptionValidationScope = undefined;
+        scope.init(globalObject, @src());
         defer scope.deinit();
         var out: String = String.dead;
         const ok = BunString__fromJS(globalObject, value, &out);
 
         // If there is a pending exception, but stringifying succeeds, we don't return JSError.
         // We do need to always call hasException() to satisfy the need for an exception check.
-        const has_exception = scope.hasException();
+        const has_exception = scope.hasExceptionOrFalseWhenAssertionsAreDisabled();
         if (ok) {
             bun.debugAssert(out.tag != .Dead);
         } else {


### PR DESCRIPTION
### What does this PR do?

Followup #20497 and #20655.

- [x] Makes sure this catch scope is always enabled so we don't fail to return `JSError`. I checked every use of `assertions_only` and this seemed to be the only wrong one.
- [x] Elaborated on some doc comments
- [x] Made `fromJSHostCallGeneric` not accept `JSValue` since that seems like a footgun
- [x] ~~Made `assertions_only` use `allow_assert` instead of `ci_assert`. With `ci_assert`, we have the risk that if you mistakenly used `assertions_only` instead of `enabled`, the catch scope will be enabled in Windows CI but disabled in the actual Windows release, so in CI it will seem as though the catch scope is checking exceptions correctly but in the binary we actually ship for Windows it will pretend there is never an exception.~~ the risk of that error is instead mitigated by having different types
- [x] Make `CatchScope` two different types, with the assertions_only one only having assertion methods, so you basically can't mess this up
- [x] Ensure the C++ binding `CatchScope__assertNoException` always asserts, fixing #20615

### How did you verify your code works?

CI