### PR TITLE
Imply `--coverage` when `--coverage-reporter` is used

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -405,6 +405,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         }
 
         if (args.options("--coverage-reporter").len > 0) {
+            // Enable coverage when --coverage-reporter is specified
+            ctx.test_options.coverage.enabled = true;
             ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false };
             for (args.options("--coverage-reporter")) |reporter| {
                 if (bun.strings.eqlComptime(reporter, "text")) {

--- a/test-coverage/simple.test.ts
+++ b/test-coverage/simple.test.ts
@@ -1,0 +1,1 @@
+import { test, expect } from "bun:test"; function add(a, b) { return a + b; } test("add", () => { expect(add(1, 2)).toBe(3); });

--- a/test-coverage/simple.test.ts
+++ b/test-coverage/simple.test.ts
@@ -1,1 +1,0 @@
-import { test, expect } from "bun:test"; function add(a, b) { return a + b; } test("add", () => { expect(add(1, 2)).toBe(3); });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -99,7 +99,7 @@ test("add", () => {
 add(5, 10);
     `,
   });
-  
+
   // Use --coverage-reporter without --coverage
   const result = Bun.spawnSync([bunExe(), "test", "--coverage-reporter", "text"], {
     cwd: dir,
@@ -108,15 +108,15 @@ add(5, 10);
     },
     stdio: [null, null, "pipe"],
   });
-  
+
   const stderr = result.stderr.toString("utf-8");
-  
+
   // Check that coverage reporting actually happened
   expect(stderr).toContain("File");
   expect(stderr).toContain("% Funcs");
   expect(stderr).toContain("% Lines");
   expect(stderr).toContain("demo.test.ts");
-  
+
   expect(result.exitCode).toBe(0);
   expect(result.signalCode).toBeUndefined();
 });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -77,3 +77,46 @@ test("coverage excludes node_modules directory", () => {
   expect(result.exitCode).toBe(0);
   expect(result.signalCode).toBeUndefined();
 });
+
+test("--coverage-reporter enables coverage", () => {
+  const dir = tempDirWithFiles("cov", {
+    "demo.test.ts": `
+import { test, expect } from "bun:test";
+
+export function add(a, b) {
+  return a + b;
+}
+
+export function multiply(a, b) {
+  return a * b;
+}
+
+test("add", () => {
+  expect(add(1, 2)).toBe(3);
+});
+
+// Call add but not multiply to have partial coverage
+add(5, 10);
+    `,
+  });
+  
+  // Use --coverage-reporter without --coverage
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage-reporter", "text"], {
+    cwd: dir,
+    env: {
+      ...bunEnv,
+    },
+    stdio: [null, null, "pipe"],
+  });
+  
+  const stderr = result.stderr.toString("utf-8");
+  
+  // Check that coverage reporting actually happened
+  expect(stderr).toContain("File");
+  expect(stderr).toContain("% Funcs");
+  expect(stderr).toContain("% Lines");
+  expect(stderr).toContain("demo.test.ts");
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+});


### PR DESCRIPTION

This PR automatically enables `--coverage` when the `--coverage-reporter` flag is used. This simplifies the command for users, as they no longer need to explicitly specify both `--coverage` and `--coverage-reporter` to generate coverage reports.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works%3F

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun-debug test test/cli/test/coverage.test.ts`)