### PR TITLE
fix(grpc/http2) fix tonic Rust support

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -700,13 +700,13 @@ pub const H2FrameParser = struct {
     // local Window limits the download of data
 
     // current window size for the connection
-    windowSize: u64 = 65535,
+    windowSize: u64 = DEFAULT_WINDOW_SIZE,
     // used window size for the connection
     usedWindowSize: u64 = 0,
 
     // remote Window limits the upload of data
     // remote window size for the connection
-    remoteWindowSize: u64 = 65535,
+    remoteWindowSize: u64 = DEFAULT_WINDOW_SIZE,
     // remote used window size for the connection
     remoteUsedWindowSize: u64 = 0,
 
@@ -4423,8 +4423,6 @@ pub const H2FrameParser = struct {
         this.strong_ctx.set(globalObject, context_obj);
 
         this.hpack = lshpack.HPACK.init(this.localSettings.headerTableSize);
-        this.windowSize = this.localSettings.initialWindowSize;
-        log("windowSize: {d} isServer: {}", .{ this.windowSize, is_server });
         if (is_server) {
             _ = this.setSettings(this.localSettings);
         } else {

--- a/test/bun.lock
+++ b/test/bun.lock
@@ -84,6 +84,7 @@
         "typeorm": "0.3.20",
         "typescript": "5.0.2",
         "undici": "5.20.0",
+        "unzipper": "^0.12.3",
         "v8-heapsnapshot": "1.3.1",
         "verdaccio": "6.0.0",
         "vitest": "0.32.2",
@@ -952,6 +953,8 @@
 
     "bl": ["bl@5.1.0", "", { "dependencies": { "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ=="],
 
+    "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
+
     "blueimp-md5": ["blueimp-md5@2.19.0", "", {}, "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="],
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
@@ -1187,6 +1190,8 @@
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "duckdb": ["duckdb@1.3.1", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "node-addon-api": "^7.0.0", "node-gyp": "^9.3.0" } }, "sha512-wSCxu6zSkHkGHtLrI5MmHYUOpbi08s2eIY/QCg2f1YsSyohjA3MRnUMdDb88oqgLa7/h+/wHuIe1RXRu4k04Sw=="],
+
+    "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
     "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
 
@@ -1886,6 +1891,8 @@
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.0.7", "", { "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w=="],
 
+    "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
+
     "node-mock-http": ["node-mock-http@1.0.0", "", {}, "sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ=="],
 
     "node-releases": ["node-releases@2.0.14", "", {}, "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="],
@@ -2518,6 +2525,8 @@
 
     "unstorage": ["unstorage@1.15.0", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^4.0.3", "destr": "^2.0.3", "h3": "^1.15.0", "lru-cache": "^10.4.3", "node-fetch-native": "^1.6.6", "ofetch": "^1.4.1", "ufo": "^1.5.4" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6.0.3", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-m40eHdGY/gA6xAPqo8eaxqXgBuzQTlAKfmB1iF7oCKXE1HfwHwzDJBywK+qQGn52dta+bPlZluPF7++yR3p/bg=="],
 
+    "unzipper": ["unzipper@0.12.3", "", { "dependencies": { "bluebird": "~3.7.2", "duplexer2": "~0.1.4", "fs-extra": "^11.2.0", "graceful-fs": "^4.2.2", "node-int64": "^0.4.0" } }, "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.0.16", "", { "dependencies": { "escalade": "^3.1.2", "picocolors": "^1.0.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -2927,6 +2936,8 @@
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "duckdb/node-gyp": ["node-gyp@9.4.1", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^7.1.4", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.0.3", "nopt": "^6.0.0", "npmlog": "^6.0.0", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.2", "which": "^2.0.2" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ=="],
+
+    "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -3465,6 +3476,12 @@
     "duckdb/node-gyp/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 
     "duckdb/node-gyp/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "duplexer2/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "duplexer2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "duplexer2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "engine.io-client/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/Cargo.toml
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/Cargo.toml
@@ -8,7 +8,5 @@ tonic = { version = "0.13.1", features = ["transport", "prost"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.11"
 prost = "0.13"
-
 [build-dependencies]
 tonic-build = "0.13.1"
-protoc-rust = "2"

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/Cargo.toml
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/Cargo.toml
@@ -11,3 +11,4 @@ prost = "0.13"
 
 [build-dependencies]
 tonic-build = "0.13.1"
+protoc-rust = "2"

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/Cargo.toml
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tonic = { version = "0.13.1", features = ["transport", "prost"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio-stream = "0.1.11"
+prost = "0.13"
+
+[build-dependencies]
+tonic-build = "0.13.1"

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/build.rs
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    tonic_build::compile_protos("proto/helloworld.proto")
+        .unwrap();
+}

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/build.rs
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/build.rs
@@ -1,4 +1,3 @@
 fn main() {
-    tonic_build::compile_protos("proto/helloworld.proto")
-        .unwrap();
+    tonic_build::compile_protos("proto/helloworld.proto").unwrap();
 }

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/proto/helloworld.proto
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/proto/helloworld.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package helloworld;
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/test/js/third_party/grpc-js/fixtures/tonic-server/src/main.rs
+++ b/test/js/third_party/grpc-js/fixtures/tonic-server/src/main.rs
@@ -1,0 +1,40 @@
+use tonic::{transport::Server, Request, Response, Status};
+use helloworld::greeter_server::{Greeter, GreeterServer};
+use helloworld::{HelloRequest, HelloReply};
+use tokio::net::TcpListener;
+
+pub mod helloworld {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        let reply = HelloReply {
+            message:  request.into_inner().name,
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let greeter = MyGreeter::default();
+    let mut server: Server = Server::builder();
+    println!("Listening on {}", addr);
+    server.add_service(GreeterServer::new(greeter))
+    .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+    .await?;
+    
+    
+    Ok(())
+}

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -1,7 +1,8 @@
 import grpc from "@grpc/grpc-js";
 import protoLoader from "@grpc/proto-loader";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { chmod, cp, mkdir, rm } from "fs/promises";
+import { rmSync } from "fs";
+import { chmod, cp, mkdir } from "fs/promises";
 import { tmpdirSync } from "harness";
 import path, { join } from "path";
 import unzipper from "unzipper";
@@ -74,7 +75,7 @@ async function startServer(): Promise<Server> {
           address: address?.trim(),
           kill: async () => {
             server.kill();
-            await rm(tmpDir, { recursive: true, force: true });
+            rmSync(tmpDir, { recursive: true, force: true });
           },
         });
         break;
@@ -95,8 +96,10 @@ describe.skipIf(!cargoBin || !releases[release])("test tonic server", () => {
     server = await startServer();
   });
 
-  afterAll(async () => {
-    await server.kill();
+  afterAll(() => {
+    try {
+      server.kill();
+    } catch {}
   });
 
   test("flow control should work in both directions", async () => {

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -1,7 +1,7 @@
 import grpc from "@grpc/grpc-js";
 import protoLoader from "@grpc/proto-loader";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { cp, rm, mkdir, chmod } from "fs/promises";
+import { chmod, cp, mkdir, rm } from "fs/promises";
 import { tmpdirSync } from "harness";
 import path from "path";
 import unzipper from "unzipper";

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -3,14 +3,14 @@ import protoLoader from "@grpc/proto-loader";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { chmod, cp, mkdir, rm } from "fs/promises";
 import { tmpdirSync } from "harness";
-import path from "path";
+import path, { join } from "path";
 import unzipper from "unzipper";
 
 const protoVersion = "31.0";
 
 const releases = {
   "win32_x86_32": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win32.zip`,
-  "win32_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win32.zip`,
+  "win32_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-win64.zip`,
   "linux_x86_32": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-linux-x86_32.zip`,
   "linux_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-linux-x86_64.zip`,
   "darwin_x86_64": `https://github.com/protocolbuffers/protobuf/releases/download/v${protoVersion}/protoc-${protoVersion}-osx-x86_64.zip`,
@@ -20,37 +20,38 @@ const releases = {
 const platform = process.platform;
 const arch = process.arch === "arm64" ? "arm64" : process.arch === "x64" ? "x86_64" : "x86_32";
 const release = platform + "_" + arch;
+const binPath = join("bin", platform === "win32" ? "protoc.exe" : "protoc");
 
 // Load proto
-const packageDefinition = protoLoader.loadSync(
-  path.join(import.meta.dir, "fixtures/tonic-server/proto/helloworld.proto"),
-  {
-    keepCase: true,
-    longs: String,
-    enums: String,
-    defaults: true,
-    oneofs: true,
-  },
-);
+const packageDefinition = protoLoader.loadSync(join(import.meta.dir, "fixtures/tonic-server/proto/helloworld.proto"), {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
 
 type Server = { address: string; kill: () => void };
 
 const cargoBin = Bun.which("cargo") as string;
 async function startServer(): Promise<Server> {
   const tmpDir = tmpdirSync();
-  await cp(path.join(import.meta.dir, "fixtures/tonic-server"), tmpDir, { recursive: true });
+  await cp(join(import.meta.dir, "fixtures/tonic-server"), tmpDir, { recursive: true });
   const protocZip = await unzipper.Open.buffer(await fetch(releases[release]).then(res => res.bytes()));
 
-  const protocPath = path.join(tmpDir, "protoc");
+  const protocPath = join(tmpDir, "protoc");
   await mkdir(protocPath, { recursive: true });
   await protocZip.extract({ path: protocPath });
-  await chmod(path.join(protocPath, "bin/protoc"), 0o755);
+  const protocExec = join(protocPath, binPath);
+  await chmod(protocExec, 0o755);
 
   const server = Bun.spawn([cargoBin, "run", "--quiet", path.join(tmpDir, "server")], {
     cwd: tmpDir,
     env: {
-      PROTOC: path.join(protocPath, "bin/protoc"),
+      PROTOC: protocExec,
       PATH: process.env.PATH,
+      CARGO_HOME: process.env.CARGO_HOME,
+      RUSTUP_HOME: process.env.RUSTUP_HOME,
     },
     stdout: "pipe",
     stdin: "ignore",
@@ -87,7 +88,7 @@ async function startServer(): Promise<Server> {
   }
 }
 
-describe.skipIf(!cargoBin)("test tonic server", () => {
+describe.skipIf(!cargoBin && !releases[release])("test tonic server", () => {
   let server: Server;
 
   beforeAll(async () => {

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -1,9 +1,9 @@
 import grpc from "@grpc/grpc-js";
 import protoLoader from "@grpc/proto-loader";
-import path from "path";
-import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { tmpdirSync } from "harness";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { cpSync, rmSync } from "fs";
+import { tmpdirSync } from "harness";
+import path from "path";
 // Load proto
 const packageDefinition = protoLoader.loadSync(
   path.join(import.meta.dir, "fixtures/tonic-server/proto/helloworld.proto"),

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -108,7 +108,7 @@ describe.skipIf(!cargoBin || !releases[release])("test tonic server", () => {
     // Create client
     const client = new hello_proto.Greeter(server.address, grpc.credentials.createInsecure());
     const payload = Buffer.alloc(1024 * 1024, "bun").toString();
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 20; i++) {
       const { promise, reject, resolve } = Promise.withResolvers<string>();
       // Call SayHello
       client.SayHello({ name: payload }, (err, response) => {
@@ -119,5 +119,6 @@ describe.skipIf(!cargoBin || !releases[release])("test tonic server", () => {
       expect(result.length).toBe(payload.length);
       expect(result).toBe(payload);
     }
-  });
+    await client.close();
+  }, 20_000); // debug can take some time
 });

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -88,7 +88,7 @@ async function startServer(): Promise<Server> {
   }
 }
 
-describe.skipIf(!cargoBin && !releases[release])("test tonic server", () => {
+describe.skipIf(!cargoBin || !releases[release])("test tonic server", () => {
   let server: Server;
 
   beforeAll(async () => {

--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -1,0 +1,91 @@
+import grpc from "@grpc/grpc-js";
+import protoLoader from "@grpc/proto-loader";
+import path from "path";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { tmpdirSync } from "harness";
+import { cpSync, rmSync } from "fs";
+// Load proto
+const packageDefinition = protoLoader.loadSync(
+  path.join(import.meta.dir, "fixtures/tonic-server/proto/helloworld.proto"),
+  {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  },
+);
+
+type Server = { address: string; kill: () => void };
+
+const cargoBin = Bun.which("cargo") as string;
+async function startServer(): Promise<Server> {
+  const tmpDir = tmpdirSync();
+  cpSync(path.join(import.meta.dir, "fixtures/tonic-server"), tmpDir, { recursive: true });
+  const server = Bun.spawn([cargoBin, "run", "--quiet", path.join(tmpDir, "server")], {
+    cwd: tmpDir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "inherit",
+  });
+
+  {
+    const { promise, reject, resolve } = Promise.withResolvers<Server>();
+    const reader = server.stdout.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      const text = decoder.decode(value);
+      if (text.includes("Listening on")) {
+        const [_, address] = text.split("Listening on ");
+        resolve({
+          address: address?.trim(),
+          kill() {
+            server.kill();
+            rmSync(tmpDir, { recursive: true, force: true });
+          },
+        });
+        break;
+      } else {
+        server.kill();
+        reject(new Error("Server not started"));
+        break;
+      }
+    }
+    return await promise;
+  }
+}
+
+describe.skipIf(!cargoBin)("test tonic server", () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    server = await startServer();
+  });
+
+  afterAll(() => {
+    server.kill();
+  });
+
+  test("flow control should work in both directions", async () => {
+    const hello_proto = grpc.loadPackageDefinition(packageDefinition).helloworld;
+
+    // Create client
+    const client = new hello_proto.Greeter(server.address, grpc.credentials.createInsecure());
+    const payload = Buffer.alloc(1024 * 1024, "bun").toString();
+    for (let i = 0; i < 100; i++) {
+      const { promise, reject, resolve } = Promise.withResolvers<string>();
+      // Call SayHello
+      client.SayHello({ name: payload }, (err, response) => {
+        if (err) reject(err);
+        else resolve(response.message);
+      });
+      const result = await promise;
+      expect(result.length).toBe(payload.length);
+      expect(result).toBe(payload);
+    }
+  });
+});

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -2051,6 +2051,7 @@ test/js/third_party/grpc-js/test-server-interceptors.test.ts
 test/js/third_party/grpc-js/test-server.test.ts
 test/js/third_party/grpc-js/test-status-builder.test.ts
 test/js/third_party/grpc-js/test-uri-parser.test.ts
+test/js/third_party/grpc-js/test-tonic.test.ts
 test/js/third_party/http2-wrapper/http2-wrapper.test.ts
 test/js/third_party/jsonwebtoken/async_sign.test.js
 test/js/third_party/jsonwebtoken/buffer.test.js

--- a/test/package.json
+++ b/test/package.json
@@ -89,7 +89,7 @@
     "typeorm": "0.3.20",
     "typescript": "5.0.2",
     "undici": "5.20.0",
-    "unzipper": "^0.12.3",
+    "unzipper": "0.12.3",
     "v8-heapsnapshot": "1.3.1",
     "verdaccio": "6.0.0",
     "vitest": "0.32.2",

--- a/test/package.json
+++ b/test/package.json
@@ -89,6 +89,7 @@
     "typeorm": "0.3.20",
     "typescript": "5.0.2",
     "undici": "5.20.0",
+    "unzipper": "^0.12.3",
     "v8-heapsnapshot": "1.3.1",
     "verdaccio": "6.0.0",
     "vitest": "0.32.2",


### PR DESCRIPTION
### What does this PR do?
Fixes: https://github.com/oven-sh/bun/issues/20631
Include padding in the windowSize check, settings only sets the stream initialWindowSize not the connection windowSize
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Test + CI
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
