### PR TITLE
Fix regression from referencing `global` inside of node fallbacks without making it === globalThis

### DIFF
--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -32,7 +32,7 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
 
   // Create the build command with all the specified options
   const buildCommand =
-    Bun.$`bun build --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
+    Bun.$`bun build --define=process.env.NODE_DEBUG:"false" --define=process.env.READABLE_STREAM="'enable'" --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
 
   commands.push(
     buildCommand.then(async text => {

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -32,7 +32,7 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
 
   // Create the build command with all the specified options
   const buildCommand =
-    Bun.$`bun build --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
+    Bun.$`bun build --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
 
   commands.push(
     buildCommand.then(async text => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -727,3 +727,68 @@ test("regression/NODE_PATHBuild api", async () => {
   expect(error).toBe("");
   expect(output.trim()).toBe("MyClass");
 });
+
+test("regression/GlobalThis", async () => {
+  const dir = tempDirWithFiles("global-this-regression", {
+    "entry.js": `
+      function identity(x) {
+        return x;
+      }
+  import * as mod1 from  'assert';
+  identity(mod1);
+import * as mod2 from  'buffer';
+identity(mod2);
+import * as mod3 from  'console';
+identity(mod3);
+import * as mod4 from  'constants';
+identity(mod4);
+import * as mod5 from  'crypto';
+identity(mod5);
+import * as mod6 from  'domain';
+identity(mod6);
+import * as mod7 from  'events';
+identity(mod7);
+import * as mod8 from  'http';
+identity(mod8);
+import * as mod9 from  'https';
+identity(mod9);
+import * as mod10 from  'net';
+identity(mod10);
+import * as mod11 from  'os';
+identity(mod11);
+import * as mod12 from  'path';
+identity(mod12);
+import * as mod13 from  'process';
+identity(mod13);
+import * as mod14 from  'punycode';
+identity(mod14);
+import * as mod15 from  'stream';
+identity(mod15);
+import * as mod16 from  'string_decoder';
+identity(mod16);
+import * as mod17 from  'sys';
+identity(mod17);
+import * as mod18 from  'timers';
+identity(mod18);
+import * as mod20 from  'tty';
+identity(mod20);
+import * as mod21 from  'url';
+identity(mod21);
+import * as mod22 from  'util';
+identity(mod22);
+import * as mod23 from  'zlib';
+identity(mod23);
+      `,
+  });
+
+  const build = await Bun.build({
+    entrypoints: [join(dir, "entry.js")],
+    target: "browser",
+  });
+
+  expect(build.success).toBe(true);
+  const text = await build.outputs[0].text();
+
+  expect(text).not.toContain(" global.");
+  expect(text).toContain(" globalThis.");
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -788,7 +788,7 @@ identity(mod23);
 
   expect(build.success).toBe(true);
   const text = await build.outputs[0].text();
-
+  expect(text).not.toContain("process.env.");
   expect(text).not.toContain(" global.");
   expect(text).toContain(" globalThis.");
 });


### PR DESCRIPTION


### What does this PR do?

Some of the node polyfills npm packages use `global` to reference `globalThis`

### How did you verify your code works?

There is a test