### PR TITLE
Fail the test when no tests match the filter

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -36,6 +36,7 @@ pub const Tag = enum(u3) {
     only,
     skip,
     todo,
+    skipped_because_label,
 };
 const debug = Output.scoped(.jest, false);
 var max_test_id_for_debugger: u32 = 0;
@@ -84,8 +85,23 @@ pub const TestRunner = struct {
     filter_buffer: MutableString,
 
     unhandled_errors_between_tests: u32 = 0,
+    summary: Summary = Summary{},
 
     pub const Drainer = JSC.AnyTask.New(TestRunner, drain);
+
+    pub const Summary = struct {
+        pass: u32 = 0,
+        expectations: u32 = 0,
+        skip: u32 = 0,
+        todo: u32 = 0,
+        fail: u32 = 0,
+        files: u32 = 0,
+        skipped_because_label: u32 = 0,
+
+        pub fn didLabelFilterOutAllTests(this: *const Summary) bool {
+            return this.skipped_because_label > 0 and (this.pass + this.skip + this.todo + this.fail + this.expectations) == 0;
+        }
+    };
 
     pub fn onTestTimeout(this: *TestRunner, now: *const bun.timespec, vm: *VirtualMachine) void {
         _ = vm; // autofix
@@ -178,6 +194,7 @@ pub const TestRunner = struct {
         onTestPass: OnTestUpdate,
         onTestFail: OnTestUpdate,
         onTestSkip: OnTestUpdate,
+        onTestFilteredOut: OnTestUpdate, // when a test is filtered out by a label
         onTestTodo: OnTestUpdate,
     };
 
@@ -199,6 +216,11 @@ pub const TestRunner = struct {
     pub fn reportTodo(this: *TestRunner, test_id: Test.ID, file: string, label: string, parent: ?*DescribeScope) void {
         this.tests.items(.status)[test_id] = .todo;
         this.callback.onTestTodo(this.callback, test_id, file, label, 0, 0, parent);
+    }
+
+    pub fn reportFilteredOut(this: *TestRunner, test_id: Test.ID, file: string, label: string, parent: ?*DescribeScope) void {
+        this.tests.items(.status)[test_id] = .skip;
+        this.callback.onTestFilteredOut(this.callback, test_id, file, label, 0, 0, parent);
     }
 
     pub fn addTestCount(this: *TestRunner, count: u32) u32 {
@@ -250,6 +272,7 @@ pub const TestRunner = struct {
             fail,
             skip,
             todo,
+            skipped_because_label,
             /// A test marked as `.failing()` actually passed
             fail_because_failing_test_passed,
             fail_because_todo_passed,
@@ -1612,6 +1635,7 @@ pub const TestRunnerTask = struct {
                 );
             },
             .skip => Jest.runner.?.reportSkip(test_id, this.source_file_path, test_.label, describe),
+            .skipped_because_label => Jest.runner.?.reportFilteredOut(test_id, this.source_file_path, test_.label, describe),
             .todo => Jest.runner.?.reportTodo(test_id, this.source_file_path, test_.label, describe),
             .fail_because_todo_passed => |count| {
                 Output.prettyErrorln("  <d>^<r> <red>this test is marked as todo but passes.<r> <d>Remove `.todo` or check that test is correct.<r>", .{});
@@ -1673,6 +1697,7 @@ pub const Result = union(TestRunner.Test.Status) {
     fail: u32,
     skip: void,
     todo: void,
+    skipped_because_label: void,
     fail_because_failing_test_passed: u32,
     fail_because_todo_passed: u32,
     fail_because_expected_has_assertions: void,
@@ -1815,15 +1840,21 @@ inline fn createScope(
 
     if (is_test) {
         if (!is_skip) {
-            if (Jest.runner.?.filter_regex) |regex| {
-                var buffer: bun.MutableString = Jest.runner.?.filter_buffer;
-                buffer.reset();
-                appendParentLabel(&buffer, parent) catch @panic("Bun ran out of memory while filtering tests");
-                buffer.append(label) catch unreachable;
-                const str = bun.String.fromBytes(buffer.slice());
-                is_skip = !regex.matches(str);
-                if (is_skip) {
-                    tag_to_use = .skip;
+            if (Jest.runner) |runner| {
+                if (runner.filter_regex) |regex| {
+                    var buffer: bun.MutableString = runner.filter_buffer;
+                    buffer.reset();
+                    appendParentLabel(&buffer, parent) catch @panic("Bun ran out of memory while filtering tests");
+                    buffer.append(label) catch unreachable;
+                    const str = bun.String.fromBytes(buffer.slice());
+                    is_skip = !regex.matches(str);
+                    if (is_skip) {
+                        tag_to_use = .skipped_because_label;
+                        if (comptime is_test) {
+                            // These won't get counted for describe scopes, which means the process will not exit with 1.
+                            runner.summary.skipped_because_label += 1;
+                        }
+                    }
                 }
             }
         }
@@ -1905,7 +1936,7 @@ inline fn createIfScope(
         .pass => .{ Scope.skip, Scope.call },
         .fail => @compileError("unreachable"),
         .only => @compileError("unreachable"),
-        .skip => .{ Scope.call, Scope.skip },
+        .skipped_because_label, .skip => .{ Scope.call, Scope.skip },
         .todo => .{ Scope.call, Scope.todo },
     };
 
@@ -2130,6 +2161,11 @@ fn eachBind(globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSVa
                 buffer.append(formattedLabel) catch unreachable;
                 const str = bun.String.fromBytes(buffer.slice());
                 is_skip = !regex.matches(str);
+                if (is_skip) {
+                    if (each_data.is_test) {
+                        Jest.runner.?.summary.skipped_because_label += 1;
+                    }
+                }
             }
 
             if (is_skip) {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -357,6 +357,7 @@ pub const Command = struct {
         only: bool = false,
         bail: u32 = 0,
         coverage: TestCommand.CodeCoverageOptions = .{},
+        test_filter_pattern: ?[]const u8 = null,
         test_filter_regex: ?*RegularExpression = null,
 
         file_reporter: ?TestCommand.FileReporter = null,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -463,6 +463,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             }
         }
         if (args.option("--test-name-pattern")) |namePattern| {
+            ctx.test_options.test_filter_pattern = namePattern;
             const regex = RegularExpression.init(bun.String.fromBytes(namePattern), RegularExpression.Flags.none) catch {
                 Output.prettyErrorln(
                     "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -398,7 +398,7 @@ pub const JunitReporter = struct {
                     \\    </testcase>
                 , .{});
             },
-            .skip => {
+            .skipped_because_label, .skip => {
                 this.testcases_metrics.skipped += 1;
                 try this.contents.appendSlice(bun.default_allocator, ">\n      <skipped />\n    </testcase>\n");
             },
@@ -462,7 +462,6 @@ pub const CommandLineReporter = struct {
     jest: TestRunner,
     callback: TestRunner.Callback,
     last_dot: u32 = 0,
-    summary: Summary = Summary{},
     prev_file: u64 = 0,
     repeat_count: u32 = 1,
 
@@ -474,15 +473,6 @@ pub const CommandLineReporter = struct {
 
     pub const FileReporter = union(enum) {
         junit: *JunitReporter,
-    };
-
-    pub const Summary = struct {
-        pass: u32 = 0,
-        expectations: u32 = 0,
-        skip: u32 = 0,
-        todo: u32 = 0,
-        fail: u32 = 0,
-        files: u32 = 0,
     };
 
     const DotColorMap = std.EnumMap(TestRunner.Test.Status, string);
@@ -607,6 +597,10 @@ pub const CommandLineReporter = struct {
         }
     }
 
+    pub inline fn summary(this: *CommandLineReporter) *TestRunner.Summary {
+        return &this.jest.summary;
+    }
+
     pub fn handleTestPass(cb: *TestRunner.Callback, id: Test.ID, file: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope) void {
         const writer_ = Output.errorWriter();
         var buffered_writer = std.io.bufferedWriter(writer_);
@@ -620,8 +614,8 @@ pub const CommandLineReporter = struct {
         printTestLine(.pass, label, elapsed_ns, parent, expectations, false, writer, file, this.file_reporter);
 
         this.jest.tests.items(.status)[id] = TestRunner.Test.Status.pass;
-        this.summary.pass += 1;
-        this.summary.expectations += expectations;
+        this.summary().pass += 1;
+        this.summary().expectations += expectations;
     }
 
     pub fn handleTestFail(cb: *TestRunner.Callback, id: Test.ID, file: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope) void {
@@ -646,11 +640,11 @@ pub const CommandLineReporter = struct {
         Output.flush();
 
         // this.updateDots();
-        this.summary.fail += 1;
-        this.summary.expectations += expectations;
+        this.summary().fail += 1;
+        this.summary().expectations += expectations;
         this.jest.tests.items(.status)[id] = TestRunner.Test.Status.fail;
 
-        if (this.jest.bail == this.summary.fail) {
+        if (this.jest.bail == this.summary().fail) {
             this.printSummary();
             Output.prettyError("\nBailed out after {d} failure{s}<r>\n", .{ this.jest.bail, if (this.jest.bail == 1) "" else "s" });
             Global.exit(1);
@@ -658,11 +652,15 @@ pub const CommandLineReporter = struct {
     }
 
     pub fn handleTestSkip(cb: *TestRunner.Callback, id: Test.ID, file: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope) void {
+        handleTestSkipImpl(cb, id, file, label, expectations, elapsed_ns, parent, false);
+    }
+
+    fn handleTestSkipImpl(cb: *TestRunner.Callback, id: Test.ID, file: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope, skipped_because_label: bool) void {
         var writer_ = Output.errorWriter();
         var this: *CommandLineReporter = @fieldParentPtr("callback", cb);
 
         // If you do it.only, don't report the skipped tests because its pretty noisy
-        if (jest.Jest.runner != null and !jest.Jest.runner.?.only) {
+        if (jest.Jest.runner != null and !jest.Jest.runner.?.only and !skipped_because_label) {
             // when the tests skip, we want to repeat the failures at the end
             // so that you can see them better when there are lots of tests that ran
             const initial_length = this.skips_to_repeat_buf.items.len;
@@ -676,9 +674,16 @@ pub const CommandLineReporter = struct {
         }
 
         // this.updateDots();
-        this.summary.skip += 1;
-        this.summary.expectations += expectations;
+        this.summary().skip += 1;
+        if (skipped_because_label) {
+            this.summary().skipped_because_label += 1;
+        }
+        this.summary().expectations += expectations;
         this.jest.tests.items(.status)[id] = TestRunner.Test.Status.skip;
+    }
+
+    pub fn handleTestFilteredOut(cb: *TestRunner.Callback, id: Test.ID, file: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope) void {
+        handleTestSkipImpl(cb, id, file, label, expectations, elapsed_ns, parent, true);
     }
 
     pub fn handleTestTodo(cb: *TestRunner.Callback, id: Test.ID, file: string, label: string, expectations: u32, elapsed_ns: u64, parent: ?*jest.DescribeScope) void {
@@ -698,16 +703,23 @@ pub const CommandLineReporter = struct {
         Output.flush();
 
         // this.updateDots();
-        this.summary.todo += 1;
-        this.summary.expectations += expectations;
+        this.summary().todo += 1;
+        this.summary().expectations += expectations;
         this.jest.tests.items(.status)[id] = TestRunner.Test.Status.todo;
     }
 
     pub fn printSummary(this: *CommandLineReporter) void {
-        const tests = this.summary.fail + this.summary.pass + this.summary.skip + this.summary.todo;
-        const files = this.summary.files;
+        const summary_ = this.summary();
+        const tests = summary_.fail + summary_.pass + summary_.skip + summary_.todo;
+        const files = summary_.files;
 
-        Output.prettyError("Ran {d} tests across {d} files. ", .{ tests, files });
+        Output.prettyError("Ran {d} test{s} across {d} file{s}. ", .{
+            tests,
+            if (tests == 1) "" else "s",
+            files,
+            if (files == 1) "" else "s",
+        });
+
         Output.printStartEnd(bun.start_time, std.time.nanoTimestamp());
     }
 
@@ -1063,6 +1075,7 @@ pub const TestCommand = struct {
             .onTestFail = CommandLineReporter.handleTestFail,
             .onTestSkip = CommandLineReporter.handleTestSkip,
             .onTestTodo = CommandLineReporter.handleTestTodo,
+            .onTestFilteredOut = CommandLineReporter.handleTestFilteredOut,
         };
         reporter.repeat_count = @max(ctx.test_options.repeat_count, 1);
         reporter.jest.callback = &reporter.callback;
@@ -1225,33 +1238,33 @@ pub const TestCommand = struct {
         const write_snapshots_success = try jest.Jest.runner.?.snapshots.writeInlineSnapshots();
         try jest.Jest.runner.?.snapshots.writeSnapshotFile();
         var coverage_options = ctx.test_options.coverage;
-        if (reporter.summary.pass > 20) {
-            if (reporter.summary.skip > 0) {
-                Output.prettyError("\n<r><d>{d} tests skipped:<r>\n", .{reporter.summary.skip});
+        if (reporter.summary().pass > 20) {
+            if (reporter.summary().skip > 0) {
+                Output.prettyError("\n<r><d>{d} tests skipped:<r>\n", .{reporter.summary().skip});
                 Output.flush();
 
                 var error_writer = Output.errorWriter();
                 error_writer.writeAll(reporter.skips_to_repeat_buf.items) catch unreachable;
             }
 
-            if (reporter.summary.todo > 0) {
-                if (reporter.summary.skip > 0) {
+            if (reporter.summary().todo > 0) {
+                if (reporter.summary().skip > 0) {
                     Output.prettyError("\n", .{});
                 }
 
-                Output.prettyError("\n<r><d>{d} tests todo:<r>\n", .{reporter.summary.todo});
+                Output.prettyError("\n<r><d>{d} tests todo:<r>\n", .{reporter.summary().todo});
                 Output.flush();
 
                 var error_writer = Output.errorWriter();
                 error_writer.writeAll(reporter.todos_to_repeat_buf.items) catch unreachable;
             }
 
-            if (reporter.summary.fail > 0) {
-                if (reporter.summary.skip > 0 or reporter.summary.todo > 0) {
+            if (reporter.summary().fail > 0) {
+                if (reporter.summary().skip > 0 or reporter.summary().todo > 0) {
                     Output.prettyError("\n", .{});
                 }
 
-                Output.prettyError("\n<r><d>{d} tests failed:<r>\n", .{reporter.summary.fail});
+                Output.prettyError("\n<r><d>{d} tests failed:<r>\n", .{reporter.summary().fail});
                 Output.flush();
 
                 var error_writer = Output.errorWriter();
@@ -1261,7 +1274,11 @@ pub const TestCommand = struct {
 
         Output.flush();
 
+        var failed_to_find_any_tests = false;
+
         if (test_files.len == 0) {
+            failed_to_find_any_tests = true;
+
             if (ctx.positionals.len == 0) {
                 Output.prettyErrorln(
                     \\<yellow>No tests found!<r>
@@ -1321,76 +1338,92 @@ pub const TestCommand = struct {
                 }
             }
 
-            if (reporter.summary.pass > 0) {
-                Output.prettyError("<r><green>", .{});
-            }
+            const summary = reporter.summary();
+            const did_label_filter_out_all_tests = summary.didLabelFilterOutAllTests() and reporter.jest.unhandled_errors_between_tests == 0;
 
-            Output.prettyError(" {d:5>} pass<r>\n", .{reporter.summary.pass});
-
-            if (reporter.summary.skip > 0) {
-                Output.prettyError(" <r><yellow>{d:5>} skip<r>\n", .{reporter.summary.skip});
-            }
-
-            if (reporter.summary.todo > 0) {
-                Output.prettyError(" <r><magenta>{d:5>} todo<r>\n", .{reporter.summary.todo});
-            }
-
-            if (reporter.summary.fail > 0) {
-                Output.prettyError("<r><red>", .{});
-            } else {
-                Output.prettyError("<r><d>", .{});
-            }
-
-            Output.prettyError(" {d:5>} fail<r>\n", .{reporter.summary.fail});
-            if (reporter.jest.unhandled_errors_between_tests > 0) {
-                Output.prettyError(" <r><red>{d:5>} error{s}<r>\n", .{ reporter.jest.unhandled_errors_between_tests, if (reporter.jest.unhandled_errors_between_tests > 1) "s" else "" });
-            }
-
-            var print_expect_calls = reporter.summary.expectations > 0;
-            if (reporter.jest.snapshots.total > 0) {
-                const passed = reporter.jest.snapshots.passed;
-                const failed = reporter.jest.snapshots.failed;
-                const added = reporter.jest.snapshots.added;
-
-                var first = true;
-                if (print_expect_calls and added == 0 and failed == 0) {
-                    print_expect_calls = false;
-                    Output.prettyError(" {d:5>} snapshots, {d:5>} expect() calls", .{ reporter.jest.snapshots.total, reporter.summary.expectations });
-                } else {
-                    Output.prettyError(" <d>snapshots:<r> ", .{});
-
-                    if (passed > 0) {
-                        Output.prettyError("<d>{d} passed<r>", .{passed});
-                        first = false;
-                    }
-
-                    if (added > 0) {
-                        if (first) {
-                            first = false;
-                            Output.prettyError("<b>+{d} added<r>", .{added});
-                        } else {
-                            Output.prettyError("<b>, {d} added<r>", .{added});
-                        }
-                    }
-
-                    if (failed > 0) {
-                        if (first) {
-                            first = false;
-                            Output.prettyError("<red>{d} failed<r>", .{failed});
-                        } else {
-                            Output.prettyError(", <red>{d} failed<r>", .{failed});
-                        }
-                    }
+            if (!did_label_filter_out_all_tests) {
+                if (summary.pass > 0) {
+                    Output.prettyError("<r><green>", .{});
                 }
 
-                Output.prettyError("\n", .{});
-            }
+                Output.prettyError(" {d:5>} pass<r>\n", .{summary.pass});
 
-            if (print_expect_calls) {
-                Output.prettyError(" {d:5>} expect() calls\n", .{reporter.summary.expectations});
-            }
+                if (summary.skip > 0) {
+                    Output.prettyError(" <r><yellow>{d:5>} skip<r>\n", .{summary.skip});
+                } else if (summary.skipped_because_label > 0) {
+                    Output.prettyError(" <r><d>{d:5>} filtered out<r>\n", .{summary.skipped_because_label});
+                }
 
-            reporter.printSummary();
+                if (summary.todo > 0) {
+                    Output.prettyError(" <r><magenta>{d:5>} todo<r>\n", .{summary.todo});
+                }
+
+                if (summary.fail > 0) {
+                    Output.prettyError("<r><red>", .{});
+                } else {
+                    Output.prettyError("<r><d>", .{});
+                }
+
+                Output.prettyError(" {d:5>} fail<r>\n", .{summary.fail});
+                if (reporter.jest.unhandled_errors_between_tests > 0) {
+                    Output.prettyError(" <r><red>{d:5>} error{s}<r>\n", .{ reporter.jest.unhandled_errors_between_tests, if (reporter.jest.unhandled_errors_between_tests > 1) "s" else "" });
+                }
+
+                var print_expect_calls = reporter.summary().expectations > 0;
+                if (reporter.jest.snapshots.total > 0) {
+                    const passed = reporter.jest.snapshots.passed;
+                    const failed = reporter.jest.snapshots.failed;
+                    const added = reporter.jest.snapshots.added;
+
+                    var first = true;
+                    if (print_expect_calls and added == 0 and failed == 0) {
+                        print_expect_calls = false;
+                        Output.prettyError(" {d:5>} snapshots, {d:5>} expect() calls", .{ reporter.jest.snapshots.total, reporter.summary().expectations });
+                    } else {
+                        Output.prettyError(" <d>snapshots:<r> ", .{});
+
+                        if (passed > 0) {
+                            Output.prettyError("<d>{d} passed<r>", .{passed});
+                            first = false;
+                        }
+
+                        if (added > 0) {
+                            if (first) {
+                                first = false;
+                                Output.prettyError("<b>+{d} added<r>", .{added});
+                            } else {
+                                Output.prettyError("<b>, {d} added<r>", .{added});
+                            }
+                        }
+
+                        if (failed > 0) {
+                            if (first) {
+                                first = false;
+                                Output.prettyError("<red>{d} failed<r>", .{failed});
+                            } else {
+                                Output.prettyError(", <red>{d} failed<r>", .{failed});
+                            }
+                        }
+                    }
+
+                    Output.prettyError("\n", .{});
+                }
+
+                if (print_expect_calls) {
+                    Output.prettyError(" {d:5>} expect() calls\n", .{reporter.summary().expectations});
+                }
+
+                reporter.printSummary();
+            } else {
+                Output.prettyError("<red>error<r><d>:<r> regex <b>{}<r> matched 0 tests. Searched {d} file{s} (skipping {d} test{s}) ", .{
+                    bun.fmt.quote(ctx.test_options.test_filter_pattern.?),
+                    summary.files,
+                    if (summary.files == 1) "" else "s",
+                    summary.skipped_because_label,
+                    if (summary.skipped_because_label == 1) "" else "s",
+                });
+                Output.printStartEnd(ctx.start_time, std.time.nanoTimestamp());
+            }
         }
 
         Output.prettyError("\n", .{});
@@ -1410,8 +1443,9 @@ pub const TestCommand = struct {
         if (vm.hot_reload == .watch) {
             vm.runWithAPILock(JSC.VirtualMachine, vm, runEventLoopForWatch);
         }
+        const summary = reporter.summary();
 
-        if (reporter.summary.fail > 0 or (coverage_options.enabled and coverage_options.fractions.failing and coverage_options.fail_on_low_coverage) or !write_snapshots_success) {
+        if (failed_to_find_any_tests or summary.didLabelFilterOutAllTests() or summary.fail > 0 or (coverage_options.enabled and coverage_options.fractions.failing and coverage_options.fail_on_low_coverage) or !write_snapshots_success) {
             Global.exit(1);
         } else if (reporter.jest.unhandled_errors_between_tests > 0) {
             Global.exit(reporter.jest.unhandled_errors_between_tests);
@@ -1523,14 +1557,14 @@ pub const TestCommand = struct {
             Output.flush();
 
             var promise = try vm.loadEntryPointForTestRunner(file_path);
-            reporter.summary.files += 1;
+            reporter.summary().files += 1;
 
             switch (promise.status(vm.global.vm())) {
                 .rejected => {
                     vm.unhandledRejection(vm.global, promise.result(vm.global.vm()), promise.asValue());
-                    reporter.summary.fail += 1;
+                    reporter.summary().fail += 1;
 
-                    if (reporter.jest.bail == reporter.summary.fail) {
+                    if (reporter.jest.bail == reporter.summary().fail) {
                         reporter.printSummary();
                         Output.prettyError("\nBailed out after {d} failure{s}<r>\n", .{ reporter.jest.bail, if (reporter.jest.bail == 1) "" else "s" });
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "bun";
+import { spawn, spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -883,6 +883,61 @@ describe("bun test", () => {
     test.todo("check formatting for %p", () => {});
   });
 
+  test("Prints error when no test matches", () => {
+    const stderr = runTest({
+      args: ["-t", "not-a-test"],
+      input: `
+        import { test, expect } from "bun:test";
+        test("test", () => {});
+      `,
+      expectExitCode: 1,
+    });
+    expect(
+      stderr
+        .replace(/bun-test-(.*)\.test\.ts/, "bun-test-*.test.ts")
+        .trim()
+        .replace(/\[.*\ms\]/, "[xx ms]"),
+    ).toMatchInlineSnapshot(`
+      "bun-test-*.test.ts:
+
+      error: regex "not-a-test" matched 0 tests. Searched 1 file (skipping 1 test) [xx ms]"
+    `);
+  });
+
+  test("Does not print the regex error when a test fails", () => {
+    const stderr = runTest({
+      args: ["-t", "not-a-test"],
+      input: `
+        import { test, expect } from "bun:test";
+        test("not-a-test", () => {
+          expect(false).toBe(true);
+        });
+      `,
+      expectExitCode: 1,
+    });
+    expect(stderr).not.toContain("error: regex");
+    expect(stderr).toContain("1 fail");
+  });
+
+  test("Does not print the regex error when a test matches and a test passes", () => {
+    const stderr = runTest({
+      args: ["-t", "not-a-test"],
+      input: `
+        import { test, expect } from "bun:test";
+        test("not-a-test", () => {
+          expect(false).toBe(true); 
+        });
+        test("not-a-test", () => {
+          expect(true).toBe(true);
+        });
+      `,
+      expectExitCode: 1,
+    });
+    expect(stderr).not.toContain("error: regex");
+    expect(stderr).toContain("1 fail");
+    expect(stderr).toContain("1 pass");
+  });
+
   test("path to a non-test.ts file will work", () => {
     const stderr = runTest({
       args: ["./index.ts"],
@@ -944,21 +999,26 @@ function runTest({
   cwd,
   args = [],
   env = {},
+  expectExitCode = undefined,
 }: {
   input?: string | (string | { filename: string; contents: string })[];
   cwd?: string;
   args?: string[];
   env?: Record<string, string | undefined>;
+  expectExitCode?: number;
 } = {}): string {
   cwd ??= createTest(input);
   try {
-    const { stderr } = spawnSync({
+    const { stderr, exitCode } = spawnSync({
       cwd,
       cmd: [bunExe(), "test", ...args],
       env: { ...bunEnv, ...env },
       stderr: "pipe",
       stdout: "ignore",
     });
+    if (expectExitCode !== undefined) {
+      expect(exitCode).toBe(expectExitCode);
+    }
     return stderr.toString();
   } finally {
     rmSync(cwd, { recursive: true });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "bun";
+import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -134,7 +134,7 @@ test("verify we print error messages passed to done callbacks", () => {
 
     0 pass
     9 fail
-    Ran 9 tests across 1 files.
+    Ran 9 tests across 1 file.
     "
   `);
 });

--- a/test/js/bun/test/test-only.test.ts
+++ b/test/js/bun/test/test-only.test.ts
@@ -9,7 +9,7 @@ test.each(["./only-fixture-1.ts", "./only-fixture-2.ts", "./only-fixture-3.ts"])
 
     expect(result.stderr.toString()).toContain(" 1 pass\n");
     expect(result.stderr.toString()).toContain(" 0 fail\n");
-    expect(result.stderr.toString()).toContain("Ran 1 tests across 1 files");
+    expect(result.stderr.toString()).toContain("Ran 1 test across 1 file");
   },
 );
 

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -297,8 +297,9 @@ it("should return non-zero exit code for invalid syntax", async () => {
       stderr: "pipe",
       env: bunEnv,
     });
-    const err = await new Response(stderr).text();
-    expect(err.replaceAll(test_dir, "<dir>").replaceAll(/\[(.*)\ms\]/g, "[xx ms]")).toMatchInlineSnapshot(`
+    const err = (await new Response(stderr).text()).replaceAll("\\", "/");
+    expect(err.replaceAll(test_dir.replaceAll("\\", "/"), "<dir>").replaceAll(/\[(.*)\ms\]/g, "[xx ms]"))
+      .toMatchInlineSnapshot(`
       "
       bad.test.js:
 

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -298,10 +298,25 @@ it("should return non-zero exit code for invalid syntax", async () => {
       env: bunEnv,
     });
     const err = await new Response(stderr).text();
-    expect(err).toContain("error: Unexpected end of file");
-    expect(err).toContain(" 0 pass");
-    expect(err).toContain(" 1 fail");
-    expect(err).toContain("Ran 1 tests across 1 files");
+    expect(err.replaceAll(test_dir, "<dir>").replaceAll(/\[(.*)\ms\]/g, "[xx ms]")).toMatchInlineSnapshot(`
+      "
+      bad.test.js:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | !!!
+            ^
+      error: Unexpected end of file
+          at <dir>/bad.test.js:1:3
+      -------------------------------
+
+
+       0 pass
+       1 fail
+       1 error
+      Ran 1 test across 1 file. [xx ms]
+      "
+    `);
     expect(stdout).toBeDefined();
     expect(await new Response(stdout).text()).toBe(`bun test ${Bun.version_with_sha}\n`);
     expect(await exited).toBe(1);
@@ -732,7 +747,7 @@ test("my-test", () => {
         expect(output).toContain("1 error");
       }
 
-      expect(output).toContain("Ran 1 tests across 1 files");
+      expect(output).toContain("Ran 1 test across 1 file");
     });
   }
 });

--- a/test/js/node/test/parallel/needs-test/README.md
+++ b/test/js/node/test/parallel/needs-test/README.md
@@ -1,8 +1,0 @@
-A good deal of parallel test cases can be run directly via `bun <filename>`.
-However, some newer cases use `node:test`.
-
-Files in this directory need to be run with `bun test <filename>`. The
-`node:test` module is shimmed via a require cache hack in
-`test/js/node/harness.js` to use `bun:test`.  Note that our test runner
-(`scripts/runner.node.mjs`) checks for `needs-test` in the names of test files,
-so don't rename this folder without updating that code.


### PR DESCRIPTION
### What does this PR do?

```js
/tmp/ok
❯ bun test -t 'no-match'
bun test v1.2.17 (68f25a8c)

foo.test.ts:

error: regex "no-match" matched 0 tests. Searched 1 file (skipping 2 tests) [42.00ms]

/tmp/ok
❯ bun-1.2.17 test -t 'no-match' # Before
bun test v1.2.17 (282dda62)

foo.test.ts:
» success! i ran nothing at all!!!
» 1 match

 0 pass
 2 skip
 0 fail
Ran 2 tests across 1 files. [8.00ms]

/tmp/ok
❯ bun test -t '1 match'
bun test v1.2.17 (68f25a8c)

foo.test.ts:
✓ 1 match [0.50ms]

 1 pass
 1 filtered out
 0 fail
Ran 1 test across 1 file. [61.00ms]

/tmp/ok
❯ bun-1.2.17 test -t '1 match' # Before
bun test v1.2.17 (282dda62)

foo.test.ts:
» success! i ran nothing at all!!!
✓ 1 match [0.07ms]

 1 pass
 1 skip
 0 fail
Ran 2 tests across 1 files. [8.00ms]
```

### How did you verify your code works?

There are tests