### PR TITLE
Fix: Dynamic imports incorrectly resolve to CSS files when code splitting is enabled

### DIFF
--- a/src/bundler/linker_context/computeChunks.zig
+++ b/src/bundler/linker_context/computeChunks.zig
@@ -297,6 +297,12 @@ pub noinline fn computeChunks(
     // to look up the path for this chunk to use with the import.
     for (chunks, 0..) |*chunk, chunk_id| {
         if (chunk.entry_point.is_entry_point) {
+            // JS entry points that import CSS files generate two chunks, a JS chunk
+            // and a CSS chunk. Don't link the CSS chunk to the JS file since the CSS
+            // chunk is secondary (the JS chunk is primary).
+            if (chunk.content == .css and css_asts[chunk.entry_point.source_index] == null) {
+                continue;
+            }
             entry_point_chunk_indices[chunk.entry_point.source_index] = @intCast(chunk_id);
         }
     }

--- a/src/bundler/linker_context/computeCrossChunkDependencies.zig
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.zig
@@ -89,7 +89,7 @@ const CrossChunkDependencies = struct {
             const wrapper_ref = deps.wrapper_refs[source_index];
             const _chunks = deps.chunks;
 
-            for (parts) |part| {
+            for (parts) |*part| {
                 if (!part.is_live)
                     continue;
 

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,0 +1,308 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  itBundled("splitting/DynamicImportCSSFile", {
+    files: {
+      "/client.tsx": `import('./test')`,
+      "/test.ts": `
+        import './test.css'
+        console.log('test.ts loaded')
+      `,
+      "/test.css": `.aaa { color: red; }`,
+    },
+    entryPoints: ["/client.tsx"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/client.js",
+      stdout: "test.ts loaded",
+    },
+  });
+
+  itBundled("splitting/DynamicImportMultipleCSSImports", {
+    files: {
+      "/entry.js": `
+        import('./module1').then(() => console.log('module1 loaded'));
+        import('./module2').then(() => console.log('module2 loaded'));
+      `,
+      "/module1.js": `
+        import './styles1.css'
+        console.log('module1.js executed')
+      `,
+      "/module2.js": `
+        import './styles2.css'
+        console.log('module2.js executed')
+      `,
+      "/styles1.css": `.class1 { color: red; }`,
+      "/styles2.css": `.class2 { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "module1.js executed\nmodule1 loaded\nmodule2.js executed\nmodule2 loaded",
+    },
+  });
+
+  itBundled("splitting/StaticAndDynamicCSSImports", {
+    files: {
+      "/entry.js": `
+        import './static.css';
+        import('./dynamic').then(() => console.log('dynamic module loaded'));
+      `,
+      "/dynamic.js": `
+        import './dynamic.css'
+        console.log('dynamic.js executed')
+      `,
+      "/static.css": `.static { color: green; }`,
+      "/dynamic.css": `.dynamic { color: purple; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "dynamic.js executed\ndynamic module loaded",
+    },
+  });
+
+  itBundled("splitting/NestedDynamicImportWithCSS", {
+    files: {
+      "/entry.js": `
+        import('./level1').then(() => console.log('level1 loaded'));
+      `,
+      "/level1.js": `
+        import './level1.css'
+        console.log('level1.js executed')
+        import('./level2').then(() => console.log('level2 loaded from level1'));
+      `,
+      "/level2.js": `
+        import './level2.css'
+        console.log('level2.js executed')
+      `,
+      "/level1.css": `.level1 { color: red; }`,
+      "/level2.css": `.level2 { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "level1.js executed\nlevel1 loaded\nlevel2.js executed\nlevel2 loaded from level1",
+    },
+  });
+
+  itBundled("splitting/SharedCSSBetweenChunks", {
+    files: {
+      "/entry.js": `
+        import('./moduleA').then(() => console.log('moduleA loaded'));
+        import('./moduleB').then(() => console.log('moduleB loaded'));
+      `,
+      "/moduleA.js": `
+        import './shared.css'
+        import './moduleA.css'
+        console.log('moduleA.js executed')
+      `,
+      "/moduleB.js": `
+        import './shared.css'
+        import './moduleB.css'
+        console.log('moduleB.js executed')
+      `,
+      "/shared.css": `.shared { color: green; }`,
+      "/moduleA.css": `.moduleA { color: red; }`,
+      "/moduleB.css": `.moduleB { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "moduleA.js executed\nmoduleA loaded\nmoduleB.js executed\nmoduleB loaded",
+    },
+  });
+
+  itBundled("splitting/DynamicImportChainWithCSS", {
+    files: {
+      "/entry.js": `
+        const chain = () => import('./chain1')
+          .then(() => {
+            console.log('chain1 loaded');
+            return import('./chain2');
+          })
+          .then(() => {
+            console.log('chain2 loaded');
+            return import('./chain3');
+          })
+          .then(() => {
+            console.log('chain3 loaded');
+          });
+        chain();
+      `,
+      "/chain1.js": `
+        import './chain1.css'
+        console.log('chain1.js executed')
+      `,
+      "/chain2.js": `
+        import './chain2.css'
+        console.log('chain2.js executed')
+      `,
+      "/chain3.js": `
+        import './chain3.css'
+        console.log('chain3.js executed')
+      `,
+      "/chain1.css": `.chain1 { color: red; }`,
+      "/chain2.css": `.chain2 { color: green; }`,
+      "/chain3.css": `.chain3 { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "chain1.js executed\nchain1 loaded\nchain2.js executed\nchain2 loaded\nchain3.js executed\nchain3 loaded",
+    },
+  });
+
+  itBundled("splitting/ConditionalDynamicImportWithCSS", {
+    files: {
+      "/entry.js": `
+        const condition = true;
+        if (condition) {
+          import('./moduleTrue').then(() => console.log('true branch loaded'));
+        } else {
+          import('./moduleFalse').then(() => console.log('false branch loaded'));
+        }
+      `,
+      "/moduleTrue.js": `
+        import './true.css'
+        console.log('moduleTrue.js executed')
+      `,
+      "/moduleFalse.js": `
+        import './false.css'
+        console.log('moduleFalse.js executed')
+      `,
+      "/true.css": `.true { color: green; }`,
+      "/false.css": `.false { color: red; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "moduleTrue.js executed\ntrue branch loaded",
+    },
+  });
+
+  itBundled("splitting/MultipleEntryPointsWithSharedCSS", {
+    files: {
+      "/entry1.js": `
+        import './shared.css'
+        import './entry1.css'
+        console.log('entry1.js executed')
+      `,
+      "/entry2.js": `
+        import './shared.css'
+        import './entry2.css'
+        console.log('entry2.js executed')
+      `,
+      "/shared.css": `.shared { font-size: 16px; }`,
+      "/entry1.css": `.entry1 { color: red; }`,
+      "/entry2.css": `.entry2 { color: blue; }`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: [
+      {
+        file: "/out/entry1.js",
+        stdout: "entry1.js executed",
+      },
+      {
+        file: "/out/entry2.js",
+        stdout: "entry2.js executed",
+      },
+    ],
+  });
+
+  itBundled("splitting/DynamicImportWithOnlyCSSNoJS", {
+    files: {
+      "/entry.js": `
+        import('./styles.css').then(() => console.log('CSS import succeeded')).catch(err => console.log('CSS import failed:', err.message));
+      `,
+      "/styles.css": `.styles { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "CSS import succeeded",
+    },
+  });
+
+  itBundled("splitting/CircularDynamicImportsWithCSS", {
+    files: {
+      "/entry.js": `
+        import('./a').then(module => {
+          console.log('a loaded from entry');
+          return import('./b');
+        }).then(module => {
+          console.log('b loaded from entry, value:', module.bValue);
+        });
+      `,
+      "/a.js": `
+        import './a.css'
+        console.log('a.js executed')
+      `,
+      "/b.js": `
+        import './b.css'
+        console.log('b.js executed')
+        export const bValue = 'B';
+        // Import a to create circular dependency
+        import * as A from './a';
+        console.log('b.js imports a', A);
+      `,
+      "/a.css": `.a { color: red; }`,
+      "/b.css": `.b { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    env: "inline",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "a.js executed\na loaded from entry\nb.js executed\nb.js imports a {}\nb loaded from entry, value: B",
+    },
+  });
+});

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -23,6 +23,7 @@ test/bundler/bundler_minify.test.ts
 test/bundler/bundler_naming.test.ts
 test/bundler/bundler_plugin.test.ts
 test/bundler/bundler_regressions.test.ts
+test/bundler/bundler_splitting.test.ts
 test/bundler/bundler_string.test.ts
 test/bundler/css/css-modules.test.ts
 test/bundler/css/wpt/background-computed.test.ts


### PR DESCRIPTION
## Summary

This PR fixes an issue where dynamic imports in JavaScript files incorrectly resolve to CSS chunk files instead of JavaScript chunks when code splitting is enabled. The bug causes runtime errors because browsers cannot execute CSS files as JavaScript modules.

## The Problem

When using `Bun.build` with `splitting: true`, if a dynamically imported JavaScript module contains CSS imports, the dynamic import gets rewritten to point to the CSS chunk instead of the JavaScript chunk.

### Example
```typescript
// client.tsx
import('./test')

// test.ts  
import './test.css'
console.log('test.ts loaded')
```

**Expected**: Dynamic import loads the JavaScript module  
**Actual**: Dynamic import tries to load the CSS file, causing:
```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/css"
```

## Root Cause

The issue occurs in `computeChunks.zig` where CSS chunks are marked as entry points and mapped in `entry_point_chunk_indices`. When a JS file imports CSS, both JS and CSS chunks are created, but the CSS chunk incorrectly overwrites the JS file's entry point mapping.

## Solution

Added a check similar to esbuild's implementation to prevent CSS chunks from being mapped as entry points for JavaScript files:

```zig
// JS entry points that import CSS files generate two chunks, a JS chunk
// and a CSS chunk. Don't link the CSS chunk to the JS file since the CSS
// chunk is secondary (the JS chunk is primary).
if (chunk.content == .css and css_asts[chunk.entry_point.source_index] == null) {
    continue;
}
```

## Testing

Added comprehensive test cases in `test/bundler/bundler_splitting.test.ts` covering:
- Basic dynamic imports with CSS
- Multiple dynamic imports with CSS  
- Nested dynamic imports
- Shared CSS between chunks
- Circular dependencies with CSS
- Multiple entry points with shared CSS
- And more edge cases

All tests verify that JavaScript modules execute correctly when dynamically imported, even when they contain CSS imports.

## Impact

This fix ensures that code splitting works correctly with CSS imports, allowing developers to use dynamic imports for code splitting without worrying about CSS imports breaking their application.

Fixes the issue reported where `splitting: true` causes dynamic imports to fail when modules import CSS files.