### PR TITLE
Remove docs from npm package distribution

### DIFF
--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -10,9 +10,6 @@
   },
   "files": [
     "./*.d.ts",
-    "docs/**/*.md",
-    "docs/*.md",
-    "CLAUDE.md",
     "README.md"
   ],
   "homepage": "https://bun.sh",


### PR DESCRIPTION
### What does this PR do?

Removes documentation files from `bun-types` package distribution to reduce package size by ~65% (from 1.69MB to ~580KB).

The docs/ folder contains literal website documentation, which increases the size without providing value to TypeScript users. This change removes:

`docs/**/*.md`, `docs/*.md` - Docs for the website
`CLAUDE.md` - Claude Code instructions

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes