### PR TITLE
Support `process.features.typescript`

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3527,6 +3527,9 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     object->putDirect(vm, Identifier::fromString(vm, "tls_ocsp"_s), jsBoolean(true));
     object->putDirect(vm, Identifier::fromString(vm, "tls"_s), jsBoolean(true));
     object->putDirect(vm, Identifier::fromString(vm, "cached_builtins"_s), jsBoolean(true));
+    object->putDirect(vm, Identifier::fromString(vm, "openssl_is_boringssl"_s), jsBoolean(true));
+    object->putDirect(vm, Identifier::fromString(vm, "require_module"_s), jsBoolean(true));
+    object->putDirect(vm, Identifier::fromString(vm, "typescript"_s), jsString(vm, String("transform"_s)));
 
     return object;
 }

--- a/test/js/node/test/parallel/test-process-features.js
+++ b/test/js/node/test/parallel/test-process-features.js
@@ -3,20 +3,24 @@
 require('../common');
 const assert = require('assert');
 
-const keys = new Set(Object.keys(process.features));
+const actualKeys = new Set(Object.keys(process.features));
+const expectedKeys = new Map([
+  ['inspector', ['boolean']],
+  ['debug', ['boolean']],
+  ['uv', ['boolean']],
+  ['ipv6', ['boolean']],
+  ['openssl_is_boringssl', ['boolean']],
+  ['tls_alpn', ['boolean']],
+  ['tls_sni', ['boolean']],
+  ['tls_ocsp', ['boolean']],
+  ['tls', ['boolean']],
+  ['cached_builtins', ['boolean']],
+  ['require_module', ['boolean']],
+  ['typescript', ['boolean', 'string']],
+]);
 
-assert.deepStrictEqual(keys, new Set([
-  'inspector',
-  'debug',
-  'uv',
-  'ipv6',
-  'tls_alpn',
-  'tls_sni',
-  'tls_ocsp',
-  'tls',
-  'cached_builtins',
-]));
+assert.deepStrictEqual(actualKeys, new Set(expectedKeys.keys()));
 
-for (const key of keys) {
-  assert.strictEqual(typeof process.features[key], 'boolean');
+for (const [key, expected] of expectedKeys) {
+  assert.ok(expected.includes(typeof process.features[key]), `typeof process.features.${key} is not one of [${expected.join(', ')}]`);
 }


### PR DESCRIPTION
### What does this PR do?

fixes #18800 by updating the `test/js/node/test/parallel/test-process-features.js` node test & implementing the missing values

> A value that is "strip" by default, "transform" if Node.js is run with --experimental-transform-types, and false if Node.js is run with --no-experimental-strip-types.
> _https://nodejs.org/api/process.html#processfeaturestypescript_

I chose "transform" as it was closest to what bun already does

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

manual & ran updated node test
