### PR TITLE
Handle AWS Lambda non-HTTP Errors

### DIFF
--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -534,7 +534,14 @@ class LambdaServer implements Server {
       };
     }
     if (!isHttpEvent(event.event)) {
-      return response.text();
+      const text = await response.text();
+      const status = response?.status ?? 200;
+      if (status >= 400) {
+        // Handle non-HTTP error.
+        // In this scenario, we need to throw an error for AWS to handle.
+        throw new Error(text);
+      }
+      return text;
     }
     return formatResponse(response);
   }


### PR DESCRIPTION
Errors are expected to be thrown in this scenario for non HTTP errors. This is tested and verified with the AWS Cognito hook lambda triggers

### What does this PR do?

This ensures that non-HTTP AWS Lambda events (such as Cognito triggers) properly throw errors when the response has a 4xx or 5xx status code. AWS requires actual exceptions to be thrown for these errors to be handled correctly. This change makes it easier to use `bun-lambda` in production with AWS services that expect this behavior.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

Manually tested this behavior using a Cognito PreSignUp Lambda trigger and confirmed AWS handled thrown errors correctly when non-HTTP responses returned status codes >= 400.

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
