### PR TITLE
Shrink `js_ast.Expr` from 32 bytes -> 24 bytes

### DIFF
--- a/src/bundler/AstBuilder.zig
+++ b/src/bundler/AstBuilder.zig
@@ -7,7 +7,7 @@
 pub const AstBuilder = struct {
     allocator: std.mem.Allocator,
     source: *const Logger.Source,
-    source_index: u31,
+    source_index: Ref.SourceIndex,
     stmts: std.ArrayListUnmanaged(Stmt),
     scopes: std.ArrayListUnmanaged(*Scope),
     symbols: std.ArrayListUnmanaged(Symbol),
@@ -98,7 +98,7 @@ pub const AstBuilder = struct {
         });
         const ref: Ref = .{
             .inner_index = inner_index,
-            .source_index = p.source_index,
+            .source_index = @intCast(p.source_index),
             .tag = .symbol,
         };
         try p.current_scope.generated.push(p.allocator, ref);

--- a/src/bundler/linker_context/convertStmtsForChunk.zig
+++ b/src/bundler/linker_context/convertStmtsForChunk.zig
@@ -398,9 +398,10 @@ pub fn convertStmtsForChunk(
                                         E.Binary{
                                             .op = .bin_assign,
                                             .left = Expr.init(
-                                                E.CommonJSExportIdentifier,
-                                                E.CommonJSExportIdentifier{
+                                                E.CommonJSExportIdentifier.Options,
+                                                .{
                                                     .ref = decl.binding.data.b_identifier.ref,
+                                                    .base = .exports,
                                                 },
                                                 decl.binding.loc,
                                             ),

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -265,6 +265,12 @@ pub const JavaScript = struct {
         };
 
         const result = parser.parse() catch |err| {
+            if (comptime Environment.isDebug) {
+                if (bun.getenvTruthy("BUN_DEBUG_PARSE_ERRORS")) {
+                    bun.handleErrorReturnTrace(err, @errorReturnTrace());
+                }
+            }
+
             if (temp_log.errors == 0) {
                 log.addRangeError(source, parser.lexer.range(), @errorName(err)) catch unreachable;
             }

--- a/src/defines.zig
+++ b/src/defines.zig
@@ -126,10 +126,10 @@ pub const DefineData = struct {
             const value = if (value_is_undefined or strings.eqlComptime(value_str, "undefined"))
                 js_ast.Expr.Data{ .e_undefined = js_ast.E.Undefined{} }
             else
-                js_ast.Expr.Data{ .e_identifier = .{
+                js_ast.Expr.Data{ .e_identifier = js_ast.E.Identifier.init(.{
                     .ref = Ref.None,
                     .can_be_removed_if_unused = true,
-                } };
+                }) };
 
             return .{
                 .value = value,

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -190,7 +190,7 @@ const MacroRefData = struct {
     name: ?string = null,
 };
 
-const MacroRefs = std.AutoArrayHashMap(Ref, MacroRefData);
+const MacroRefs = std.ArrayHashMap(Ref, MacroRefData, Ref.ArrayHashCtx, false);
 
 const Substitution = union(enum) {
     success: Expr,
@@ -2464,7 +2464,7 @@ fn statementCaresAboutScope(stmt: Stmt) bool {
     };
 }
 
-const ExprIn = struct {
+const ExprIn = packed struct(u8) {
     // This tells us if there are optional chain expressions (EDot, EIndex, or
     // ECall) that are chained on to this expression. Because of the way the AST
     // works, chaining expressions on to this expression means they are our
@@ -2530,6 +2530,8 @@ const ExprIn = struct {
     is_immediately_assigned_to_decl: bool = false,
 
     property_access_for_method_call_maybe_should_replace_with_undefined: bool = false,
+
+    _padding: u2 = 0,
 };
 
 // This function exists to tie all of these checks together in one place
@@ -4697,13 +4699,15 @@ pub const KnownGlobal = enum {
 pub const MacroState = struct {
     refs: MacroRefs,
     prepend_stmts: *ListManaged(Stmt) = undefined,
-    imports: std.AutoArrayHashMap(i32, Ref),
+    imports: ImportMap,
+
+    pub const ImportMap = std.AutoArrayHashMap(i32, Ref);
 
     pub fn init(allocator: Allocator) MacroState {
         return MacroState{
             .refs = MacroRefs.init(allocator),
             .prepend_stmts = undefined,
-            .imports = std.AutoArrayHashMap(i32, Ref).init(allocator),
+            .imports = .init(allocator),
         };
     }
 };
@@ -5555,52 +5559,51 @@ fn NewParser_(
             return freq;
         }
 
-        pub fn newExpr(noalias p: *P, t: anytype, loc: logger.Loc) Expr {
+        fn newExprForScanningImports(noalias p: *P, t: anytype, loc: logger.Loc) Expr {
             const Type = @TypeOf(t);
-
-            comptime {
-                if (jsx_transform_type == .none) {
-                    if (Type == E.JSXElement or Type == *E.JSXElement) {
-                        @compileError("JSXElement is not supported in this environment");
-                    }
-                }
-            }
 
             // Output.print("\nExpr: {s} - {d}\n", .{ @typeName(@TypeOf(t)), loc.start });
             if (@typeInfo(Type) == .pointer) {
-                if (comptime only_scan_imports_and_do_not_visit) {
-                    if (Type == *E.Call) {
-                        const call: *E.Call = t;
-                        switch (call.target.data) {
-                            .e_identifier => |ident| {
-                                // is this a require("something")
-                                if (strings.eqlComptime(p.loadNameFromRef(ident.ref), "require") and call.args.len == 1 and std.meta.activeTag(call.args.ptr[0].data) == .e_string) {
-                                    _ = p.addImportRecord(.require, loc, call.args.first_().data.e_string.string(p.allocator) catch unreachable);
-                                }
-                            },
-                            else => {},
-                        }
+                if (Type == *E.Call) {
+                    const call: *E.Call = t;
+                    switch (call.target.data) {
+                        .e_identifier => |ident| {
+                            // is this a require("something")
+                            if (strings.eqlComptime(p.loadNameFromRef(ident.ref), "require") and call.args.len == 1 and std.meta.activeTag(call.args.ptr[0].data) == .e_string) {
+                                _ = p.addImportRecord(.require, loc, call.args.first_().data.e_string.string(p.allocator) catch unreachable);
+                            }
+                        },
+                        else => {},
                     }
                 }
                 return Expr.init(std.meta.Child(Type), t.*, loc);
             } else {
-                if (comptime only_scan_imports_and_do_not_visit) {
-                    if (Type == E.Call) {
-                        const call: E.Call = t;
-                        switch (call.target.data) {
-                            .e_identifier => |ident| {
-                                // is this a require("something")
-                                if (strings.eqlComptime(p.loadNameFromRef(ident.ref), "require") and call.args.len == 1 and std.meta.activeTag(call.args.ptr[0].data) == .e_string) {
-                                    _ = p.addImportRecord(.require, loc, call.args.first_().data.e_string.string(p.allocator) catch unreachable);
-                                }
-                            },
-                            else => {},
-                        }
+                if (Type == E.Call) {
+                    const call: E.Call = t;
+                    switch (call.target.data) {
+                        .e_identifier => |ident| {
+                            // is this a require("something")
+                            if (strings.eqlComptime(p.loadNameFromRef(ident.ref), "require") and call.args.len == 1 and std.meta.activeTag(call.args.ptr[0].data) == .e_string) {
+                                _ = p.addImportRecord(.require, loc, call.args.first_().data.e_string.string(p.allocator) catch unreachable);
+                            }
+                        },
+                        else => {},
                     }
                 }
                 return Expr.init(Type, t, loc);
             }
         }
+
+        fn newExprForRegularParsing(noalias _: *const P, t: anytype, loc: logger.Loc) Expr {
+            const Type = @TypeOf(t);
+            if (comptime @typeInfo(Type) == .pointer) {
+                return Expr.init(std.meta.Child(Type), t.*, loc);
+            } else {
+                return Expr.init(Type, t, loc);
+            }
+        }
+
+        pub const newExpr = if (only_scan_imports_and_do_not_visit) newExprForScanningImports else newExprForRegularParsing;
 
         pub fn b(p: *P, t: anytype, loc: logger.Loc) Binding {
             if (@typeInfo(@TypeOf(t)) == .pointer) {
@@ -8016,7 +8019,9 @@ fn NewParser_(
                 //   }
                 //
                 // This matches the behavior of the TypeScript compiler.
-                try decorators.append(try p.parseExprWithFlags(.new, Expr.EFlags.ts_decorator));
+                try decorators.ensureUnusedCapacity(1);
+                try p.parseExprWithFlags(.new, Expr.EFlags.ts_decorator, &decorators.unusedCapacitySlice()[0]);
+                decorators.items.len += 1;
             }
 
             return decorators.items;
@@ -9588,10 +9593,11 @@ fn NewParser_(
 
                                 const defaultName = try createDefaultName(p, loc);
 
-                                const prefix_expr = try p.parseAsyncPrefixExpr(async_range, Level.comma);
-                                const expr = try p.parseSuffix(prefix_expr, Level.comma, null, Expr.EFlags.none);
+                                var value = js_ast.StmtOrExpr{ .expr = undefined };
+                                try p.parseAsyncPrefixExpr(async_range, Level.comma, &value.expr);
+                                try p.parseSuffix(&value.expr, Level.comma, null, Expr.EFlags.none);
                                 try p.lexer.expectOrInsertSemicolon();
-                                const value = js_ast.StmtOrExpr{ .expr = expr };
+
                                 p.has_export_default = true;
                                 return p.s(S.ExportDefault{ .default_name = defaultName, .value = value }, loc);
                             }
@@ -10329,11 +10335,11 @@ fn NewParser_(
                         // "import.meta"
                         .t_open_paren, .t_dot => {
                             p.esm_import_keyword = previous_import_keyword; // this wasn't an esm import statement after all
-                            const expr = try p.parseSuffix(try p.parseImportExpr(loc, .lowest), .lowest, null, Expr.EFlags.none);
+                            var expr: Expr = undefined;
+                            try p.parseImportExpr(loc, .lowest, &expr);
+                            try p.parseSuffix(&expr, .lowest, null, Expr.EFlags.none);
                             try p.lexer.expectOrInsertSemicolon();
-                            return p.s(S.SExpr{
-                                .value = expr,
-                            }, loc);
+                            return p.s(S.SExpr{ .value = expr }, loc);
                         },
                         .t_string_literal, .t_no_substitution_template_literal => {
                             // "import 'path'"
@@ -10567,7 +10573,8 @@ fn NewParser_(
                             return try p.parseFnStmt(async_range.loc, opts, async_range);
                         }
 
-                        expr = try p.parseSuffix(try p.parseAsyncPrefixExpr(async_range, .lowest), .lowest, null, Expr.EFlags.none);
+                        try p.parseAsyncPrefixExpr(async_range, .lowest, &expr);
+                        try p.parseSuffix(&expr, .lowest, null, Expr.EFlags.none);
                     } else {
                         const exprOrLet = try p.parseExprOrLetStmt(opts);
                         switch (exprOrLet.stmt_or_expr) {
@@ -11389,7 +11396,7 @@ fn NewParser_(
                 try p.lexer.next();
 
                 const raw2 = p.lexer.raw();
-                const value = if (p.lexer.token == .t_identifier and strings.eqlComptime(raw2, "using")) value: {
+                var value = if (p.lexer.token == .t_identifier and strings.eqlComptime(raw2, "using")) value: {
                     // const using_loc = p.saveExprCommentsHere();
                     const using_range = p.lexer.range();
                     try p.lexer.next();
@@ -11425,13 +11432,17 @@ fn NewParser_(
                 if (p.lexer.token == .t_asterisk_asterisk) {
                     try p.lexer.unexpected();
                 }
-                const expr = p.newExpr(
-                    E.Await{ .value = try p.parseSuffix(value, .prefix, null, .none) },
+
+                try p.parseSuffix(&value, .prefix, null, .none);
+
+                var await_value = p.newExpr(
+                    E.Await{ .value = value },
                     token_range.loc,
                 );
+                try p.parseSuffix(&await_value, .lowest, null, .none);
                 return ExprOrLetStmt{
                     .stmt_or_expr = js_ast.StmtOrExpr{
-                        .expr = try p.parseSuffix(expr, .lowest, null, .none),
+                        .expr = value,
                     },
                 };
             } else {
@@ -11442,12 +11453,15 @@ fn NewParser_(
                 };
             }
 
-            // Parse the remainder of this expression that starts with an identifier
-            const ref = try p.storeNameInRef(raw);
-            const expr = p.newExpr(E.Identifier{ .ref = ref }, token_range.loc);
             return ExprOrLetStmt{
                 .stmt_or_expr = js_ast.StmtOrExpr{
-                    .expr = try p.parseSuffix(expr, .lowest, null, .none),
+                    .expr = brk: {
+                        // Parse the remainder of this expression that starts with an identifier
+                        const ref = try p.storeNameInRef(raw);
+                        var expr = p.newExpr(E.Identifier{ .ref = ref }, token_range.loc);
+                        try p.parseSuffix(&expr, .lowest, null, .none);
+                        break :brk expr;
+                    },
                 },
             };
         }
@@ -12558,7 +12572,7 @@ fn NewParser_(
             }
         }
 
-        fn parseFnExpr(p: *P, loc: logger.Loc, is_async: bool, async_range: logger.Range) !Expr {
+        fn parseFnExpr(p: *P, loc: logger.Loc, is_async: bool, async_range: logger.Range, value: *Expr) !void {
             try p.lexer.next();
             const is_generator = p.lexer.token == T.t_asterisk;
             if (is_generator) {
@@ -12604,7 +12618,7 @@ fn NewParser_(
             p.validateFunctionName(func, .expr);
             p.popScope();
 
-            return p.newExpr(js_ast.E.Function{
+            value.* = p.newExpr(js_ast.E.Function{
                 .func = func,
             }, loc);
         }
@@ -12731,10 +12745,11 @@ fn NewParser_(
 
         // This parses an expression. This assumes we've already parsed the "async"
         // keyword and are currently looking at the following token.
-        pub fn parseAsyncPrefixExpr(p: *P, async_range: logger.Range, level: Level) !Expr {
+        pub fn parseAsyncPrefixExpr(p: *P, async_range: logger.Range, level: Level, value: *Expr) !void {
             // "async function() {}"
             if (!p.lexer.has_newline_before and p.lexer.token == T.t_function) {
-                return try p.parseFnExpr(async_range.loc, true, async_range);
+                try p.parseFnExpr(async_range.loc, true, async_range, value);
+                return;
             }
 
             // Check the precedence level to avoid parsing an arrow function in
@@ -12758,7 +12773,8 @@ fn NewParser_(
                             };
                             const arrow_body = try p.parseArrowBody(args, &data);
                             p.popScope();
-                            return p.newExpr(arrow_body, async_range.loc);
+                            value.* = p.newExpr(arrow_body, async_range.loc);
+                            return;
                         }
                     },
                     // "async x => {}"
@@ -12785,7 +12801,8 @@ fn NewParser_(
                             };
                             var arrowBody = try p.parseArrowBody(args, &data);
                             arrowBody.is_async = true;
-                            return p.newExpr(arrowBody, async_range.loc);
+                            value.* = p.newExpr(arrowBody, async_range.loc);
+                            return;
                         }
                     },
 
@@ -12793,7 +12810,8 @@ fn NewParser_(
                     // "async () => {}"
                     .t_open_paren => {
                         try p.lexer.next();
-                        return p.parseParenExpr(async_range.loc, level, ParenExprOpts{ .is_async = true, .async_range = async_range });
+                        try p.parseParenExpr(async_range.loc, level, ParenExprOpts{ .is_async = true, .async_range = async_range }, value);
+                        return;
                     },
 
                     // "async<T>()"
@@ -12804,11 +12822,12 @@ fn NewParser_(
                                 .did_not_skip_anything => {},
                                 else => |result| {
                                     try p.lexer.next();
-                                    return p.parseParenExpr(async_range.loc, level, ParenExprOpts{
+                                    try p.parseParenExpr(async_range.loc, level, ParenExprOpts{
                                         .is_async = true,
                                         .async_range = async_range,
                                         .force_arrow_fn = result == .definitely_type_parameters,
-                                    });
+                                    }, value);
+                                    return;
                                 },
                             }
                         }
@@ -12820,7 +12839,7 @@ fn NewParser_(
 
             // "async"
             // "async + 1"
-            return p.newExpr(
+            value.* = p.newExpr(
                 E.Identifier{ .ref = try p.storeNameInRef("async") },
                 async_range.loc,
             );
@@ -12979,25 +12998,27 @@ fn NewParser_(
             return Backtracking.lexerBacktrackerWithArgs(p, Backtracking.skipTypeScriptConstraintOfInferTypeWithBacktracking, .{ p, flags }, bool);
         }
 
-        pub inline fn parseExprOrBindings(p: *P, level: Level, errors: ?*DeferredErrors) anyerror!Expr {
-            return try p.parseExprCommon(level, errors, Expr.EFlags.none);
+        pub inline fn parseExprOrBindings(p: *P, level: Level, errors: ?*DeferredErrors, expr: *Expr) anyerror!void {
+            return p.parseExprCommon(level, errors, Expr.EFlags.none, expr);
         }
 
         pub inline fn parseExpr(p: *P, level: Level) anyerror!Expr {
-            return try p.parseExprCommon(level, null, Expr.EFlags.none);
+            var expr: Expr = undefined;
+            try p.parseExprCommon(level, null, Expr.EFlags.none, &expr);
+            return expr;
         }
 
-        pub inline fn parseExprWithFlags(p: *P, level: Level, flags: Expr.EFlags) anyerror!Expr {
-            return try p.parseExprCommon(level, null, flags);
+        pub inline fn parseExprWithFlags(p: *P, level: Level, flags: Expr.EFlags, expr: *Expr) anyerror!void {
+            return p.parseExprCommon(level, null, flags, expr);
         }
 
-        fn parseExprCommon(p: *P, level: Level, errors: ?*DeferredErrors, flags: Expr.EFlags) anyerror!Expr {
+        fn parseExprCommon(p: *P, level: Level, errors: ?*DeferredErrors, flags: Expr.EFlags, expr: *Expr) anyerror!void {
             if (!p.stack_check.isSafeToRecurse()) {
                 try bun.throwStackOverflow();
             }
 
             const had_pure_comment_before = p.lexer.has_pure_comment_before and !p.options.ignore_dce_annotations;
-            var expr = try p.parsePrefix(level, errors, flags);
+            try p.parsePrefix(expr, level, errors, flags);
 
             // There is no formal spec for "__PURE__" comments but from reverse-
             // engineering, it looks like they apply to the next CallExpression or
@@ -13005,7 +13026,7 @@ fn NewParser_(
             // to the expression "a().b()".
 
             if (had_pure_comment_before and level.lt(.call)) {
-                expr = try p.parseSuffix(expr, @as(Level, @enumFromInt(@intFromEnum(Level.call) - 1)), errors, flags);
+                try p.parseSuffix(expr, @as(Level, @enumFromInt(@intFromEnum(Level.call) - 1)), errors, flags);
                 switch (expr.data) {
                     .e_call => |ex| {
                         ex.can_be_unwrapped_if_unused = true;
@@ -13017,7 +13038,7 @@ fn NewParser_(
                 }
             }
 
-            return try p.parseSuffix(expr, level, errors, flags);
+            try p.parseSuffix(expr, level, errors, flags);
         }
 
         pub inline fn addImportRecord(p: *P, kind: ImportKind, loc: logger.Loc, name: string) u32 {
@@ -13112,7 +13133,7 @@ fn NewParser_(
             }
         }
 
-        pub fn parseYieldExpr(p: *P, loc: logger.Loc) !ExprNodeIndex {
+        pub fn parseYieldExpr(p: *P, loc: logger.Loc, value: *Expr) !void {
             // Parse a yield-from expression, which yields from an iterator
             const isStar = p.lexer.token == T.t_asterisk;
 
@@ -13124,20 +13145,19 @@ fn NewParser_(
                 try p.lexer.next();
             }
 
-            var value: ?ExprNodeIndex = null;
+            value.* = Expr{ .data = .e_missing, .loc = loc };
+
             switch (p.lexer.token) {
                 .t_close_brace, .t_close_paren, .t_close_bracket, .t_colon, .t_comma, .t_semicolon => {},
                 else => {
                     if (isStar or !p.lexer.has_newline_before) {
-                        value = try p.parseExpr(.yield);
+                        try p.parseExprCommon(.yield, null, .none, value);
                     }
                 },
             }
 
-            return p.newExpr(E.Yield{
-                .value = value,
-                .is_star = isStar,
-            }, loc);
+            value.* = p.newExpr(E.Yield{ .value = if (value.data == .e_missing) null else value.*, .is_star = isStar }, loc);
+            return;
         }
 
         pub fn parseProperty(p: *P, kind: Property.Kind, opts: *PropertyOpts, errors: ?*DeferredErrors) anyerror!?G.Property {
@@ -13641,16 +13661,17 @@ fn NewParser_(
 
             // Parse an object key/value pair
             try p.lexer.expect(.t_colon);
-            const value = try p.parseExprOrBindings(.comma, errors);
-
-            return G.Property{
+            var property: G.Property = .{
                 .kind = kind,
                 .flags = Flags.Property.init(.{
                     .is_computed = is_computed,
                 }),
                 .key = key,
-                .value = value,
+                .value = Expr{ .data = .e_missing, .loc = .{} },
             };
+
+            try p.parseExprOrBindings(.comma, errors, &property.value.?);
+            return property;
         }
 
         // By the time we call this, the identifier and type parameters have already
@@ -13866,8 +13887,9 @@ fn NewParser_(
             return ExprListLoc{ .list = ExprNodeList.fromList(args), .loc = close_paren_loc };
         }
 
-        pub fn parseSuffix(noalias p: *P, _left: Expr, level: Level, noalias errors: ?*DeferredErrors, flags: Expr.EFlags) anyerror!Expr {
-            var left = _left;
+        pub fn parseSuffix(noalias p: *P, left_and_out: *Expr, level: Level, noalias errors: ?*DeferredErrors, flags: Expr.EFlags) anyerror!void {
+            var left = left_and_out.*;
+
             var optional_chain: ?js_ast.OptionalChain = null;
             while (true) {
                 if (p.lexer.loc().start == p.after_arrow_body_loc.start) {
@@ -13875,7 +13897,8 @@ fn NewParser_(
                         switch (p.lexer.token) {
                             .t_comma => {
                                 if (level.gte(.comma)) {
-                                    return left;
+                                    left_and_out.* = left;
+                                    return;
                                 }
 
                                 try p.lexer.next();
@@ -13886,7 +13909,8 @@ fn NewParser_(
                                 }, left.loc);
                             },
                             else => {
-                                return left;
+                                left_and_out.* = left;
+                                return;
                             },
                         }
                     }
@@ -13895,7 +13919,8 @@ fn NewParser_(
                 if (comptime is_typescript_enabled) {
                     // Stop now if this token is forbidden to follow a TypeScript "as" cast
                     if (p.forbid_suffix_after_as_loc.start > -1 and p.lexer.loc().start == p.forbid_suffix_after_as_loc.start) {
-                        return left;
+                        left_and_out.* = left;
+                        return;
                     }
                 }
 
@@ -13981,7 +14006,8 @@ fn NewParser_(
                             .t_open_paren => {
                                 // "a?.()"
                                 if (level.gte(.call)) {
-                                    return left;
+                                    left_and_out.* = left;
+                                    return;
                                 }
 
                                 const list_loc = try p.parseCallArgs();
@@ -14005,7 +14031,8 @@ fn NewParser_(
                                 }
 
                                 if (level.gte(.call)) {
-                                    return left;
+                                    left_and_out.* = left;
+                                    return;
                                 }
 
                                 const list_loc = try p.parseCallArgs();
@@ -14093,7 +14120,8 @@ fn NewParser_(
                         //
                         // This matches the behavior of the TypeScript compiler.
                         if (flags == .ts_decorator) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14117,7 +14145,8 @@ fn NewParser_(
                     },
                     .t_open_paren => {
                         if (level.gte(.call)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         const list_loc = try p.parseCallArgs();
@@ -14134,7 +14163,8 @@ fn NewParser_(
                     },
                     .t_question => {
                         if (level.gte(.conditional)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
 
@@ -14150,7 +14180,8 @@ fn NewParser_(
                                 return error.SyntaxError;
                             }
                             errors.?.invalid_expr_after_question = p.lexer.range();
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         // Allow "in" in between "?" and ":"
@@ -14173,7 +14204,8 @@ fn NewParser_(
                     .t_exclamation => {
                         // Skip over TypeScript non-null assertions
                         if (p.lexer.has_newline_before) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         if (!is_typescript_enabled) {
@@ -14186,7 +14218,8 @@ fn NewParser_(
                     },
                     .t_minus_minus => {
                         if (p.lexer.has_newline_before or level.gte(.postfix)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14194,7 +14227,8 @@ fn NewParser_(
                     },
                     .t_plus_plus => {
                         if (p.lexer.has_newline_before or level.gte(.postfix)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14202,7 +14236,8 @@ fn NewParser_(
                     },
                     .t_comma => {
                         if (level.gte(.comma)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14210,7 +14245,8 @@ fn NewParser_(
                     },
                     .t_plus => {
                         if (level.gte(.add)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14218,7 +14254,8 @@ fn NewParser_(
                     },
                     .t_plus_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14226,7 +14263,8 @@ fn NewParser_(
                     },
                     .t_minus => {
                         if (level.gte(.add)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14234,7 +14272,8 @@ fn NewParser_(
                     },
                     .t_minus_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14242,7 +14281,8 @@ fn NewParser_(
                     },
                     .t_asterisk => {
                         if (level.gte(.multiply)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14250,7 +14290,8 @@ fn NewParser_(
                     },
                     .t_asterisk_asterisk => {
                         if (level.gte(.exponentiation)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14258,7 +14299,8 @@ fn NewParser_(
                     },
                     .t_asterisk_asterisk_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14266,7 +14308,8 @@ fn NewParser_(
                     },
                     .t_asterisk_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14274,7 +14317,8 @@ fn NewParser_(
                     },
                     .t_percent => {
                         if (level.gte(.multiply)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14282,7 +14326,8 @@ fn NewParser_(
                     },
                     .t_percent_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14290,7 +14335,8 @@ fn NewParser_(
                     },
                     .t_slash => {
                         if (level.gte(.multiply)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14298,7 +14344,8 @@ fn NewParser_(
                     },
                     .t_slash_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14306,7 +14353,8 @@ fn NewParser_(
                     },
                     .t_equals_equals => {
                         if (level.gte(.equals)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14314,7 +14362,8 @@ fn NewParser_(
                     },
                     .t_exclamation_equals => {
                         if (level.gte(.equals)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14322,7 +14371,8 @@ fn NewParser_(
                     },
                     .t_equals_equals_equals => {
                         if (level.gte(.equals)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14330,7 +14380,8 @@ fn NewParser_(
                     },
                     .t_exclamation_equals_equals => {
                         if (level.gte(.equals)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14346,28 +14397,32 @@ fn NewParser_(
                         }
 
                         if (level.gte(.compare)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_lt, .left = left, .right = try p.parseExpr(.compare) }, left.loc);
                     },
                     .t_less_than_equals => {
                         if (level.gte(.compare)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_le, .left = left, .right = try p.parseExpr(.compare) }, left.loc);
                     },
                     .t_greater_than => {
                         if (level.gte(.compare)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_gt, .left = left, .right = try p.parseExpr(.compare) }, left.loc);
                     },
                     .t_greater_than_equals => {
                         if (level.gte(.compare)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_ge, .left = left, .right = try p.parseExpr(.compare) }, left.loc);
@@ -14382,14 +14437,16 @@ fn NewParser_(
                         }
 
                         if (level.gte(.shift)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_shl, .left = left, .right = try p.parseExpr(.shift) }, left.loc);
                     },
                     .t_less_than_less_than_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14397,14 +14454,16 @@ fn NewParser_(
                     },
                     .t_greater_than_greater_than => {
                         if (level.gte(.shift)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_shr, .left = left, .right = try p.parseExpr(.shift) }, left.loc);
                     },
                     .t_greater_than_greater_than_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14412,14 +14471,16 @@ fn NewParser_(
                     },
                     .t_greater_than_greater_than_greater_than => {
                         if (level.gte(.shift)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         left = p.newExpr(E.Binary{ .op = .bin_u_shr, .left = left, .right = try p.parseExpr(.shift) }, left.loc);
                     },
                     .t_greater_than_greater_than_greater_than_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14427,7 +14488,8 @@ fn NewParser_(
                     },
                     .t_question_question => {
                         if (level.gte(.nullish_coalescing)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
                         try p.lexer.next();
                         const prev = left;
@@ -14435,7 +14497,8 @@ fn NewParser_(
                     },
                     .t_question_question_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14443,7 +14506,8 @@ fn NewParser_(
                     },
                     .t_bar_bar => {
                         if (level.gte(.logical_or)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         // Prevent "||" inside "??" from the right
@@ -14457,7 +14521,7 @@ fn NewParser_(
                         left = p.newExpr(E.Binary{ .op = Op.Code.bin_logical_or, .left = left, .right = right }, left.loc);
 
                         if (level.lt(.nullish_coalescing)) {
-                            left = try p.parseSuffix(left, Level.nullish_coalescing.addF(1), null, flags);
+                            try p.parseSuffix(&left, Level.nullish_coalescing.addF(1), null, flags);
 
                             if (p.lexer.token == .t_question_question) {
                                 try p.lexer.unexpected();
@@ -14467,7 +14531,8 @@ fn NewParser_(
                     },
                     .t_bar_bar_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14475,7 +14540,8 @@ fn NewParser_(
                     },
                     .t_ampersand_ampersand => {
                         if (level.gte(.logical_and)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         // Prevent "&&" inside "??" from the right
@@ -14489,7 +14555,7 @@ fn NewParser_(
 
                         // Prevent "&&" inside "??" from the left
                         if (level.lt(.nullish_coalescing)) {
-                            left = try p.parseSuffix(left, Level.nullish_coalescing.addF(1), null, flags);
+                            try p.parseSuffix(&left, Level.nullish_coalescing.addF(1), null, flags);
 
                             if (p.lexer.token == .t_question_question) {
                                 try p.lexer.unexpected();
@@ -14499,7 +14565,8 @@ fn NewParser_(
                     },
                     .t_ampersand_ampersand_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14507,7 +14574,8 @@ fn NewParser_(
                     },
                     .t_bar => {
                         if (level.gte(.bitwise_or)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14515,7 +14583,8 @@ fn NewParser_(
                     },
                     .t_bar_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14523,7 +14592,8 @@ fn NewParser_(
                     },
                     .t_ampersand => {
                         if (level.gte(.bitwise_and)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14531,7 +14601,8 @@ fn NewParser_(
                     },
                     .t_ampersand_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14539,7 +14610,8 @@ fn NewParser_(
                     },
                     .t_caret => {
                         if (level.gte(.bitwise_xor)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14547,7 +14619,8 @@ fn NewParser_(
                     },
                     .t_caret_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14555,7 +14628,8 @@ fn NewParser_(
                     },
                     .t_equals => {
                         if (level.gte(.assign)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         try p.lexer.next();
@@ -14564,7 +14638,8 @@ fn NewParser_(
                     },
                     .t_in => {
                         if (level.gte(.compare) or !p.allow_in) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         // Warn about "!a in b" instead of "!(a in b)"
@@ -14583,7 +14658,8 @@ fn NewParser_(
                     },
                     .t_instanceof => {
                         if (level.gte(.compare)) {
-                            return left;
+                            left_and_out.* = left;
+                            return;
                         }
 
                         // Warn about "!a instanceof b" instead of "!(a instanceof b)". Here's an
@@ -14626,19 +14702,22 @@ fn NewParser_(
                                 .t_question_dot,
                                 => {
                                     p.forbid_suffix_after_as_loc = p.lexer.loc();
-                                    return left;
+                                    left_and_out.* = left;
+                                    return;
                                 },
                                 else => {},
                             }
 
                             if (p.lexer.token.isAssign()) {
                                 p.forbid_suffix_after_as_loc = p.lexer.loc();
-                                return left;
+                                left_and_out.* = left;
+                                return;
                             }
                             continue;
                         }
 
-                        return left;
+                        left_and_out.* = left;
+                        return;
                     },
                 }
             }
@@ -14650,6 +14729,7 @@ fn NewParser_(
         }
 
         pub fn panicLoc(p: *P, comptime fmt: string, args: anytype, loc: ?logger.Loc) noreturn {
+            @branchHint(.cold);
             var panic_buffer = p.allocator.alloc(u8, 32 * 1024) catch unreachable;
             var panic_stream = std.io.fixedBufferStream(panic_buffer);
 
@@ -14672,7 +14752,7 @@ fn NewParser_(
             Output.panic(fmt ++ "\n{s}", args ++ .{panic_buffer[0..panic_stream.pos]});
         }
 
-        pub fn parsePrefix(noalias p: *P, level: Level, noalias errors: ?*DeferredErrors, flags: Expr.EFlags) anyerror!Expr {
+        pub fn parsePrefix(noalias p: *P, value: *Expr, level: Level, noalias errors: ?*DeferredErrors, flags: Expr.EFlags) anyerror!void {
             const loc = p.lexer.loc();
             const l = @intFromEnum(level);
             // Output.print("Parse Prefix {s}:{s} @{s} ", .{ p.lexer.token, p.lexer.raw(), @tagName(level) });
@@ -14685,19 +14765,22 @@ fn NewParser_(
                     switch (p.lexer.token) {
                         .t_open_paren => {
                             if (l < @intFromEnum(Level.call) and p.fn_or_arrow_data_parse.allow_super_call) {
-                                return p.newExpr(E.Super{}, loc);
+                                value.* = p.newExpr(E.Super{}, loc);
+                                return;
                             }
                         },
                         .t_dot, .t_open_bracket => {
                             if (p.fn_or_arrow_data_parse.allow_super_property) {
-                                return p.newExpr(E.Super{}, loc);
+                                value.* = p.newExpr(E.Super{}, loc);
+                                return;
                             }
                         },
                         else => {},
                     }
 
                     p.log.addRangeError(p.source, superRange, "Unexpected \"super\"") catch unreachable;
-                    return p.newExpr(E.Super{}, loc);
+                    value.* = p.newExpr(E.Super{}, loc);
+                    return;
                 },
                 .t_open_paren => {
                     try p.lexer.next();
@@ -14708,34 +14791,39 @@ fn NewParser_(
                         const oldAllowIn = p.allow_in;
                         p.allow_in = true;
 
-                        var value = try p.parseExpr(Level.lowest);
-                        p.markExprAsParenthesized(&value);
+                        try p.parseExprWithFlags(Level.lowest, .none, value);
+                        p.markExprAsParenthesized(value);
                         try p.lexer.expect(.t_close_paren);
 
                         p.allow_in = oldAllowIn;
-                        return value;
+                        return;
                     }
 
-                    return p.parseParenExpr(loc, level, ParenExprOpts{});
+                    try p.parseParenExpr(loc, level, ParenExprOpts{}, value);
+                    return;
                 },
                 .t_false => {
                     try p.lexer.next();
-                    return p.newExpr(E.Boolean{ .value = false }, loc);
+                    value.* = p.newExpr(E.Boolean{ .value = false }, loc);
+                    return;
                 },
                 .t_true => {
                     try p.lexer.next();
-                    return p.newExpr(E.Boolean{ .value = true }, loc);
+                    value.* = p.newExpr(E.Boolean{ .value = true }, loc);
+                    return;
                 },
                 .t_null => {
                     try p.lexer.next();
-                    return p.newExpr(E.Null{}, loc);
+                    value.* = p.newExpr(E.Null{}, loc);
+                    return;
                 },
                 .t_this => {
                     if (p.fn_or_arrow_data_parse.is_this_disallowed) {
                         p.log.addRangeError(p.source, p.lexer.range(), "Cannot use \"this\" here") catch unreachable;
                     }
                     try p.lexer.next();
-                    return Expr{ .data = Prefill.Data.This, .loc = loc };
+                    value.* = Expr{ .data = Prefill.Data.This, .loc = loc };
+                    return;
                 },
                 .t_private_identifier => {
                     if (!p.allow_private_identifiers or !p.allow_in or level.gte(.compare)) {
@@ -14751,7 +14839,8 @@ fn NewParser_(
                         try p.lexer.expected(.t_in);
                     }
 
-                    return p.newExpr(E.PrivateIdentifier{ .ref = try p.storeNameInRef(name) }, loc);
+                    value.* = p.newExpr(E.PrivateIdentifier{ .ref = try p.storeNameInRef(name) }, loc);
+                    return;
                 },
                 .t_identifier => {
                     const name = p.lexer.identifier;
@@ -14764,7 +14853,8 @@ fn NewParser_(
                     switch (AsyncPrefixExpression.find(name)) {
                         .is_async => {
                             if ((raw.ptr == name.ptr and raw.len == name.len) or AsyncPrefixExpression.find(raw) == .is_async) {
-                                return try p.parseAsyncPrefixExpr(name_range, level);
+                                try p.parseAsyncPrefixExpr(name_range, level, value);
+                                return;
                             }
                         },
 
@@ -14785,13 +14875,14 @@ fn NewParser_(
                                             p.fn_or_arrow_data_parse.arrow_arg_errors.invalid_expr_await = name_range;
                                         }
 
-                                        const value = try p.parseExpr(.prefix);
+                                        try p.parseExprCommon(.prefix, null, .none, value);
                                         if (p.lexer.token == T.t_asterisk_asterisk) {
                                             try p.lexer.unexpected();
                                             return error.SyntaxError;
                                         }
 
-                                        return p.newExpr(E.Await{ .value = value }, loc);
+                                        value.* = p.newExpr(E.Await{ .value = value.* }, loc);
+                                        return;
                                     }
                                 },
                                 .allow_ident => {
@@ -14819,7 +14910,8 @@ fn NewParser_(
                                             p.fn_or_arrow_data_parse.arrow_arg_errors.invalid_expr_yield = name_range;
                                         }
 
-                                        return p.parseYieldExpr(loc);
+                                        try p.parseYieldExpr(loc, value);
+                                        return;
                                     }
                                 },
                                 // .allow_ident => {
@@ -14855,15 +14947,18 @@ fn NewParser_(
                         var fn_or_arrow_data = FnOrArrowDataParse{
                             .needs_async_loc = loc,
                         };
-                        return p.newExpr(try p.parseArrowBody(args, &fn_or_arrow_data), loc);
+                        value.* = p.newExpr(try p.parseArrowBody(args, &fn_or_arrow_data), loc);
+                        return;
                     }
 
                     const ref = p.storeNameInRef(name) catch unreachable;
 
-                    return Expr.initIdentifier(ref, loc);
+                    value.* = Expr.initIdentifier(ref, loc);
+                    return;
                 },
                 .t_string_literal, .t_no_substitution_template_literal => {
-                    return try p.parseStringLiteral();
+                    value.* = try p.parseStringLiteral();
+                    return;
                 },
                 .t_template_head => {
                     const head = try p.lexer.toEString();
@@ -14873,58 +14968,62 @@ fn NewParser_(
                     // Check if TemplateLiteral is unsupported. We don't care for this product.`
                     // if ()
 
-                    return p.newExpr(E.Template{
+                    value.* = p.newExpr(E.Template{
                         .head = .{ .cooked = head },
                         .parts = parts,
                     }, loc);
+                    return;
                 },
                 .t_numeric_literal => {
-                    const value = p.newExpr(E.Number{ .value = p.lexer.number }, loc);
+                    value.* = p.newExpr(E.Number{ .value = p.lexer.number }, loc);
                     // p.checkForLegacyOctalLiteral()
                     try p.lexer.next();
-                    return value;
+                    return;
                 },
                 .t_big_integer_literal => {
-                    const value = p.lexer.identifier;
+                    value.* = p.newExpr(E.BigInt{ .value = p.lexer.identifier }, loc);
                     // markSyntaxFeature bigInt
                     try p.lexer.next();
-                    return p.newExpr(E.BigInt{ .value = value }, loc);
+                    return;
                 },
                 .t_slash, .t_slash_equals => {
                     try p.lexer.scanRegExp();
                     // always set regex_flags_start to null to make sure we don't accidentally use the wrong value later
                     defer p.lexer.regex_flags_start = null;
-                    const value = p.lexer.raw();
+                    const raw = p.lexer.raw();
                     try p.lexer.next();
 
-                    return p.newExpr(E.RegExp{ .value = value, .flags_offset = p.lexer.regex_flags_start }, loc);
+                    value.* = p.newExpr(E.RegExp{ .value = raw, .flags_offset = p.lexer.regex_flags_start }, loc);
+                    return;
                 },
                 .t_void => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
                     }
 
-                    return p.newExpr(E.Unary{
+                    value.* = p.newExpr(E.Unary{
                         .op = .un_void,
-                        .value = value,
+                        .value = value.*,
                     }, loc);
+                    return;
                 },
                 .t_typeof => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
                     }
 
-                    return p.newExpr(E.Unary{ .op = .un_typeof, .value = value }, loc);
+                    value.* = p.newExpr(E.Unary{ .op = .un_typeof, .value = value.* }, loc);
+                    return;
                 },
                 .t_delete => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
@@ -14938,58 +15037,68 @@ fn NewParser_(
                         }
                     }
 
-                    return p.newExpr(E.Unary{ .op = .un_delete, .value = value }, loc);
+                    value.* = p.newExpr(E.Unary{ .op = .un_delete, .value = value.* }, loc);
+                    return;
                 },
                 .t_plus => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
                     }
 
-                    return p.newExpr(E.Unary{ .op = .un_pos, .value = value }, loc);
+                    value.* = p.newExpr(E.Unary{ .op = .un_pos, .value = value.* }, loc);
+                    return;
                 },
                 .t_minus => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
                     }
 
-                    return p.newExpr(E.Unary{ .op = .un_neg, .value = value }, loc);
+                    value.* = p.newExpr(E.Unary{ .op = .un_neg, .value = value.* }, loc);
+                    return;
                 },
                 .t_tilde => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
                     }
 
-                    return p.newExpr(E.Unary{ .op = .un_cpl, .value = value }, loc);
+                    value.* = p.newExpr(E.Unary{ .op = .un_cpl, .value = value.* }, loc);
+                    return;
                 },
                 .t_exclamation => {
                     try p.lexer.next();
-                    const value = try p.parseExpr(.prefix);
+                    try p.parseExprCommon(.prefix, null, .none, value);
                     if (p.lexer.token == .t_asterisk_asterisk) {
                         try p.lexer.unexpected();
                         return error.SyntaxError;
                     }
 
-                    return p.newExpr(E.Unary{ .op = .un_not, .value = value }, loc);
+                    value.* = p.newExpr(E.Unary{ .op = .un_not, .value = value.* }, loc);
+                    return;
                 },
                 .t_minus_minus => {
                     try p.lexer.next();
-                    return p.newExpr(E.Unary{ .op = .un_pre_dec, .value = try p.parseExpr(.prefix) }, loc);
+                    try p.parseExprCommon(.prefix, null, .none, value);
+                    value.* = p.newExpr(E.Unary{ .op = .un_pre_dec, .value = value.* }, loc);
+                    return;
                 },
                 .t_plus_plus => {
                     try p.lexer.next();
-                    return p.newExpr(E.Unary{ .op = .un_pre_inc, .value = try p.parseExpr(.prefix) }, loc);
+                    try p.parseExprCommon(.prefix, null, .none, value);
+                    value.* = p.newExpr(E.Unary{ .op = .un_pre_inc, .value = value.* }, loc);
+                    return;
                 },
                 .t_function => {
-                    return try p.parseFnExpr(loc, false, logger.Range.None);
+                    try p.parseFnExpr(loc, false, logger.Range.None, value);
+                    return;
                 },
                 .t_class => {
                     const classKeyword = p.lexer.range();
@@ -15026,7 +15135,8 @@ fn NewParser_(
                     const class = try p.parseClass(classKeyword, name, ParseClassOptions{});
                     p.popScope();
 
-                    return p.newExpr(class, loc);
+                    value.* = p.newExpr(class, loc);
+                    return;
                 },
                 .t_new => {
                     try p.lexer.next();
@@ -15042,10 +15152,11 @@ fn NewParser_(
                         const range = logger.Range{ .loc = loc, .len = p.lexer.range().end().start - loc.start };
 
                         try p.lexer.next();
-                        return p.newExpr(E.NewTarget{ .range = range }, loc);
+                        value.* = p.newExpr(E.NewTarget{ .range = range }, loc);
+                        return;
                     }
 
-                    const target = try p.parseExprWithFlags(.member, flags);
+                    try p.parseExprWithFlags(.member, flags, value);
                     var args = ExprNodeList{};
 
                     if (comptime is_typescript_enabled) {
@@ -15062,11 +15173,12 @@ fn NewParser_(
                         close_parens_loc = call_args.loc;
                     }
 
-                    return p.newExpr(E.New{
-                        .target = target,
+                    value.* = p.newExpr(E.New{
+                        .target = value.*,
                         .args = args,
                         .close_parens_loc = close_parens_loc,
                     }, loc);
+                    return;
                 },
                 .t_open_bracket => {
                     try p.lexer.next();
@@ -15090,9 +15202,11 @@ fn NewParser_(
 
                                 const dots_loc = p.lexer.loc();
                                 try p.lexer.next();
-                                items.append(
-                                    p.newExpr(E.Spread{ .value = try p.parseExprOrBindings(.comma, &self_errors) }, dots_loc),
-                                ) catch unreachable;
+                                try items.ensureUnusedCapacity(1);
+                                const spread_expr: *Expr = &items.unusedCapacitySlice()[0];
+                                spread_expr.* = p.newExpr(E.Spread{ .value = undefined }, dots_loc);
+                                try p.parseExprOrBindings(.comma, &self_errors, &spread_expr.data.e_spread.value);
+                                items.items.len += 1;
 
                                 // Commas are not allowed here when destructuring
                                 if (p.lexer.token == .t_comma) {
@@ -15100,9 +15214,10 @@ fn NewParser_(
                                 }
                             },
                             else => {
-                                items.append(
-                                    try p.parseExprOrBindings(.comma, &self_errors),
-                                ) catch unreachable;
+                                try items.ensureUnusedCapacity(1);
+                                const item: *Expr = &items.unusedCapacitySlice()[0];
+                                try p.parseExprOrBindings(.comma, &self_errors, item);
+                                items.items.len += 1;
                             },
                         }
 
@@ -15139,12 +15254,13 @@ fn NewParser_(
                         // In this case, we can't distinguish between the two yet
                         self_errors.mergeInto(errors.?);
                     }
-                    return p.newExpr(E.Array{
+                    value.* = p.newExpr(E.Array{
                         .items = ExprNodeList.fromList(items),
                         .comma_after_spread = comma_after_spread.toNullable(),
                         .is_single_line = is_single_line,
                         .close_bracket_loc = close_bracket_loc,
                     }, loc);
+                    return;
                 },
                 .t_open_brace => {
                     try p.lexer.next();
@@ -15160,7 +15276,19 @@ fn NewParser_(
                     while (p.lexer.token != .t_close_brace) {
                         if (p.lexer.token == .t_dot_dot_dot) {
                             try p.lexer.next();
-                            properties.append(G.Property{ .kind = .spread, .value = try p.parseExpr(.comma) }) catch unreachable;
+                            try properties.ensureUnusedCapacity(1);
+                            const property: *G.Property = &properties.unusedCapacitySlice()[0];
+                            property.* = .{
+                                .kind = .spread,
+                                .value = Expr.empty,
+                            };
+
+                            try p.parseExprOrBindings(
+                                .comma,
+                                &self_errors,
+                                &(property.value.?),
+                            );
+                            properties.items.len += 1;
 
                             // Commas are not allowed here when destructuring
                             if (p.lexer.token == .t_comma) {
@@ -15210,7 +15338,7 @@ fn NewParser_(
                         self_errors.mergeInto(errors.?);
                     }
 
-                    return p.newExpr(E.Object{
+                    value.* = p.newExpr(E.Object{
                         .properties = G.Property.List.fromList(properties),
                         .comma_after_spread = if (comma_after_spread.start > 0)
                             comma_after_spread
@@ -15219,6 +15347,7 @@ fn NewParser_(
                         .is_single_line = is_single_line,
                         .close_brace_loc = close_brace_loc,
                     }, loc);
+                    return;
                 },
                 .t_less_than => {
                     // This is a very complicated and highly ambiguous area of TypeScript
@@ -15259,21 +15388,22 @@ fn NewParser_(
                                 .allow_const_modifier = true,
                             });
                             try p.lexer.expect(.t_open_paren);
-                            return try p.parseParenExpr(loc, level, ParenExprOpts{ .force_arrow_fn = true });
+                            try p.parseParenExpr(loc, level, ParenExprOpts{ .force_arrow_fn = true }, value);
+                            return;
                         }
                     }
 
                     if (is_jsx_enabled) {
                         // Use NextInsideJSXElement() instead of Next() so we parse "<<" as "<"
                         try p.lexer.nextInsideJSXElement();
-                        const element = try p.parseJSXElement(loc);
+                        value.* = try p.parseJSXElement(loc);
 
                         // The call to parseJSXElement() above doesn't consume the last
                         // TGreaterThan because the caller knows what Next() function to call.
                         // Use Next() instead of NextInsideJSXElement() here since the next
                         // token is an expression.
                         try p.lexer.next();
-                        return element;
+                        return;
                     }
 
                     if (is_typescript_enabled) {
@@ -15287,7 +15417,7 @@ fn NewParser_(
                                 try p.lexer.expect(.t_open_paren);
                                 return p.parseParenExpr(loc, level, ParenExprOpts{
                                     .force_arrow_fn = result == .definitely_type_parameters,
-                                });
+                                }, value);
                             },
                         }
 
@@ -15295,7 +15425,8 @@ fn NewParser_(
                         try p.lexer.next();
                         try p.skipTypeScriptType(.lowest);
                         try p.lexer.expectGreaterThan(false);
-                        return p.parsePrefix(level, errors, flags);
+                        try p.parsePrefix(value, level, errors, flags);
+                        return;
                     }
 
                     try p.lexer.unexpected();
@@ -15303,7 +15434,8 @@ fn NewParser_(
                 },
                 .t_import => {
                     try p.lexer.next();
-                    return p.parseImportExpr(loc, level);
+                    try p.parseImportExpr(loc, level, value);
+                    return;
                 },
                 else => {
                     try p.lexer.unexpected();
@@ -15370,7 +15502,7 @@ fn NewParser_(
         }
 
         // Note: The caller has already parsed the "import" keyword
-        fn parseImportExpr(noalias p: *P, loc: logger.Loc, level: Level) anyerror!Expr {
+        fn parseImportExpr(noalias p: *P, loc: logger.Loc, level: Level, value: *Expr) anyerror!void {
             // Parse an "import.meta" expression
             if (p.lexer.token == .t_dot) {
                 p.esm_import_keyword = js_lexer.rangeOfIdentifier(p.source, loc);
@@ -15378,7 +15510,8 @@ fn NewParser_(
                 if (p.lexer.isContextualKeyword("meta")) {
                     try p.lexer.next();
                     p.has_import_meta = true;
-                    return p.newExpr(E.ImportMeta{}, loc);
+                    value.* = p.newExpr(E.ImportMeta{}, loc);
+                    return;
                 } else {
                     try p.lexer.expectedString("\"meta\"");
                 }
@@ -15401,7 +15534,7 @@ fn NewParser_(
 
             p.lexer.preserve_all_comments_before = false;
 
-            const value = try p.parseExpr(.comma);
+            try p.parseExprCommon(.comma, null, .none, value);
 
             var import_options = Expr.empty;
             if (p.lexer.token == .t_comma) {
@@ -15410,7 +15543,7 @@ fn NewParser_(
 
                 if (p.lexer.token != .t_close_paren) {
                     // "import('./foo.json', { assert: { type: 'json' } })"
-                    import_options = try p.parseExpr(.comma);
+                    try p.parseExprCommon(.comma, null, .none, &import_options);
 
                     if (p.lexer.token == .t_comma) {
                         // "import('./foo.json', { assert: { type: 'json' } }, )"
@@ -15427,23 +15560,25 @@ fn NewParser_(
                 if (value.data == .e_string and value.data.e_string.isUTF8() and value.data.e_string.isPresent()) {
                     const import_record_index = p.addImportRecord(.dynamic, value.loc, value.data.e_string.slice(p.allocator));
 
-                    return p.newExpr(E.Import{
-                        .expr = value,
+                    value.* = p.newExpr(E.Import{
+                        .expr = value.*,
                         // .leading_interior_comments = comments,
                         .import_record_index = import_record_index,
                         .options = import_options,
                     }, loc);
+                    return;
                 }
             }
 
             // _ = comments; // TODO: leading_interior comments
 
-            return p.newExpr(E.Import{
-                .expr = value,
+            value.* = p.newExpr(E.Import{
+                .expr = value.*,
                 // .leading_interior_comments = comments,
                 .import_record_index = std.math.maxInt(u32),
                 .options = import_options,
             }, loc);
+            return;
         }
 
         fn parseJSXPropValueIdentifier(noalias p: *P, previous_string_with_backslash_loc: *logger.Loc) !Expr {
@@ -22749,7 +22884,7 @@ fn NewParser_(
         }
 
         // This assumes that the open parenthesis has already been parsed by the caller
-        pub fn parseParenExpr(p: *P, loc: logger.Loc, level: Level, opts: ParenExprOpts) anyerror!Expr {
+        pub fn parseParenExpr(p: *P, loc: logger.Loc, level: Level, opts: ParenExprOpts, value: *Expr) anyerror!void {
             var items_list = ListManaged(Expr).init(p.allocator);
             var errors = DeferredErrors{};
             var arrowArgErrors = DeferredArrowArgErrors{};
@@ -22788,10 +22923,12 @@ fn NewParser_(
                 // We don't know yet whether these are arguments or expressions, so parse
                 p.latest_arrow_arg_loc = p.lexer.loc();
 
-                var item = try p.parseExprOrBindings(.comma, &errors);
+                try items_list.ensureUnusedCapacity(1);
+                const item: *Expr = &items_list.unusedCapacitySlice()[0];
+                try p.parseExprOrBindings(.comma, &errors, item);
 
                 if (is_spread) {
-                    item = p.newExpr(E.Spread{ .value = item }, loc);
+                    item.* = p.newExpr(E.Spread{ .value = item.* }, loc);
                 }
 
                 // Skip over types
@@ -22804,10 +22941,10 @@ fn NewParser_(
                 // There may be a "=" after the type (but not after an "as" cast)
                 if (is_typescript_enabled and p.lexer.token == .t_equals and !p.forbid_suffix_after_as_loc.eql(p.lexer.loc())) {
                     try p.lexer.next();
-                    item = Expr.assign(item, try p.parseExpr(.comma));
+                    item.* = Expr.assign(item.*, try p.parseExpr(.comma));
                 }
 
-                items_list.append(item) catch unreachable;
+                items_list.items.len += 1;
 
                 if (p.lexer.token != .t_comma) {
                     break;
@@ -22897,7 +23034,8 @@ fn NewParser_(
                     arrow.is_async = opts.is_async;
                     arrow.has_rest_arg = spread_range.len > 0;
                     p.popScope();
-                    return p.newExpr(arrow, loc);
+                    value.* = p.newExpr(arrow, loc);
+                    return;
                 }
             }
 
@@ -22916,7 +23054,8 @@ fn NewParser_(
             if (opts.is_async) {
                 p.logExprErrors(&errors);
                 const async_expr = p.newExpr(E.Identifier{ .ref = try p.storeNameInRef("async") }, loc);
-                return p.newExpr(E.Call{ .target = async_expr, .args = ExprNodeList.init(items) }, loc);
+                value.* = p.newExpr(E.Call{ .target = async_expr, .args = ExprNodeList.init(items) }, loc);
+                return;
             }
 
             // Is this a chain of expressions and comma operators?
@@ -22927,9 +23066,9 @@ fn NewParser_(
                     return error.SyntaxError;
                 }
 
-                var value = Expr.joinAllWithComma(items, p.allocator);
-                p.markExprAsParenthesized(&value);
-                return value;
+                value.* = Expr.joinAllWithComma(items, p.allocator);
+                p.markExprAsParenthesized(value);
+                return;
             }
 
             // Indicate that we expected an arrow function

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -13915,6 +13915,7 @@ fn NewParser_(
                             name_loc,
                         ),
                         .optional_chain = optional_chain.*,
+                        .optional_chain = old_optional_chain,
                     }, left.loc);
                 } else {
                     // "a.b"
@@ -13927,7 +13928,15 @@ fn NewParser_(
                     const name_loc = p.lexer.loc();
                     try p.lexer.next();
 
-                    left.* = p.newExpr(E.Dot{ .target = left.*, .name = name, .name_loc = name_loc, .optional_chain = old_optional_chain }, left.loc);
+                    left.* = p.newExpr(
+                        E.Dot{
+                            .target = left.*,
+                            .name = name,
+                            .name_loc = name_loc,
+                            .optional_chain = old_optional_chain,
+                        },
+                        left.loc,
+                    );
                 }
                 optional_chain.* = old_optional_chain;
                 return .next;
@@ -14052,6 +14061,7 @@ fn NewParser_(
                 // p.markSyntaxFeature(compat.TemplateLiteral, p.lexer.Range());
                 const head = p.lexer.rawTemplateContents();
                 try p.lexer.next();
+
                 left.* = p.newExpr(E.Template{
                     .tag = left.*,
                     .head = .{ .raw = head },
@@ -15209,10 +15219,8 @@ fn NewParser_(
                         _ = try p.skipTypeScriptTypeParameters(.{ .allow_in_out_variance_annotations = true, .allow_const_modifier = true });
                     }
 
-                    const class = try p.parseClass(classKeyword, name, ParseClassOptions{});
+                    value.* = p.newExpr(try p.parseClass(classKeyword, name, ParseClassOptions{}), loc);
                     p.popScope();
-
-                    value.* = p.newExpr(class, loc);
                     return;
                 },
                 .t_new => {

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -13892,6 +13892,8 @@ fn NewParser_(
             const Continuation = enum { next, done };
             pub fn t_dot(p: *P, _: Level, optional_chain: *?OptionalChain, old_optional_chain: ?OptionalChain, left: *Expr) anyerror!Continuation {
                 try p.lexer.next();
+                const target = left.*;
+
                 if (p.lexer.token == .t_private_identifier and p.allow_private_identifiers) {
                     // "a.#b"
                     // "a?.b.#c"
@@ -13907,7 +13909,7 @@ fn NewParser_(
                     try p.lexer.next();
                     const ref = p.storeNameInRef(name) catch unreachable;
                     left.* = p.newExpr(E.Index{
-                        .target = left.*,
+                        .target = target,
                         .index = p.newExpr(
                             E.PrivateIdentifier{
                                 .ref = ref,
@@ -13929,7 +13931,7 @@ fn NewParser_(
 
                     left.* = p.newExpr(
                         E.Dot{
-                            .target = left.*,
+                            .target = target,
                             .name = name,
                             .name_loc = name_loc,
                             .optional_chain = old_optional_chain,

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -13914,7 +13914,6 @@ fn NewParser_(
                             },
                             name_loc,
                         ),
-                        .optional_chain = optional_chain.*,
                         .optional_chain = old_optional_chain,
                     }, left.loc);
                 } else {

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -2178,7 +2178,7 @@ fn NewPrinter(
                         if (value.loc_ref.ref.?.eql(id.ref)) {
                             if (p.options.commonjs_named_exports_deoptimized or value.needs_decl) {
                                 if (p.options.commonjs_module_exports_assigned_deoptimized and
-                                    id.base == .module_dot_exports and
+                                    id.base() == .module_dot_exports and
                                     p.options.commonjs_module_ref.isValid())
                                 {
                                     p.printSymbol(p.options.commonjs_module_ref);
@@ -2926,7 +2926,7 @@ fn NewPrinter(
                                 didPrint = true;
 
                                 if (p.call_target) |target| {
-                                    wrap = e.was_originally_identifier and (target == .e_identifier and
+                                    wrap = e.was_originally_identifier() and (target == .e_identifier and
                                         target.e_identifier.ref.eql(expr.data.e_import_identifier.ref));
                                 }
 
@@ -2956,7 +2956,7 @@ fn NewPrinter(
                             didPrint = true;
 
                             const wrap = if (p.call_target) |target|
-                                e.was_originally_identifier and (target == .e_identifier and
+                                e.was_originally_identifier() and (target == .e_identifier and
                                     target.e_identifier.ref.eql(expr.data.e_import_identifier.ref))
                             else
                                 false;

--- a/src/options.zig
+++ b/src/options.zig
@@ -836,7 +836,7 @@ pub const Loader = enum(u8) {
             slice = slice[1..];
         }
 
-        return names.getWithEql(slice, strings.eqlCaseInsensitiveASCIIICheckLength);
+        return names.getASCIIICaseInsensitive(slice);
     }
 
     pub fn supportsClientEntryPoint(this: Loader) bool {


### PR DESCRIPTION
### What does this PR do?

Shrink Expr from 32 bytes -> 24 bytes

Pack 3 booleans inside of `Ref` that are used by:
- `E.Identifier`
- `E.ImportIdentifier`
- `E.CommonJSExportsIdentifier`

Now the largest member of the `Expr.Data` union is 8 bytes.

This turns `Expr.Data` into 16 bytes because the tag in `union(Tag)` rounds up to 8 bytes due to alignment. 

So even though Expr has a 1 byte tag, a 4 byte `loc`, and an 8 byte pointer (13 bytes), it becomes 24 bytes due to alignment and padding -- which is still better than 32 bytes where we started.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
