### PR TITLE
Add HTML entity decoder

### DIFF
--- a/cmake/sources/CxxSources.txt
+++ b/cmake/sources/CxxSources.txt
@@ -51,6 +51,7 @@ src/bun.js/bindings/ffi.cpp
 src/bun.js/bindings/helpers.cpp
 src/bun.js/bindings/highway_strings.cpp
 src/bun.js/bindings/HTMLEntryPoint.cpp
+src/bun.js/bindings/HTMLEntityDecoder.cpp
 src/bun.js/bindings/ImportMetaObject.cpp
 src/bun.js/bindings/inlines.cpp
 src/bun.js/bindings/InspectorBunFrontendDevServerAgent.cpp

--- a/cmake/sources/CxxSources.txt
+++ b/cmake/sources/CxxSources.txt
@@ -50,8 +50,8 @@ src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
 src/bun.js/bindings/ffi.cpp
 src/bun.js/bindings/helpers.cpp
 src/bun.js/bindings/highway_strings.cpp
-src/bun.js/bindings/HTMLEntryPoint.cpp
 src/bun.js/bindings/HTMLEntityDecoder.cpp
+src/bun.js/bindings/HTMLEntryPoint.cpp
 src/bun.js/bindings/ImportMetaObject.cpp
 src/bun.js/bindings/inlines.cpp
 src/bun.js/bindings/InspectorBunFrontendDevServerAgent.cpp

--- a/src/bun.js/bindings/HTMLEntityDecoder.cpp
+++ b/src/bun.js/bindings/HTMLEntityDecoder.cpp
@@ -8,7 +8,7 @@ namespace Bun {
 using namespace JSC;
 using namespace WTF;
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionDecodeHTMLEntity, (JSGlobalObject* globalObject, CallFrame* callFrame))
+JSC_DEFINE_HOST_FUNCTION(jsFunctionDecodeHTMLEntity, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/bun.js/bindings/HTMLEntityDecoder.cpp
+++ b/src/bun.js/bindings/HTMLEntityDecoder.cpp
@@ -1,0 +1,61 @@
+#include "root.h"
+#include <wtf/text/WTFString.h>
+#include <wtf/text/StringBuilder.h>
+
+extern "C" bool Bun__decodeEntity(const BunString* in, BunString* out);
+
+namespace Bun {
+using namespace JSC;
+using namespace WTF;
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionDecodeHTMLEntity, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue arg = callFrame->argument(0);
+    String input = arg.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    StringBuilder builder;
+    builder.reserveCapacity(input.length());
+    size_t index = 0;
+    while (true) {
+        size_t amp = input.find('&', index);
+        if (amp == WTF::notFound) {
+            builder.append(input.substring(index));
+            break;
+        }
+        builder.append(input.substring(index, amp - index));
+        size_t semi = input.find(';', amp + 1);
+        if (semi == WTF::notFound) {
+            builder.append(input.substring(amp));
+            break;
+        }
+        size_t len = semi - amp - 1;
+        if (len == 0) {
+            builder.append(input.substring(amp, semi - amp + 1));
+            index = semi + 1;
+            continue;
+        }
+        BunString bunIn;
+        if (input.is8Bit()) {
+            auto span = input.span8().subspan(amp + 1, len);
+            bunIn = BunString__fromLatin1(reinterpret_cast<const char*>(span.data()), span.size());
+        } else {
+            auto span = input.span16().subspan(amp + 1, len);
+            bunIn = BunString__fromUTF16(span.data(), span.size());
+        }
+        BunString bunOut;
+        bool ok = Bun__decodeEntity(&bunIn, &bunOut);
+        if (ok) {
+            builder.append(bunOut.toWTFString(BunString::NonNull));
+        } else {
+            builder.append(input.substring(amp, semi - amp + 1));
+        }
+        index = semi + 1;
+    }
+
+    return JSValue::encode(jsString(vm, builder.toString()));
+}
+
+} // namespace Bun

--- a/src/js_lexer_tables.zig
+++ b/src/js_lexer_tables.zig
@@ -194,6 +194,18 @@ pub const Keywords = ComptimeStringMap(T, .{
     .{ "with", .t_with },
 });
 
+export fn Bun__decodeEntity(input: *bun.String, out: *bun.String) bool {
+    const utf8 = input.toUTF8(bun.default_allocator);
+    defer utf8.deinit();
+    if (jsxEntity.get(utf8.slice())) |cp| {
+        var buf: [4]u8 = undefined;
+        const len = std.unicode.utf8Encode(@as(u21, @intCast(cp)), &buf) catch unreachable;
+        out.* = bun.String.createUTF8(buf[0..len]);
+        return true;
+    }
+    return false;
+}
+
 pub const StrictModeReservedWords = ComptimeStringMap(void, .{
     .{ "implements", {} },
     .{ "interface", {} },

--- a/test/js/bun/util/decodeHTMLEntity.test.ts
+++ b/test/js/bun/util/decodeHTMLEntity.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "bun:test";
+
+describe("decodeHTMLEntity", () => {
+  it("decodes named entities", () => {
+    expect(Bun.decodeHTMLEntity("&amp;")).toBe("&");
+    expect(Bun.decodeHTMLEntity("Tom &amp; Jerry")).toBe("Tom & Jerry");
+    expect(Bun.decodeHTMLEntity("&lt;div&gt;")).toBe("<div>");
+  });
+
+  it("returns input when entity unknown", () => {
+    expect(Bun.decodeHTMLEntity("&notanentity;")).toBe("&notanentity;");
+  });
+});

--- a/test/js/bun/util/decodeHTMLEntity.test.ts
+++ b/test/js/bun/util/decodeHTMLEntity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 describe("decodeHTMLEntity", () => {
   it("decodes named entities", () => {


### PR DESCRIPTION
## Summary
- implement HTML entity decoding logic using existing JSX entity table
- expose `Bun.decodeHTMLEntity`
- wire new decoder into build and Bun object
- add tests for entity decoding

## Testing
- `bun run clang-format src/bun.js/bindings/HTMLEntityDecoder.cpp src/bun.js/bindings/BunObject.cpp` *(fails: Command exited with code 1)*
- `bun run zig-format src/js_lexer_tables.zig` *(fails: Command exited with code 1)*
- `bun run prettier test/js/bun/util/decodeHTMLEntity.test.ts` *(fails: command not found)*
- `bun bd test test/js/bun/util/decodeHTMLEntity.test.ts` *(fails: CMake configure error)*

------
https://chatgpt.com/codex/tasks/task_e_686921067aa48328a3ea00b0abeb850a