### PR TITLE
Remove duplicate toBeInstanceOf type declaration for Expect

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1185,14 +1185,6 @@ declare module "bun:test" {
      */
     toBeInstanceOf(value: unknown): void;
     /**
-     * Asserts that the expected value is an instance of value
-     *
-     * @example
-     * expect([]).toBeInstanceOf(Array);
-     * expect(null).toBeInstanceOf(Array); // fail
-     */
-    toBeInstanceOf(value: unknown): void;
-    /**
      * Asserts that a value is `undefined`.
      *
      * @example


### PR DESCRIPTION
### What does this PR do?

Removes a duplicate type declaration for the `toBeInstanceOf` method in Bun's `Expect` object. The duplicate declaration was added in [#2453](https://github.com/oven-sh/bun/pull/2453/files#diff-03a81e374ac6268f0e975230ed39affab3e807b987000fc5c8fd513359a82fd7R349-R364).

- [x] Documentation or TypeScript types

### How did you verify your code works?

The number of errors from `bun typecheck` didn't increase.