### PR TITLE
Speculative test for lockfile install hang

### DIFF
--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -426,6 +426,10 @@ pub fn installWithManager(
             while (iter.next()) |entry| manager.enqueuePatchTaskPre(PatchTask.newCalcPatchHash(manager, entry.key_ptr.*, null));
         }
         manager.enqueueDependencyList(root.dependencies);
+        // schedule any downloads or patch tasks for the initial install
+        // otherwise pendingTaskCount() will remain zero and runTasks will never
+        // be triggered
+        manager.drainDependencyList();
     } else {
         {
             var iter = manager.lockfile.patched_dependencies.iterator();

--- a/test/regression/issue/020850.test.ts
+++ b/test/regression/issue/020850.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// Regression test for hanging installs when creating a new lockfile
+// Ensure tasks are scheduled on first install
+
+test("install completes with new lockfile", async () => {
+  const tarball = join(import.meta.dir, "../..", "cli", "install", "bar-0.0.2.tgz");
+  const dir = tempDirWithFiles("install-new-lockfile", {
+    "package.json": JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: { bar: "file:" + tarball },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: dir,
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/020850.test.ts
+++ b/test/regression/issue/020850.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv, tempDirWithFiles } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 // Regression test for hanging installs when creating a new lockfile


### PR DESCRIPTION
## Summary
- schedule dependency downloads when creating a new lockfile so async tasks run
- add regression test for new lockfile installs

## Testing
- `node_modules/.bin/prettier -w test/regression/issue/020850.test.ts`
- `bun run clang-format` *(fails: could not download build dependencies)*
- `bun run zig-format` *(fails: could not download build dependencies)*
- `bun bd test test/regression/issue/020850.test.ts` *(fails: could not download build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a61606cdc832887207b5da826083d