### PR TITLE
Implement `"node:module"`'s `findSourceMap` and `SourceMap` class

### DIFF
--- a/bench/snippets/source-map.js
+++ b/bench/snippets/source-map.js
@@ -1,0 +1,28 @@
+import { SourceMap } from "node:module";
+import { readFileSync } from "node:fs";
+import { bench, run } from "../runner.mjs";
+const json = JSON.parse(readFileSync(process.argv.at(-1), "utf-8"));
+
+bench("new SourceMap(json)", () => {
+  return new SourceMap(json);
+});
+
+const map = new SourceMap(json);
+
+const toRotate = [];
+for (let j = 0; j < 10000; j++) {
+  if (map.findEntry(0, j).generatedColumn) {
+    toRotate.push(j);
+    if (toRotate.length > 5) break;
+  }
+}
+let i = 0;
+bench("findEntry (match)", () => {
+  return map.findEntry(0, toRotate[i++ % 3]).generatedColumn;
+});
+
+bench("findEntry (no match)", () => {
+  return map.findEntry(0, 9999).generatedColumn;
+});
+
+await run();

--- a/cmake/sources/ZigGeneratedClassesSources.txt
+++ b/cmake/sources/ZigGeneratedClassesSources.txt
@@ -22,3 +22,4 @@ src/bun.js/resolve_message.classes.ts
 src/bun.js/test/jest.classes.ts
 src/bun.js/webcore/encoding.classes.ts
 src/bun.js/webcore/response.classes.ts
+src/bun.js/api/sourcemap.classes.ts

--- a/cmake/sources/ZigGeneratedClassesSources.txt
+++ b/cmake/sources/ZigGeneratedClassesSources.txt
@@ -14,6 +14,7 @@ src/bun.js/api/server.classes.ts
 src/bun.js/api/Shell.classes.ts
 src/bun.js/api/ShellArgs.classes.ts
 src/bun.js/api/sockets.classes.ts
+src/bun.js/api/sourcemap.classes.ts
 src/bun.js/api/streams.classes.ts
 src/bun.js/api/valkey.classes.ts
 src/bun.js/api/zlib.classes.ts
@@ -22,4 +23,3 @@ src/bun.js/resolve_message.classes.ts
 src/bun.js/test/jest.classes.ts
 src/bun.js/webcore/encoding.classes.ts
 src/bun.js/webcore/response.classes.ts
-src/bun.js/api/sourcemap.classes.ts

--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -121,8 +121,6 @@ src/bun.js/bindings/Exception.zig
 src/bun.js/bindings/FetchHeaders.zig
 src/bun.js/bindings/FFI.zig
 src/bun.js/bindings/generated_classes_list.zig
-src/bun.js/bindings/GeneratedBindings.zig
-src/bun.js/bindings/GeneratedJS2Native.zig
 src/bun.js/bindings/GetterSetter.zig
 src/bun.js/bindings/HTTPServerAgent.zig
 src/bun.js/bindings/JSArray.zig

--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -121,6 +121,8 @@ src/bun.js/bindings/Exception.zig
 src/bun.js/bindings/FetchHeaders.zig
 src/bun.js/bindings/FFI.zig
 src/bun.js/bindings/generated_classes_list.zig
+src/bun.js/bindings/GeneratedBindings.zig
+src/bun.js/bindings/GeneratedJS2Native.zig
 src/bun.js/bindings/GetterSetter.zig
 src/bun.js/bindings/HTTPServerAgent.zig
 src/bun.js/bindings/JSArray.zig
@@ -729,6 +731,7 @@ src/shell/subproc.zig
 src/shell/util.zig
 src/shell/Yield.zig
 src/sourcemap/CodeCoverage.zig
+src/sourcemap/JSSourceMap.zig
 src/sourcemap/LineOffsetTable.zig
 src/sourcemap/sourcemap.zig
 src/sourcemap/VLQ.zig

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -237,6 +237,7 @@ pub const StandaloneModuleGraph = struct {
                         null,
                         std.math.maxInt(i32),
                         std.math.maxInt(i32),
+                        .{},
                     )) {
                         .success => |x| x,
                         .fail => {

--- a/src/baby_list.zig
+++ b/src/baby_list.zig
@@ -417,6 +417,10 @@ pub fn BabyList(comptime Type: type) type {
             @as([*]align(1) Int, @ptrCast(this.ptr[this.len .. this.len + @sizeOf(Int)]))[0] = int;
             this.len += @sizeOf(Int);
         }
+
+        pub fn memoryCost(self: *const @This()) usize {
+            return self.cap;
+        }
     };
 }
 

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -8040,6 +8040,7 @@ pub const SourceMapStore = struct {
             null,
             @intCast(entry.paths.len),
             0, // unused
+            .{},
         )) {
             .fail => |fail| {
                 Output.debugWarn("Failed to re-parse source map: {s}", .{fail.msg});
@@ -8199,7 +8200,7 @@ const ErrorReportRequest = struct {
             const result: *const SourceMapStore.GetResult = &(gop.value_ptr.* orelse continue);
 
             // When before the first generated line, remap to the HMR runtime
-            const generated_mappings = result.mappings.items(.generated);
+            const generated_mappings = result.mappings.generated();
             if (frame.position.line.oneBased() < generated_mappings[1].lines) {
                 frame.source_url = .init(runtime_name); // matches value in source map
                 frame.position = .invalid;
@@ -8207,8 +8208,7 @@ const ErrorReportRequest = struct {
             }
 
             // Remap the frame
-            const remapped = SourceMap.Mapping.find(
-                result.mappings,
+            const remapped = result.mappings.find(
                 frame.position.line.oneBased(),
                 frame.position.column.zeroBased(),
             );

--- a/src/bun.js/SavedSourceMap.zig
+++ b/src/bun.js/SavedSourceMap.zig
@@ -50,6 +50,7 @@ pub const SavedMappings = struct {
             @as(usize, @bitCast(this.data[8..16].*)),
             1,
             @as(usize, @bitCast(this.data[16..24].*)),
+            .{},
         );
         switch (result) {
             .fail => |fail| {
@@ -310,7 +311,7 @@ pub fn resolveMapping(
     const map = parse.map orelse return null;
 
     const mapping = parse.mapping orelse
-        SourceMap.Mapping.find(map.mappings, line, column) orelse
+        map.mappings.find(line, column) orelse
         return null;
 
     return .{

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3408,7 +3408,7 @@ pub fn resolveSourceMapping(
             this.source_mappings.putValue(path, SavedSourceMap.Value.init(map)) catch
                 bun.outOfMemory();
 
-            const mapping = SourceMap.Mapping.find(map.mappings, line, column) orelse
+            const mapping = map.mappings.find(line, column) orelse
                 return null;
 
             return .{

--- a/src/bun.js/api/sourcemap.classes.ts
+++ b/src/bun.js/api/sourcemap.classes.ts
@@ -1,0 +1,29 @@
+import { define } from "../../codegen/class-definitions";
+
+export default [
+  define({
+    name: "SourceMap",
+    JSType: "0b11101110",
+    proto: {
+      findOrigin: {
+        fn: "findOrigin",
+        length: 2,
+      },
+      findEntry: {
+        fn: "findEntry", 
+        length: 2,
+      },
+      payload: {
+        getter: "getPayload",
+        cache: true,
+      },
+      lineLengths: {
+        getter: "getLineLengths",
+        cache: true,
+      },
+    },
+    finalize: true,
+    construct: true,
+    structuredClone: false,
+  }),
+];

--- a/src/bun.js/api/sourcemap.classes.ts
+++ b/src/bun.js/api/sourcemap.classes.ts
@@ -10,7 +10,7 @@ export default [
         length: 2,
       },
       findEntry: {
-        fn: "findEntry", 
+        fn: "findEntry",
         length: 2,
       },
       payload: {
@@ -24,6 +24,9 @@ export default [
     },
     finalize: true,
     construct: true,
+    constructNeedsThis: true,
+    memoryCost: true,
+    estimatedSize: true,
     structuredClone: false,
   }),
 ];

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -461,6 +461,8 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_nodeModuleConstructor)                                 \
+    V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapEntryStructure)                    \
+    V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapOriginStructure)                   \
                                                                                                              \
     V(public, WriteBarrier<Bun::JSNextTickQueue>, m_nextTickQueue)                                           \
                                                                                                              \

--- a/src/bun.js/bindings/generated_classes_list.zig
+++ b/src/bun.js/bindings/generated_classes_list.zig
@@ -89,4 +89,5 @@ pub const Classes = struct {
     pub const RedisClient = api.Valkey;
     pub const BlockList = api.BlockList;
     pub const NativeZstd = api.NativeZstd;
+    pub const SourceMap = bun.sourcemap.JSSourceMap;
 };

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -20,6 +20,7 @@
 #include "ErrorCode.h"
 
 #include "GeneratedNodeModuleModule.h"
+#include "ZigGeneratedClasses.h"
 
 namespace Bun {
 
@@ -34,9 +35,9 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveFileName);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveLookupPaths);
-JSC_DECLARE_HOST_FUNCTION(jsFunctionSourceMap);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionSyncBuiltinExports);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionWrap);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionSourceMapStub);
 
 JSC_DECLARE_CUSTOM_GETTER(getterRequireFunction);
 JSC_DECLARE_CUSTOM_SETTER(setterRequireFunction);
@@ -294,6 +295,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionFindSourceMap,
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionSourceMapStub,
+    (JSGlobalObject * globalObject,
+        CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    throwException(globalObject, scope, 
+        createError(globalObject, "SourceMap is not yet implemented"_s));
+    return {};
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSyncBuiltinExports,
     (JSGlobalObject * globalObject,
         CallFrame* callFrame))
@@ -301,14 +313,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSyncBuiltinExports,
     return JSValue::encode(jsUndefined());
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionSourceMap, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    throwException(globalObject, scope,
-        createError(globalObject, "Not implemented"_s));
-    return {};
-}
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
     (JSC::JSGlobalObject * globalObject,
@@ -585,10 +589,10 @@ static JSValue getPathCacheObject(VM& vm, JSObject* moduleObject)
 static JSValue getSourceMapFunction(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    JSFunction* sourceMapFunction = JSFunction::create(
-        vm, globalObject, 1, "SourceMap"_s, jsFunctionSourceMap,
-        ImplementationVisibility::Public, NoIntrinsic, jsFunctionSourceMap);
-    return sourceMapFunction;
+    auto* zigGlobalObject = jsCast<Zig::GlobalObject*>(globalObject);
+    
+    // Return the actual SourceMap constructor from code generation
+    return zigGlobalObject->JSSourceMapConstructor();
 }
 
 static JSValue getBuiltinModulesObject(VM& vm, JSObject* moduleObject)

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -919,7 +919,6 @@ static JSC::Structure* createNodeModuleSourceMapEntryStructure(JSC::VM& vm, JSC:
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "originalSource"), 0, offset);
     RELEASE_ASSERT(offset == 4);
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->name, 0, offset);
-    RELEASE_ASSERT(offset == 5);
 
     return structure;
 }
@@ -935,7 +934,7 @@ extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapEntryObject(
 {
     auto& vm = globalObject->vm();
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapEntryStructure.getInitializedOnMainThread(zigGlobalObject));
+    JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapEntryStructure.getInitializedOnMainThread(globalObject));
     object->putDirectOffset(vm, 0, JSC::JSValue::decode(encodedGeneratedLine));
     object->putDirectOffset(vm, 1, JSC::JSValue::decode(encodedGeneratedColumn));
     object->putDirectOffset(vm, 2, JSC::JSValue::decode(encodedOriginalLine));
@@ -957,7 +956,6 @@ static JSC::Structure* createNodeModuleSourceMapOriginStructure(JSC::VM& vm, JSC
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "column"), 0, offset);
     RELEASE_ASSERT(offset == 2);
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "fileName"), 0, offset);
-    RELEASE_ASSERT(offset == 3);
 
     return structure;
 }

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -905,7 +905,7 @@ const JSC::ClassInfo JSModuleConstructor::s_info = {
 
 static JSC::Structure* createNodeModuleSourceMapEntryStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
-    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), 5);
+    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), 6);
     PropertyOffset offset;
 
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "generatedLine"), 0, offset);
@@ -934,7 +934,7 @@ extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapEntryObject(
 {
     auto& vm = globalObject->vm();
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapEntryStructure.getInitializedOnMainThread(globalObject));
+    JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapEntryStructure.getInitializedOnMainThread(zigGlobalObject));
     object->putDirectOffset(vm, 0, JSC::JSValue::decode(encodedGeneratedLine));
     object->putDirectOffset(vm, 1, JSC::JSValue::decode(encodedGeneratedColumn));
     object->putDirectOffset(vm, 2, JSC::JSValue::decode(encodedOriginalLine));

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -919,6 +919,7 @@ static JSC::Structure* createNodeModuleSourceMapEntryStructure(JSC::VM& vm, JSC:
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "originalSource"), 0, offset);
     RELEASE_ASSERT(offset == 4);
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->name, 0, offset);
+    RELEASE_ASSERT(offset == 5);
 
     return structure;
 }
@@ -956,6 +957,7 @@ static JSC::Structure* createNodeModuleSourceMapOriginStructure(JSC::VM& vm, JSC
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "column"), 0, offset);
     RELEASE_ASSERT(offset == 2);
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "fileName"), 0, offset);
+    RELEASE_ASSERT(offset == 3);
 
     return structure;
 }

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -26,10 +26,11 @@ namespace Bun {
 
 using namespace JSC;
 
+BUN_DECLARE_HOST_FUNCTION(Bun__JSSourceMap__find);
+
 BUN_DECLARE_HOST_FUNCTION(Resolver__nodeModulePathsForJS);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionDebugNoop);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionFindPath);
-JSC_DECLARE_HOST_FUNCTION(jsFunctionFindSourceMap);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionIsBuiltinModule);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor);
@@ -37,7 +38,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveFileName);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveLookupPaths);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionSyncBuiltinExports);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionWrap);
-JSC_DECLARE_HOST_FUNCTION(jsFunctionSourceMapStub);
 
 JSC_DECLARE_CUSTOM_GETTER(getterRequireFunction);
 JSC_DECLARE_CUSTOM_SETTER(setterRequireFunction);
@@ -288,31 +288,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
         scope, JSValue::encode(Bun::JSCommonJSModule::createBoundRequireFunction(vm, globalObject, val)));
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionFindSourceMap,
-    (JSGlobalObject * globalObject,
-        CallFrame* callFrame))
-{
-    return JSValue::encode(jsUndefined());
-}
-
-JSC_DEFINE_HOST_FUNCTION(jsFunctionSourceMapStub,
-    (JSGlobalObject * globalObject,
-        CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    throwException(globalObject, scope, 
-        createError(globalObject, "SourceMap is not yet implemented"_s));
-    return {};
-}
-
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSyncBuiltinExports,
     (JSGlobalObject * globalObject,
         CallFrame* callFrame))
 {
     return JSValue::encode(jsUndefined());
 }
-
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
     (JSC::JSGlobalObject * globalObject,
@@ -590,7 +571,7 @@ static JSValue getSourceMapFunction(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
     auto* zigGlobalObject = jsCast<Zig::GlobalObject*>(globalObject);
-    
+
     // Return the actual SourceMap constructor from code generation
     return zigGlobalObject->JSSourceMapConstructor();
 }
@@ -851,7 +832,7 @@ builtinModules          getBuiltinModulesObject           PropertyCallback
 constants               getConstantsObject                PropertyCallback
 createRequire           jsFunctionNodeModuleCreateRequire Function 1
 enableCompileCache      jsFunctionEnableCompileCache      Function 0
-findSourceMap           jsFunctionFindSourceMap           Function 0
+findSourceMap           Bun__JSSourceMap__find           Function 1
 getCompileCacheDir      jsFunctionGetCompileCacheDir      Function 0
 globalPaths             getGlobalPathsObject              PropertyCallback
 isBuiltin               jsFunctionIsBuiltinModule         Function 1

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -903,6 +903,82 @@ const JSC::ClassInfo JSModuleConstructor::s_info = {
     CREATE_METHOD_TABLE(JSModuleConstructor)
 };
 
+static JSC::Structure* createNodeModuleSourceMapEntryStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), 5);
+    PropertyOffset offset;
+
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "generatedLine"), 0, offset);
+    RELEASE_ASSERT(offset == 0);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "generatedColumn"), 0, offset);
+    RELEASE_ASSERT(offset == 1);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "originalLine"), 0, offset);
+    RELEASE_ASSERT(offset == 2);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "originalColumn"), 0, offset);
+    RELEASE_ASSERT(offset == 3);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "originalSource"), 0, offset);
+    RELEASE_ASSERT(offset == 4);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->name, 0, offset);
+    RELEASE_ASSERT(offset == 5);
+
+    return structure;
+}
+
+extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapEntryObject(
+    JSC::JSGlobalObject* globalObject,
+    JSC::EncodedJSValue encodedGeneratedLine,
+    JSC::EncodedJSValue encodedGeneratedColumn,
+    JSC::EncodedJSValue encodedOriginalLine,
+    JSC::EncodedJSValue encodedOriginalColumn,
+    JSC::EncodedJSValue encodedOriginalSource,
+    JSC::EncodedJSValue encodedName)
+{
+    auto& vm = globalObject->vm();
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+    JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapEntryStructure.getInitializedOnMainThread(zigGlobalObject));
+    object->putDirectOffset(vm, 0, JSC::JSValue::decode(encodedGeneratedLine));
+    object->putDirectOffset(vm, 1, JSC::JSValue::decode(encodedGeneratedColumn));
+    object->putDirectOffset(vm, 2, JSC::JSValue::decode(encodedOriginalLine));
+    object->putDirectOffset(vm, 3, JSC::JSValue::decode(encodedOriginalColumn));
+    object->putDirectOffset(vm, 4, JSC::JSValue::decode(encodedOriginalSource));
+    object->putDirectOffset(vm, 5, JSC::JSValue::decode(encodedName));
+    return JSValue::encode(object);
+}
+
+static JSC::Structure* createNodeModuleSourceMapOriginStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(globalObject, globalObject->objectPrototype(), 4);
+    PropertyOffset offset;
+
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->name, 0, offset);
+    RELEASE_ASSERT(offset == 0);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "line"), 0, offset);
+    RELEASE_ASSERT(offset == 1);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "column"), 0, offset);
+    RELEASE_ASSERT(offset == 2);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "fileName"), 0, offset);
+    RELEASE_ASSERT(offset == 3);
+
+    return structure;
+}
+
+extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapOriginObject(
+    JSC::JSGlobalObject* globalObject,
+    JSC::EncodedJSValue encodedName,
+    JSC::EncodedJSValue encodedLine,
+    JSC::EncodedJSValue encodedColumn,
+    JSC::EncodedJSValue encodedSource)
+{
+    auto& vm = globalObject->vm();
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+    JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapOriginStructure.getInitializedOnMainThread(zigGlobalObject));
+    object->putDirectOffset(vm, 0, JSC::JSValue::decode(encodedName));
+    object->putDirectOffset(vm, 1, JSC::JSValue::decode(encodedLine));
+    object->putDirectOffset(vm, 2, JSC::JSValue::decode(encodedColumn));
+    object->putDirectOffset(vm, 3, JSC::JSValue::decode(encodedSource));
+    return JSValue::encode(object);
+}
+
 void addNodeModuleConstructorProperties(JSC::VM& vm,
     Zig::GlobalObject* globalObject)
 {
@@ -911,6 +987,15 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
             JSObject* moduleConstructor = JSModuleConstructor::create(
                 init.vm, static_cast<Zig::GlobalObject*>(init.owner));
             init.set(moduleConstructor);
+        });
+
+    globalObject->m_nodeModuleSourceMapEntryStructure.initLater(
+        [](const Zig::GlobalObject::Initializer<Structure>& init) {
+            init.set(createNodeModuleSourceMapEntryStructure(init.vm, init.owner));
+        });
+    globalObject->m_nodeModuleSourceMapOriginStructure.initLater(
+        [](const Zig::GlobalObject::Initializer<Structure>& init) {
+            init.set(createNodeModuleSourceMapOriginStructure(init.vm, init.owner));
         });
 
     globalObject->m_moduleRunMainFunction.initLater(

--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -92,9 +92,21 @@ export class ClassDefinition {
    */
   name: string;
   /**
-   * Class constructor is newable.
+   * Class constructor is newable. Called before the JSValue corresponding to
+   * the object is created. Throwing an exception prevents the object from being
+   * created.
    */
   construct?: boolean;
+
+  /**
+   * Class constructor needs `this` value.
+   *
+   * Makes the code generator call the Zig constructor function **after** the
+   * JSValue is instantiated. Only use this if you must, as it probably isn't
+   * good for GC since it means if the constructor throws the GC will have to
+   * clean up the object that never reached JS.
+   */
+  constructNeedsThis?: boolean;
   /**
    * Class constructor is callable. In JS, ES6 class constructors are not
    * callable.
@@ -167,10 +179,6 @@ export class ClassDefinition {
   noConstructor?: boolean;
 
   final?: boolean;
-
-  // Do not try to track the `this` value in the constructor automatically.
-  // That is a memory leak.
-  wantsThis?: never;
 
   /**
    * Class has an `estimatedSize` function that reports external allocations to GC.

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -64,8 +64,8 @@ pub const Kind = enum(u8) {
 pub const Loc = struct {
     start: i32 = -1,
 
-    pub inline fn toNullable(loc: *Loc) ?Loc {
-        return if (loc.start == -1) null else loc.*;
+    pub inline fn toNullable(loc: Loc) ?Loc {
+        return if (loc.start == -1) null else loc;
     }
 
     pub const toUsize = i;

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -561,7 +561,7 @@ pub const ByteRangeMapping = struct {
                     }
                     const column_position = byte_offset -| line_start_byte_offset;
 
-                    if (SourceMap.Mapping.find(parsed_mapping.mappings, @intCast(new_line_index), @intCast(column_position))) |point| {
+                    if (parsed_mapping.mappings.find(@intCast(new_line_index), @intCast(column_position))) |*point| {
                         if (point.original.lines < 0) continue;
 
                         const line: u32 = @as(u32, @intCast(point.original.lines));
@@ -605,7 +605,7 @@ pub const ByteRangeMapping = struct {
 
                     const column_position = byte_offset -| line_start_byte_offset;
 
-                    if (SourceMap.Mapping.find(parsed_mapping.mappings, @intCast(new_line_index), @intCast(column_position))) |point| {
+                    if (parsed_mapping.mappings.find(@intCast(new_line_index), @intCast(column_position))) |point| {
                         if (point.original.lines < 0) continue;
 
                         const line: u32 = @as(u32, @intCast(point.original.lines));

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -1,7 +1,6 @@
 const bun = @import("bun");
 const std = @import("std");
 const LineOffsetTable = bun.sourcemap.LineOffsetTable;
-const SourceMap = bun.sourcemap;
 const Bitset = bun.bit_set.DynamicBitSetUnmanaged;
 const LinesHits = @import("../baby_list.zig").BabyList(u32);
 const Output = bun.Output;

--- a/src/sourcemap/JSSourceMap.zig
+++ b/src/sourcemap/JSSourceMap.zig
@@ -5,11 +5,6 @@ const JSSourceMap = @This();
 sourcemap: *bun.sourcemap.ParsedSourceMap,
 sources: []bun.String = &.{},
 
-pub const js = JSC.Codegen.JSSourceMap;
-pub const toJS = js.toJS;
-pub const fromJS = js.fromJS;
-pub const fromJSDirect = js.fromJSDirect;
-
 fn findSourceMap(
     globalObject: *JSGlobalObject,
     callFrame: *CallFrame,
@@ -238,9 +233,16 @@ comptime {
 // @sortImports
 
 const std = @import("std");
+
 const bun = @import("bun");
-const JSC = bun.JSC;
-const JSValue = JSC.JSValue;
-const JSGlobalObject = JSC.JSGlobalObject;
-const CallFrame = JSC.CallFrame;
 const string = bun.string;
+
+const JSC = bun.JSC;
+const CallFrame = JSC.CallFrame;
+const JSGlobalObject = JSC.JSGlobalObject;
+const JSValue = JSC.JSValue;
+
+pub const js = JSC.Codegen.JSSourceMap;
+pub const fromJS = js.fromJS;
+pub const fromJSDirect = js.fromJSDirect;
+pub const toJS = js.toJS;

--- a/src/sourcemap/JSSourceMap.zig
+++ b/src/sourcemap/JSSourceMap.zig
@@ -36,6 +36,7 @@ fn findSourceMap(
 
             source_url_string.deref();
             source_url_slice.deinit();
+            source_url_string = path;
             source_url_slice = path.toUTF8(bun.default_allocator);
             source_url = source_url_slice.slice();
         }

--- a/src/sourcemap/JSSourceMap.zig
+++ b/src/sourcemap/JSSourceMap.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+const bun = @import("bun");
+const JSC = bun.JSC;
+const JSValue = JSC.JSValue;
+const JSGlobalObject = JSC.JSGlobalObject;
+const CallFrame = JSC.CallFrame;
+const string = bun.string;
+
+pub const JSSourceMap = struct {
+    pub const js = JSC.Codegen.JSSourceMap;
+    pub const toJS = js.toJS;
+    pub const fromJS = js.fromJS;
+    pub const fromJSDirect = js.fromJSDirect;
+
+    sourcemap: bun.sourcemap.SourceMap,
+    payload: JSValue = .zero,
+    line_lengths: JSValue = .zero,
+    sources: []JSC.ZigString.Slice = &.{},
+
+    pub fn constructor(
+        globalObject: *JSGlobalObject,
+        callFrame: *CallFrame,
+    ) bun.JSError!*JSSourceMap {
+        
+        if (callFrame.argumentsCount() < 1) {
+            return globalObject.throw("SourceMap constructor requires a payload argument", .{});
+        }
+
+        const payload_arg = callFrame.argument(0);
+        const options_arg = callFrame.argument(1);
+
+        if (!payload_arg.isObject()) {
+            return globalObject.throw("payload must be an object", .{});
+        }
+
+        var line_lengths: JSValue = .zero;
+        if (!options_arg.isUndefinedOrNull()) {
+            if (!options_arg.isObject()) {
+                return globalObject.throw("options must be an object", .{});
+            }
+            
+            if (try options_arg.getIfPropertyExists(globalObject, "lineLengths")) |lengths| {
+                if (!lengths.isUndefinedOrNull() and !lengths.jsType().isArray()) {
+                    return globalObject.throw("lineLengths must be an array", .{});
+                }
+                line_lengths = lengths;
+            }
+        }
+
+        // Parse the payload to create a proper sourcemap
+        var arena = bun.ArenaAllocator.init(bun.default_allocator);
+        defer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        // Extract mappings string from payload
+        const mappings_value = try payload_arg.getIfPropertyExists(globalObject, "mappings") orelse {
+            return globalObject.throw("payload must have a 'mappings' property", .{});
+        };
+        
+        if (!mappings_value.isString()) {
+            return globalObject.throw("mappings must be a string", .{});
+        }
+        
+        const mappings_zigstring = try mappings_value.getZigString(globalObject);
+        const mappings_slice = mappings_zigstring.toSlice(arena_allocator);
+        defer mappings_slice.deinit();
+        const mappings_str = mappings_slice.slice();
+
+        // Extract sources array from payload
+        const sources_value = try payload_arg.getIfPropertyExists(globalObject, "sources") orelse {
+            return globalObject.throw("payload must have a 'sources' property", .{});
+        };
+        
+        if (!sources_value.jsType().isArray()) {
+            return globalObject.throw("sources must be an array", .{});
+        }
+        
+        const sources_length = try sources_value.getLength(globalObject);
+        
+        // Convert sources array to ZigString.Slice objects
+        const sources_slices = try bun.default_allocator.alloc(JSC.ZigString.Slice, sources_length);
+        const sources_ptrs = try bun.default_allocator.alloc([]const u8, sources_length);
+        
+        for (0..sources_length) |i| {
+            const source_val = try sources_value.getIndex(globalObject, @intCast(i));
+            if (!source_val.isString()) {
+                return globalObject.throw("all sources must be strings", .{});
+            }
+            const source_zigstring = try source_val.getZigString(globalObject);
+            sources_slices[i] = source_zigstring.toSlice(bun.default_allocator);
+            sources_ptrs[i] = sources_slices[i].slice();
+        }
+
+        // Parse the VLQ mappings
+        const parse_result = bun.sourcemap.Mapping.parse(
+            bun.default_allocator,
+            mappings_str,
+            null, // estimated_mapping_count
+            @intCast(sources_ptrs.len), // sources_count
+            100, // input_line_count (estimate)
+        );
+
+        const mapping_list = switch (parse_result) {
+            .success => |parsed| parsed.mappings,
+            .fail => |fail| {
+                // Clean up sources on error
+                for (sources_slices) |slice| slice.deinit();
+                bun.default_allocator.free(sources_slices);
+                bun.default_allocator.free(sources_ptrs);
+                return globalObject.throw("failed to parse sourcemap mappings: {s}", .{fail.msg});
+            },
+        };
+
+        const empty_strings: []string = &.{};
+        const source_map = bun.new(JSSourceMap, .{
+            .sourcemap = .{
+                .sources = sources_ptrs,
+                .sources_content = empty_strings,
+                .mapping = mapping_list,
+                .allocator = bun.default_allocator,
+            },
+            .payload = payload_arg,
+            .line_lengths = line_lengths,
+            .sources = sources_slices,
+        });
+
+        return source_map;
+    }
+
+    pub fn getPayload(this: *JSSourceMap, globalObject: *JSGlobalObject) JSValue {
+        _ = globalObject;
+        return this.payload;
+    }
+
+    pub fn getLineLengths(this: *JSSourceMap, globalObject: *JSGlobalObject) JSValue {
+        _ = globalObject;
+        if (this.line_lengths == .zero) {
+            return .js_undefined;
+        }
+        return this.line_lengths;
+    }
+
+    pub fn findOrigin(this: *JSSourceMap, globalObject: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
+        if (callFrame.argumentsCount() < 2) {
+            return globalObject.throw("findOrigin requires lineNumber and columnNumber arguments", .{});
+        }
+
+        const line_number_arg = callFrame.argument(0);
+        const column_number_arg = callFrame.argument(1);
+
+        if (!line_number_arg.isNumber()) {
+            return globalObject.throw("lineNumber must be a number", .{});
+        }
+        if (!column_number_arg.isNumber()) {
+            return globalObject.throw("columnNumber must be a number", .{});
+        }
+
+        const line_number = line_number_arg.toInt32();
+        const column_number = column_number_arg.toInt32();
+
+        // Use bun.sourcemap.find to get the mapping
+        if (bun.sourcemap.Mapping.find(this.sourcemap.mapping, line_number, column_number)) |mapping| {
+            const result = JSC.JSValue.createEmptyObject(globalObject, 4);
+            result.put(globalObject, JSC.ZigString.static("line"), JSC.JSValue.jsNumber(mapping.originalLine()));
+            result.put(globalObject, JSC.ZigString.static("column"), JSC.JSValue.jsNumber(mapping.originalColumn()));
+            
+            // Add source filename if available
+            if (mapping.sourceIndex() >= 0 and mapping.sourceIndex() < this.sourcemap.sources.len) {
+                const source_name = this.sourcemap.sources[@intCast(mapping.sourceIndex())];
+                result.put(globalObject, JSC.ZigString.static("source"), JSC.ZigString.init(source_name).toJS(globalObject));
+            }
+            
+            // Note: name is not implemented yet as it would require names array
+            result.put(globalObject, JSC.ZigString.static("name"), JSC.JSValue.jsNull());
+            
+            return result;
+        }
+
+        return JSC.JSValue.createEmptyObject(globalObject, 0);
+    }
+
+    pub fn findEntry(this: *JSSourceMap, globalObject: *JSGlobalObject, callFrame: *CallFrame) bun.JSError!JSValue {
+        if (callFrame.argumentsCount() < 2) {
+            return globalObject.throw("findEntry requires lineNumber and columnNumber arguments", .{});
+        }
+
+        const line_number_arg = callFrame.argument(0);
+        const column_number_arg = callFrame.argument(1);
+
+        if (!line_number_arg.isNumber()) {
+            return globalObject.throw("lineNumber must be a number", .{});
+        }
+        if (!column_number_arg.isNumber()) {
+            return globalObject.throw("columnNumber must be a number", .{});
+        }
+
+        const line_number = line_number_arg.toInt32();
+        const column_number = column_number_arg.toInt32();
+
+        // Use bun.sourcemap.find to get the mapping
+        if (bun.sourcemap.Mapping.find(this.sourcemap.mapping, line_number, column_number)) |mapping| {
+            const result = JSC.JSValue.createEmptyObject(globalObject, 3);
+            result.put(globalObject, JSC.ZigString.static("generatedLine"), JSC.JSValue.jsNumber(mapping.generatedLine()));
+            result.put(globalObject, JSC.ZigString.static("generatedColumn"), JSC.JSValue.jsNumber(mapping.generatedColumn()));
+            result.put(globalObject, JSC.ZigString.static("originalLine"), JSC.JSValue.jsNumber(mapping.originalLine()));
+            result.put(globalObject, JSC.ZigString.static("originalColumn"), JSC.JSValue.jsNumber(mapping.originalColumn()));
+            result.put(globalObject, JSC.ZigString.static("source"), JSC.JSValue.jsNumber(mapping.sourceIndex()));
+            return result;
+        }
+
+        return JSC.JSValue.createEmptyObject(globalObject, 0);
+    }
+
+    pub fn deinit(this: *JSSourceMap) void {
+        // Clean up ZigString.Slice objects
+        for (this.sources) |slice| {
+            slice.deinit();
+        }
+        if (this.sources.len > 0) {
+            this.sourcemap.allocator.free(this.sources);
+        }
+        
+        // Clean up sources pointer array
+        if (this.sourcemap.sources.len > 0) {
+            this.sourcemap.allocator.free(this.sourcemap.sources);
+        }
+        
+        // Clean up mapping list
+        this.sourcemap.mapping.deinit(this.sourcemap.allocator);
+        
+        bun.destroy(this);
+    }
+
+    pub fn finalize(this: *JSSourceMap) void {
+        this.deinit();
+    }
+};

--- a/src/sourcemap/JSSourceMap.zig
+++ b/src/sourcemap/JSSourceMap.zig
@@ -34,6 +34,7 @@ fn findSourceMap(
                 return globalObject.ERR(.INVALID_URL, "Invalid URL: {s}", .{source_url}).throw();
             }
 
+            // Replace the file:// URL with the absolute path.
             source_url_string.deref();
             source_url_slice.deinit();
             source_url_string = path;

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -306,7 +306,7 @@ pub const Mapping = struct {
             }
         };
 
-        pub fn ensureWithNames(this: *List, allocator: std.mem.Allocator) !void {
+        fn ensureWithNames(this: *List, allocator: std.mem.Allocator) !void {
             if (this.impl == .with_names) return;
 
             var without_names = this.impl.without_names;

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -1671,7 +1671,7 @@ const assert = bun.assert;
 pub const coverage = @import("./CodeCoverage.zig");
 pub const VLQ = @import("./VLQ.zig");
 pub const LineOffsetTable = @import("./LineOffsetTable.zig");
-pub const JSSourceMap = @import("./JSSourceMap.zig").JSSourceMap;
+pub const JSSourceMap = @import("./JSSourceMap.zig");
 
 const decodeVLQAssumeValid = VLQ.decodeAssumeValid;
 const decodeVLQ = VLQ.decode;

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -42,7 +42,11 @@ pub const ParseUrlResultHint = union(enum) {
     /// In order to fetch source contents, you need to know the
     /// index, but you cant know the index until the mappings
     /// are loaded. So pass in line+col.
-    all: struct { line: i32, column: i32 },
+    all: struct {
+        line: i32,
+        column: i32,
+        include_names: bool = false,
+    },
 };
 
 pub const ParseUrl = struct {
@@ -179,19 +183,46 @@ pub fn parseJSON(
     };
 
     const map = if (hint != .source_only) map: {
-        const map_data = switch (Mapping.parse(
+        var map_data = switch (Mapping.parse(
             alloc,
             mappings_str.data.e_string.slice(arena),
             null,
             std.math.maxInt(i32),
             std.math.maxInt(i32),
+            .{ .allow_names = hint == .all and hint.all.include_names, .sort = true },
         )) {
             .success => |x| x,
             .fail => |fail| return fail.err,
         };
 
+        if (hint == .all and hint.all.include_names and map_data.mappings.impl == .with_names) {
+            if (json.get("names")) |names| {
+                if (names.data == .e_array) {
+                    var names_list = try std.ArrayListUnmanaged(bun.Semver.String).initCapacity(alloc, names.data.e_array.items.len);
+                    errdefer names_list.deinit(alloc);
+
+                    var names_buffer = std.ArrayListUnmanaged(u8){};
+                    errdefer names_buffer.deinit(alloc);
+
+                    for (names.data.e_array.items.slice()) |*item| {
+                        if (item.data != .e_string) {
+                            return error.InvalidSourceMap;
+                        }
+
+                        const str = try item.data.e_string.string(arena);
+
+                        names_list.appendAssumeCapacity(try bun.Semver.String.initAppendIfNeeded(alloc, &names_buffer, str));
+                    }
+
+                    map_data.mappings.names = names_list.items;
+                    map_data.mappings.names_buffer = .fromList(names_buffer);
+                }
+            }
+        }
+
         const ptr = bun.new(ParsedSourceMap, map_data);
         ptr.external_source_names = source_paths_slice.?;
+
         break :map ptr;
     } else null;
     errdefer if (map) |m| m.deref();
@@ -199,7 +230,7 @@ pub fn parseJSON(
     const mapping, const source_index = switch (hint) {
         .source_only => |index| .{ null, index },
         .all => |loc| brk: {
-            const mapping = Mapping.find(map.?.mappings, loc.line, loc.column) orelse
+            const mapping = map.?.mappings.find(loc.line, loc.column) orelse
                 break :brk .{ null, null };
             break :brk .{ mapping, std.math.cast(u32, mapping.source_index) };
         },
@@ -234,8 +265,206 @@ pub const Mapping = struct {
     generated: LineColumnOffset,
     original: LineColumnOffset,
     source_index: i32,
+    name_index: i32 = -1,
 
-    pub const List = bun.MultiArrayList(Mapping);
+    /// Optimization: if we don't care about the "names" column, then don't store the names.
+    pub const MappingWithoutName = struct {
+        generated: LineColumnOffset,
+        original: LineColumnOffset,
+        source_index: i32,
+
+        pub fn toNamed(this: *const MappingWithoutName) Mapping {
+            return .{
+                .generated = this.generated,
+                .original = this.original,
+                .source_index = this.source_index,
+                .name_index = -1,
+            };
+        }
+    };
+
+    pub const List = struct {
+        impl: Value = .{ .without_names = .{} },
+        names: []const bun.Semver.String = &[_]bun.Semver.String{},
+        names_buffer: bun.ByteList = .{},
+
+        pub const Value = union(enum) {
+            without_names: bun.MultiArrayList(MappingWithoutName),
+            with_names: bun.MultiArrayList(Mapping),
+
+            pub fn memoryCost(this: *const Value) usize {
+                return switch (this.*) {
+                    .without_names => |*list| list.memoryCost(),
+                    .with_names => |*list| list.memoryCost(),
+                };
+            }
+
+            pub fn ensureTotalCapacity(this: *Value, allocator: std.mem.Allocator, count: usize) !void {
+                switch (this.*) {
+                    inline else => |*list| try list.ensureTotalCapacity(allocator, count),
+                }
+            }
+        };
+
+        pub fn ensureWithNames(this: *List, allocator: std.mem.Allocator) !void {
+            if (this.impl == .with_names) return;
+
+            var without_names = this.impl.without_names;
+            var with_names = bun.MultiArrayList(Mapping){};
+            try with_names.ensureTotalCapacity(allocator, without_names.len);
+            defer without_names.deinit(allocator);
+
+            with_names.len = without_names.len;
+            var old_slices = without_names.slice();
+            var new_slices = with_names.slice();
+
+            @memcpy(new_slices.items(.generated), old_slices.items(.generated));
+            @memcpy(new_slices.items(.original), old_slices.items(.original));
+            @memcpy(new_slices.items(.source_index), old_slices.items(.source_index));
+            @memset(new_slices.items(.name_index), -1);
+
+            this.impl = .{ .with_names = with_names };
+        }
+
+        fn findIndexFromGenerated(line_column_offsets: []const LineColumnOffset, line: i32, column: i32) ?usize {
+            var count = line_column_offsets.len;
+            var index: usize = 0;
+            while (count > 0) {
+                const step = count / 2;
+                const i: usize = index + step;
+                const mapping = line_column_offsets[i];
+                if (mapping.lines < line or (mapping.lines == line and mapping.columns <= column)) {
+                    index = i + 1;
+                    count -|= step + 1;
+                } else {
+                    count = step;
+                }
+            }
+
+            if (index > 0) {
+                if (line_column_offsets[index - 1].lines == line) {
+                    return index - 1;
+                }
+            }
+
+            return null;
+        }
+
+        pub fn findIndex(this: *const List, line: i32, column: i32) ?usize {
+            switch (this.impl) {
+                inline else => |*list| {
+                    if (findIndexFromGenerated(list.items(.generated), line, column)) |i| {
+                        return i;
+                    }
+                },
+            }
+
+            return null;
+        }
+
+        const SortContext = struct {
+            generated: []const LineColumnOffset,
+            pub fn lessThan(ctx: SortContext, a_index: usize, b_index: usize) bool {
+                const a = ctx.generated[a_index];
+                const b = ctx.generated[b_index];
+
+                return a.lines < b.lines or (a.lines == b.lines and a.columns <= b.columns);
+            }
+        };
+
+        pub fn sort(this: *List) void {
+            switch (this.impl) {
+                .without_names => |*list| list.sort(SortContext{ .generated = list.items(.generated) }),
+                .with_names => |*list| list.sort(SortContext{ .generated = list.items(.generated) }),
+            }
+        }
+
+        pub fn append(this: *List, allocator: std.mem.Allocator, mapping: *const Mapping) !void {
+            switch (this.impl) {
+                .without_names => |*list| {
+                    try list.append(allocator, .{
+                        .generated = mapping.generated,
+                        .original = mapping.original,
+                        .source_index = mapping.source_index,
+                    });
+                },
+                .with_names => |*list| {
+                    try list.append(allocator, mapping.*);
+                },
+            }
+        }
+
+        pub fn find(this: *const List, line: i32, column: i32) ?Mapping {
+            switch (this.impl) {
+                inline else => |*list, tag| {
+                    if (findIndexFromGenerated(list.items(.generated), line, column)) |i| {
+                        if (tag == .without_names) {
+                            return list.get(i).toNamed();
+                        } else {
+                            return list.get(i);
+                        }
+                    }
+                },
+            }
+
+            return null;
+        }
+        pub fn generated(self: *const List) []const LineColumnOffset {
+            return switch (self.impl) {
+                inline else => |*list| list.items(.generated),
+            };
+        }
+
+        pub fn original(self: *const List) []const LineColumnOffset {
+            return switch (self.impl) {
+                inline else => |*list| list.items(.original),
+            };
+        }
+
+        pub fn sourceIndex(self: *const List) []const i32 {
+            return switch (self.impl) {
+                inline else => |*list| list.items(.source_index),
+            };
+        }
+
+        pub fn nameIndex(self: *const List) []const i32 {
+            return switch (self.impl) {
+                inline else => |*list| list.items(.name_index),
+            };
+        }
+
+        pub fn deinit(self: *List, allocator: std.mem.Allocator) void {
+            switch (self.impl) {
+                inline else => |*list| list.deinit(allocator),
+            }
+
+            self.names_buffer.deinitWithAllocator(allocator);
+            allocator.free(self.names);
+        }
+
+        pub fn getName(this: *List, index: i32) ?[]const u8 {
+            if (index < 0) return null;
+            const i: usize = @intCast(index);
+
+            if (i >= this.names.len) return null;
+
+            if (this.impl == .with_names) {
+                const str: *const bun.Semver.String = &this.names[i];
+                return str.slice(this.names_buffer.slice());
+            }
+
+            return null;
+        }
+
+        pub fn memoryCost(this: *const List) usize {
+            return this.impl.memoryCost() + this.names_buffer.memoryCost() +
+                (this.names.len * @sizeOf(bun.Semver.String));
+        }
+
+        pub fn ensureTotalCapacity(this: *List, allocator: std.mem.Allocator, count: usize) !void {
+            try this.impl.ensureTotalCapacity(allocator, count);
+        }
+    };
 
     pub const Lookup = struct {
         mapping: Mapping,
@@ -243,6 +472,8 @@ pub const Mapping = struct {
         /// Owned by default_allocator always
         /// use `getSourceCode` to access this as a Slice
         prefetched_source_code: ?[]const u8,
+
+        name: ?[]const u8 = null,
 
         /// This creates a bun.String if the source remap *changes* the source url,
         /// which is only possible if the executed file differs from the source file:
@@ -336,58 +567,28 @@ pub const Mapping = struct {
         }
     };
 
-    pub inline fn generatedLine(mapping: Mapping) i32 {
+    pub inline fn generatedLine(mapping: *const Mapping) i32 {
         return mapping.generated.lines;
     }
 
-    pub inline fn generatedColumn(mapping: Mapping) i32 {
+    pub inline fn generatedColumn(mapping: *const Mapping) i32 {
         return mapping.generated.columns;
     }
 
-    pub inline fn sourceIndex(mapping: Mapping) i32 {
+    pub inline fn sourceIndex(mapping: *const Mapping) i32 {
         return mapping.source_index;
     }
 
-    pub inline fn originalLine(mapping: Mapping) i32 {
+    pub inline fn originalLine(mapping: *const Mapping) i32 {
         return mapping.original.lines;
     }
 
-    pub inline fn originalColumn(mapping: Mapping) i32 {
+    pub inline fn originalColumn(mapping: *const Mapping) i32 {
         return mapping.original.columns;
     }
 
-    pub fn find(mappings: Mapping.List, line: i32, column: i32) ?Mapping {
-        if (findIndex(mappings, line, column)) |i| {
-            return mappings.get(i);
-        }
-
-        return null;
-    }
-
-    pub fn findIndex(mappings: Mapping.List, line: i32, column: i32) ?usize {
-        const generated = mappings.items(.generated);
-
-        var count = generated.len;
-        var index: usize = 0;
-        while (count > 0) {
-            const step = count / 2;
-            const i: usize = index + step;
-            const mapping = generated[i];
-            if (mapping.lines < line or (mapping.lines == line and mapping.columns <= column)) {
-                index = i + 1;
-                count -|= step + 1;
-            } else {
-                count = step;
-            }
-        }
-
-        if (index > 0) {
-            if (generated[index - 1].lines == line) {
-                return index - 1;
-            }
-        }
-
-        return null;
+    pub inline fn nameIndex(mapping: *const Mapping) i32 {
+        return mapping.name_index;
     }
 
     pub fn parse(
@@ -396,19 +597,35 @@ pub const Mapping = struct {
         estimated_mapping_count: ?usize,
         sources_count: i32,
         input_line_count: usize,
+        options: struct {
+            allow_names: bool = false,
+            sort: bool = false,
+        },
     ) ParseResult {
         debug("parse mappings ({d} bytes)", .{bytes.len});
 
         var mapping = Mapping.List{};
+        errdefer mapping.deinit(allocator);
+
         if (estimated_mapping_count) |count| {
-            mapping.ensureTotalCapacity(allocator, count) catch unreachable;
+            mapping.ensureTotalCapacity(allocator, count) catch {
+                return .{
+                    .fail = .{
+                        .msg = "Out of memory",
+                        .err = error.OutOfMemory,
+                        .loc = .{},
+                    },
+                };
+            };
         }
 
         var generated = LineColumnOffset{ .lines = 0, .columns = 0 };
         var original = LineColumnOffset{ .lines = 0, .columns = 0 };
+        var name_index: i32 = 0;
         var source_index: i32 = 0;
         var needs_sort = false;
         var remain = bytes;
+        var has_names = false;
         while (remain.len > 0) {
             if (remain[0] == ';') {
                 generated.columns = 0;
@@ -558,26 +775,68 @@ pub const Mapping = struct {
             if (remain.len > 0) {
                 switch (remain[0]) {
                     ',' => {
+                        // 4 column, but there's more on this line.
                         remain = remain[1..];
                     },
+                    // 4 column, and there's no more on this line.
                     ';' => {},
+
+                    // 5th column: the name
                     else => |c| {
-                        return .{
-                            .fail = .{
-                                .msg = "Invalid character after mapping",
-                                .err = error.InvalidSourceMap,
-                                .value = @as(i32, @intCast(c)),
-                                .loc = .{ .start = @as(i32, @intCast(bytes.len - remain.len)) },
-                            },
-                        };
+                        // Read the name index
+                        const name_index_delta = decodeVLQ(remain, 0);
+                        if (name_index_delta.start == 0) {
+                            return .{
+                                .fail = .{
+                                    .msg = "Invalid name index delta",
+                                    .err = error.InvalidNameIndexDelta,
+                                    .value = @intCast(c),
+                                    .loc = .{ .start = @as(i32, @intCast(bytes.len - remain.len)) },
+                                },
+                            };
+                        }
+                        remain = remain[name_index_delta.start..];
+
+                        if (options.allow_names) {
+                            name_index += name_index_delta.value;
+                            if (!has_names) {
+                                mapping.ensureWithNames(allocator) catch {
+                                    return .{
+                                        .fail = .{
+                                            .msg = "Out of memory",
+                                            .err = error.OutOfMemory,
+                                            .loc = .{ .start = @as(i32, @intCast(bytes.len - remain.len)) },
+                                        },
+                                    };
+                                };
+                            }
+                            has_names = true;
+                        }
+
+                        if (remain.len > 0) {
+                            switch (remain[0]) {
+                                // There's more on this line.
+                                ',' => {
+                                    remain = remain[1..];
+                                },
+                                // That's the end of the line.
+                                ';' => {},
+                                else => {},
+                            }
+                        }
                     },
                 }
             }
-            mapping.append(allocator, .{
+            mapping.append(allocator, &.{
                 .generated = generated,
                 .original = original,
                 .source_index = source_index,
+                .name_index = name_index,
             }) catch bun.outOfMemory();
+        }
+
+        if (needs_sort and options.sort) {
+            mapping.sort();
         }
 
         return .{ .success = .{
@@ -622,6 +881,7 @@ pub const ParsedSourceMap = struct {
 
     input_line_count: usize = 0,
     mappings: Mapping.List = .{},
+
     /// If this is empty, this implies that the source code is a single file
     /// transpiled on-demand. If there are items, then it means this is a file
     /// loaded without transpilation but with external sources. This array
@@ -714,16 +974,16 @@ pub const ParsedSourceMap = struct {
         return @sizeOf(ParsedSourceMap) + this.mappings.memoryCost() + this.external_source_names.len * @sizeOf([]const u8);
     }
 
-    pub fn writeVLQs(map: ParsedSourceMap, writer: anytype) !void {
+    pub fn writeVLQs(map: *const ParsedSourceMap, writer: anytype) !void {
         var last_col: i32 = 0;
         var last_src: i32 = 0;
         var last_ol: i32 = 0;
         var last_oc: i32 = 0;
         var current_line: i32 = 0;
         for (
-            map.mappings.items(.generated),
-            map.mappings.items(.original),
-            map.mappings.items(.source_index),
+            map.mappings.generated(),
+            map.mappings.original(),
+            map.mappings.sourceIndex(),
             0..,
         ) |gen, orig, source_index, i| {
             if (current_line != gen.lines) {
@@ -1060,7 +1320,7 @@ pub fn find(
     line: i32,
     column: i32,
 ) ?Mapping {
-    return Mapping.find(this.mapping, line, column);
+    return this.mapping.find(line, column);
 }
 
 pub const SourceMapShifts = struct {

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -710,6 +710,10 @@ pub const ParsedSourceMap = struct {
         return @ptrFromInt(this.underlying_provider.data);
     }
 
+    pub fn memoryCost(this: *const ParsedSourceMap) usize {
+        return @sizeOf(ParsedSourceMap) + this.mappings.memoryCost() + this.external_source_names.len * @sizeOf([]const u8);
+    }
+
     pub fn writeVLQs(map: ParsedSourceMap, writer: anytype) !void {
         var last_col: i32 = 0;
         var last_src: i32 = 0;

--- a/src/sourcemap/sourcemap.zig
+++ b/src/sourcemap/sourcemap.zig
@@ -10,7 +10,7 @@ const JSPrinter = bun.js_printer;
 const URL = bun.URL;
 const FileSystem = bun.fs.FileSystem;
 
-const SourceMap = @This();
+pub const SourceMap = @This();
 const debug = bun.Output.scoped(.SourceMap, false);
 
 /// Coordinates in source maps are stored using relative offsets for size
@@ -1671,6 +1671,7 @@ const assert = bun.assert;
 pub const coverage = @import("./CodeCoverage.zig");
 pub const VLQ = @import("./VLQ.zig");
 pub const LineOffsetTable = @import("./LineOffsetTable.zig");
+pub const JSSourceMap = @import("./JSSourceMap.zig").JSSourceMap;
 
 const decodeVLQAssumeValid = VLQ.decodeAssumeValid;
 const decodeVLQ = VLQ.decode;

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -34,7 +34,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
 
   [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 243, regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
-  "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1867 },
+  "catch unreachable": { reason: "For out-of-memory, prefer 'catch bun.outOfMemory()'", limit: 1866 },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 179 },
   "std.fs.cwd": { reason: "Prefer bun.FD.cwd()", limit: 103 },

--- a/test/js/node/module/module-sourcemap.test.js
+++ b/test/js/node/module/module-sourcemap.test.js
@@ -1,0 +1,27 @@
+const { test, expect } = require("bun:test");
+
+test("SourceMap is available from node:module", () => {
+  const module = require("node:module");
+  expect(module.SourceMap).toBeDefined();
+  expect(typeof module.SourceMap).toBe("function");
+});
+
+test("SourceMap from require('module') works", () => {
+  const module = require("module");
+  expect(module.SourceMap).toBeDefined();
+  expect(typeof module.SourceMap).toBe("function");
+});
+
+test("Can create SourceMap instance from node:module", () => {
+  const { SourceMap } = require("node:module");
+  const payload = {
+    version: 3,
+    sources: ["test.js"],
+    names: [],
+    mappings: "AAAA"
+  };
+  
+  const sourceMap = new SourceMap(payload);
+  expect(sourceMap).toBeInstanceOf(SourceMap);
+  expect(sourceMap.payload).toBe(payload);
+});

--- a/test/js/node/module/module-sourcemap.test.js
+++ b/test/js/node/module/module-sourcemap.test.js
@@ -18,9 +18,9 @@ test("Can create SourceMap instance from node:module", () => {
     version: 3,
     sources: ["test.js"],
     names: [],
-    mappings: "AAAA"
+    mappings: "AAAA",
   };
-  
+
   const sourceMap = new SourceMap(payload);
   expect(sourceMap).toBeInstanceOf(SourceMap);
   expect(sourceMap.payload).toBe(payload);

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -1,0 +1,129 @@
+const { test, expect } = require("bun:test");
+const { SourceMap } = require("node:module");
+
+test("SourceMap class exists", () => {
+  expect(SourceMap).toBeDefined();
+  expect(typeof SourceMap).toBe("function");
+  expect(SourceMap.name).toBe("SourceMap");
+});
+
+test("SourceMap constructor requires payload", () => {
+  expect(() => {
+    new SourceMap();
+  }).toThrow("SourceMap constructor requires a payload argument");
+});
+
+test("SourceMap payload must be an object", () => {
+  expect(() => {
+    new SourceMap("not an object");
+  }).toThrow("payload must be an object");
+});
+
+test("SourceMap lineLengths must be an array if provided", () => {
+  expect(() => {
+    new SourceMap({}, { lineLengths: "not an array" });
+  }).toThrow("lineLengths must be an array");
+});
+
+test("SourceMap instance has expected methods", () => {
+  const sourceMap = new SourceMap({ 
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA"
+  });
+  
+  expect(typeof sourceMap.findOrigin).toBe("function");
+  expect(typeof sourceMap.findEntry).toBe("function");
+  expect(sourceMap.findOrigin.length).toBe(2);
+  expect(sourceMap.findEntry.length).toBe(2);
+});
+
+test("SourceMap payload getter", () => {
+  const payload = { 
+    version: 3, 
+    sources: ["test.js"], 
+    mappings: "AAAA" 
+  };
+  const sourceMap = new SourceMap(payload);
+  
+  expect(sourceMap.payload).toBe(payload);
+});
+
+test("SourceMap lineLengths getter", () => {
+  const payload = { 
+    version: 3, 
+    sources: ["test.js"], 
+    mappings: "AAAA" 
+  };
+  const lineLengths = [10, 20, 30];
+  const sourceMap = new SourceMap(payload, { lineLengths });
+  
+  expect(sourceMap.lineLengths).toBe(lineLengths);
+});
+
+test("SourceMap lineLengths undefined when not provided", () => {
+  const sourceMap = new SourceMap({ 
+    version: 3, 
+    sources: ["test.js"], 
+    mappings: "AAAA" 
+  });
+  
+  expect(sourceMap.lineLengths).toBeUndefined();
+});
+
+test("SourceMap findOrigin requires numeric arguments", () => {
+  const sourceMap = new SourceMap({ 
+    version: 3, 
+    sources: ["test.js"], 
+    mappings: "AAAA" 
+  });
+  
+  expect(() => {
+    sourceMap.findOrigin();
+  }).toThrow("findOrigin requires lineNumber and columnNumber arguments");
+  
+  expect(() => {
+    sourceMap.findOrigin(1);
+  }).toThrow("findOrigin requires lineNumber and columnNumber arguments");
+  
+  expect(() => {
+    sourceMap.findOrigin("not a number", 1);
+  }).toThrow("lineNumber must be a number");
+  
+  expect(() => {
+    sourceMap.findOrigin(1, "not a number");
+  }).toThrow("columnNumber must be a number");
+});
+
+test("SourceMap findEntry returns mapping data", () => {
+  const sourceMap = new SourceMap({ 
+    version: 3, 
+    sources: ["test.js"], 
+    mappings: "AAAA" 
+  });
+  const result = sourceMap.findEntry(0, 0);
+  
+  expect(typeof result).toBe("object");
+  // Should now return actual mapping data instead of empty object
+  expect(result).toHaveProperty("generatedLine");
+  expect(result).toHaveProperty("generatedColumn");
+  expect(result).toHaveProperty("originalLine");
+  expect(result).toHaveProperty("originalColumn");
+  expect(result).toHaveProperty("source");
+});
+
+test("SourceMap findOrigin returns origin data", () => {
+  const sourceMap = new SourceMap({ 
+    version: 3, 
+    sources: ["test.js"], 
+    mappings: "AAAA" 
+  });
+  const result = sourceMap.findOrigin(0, 0);
+  
+  expect(typeof result).toBe("object");
+  // Should now return actual origin data instead of empty object
+  expect(result).toHaveProperty("line");
+  expect(result).toHaveProperty("column");
+  expect(result).toHaveProperty("source");
+  expect(result).toHaveProperty("name");
+});

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -74,13 +74,16 @@ test("SourceMap findEntry returns mapping data", () => {
   });
   const result = sourceMap.findEntry(0, 0);
 
-  expect(typeof result).toBe("object");
-  // Should now return actual mapping data instead of empty object
-  expect(result).toHaveProperty("generatedLine");
-  expect(result).toHaveProperty("generatedColumn");
-  expect(result).toHaveProperty("originalLine");
-  expect(result).toHaveProperty("originalColumn");
-  expect(result).toHaveProperty("source");
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "generatedColumn": 0,
+      "generatedLine": 0,
+      "name": undefined,
+      "originalColumn": 0,
+      "originalLine": 0,
+      "originalSource": "test.js",
+    }
+  `);
 });
 
 test("SourceMap findOrigin returns origin data", () => {
@@ -91,10 +94,84 @@ test("SourceMap findOrigin returns origin data", () => {
   });
   const result = sourceMap.findOrigin(0, 0);
 
-  expect(typeof result).toBe("object");
-  // Should now return actual origin data instead of empty object
-  expect(result).toHaveProperty("line");
-  expect(result).toHaveProperty("column");
-  expect(result).toHaveProperty("source");
-  expect(result).toHaveProperty("name");
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "column": 0,
+      "fileName": "test.js",
+      "line": 0,
+      "name": undefined,
+    }
+  `);
+});
+
+test("SourceMap with names returns name property correctly", () => {
+  const sourceMap = new SourceMap({
+    version: 3,
+    sources: ["test.js"],
+    names: ["myFunction", "myVariable"],
+    mappings: "AAAAA,CAACC", // Both segments reference names
+  });
+
+  const result = sourceMap.findEntry(0, 0);
+  const resultWithName = sourceMap.findEntry(0, 6);
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "generatedColumn": 0,
+      "generatedLine": 0,
+      "name": "myFunction",
+      "originalColumn": 0,
+      "originalLine": 0,
+      "originalSource": "test.js",
+    }
+  `);
+  expect(resultWithName).toMatchInlineSnapshot(`
+    {
+      "generatedColumn": 1,
+      "generatedLine": 0,
+      "name": "myVariable",
+      "originalColumn": 1,
+      "originalLine": 0,
+      "originalSource": "test.js",
+    }
+  `);
+});
+
+test("SourceMap without names has undefined name property", () => {
+  const sourceMap = new SourceMap({
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA",
+  });
+
+  const result = sourceMap.findEntry(0, 0);
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "generatedColumn": 0,
+      "generatedLine": 0,
+      "name": undefined,
+      "originalColumn": 0,
+      "originalLine": 0,
+      "originalSource": "test.js",
+    }
+  `);
+});
+
+test("SourceMap with invalid name index has undefined name property", () => {
+  const sourceMap = new SourceMap({
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAAA,CAACC", // Both segments reference names
+  });
+
+  const result = sourceMap.findEntry(0, 0);
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "generatedColumn": 0,
+      "generatedLine": 0,
+      "name": undefined,
+      "originalColumn": 0,
+      "originalLine": 0,
+      "originalSource": "test.js",
+    }
+  `);
 });

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -10,28 +10,24 @@ test("SourceMap class exists", () => {
 test("SourceMap constructor requires payload", () => {
   expect(() => {
     new SourceMap();
-  }).toThrow("SourceMap constructor requires a payload argument");
+  }).toThrowErrorMatchingInlineSnapshot(`"The "payload" argument must be of type object. Received undefined"`);
 });
 
 test("SourceMap payload must be an object", () => {
   expect(() => {
     new SourceMap("not an object");
-  }).toThrow("payload must be an object");
-});
-
-test("SourceMap lineLengths must be an array if provided", () => {
-  expect(() => {
-    new SourceMap({}, { lineLengths: "not an array" });
-  }).toThrow("lineLengths must be an array");
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"The "payload" argument must be of type object. Received type string ('not an object')"`,
+  );
 });
 
 test("SourceMap instance has expected methods", () => {
-  const sourceMap = new SourceMap({ 
+  const sourceMap = new SourceMap({
     version: 3,
     sources: ["test.js"],
-    mappings: "AAAA"
+    mappings: "AAAA",
   });
-  
+
   expect(typeof sourceMap.findOrigin).toBe("function");
   expect(typeof sourceMap.findEntry).toBe("function");
   expect(sourceMap.findOrigin.length).toBe(2);
@@ -39,70 +35,45 @@ test("SourceMap instance has expected methods", () => {
 });
 
 test("SourceMap payload getter", () => {
-  const payload = { 
-    version: 3, 
-    sources: ["test.js"], 
-    mappings: "AAAA" 
+  const payload = {
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA",
   };
   const sourceMap = new SourceMap(payload);
-  
+
   expect(sourceMap.payload).toBe(payload);
 });
 
 test("SourceMap lineLengths getter", () => {
-  const payload = { 
-    version: 3, 
-    sources: ["test.js"], 
-    mappings: "AAAA" 
+  const payload = {
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA",
   };
   const lineLengths = [10, 20, 30];
   const sourceMap = new SourceMap(payload, { lineLengths });
-  
+
   expect(sourceMap.lineLengths).toBe(lineLengths);
 });
 
 test("SourceMap lineLengths undefined when not provided", () => {
-  const sourceMap = new SourceMap({ 
-    version: 3, 
-    sources: ["test.js"], 
-    mappings: "AAAA" 
+  const sourceMap = new SourceMap({
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA",
   });
-  
+
   expect(sourceMap.lineLengths).toBeUndefined();
 });
-
-test("SourceMap findOrigin requires numeric arguments", () => {
-  const sourceMap = new SourceMap({ 
-    version: 3, 
-    sources: ["test.js"], 
-    mappings: "AAAA" 
-  });
-  
-  expect(() => {
-    sourceMap.findOrigin();
-  }).toThrow("findOrigin requires lineNumber and columnNumber arguments");
-  
-  expect(() => {
-    sourceMap.findOrigin(1);
-  }).toThrow("findOrigin requires lineNumber and columnNumber arguments");
-  
-  expect(() => {
-    sourceMap.findOrigin("not a number", 1);
-  }).toThrow("lineNumber must be a number");
-  
-  expect(() => {
-    sourceMap.findOrigin(1, "not a number");
-  }).toThrow("columnNumber must be a number");
-});
-
 test("SourceMap findEntry returns mapping data", () => {
-  const sourceMap = new SourceMap({ 
-    version: 3, 
-    sources: ["test.js"], 
-    mappings: "AAAA" 
+  const sourceMap = new SourceMap({
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA",
   });
   const result = sourceMap.findEntry(0, 0);
-  
+
   expect(typeof result).toBe("object");
   // Should now return actual mapping data instead of empty object
   expect(result).toHaveProperty("generatedLine");
@@ -113,13 +84,13 @@ test("SourceMap findEntry returns mapping data", () => {
 });
 
 test("SourceMap findOrigin returns origin data", () => {
-  const sourceMap = new SourceMap({ 
-    version: 3, 
-    sources: ["test.js"], 
-    mappings: "AAAA" 
+  const sourceMap = new SourceMap({
+    version: 3,
+    sources: ["test.js"],
+    mappings: "AAAA",
   });
   const result = sourceMap.findOrigin(0, 0);
-  
+
   expect(typeof result).toBe("object");
   // Should now return actual origin data instead of empty object
   expect(result).toHaveProperty("line");

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -195,6 +195,7 @@ test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
 test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
 test/js/bun/spawn/spawn-stream-serve.test.ts
 test/js/bun/spawn/spawn-streaming-stdout.test.ts
+test/js/node/module/sourcemap.test.js
 test/js/bun/spawn/spawn-stress.test.ts
 test/js/bun/spawn/spawn.ipc.bun-node.test.ts
 test/js/bun/spawn/spawn.ipc.node-bun.test.ts


### PR DESCRIPTION
### What does this PR do?

This implements `"node:module"`'s `findSourceMap` and `SourceMap` class. It does not implement `--enable-source-maps`, which will be a separate PR after this.

This also:
- Fixes a bug when parsing sourcemaps that contain `"names"`
- Implements optional support for sourcemaps with `"names"`, while maintaining the optimization to not store the names indices unless necessary
- Sorts the sourcemaps from user input
- Fixes a potential memory leak when sourcemaps fail to parse

### How did you verify your code works?

The behavior matches Node's `SourceMap` class, and there are some tests. Node's tests won't pass in Bun until we also implement `--enable-source-maps`, but that involves a bunch of small parser/printer changes so it would be easier to split that into a separate PR and this is still useful on it's own.