### PR TITLE
fix(http2) avoid sending RST multiple times per stream

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -1329,6 +1329,9 @@ pub const H2FrameParser = struct {
 
     pub fn endStream(this: *H2FrameParser, stream: *Stream, rstCode: ErrorCode) void {
         log("HTTP_FRAME_RST_STREAM id: {} code: {}", .{ stream.id, @intFromEnum(rstCode) });
+        if (stream.state == .CLOSED) {
+            return;
+        }
         var buffer: [FrameHeader.byteSize + 4]u8 = undefined;
         @memset(&buffer, 0);
         var writerStream = std.io.fixedBufferStream(&buffer);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2447,10 +2447,13 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
       stream.resume(); // we have a error we consume and close
       pushToStream(stream, null);
     }
-    markStreamClosed(stream);
+
     if (destroy) stream.destroy(error_instance, stream.rstCode);
-    else if (error_instance) {
-      stream.emit("error", error_instance);
+    else {
+      markStreamClosed(stream);
+      if (error_instance) {
+        stream.emit("error", error_instance);
+      }
     }
 
     if (destroy_self) self.destroy();
@@ -2625,8 +2628,8 @@ class ServerHttp2Session extends Http2Session {
       }
       // 7 = closed, in this case we already send everything and received everything
       if (state === 7) {
-        markStreamClosed(stream);
         self.#connections--;
+        markStreamClosed(stream);
         stream.destroy();
         if (self.#connections === 0 && self.#closed) {
           self.destroy();
@@ -3110,8 +3113,8 @@ class ClientHttp2Session extends Http2Session {
 
       // 7 = closed, in this case we already send everything and received everything
       if (state === 7) {
-        markStreamClosed(stream);
         self.#connections--;
+        markStreamClosed(stream);
         stream.destroy();
         if (self.#connections === 0 && self.#closed) {
           self.destroy();


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/oven-sh/bun/issues/20818

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Missing repro, fix is to check state before sending endStream/rstStream 
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
