### PR TITLE
node:fs.glob support array of excludes and globs

### DIFF
--- a/src/glob/match.zig
+++ b/src/glob/match.zig
@@ -289,7 +289,7 @@ inline fn globMatchImpl(state: *State, glob: []const u8, glob_start: u32, path: 
                 }
                 const cc_len = bun.strings.wtf8ByteSequenceLength(cc);
 
-                const is_match = if (cc == bun.path.sep)
+                const is_match = if (cc == '/')
                     isSeparator(path[state.path_index])
                 else if (cc_len > 1)
                     state.path_index + cc_len <= path.len and std.mem.eql(u8, path[state.path_index..][0..cc_len], glob[state.glob_index..][0..cc_len])

--- a/src/glob/match.zig
+++ b/src/glob/match.zig
@@ -289,7 +289,7 @@ inline fn globMatchImpl(state: *State, glob: []const u8, glob_start: u32, path: 
                 }
                 const cc_len = bun.strings.wtf8ByteSequenceLength(cc);
 
-                const is_match = if (cc == '/')
+                const is_match = if (cc == bun.path.sep)
                     isSeparator(path[state.path_index])
                 else if (cc_len > 1)
                     state.path_index + cc_len <= path.len and std.mem.eql(u8, path[state.path_index..][0..cc_len], glob[state.glob_index..][0..cc_len])

--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -13,15 +13,9 @@ interface GlobOptions {
   withFileTypes?: boolean;
 }
 
-interface ExcludeOptionFn {
-  exclude: (ent: string) => boolean;
+interface ExtendedGlobOptions extends GlobScanOptions {
+  exclude: ((ent: string) => boolean) | string[];
 }
-
-interface ExcludeOptionArray {
-  exclude: string[];
-}
-
-type ExtendedGlobOptions = GlobScanOptions & (ExcludeOptionFn | ExcludeOptionArray);
 
 async function* glob(pattern: string | string[], options?: GlobOptions): AsyncGenerator<string> {
   pattern = validatePattern(pattern);

--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -22,9 +22,7 @@ async function* glob(pattern: string | string[], options?: GlobOptions): AsyncGe
   const globOptions = mapOptions(options || {});
   let it = new Bun.Glob(pattern).scan(globOptions);
   const exclude = globOptions.exclude;
-  const excludeGlobs = Array.isArray(exclude)
-    ? exclude.map(p => [new Bun.Glob(p), p] as const)
-    : null;
+  const excludeGlobs = Array.isArray(exclude) ? exclude.map(p => [new Bun.Glob(p), p] as const) : null;
 
   for await (const ent of it) {
     if (typeof exclude === "function" && exclude(ent)) continue;
@@ -38,9 +36,7 @@ function* globSync(pattern: string | string[], options?: GlobOptions): Generator
   const globOptions = mapOptions(options || {});
   const g = new Bun.Glob(pattern);
   const exclude = globOptions.exclude;
-  const excludeGlobs = Array.isArray(exclude)
-    ? exclude.map(p => [new Bun.Glob(p), p] as const)
-    : null;
+  const excludeGlobs = Array.isArray(exclude) ? exclude.map(p => [new Bun.Glob(p), p] as const) : null;
 
   for (const ent of g.scanSync(globOptions)) {
     if (typeof exclude === "function" && exclude(ent)) continue;

--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -24,7 +24,7 @@ async function* glob(pattern: string | string[], options?: GlobOptions): AsyncGe
     for await (const ent of new Bun.Glob(pat).scan(globOptions)) {
       const _ent = ent.replaceAll(sep, "/");
       if (typeof exclude === "function" && exclude(ent)) continue;
-      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + sep))) continue;
+      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + "/"))) continue;
       yield ent;
     }
   }
@@ -40,7 +40,7 @@ function* globSync(pattern: string | string[], options?: GlobOptions): Generator
     for (const ent of new Bun.Glob(pat).scanSync(globOptions)) {
       const _ent = ent.replaceAll(sep, "/");
       if (typeof exclude === "function" && exclude(ent)) continue;
-      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + sep))) continue;
+      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + "/"))) continue;
       yield ent;
     }
   }
@@ -64,6 +64,9 @@ function mapOptions(options: GlobOptions): GlobScanOptions & { exclude: GlobOpti
   let exclude = options.exclude ?? no;
   if (Array.isArray(exclude)) {
     validateArray(exclude, "options.exclude");
+    if (isWindows) {
+      exclude = exclude.map((pattern: string) => pattern.replaceAll("\\", "/"));
+    }
   } else {
     validateFunction(exclude, "options.exclude");
   }

--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -55,14 +55,14 @@ function validatePattern(pattern: string | string[]): string[] {
   });
 }
 
-function mapOptions(options: GlobOptions): GlobScanOptions {
+function mapOptions(options: GlobOptions): GlobScanOptions & { exclude: GlobOptions["exclude"] } {
   validateObject(options, "options");
 
-  const exclude = options.exclude ?? no;
+  let exclude = options.exclude ?? no;
   if (Array.isArray(exclude)) {
     validateArray(exclude, "options.exclude");
     if (isWindows) {
-      options.exclude = exclude.map((pattern: string) => pattern.replaceAll("/", "\\"));
+      exclude = exclude.map((pattern: string) => pattern.replaceAll("/", "\\"));
     }
   } else {
     validateFunction(exclude, "options.exclude");

--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -22,9 +22,8 @@ async function* glob(pattern: string | string[], options?: GlobOptions): AsyncGe
 
   for (const pat of patterns) {
     for await (const ent of new Bun.Glob(pat).scan(globOptions)) {
-      const _ent = ent.replaceAll("/", sep);
       if (typeof exclude === "function" && exclude(ent)) continue;
-      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + sep))) continue;
+      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || ent === p || ent.startsWith(p + sep))) continue;
       yield ent;
     }
   }
@@ -38,9 +37,8 @@ function* globSync(pattern: string | string[], options?: GlobOptions): Generator
 
   for (const pat of patterns) {
     for (const ent of new Bun.Glob(pat).scanSync(globOptions)) {
-      const _ent = ent.replaceAll("/", sep);
       if (typeof exclude === "function" && exclude(ent)) continue;
-      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + sep))) continue;
+      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || ent === p || ent.startsWith(p + sep))) continue;
       yield ent;
     }
   }
@@ -64,9 +62,6 @@ function mapOptions(options: GlobOptions): GlobScanOptions & { exclude: GlobOpti
   let exclude = options.exclude ?? no;
   if (Array.isArray(exclude)) {
     validateArray(exclude, "options.exclude");
-    if (isWindows) {
-      exclude = exclude.map((pattern: string) => pattern.replaceAll("/", sep));
-    }
   } else {
     validateFunction(exclude, "options.exclude");
   }

--- a/src/js/internal/fs/glob.ts
+++ b/src/js/internal/fs/glob.ts
@@ -22,8 +22,9 @@ async function* glob(pattern: string | string[], options?: GlobOptions): AsyncGe
 
   for (const pat of patterns) {
     for await (const ent of new Bun.Glob(pat).scan(globOptions)) {
+      const _ent = ent.replaceAll(sep, "/");
       if (typeof exclude === "function" && exclude(ent)) continue;
-      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || ent === p || ent.startsWith(p + sep))) continue;
+      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + sep))) continue;
       yield ent;
     }
   }
@@ -37,8 +38,9 @@ function* globSync(pattern: string | string[], options?: GlobOptions): Generator
 
   for (const pat of patterns) {
     for (const ent of new Bun.Glob(pat).scanSync(globOptions)) {
+      const _ent = ent.replaceAll(sep, "/");
       if (typeof exclude === "function" && exclude(ent)) continue;
-      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || ent === p || ent.startsWith(p + sep))) continue;
+      if (excludeGlobs?.some(([glob, p]) => glob.match(ent) || _ent === p || _ent.startsWith(p + sep))) continue;
       yield ent;
     }
   }

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -16,7 +16,9 @@ beforeAll(() => {
     },
     "folder.test": {
       "file.txt": "content",
-      "another-folder": {},
+      "another-folder": {
+        "some-file.txt": "content",
+      },
     },
   });
 });
@@ -46,6 +48,19 @@ describe("fs.glob", () => {
 
   it("can filter out files", done => {
     const exclude = (path: string) => path.endsWith(".js");
+    fs.glob("a/*", { cwd: tmp, exclude }, (err, paths) => {
+      if (err) done(err);
+      if (isWindows) {
+        expect(paths).toStrictEqual(["a\\bar.txt"]);
+      } else {
+        expect(paths).toStrictEqual(["a/bar.txt"]);
+      }
+      done();
+    });
+  });
+
+  it("can filter out files (2)", done => {
+    const exclude = ["**/*.js"];
     fs.glob("a/*", { cwd: tmp, exclude }, (err, paths) => {
       if (err) done(err);
       if (isWindows) {
@@ -107,6 +122,11 @@ describe("fs.globSync", () => {
 
   it("can filter out files", () => {
     const exclude = (path: string) => path.endsWith(".js");
+    const expected = isWindows ? ["a\\bar.txt"] : ["a/bar.txt"];
+    expect(fs.globSync("a/*", { cwd: tmp, exclude })).toStrictEqual(expected);
+  });
+  it("can filter out files (2)", () => {
+    const exclude = ["**/*.js"];
     const expected = isWindows ? ["a\\bar.txt"] : ["a/bar.txt"];
     expect(fs.globSync("a/*", { cwd: tmp, exclude })).toStrictEqual(expected);
   });
@@ -184,5 +204,21 @@ describe("fs.promises.glob", () => {
       count++;
     }
     expect(count).toBe(1);
+  });
+
+  it("can filter out files", async () => {
+    const exclude = (path: string) => path.endsWith(".js");
+    const expected = isWindows ? ["a\\bar.txt"] : ["a/bar.txt"];
+    expect(Array.fromAsync(fs.promises.glob("a/*", { cwd: tmp, exclude }))).resolves.toStrictEqual(expected);
+  });
+
+  it("can filter out files (2)", async () => {
+    const exclude = ["**/*.js"];
+    const expected = isWindows ? ["a\\bar.txt"] : ["a/bar.txt"];
+    expect(Array.fromAsync(fs.promises.glob("a/*", { cwd: tmp, exclude }))).resolves.toStrictEqual(expected);
+
+    const exclude2 = ["another-folder"];
+    const expected2 = isWindows ? ["folder.test\\file.txt"] : ["folder.test/file.txt"];
+    expect(Array.fromAsync(fs.promises.glob("folder.test/**/*", { cwd: tmp, exclude: exclude2 }))).resolves.toStrictEqual(expected2);
   });
 }); // </fs.promises.glob>

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -219,6 +219,8 @@ describe("fs.promises.glob", () => {
 
     const exclude2 = ["another-folder"];
     const expected2 = isWindows ? ["folder.test\\file.txt"] : ["folder.test/file.txt"];
-    expect(Array.fromAsync(fs.promises.glob("folder.test/**/*", { cwd: tmp, exclude: exclude2 }))).resolves.toStrictEqual(expected2);
+    expect(
+      Array.fromAsync(fs.promises.glob("folder.test/**/*", { cwd: tmp, exclude: exclude2 })),
+    ).resolves.toStrictEqual(expected2);
   });
 }); // </fs.promises.glob>

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -85,6 +85,11 @@ describe("fs.glob", () => {
     const paths = fs.globSync("*.test", { cwd: tmp });
     expect(paths).toContain("folder.test");
   });
+
+  it("supports arrays of patterns", () => {
+    const expected = isWindows ? ["a\\bar.txt", "a\\baz.js"] : ["a/bar.txt", "a/baz.js"];
+    expect(fs.globSync(["a/bar.txt", "a/baz.js"], { cwd: tmp })).toStrictEqual(expected);
+  });
 }); // </fs.glob>
 
 describe("fs.globSync", () => {
@@ -143,16 +148,14 @@ describe("fs.globSync", () => {
     }
   });
 
-  describe("invalid arguments", () => {
-    // TODO: GlobSet
-    it("does not support arrays of patterns yet", () => {
-      expect(() => fs.globSync(["*.txt"])).toThrow(TypeError);
-    });
-  });
-
   it("matches directories", () => {
     const paths = fs.globSync("*.test", { cwd: tmp });
     expect(paths).toContain("folder.test");
+  });
+
+  it("supports arrays of patterns", () => {
+    const expected = isWindows ? ["a\\bar.txt", "a\\baz.js"] : ["a/bar.txt", "a/baz.js"];
+    expect(fs.globSync(["a/bar.txt", "a/baz.js"], { cwd: tmp })).toStrictEqual(expected);
   });
 }); // </fs.globSync>
 
@@ -222,5 +225,10 @@ describe("fs.promises.glob", () => {
     expect(
       Array.fromAsync(fs.promises.glob("folder.test/**/*", { cwd: tmp, exclude: exclude2 })),
     ).resolves.toStrictEqual(expected2);
+  });
+
+  it("supports arrays of patterns", async () => {
+    const expected = isWindows ? ["a\\bar.txt", "a\\baz.js"] : ["a/bar.txt", "a/baz.js"];
+    expect(Array.fromAsync(fs.promises.glob(["a/bar.txt", "a/baz.js"], { cwd: tmp }))).resolves.toStrictEqual(expected);
   });
 }); // </fs.promises.glob>

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -217,7 +217,7 @@ describe("fs.promises.glob", () => {
     const expected = isWindows ? ["a\\bar.txt"] : ["a/bar.txt"];
     expect(Array.fromAsync(fs.promises.glob("a/*", { cwd: tmp, exclude }))).resolves.toStrictEqual(expected);
 
-    const exclude2 = ["another-folder"];
+    const exclude2 = ["folder.test/another-folder"];
     const expected2 = isWindows ? ["folder.test\\file.txt"] : ["folder.test/file.txt"];
     expect(
       Array.fromAsync(fs.promises.glob("folder.test/**/*", { cwd: tmp, exclude: exclude2 })),


### PR DESCRIPTION
### What does this PR do?

fixes #20873 & also implements array of glob inputs

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

I tried as much as possible to match node's behavior & made tests
