### PR TITLE
fix(install): don't replace existing dependency if npm name matches workspace

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -951,14 +951,22 @@ endif()
 
 if(APPLE)
   target_link_options(${bun} PUBLIC
-    -dead_strip
-    -dead_strip_dylibs
     -Wl,-ld_new
     -Wl,-no_compact_unwind
     -Wl,-stack_size,0x1200000
     -fno-keep-static-consts
     -Wl,-map,${bun}.linker-map
   )
+
+  # don't strip in debug, this seems to be needed so that the Zig std library
+  # `*dbHelper` DWARF symbols (used by LLDB for pretty printing) are in the
+  # output executable
+  if(NOT DEBUG)
+    target_link_options(${bun} PUBLIC
+      -dead_strip
+      -dead_strip_dylibs
+    )
+  endif()
 endif()
 
 if(LINUX)
@@ -995,7 +1003,6 @@ if(LINUX)
     -Wl,-no-pie
     -Wl,-icf=safe
     -Wl,--as-needed
-    -Wl,--gc-sections
     -Wl,-z,stack-size=12800000
     -Wl,--compress-debug-sections=zlib
     -Wl,-z,lazy
@@ -1011,6 +1018,15 @@ if(LINUX)
     -Wl,--build-id=sha1  # Better for debugging than default
     -Wl,-Map=${bun}.linker-map
   )
+
+  # don't strip in debug, this seems to be needed so that the Zig std library
+  # `*dbHelper` DWARF symbols (used by LLDB for pretty printing) are in the
+  # output executable
+  if(NOT DEBUG)
+    target_link_options(${bun} PUBLIC
+      -Wl,--gc-sections
+    )
+  endif()
 endif()
 
 # --- Symbols list ---

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -167,6 +167,7 @@ pub const Features = struct {
     };
 
     pub const workspace = Features{
+        .check_for_duplicate_dependencies = true,
         .dev_dependencies = true,
         .optional_dependencies = true,
         .trusted_dependencies = true,

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -1,0 +1,277 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+import { mkdirSync, rmSync } from "fs";
+
+test("workspace devDependencies should take priority over peerDependencies for resolution", async () => {
+  const dir = tempDirWithFiles("dev-peer-priority", {
+    "package.json": JSON.stringify({
+      name: "test-monorepo",
+      version: "1.0.0",
+      workspaces: {
+        packages: ["packages/*"],
+        nodeLinker: "isolated",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "my-dep": "workspace:*", // Use workspace protocol for dev
+      },
+      peerDependencies: {
+        "my-dep": "^1.0.0", // Range that wants 1.x
+      },
+    }),
+    "packages/lib/test.js": `const dep = require("my-dep"); console.log(dep.version);`,
+    // Only provide workspace package with version 2.0.0
+    "packages/my-dep/package.json": JSON.stringify({
+      name: "my-dep",
+      version: "2.0.0",
+      main: "index.js",
+    }),
+    "packages/my-dep/index.js": `module.exports = { version: "2.0.0" };`,
+  });
+
+  // Run bun install with a dead registry to ensure no network requests
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: {
+          ...bunEnv,
+          NPM_CONFIG_REGISTRY: "http://localhost:9999/", // Dead URL - will fail if used
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Check that no network requests were made for packages that should be resolved locally
+  expect(stderr).not.toContain("GET");
+  expect(stderr).not.toContain("http");
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+
+  // Verify that version 2.0.0 (devDependency) was linked
+  // If peerDependency range ^1.0.0 was used, it would try to fetch from npm and fail
+  const testResult = await new Promise<string>(resolve => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "packages/lib/test.js"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+
+    new Response(proc.stdout).text().then(resolve);
+  });
+
+  expect(testResult.trim()).toBe("2.0.0");
+});
+
+test("devDependencies and peerDependencies with different versions should coexist", async () => {
+  const dir = tempDirWithFiles("dev-peer-different-versions", {
+    "package.json": JSON.stringify({
+      name: "test-monorepo",
+      version: "1.0.0",
+      workspaces: {
+        packages: ["packages/*"],
+        nodeLinker: "isolated",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "utils": "1.0.0",
+      },
+      peerDependencies: {
+        "utils": "^1.0.0",
+      },
+    }),
+    "packages/lib/index.js": `console.log("lib");`,
+    "packages/utils/package.json": JSON.stringify({
+      name: "utils",
+      version: "1.0.0",
+      main: "index.js",
+    }),
+    "packages/utils/index.js": `console.log("utils");`,
+  });
+
+  // Run bun install in the monorepo
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+});
+
+test("dependency behavior comparison prioritizes devDependencies", async () => {
+  const dir = tempDirWithFiles("behavior-comparison", {
+    "package.json": JSON.stringify({
+      name: "test-app",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "typescript": "^5.0.0",
+      },
+      peerDependencies: {
+        "typescript": "^4.0.0 || ^5.0.0",
+      },
+    }),
+    "index.js": `console.log("app");`,
+  });
+
+  // Run bun install
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+});
+
+test("Next.js monorepo scenario should not make unnecessary network requests", async () => {
+  const dir = tempDirWithFiles("nextjs-monorepo", {
+    "package.json": JSON.stringify({
+      name: "nextjs-monorepo",
+      version: "1.0.0",
+      workspaces: {
+        packages: ["packages/*"],
+        nodeLinker: "isolated",
+      },
+    }),
+    "packages/web/package.json": JSON.stringify({
+      name: "web",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "next": "15.0.0-canary.119", // Specific canary version for dev
+      },
+      peerDependencies: {
+        "next": "^14.0.0 || ^15.0.0", // Range that would accept 14.x or 15.x stable
+      },
+    }),
+    "packages/web/test.js": `const next = require("next/package.json"); console.log(next.version);`,
+    // Only provide the canary version that matches devDependencies
+    "packages/next/package.json": JSON.stringify({
+      name: "next",
+      version: "15.0.0-canary.119",
+      main: "index.js",
+    }),
+    "packages/next/index.js": `console.log("next workspace");`,
+  });
+
+  // Run bun install with dead registry
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: {
+          ...bunEnv,
+          NPM_CONFIG_REGISTRY: "http://localhost:9999/", // Dead URL
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  expect(exitCode).toBe(0);
+
+  // The key test: should not make network requests for packages that exist in workspace
+  // When devDependencies are prioritized over peerDependencies, the workspace version should be used
+  expect(stderr).not.toContain("GET");
+  expect(stderr).not.toContain("404");
+  expect(stderr).not.toContain("http");
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+
+  // Verify that version 15.0.0-canary.119 (devDependency) was used
+  // If peer range was used, it would try to fetch a stable version from npm and fail
+  const testResult = await new Promise<string>(resolve => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "packages/web/test.js"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+
+    new Response(proc.stdout).text().then(resolve);
+  });
+
+  expect(testResult.trim()).toBe("15.0.0-canary.119");
+});

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -1,7 +1,6 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
-import { mkdirSync, rmSync } from "fs";
 
 test("workspace devDependencies should take priority over peerDependencies for resolution", async () => {
   const dir = tempDirWithFiles("dev-peer-priority", {


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
test
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
