### PR TITLE
fix(install): clone arena memory on manifest parse errors

### DIFF
--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1572,7 +1572,14 @@ pub const PackageManifest = struct {
             source,
             log,
             arena.allocator(),
-        ) catch return null;
+        ) catch {
+            // don't use the arena memory!
+            var cloned_log: logger.Log = .init(bun.default_allocator);
+            try log.cloneTo(&cloned_log);
+            log.* = cloned_log;
+
+            return null;
+        };
 
         if (json.asProperty("error")) |error_q| {
             if (error_q.expr.asString(allocator)) |err| {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1575,7 +1575,7 @@ pub const PackageManifest = struct {
         ) catch {
             // don't use the arena memory!
             var cloned_log: logger.Log = .init(bun.default_allocator);
-            try log.cloneTo(&cloned_log);
+            try log.cloneToWithRecycled(&cloned_log, true);
             log.* = cloned_log;
 
             return null;


### PR DESCRIPTION
### What does this PR do?
Fixes asan errors in `bun-install.test.ts`
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
