### PR TITLE
[publish images] Remove DEFAULT_{C,CXX}FLAGS from .buildkite/Dockerfile

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,8 +1,6 @@
 ARG LLVM_VERSION="19"
 ARG REPORTED_LLVM_VERSION="19.1.7"
 ARG OLD_BUN_VERSION="1.1.38"
-ARG DEFAULT_CFLAGS="-mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -ffunction-sections -fdata-sections -faddrsig -fno-unwind-tables -fno-asynchronous-unwind-tables"
-ARG DEFAULT_CXXFLAGS="-flto=full -fwhole-program-vtables -fforce-emit-vtables"
 ARG BUILDKITE_AGENT_TAGS="queue=linux,os=linux,arch=${TARGETARCH}"
 
 FROM --platform=$BUILDPLATFORM ubuntu:20.04 as base-arm64
@@ -12,8 +10,6 @@ FROM base-$TARGETARCH as base
 ARG LLVM_VERSION
 ARG OLD_BUN_VERSION
 ARG TARGETARCH
-ARG DEFAULT_CXXFLAGS
-ARG DEFAULT_CFLAGS
 ARG REPORTED_LLVM_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -64,9 +60,7 @@ RUN echo "ARCH_PATH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-linux-gnu" ||
 ENV LD_LIBRARY_PATH=/usr/lib/gcc/${ARCH_PATH}/13:/usr/lib/${ARCH_PATH} \
    LIBRARY_PATH=/usr/lib/gcc/${ARCH_PATH}/13:/usr/lib/${ARCH_PATH} \
    CPLUS_INCLUDE_PATH=/usr/include/c++/13:/usr/include/${ARCH_PATH}/c++/13 \
-   C_INCLUDE_PATH=/usr/lib/gcc/${ARCH_PATH}/13/include \
-   CFLAGS=${DEFAULT_CFLAGS} \
-   CXXFLAGS="${DEFAULT_CFLAGS} ${DEFAULT_CXXFLAGS}"
+   C_INCLUDE_PATH=/usr/lib/gcc/${ARCH_PATH}/13/include
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
        export ARCH_PATH="aarch64-linux-gnu"; \

--- a/test/regression/issue/20927.test.js
+++ b/test/regression/issue/20927.test.js
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+
+// This used to break in ASAN builds of Bun in CI due to LTO flags being passed
+// to CMake. Specifically, the callback passed to `vm.deferredWorkTimer->scheduleWorkSoon(ticket, ...)`
+// never gets called (see JSFinalizationRegistry.cpp in WebKit).
+test("FinalizationRegistry callback should be called", async () => {
+  const registry = new FinalizationRegistry(value => value(123));
+  const promise = new Promise(resolve => registry.register({}, resolve));
+
+  Bun.gc(true);
+  await expect(promise).resolves.toBe(123);
+});


### PR DESCRIPTION
### What does this PR do?

Remove `DEFAULT_C_FLAGS` and `DEFAULT_CXX_FLAGS` from .buildkite/Dockerfile. All these flags are specified by CMake (in CompilerFlags.cmake) when they are appropriate, and the three LTO flags actually break the ASAN build (a test is added that fails with these flags).

Fixes #20930.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I ran a build *with* these flags locally, and the newly added test should pass with ASAN in CI.

<!-- I wrote automated tests -->

- [x] I included a test for the new code, or existing tests cover it
- [x] I ran my tests locally and they pass (`bun test test/regression/issue/20927.test`)
