### PR TITLE
fix(install): fix duplicate dependency `bun.lock` loading

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -1413,15 +1413,15 @@ pub const Behavior = packed struct(u8) {
                 .gt;
         }
 
-        if (lhs.isProd() != rhs.isProd()) {
-            return if (lhs.isProd())
+        if (lhs.isPeer() != rhs.isPeer()) {
+            return if (lhs.isPeer())
                 .gt
             else
                 .lt;
         }
 
-        if (lhs.isDev() != rhs.isDev()) {
-            return if (lhs.isDev())
+        if (lhs.isProd() != rhs.isProd()) {
+            return if (lhs.isProd())
                 .gt
             else
                 .lt;
@@ -1434,8 +1434,8 @@ pub const Behavior = packed struct(u8) {
                 .lt;
         }
 
-        if (lhs.isPeer() != rhs.isPeer()) {
-            return if (lhs.isPeer())
+        if (lhs.isDev() != rhs.isDev()) {
+            return if (lhs.isDev())
                 .gt
             else
                 .lt;

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -1413,15 +1413,15 @@ pub const Behavior = packed struct(u8) {
                 .gt;
         }
 
-        if (lhs.isPeer() != rhs.isPeer()) {
-            return if (lhs.isPeer())
+        if (lhs.isProd() != rhs.isProd()) {
+            return if (lhs.isProd())
                 .gt
             else
                 .lt;
         }
 
-        if (lhs.isProd() != rhs.isProd()) {
-            return if (lhs.isProd())
+        if (lhs.isDev() != rhs.isDev()) {
+            return if (lhs.isDev())
                 .gt
             else
                 .lt;
@@ -1434,8 +1434,8 @@ pub const Behavior = packed struct(u8) {
                 .lt;
         }
 
-        if (lhs.isDev() != rhs.isDev()) {
-            return if (lhs.isDev())
+        if (lhs.isPeer() != rhs.isPeer()) {
+            return if (lhs.isPeer())
                 .gt
             else
                 .lt;

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -2141,51 +2141,58 @@ pub const Package = extern struct {
     };
 };
 
+const string = []const u8;
+
 // @sortImports
 
-const TrustedDependenciesSet = Lockfile.TrustedDependenciesSet;
-const Aligner = install.Aligner;
+const std = @import("std");
 const Allocator = std.mem.Allocator;
+
+const bun = @import("bun");
 const ArrayIdentityContext = bun.ArrayIdentityContext;
-const Behavior = Dependency.Behavior;
-const Bin = install.Bin;
-const Cloner = Lockfile.Cloner;
-const Dependency = bun.install.Dependency;
-const DependencySlice = Lockfile.DependencySlice;
 const Environment = bun.Environment;
+const Global = bun.Global;
+const JSON = bun.JSON;
+const Output = bun.Output;
+const PackageJSON = bun.PackageJSON;
+const Path = bun.path;
+const assert = bun.assert;
+const logger = bun.logger;
+const strings = bun.strings;
+const FileSystem = bun.fs.FileSystem;
+
+const JSAst = bun.JSAst;
 const Expr = bun.JSAst.Expr;
+
+const Semver = bun.Semver;
 const ExternalString = Semver.ExternalString;
+const String = Semver.String;
+
+const install = bun.install;
+const Aligner = install.Aligner;
+const Bin = install.Bin;
 const ExternalStringList = install.ExternalStringList;
 const ExternalStringMap = install.ExternalStringMap;
 const Features = install.Features;
-const FileSystem = bun.fs.FileSystem;
-const Global = bun.Global;
-const JSAst = bun.JSAst;
-const JSON = bun.JSON;
-const Lockfile = install.Lockfile;
 const Npm = install.Npm;
-const Output = bun.Output;
 const PackageID = bun.install.PackageID;
-const PackageIDSlice = Lockfile.PackageIDSlice;
-const PackageJSON = bun.PackageJSON;
 const PackageManager = install.PackageManager;
 const PackageNameHash = install.PackageNameHash;
-const Path = bun.path;
 const Repository = install.Repository;
 const Resolution = bun.install.Resolution;
-const Semver = bun.Semver;
-const Stream = Lockfile.Stream;
-const String = Semver.String;
-const StringBuilder = Lockfile.StringBuilder;
 const TruncatedPackageNameHash = install.TruncatedPackageNameHash;
-const assert = bun.assert;
-const assertNoUninitializedPadding = Lockfile.assertNoUninitializedPadding;
-const bun = @import("bun");
-const default_trusted_dependencies = Lockfile.default_trusted_dependencies;
 const initializeStore = install.initializeStore;
-const install = bun.install;
 const invalid_package_id = install.invalid_package_id;
-const logger = bun.logger;
-const std = @import("std");
-const string = []const u8;
-const strings = bun.strings;
+
+const Dependency = bun.install.Dependency;
+const Behavior = Dependency.Behavior;
+
+const Lockfile = install.Lockfile;
+const Cloner = Lockfile.Cloner;
+const DependencySlice = Lockfile.DependencySlice;
+const PackageIDSlice = Lockfile.PackageIDSlice;
+const Stream = Lockfile.Stream;
+const StringBuilder = Lockfile.StringBuilder;
+const TrustedDependenciesSet = Lockfile.TrustedDependenciesSet;
+const assertNoUninitializedPadding = Lockfile.assertNoUninitializedPadding;
+const default_trusted_dependencies = Lockfile.default_trusted_dependencies;

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1112,7 +1112,7 @@ pub const Package = extern struct {
                     } else {
                         // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
                         for (package_dependencies[0..dependencies_count]) |*dep| {
-                            if (dep.name_hash == name_hash and dep.version.tag == .workspace) {
+                            if (dep.name_hash == name_hash and dep.behavior.isWorkspaceOnly()) {
                                 dep.* = .{
                                     .behavior = if (in_workspace) group.behavior.add(.workspace) else group.behavior,
                                     .name = external_alias.value,
@@ -2140,6 +2140,8 @@ pub const Package = extern struct {
         }
     };
 };
+
+// @sortImports
 
 const TrustedDependenciesSet = Lockfile.TrustedDependenciesSet;
 const Aligner = install.Aligner;

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -1,0 +1,323 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+test("workspace devDependencies should take priority over peerDependencies for resolution", async () => {
+  const dir = tempDirWithFiles("dev-peer-priority", {
+    "package.json": JSON.stringify({
+      name: "test-monorepo",
+      version: "1.0.0",
+      workspaces: {
+        packages: ["packages/*"],
+        nodeLinker: "isolated",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "jquery": "workspace:*", // Use workspace protocol for dev
+      },
+      peerDependencies: {
+        "jquery": "3.7.0", // Range wants 3.7.0
+      },
+    }),
+    "packages/lib/test.js": `const dep = require("jquery"); console.log(dep.version);`,
+    // Only provide workspace package with version 2.0.0
+    "packages/my-dep/package.json": JSON.stringify({
+      name: "jquery",
+      version: "2.0.0",
+      main: "index.js",
+    }),
+    "packages/my-dep/index.js": `module.exports = { version: "2.0.0" };`,
+  });
+
+  // Run initial install
+  let { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Now run bun install with a dead registry to ensure no network requests
+  ({ stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(resolve => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        NPM_CONFIG_REGISTRY: "http://localhost:9999/", // Dead URL - will fail if used
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    proc.exited.then(exitCode => {
+      Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+        resolve({ stdout, stderr, exitCode });
+      });
+    });
+  }));
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Check that no network requests were made for packages that should be resolved locally
+  expect(stderr).not.toContain("GET");
+  expect(stderr).not.toContain("http");
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+
+  // Verify that version 2.0.0 (devDependency) was linked
+  // If peerDependency range ^1.0.0 was used, it would try to fetch from npm and fail
+  const testResult = await new Promise<string>(resolve => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "packages/lib/test.js"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+
+    new Response(proc.stdout).text().then(resolve);
+  });
+
+  expect(testResult.trim()).toBe("2.0.0");
+});
+
+test("devDependencies and peerDependencies with different versions should coexist", async () => {
+  const dir = tempDirWithFiles("dev-peer-different-versions", {
+    "package.json": JSON.stringify({
+      name: "test-monorepo",
+      version: "1.0.0",
+      workspaces: {
+        packages: ["packages/*"],
+        nodeLinker: "isolated",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "utils": "1.0.0",
+      },
+      peerDependencies: {
+        "utils": "^1.0.0",
+      },
+    }),
+    "packages/lib/index.js": `console.log("lib");`,
+    "packages/utils/package.json": JSON.stringify({
+      name: "utils",
+      version: "1.0.0",
+      main: "index.js",
+    }),
+    "packages/utils/index.js": `console.log("utils");`,
+  });
+
+  // Run bun install in the monorepo
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+});
+
+test("dependency behavior comparison prioritizes devDependencies", async () => {
+  const dir = tempDirWithFiles("behavior-comparison", {
+    "package.json": JSON.stringify({
+      name: "test-app",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "typescript": "^5.0.0",
+      },
+      peerDependencies: {
+        "typescript": "^4.0.0 || ^5.0.0",
+      },
+    }),
+    "index.js": `console.log("app");`,
+  });
+
+  // Run bun install
+  const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+});
+
+test("Next.js monorepo scenario should not make unnecessary network requests", async () => {
+  const dir = tempDirWithFiles("nextjs-monorepo", {
+    "package.json": JSON.stringify({
+      name: "nextjs-monorepo",
+      version: "1.0.0",
+      workspaces: {
+        packages: ["packages/*"],
+        nodeLinker: "isolated",
+      },
+    }),
+    "packages/web/package.json": JSON.stringify({
+      name: "web",
+      version: "1.0.0",
+      dependencies: {},
+      devDependencies: {
+        "next": "15.0.0-canary.119", // Specific canary version for dev
+      },
+      peerDependencies: {
+        "next": "^14.0.0 || ^15.0.0", // Range that would accept 14.x or 15.x stable
+      },
+    }),
+    "packages/web/test.js": `const next = require("next/package.json"); console.log(next.version);`,
+    // Only provide the canary version that matches devDependencies
+    "packages/next/package.json": JSON.stringify({
+      name: "next",
+      version: "15.0.0-canary.119",
+      main: "index.js",
+    }),
+    "packages/next/index.js": `console.log("next workspace");`,
+  });
+
+  // Run initial install
+  let { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    resolve => {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      proc.exited.then(exitCode => {
+        Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+          resolve({ stdout, stderr, exitCode });
+        });
+      });
+    },
+  );
+
+  if (exitCode !== 0) {
+    console.error("Install failed with exit code:", exitCode);
+    console.error("stdout:", stdout);
+    console.error("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+
+  // Run bun install with dead registry
+  ({ stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>(resolve => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-progress", "--no-summary"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        NPM_CONFIG_REGISTRY: "http://localhost:9999/", // Dead URL
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    proc.exited.then(exitCode => {
+      Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]).then(([stdout, stderr]) => {
+        resolve({ stdout, stderr, exitCode });
+      });
+    });
+  }));
+
+  expect(exitCode).toBe(0);
+
+  // The key test: should not make network requests for packages that exist in workspace
+  // When devDependencies are prioritized over peerDependencies, the workspace version should be used
+  expect(stderr).not.toContain("GET");
+  expect(stderr).not.toContain("404");
+  expect(stderr).not.toContain("http");
+
+  // Check that the lockfile was created correctly
+  const lockfilePath = join(dir, "bun.lock");
+  expect(await Bun.file(lockfilePath).exists()).toBe(true);
+
+  // Verify that version 15.0.0-canary.119 (devDependency) was used
+  // If peer range was used, it would try to fetch a stable version from npm and fail
+  const testResult = await new Promise<string>(resolve => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "packages/web/test.js"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+
+    new Response(proc.stdout).text().then(resolve);
+  });
+
+  expect(testResult.trim()).toBe("15.0.0-canary.119");
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
