### PR TITLE
docs: document BUN_BE_BUN

### DIFF
--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -160,7 +160,7 @@ bun install v1.2.16-canary.1 (1d1db811)
 Checked 63 installs across 64 packages (no changes) [5.00ms]
 ```
 
-This is useful for building CLI tools on top of Bun that may need to install packages, bundle dependencies,  run different or local files and more without needing to download a separate binary or install bun.
+This is useful for building CLI tools on top of Bun that may need to install packages, bundle dependencies, run different or local files and more without needing to download a separate binary or install bun.
 
 ## Full-stack executables
 

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -126,6 +126,42 @@ The `--sourcemap` argument embeds a sourcemap compressed with zstd, so that erro
 
 The `--bytecode` argument enables bytecode compilation. Every time you run JavaScript code in Bun, JavaScriptCore (the engine) will compile your source code into bytecode. We can move this parsing work from runtime to bundle time, saving you startup time.
 
+## Act as the Bun CLI
+
+{% note %}
+
+New in Bun v1.2.16
+
+{% /note %}
+
+You can run a standalone executable as if it were the `bun` CLI itself by setting the `BUN_BE_BUN=1` environment variable. When this variable is set, the executable will ignore its bundled entrypoint and instead expose all the features of Bun's CLI.
+
+For example, consider an executable compiled from a simple script:
+
+```sh
+$ cat such-bun.js
+console.log("you shouldn't see this");
+
+$ bun build --compile ./such-bun.js
+ [3ms] bundle 1 modules
+[89ms] compile such-bun
+```
+
+Normally, running `./such-bun` with arguments would execute the script. However, with the `BUN_BE_BUN=1` environment variable, it acts just like the `bun` binary:
+
+```sh
+# Executable runs its own entrypoint by default
+$ ./such-bun install
+you shouldn't see this
+
+# With the env var, the executable acts like the `bun` CLI
+$ BUN_BE_BUN=1 ./such-bun install
+bun install v1.2.16-canary.1 (1d1db811)
+Checked 63 installs across 64 packages (no changes) [5.00ms]
+```
+
+This is useful for building CLI tools on top of Bun that may need to install packages, bundle dependencies,  run different or local files and more without needing to download a separate binary or install bun.
+
 ## Full-stack executables
 
 {% note %}


### PR DESCRIPTION
### What does this PR do?

I wrote a little section inside bun single file executable documentation that explains about BUN_BE_BUN. Just thought it might help, though the writing style could be a bit different.

closes #20948

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes