### PR TITLE
.gitignore: ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 *.out.refresh.js
 *.pdb
 *.sqlite
+*.swp
 *.tmp
 *.trace
 *.wat


### PR DESCRIPTION
Ignore Vim swap files (*.swp).