### PR TITLE
fix(types): Non-empty TextDecoderStream and TextEncoderStream when outside DOM

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -15,8 +15,14 @@ declare module "bun" {
     type LibEmptyOrBunWebSocket = LibDomIsLoaded extends true ? {} : Bun.WebSocket;
 
     type LibEmptyOrNodeUtilTextEncoder = LibDomIsLoaded extends true ? {} : import("node:util").TextEncoder;
+    type LibEmptyOrNodeStreamWebTextEncoderStream = LibDomIsLoaded extends true
+      ? {}
+      : import("node:stream/web").TextEncoderStream;
 
     type LibEmptyOrNodeUtilTextDecoder = LibDomIsLoaded extends true ? {} : import("node:util").TextDecoder;
+    type LibEmptyOrNodeStreamWebTextDecoderStream = LibDomIsLoaded extends true
+      ? {}
+      : import("node:stream/web").TextDecoderStream;
 
     type LibEmptyOrNodeReadableStream<T> = LibDomIsLoaded extends true
       ? {}
@@ -1656,13 +1662,13 @@ declare var ReadableStreamBYOBRequest: Bun.__internal.UseLibDomIfAvailable<
   { prototype: ReadableStreamBYOBRequest; new (): ReadableStreamBYOBRequest }
 >;
 
-interface TextDecoderStream {}
+interface TextDecoderStream extends Bun.__internal.LibEmptyOrNodeStreamWebTextDecoderStream {}
 declare var TextDecoderStream: Bun.__internal.UseLibDomIfAvailable<
   "TextDecoderStream",
   { prototype: TextDecoderStream; new (): TextDecoderStream }
 >;
 
-interface TextEncoderStream {}
+interface TextEncoderStream extends Bun.__internal.LibEmptyOrNodeStreamWebTextEncoderStream {}
 declare var TextEncoderStream: Bun.__internal.UseLibDomIfAvailable<
   "TextEncoderStream",
   { prototype: TextEncoderStream; new (): TextEncoderStream }

--- a/test/integration/bun-types/fixture/streams.ts
+++ b/test/integration/bun-types/fixture/streams.ts
@@ -45,3 +45,16 @@ expectType(stream.json()).is<Promise<any>>();
 expectType(stream.bytes()).is<Promise<Uint8Array>>();
 expectType(stream.text()).is<Promise<string>>();
 expectType(stream.blob()).is<Promise<Blob>>();
+
+Bun.file("./foo.csv").stream().pipeThrough(new TextDecoderStream()).pipeThrough(new TextEncoderStream());
+
+Bun.file("./foo.csv")
+  .stream()
+  .pipeThrough(new TextDecoderStream())
+  .pipeTo(
+    new WritableStream({
+      write(chunk) {
+        expectType(chunk).is<string>();
+      },
+    }),
+  );


### PR DESCRIPTION
### What does this PR do?

Fixes #20944

Fixes TextEncoderStream and TextDecoderStream being empty, adds a test case

This is a partial fix for #18953, but is enough to close #20944

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
