### PR TITLE
Add LLDB pretty printing for bun.BabyList

### DIFF
--- a/misctools/lldb/bun_pretty_printer.py
+++ b/misctools/lldb/bun_pretty_printer.py
@@ -1,0 +1,74 @@
+# Pretty printers for Bun data structures
+import lldb
+import re
+
+class bun_BabyList_SynthProvider:
+    def __init__(self, value, _=None): 
+        self.value = value
+        
+    def update(self):
+        try:
+            self.ptr = self.value.GetChildMemberWithName('ptr')
+            self.len = self.value.GetChildMemberWithName('len').unsigned
+            self.cap = self.value.GetChildMemberWithName('cap').unsigned
+            self.elem_type = self.ptr.type.GetPointeeType()
+            self.elem_size = self.elem_type.size
+        except:
+            pass
+            
+    def has_children(self): 
+        return True
+        
+    def num_children(self): 
+        return self.len or 0
+        
+    def get_child_index(self, name):
+        try: 
+            return int(name.removeprefix('[').removesuffix(']'))
+        except: 
+            return -1
+            
+    def get_child_at_index(self, index):
+        if index not in range(self.len): 
+            return None
+        try: 
+            return self.ptr.CreateChildAtOffset('[%d]' % index, index * self.elem_size, self.elem_type)
+        except: 
+            return None
+
+def bun_BabyList_SummaryProvider(value, _=None):
+    try:
+        # Get the non-synthetic value to access raw members
+        value = value.GetNonSyntheticValue()
+        len_val = value.GetChildMemberWithName('len')
+        cap_val = value.GetChildMemberWithName('cap')
+        return 'len=%d cap=%d' % (len_val.unsigned, cap_val.unsigned)
+    except:
+        return 'len=? cap=?'
+
+def add(debugger, *, category, regex=False, type, identifier=None, synth=False, inline_children=False, expand=False, summary=False):
+    prefix = '.'.join((__name__, (identifier or type).replace('.', '_').replace(':', '_')))
+    if summary: 
+        debugger.HandleCommand('type summary add --category %s%s%s "%s"' % (
+            category, 
+            ' --inline-children' if inline_children else ''.join((' --expand' if expand else '', ' --python-function %s_SummaryProvider' % prefix if summary == True else ' --summary-string "%s"' % summary)), 
+            ' --regex' if regex else '', 
+            type
+        ))
+    if synth: 
+        debugger.HandleCommand('type synthetic add --category %s%s --python-class %s_SynthProvider "%s"' % (
+            category, 
+            ' --regex' if regex else '', 
+            prefix, 
+            type
+        ))
+
+def __lldb_init_module(debugger, _=None):
+    # Initialize Bun Category
+    debugger.HandleCommand('type category define --language c99 bun')
+    
+    # Initialize Bun Data Structures
+    add(debugger, category='bun', regex=True, type='^baby_list\\.BabyList\\(.*\\)$', identifier='bun_BabyList', synth=True, expand=True, summary=True)
+    
+    # Enable the category
+    debugger.HandleCommand('type category enable bun')

--- a/misctools/lldb/bun_pretty_printer.py
+++ b/misctools/lldb/bun_pretty_printer.py
@@ -7,6 +7,7 @@ class bun_BabyList_SynthProvider:
         self.value = value
         
     def update(self):
+
         try:
             self.ptr = self.value.GetChildMemberWithName('ptr')
             self.len = self.value.GetChildMemberWithName('len').unsigned
@@ -14,7 +15,10 @@ class bun_BabyList_SynthProvider:
             self.elem_type = self.ptr.type.GetPointeeType()
             self.elem_size = self.elem_type.size
         except:
+            self.len = 0
+            self.cap = 0
             pass
+
             
     def has_children(self): 
         return True

--- a/misctools/lldb/init.lldb
+++ b/misctools/lldb/init.lldb
@@ -15,5 +15,7 @@ type category enable zig.std
 
 command script import -c lldb_webkit.py
 
+command script import -c bun_pretty_printer.py
+
 command script delete btjs
 command alias btjs p {printf("gathering btjs trace...\n");printf("%s\n", (char*)dumpBtjsTrace())}


### PR DESCRIPTION
### What does this PR do?

Adds script to enable pretty printing for bun.BabyList(T) types in LLDB:

<img width="810" height="530" alt="image" src="https://github.com/user-attachments/assets/45f80d3d-8d4a-4dcf-a9a5-79e70b7505a4" />

