### PR TITLE
types: NodeJS.ProcessEnv does not extend ImportMetaEnv

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -23,7 +23,7 @@ declare module "stream/web" {
 
 declare global {
   namespace NodeJS {
-    interface ProcessEnv extends Bun.Env, ImportMetaEnv {}
+    interface ProcessEnv extends Bun.Env {}
 
     interface Process {
       readonly version: string;

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -47,7 +47,7 @@ export const isBroken = isCI;
 export const isASAN = basename(process.execPath).includes("bun-asan");
 
 export const bunEnv: NodeJS.Dict<string> = {
-  ...(process.env as NodeJS.Dict<string>),
+  ...process.env,
   GITHUB_ACTIONS: "false",
   BUN_DEBUG_QUIET_LOGS: "1",
   NO_COLOR: "1",

--- a/test/integration/bun-types/fixture/env.ts
+++ b/test/integration/bun-types/fixture/env.ts
@@ -33,9 +33,9 @@ declare global {
   }
 }
 expectType(Bun.env.BAZ).is<"BAZ">();
-// expectType(process.env.BAZ).is<"BAZ">(); // ImportMetaEnv does NOT extend ProcessEnv
+// expectType(process.env.BAZ).is<"BAZ">(); // ProcessEnv does NOT extend ImportMetaEnv
 expectType(import.meta.env.BAZ).is<"BAZ">();
-// expectType(node_env.BAZ).is<"BAZ">(); // ImportMetaEnv does NOT extend ProcessEnv
+// expectType(node_env.BAZ).is<"BAZ">(); // ProcessEnv does NOT extend ImportMetaEnv
 expectType(bun_env.BAZ).is<"BAZ">();
 
 expectType(Bun.env.OTHER).is<string | undefined>();
@@ -53,7 +53,7 @@ function isAllSame<T>(a: T, b: T, c: T, d: T, e: T) {
 
   isAllSame              <"FOO"> (process.env.FOO,   Bun.env.FOO,   import.meta.env.FOO,   node_env.FOO,   bun_env.FOO);
   isAllSame              <"BAR"> (process.env.BAR,   Bun.env.BAR,   import.meta.env.BAR,   node_env.BAR,   bun_env.BAR);
-  isAllSame              <"BAZ"> (          "BAZ",   Bun.env.BAZ,   import.meta.env.BAZ,          "BAZ",   bun_env.BAZ); // ImportMetaEnv does NOT extend ProcessEnv
+  isAllSame              <"BAZ"> (          "BAZ",   Bun.env.BAZ,   import.meta.env.BAZ,          "BAZ",   bun_env.BAZ); // ProcessEnv does NOT extend ImportMetaEnv
   isAllSame <string | undefined> (process.env.OTHER, Bun.env.OTHER, import.meta.env.OTHER, node_env.OTHER, bun_env.OTHER);
 
 }

--- a/test/integration/bun-types/fixture/env.ts
+++ b/test/integration/bun-types/fixture/env.ts
@@ -33,9 +33,9 @@ declare global {
   }
 }
 expectType(Bun.env.BAZ).is<"BAZ">();
-expectType(process.env.BAZ).is<"BAZ">();
+// expectType(process.env.BAZ).is<"BAZ">(); // ImportMetaEnv does NOT extend ProcessEnv
 expectType(import.meta.env.BAZ).is<"BAZ">();
-expectType(node_env.BAZ).is<"BAZ">();
+// expectType(node_env.BAZ).is<"BAZ">(); // ImportMetaEnv does NOT extend ProcessEnv
 expectType(bun_env.BAZ).is<"BAZ">();
 
 expectType(Bun.env.OTHER).is<string | undefined>();
@@ -53,7 +53,7 @@ function isAllSame<T>(a: T, b: T, c: T, d: T, e: T) {
 
   isAllSame              <"FOO"> (process.env.FOO,   Bun.env.FOO,   import.meta.env.FOO,   node_env.FOO,   bun_env.FOO);
   isAllSame              <"BAR"> (process.env.BAR,   Bun.env.BAR,   import.meta.env.BAR,   node_env.BAR,   bun_env.BAR);
-  isAllSame              <"BAZ"> (process.env.BAZ,   Bun.env.BAZ,   import.meta.env.BAZ,   node_env.BAZ,   bun_env.BAZ);
+  isAllSame              <"BAZ"> (          "BAZ",   Bun.env.BAZ,   import.meta.env.BAZ,          "BAZ",   bun_env.BAZ); // ImportMetaEnv does NOT extend ProcessEnv
   isAllSame <string | undefined> (process.env.OTHER, Bun.env.OTHER, import.meta.env.OTHER, node_env.OTHER, bun_env.OTHER);
 
 }


### PR DESCRIPTION
### What does this PR do?

Fixes #20961

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

updated tests