### PR TITLE
Add non-default-referenced ambient declaration file to globally declare test runner symbols

### DIFF
--- a/packages/bun-types/test-globals.d.ts
+++ b/packages/bun-types/test-globals.d.ts
@@ -1,0 +1,20 @@
+// Do not include this file in ./index.d.ts
+//
+// This file gets loaded by developers including the following triple slash directive:
+//
+// ```ts
+// /// <reference types="bun/test-globals" />
+// ```
+
+declare var test: typeof import("bun:test").test;
+declare var it: typeof import("bun:test").it;
+declare var describe: typeof import("bun:test").describe;
+declare var expect: typeof import("bun:test").expect;
+declare var beforeAll: typeof import("bun:test").beforeAll;
+declare var beforeEach: typeof import("bun:test").beforeEach;
+declare var afterEach: typeof import("bun:test").afterEach;
+declare var afterAll: typeof import("bun:test").afterAll;
+declare var setDefaultTimeout: typeof import("bun:test").setDefaultTimeout;
+declare var mock: typeof import("bun:test").mock;
+declare var spyOn: typeof import("bun:test").spyOn;
+declare var jest: typeof import("bun:test").jest;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -268,7 +268,7 @@ describe("@types/bun integration test", () => {
       expect(diagnostics).toEqual([]);
     });
 
-    test("test-globals FAILS when the test-globals.d.ts is not references", async () => {
+    test("test-globals FAILS when the test-globals.d.ts is not referenced", async () => {
       const { diagnostics, emptyInterfaces } = await diagnose(FIXTURE_DIR, {
         files: { "my-test.test.ts": code }, // no reference to bun/test-globals
       });

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -213,6 +213,19 @@ describe("@types/bun integration test", () => {
     expect(diagnostics).toEqual([]);
   });
 
+  // This is not a super great way to be testing that test-globals is safe, but it does work for now.
+  // Ideally we should have a way to include custom test files in the fixture. This could
+  // be a change to the `diagnose` function to accept a DirectoryTree kind of structure (we do
+  // this in harness.ts and a few other places, so it would follow convention).
+  test("checks without lib.dom.d.ts and test-globals references", async () => {
+    const { diagnostics, emptyInterfaces } = await diagnose(FIXTURE_DIR, {
+      types: ["bun", "node", "bun/test-globals"],
+    });
+
+    expect(emptyInterfaces).toEqual(new Set());
+    expect(diagnostics).toEqual([]);
+  });
+
   test("checks with lib.dom.d.ts", async () => {
     const { diagnostics, emptyInterfaces } = await diagnose(FIXTURE_DIR, {
       lib: ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"].map(name => `lib.${name.toLowerCase()}.d.ts`),

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -241,24 +241,26 @@ describe("@types/bun integration test", () => {
   });
 
   describe("test-globals reference", () => {
+    const code = `
+      const test_shouldBeAFunction: Function = test;
+      const it_shouldBeAFunction: Function = it;
+      const describe_shouldBeAFunction: Function = describe;
+      const expect_shouldBeAFunction: Function = expect;
+      const beforeAll_shouldBeAFunction: Function = beforeAll;
+      const beforeEach_shouldBeAFunction: Function = beforeEach;
+      const afterEach_shouldBeAFunction: Function = afterEach;
+      const afterAll_shouldBeAFunction: Function = afterAll;
+      const setDefaultTimeout_shouldBeAFunction: Function = setDefaultTimeout;
+      const mock_shouldBeAFunction: Function = mock;
+      const spyOn_shouldBeAFunction: Function = spyOn;
+      const jest_shouldBeDefined: object = jest;
+    `;
+
     test("checks without lib.dom.d.ts and test-globals references", async () => {
       const { diagnostics, emptyInterfaces } = await diagnose(FIXTURE_DIR, {
         files: {
           "reference-the-globals.ts": `/// <reference types="bun/test-globals" />`,
-          "my-test.test.ts": `
-             const test_shouldBeAFunction: Function = test;
-             const it_shouldBeAFunction: Function = it;
-             const describe_shouldBeAFunction: Function = describe;
-             const expect_shouldBeAFunction: Function = expect;
-             const beforeAll_shouldBeAFunction: Function = beforeAll;
-             const beforeEach_shouldBeAFunction: Function = beforeEach;
-             const afterEach_shouldBeAFunction: Function = afterEach;
-             const afterAll_shouldBeAFunction: Function = afterAll;
-             const setDefaultTimeout_shouldBeAFunction: Function = setDefaultTimeout;
-             const mock_shouldBeAFunction: Function = mock;
-             const spyOn_shouldBeAFunction: Function = spyOn;
-             const jest_shouldBeDefined: object = jest;
-           `,
+          "my-test.test.ts": code,
         },
       });
 
@@ -268,24 +270,7 @@ describe("@types/bun integration test", () => {
 
     test("test-globals FAILS when the test-globals.d.ts is not references", async () => {
       const { diagnostics, emptyInterfaces } = await diagnose(FIXTURE_DIR, {
-        files: {
-          // Intentionally left out to demonstrate that this should fail
-          // "reference-the-globals.ts": `/// <reference types="bun/test-globals" />`,
-          "my-test.test.ts": `
-             const test_shouldBeAFunction: Function = test;
-             const it_shouldBeAFunction: Function = it;
-             const describe_shouldBeAFunction: Function = describe;
-             const expect_shouldBeAFunction: Function = expect;
-             const beforeAll_shouldBeAFunction: Function = beforeAll;
-             const beforeEach_shouldBeAFunction: Function = beforeEach;
-             const afterEach_shouldBeAFunction: Function = afterEach;
-             const afterAll_shouldBeAFunction: Function = afterAll;
-             const setDefaultTimeout_shouldBeAFunction: Function = setDefaultTimeout;
-             const mock_shouldBeAFunction: Function = mock;
-             const spyOn_shouldBeAFunction: Function = spyOn;
-             const jest_shouldBeDefined: object = jest;
-           `,
-        },
+        files: { "my-test.test.ts": code }, // no reference to bun/test-globals
       });
 
       expect(emptyInterfaces).toEqual(new Set()); // should still have no empty interfaces

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -93,7 +93,7 @@ async function diagnose(
   const files = (await Array.fromAsync(glob)).filter(file => !file.includes("node_modules"));
 
   if (extraFiles) {
-    for (const [relativePath] of Object.entries(extraFiles)) {
+    for (const relativePath of Object.keys(extraFiles)) {
       const absolutePath = join(fixtureDir, relativePath);
       if (!files.includes(absolutePath)) {
         files.push(absolutePath);


### PR DESCRIPTION
### What does this PR do?

Fixes #4376

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

Updated bun-types integration test to include one that references the test globals