### PR TITLE
fix #20978

### DIFF
--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -1,7 +1,7 @@
 // This file is checked in the `bun-types.test.ts` integration test for successful typechecking, but also checked
 // on its own to make sure that the types line up with actual implementation of Bun.serve()
 
-import { expect, test as it } from "bun:test";
+import { expect, it } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
@@ -17,8 +17,8 @@ function expectInstanceOf<T>(value: unknown, constructor: new (...args: any[]) =
   expect(value).toBeInstanceOf(constructor);
 }
 
-let id = 0;
 function test<T, R extends { [K in keyof R]: Bun.RouterTypes.RouteValue<K & string> }>(
+  name: string,
   serveConfig: Bun.ServeFunctionOptions<T, R>,
   {
     onConstructorFailure,
@@ -45,7 +45,7 @@ function test<T, R extends { [K in keyof R]: Bun.RouterTypes.RouteValue<K & stri
     }
   }
 
-  it(`Bun.serve() types test ${++id}`, async () => {
+  it(name, async () => {
     try {
       using server = Bun.serve(serveConfig);
       try {
@@ -62,7 +62,7 @@ function test<T, R extends { [K in keyof R]: Bun.RouterTypes.RouteValue<K & stri
   });
 }
 
-test({
+test("basic", {
   fetch(req) {
     console.log(req.url); // => http://localhost:3000/
     return new Response("Hello World");
@@ -70,6 +70,7 @@ test({
 });
 
 test(
+  "basic + tls",
   {
     fetch(req) {
       console.log(req.url); // => http://localhost:3000/
@@ -88,6 +89,7 @@ test(
 );
 
 test(
+  "basic + invalid route value",
   {
     routes: {
       "/": new Response("Hello World"),
@@ -102,7 +104,7 @@ test(
   },
 );
 
-test({
+test("basic + websocket + upgrade", {
   websocket: {
     message(ws, message) {
       expectType<typeof ws>().is<Bun.ServerWebSocket<unknown>>();
@@ -123,7 +125,7 @@ test({
   },
 });
 
-test({
+test("basic + websocket + upgrade + all handlers", {
   fetch(req, server) {
     const url = new URL(req.url);
     if (url.pathname === "/chat") {
@@ -167,6 +169,7 @@ test({
 });
 
 test(
+  "basic error handling",
   {
     fetch(req) {
       throw new Error("woops!");
@@ -189,7 +192,7 @@ test(
   },
 );
 
-test({
+test("port 0 + websocket + upgrade", {
   port: 0,
   fetch(req, server) {
     server.upgrade(req);
@@ -204,6 +207,7 @@ test({
 });
 
 test(
+  "basic unix socket",
   {
     unix: `${tmpdirSync()}/bun.sock`,
     fetch() {
@@ -220,6 +224,7 @@ test(
 );
 
 test(
+  "basic unix socket + websocket + upgrade",
   // @ts-expect-error - TODO Fix this
   {
     unix: `${tmpdirSync()}/bun.sock`,
@@ -240,6 +245,7 @@ test(
 );
 
 test(
+  "basic unix socket + websocket + upgrade + tls",
   // @ts-expect-error - TODO Fix this
   {
     unix: `${tmpdirSync()}/bun.sock`,
@@ -261,6 +267,7 @@ test(
 );
 
 test(
+  "basic unix socket 2",
   {
     unix: `${tmpdirSync()}/bun.sock`,
     fetch(req, server) {
@@ -278,6 +285,7 @@ test(
 );
 
 test(
+  "basic unix socket + upgrade + cheap request to check upgrade",
   // @ts-expect-error - TODO Fix this
   {
     unix: `${tmpdirSync()}/bun.sock`,
@@ -341,6 +349,7 @@ test(
 );
 
 test(
+  "basic unix socket + routes",
   {
     unix: `${tmpdirSync()}/bun.sock`,
     routes: {
@@ -357,6 +366,7 @@ test(
 );
 
 test(
+  "unix socket with no routes or fetch handler (should fail)",
   // @ts-expect-error - Missing fetch or routes
   {
     unix: `${tmpdirSync()}/bun.sock`,
@@ -370,7 +380,7 @@ test(
   },
 );
 
-test({
+test("basic routes + fetch + websocket + upgrade", {
   routes: {
     "/:test": req => {
       return new Response(req.params.test);
@@ -391,7 +401,7 @@ test({
   },
 });
 
-test({
+test("basic routes + fetch", {
   routes: {
     "/:test": req => {
       return new Response(req.params.test);
@@ -403,13 +413,13 @@ test({
   },
 });
 
-test({
+test("very basic fetch", {
   fetch: (req, server) => {
     return new Response("cool");
   },
 });
 
-test({
+test("very basic single route with url params", {
   routes: {
     "/:test": req => {
       return new Response(req.params.test);
@@ -417,7 +427,7 @@ test({
   },
 });
 
-test({
+test("very basic fetch with websocket message handler", {
   fetch: () => new Response("ok"),
   websocket: {
     message: ws => {
@@ -426,7 +436,7 @@ test({
   },
 });
 
-test({
+test("yet another basic fetch and websocket message handler", {
   websocket: {
     message: () => {
       //
@@ -441,7 +451,7 @@ test({
   },
 });
 
-test({
+test("websocket + upgrade on a route path", {
   websocket: {
     message: () => {
       //
@@ -460,7 +470,7 @@ test({
 
 const files = {} as Record<string, Bun.BunFile>;
 
-test({
+test("permutations of valid route values", {
   routes: {
     "/this/:test": Bun.file(import.meta.file),
     "/index.test-d.ts": Bun.file("index.test-d.ts"),
@@ -478,7 +488,7 @@ test({
   },
 });
 
-test({
+test("basic websocket upgrade and ws publish/subscribe to topics", {
   fetch(req, server) {
     server.upgrade(req);
   },
@@ -496,6 +506,7 @@ test({
 });
 
 test(
+  "port with unix socket (is a type error)",
   {
     unix: `${tmpdirSync()}/bun.sock`,
     // @ts-expect-error
@@ -514,6 +525,7 @@ test(
 );
 
 test(
+  "port with unix socket with websocket + upgrade (is a type error)",
   {
     unix: `${tmpdirSync()}/bun.sock`,
     // @ts-expect-error


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
