### PR TITLE
feature(postgres) add pipelining support

### DIFF
--- a/src/bun.js/api/postgres.classes.ts
+++ b/src/bun.js/api/postgres.classes.ts
@@ -32,7 +32,10 @@ export default [
       flush: {
         fn: "doFlush",
       },
-
+      setPipelining: {
+        fn: "doSetPipelining",
+        length: 1,
+      },
       queries: {
         getter: "getQueries",
         this: true,

--- a/src/bun.js/api/postgres.classes.ts
+++ b/src/bun.js/api/postgres.classes.ts
@@ -32,10 +32,6 @@ export default [
       flush: {
         fn: "doFlush",
       },
-      setPipelining: {
-        fn: "doSetPipelining",
-        length: 1,
-      },
       queries: {
         getter: "getQueries",
         this: true,

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -719,7 +719,6 @@ class PooledConnection {
   flags: number = 0;
   /// queryCount is used to indicate the number of queries using the connection, if a connection is reserved or if its a transaction queryCount will be 1 independently of the number of queries
   queryCount: number = 0;
-  enablePipelining: boolean = true;
   #onConnected(err, _) {
     const connectionInfo = this.connectionInfo;
     if (connectionInfo?.onconnect) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -721,7 +721,6 @@ class PooledConnection {
   queryCount: number = 0;
   enablePipelining: boolean = true;
   #onConnected(err, _) {
-    this.connection?.setPipelining(this.enablePipelining);
     const connectionInfo = this.connectionInfo;
     if (connectionInfo?.onconnect) {
       connectionInfo.onconnect(err);
@@ -796,10 +795,7 @@ class PooledConnection {
     // @ts-ignore
     query.finally(onQueryFinish.bind(this, onClose));
   }
-  setPipelining(pipelining: boolean) {
-    this.enablePipelining = pipelining;
-    this.connection?.setPipelining(pipelining);
-  }
+
   #doRetry() {
     if (this.pool.closed) {
       return;
@@ -910,9 +906,6 @@ class ConnectionPool {
     if (currentQueryCount == 0) {
       connection.flags &= ~PooledConnectionFlags.reserved;
       connection.flags &= ~PooledConnectionFlags.preReserved;
-      if (!connection.enablePipelining) {
-        connection.setPipelining(true);
-      }
     }
     if (this.onAllQueriesFinished) {
       // we are waiting for all queries to finish, lets check if we can call it
@@ -1952,7 +1945,6 @@ function SQL(o, e = {}) {
     if (err) {
       return reject(err);
     }
-    pooledConnection.setPipelining(false);
     const state = {
       connectionState: ReservedConnectionState.acceptQueries,
       reject,

--- a/src/sql/postgres/ConnectionFlags.zig
+++ b/src/sql/postgres/ConnectionFlags.zig
@@ -2,6 +2,7 @@ pub const ConnectionFlags = packed struct {
     is_ready_for_query: bool = false,
     is_processing_data: bool = false,
     use_unnamed_prepared_statements: bool = false,
+    waiting_to_prepare: bool = false,
 };
 
 // @sortImports

--- a/src/sql/postgres/ConnectionFlags.zig
+++ b/src/sql/postgres/ConnectionFlags.zig
@@ -3,6 +3,7 @@ pub const ConnectionFlags = packed struct {
     is_processing_data: bool = false,
     use_unnamed_prepared_statements: bool = false,
     waiting_to_prepare: bool = false,
+    has_backpressure: bool = false,
 };
 
 // @sortImports

--- a/src/sql/postgres/ConnectionFlags.zig
+++ b/src/sql/postgres/ConnectionFlags.zig
@@ -4,7 +4,6 @@ pub const ConnectionFlags = packed struct {
     use_unnamed_prepared_statements: bool = false,
     waiting_to_prepare: bool = false,
     has_backpressure: bool = false,
-    disable_pipelining: bool = false,
 };
 
 // @sortImports

--- a/src/sql/postgres/ConnectionFlags.zig
+++ b/src/sql/postgres/ConnectionFlags.zig
@@ -4,6 +4,7 @@ pub const ConnectionFlags = packed struct {
     use_unnamed_prepared_statements: bool = false,
     waiting_to_prepare: bool = false,
     has_backpressure: bool = false,
+    disable_pipelining: bool = false,
 };
 
 // @sortImports

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -407,7 +407,7 @@ pub fn onDrain(this: *PostgresSQLConnection) void {
 
     this.flushData();
 
-    if (this.flags.is_ready_for_query) {
+    if (this.flags.is_ready_for_query and !this.flags.has_backpressure) {
         this.advance();
         this.flushData();
     }

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1660,6 +1660,8 @@ const PreparedStatementsMap = std.HashMapUnmanaged(u64, *PostgresSQLStatement, b
 
 const debug = bun.Output.scoped(.Postgres, false);
 
+const MAX_PIPELINE_SIZE = 1024 * 64;
+
 // @sortImports
 
 const PostgresCachedStructure = @import("./PostgresCachedStructure.zig");
@@ -1687,6 +1689,7 @@ const assert = bun.assert;
 
 const JSC = bun.JSC;
 const JSValue = JSC.JSValue;
+const AutoFlusher = JSC.WebCore.AutoFlusher;
 
 pub const js = JSC.Codegen.JSPostgresSQLConnection;
 pub const fromJS = js.fromJS;
@@ -1695,6 +1698,3 @@ pub const toJS = js.toJS;
 
 const uws = bun.uws;
 const Socket = uws.AnySocket;
-const AutoFlusher = JSC.WebCore.AutoFlusher;
-
-const MAX_PIPELINE_SIZE = 1024 * 64;

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -989,14 +989,8 @@ fn advance(this: *PostgresSQLConnection) void {
                     return;
                 } else {
                     const stmt = req.statement orelse {
-                        req.onWriteFail(AnyPostgresError.ExpectedStatement, this.globalObject, this.getQueriesArray());
-                        if (offset == 0) {
-                            req.deref();
-                            this.requests.discard(1);
-                        } else {
-                            // deinit later
-                            req.status = .fail;
-                        }
+                        // statement is not set yet waiting it to RUN before actually doing anything
+                        offset += 1;
                         continue;
                     };
 

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1683,6 +1683,8 @@ const PreparedStatementsMap = std.HashMapUnmanaged(u64, *PostgresSQLStatement, b
 
 const debug = bun.Output.scoped(.Postgres, false);
 
+const MAX_PIPELINE_SIZE = std.math.maxInt(u16); // about 64KB per connection
+
 // @sortImports
 
 const PostgresCachedStructure = @import("./PostgresCachedStructure.zig");
@@ -1710,6 +1712,7 @@ const assert = bun.assert;
 
 const JSC = bun.JSC;
 const JSValue = JSC.JSValue;
+const AutoFlusher = JSC.WebCore.AutoFlusher;
 
 pub const js = JSC.Codegen.JSPostgresSQLConnection;
 pub const fromJS = js.fromJS;
@@ -1718,6 +1721,3 @@ pub const toJS = js.toJS;
 
 const uws = bun.uws;
 const Socket = uws.AnySocket;
-const AutoFlusher = JSC.WebCore.AutoFlusher;
-
-const MAX_PIPELINE_SIZE = std.math.maxInt(u16); // about 64KB per connection

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1683,8 +1683,6 @@ const PreparedStatementsMap = std.HashMapUnmanaged(u64, *PostgresSQLStatement, b
 
 const debug = bun.Output.scoped(.Postgres, false);
 
-const MAX_PIPELINE_SIZE = 1024 * 64;
-
 // @sortImports
 
 const PostgresCachedStructure = @import("./PostgresCachedStructure.zig");


### PR DESCRIPTION
### What does this PR do?
Add pipelining to improve performance and add better connection distribution.

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?
Existing tests + manually benchmark:


```js
// 1 connection because we are testing pipelining performance here
import { SQL } from "bun";
let sql;
if (Bun.argv.includes("--bunsql")) {
  sql = new SQL({
    max: 1,
    url,
  });
} else {
  const postgres = require("postgres").default;
  sql = postgres(url, {
    max: 1,
  });
}

async function test(name, quantity, limit = Infinity) {
  let res = [];
  console.time(name);
  for (let i = 1; i <= quantity; i++) {
    res.push(sql`select id from users where "name" = ${"John" + i % 1000} limit 1`.execute());
    if (res.length >= limit) {
      await Promise.all(res);
      res = [];
    }
  }

  await Promise.all(res);
  console.timeEnd(name);
}

await test("warmup", 1000, 50);
await Bun.sleep(1000);
await test("test", 10000);
await sql.end();
```

Output using neon database (sslmode=require):
```bash
postgres.js:
[2.19s] warmup
[7.25s] test

this PR:
[1.92s] warmup
[1.59s] test

postgres.js + node v23.9.0:
warmup: 2.193s
test: 12.785s
```
without warmup:
```bash
 hyperfine "/Users/cirospaciari/Repos/bun/build/release/bun-profile test.mjs --bunsql" "bun test.mjs --postgresjs" "node test-node.mjs --postgresjs"
Benchmark 1: /Users/cirospaciari/Repos/bun/build/release/bun-profile test.mjs --bunsql
  Time (mean ± σ):      2.286 s ±  0.071 s    [User: 0.402 s, System: 0.153 s]
  Range (min … max):    2.222 s …  2.447 s    10 runs
 
Benchmark 2: bun test.mjs --postgresjs
  Time (mean ± σ):      7.729 s ±  0.168 s    [User: 3.422 s, System: 2.959 s]
  Range (min … max):    7.506 s …  8.005 s    10 runs
 
Benchmark 3: node test-node.mjs --postgresjs
  Time (mean ± σ):     13.663 s ±  0.345 s    [User: 0.650 s, System: 0.095 s]
  Range (min … max):   13.404 s … 14.420 s    10 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (14.162 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Summary
  /Users/cirospaciari/Repos/bun/build/release/bun-profile test.mjs --bunsql ran
    3.38 ± 0.13 times faster than bun test.mjs --postgresjs
    5.98 ± 0.24 times faster than node test-node.mjs --postgresjs

```

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
