### PR TITLE
Fix `bun add` with multiple packages

### DIFF
--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -187,6 +187,7 @@ it("bun add --only-missing should not install existing package", async () => {
       stdout: "pipe",
       stdin: "pipe",
       stderr: "pipe",
+      env,
     });
     const out = await new Response(stdout).text();
     expect(out).not.toContain("Saved lockfile");
@@ -260,6 +261,7 @@ it("bun add --analyze should scan dependencies", async () => {
       stdout: "pipe",
       stdin: "pipe",
       stderr: "pipe",
+      env,
     });
     const out = await new Response(stdout).text();
     expect(out).not.toContain("Saved lockfile");

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2292,6 +2292,7 @@ it("should add multiple dependencies specified on command line", async () => {
     stdout: "pipe",
     stdin: "pipe",
     stderr: "pipe",
+    env,
   });
   await writeFile(
     join(add_dir, "package.json"),


### PR DESCRIPTION
Fixes #11116.

Commands like this previously failed, but now work as intended:

```
bun add https://github.com/jquery/esprima is-number
```