### PR TITLE
test: delete bundler test temp folders upon success

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1640,6 +1640,8 @@ for (const [key, blob] of build.outputs) {
       }
     }
 
+    rmdirSync(root, { recursive: true });
+
     return testRef(id, opts);
   })();
 }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -5,7 +5,17 @@ import { BuildConfig, BuildOutput, BunPlugin, fileURLToPath, PluginBuilder, Load
 import { callerSourceOrigin } from "bun:jsc";
 import type { Matchers } from "bun:test";
 import * as esbuild from "esbuild";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
 import { bunEnv, bunExe, isCI, isDebug } from "harness";
 import { tmpdir } from "os";
 import path from "path";


### PR DESCRIPTION
observed lots of ENOSPC in CI
ran locally first to verify
