### PR TITLE
docs: fix writing guideline violations

### DIFF
--- a/docs/api/cookie.md
+++ b/docs/api/cookie.md
@@ -1,4 +1,4 @@
-Bun provides native APIs for working with HTTP cookies through `Bun.Cookie` and `Bun.CookieMap`. These APIs offer fast, easy-to-use methods for parsing, generating, and manipulating cookies in HTTP requests and responses.
+Bun provides native APIs for working with HTTP cookies through `Bun.Cookie` and `Bun.CookieMap`. These APIs offer fast methods for parsing, generating, and manipulating cookies in HTTP requests and responses.
 
 ## CookieMap class
 
@@ -138,7 +138,7 @@ const json = cookies.toJSON();
 
 Returns an array of values for Set-Cookie headers that can be used to apply all cookie changes.
 
-When using `Bun.serve()`, you don't need to call this method explicitly. Any changes made to the `req.cookies` map are automatically applied to the response headers. This method is primarily useful when working with other HTTP server implementations.
+When using `Bun.serve()`, you can skip calling this method explicitly. Any changes made to the `req.cookies` map are automatically applied to the response headers. This method is primarily useful when working with other HTTP server implementations.
 
 ```js
 import { createServer } from "node:http";

--- a/docs/api/dns.md
+++ b/docs/api/dns.md
@@ -10,9 +10,9 @@ console.log(addrs);
 
 ## DNS caching in Bun
 
-In Bun v1.1.9, we added support for DNS caching. This cache makes repeated connections to the same hosts faster.
+In Bun v1.1.9, Bun added support for DNS caching. This cache makes repeated connections to the same hosts faster.
 
-At the time of writing, we cache up to 255 entries for a maximum of 30 seconds (each). If any connections to a host fail, we remove the entry from the cache. When multiple connections are made to the same host simultaneously, DNS lookups are deduplicated to avoid making multiple requests for the same host.
+At the time of writing, Bun caches up to 255 entries for a maximum of 30 seconds (each). If any connections to a host fail, Bun removes the entry from the cache. When multiple connections are made to the same host simultaneously, DNS lookups are deduplicated to avoid making multiple requests for the same host.
 
 This cache is automatically used by:
 
@@ -23,7 +23,7 @@ This cache is automatically used by:
 - `node:net`
 - `node:tls`
 
-### When should I prefetch a DNS entry?
+### When should you prefetch a DNS entry?
 
 Web browsers expose [`<link rel="dns-prefetch">`](https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch) to allow developers to prefetch DNS entries. This is useful when you know you'll need to connect to a host in the near future and want to avoid the initial DNS lookup.
 

--- a/docs/api/redis.md
+++ b/docs/api/redis.md
@@ -29,7 +29,7 @@ To use the Redis client, you first need to create a connection:
 import { redis, RedisClient } from "bun";
 
 // Using the default client (reads connection info from environment)
-// process.env.REDIS_URL is used by default
+// Bun uses process.env.REDIS_URL by default
 await redis.set("hello", "world");
 const result = await redis.get("hello");
 

--- a/docs/api/semver.md
+++ b/docs/api/semver.md
@@ -1,4 +1,4 @@
-Bun implements a semantic versioning API which can be used to compare versions and determine if a version is compatible with another range of versions. The versions and ranges are designed to be compatible with `node-semver`, which is used by npm clients.
+Bun implements a semantic versioning API which can be used to compare versions and determine if a version is compatible with another range of versions. The versions and ranges are designed to be compatible with `node-semver`, which npm clients use.
 
 It's about 20x faster than `node-semver`.
 

--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -1,4 +1,4 @@
-Bun provides native bindings for working with PostgreSQL databases with a modern, Promise-based API. The interface is designed to be simple and performant, using tagged template literals for queries and offering features like connection pooling, transactions, and prepared statements.
+Bun provides native bindings for working with PostgreSQL databases with a modern, Promise-based API. The interface is designed for performance, using tagged template literals for queries and offering features like connection pooling, transactions, and prepared statements.
 
 ```ts
 import { sql } from "bun";

--- a/docs/api/streams.md
+++ b/docs/api/streams.md
@@ -54,11 +54,11 @@ const stream = new ReadableStream({
 });
 ```
 
-When using a direct `ReadableStream`, all chunk queueing is handled by the destination. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
+When using a direct `ReadableStream`, the destination handles all chunk queueing. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
 
 ## Async generator streams
 
-Bun also supports async generator functions as a source for `Response` and `Request`. This is an easy way to create a `ReadableStream` that fetches data from an asynchronous source.
+Bun also supports async generator functions as a source for `Response` and `Request`. This approach allows you to create a `ReadableStream` that fetches data from an asynchronous source.
 
 ```ts
 const response = new Response(

--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -52,7 +52,7 @@ The specifier passed to `Worker` is resolved relative to the project root (like 
 
 ### `preload` - load modules before the worker starts
 
-You can pass an array of module specifiers to the `preload` option to load modules before the worker starts. This is useful when you want to ensure some code is always loaded before the application starts, like loading OpenTelemetry, Sentry, DataDog, etc.
+You can pass an array of module specifiers to the `preload` option to load modules before the worker starts. This approach helps ensure some code is always loaded before the application starts. Examples include loading OpenTelemetry, Sentry, or DataDog.
 
 ```js
 const worker = new Worker("./worker.ts", {

--- a/docs/bundler/vs-esbuild.md
+++ b/docs/bundler/vs-esbuild.md
@@ -874,7 +874,7 @@ In Bun's CLI, simple boolean flags like `--minify` do not accept an argument. Ot
 Bun's plugin API is designed to be esbuild compatible. Bun doesn't support esbuild's entire plugin API surface, but the core functionality is implemented. Many third-party `esbuild` plugins will work out of the box with Bun.
 
 {% callout %}
-Long term, we aim for feature parity with esbuild's API, so if something doesn't work please file an issue to help us prioritize.
+Long term, Bun aims for feature parity with esbuild's API, so if something doesn't work please file an issue to help us prioritize.
 
 {% /callout %}
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -193,7 +193,7 @@ In memory-constrained environments, use the `--smol` flag to reduce memory usage
 $ bun --smol run index.tsx
 ```
 
-This causes the garbage collector to run more frequently, which can slow down execution. However, it can be useful in environments with limited memory. Bun automatically adjusts the garbage collector's heap size based on the available memory (accounting for cgroups and other memory limits) with and without the `--smol` flag, so this is mostly useful for cases where you want to make the heap size grow more slowly.
+The `--smol` flag causes the garbage collector to run more frequently, which can slow down execution. However, it can be useful in environments with limited memory. Bun automatically adjusts the garbage collector's heap size based on the available memory (accounting for cgroups and other memory limits) with and without the `--smol` flag, so this is mostly useful for cases where you want to make the heap size grow more slowly.
 
 ## Resolution order
 

--- a/docs/contributing/upgrading-webkit.md
+++ b/docs/contributing/upgrading-webkit.md
@@ -54,4 +54,4 @@ Now update Bun's bindings wherever there are compiler errors:
 make bindings -j10
 ```
 
-This is the hard part. It might involve digging through WebKit's commit history to figure out what changed and why. Fortunately, WebKit contributors write great commit messages.
+Updating the bindings is the challenging part. It might involve digging through WebKit's commit history to figure out what changed and why. Fortunately, WebKit contributors write great commit messages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,9 @@ JavaScript was [initially designed](https://en.wikipedia.org/wiki/JavaScript) as
 
 ### Node.js
 
-Similarly, Node.js is a JavaScript runtime that can be used in non-browser environments, like servers. JavaScript programs executed by Node.js have access to a set of Node.js-specific [globals](https://nodejs.org/api/globals.html) like `Buffer`, `process`, and `__dirname` in addition to built-in modules for performing OS-level tasks like reading/writing files (`node:fs`) and networking (`node:net`, `node:http`). Node.js also implements a CommonJS-based module system and resolution algorithm that pre-dates JavaScript's native module system.
+Similarly, Node.js is a JavaScript runtime that can be used in non-browser environments, like servers. JavaScript programs executed by Node.js have access to a set of Node.js-specific [globals](https://nodejs.org/api/globals.html) like `Buffer`, `process`, and `__dirname`.
+
+Node.js also provides built-in modules for performing OS-level tasks like reading/writing files (`node:fs`) and networking (`node:net`, `node:http`). Node.js implements a CommonJS-based module system and resolution algorithm that pre-dates JavaScript's native module system.
 
 <!-- Bun.js prefers Web API compatibility instead of designing new APIs when possible. Bun.js also implements some Node.js APIs. -->
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ $ curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_LATEST_VERSION"
 ```
 
 ```bash#npm
-$ npm install -g bun # the last `npm` command you'll ever need
+$ npm install -g bun # the last `npm` command you will ever need
 ```
 
 ```bash#Homebrew
@@ -43,7 +43,7 @@ To install, paste this into a terminal:
 ```
 
 ```powershell#npm
-> npm install -g bun # the last `npm` command you'll ever need
+> npm install -g bun # the last `npm` command you will ever need
 ```
 
 ```powershell#Scoop
@@ -85,7 +85,7 @@ $ bun --version
 1.x.y
 ```
 
-To see the precise commit of [oven-sh/bun](https://github.com/oven-sh/bun) that you're using, run `bun --revision`.
+To see the precise commit of [oven-sh/bun](https://github.com/oven-sh/bun) that you are using, run `bun --revision`.
 
 ```sh
 $ bun --revision
@@ -97,7 +97,7 @@ If you've installed Bun but are seeing a `command not found` error, you may have
 ### How to add your `PATH`
 
 {% details summary="Linux / Mac" %}
-First, determine what shell you're using:
+First, determine what shell you are using:
 
 ```sh
 $ echo $SHELL
@@ -221,7 +221,7 @@ For convenience, here are download links for the latest version:
 - [`bun-linux-aarch64-musl.zip`](https://github.com/oven-sh/bun/releases/latest/download/bun-linux-aarch64-musl.zip)
 - [`bun-darwin-x64.zip`](https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip)
 
-The `musl` binaries are built for distributions that do not ship with the glibc libraries by default, instead relying on musl. The two most popular distros are Void Linux and Alpine Linux, with the latter is used heavily in Docker containers. If you encounter an error like the following: `bun: /lib/x86_64-linux-gnu/libm.so.6: version GLIBC_2.29' not found (required by bun)`, try using the musl binary. Bun's install script automatically chooses the correct binary for your system.
+The `musl` binaries are built for distributions that do not ship with the glibc libraries by default, instead relying on musl. The two most popular distros are Void Linux and Alpine Linux, with Docker containers heavily using Alpine Linux. If you encounter an error like the following: `bun: /lib/x86_64-linux-gnu/libm.so.6: version GLIBC_2.29' not found (required by bun)`, try using the musl binary. Bun's install script automatically chooses the correct binary for your system.
 
 ### CPU requirements and `baseline` builds
 
@@ -285,7 +285,7 @@ this is some output
 
 Shell auto-completion should be configured automatically when Bun is installed!
 
-If not, run the following command. It uses `$SHELL` to determine which shell you're using and writes a completion file to the appropriate place on disk. It's automatically re-run on every `bun upgrade`.
+If not, run the following command. It uses `$SHELL` to determine which shell you are using and writes a completion file to the appropriate place on disk. It's automatically re-run on every `bun upgrade`.
 
 ```bash
 $ bun completions

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ $ mkdir quickstart
 $ cd quickstart
 ```
 
-Run `bun init` to scaffold a new project. It's an interactive tool; for this tutorial, just press `enter` to accept the default answer for each prompt.
+Run `bun init` to scaffold a new project. It's an interactive tool; for this tutorial, press `enter` to accept the default answer for each prompt.
 
 ```bash
 $ bun init
@@ -29,7 +29,7 @@ Since our entry point is a `*.ts` file, Bun generates a `tsconfig.json` for you.
 
 ## Run a file
 
-Open `index.ts` and paste the following code snippet, which implements a simple HTTP server with [`Bun.serve`](https://bun.sh/docs/api/http).
+Open `index.ts` and paste the following code snippet, which implements an HTTP server with [`Bun.serve`](https://bun.sh/docs/api/http).
 
 ```ts
 const server = Bun.serve({

--- a/docs/runtime/bunfig.md
+++ b/docs/runtime/bunfig.md
@@ -516,7 +516,7 @@ shell = "bun"
 
 When `true`, this prepends `$PATH` with a `node` symlink that points to the `bun` binary for all scripts or executables invoked by `bun run` or `bun`.
 
-This means that if you have a script that runs `node`, it will actually run `bun` instead, without needing to change your script. This works recursively, so if your script runs another script that runs `node`, it will also run `bun` instead. This applies to shebangs as well, so if you have a script with a shebang that points to `node`, it will actually run `bun` instead.
+Enabling this setting means that if you have a script that runs `node`, it will actually run `bun` instead, without needing to change your script. This works recursively, so if your script runs another script that runs `node`, it will also run `bun` instead. This applies to shebangs as well, so if you have a script with a shebang that points to `node`, it will actually run `bun` instead.
 
 By default, this is enabled if `node` is not already in your `$PATH`.
 


### PR DESCRIPTION
Updates documentation to follow writing guidelines by:
- Converting passive voice to active voice
- Removing subjective words (easy, simple, just)
- Clarifying ambiguous "this" references
- Using second person voice consistently
- Breaking up overly complex sentences
- Expanding contractions for clarity

Improves readability and consistency across 14 documentation files.

🤖 Generated with [Claude Code](https://claude.ai/code)

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
