### PR TITLE
fix(cmake): reduce noise in debug build linker flags on Linux

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -993,24 +993,29 @@ if(LINUX)
     --ld-path=${LLD_PROGRAM}
     -fno-pic
     -Wl,-no-pie
-    -Wl,-icf=safe
     -Wl,--as-needed
     -Wl,--gc-sections
     -Wl,-z,stack-size=12800000
     -Wl,--compress-debug-sections=zlib
     -Wl,-z,lazy
     -Wl,-z,norelro
-    # enable string tail merging
-    -Wl,-O2
-    # make debug info faster to load
-    -Wl,--gdb-index
-    -Wl,-z,combreloc
     -Wl,--no-eh-frame-hdr
     -Wl,--sort-section=name
     -Wl,--hash-style=both
     -Wl,--build-id=sha1  # Better for debugging than default
+    # make debug info faster to load
+    -Wl,--gdb-index
     -Wl,-Map=${bun}.linker-map
   )
+
+  if(RELEASE)
+    target_link_options(${bun} PUBLIC
+      -Wl,-icf=safe
+      # enable string tail merging
+      -Wl,-O2
+      -Wl,-z,combreloc
+    )
+  endif()
 endif()
 
 # --- Symbols list ---


### PR DESCRIPTION


### What does this PR do?

Move Linux optimization-focused linker flags to release builds only:
- --icf=safe: identical code folding for size optimization
- -O2: enable string tail merging optimization
- -z,combreloc: combine relocations for faster loading

Keep debugging-related flags in all builds:
- --compress-debug-sections=zlib: compress debug sections for smaller files
- --gdb-index: faster debug symbol loading in GDB

This reduces verbose linker output and link times in debug builds while preserving essential debugging functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
