### PR TITLE
fix `Bun.build` with `{ sourcemap: true }`

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -184,7 +184,7 @@ pub const JSBundler = struct {
             }
 
             if (try config.getTruthy(globalThis, "sourcemap")) |source_map_js| {
-                if (config.isBoolean()) {
+                if (source_map_js.isBoolean()) {
                     if (source_map_js == .true) {
                         this.source_map = if (has_out_dir)
                             .linked

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -807,7 +807,7 @@ describe("sourcemap boolean values", () => {
     expect(build.success).toBe(true);
     expect(build.outputs).toHaveLength(1);
     expect(build.outputs[0].kind).toBe("entry-point");
-    
+
     const output = await build.outputs[0].text();
     expect(output).toContain("//# sourceMappingURL=data:application/json;base64,");
   });
@@ -825,7 +825,7 @@ describe("sourcemap boolean values", () => {
     expect(build.success).toBe(true);
     expect(build.outputs).toHaveLength(1);
     expect(build.outputs[0].kind).toBe("entry-point");
-    
+
     const output = await build.outputs[0].text();
     expect(output).not.toContain("//# sourceMappingURL=");
   });
@@ -843,14 +843,14 @@ describe("sourcemap boolean values", () => {
 
     expect(build.success).toBe(true);
     expect(build.outputs).toHaveLength(2);
-    
+
     const jsOutput = build.outputs.find(o => o.kind === "entry-point");
     const mapOutput = build.outputs.find(o => o.kind === "sourcemap");
-    
+
     expect(jsOutput).toBeTruthy();
     expect(mapOutput).toBeTruthy();
     expect(jsOutput!.sourcemap).toBe(mapOutput);
-    
+
     const jsText = await jsOutput!.text();
     expect(jsText).toContain("//# sourceMappingURL=index.js.map");
   });


### PR DESCRIPTION
### What does this PR do?

fix #21027

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

made test
