### PR TITLE
Add `bun un` alias for `bun remove`

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -591,6 +591,7 @@ pub const Command = struct {
             RootCommandMatcher.case("remove"),
             RootCommandMatcher.case("rm"),
             RootCommandMatcher.case("uninstall"),
+            RootCommandMatcher.case("un"),
             => .RemoveCommand,
 
             RootCommandMatcher.case("run") => .RunCommand,


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/20951

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

This aliases `bun remove lodash` to `bun un lodash`

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

Honestly, I didn't! I just based it on the previous change https://github.com/oven-sh/bun/commit/9024125d41751895496048e30e3fdc30019ef4ad

Totally understandable if that's not the bar anymore, just opening this in case it's considered ok.

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
