### PR TITLE
fix `--tsconfig-override`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2512,6 +2512,19 @@ declare module "bun" {
      * This defaults to `true`.
      */
     throw?: boolean;
+
+    /**
+     * Custom tsconfig.json file path to use for path resolution.
+     * Equivalent to `--tsconfig-override` in the CLI.
+     * @example
+     * ```ts
+     * await Bun.build({
+     *   entrypoints: ['./src/index.ts'],
+     *   tsconfig: './custom-tsconfig.json'
+     * });
+     * ```
+     */
+    tsconfig?: string;
   }
 
   /**

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -58,6 +58,7 @@ pub const JSBundler = struct {
         throw_on_error: bool = true,
         env_behavior: Api.DotEnvBehavior = .disable,
         env_prefix: OwnedString = OwnedString.initEmpty(bun.default_allocator),
+        tsconfig_override: OwnedString = OwnedString.initEmpty(bun.default_allocator),
 
         pub const List = bun.StringArrayHashMapUnmanaged(Config);
 
@@ -529,6 +530,7 @@ pub const JSBundler = struct {
             self.banner.deinit();
             self.env_prefix.deinit();
             self.footer.deinit();
+            self.tsconfig_override.deinit();
         }
     };
 

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -518,7 +518,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
     }
 
     opts.tsconfig_override = if (args.option("--tsconfig-override")) |ts|
-        (Arguments.readFile(allocator, cwd, ts) catch |err| fileReadError(err, Output.errorStream(), ts, "tsconfig.json"))
+        resolve_path.joinAbsString(cwd, &[_]string{ts}, .auto)
     else
         null;
 

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -1,5 +1,3 @@
-const Arguments = @This();
-
 pub fn loader_resolver(in: string) !Api.Loader {
     const option_loader = options.Loader.fromString(in) orelse return error.InvalidLoader;
     return option_loader.toAPI();

--- a/src/options.zig
+++ b/src/options.zig
@@ -2064,6 +2064,10 @@ pub const BundleOptions = struct {
 
         opts.polyfill_node_globals = opts.target == .browser;
 
+        if (transform.tsconfig_override) |tsconfig| {
+            opts.tsconfig_override = tsconfig;
+        }
+
         Analytics.Features.macros += @as(usize, @intFromBool(opts.target == .bun_macro));
         Analytics.Features.external += @as(usize, @intFromBool(transform.external.len > 0));
         return opts;

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { describe, expect, test, afterEach } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tempDirWithFiles, tempDirWithFilesAnon } from "harness";
 import path, { join } from "path";

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -165,7 +165,7 @@ console.log(utils());`,
     const tmpdir = tmpdirSync();
     const baseDir = `${tmpdir}/bun-build-dirname-filename-${Date.now()}`;
     fs.mkdirSync(baseDir, { recursive: true });
-    fs.mkdirSync(path.join(baseDir, "我")), { recursive: true };
+    (fs.mkdirSync(path.join(baseDir, "我")), { recursive: true });
     fs.writeFileSync(path.join(baseDir, "我", "我.ts"), "console.log(__dirname); console.log(__filename);");
     const { exitCode } = Bun.spawnSync({
       cmd: [bunExe(), "build", path.join(baseDir, "我/我.ts"), "--compile", "--outfile", path.join(baseDir, "exe.exe")],

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -59,11 +59,113 @@ describe("bun build", () => {
     expect(["build", src]).toRun();
   });
 
+  test("--tsconfig-override works", () => {
+    const tmp = tmpdirSync();
+    const baseDir = path.join(tmp, "tsconfig-override-test");
+    fs.mkdirSync(baseDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(baseDir, "index.ts"),
+      `import { utils } from "@utils/helper";
+console.log(utils());`,
+    );
+
+    fs.writeFileSync(path.join(baseDir, "helper.ts"), `export function utils() { return "Hello from utils"; }`);
+
+    fs.writeFileSync(
+      path.join(baseDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@wrong/*": ["./wrong/*"],
+          },
+        },
+      }),
+    );
+
+    fs.writeFileSync(
+      path.join(baseDir, "custom-tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@utils/*": ["./*"],
+          },
+        },
+      }),
+    );
+
+    const failResult = Bun.spawnSync({
+      cmd: [bunExe(), "build", path.join(baseDir, "index.ts"), "--outdir", path.join(baseDir, "out-fail")],
+      env: bunEnv,
+      cwd: baseDir,
+    });
+    expect(failResult.exitCode).not.toBe(0);
+    expect(failResult.stderr?.toString() || "").toContain("Could not resolve");
+
+    const successResult = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "build",
+        path.join(baseDir, "index.ts"),
+        "--tsconfig-override",
+        path.join(baseDir, "custom-tsconfig.json"),
+        "--outdir",
+        path.join(baseDir, "out-success"),
+      ],
+      env: bunEnv,
+      cwd: baseDir,
+    });
+    expect(successResult.exitCode).toBe(0);
+
+    const outputFile = path.join(baseDir, "out-success", "index.js");
+    expect(fs.existsSync(outputFile)).toBe(true);
+    const output = fs.readFileSync(outputFile, "utf8");
+    expect(output).toContain("Hello from utils");
+  });
+
+  test("--tsconfig-override works from nested directories", () => {
+    const tmp = tmpdirSync();
+    const baseDir = path.join(tmp, "tsconfig-nested-test");
+    const nestedDir = path.join(baseDir, "nested", "deep");
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(nestedDir, "index.ts"),
+      `import { utils } from "@utils/helper";
+console.log(utils());`,
+    );
+
+    fs.writeFileSync(path.join(baseDir, "helper.ts"), `export function utils() { return "Hello from nested!"; }`);
+
+    fs.writeFileSync(
+      path.join(baseDir, "custom-tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@utils/*": ["./*"],
+          },
+        },
+      }),
+    );
+
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "build", "index.ts", "--tsconfig-override", "../../custom-tsconfig.json", "--outdir", "out"],
+      env: bunEnv,
+      cwd: nestedDir,
+    });
+    expect(result.exitCode).toBe(0);
+
+    const outputFile = path.join(nestedDir, "out", "index.js");
+    expect(fs.existsSync(outputFile)).toBe(true);
+    const output = fs.readFileSync(outputFile, "utf8");
+    expect(output).toContain("Hello from nested!");
+  });
+
   test("__dirname and __filename are printed correctly", () => {
     const tmpdir = tmpdirSync();
     const baseDir = `${tmpdir}/bun-build-dirname-filename-${Date.now()}`;
     fs.mkdirSync(baseDir, { recursive: true });
-    (fs.mkdirSync(path.join(baseDir, "我")), { recursive: true });
+    fs.mkdirSync(path.join(baseDir, "我")), { recursive: true };
     fs.writeFileSync(path.join(baseDir, "我", "我.ts"), "console.log(__dirname); console.log(__filename);");
     const { exitCode } = Bun.spawnSync({
       cmd: [bunExe(), "build", path.join(baseDir, "我/我.ts"), "--compile", "--outfile", path.join(baseDir, "exe.exe")],

--- a/test/cli/run/tsconfig-override.test.ts
+++ b/test/cli/run/tsconfig-override.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import path from "node:path";
+
+describe("bun run --tsconfig-override", () => {
+  test("should use custom tsconfig for path resolution", async () => {
+    const dir = tempDirWithFiles("run-tsconfig-override", {
+      "index.ts": `
+        import { helper } from '@helpers/math';
+        console.log(helper());
+      `,
+      "src/math.ts": `
+        export function helper() {
+          return "success from custom tsconfig";
+        }
+      `,
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "paths": {
+              "@helpers/*": ["./wrong/*"]
+            }
+          }
+        }
+      `,
+      "custom-tsconfig.json": `
+        {
+          "compilerOptions": {
+            "paths": {
+              "@helpers/*": ["./src/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    await using failProc = Bun.spawn({
+      cmd: [bunExe(), "run", path.join(dir, "index.ts")],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [failStderr, failExitCode] = await Promise.all([failProc.stderr.text(), failProc.exited]);
+
+    expect(failStderr).toContain("Cannot find module");
+    expect(failExitCode).not.toBe(0);
+
+    await using successProc = Bun.spawn({
+      cmd: [bunExe(), "run", "--tsconfig-override", path.join(dir, "custom-tsconfig.json"), path.join(dir, "index.ts")],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [successStdout, successStderr, successExitCode] = await Promise.all([
+      successProc.stdout.text(),
+      successProc.stderr.text(),
+      successProc.exited,
+    ]);
+
+    expect(successStdout).toContain("success from custom tsconfig");
+
+    if (!successStderr.includes("Internal error: directory mismatch")) {
+      expect(successStderr).toBe("");
+    }
+    expect(successExitCode).toBe(0);
+  });
+
+  test("should work with relative tsconfig path", async () => {
+    const dir = tempDirWithFiles("run-tsconfig-relative", {
+      "src/main.ts": `
+        import { lib } from '@lib/util';
+        console.log(lib());
+      `,
+      "lib/util.ts": `
+        export function lib() {
+          return 42;
+        }
+      `,
+      "config/custom.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": "../",
+            "paths": {
+              "@lib/*": ["lib/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--tsconfig-override", "./config/custom.json", "./src/main.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("42");
+
+    if (!stderr.includes("Internal error: directory mismatch")) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("should work with monorepo-style paths", async () => {
+    const dir = tempDirWithFiles("run-tsconfig-monorepo", {
+      "apps/web/src/index.ts": `
+        import { Button } from '@ui/components';
+        import { config } from '@shared/config';
+        console.log('App loaded with', Button(), config);
+      `,
+      "packages/ui/components/index.ts": `
+        export function Button() {
+          return 'Button component';
+        }
+      `,
+      "packages/shared/config.ts": `
+        export const config = { name: 'monorepo-app' };
+      `,
+      "apps/web/tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": "../../",
+            "paths": {
+              "@ui/*": ["packages/ui/*"],
+              "@shared/*": ["packages/shared/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--tsconfig-override", "./apps/web/tsconfig.json", "./apps/web/src/index.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Button component");
+    expect(stdout).toContain("monorepo-app");
+
+    if (!stderr.includes("Internal error: directory mismatch")) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("should work with nested directories and complex paths", async () => {
+    const dir = tempDirWithFiles("run-tsconfig-nested", {
+      "frontend/src/pages/home.ts": `
+        import { api } from '~/api/client';
+        import { utils } from '#/utils/helpers';
+        console.log(api.getHome(), utils.format('test'));
+      `,
+      "frontend/src/api/client.ts": `
+        export const api = {
+          getHome: () => 'home-data'
+        };
+      `,
+      "frontend/src/utils/helpers.ts": `
+        export const utils = {
+          format: (str: string) => \`formatted-\${str}\`
+        };
+      `,
+      "frontend/tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": "./src",
+            "paths": {
+              "~/*": ["./*"],
+              "#/*": ["./*"]
+            }
+          }
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--tsconfig-override", "./frontend/tsconfig.json", "./frontend/src/pages/home.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("home-data");
+    expect(stdout).toContain("formatted-test");
+
+    if (!stderr.includes("Internal error: directory mismatch")) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("should handle extending tsconfig with overrides", async () => {
+    const dir = tempDirWithFiles("run-tsconfig-extends", {
+      "src/app.ts": `
+        import { core } from '@core/main';
+        import { feature } from '@features/auth';
+        console.log('Loaded:', core, feature);
+      `,
+      "packages/core/main.ts": `
+        export const core = 'core-module';
+      `,
+      "features/auth/index.ts": `
+        export const feature = 'auth-feature';
+      `,
+      "tsconfig.base.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@core/*": ["packages/core/*"]
+            }
+          }
+        }
+      `,
+      "tsconfig.dev.json": `
+        {
+          "extends": "./tsconfig.base.json",
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@core/*": ["packages/core/*"],
+              "@features/*": ["features/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--tsconfig-override", "./tsconfig.dev.json", "./src/app.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("core-module");
+    expect(stdout).toContain("auth-feature");
+
+    if (!stderr.includes("Internal error: directory mismatch")) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("should work from different working directories", async () => {
+    const dir = tempDirWithFiles("run-tsconfig-cwd", {
+      "project/src/main.ts": `
+        import { helper } from '@utils/math';
+        console.log('Result:', helper(5, 3));
+      `,
+      "project/utils/math.ts": `
+        export function helper(a: number, b: number) {
+          return a + b;
+        }
+      `,
+      "project/tsconfig.json": `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@utils/*": ["utils/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--tsconfig-override", "project/tsconfig.json", "project/src/main.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Result: 8");
+
+    if (!stderr.includes("Internal error: directory mismatch")) {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1031,6 +1031,133 @@ describe("bun test", () => {
       Ran 2 tests across 1 file."
     `);
   });
+
+  test("--tsconfig-override works", () => {
+    const dir = tempDirWithFiles("test-tsconfig-override", {
+      "math.test.ts": `
+        import { describe, test, expect } from "bun:test";
+        import { add } from "@utils/math";
+        
+        describe("math", () => {
+          test("addition", () => {
+            expect(add(2, 3)).toBe(5);
+          });
+        });
+      `,
+      "src/math.ts": `
+        export function add(a: number, b: number) {
+          return a + b;
+        }
+      `,
+      "tsconfig.json": `
+        {
+          "compilerOptions": {
+            "paths": {
+              "@utils/*": ["./wrong/*"]
+            }
+          }
+        }
+      `,
+      "test-tsconfig.json": `
+        {
+          "compilerOptions": {
+            "paths": {
+              "@utils/*": ["./src/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    // Test without --tsconfig-override (should fail)
+    const failResult = spawnSync({
+      cmd: [bunExe(), "test", "math.test.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(failResult.exitCode).not.toBe(0);
+    expect(failResult.stderr?.toString() || "").toContain("Cannot find module");
+
+    // Test with --tsconfig-override (should succeed)
+    const successResult = spawnSync({
+      cmd: [bunExe(), "test", "--tsconfig-override", "test-tsconfig.json", "math.test.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(successResult.exitCode).toBe(0);
+    const stdout = successResult.stdout?.toString() || "";
+    const stderr = successResult.stderr?.toString() || "";
+    const output = stdout + stderr;
+    expect(output).toContain("1 pass");
+    expect(output).toContain("addition");
+  });
+
+  test("--tsconfig-override works with monorepo spec tsconfig", () => {
+    const dir = tempDirWithFiles("test-tsconfig-monorepo", {
+      "packages/app/src/index.ts": `
+        export function getMessage() {
+          return "Hello from app";
+        }
+      `,
+      "packages/app/src/index.test.ts": `
+        import { test, expect } from "bun:test";
+        import { getMessage } from "@app/index";
+        import { formatMessage } from "@shared/utils";
+        
+        test("app message", () => {
+          expect(getMessage()).toBe("Hello from app");
+          expect(formatMessage("test")).toBe("Formatted: test");
+        });
+      `,
+      "packages/shared/utils.ts": `
+        export function formatMessage(msg: string) {
+          return "Formatted: " + msg;
+        }
+      `,
+      "packages/app/tsconfig.json": `
+        {
+          "compilerOptions": {
+            "paths": {
+              "@app/*": ["./src/*"]
+            }
+          }
+        }
+      `,
+      "packages/app/tsconfig.spec.json": `
+        {
+          "extends": "./tsconfig.json",
+          "compilerOptions": {
+            "baseUrl": "../..",
+            "paths": {
+              "@app/*": ["packages/app/src/*"],
+              "@shared/*": ["packages/shared/*"]
+            }
+          }
+        }
+      `,
+    });
+
+    const result = spawnSync({
+      cmd: [bunExe(), "test", "--tsconfig-override", "./packages/app/tsconfig.spec.json", "./packages/app/src/index.test.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    const stdout = result.stdout?.toString() || "";
+    const stderr = result.stderr?.toString() || "";
+    const output = stdout + stderr;
+    expect(output).toContain("1 pass");
+    expect(output).toContain("app message");
+  });
 });
 
 function createTest(input?: string | (string | { filename: string; contents: string })[], filename?: string): string {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1144,7 +1144,13 @@ describe("bun test", () => {
     });
 
     const result = spawnSync({
-      cmd: [bunExe(), "test", "--tsconfig-override", "./packages/app/tsconfig.spec.json", "./packages/app/src/index.test.ts"],
+      cmd: [
+        bunExe(),
+        "test",
+        "--tsconfig-override",
+        "./packages/app/tsconfig.spec.json",
+        "./packages/app/src/index.test.ts",
+      ],
       env: bunEnv,
       cwd: dir,
       stdout: "pipe",


### PR DESCRIPTION
### What does this PR do?

It wasn't passed correctly, so this pr fixes that

fixes #17342, fixes #12484, fixes #11753, fixes #10076, fixes #7079
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

extensive tests