### PR TITLE
implement `bun pm pkg`

### DIFF
--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -343,6 +343,7 @@ src/cli/pack_command.zig
 src/cli/package_manager_command.zig
 src/cli/patch_command.zig
 src/cli/patch_commit_command.zig
+src/cli/pm_pkg_command.zig
 src/cli/pm_trusted_command.zig
 src/cli/pm_version_command.zig
 src/cli/pm_view_command.zig

--- a/docs/cli/pm.md
+++ b/docs/cli/pm.md
@@ -193,3 +193,38 @@ v1.0.1
 ```
 
 Supports `patch`, `minor`, `major`, `premajor`, `preminor`, `prepatch`, `prerelease`, `from-git`, or specific versions like `1.2.3`. By default creates git commit and tag unless `--no-git-tag-version` was used to skip.
+
+## pkg
+
+Manage `package.json` data with get, set, delete, and fix operations.
+
+All commands support dot and bracket notation:
+
+```bash
+scripts.build              # dot notation
+contributors[0]            # array access
+workspaces.0               # dot with numeric index
+scripts[test:watch]        # bracket for special chars
+```
+
+Examples:
+
+```bash
+# set
+$ bun pm pkg get name                               # single property
+$ bun pm pkg get name version                       # multiple properties
+$ bun pm pkg get                                    # entire package.json
+$ bun pm pkg get scripts.build                      # nested property
+
+# set
+$ bun pm pkg set name="my-package"                  # simple property
+$ bun pm pkg set scripts.test="jest" version=2.0.0  # multiple properties
+$ bun pm pkg set {"private":"true"} --json          # JSON values with --json flag
+
+# delete
+$ bun pm pkg delete description                     # single property
+$ bun pm pkg delete scripts.test contributors[0]    # multiple/nested
+
+# fix
+$ bun pm pkg fix                                    # auto-fix common issues
+```

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -23,6 +23,7 @@ pub const PackCommand = @import("./pack_command.zig").PackCommand;
 const Npm = Install.Npm;
 const PmViewCommand = @import("./pm_view_command.zig");
 const PmVersionCommand = @import("./pm_version_command.zig").PmVersionCommand;
+const PmPkgCommand = @import("./pm_pkg_command.zig").PmPkgCommand;
 const File = bun.sys.File;
 
 const ByName = struct {
@@ -130,6 +131,11 @@ pub const PackageManagerCommand = struct {
             \\  <b><green>bun pm<r> <blue>view<r> <d>name[@version]<r>  view package metadata from the registry <d>(use `bun info` instead)<r>
             \\  <b><green>bun pm<r> <blue>version<r> <d>[increment]<r>  bump the version in package.json and create a git tag
             \\  <d>└<r> <cyan>increment<r>                 patch, minor, major, prepatch, preminor, premajor, prerelease, from-git, or a specific version
+            \\  <b><green>bun pm<r> <blue>pkg<r>                  manage data in package.json
+            \\  <d>├<r> <cyan>get<r> <d>[key ...]<r> 
+            \\  <d>├<r> <cyan>set<r> <d>key=value ...<r>
+            \\  <d>├<r> <cyan>delete<r> <d>key ...<r>
+            \\  <d>└<r> <cyan>fix<r>                       auto-correct common package.json errors
             \\  <b><green>bun pm<r> <blue>hash<r>                 generate & print the hash of the current lockfile
             \\  <b><green>bun pm<r> <blue>hash-string<r>          print the string used to hash the lockfile
             \\  <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile
@@ -433,6 +439,9 @@ pub const PackageManagerCommand = struct {
             Global.exit(0);
         } else if (strings.eqlComptime(subcommand, "version")) {
             try PmVersionCommand.exec(ctx, pm, pm.options.positionals, cwd);
+            Global.exit(0);
+        } else if (strings.eqlComptime(subcommand, "pkg")) {
+            try PmPkgCommand.exec(ctx, pm, pm.options.positionals, cwd);
             Global.exit(0);
         }
 

--- a/src/cli/pm_pkg_command.zig
+++ b/src/cli/pm_pkg_command.zig
@@ -48,7 +48,6 @@ pub const PmPkgCommand = struct {
     fn printHelp() void {
         Output.prettyln("<r><b>bun pm pkg<r> <d>v" ++ Global.package_json_version_with_sha ++ "<r>", .{});
         const help_text =
-            \\
             \\  Manage data in package.json
             \\
             \\<b>Subcommands<r>:
@@ -68,7 +67,7 @@ pub const PmPkgCommand = struct {
             \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>delete<r> <blue>scripts.test devDependencies.webpack<r>
             \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>fix<r>
             \\
-            \\<b>More info<r>: <magenta>https:
+            \\<b>More info<r>: <magenta>https://bun.com/docs/cli/pm#pkg<r>
             \\
         ;
         Output.pretty(help_text, .{});

--- a/src/cli/pm_pkg_command.zig
+++ b/src/cli/pm_pkg_command.zig
@@ -152,7 +152,7 @@ pub const PmPkgCommand = struct {
             return;
         }
 
-        var results = std.StringArrayHashMap([]const u8).init(ctx.allocator);
+        var results = bun.StringArrayHashMap([]const u8).init(ctx.allocator);
         defer {
             for (results.values()) |val| ctx.allocator.free(val);
             results.deinit();

--- a/src/cli/pm_pkg_command.zig
+++ b/src/cli/pm_pkg_command.zig
@@ -1,0 +1,785 @@
+const std = @import("std");
+const bun = @import("bun");
+const string = bun.string;
+const strings = bun.strings;
+const Global = bun.Global;
+const Output = bun.Output;
+const Command = bun.CLI.Command;
+const PackageManager = bun.install.PackageManager;
+const logger = bun.logger;
+const js_ast = bun.js_ast;
+const JSPrinter = bun.js_printer;
+const JSON = bun.JSON;
+
+pub const PmPkgCommand = struct {
+    const SubCommand = enum {
+        get,
+        set,
+        delete,
+        fix,
+        help,
+
+        fn fromString(str: []const u8) ?SubCommand {
+            return std.meta.stringToEnum(SubCommand, str);
+        }
+    };
+
+    pub fn exec(ctx: Command.Context, pm: *PackageManager, positionals: []const string, cwd: []const u8) !void {
+        if (positionals.len <= 1) {
+            printHelp();
+            return;
+        }
+
+        const subcommand = SubCommand.fromString(positionals[1]) orelse {
+            Output.errGeneric("Unknown subcommand: {s}", .{positionals[1]});
+            printHelp();
+            Global.exit(1);
+        };
+
+        switch (subcommand) {
+            .get => try execGet(ctx, pm, positionals[2..], cwd),
+            .set => try execSet(ctx, pm, positionals[2..], cwd),
+            .delete => try execDelete(ctx, pm, positionals[2..], cwd),
+            .fix => try execFix(ctx, pm, cwd),
+            .help => printHelp(),
+        }
+    }
+
+    fn printHelp() void {
+        Output.prettyln("<r><b>bun pm pkg<r> <d>v" ++ Global.package_json_version_with_sha ++ "<r>", .{});
+        const help_text =
+            \\
+            \\  Manage data in package.json
+            \\
+            \\<b>Subcommands<r>:
+            \\  <cyan>get<r> <blue>[key ...]<r>          Get values from package.json
+            \\  <cyan>set<r> <blue>key=value ...<r>      Set values in package.json
+            \\    <d>└<r> <cyan>--json<r>             Parse values as JSON (e.g. {{"a":1}})
+            \\  <cyan>delete<r> <blue>key ...<r>         Delete keys from package.json
+            \\  <cyan>fix<r>                    Auto-correct common package.json errors
+            \\
+            \\<b>Examples<r>:
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>get<r> <blue>name version<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>description="My awesome package"<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>keywords='["test","demo","example"]'<r> <cyan>--json<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>config='{{"port":3000,"debug":true}}'<r> <cyan>--json<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>scripts.test="bun test"<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>bin.mycli=cli.js<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>delete<r> <blue>scripts.test devDependencies.webpack<r>
+            \\  <d>$<r> <b><green>bun pm pkg<r> <cyan>fix<r>
+            \\
+            \\<b>More info<r>: <magenta>https:
+            \\
+        ;
+        Output.pretty(help_text, .{});
+        Output.flush();
+    }
+
+    fn findPackageJson(allocator: std.mem.Allocator, cwd: []const u8) ![]const u8 {
+        var path_buf: bun.PathBuffer = undefined;
+        var current_dir = cwd;
+
+        while (true) {
+            const pkg_path = bun.path.joinAbsStringBufZ(current_dir, &path_buf, &.{"package.json"}, .auto);
+            if (bun.sys.existsZ(pkg_path)) {
+                return try allocator.dupe(u8, pkg_path);
+            }
+
+            const parent = bun.path.dirname(current_dir, .auto);
+            if (strings.eql(parent, current_dir)) {
+                break;
+            }
+            current_dir = parent;
+        }
+
+        Output.errGeneric("No package.json found", .{});
+        Global.exit(1);
+    }
+
+    const PackageJson = struct {
+        root: js_ast.Expr,
+        contents: []const u8,
+        source: logger.Source,
+        indentation: JSPrinter.Options.Indentation,
+    };
+
+    fn loadPackageJson(ctx: Command.Context, allocator: std.mem.Allocator, path: []const u8) !PackageJson {
+        const contents = bun.sys.File.readFrom(bun.FD.cwd(), path, allocator).unwrap() catch |err| {
+            Output.errGeneric("Failed to read package.json: {s}", .{@errorName(err)});
+            Global.exit(1);
+        };
+
+        const source = logger.Source.initPathString(path, contents);
+        const result = JSON.parsePackageJSONUTF8WithOpts(
+            &source,
+            ctx.log,
+            allocator,
+            .{
+                .is_json = true,
+                .allow_comments = true,
+                .allow_trailing_commas = true,
+                .guess_indentation = true,
+            },
+        ) catch |err| {
+            Output.errGeneric("Failed to parse package.json: {s}", .{@errorName(err)});
+            Global.exit(1);
+        };
+
+        return PackageJson{
+            .root = result.root,
+            .contents = contents,
+            .source = source,
+            .indentation = result.indentation,
+        };
+    }
+
+    fn execGet(ctx: Command.Context, pm: *PackageManager, args: []const string, cwd: []const u8) !void {
+        _ = pm;
+        const path = try findPackageJson(ctx.allocator, cwd);
+        defer ctx.allocator.free(path);
+
+        const pkg = try loadPackageJson(ctx, ctx.allocator, path);
+        defer ctx.allocator.free(pkg.contents);
+
+        if (pkg.root.data != .e_object) {
+            Output.errGeneric("package.json root must be an object", .{});
+            Global.exit(1);
+        }
+
+        if (args.len == 0) {
+            const formatted = try formatJson(ctx.allocator, pkg.root, null);
+            defer ctx.allocator.free(formatted);
+            Output.println("{s}", .{formatted});
+            return;
+        }
+
+        var results = std.StringArrayHashMap([]const u8).init(ctx.allocator);
+        defer {
+            for (results.values()) |val| ctx.allocator.free(val);
+            results.deinit();
+        }
+
+        for (args) |key| {
+            if (getJsonValue(ctx.allocator, pkg.root, key, if (args.len > 1) 4 else 2)) |value| {
+                if (args.len > 1) {
+                    if (strings.lastIndexOfChar(value, '}')) |last_index| {
+                        const new_value = try std.fmt.allocPrint(ctx.allocator, "{s}  {s}", .{ value[0..last_index], value[last_index..] });
+                        try results.put(key, new_value);
+                        continue;
+                    }
+                }
+                try results.put(key, value);
+            } else |err| {
+                if (err == error.InvalidPath) {
+                    if (strings.indexOf(key, "[]")) |_| {
+                        Output.errGeneric("Empty brackets are not valid syntax for retrieving values.", .{});
+                        Global.exit(1);
+                    }
+                }
+                if (err != error.NotFound) return err;
+            }
+        }
+
+        if (results.count() == 0) {
+            Output.println("{{}}", .{});
+        } else if (results.count() == 1) {
+            const value = results.values()[0];
+            Output.println("{s}", .{value});
+        } else {
+            Output.println("{{", .{});
+            for (results.keys(), results.values(), 0..) |key, value, i| {
+                const comma = if (i == results.count() - 1) "" else ",";
+                Output.println("  \"{s}\": {s}{s}", .{ key, value, comma });
+            }
+            Output.println("}}", .{});
+        }
+    }
+
+    fn execSet(ctx: Command.Context, pm: *PackageManager, args: []const string, cwd: []const u8) !void {
+        if (args.len == 0) {
+            Output.errGeneric("<blue>bun pm pkg set<r> expects a key=value pair of args", .{});
+            Global.exit(1);
+        }
+
+        const parse_json = pm.options.json_output;
+
+        const path = try findPackageJson(ctx.allocator, cwd);
+        defer ctx.allocator.free(path);
+
+        const pkg = try loadPackageJson(ctx, ctx.allocator, path);
+        defer ctx.allocator.free(pkg.contents);
+
+        var root = pkg.root;
+        if (root.data != .e_object) {
+            Output.errGeneric("package.json root must be an object", .{});
+            Global.exit(1);
+        }
+
+        var modified = false;
+        for (args) |arg| {
+            const eq_pos = strings.indexOf(arg, "=") orelse {
+                Output.errGeneric("Invalid argument: {s} (expected key=value)", .{arg});
+                Global.exit(1);
+            };
+
+            const key = arg[0..eq_pos];
+            const value = arg[eq_pos + 1 ..];
+
+            if (key.len == 0) {
+                Output.errGeneric("Empty key in argument: {s}", .{arg});
+                Global.exit(1);
+            }
+
+            if (value.len == 0) {
+                Output.errGeneric("Empty value in argument: {s}", .{arg});
+                Global.exit(1);
+            }
+
+            try setValue(ctx.allocator, &root, key, value, parse_json);
+            modified = true;
+        }
+
+        if (modified) {
+            try savePackageJson(ctx.allocator, path, root, &pkg);
+        }
+    }
+
+    fn execDelete(ctx: Command.Context, pm: *PackageManager, args: []const string, cwd: []const u8) !void {
+        _ = pm;
+        if (args.len == 0) {
+            Output.errGeneric("<blue>bun pm pkg <b>delete<r> expects key args", .{});
+            Global.exit(1);
+        }
+
+        const path = try findPackageJson(ctx.allocator, cwd);
+        defer ctx.allocator.free(path);
+
+        const pkg = try loadPackageJson(ctx, ctx.allocator, path);
+        defer ctx.allocator.free(pkg.contents);
+
+        var root = pkg.root;
+        if (root.data != .e_object) {
+            Output.errGeneric("package.json root must be an object", .{});
+            Global.exit(1);
+        }
+
+        var modified = false;
+        for (args) |key| {
+            if (deleteValue(ctx.allocator, &root, key)) |deleted| {
+                if (deleted) modified = true;
+            } else |err| {
+                if (err != error.NotFound) return err;
+            }
+        }
+
+        if (modified) {
+            try savePackageJson(ctx.allocator, path, root, &pkg);
+        }
+    }
+
+    fn execFix(ctx: Command.Context, pm: *PackageManager, cwd: []const u8) !void {
+        _ = pm;
+        const path = try findPackageJson(ctx.allocator, cwd);
+        defer ctx.allocator.free(path);
+
+        const pkg = try loadPackageJson(ctx, ctx.allocator, path);
+        defer ctx.allocator.free(pkg.contents);
+
+        var root = pkg.root;
+        if (root.data != .e_object) {
+            Output.errGeneric("package.json root must be an object", .{});
+            Global.exit(1);
+        }
+
+        var modified = false;
+
+        if (root.get("name")) |name_prop| {
+            switch (name_prop.data) {
+                .e_string => |str| {
+                    const name_str = str.slice(ctx.allocator);
+                    const lowercase = try std.ascii.allocLowerString(ctx.allocator, name_str);
+                    defer ctx.allocator.free(lowercase);
+
+                    if (!strings.eql(name_str, lowercase)) {
+                        try setValue(ctx.allocator, &root, "name", lowercase, false);
+                        modified = true;
+                    }
+                },
+                else => {},
+            }
+        }
+
+        if (root.get("bin")) |bin_prop| {
+            if (bin_prop.data == .e_object) {
+                const props = bin_prop.data.e_object.properties.slice();
+                for (props) |prop| {
+                    const value = prop.value orelse continue;
+
+                    switch (value.data) {
+                        .e_string => |str| {
+                            const bin_path = str.slice(ctx.allocator);
+                            var pkg_dir = bun.path.dirname(path, .auto);
+                            if (pkg_dir.len == 0) pkg_dir = cwd;
+                            var buf: bun.PathBuffer = undefined;
+                            const full_path = bun.path.joinAbsStringBufZ(pkg_dir, &buf, &.{bin_path}, .auto);
+
+                            if (!bun.sys.existsZ(full_path)) {
+                                Output.warn("No bin file found at {s}", .{bin_path});
+                            }
+                        },
+                        else => {},
+                    }
+                }
+            }
+        }
+
+        if (modified) {
+            try savePackageJson(ctx.allocator, path, root, &pkg);
+        }
+    }
+
+    fn formatJson(allocator: std.mem.Allocator, expr: js_ast.Expr, initial_indent: ?usize) ![]const u8 {
+        switch (expr.data) {
+            .e_boolean => |b| {
+                return try allocator.dupe(u8, if (b.value) "true" else "false");
+            },
+            .e_number => |n| {
+                if (@floor(n.value) == n.value) {
+                    return try std.fmt.allocPrint(allocator, "{d:.0}", .{n.value});
+                } else {
+                    return try std.fmt.allocPrint(allocator, "{d}", .{n.value});
+                }
+            },
+            .e_null => {
+                return try allocator.dupe(u8, "null");
+            },
+            else => {
+                const buffer_writer = JSPrinter.BufferWriter.init(allocator);
+                var printer = JSPrinter.BufferPrinter.init(buffer_writer);
+
+                _ = JSPrinter.printJSON(
+                    @TypeOf(&printer),
+                    &printer,
+                    expr,
+                    &logger.Source.initEmptyFile("expression.json"),
+                    .{
+                        .mangled_props = null,
+                        .indent = if (initial_indent) |indent| .{
+                            .scalar = indent,
+                            .count = 0,
+                        } else .{
+                            .scalar = 2,
+                            .count = 0,
+                        },
+                    },
+                ) catch |err| {
+                    return err;
+                };
+
+                const written = printer.ctx.getWritten();
+                return try allocator.dupe(u8, written);
+            },
+        }
+    }
+
+    fn getJsonValue(allocator: std.mem.Allocator, root: js_ast.Expr, key: []const u8, initial_indent: ?usize) ![]const u8 {
+        const expr = try resolvePath(root, key);
+        return try formatJson(allocator, expr, initial_indent);
+    }
+
+    fn resolvePath(root: js_ast.Expr, key: []const u8) !js_ast.Expr {
+        if (root.data != .e_object) {
+            return error.NotFound;
+        }
+
+        var parts = std.mem.tokenizeScalar(u8, key, '.');
+        var current = root;
+
+        while (parts.next()) |part| {
+            if (strings.indexOf(part, "[")) |first_bracket| {
+                var remaining_part = part;
+
+                if (first_bracket > 0) {
+                    const prop_name = part[0..first_bracket];
+                    if (current.data != .e_object) {
+                        return error.NotFound;
+                    }
+                    current = current.get(prop_name) orelse return error.NotFound;
+                    remaining_part = part[first_bracket..];
+                }
+
+                while (strings.indexOf(remaining_part, "[")) |bracket_start| {
+                    const bracket_end = strings.indexOf(remaining_part[bracket_start..], "]") orelse return error.InvalidPath;
+                    const actual_bracket_end = bracket_start + bracket_end;
+                    const index_str = remaining_part[bracket_start + 1 .. actual_bracket_end];
+
+                    if (index_str.len == 0) {
+                        return error.InvalidPath;
+                    }
+
+                    if (std.fmt.parseInt(usize, index_str, 10)) |index| {
+                        if (current.data != .e_array) {
+                            return error.NotFound;
+                        }
+
+                        if (index >= current.data.e_array.items.len) {
+                            return error.NotFound;
+                        }
+
+                        current = current.data.e_array.items.ptr[index];
+                    } else |_| {
+                        if (current.data != .e_object) {
+                            return error.NotFound;
+                        }
+                        current = current.get(index_str) orelse return error.NotFound;
+                    }
+
+                    remaining_part = remaining_part[actual_bracket_end + 1 ..];
+                    if (remaining_part.len == 0) break;
+                }
+            } else {
+                if (std.fmt.parseInt(usize, part, 10)) |index| {
+                    if (current.data == .e_array) {
+                        if (index >= current.data.e_array.items.len) {
+                            return error.NotFound;
+                        }
+                        current = current.data.e_array.items.ptr[index];
+                    } else if (current.data == .e_object) {
+                        current = current.get(part) orelse return error.NotFound;
+                    } else {
+                        return error.NotFound;
+                    }
+                } else |_| {
+                    if (current.data != .e_object) {
+                        return error.NotFound;
+                    }
+                    current = current.get(part) orelse return error.NotFound;
+                }
+            }
+        }
+
+        return current;
+    }
+
+    fn parseKeyPath(allocator: std.mem.Allocator, key: []const u8) !std.ArrayList([]const u8) {
+        var path_parts = std.ArrayList([]const u8).init(allocator);
+        errdefer {
+            for (path_parts.items) |item| allocator.free(item);
+            path_parts.deinit();
+        }
+
+        var parts = std.mem.tokenizeScalar(u8, key, '.');
+
+        while (parts.next()) |part| {
+            if (strings.indexOf(part, "[")) |first_bracket| {
+                var remaining_part = part;
+
+                if (first_bracket > 0) {
+                    const prop_name = part[0..first_bracket];
+                    const prop_copy = try allocator.dupe(u8, prop_name);
+                    try path_parts.append(prop_copy);
+                    remaining_part = part[first_bracket..];
+                }
+
+                while (strings.indexOf(remaining_part, "[")) |bracket_start| {
+                    const bracket_end = strings.indexOf(remaining_part[bracket_start..], "]") orelse {
+                        return error.InvalidPath;
+                    };
+                    const actual_bracket_end = bracket_start + bracket_end;
+                    const index_str = remaining_part[bracket_start + 1 .. actual_bracket_end];
+
+                    if (index_str.len == 0) {
+                        return error.InvalidPath;
+                    }
+
+                    const index_copy = try allocator.dupe(u8, index_str);
+                    try path_parts.append(index_copy);
+
+                    remaining_part = remaining_part[actual_bracket_end + 1 ..];
+                    if (remaining_part.len == 0) break;
+                }
+            } else {
+                const part_copy = try allocator.dupe(u8, part);
+                try path_parts.append(part_copy);
+            }
+        }
+
+        return path_parts;
+    }
+
+    fn setValue(allocator: std.mem.Allocator, root: *js_ast.Expr, key: []const u8, value: []const u8, parse_json: bool) !void {
+        if (root.data != .e_object) {
+            return error.InvalidRoot;
+        }
+
+        if (strings.indexOf(key, "[") == null) {
+            var parts = std.mem.tokenizeScalar(u8, key, '.');
+            var path_parts = std.ArrayList([]const u8).init(allocator);
+            defer path_parts.deinit();
+
+            while (parts.next()) |part| {
+                try path_parts.append(part);
+            }
+
+            if (path_parts.items.len == 0) {
+                return error.EmptyKey;
+            }
+
+            if (path_parts.items.len == 1) {
+                const expr = try parseValue(allocator, value, parse_json);
+                try root.data.e_object.put(allocator, path_parts.items[0], expr);
+                return;
+            }
+
+            try setNestedSimple(allocator, root, path_parts.items, value, parse_json);
+            return;
+        }
+
+        var path_parts = parseKeyPath(allocator, key) catch |err| {
+            return err;
+        };
+        defer {
+            for (path_parts.items) |part| {
+                if (part.len > 0) allocator.free(part);
+            }
+            path_parts.deinit();
+        }
+
+        if (path_parts.items.len == 0) {
+            return error.EmptyKey;
+        }
+
+        if (path_parts.items.len == 1) {
+            const expr = try parseValue(allocator, value, parse_json);
+
+            try root.data.e_object.put(allocator, path_parts.items[0], expr);
+
+            path_parts.items[0] = "";
+            return;
+        }
+
+        try setNested(allocator, root, path_parts.items, value, parse_json);
+    }
+
+    fn setNestedSimple(allocator: std.mem.Allocator, root: *js_ast.Expr, path: []const []const u8, value: []const u8, parse_json: bool) !void {
+        if (path.len == 0) return;
+
+        const current_key = path[0];
+        const remaining_path = path[1..];
+
+        if (remaining_path.len == 0) {
+            const expr = try parseValue(allocator, value, parse_json);
+            try root.data.e_object.put(allocator, current_key, expr);
+            return;
+        }
+
+        var nested_obj = root.get(current_key);
+        if (nested_obj == null or nested_obj.?.data != .e_object) {
+            const new_obj = js_ast.Expr.init(js_ast.E.Object, js_ast.E.Object{}, logger.Loc.Empty);
+            try root.data.e_object.put(allocator, current_key, new_obj);
+            nested_obj = root.get(current_key);
+        }
+
+        if (nested_obj.?.data != .e_object) {
+            return error.ExpectedObject;
+        }
+
+        var nested = nested_obj.?;
+        try setNestedSimple(allocator, &nested, remaining_path, value, parse_json);
+        try root.data.e_object.put(allocator, current_key, nested);
+    }
+
+    fn setNested(allocator: std.mem.Allocator, root: *js_ast.Expr, path: [][]const u8, value: []const u8, parse_json: bool) !void {
+        if (path.len == 0) return;
+
+        const current_key = path[0];
+        const remaining_path = path[1..];
+
+        if (remaining_path.len == 0) {
+            const expr = try parseValue(allocator, value, parse_json);
+
+            try root.data.e_object.put(allocator, current_key, expr);
+
+            path[0] = "";
+            return;
+        }
+
+        var nested_obj = root.get(current_key);
+        if (nested_obj == null or nested_obj.?.data != .e_object) {
+            const new_obj = js_ast.Expr.init(js_ast.E.Object, js_ast.E.Object{}, logger.Loc.Empty);
+
+            try root.data.e_object.put(allocator, current_key, new_obj);
+
+            path[0] = "";
+            nested_obj = root.get(current_key);
+        }
+
+        if (nested_obj.?.data != .e_object) {
+            return error.ExpectedObject;
+        }
+
+        var nested = nested_obj.?;
+        try setNested(allocator, &nested, remaining_path, value, parse_json);
+    }
+
+    fn parseValue(allocator: std.mem.Allocator, value: []const u8, parse_json: bool) !js_ast.Expr {
+        if (parse_json) {
+            if (strings.eqlComptime(value, "true")) {
+                return js_ast.Expr.init(js_ast.E.Boolean, js_ast.E.Boolean{ .value = true }, logger.Loc.Empty);
+            } else if (strings.eqlComptime(value, "false")) {
+                return js_ast.Expr.init(js_ast.E.Boolean, js_ast.E.Boolean{ .value = false }, logger.Loc.Empty);
+            } else if (strings.eqlComptime(value, "null")) {
+                return js_ast.Expr.init(js_ast.E.Null, js_ast.E.Null{}, logger.Loc.Empty);
+            }
+
+            if (std.fmt.parseInt(i64, value, 10)) |int_val| {
+                return js_ast.Expr.init(js_ast.E.Number, js_ast.E.Number{ .value = @floatFromInt(int_val) }, logger.Loc.Empty);
+            } else |_| {}
+
+            if (std.fmt.parseFloat(f64, value)) |float_val| {
+                return js_ast.Expr.init(js_ast.E.Number, js_ast.E.Number{ .value = float_val }, logger.Loc.Empty);
+            } else |_| {}
+
+            const temp_source = logger.Source.initPathString("package.json", value);
+            var temp_log = logger.Log.init(allocator);
+            if (JSON.parsePackageJSONUTF8(&temp_source, &temp_log, allocator)) |json_expr| {
+                return json_expr;
+            } else |_| {
+                const data = try allocator.dupe(u8, value);
+                return js_ast.Expr.init(js_ast.E.String, js_ast.E.String.init(data), logger.Loc.Empty);
+            }
+        } else {
+            const data = try allocator.dupe(u8, value);
+            return js_ast.Expr.init(js_ast.E.String, js_ast.E.String.init(data), logger.Loc.Empty);
+        }
+    }
+
+    fn deleteValue(allocator: std.mem.Allocator, root: *js_ast.Expr, key: []const u8) !bool {
+        if (root.data != .e_object) return false;
+
+        var parts = std.mem.tokenizeScalar(u8, key, '.');
+        var path_parts = std.ArrayList([]const u8).init(allocator);
+        defer path_parts.deinit();
+
+        while (parts.next()) |part| {
+            try path_parts.append(part);
+        }
+
+        if (path_parts.items.len == 0) return false;
+
+        if (path_parts.items.len == 1) {
+            const exists = root.get(path_parts.items[0]) != null;
+            if (exists) {
+                return try removeProperty(allocator, root, path_parts.items[0]);
+            }
+            return false;
+        }
+
+        return try deleteNested(allocator, root, path_parts.items);
+    }
+
+    fn deleteNested(allocator: std.mem.Allocator, root: *js_ast.Expr, path: []const []const u8) !bool {
+        if (path.len == 0) return false;
+
+        const current_key = path[0];
+        const remaining_path = path[1..];
+
+        if (remaining_path.len == 0) {
+            const exists = root.get(current_key) != null;
+            if (exists) {
+                return try removeProperty(allocator, root, current_key);
+            }
+            return false;
+        }
+
+        const nested_obj = root.get(current_key);
+        if (nested_obj == null or nested_obj.?.data != .e_object) {
+            return false;
+        }
+
+        var nested = nested_obj.?;
+        const deleted = try deleteNested(allocator, &nested, remaining_path);
+
+        if (deleted) {
+            try root.data.e_object.put(allocator, current_key, nested);
+        }
+
+        return deleted;
+    }
+
+    fn removeProperty(allocator: std.mem.Allocator, obj: *js_ast.Expr, key: []const u8) !bool {
+        if (obj.data != .e_object) return false;
+
+        const old_props = obj.data.e_object.properties.slice();
+        var found = false;
+        for (old_props) |prop| {
+            if (prop.key) |k| {
+                switch (k.data) {
+                    .e_string => |s| {
+                        if (strings.eql(s.data, key)) {
+                            found = true;
+                            break;
+                        }
+                    },
+                    else => {},
+                }
+            }
+        }
+
+        if (!found) return false;
+        var new_props = try allocator.alloc(js_ast.G.Property, old_props.len - 1);
+        var new_index: usize = 0;
+
+        for (old_props) |prop| {
+            if (prop.key) |k| {
+                switch (k.data) {
+                    .e_string => |s| {
+                        if (strings.eql(s.data, key)) {
+                            continue;
+                        }
+                    },
+                    else => {},
+                }
+            }
+            new_props[new_index] = prop;
+            new_index += 1;
+        }
+        const new_list = js_ast.G.Property.List.init(new_props);
+        obj.data.e_object.properties = new_list;
+
+        return true;
+    }
+
+    fn savePackageJson(allocator: std.mem.Allocator, path: []const u8, root: js_ast.Expr, pkg: *const PackageJson) !void {
+        const preserve_newline = pkg.contents.len > 0 and pkg.contents[pkg.contents.len - 1] == '\n';
+
+        var buffer_writer = JSPrinter.BufferWriter.init(allocator);
+        try buffer_writer.buffer.list.ensureTotalCapacity(allocator, pkg.contents.len + 1);
+        buffer_writer.append_newline = preserve_newline;
+
+        var writer = JSPrinter.BufferPrinter.init(buffer_writer);
+
+        _ = JSPrinter.printJSON(
+            @TypeOf(&writer),
+            &writer,
+            root,
+            &pkg.source,
+            .{
+                .indent = pkg.indentation,
+                .mangled_props = null,
+            },
+        ) catch |err| {
+            Output.errGeneric("Failed to serialize package.json: {s}", .{@errorName(err)});
+            Global.exit(1);
+        };
+
+        const content = writer.ctx.writtenWithoutTrailingZero();
+        std.fs.cwd().writeFile(.{
+            .sub_path = path,
+            .data = content,
+        }) catch |err| {
+            Output.errGeneric("Failed to write package.json: {s}", .{@errorName(err)});
+            Global.exit(1);
+        };
+    }
+};

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -1,0 +1,1124 @@
+import { spawn } from "bun";
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+import { rmSync, writeFileSync, mkdirSync } from "fs";
+
+async function runPmPkg(args: string[], cwd: string, expectSuccess = true) {
+  await using proc = spawn({
+    cmd: [bunExe(), "pm", "pkg", ...args],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+  const exitCode = await proc.exited;
+
+  if (expectSuccess && exitCode !== 0) {
+    throw new Error(`Expected success but got code ${exitCode}. stderr: ${stderr}`);
+  }
+
+  return { output: stdout, error: stderr, code: exitCode };
+}
+
+function createTestPackageJson(overrides = {}) {
+  return JSON.stringify(
+    {
+      name: "test-package",
+      version: "1.0.0",
+      description: "A test package",
+      main: "index.js",
+      scripts: {
+        test: "echo 'test'",
+        build: "echo 'build'",
+      },
+      keywords: ["test", "package"],
+      author: "Test Author",
+      license: "MIT",
+      dependencies: {
+        "lodash": "^4.17.21",
+        "react": "^18.0.0",
+      },
+      devDependencies: {
+        "typescript": "^5.0.0",
+        "@types/node": "^20.0.0",
+      },
+      engines: {
+        node: ">=18",
+      },
+      bin: {
+        "test-cli": "./bin/cli.js",
+      },
+      contributors: [
+        {
+          name: "John Doe",
+          email: "john@example.com",
+        },
+        {
+          name: "Jane Smith",
+        },
+      ],
+      private: false,
+      testBoolean: true,
+      testNumber: 42,
+      testNull: null,
+      ...overrides,
+    },
+    null,
+    2,
+  );
+}
+
+describe("bun pm pkg", () => {
+  let testDir: string | undefined;
+
+  beforeEach(() => {
+    testDir = tempDirWithFiles("pm-pkg-test", {
+      "package.json": createTestPackageJson(),
+    });
+  });
+
+  afterEach(() => {
+    if (testDir!) {
+      rmSync(testDir!, { recursive: true, force: true });
+    }
+  });
+
+  describe("get command", () => {
+    it("should get a single property", async () => {
+      const { output, code } = await runPmPkg(["get", "name"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"test-package"');
+    });
+
+    it("should get multiple properties", async () => {
+      const { output, code } = await runPmPkg(["get", "name", "version"], testDir!);
+      expect(code).toBe(0);
+
+      expect(output).toContain('"name":');
+      expect(output).toContain('"version":');
+      expect(output).toContain("test-package");
+      expect(output).toContain("1.0.0");
+    });
+
+    it("should get entire package.json when no args provided", async () => {
+      const { output, code } = await runPmPkg(["get"], testDir!);
+      expect(code).toBe(0);
+
+      const parsed = JSON.parse(output);
+      expect(parsed.name).toBe("test-package");
+      expect(parsed.version).toBe("1.0.0");
+      expect(parsed.description).toBe("A test package");
+    });
+
+    it("should get nested properties with dot notation", async () => {
+      const { output, code } = await runPmPkg(["get", "scripts.test"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("\"echo 'test'\"");
+    });
+
+    it("should get array elements with bracket notation", async () => {
+      const { output, code } = await runPmPkg(["get", "contributors[0].name"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"John Doe"');
+    });
+
+    it("should get object properties with bracket notation", async () => {
+      const { output, code } = await runPmPkg(["get", "scripts[test]"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("\"echo 'test'\"");
+    });
+
+    it("should get array elements with dot notation (npm compatibility)", async () => {
+      const { output, code } = await runPmPkg(["get", "contributors.0.name"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"John Doe"');
+    });
+
+    it("should get array elements with dot numeric index", async () => {
+      const { output, code } = await runPmPkg(["get", "keywords.0"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"test"');
+    });
+
+    it("should get array elements without index (entire array)", async () => {
+      const { output, code } = await runPmPkg(["get", "contributors"], testDir!);
+      expect(code).toBe(0);
+
+      const parsed = JSON.parse(output);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].name).toBe("John Doe");
+    });
+
+    it("should handle missing properties gracefully", async () => {
+      const { output, code } = await runPmPkg(["get", "nonexistent"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("{}");
+    });
+
+    it("should handle mixed existing and missing properties", async () => {
+      const { output, code } = await runPmPkg(["get", "name", "nonexistent", "version"], testDir!);
+      expect(code).toBe(0);
+
+      expect(output).toContain('"name":');
+      expect(output).toContain('"version":');
+      expect(output).toContain("test-package");
+      expect(output).toContain("1.0.0");
+    });
+
+    it("should handle boolean values", async () => {
+      const { output, code } = await runPmPkg(["get", "testBoolean"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("true");
+    });
+
+    it("should handle number values", async () => {
+      const { output, code } = await runPmPkg(["get", "testNumber"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("42");
+    });
+
+    it("should handle null values", async () => {
+      const { output, code } = await runPmPkg(["get", "testNull"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("null");
+    });
+
+    it("should handle numeric property names on objects", async () => {
+      // First set a numeric property name
+      const { code: setCode } = await runPmPkg(["set", "config.123=test-value"], testDir!);
+      expect(setCode).toBe(0);
+
+      // Then retrieve it using dot notation
+      const { output, code } = await runPmPkg(["get", "config.123"], testDir!);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"test-value"');
+    });
+
+    it("should fail gracefully when no package.json found", async () => {
+      const emptyDir = tempDirWithFiles("empty-test", {});
+
+      const { error, code } = await runPmPkg(["get", "name"], emptyDir, false);
+      expect(code).toBe(1);
+      expect(error).toContain("No package.json was found");
+
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("set command", () => {
+    it("should set a simple string property", async () => {
+      const { code } = await runPmPkg(["set", "description=New description"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "description"], testDir!);
+      expect(getOutput.trim()).toBe('"New description"');
+    });
+
+    it("should set multiple properties", async () => {
+      const { code } = await runPmPkg(["set", "version=2.0.0", "description=Updated"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "version", "description"], testDir!);
+      expect(getOutput).toContain('"version": "2.0.0"');
+      expect(getOutput).toContain('"description": "Updated"');
+    });
+
+    it("should set nested properties with dot notation", async () => {
+      const { code } = await runPmPkg(["set", "scripts.newScript=echo hello"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "scripts.newScript"], testDir!);
+      expect(getOutput.trim()).toBe('"echo hello"');
+    });
+
+    it("should create nested objects when they don't exist", async () => {
+      const { code } = await runPmPkg(["set", "config.debug=true"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "config"], testDir!);
+      const parsed = JSON.parse(getOutput);
+      expect(parsed.debug).toBe("true");
+    });
+
+    it("should handle JSON boolean true with --json flag", async () => {
+      const { code } = await runPmPkg(["set", "private=true", "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "private"], testDir!);
+      expect(getOutput.trim()).toBe("true");
+    });
+
+    it("should handle JSON boolean false with --json flag", async () => {
+      const { code } = await runPmPkg(["set", "testBool=false", "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "testBool"], testDir!);
+      expect(getOutput.trim()).toBe("false");
+    });
+
+    it("should handle JSON null with --json flag", async () => {
+      const { code } = await runPmPkg(["set", "testNull=null", "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "testNull"], testDir!);
+      expect(getOutput.trim()).toBe("null");
+    });
+
+    it("should handle JSON integers with --json flag", async () => {
+      const { code } = await runPmPkg(["set", "testInt=42", "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "testInt"], testDir!);
+      expect(getOutput.trim()).toBe("42");
+    });
+
+    it("should handle JSON floats with --json flag", async () => {
+      const { code } = await runPmPkg(["set", "testFloat=3.14", "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "testFloat"], testDir!);
+      expect(getOutput.trim()).toBe("3.14");
+    });
+
+    it("should handle JSON objects with --json flag", async () => {
+      const { code } = await runPmPkg(["set", 'newObject={"key":"value","number":123}', "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "newObject"], testDir!);
+      const parsed = JSON.parse(getOutput);
+      expect(parsed.key).toBe("value");
+      expect(parsed.number).toBe(123);
+    });
+
+    it("should handle JSON arrays with --json flag", async () => {
+      const { code } = await runPmPkg(["set", 'newArray=["one","two","three"]', "--json"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "newArray"], testDir!);
+      const parsed = JSON.parse(getOutput);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toEqual(["one", "two", "three"]);
+    });
+
+    it("should treat values as strings without --json flag", async () => {
+      const { code } = await runPmPkg(
+        ["set", "stringTrue=true", "stringFalse=false", "stringNull=null", "stringNumber=42"],
+        testDir!,
+      );
+      expect(code).toBe(0);
+
+      const { output: getTrue } = await runPmPkg(["get", "stringTrue"], testDir!);
+      expect(getTrue.trim()).toBe('"true"');
+
+      const { output: getFalse } = await runPmPkg(["get", "stringFalse"], testDir!);
+      expect(getFalse.trim()).toBe('"false"');
+
+      const { output: getNull } = await runPmPkg(["get", "stringNull"], testDir!);
+      expect(getNull.trim()).toBe('"null"');
+
+      const { output: getNumber } = await runPmPkg(["get", "stringNumber"], testDir!);
+      expect(getNumber.trim()).toBe('"42"');
+    });
+
+    it("should preserve file formatting", async () => {
+      await runPmPkg(["set", "version=1.0.1"], testDir!);
+
+      const modifiedContent = await Bun.file(join(testDir!, "package.json")).text();
+
+      expect(modifiedContent).toContain('  "version": "1.0.1"');
+
+      expect(() => JSON.parse(modifiedContent)).not.toThrow();
+    });
+
+    it("should fail with invalid key=value format", async () => {
+      const { error, code } = await runPmPkg(["set", "invalidformat"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("Invalid argument");
+    });
+
+    it("should fail with empty key", async () => {
+      const { error, code } = await runPmPkg(["set", "=value"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("Empty key");
+    });
+
+    it("should fail when no arguments provided", async () => {
+      const { error, code } = await runPmPkg(["set"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("set expects a key=value pair");
+    });
+  });
+
+  describe("delete command", () => {
+    it("should delete a property", async () => {
+      const { code } = await runPmPkg(["delete", "description"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "description"], testDir!);
+      expect(getOutput.trim()).toBe("{}");
+    });
+
+    it("should delete nested properties", async () => {
+      const { code } = await runPmPkg(["delete", "scripts.test"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "scripts.test"], testDir!);
+      expect(getOutput.trim()).toBe("{}");
+
+      const { output: scriptsOutput } = await runPmPkg(["get", "scripts"], testDir!);
+      const scripts = JSON.parse(scriptsOutput);
+      expect(scripts.build).toBe("echo 'build'");
+      expect(scripts.test).toBeUndefined();
+    });
+
+    it("should handle deleting non-existent properties", async () => {
+      const { code } = await runPmPkg(["delete", "nonexistent"], testDir!);
+      expect(code).toBe(0);
+    });
+
+    it("should delete multiple properties", async () => {
+      const { code } = await runPmPkg(["delete", "keywords", "author", "license"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "keywords", "author", "license"], testDir!);
+      expect(getOutput.trim()).toBe("{}");
+    });
+
+    it("should fail when no arguments provided", async () => {
+      const { error, code } = await runPmPkg(["delete"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("delete expects key args");
+    });
+  });
+
+  describe("help command", () => {
+    it("should show help", async () => {
+      const { output, code } = await runPmPkg(["help"], testDir!);
+      expect(code).toBe(0);
+      expect(output).toContain("bun pm pkg");
+      expect(output).toContain("get");
+      expect(output).toContain("set");
+      expect(output).toContain("delete");
+      expect(output).toContain("fix");
+    });
+
+    it("should show help when no subcommand provided", async () => {
+      const { output, code } = await runPmPkg([], testDir!);
+      expect(code).toBe(0);
+      expect(output).toContain("bun pm pkg");
+    });
+
+    it("should show help for unknown subcommand", async () => {
+      const { output, error, code } = await runPmPkg(["unknown"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("Unknown subcommand");
+      expect(output).toContain("bun pm pkg");
+    });
+  });
+
+  describe("edge cases and error handling", () => {
+    it("should handle malformed JSON gracefully", async () => {
+      writeFileSync(join(testDir!, "package.json"), '{ "name": "test", invalid }');
+
+      const { error, code } = await runPmPkg(["get", "name"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("Failed to parse package.json");
+    });
+
+    it("should handle non-object root gracefully", async () => {
+      writeFileSync(join(testDir!, "package.json"), '["not", "an", "object"]');
+
+      const { error, code } = await runPmPkg(["get", "name"], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("package.json root must be an object");
+    });
+
+    it("should handle very deeply nested properties", async () => {
+      const { code } = await runPmPkg(["set", "very.deeply.nested.property=value"], testDir!);
+      expect(code).toBe(0);
+
+      const { output: getOutput } = await runPmPkg(["get", "very.deeply.nested.property"], testDir!);
+      expect(getOutput.trim()).toBe('"value"');
+    });
+
+    it("should maintain npm pkg compatibility", async () => {
+      const { error, code } = await runPmPkg(["set", "emptyString="], testDir!, false);
+      expect(code).toBe(1);
+      expect(error).toContain("Empty value");
+    });
+  });
+
+  describe("workspace compatibility", () => {
+    it("should work in workspace root", async () => {
+      const workspaceDir = tempDirWithFiles("workspace-test", {
+        "package.json": JSON.stringify({
+          name: "workspace-root",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "@workspace/pkg-a",
+          version: "1.0.0",
+        }),
+      });
+
+      const { output, code } = await runPmPkg(["get", "name"], workspaceDir);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"workspace-root"');
+
+      rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    it("should work in workspace package directory", async () => {
+      const workspaceDir = tempDirWithFiles("workspace-test", {
+        "package.json": JSON.stringify({
+          name: "workspace-root",
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "@workspace/pkg-a",
+          version: "1.0.0",
+        }),
+      });
+
+      const pkgDir = join(workspaceDir, "packages", "pkg-a");
+      const { output, code } = await runPmPkg(["get", "name"], pkgDir);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"@workspace/pkg-a"');
+
+      rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    it("should modify workspace package.json without affecting root", async () => {
+      const workspaceDir = tempDirWithFiles("workspace-test", {
+        "package.json": JSON.stringify({
+          name: "workspace-root",
+          version: "1.0.0",
+          description: "Root package",
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "@workspace/pkg-a",
+          version: "1.0.0",
+          description: "Package A",
+        }),
+      });
+
+      const pkgDir = join(workspaceDir, "packages", "pkg-a");
+
+      const { code } = await runPmPkg(["set", "description=Updated Package A"], pkgDir);
+      expect(code).toBe(0);
+
+      const { output: pkgOutput } = await runPmPkg(["get", "description"], pkgDir);
+      expect(pkgOutput.trim()).toBe('"Updated Package A"');
+
+      const { output: rootOutput } = await runPmPkg(["get", "description"], workspaceDir);
+      expect(rootOutput.trim()).toBe('"Root package"');
+
+      rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    it("should modify root without affecting workspace packages", async () => {
+      const workspaceDir = tempDirWithFiles("workspace-test", {
+        "package.json": JSON.stringify({
+          name: "workspace-root",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+        }),
+        "packages/pkg-a/package.json": JSON.stringify({
+          name: "@workspace/pkg-a",
+          version: "1.0.0",
+        }),
+        "packages/pkg-b/package.json": JSON.stringify({
+          name: "@workspace/pkg-b",
+          version: "2.0.0",
+        }),
+      });
+
+      const { code } = await runPmPkg(["set", "version=1.0.1"], workspaceDir);
+      expect(code).toBe(0);
+
+      const { output: rootOutput } = await runPmPkg(["get", "version"], workspaceDir);
+      expect(rootOutput.trim()).toBe('"1.0.1"');
+
+      const pkgADir = join(workspaceDir, "packages", "pkg-a");
+      const { output: pkgAOutput } = await runPmPkg(["get", "version"], pkgADir);
+      expect(pkgAOutput.trim()).toBe('"1.0.0"');
+
+      const pkgBDir = join(workspaceDir, "packages", "pkg-b");
+      const { output: pkgBOutput } = await runPmPkg(["get", "version"], pkgBDir);
+      expect(pkgBOutput.trim()).toBe('"2.0.0"');
+
+      rmSync(workspaceDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("deeply nested directory scenarios", () => {
+    let nestedDir: string;
+
+    afterEach(() => {
+      if (nestedDir) {
+        rmSync(nestedDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should find package.json in deeply nested directories", async () => {
+      nestedDir = tempDirWithFiles("nested-test", {
+        "package.json": JSON.stringify(
+          {
+            name: "root-package",
+            version: "1.0.0",
+          },
+          null,
+          2,
+        ),
+      });
+
+      const deepPath = join(nestedDir, "src", "components", "ui", "buttons", "primary");
+      mkdirSync(deepPath, { recursive: true });
+
+      const { output, code } = await runPmPkg(["get", "name"], deepPath);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"root-package"');
+    });
+
+    it("should find nearest package.json in nested structure", async () => {
+      nestedDir = tempDirWithFiles("nested-test", {
+        "package.json": JSON.stringify(
+          {
+            name: "root-package",
+            version: "1.0.0",
+          },
+          null,
+          2,
+        ),
+      });
+
+      const uiDir = join(nestedDir, "packages", "ui");
+      mkdirSync(uiDir, { recursive: true });
+      writeFileSync(
+        join(uiDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "ui-package",
+            version: "2.0.0",
+          },
+          null,
+          2,
+        ),
+      );
+
+      const deepDir = join(uiDir, "src", "components");
+      mkdirSync(deepDir, { recursive: true });
+
+      const { output: rootOutput, code: rootCode } = await runPmPkg(["get", "name"], nestedDir);
+      expect(rootCode).toBe(0);
+      expect(rootOutput.trim()).toBe('"root-package"');
+
+      const { output: uiOutput, code: uiCode } = await runPmPkg(["get", "name"], uiDir);
+      expect(uiCode).toBe(0);
+      expect(uiOutput.trim()).toBe('"ui-package"');
+
+      const { output: deepOutput, code: deepCode } = await runPmPkg(["get", "name"], deepDir);
+      expect(deepCode).toBe(0);
+      expect(deepOutput.trim()).toBe('"ui-package"');
+    });
+
+    it("should handle modifications from deeply nested directories", async () => {
+      nestedDir = tempDirWithFiles("nested-test", {
+        "package.json": JSON.stringify(
+          {
+            name: "my-project",
+            version: "1.0.0",
+            scripts: {
+              test: "jest",
+            },
+          },
+          null,
+          2,
+        ),
+      });
+
+      const deepDir = join(nestedDir, "src", "utils", "helpers", "string");
+      mkdirSync(deepDir, { recursive: true });
+
+      const { code: setCode } = await runPmPkg(["set", "scripts.build=webpack"], deepDir);
+      expect(setCode).toBe(0);
+
+      const { output: deepOutput } = await runPmPkg(["get", "scripts.build"], deepDir);
+      expect(deepOutput.trim()).toBe('"webpack"');
+
+      const { output: rootOutput } = await runPmPkg(["get", "scripts.build"], nestedDir);
+      expect(rootOutput.trim()).toBe('"webpack"');
+
+      const pkgContent = await Bun.file(join(nestedDir, "package.json")).json();
+      expect(pkgContent.scripts.build).toBe("webpack");
+    });
+  });
+
+  describe("npm pkg compatibility tests", () => {
+    it("should handle all data types correctly", async () => {
+      const testCases = [
+        ["testBoolean", "true"],
+        ["testNumber", "42"],
+        ["testNull", "null"],
+        ["name", '"test-package"'],
+      ];
+
+      for (const [key, expected] of testCases) {
+        const { output: testOutput, code: testCode } = await runPmPkg(["get", key.toString()], testDir!);
+        expect(testCode).toBe(0);
+
+        if (typeof expected === "string") {
+          expect(testOutput.trim()).toBe(expected);
+        } else {
+          expect(testOutput.trim()).toMatch(expected);
+        }
+      }
+    });
+
+    it("should handle complex nested structures", async () => {
+      const { output: scriptsOutput, code: scriptsCode } = await runPmPkg(["get", "scripts"], testDir!);
+      expect(scriptsCode).toBe(0);
+
+      const scripts = JSON.parse(scriptsOutput);
+      expect(scripts.test).toBe("echo 'test'");
+      expect(scripts.build).toBe("echo 'build'");
+
+      const { output: contribOutput, code: contribCode } = await runPmPkg(["get", "contributors[0]"], testDir!);
+      expect(contribCode).toBe(0);
+
+      const firstContrib = JSON.parse(contribOutput);
+      expect(firstContrib.name).toBe("John Doe");
+      expect(firstContrib.email).toBe("john@example.com");
+    });
+
+    it("should produce equivalent output to npm pkg for common operations", async () => {
+      const { output: nameOutput } = await runPmPkg(["get", "name"], testDir!);
+      expect(nameOutput.trim()).toBe('"test-package"');
+
+      const { output: multiOutput } = await runPmPkg(["get", "name", "version"], testDir!);
+      expect(multiOutput).toContain('"name":');
+      expect(multiOutput).toContain('"version":');
+
+      const { output: missingOutput } = await runPmPkg(["get", "nonexistent"], testDir!);
+      expect(missingOutput.trim()).toBe("{}");
+    });
+  });
+
+  describe("comprehensive notation compatibility tests", () => {
+    it("should handle mixed bracket and dot notation equivalently", async () => {
+      // Test that bracket[0] and dot.0 notation produce identical results
+      const { output: bracketOutput } = await runPmPkg(["get", "contributors[0].name"], testDir!);
+      const { output: dotOutput } = await runPmPkg(["get", "contributors.0.name"], testDir!);
+      
+      expect(bracketOutput.trim()).toBe(dotOutput.trim());
+      expect(bracketOutput.trim()).toBe('"John Doe"');
+    });
+
+    it("should handle complex mixed notation patterns", async () => {
+      // Set up a complex nested structure for testing
+      const { code: setCode } = await runPmPkg(["set", "nested.array=[{\"prop\":\"value1\"},{\"prop\":\"value2\"}]", "--json"], testDir!);
+      expect(setCode).toBe(0);
+
+      // Test various notation combinations
+      const testCases = [
+        "nested.array.0.prop",      // dot.dot.dot
+        "nested.array[0].prop",     // dot.bracket.dot  
+        "nested[array][0][prop]",   // bracket.bracket.bracket
+        "nested[array].0.prop",     // bracket.dot.dot
+      ];
+
+      for (const notation of testCases) {
+        const { output, code } = await runPmPkg(["get", notation], testDir!);
+        expect(code).toBe(0);
+        expect(output.trim()).toBe('"value1"');
+      }
+    });
+
+    it("should handle string properties in bracket notation", async () => {
+      // Test various string property access patterns
+      const testCases = [
+        ["scripts[test]", '"echo \'test\'"'],
+        ["scripts[build]", '"echo \'build\'"'],
+        ["engines[node]", '">=18"'],
+        ["bin[test-cli]", '"./bin/cli.js"'],
+      ];
+
+      for (const [notation, expected] of testCases) {
+        const { output, code } = await runPmPkg(["get", notation], testDir!);
+        expect(code).toBe(0);
+        expect(output.trim()).toBe(expected);
+      }
+    });
+
+    it("should handle numeric indices with different data types", async () => {
+      // Test numeric access on arrays vs objects
+      const { output: arrayAccess } = await runPmPkg(["get", "keywords.0"], testDir!);
+      expect(arrayAccess.trim()).toBe('"test"');
+
+      const { output: arrayAccess2 } = await runPmPkg(["get", "keywords.1"], testDir!);
+      expect(arrayAccess2.trim()).toBe('"package"');
+
+      // Test numeric property on object (not array)
+      const { code: setCode } = await runPmPkg(["set", "config.0=zero-value"], testDir!);
+      expect(setCode).toBe(0);
+
+      const { output: objectNumericAccess } = await runPmPkg(["get", "config.0"], testDir!);
+      expect(objectNumericAccess.trim()).toBe('"zero-value"');
+    });
+
+    it("should gracefully handle invalid notation patterns", async () => {
+      const invalidCases = [
+        "contributors.999",         // Out of bounds array index
+        "scripts[nonexistent]",     // Non-existent property
+        "keywords.abc",            // Non-numeric on array
+        "nonexistent.0",           // Non-existent parent
+      ];
+
+      for (const notation of invalidCases) {
+        const { output, code } = await runPmPkg(["get", notation], testDir!);
+        expect(code).toBe(0);
+        expect(output.trim()).toBe("{}");
+      }
+    });
+
+    it("should reject empty bracket notation for get operations (npm compatibility)", async () => {
+      // Empty brackets are not valid for retrieving values, only for setting
+      const invalidEmptyBracketCases = [
+        "contributors[]",
+        "contributors[].name",
+        "scripts[]",
+      ];
+
+      for (const notation of invalidEmptyBracketCases) {
+        const { error, code } = await runPmPkg(["get", notation], testDir!, false);
+        expect(code).toBe(1);
+        expect(error).toContain("Empty brackets are not valid syntax for retrieving values");
+      }
+    });
+
+    it("should maintain consistency between set and get operations", async () => {
+      // Set using dot notation with numeric property, get using same dot notation
+      const { code: setCode1 } = await runPmPkg(["set", "test.array.0=first"], testDir!);
+      expect(setCode1).toBe(0);
+
+      const { output: getOutput1 } = await runPmPkg(["get", "test.array.0"], testDir!);
+      expect(getOutput1.trim()).toBe('"first"');
+
+      // Set using dot notation, get using dot notation  
+      const { code: setCode2 } = await runPmPkg(["set", "test.bracket.access=success"], testDir!);
+      expect(setCode2).toBe(0);
+
+      const { output: getOutput2 } = await runPmPkg(["get", "test.bracket.access"], testDir!);
+      expect(getOutput2.trim()).toBe('"success"');
+    });
+
+    it("should handle edge cases with special characters", async () => {
+      // Test properties with hyphens, dots, and other special chars
+      const { code: setCode1 } = await runPmPkg(["set", "special-key=hyphen-value"], testDir!);
+      expect(setCode1).toBe(0);
+
+      const { output: getOutput1 } = await runPmPkg(["get", "special-key"], testDir!);
+      expect(getOutput1.trim()).toBe('"hyphen-value"');
+
+      // Test bracket notation with special characters
+      const { output: getOutput2 } = await runPmPkg(["get", "contributors[0][name]"], testDir!);
+      expect(getOutput2.trim()).toBe('"John Doe"');
+    });
+
+    it("should verify npm compatibility with real-world patterns", async () => {
+      // Create a package.json structure similar to real projects
+      const realWorldDir = tempDirWithFiles("real-world-test", {
+        "package.json": JSON.stringify({
+          name: "my-project",
+          version: "1.0.0",
+          scripts: {
+            "test": "jest",
+            "test:watch": "jest --watch",
+            "build": "webpack",
+            "build:prod": "webpack --mode=production"
+          },
+          dependencies: {
+            "react": "^18.0.0",
+            "@types/node": "^20.0.0"
+          },
+          workspaces: [
+            "packages/*",
+            "apps/*"
+          ],
+          publishConfig: {
+            registry: "https://npm.pkg.github.com"
+          }
+        }, null, 2)
+      });
+
+      try {
+        // Test common real-world access patterns
+        const testCases = [
+          ["scripts[test]", '"jest"'],
+          ["scripts[test:watch]", '"jest --watch"'],
+          ["workspaces.0", '"packages/*"'],
+          ["workspaces[1]", '"apps/*"'],
+          ["dependencies[react]", '"^18.0.0"'],
+          ["dependencies[@types/node]", '"^20.0.0"'],
+          ["publishConfig[registry]", '"https://npm.pkg.github.com"'],
+        ];
+
+        for (const [notation, expected] of testCases) {
+          const { output, code } = await runPmPkg(["get", notation], realWorldDir);
+          expect(code).toBe(0);
+          expect(output.trim()).toBe(expected);
+        }
+      } finally {
+        rmSync(realWorldDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("fix command", () => {
+    let fixTestDir: string;
+
+    beforeEach(() => {
+      fixTestDir = tempDirWithFiles("fix-test", {
+        "package.json": JSON.stringify({
+          name: "TEST-PACKAGE",
+          version: "1.0.0",
+          description: "Test package",
+          main: "index.js",
+          bin: {
+            "mycli": "./bin/nonexistent.js",
+            "othercli": "./bin/also-missing.js"
+          },
+          dependencies: {
+            "react": "^18.0.0"
+          }
+        }, null, 2)
+      });
+    });
+
+    afterEach(() => {
+      if (fixTestDir) {
+        rmSync(fixTestDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should fix uppercase package names to lowercase", async () => {
+      const { code } = await runPmPkg(["fix"], fixTestDir);
+      expect(code).toBe(0);
+
+      const { output: nameOutput } = await runPmPkg(["get", "name"], fixTestDir);
+      expect(nameOutput.trim()).toBe('"test-package"');
+    });
+
+    it("should warn about missing bin files", async () => {
+      const { code, error } = await runPmPkg(["fix"], fixTestDir);
+      expect(code).toBe(0);
+      expect(error).toContain("No bin file found at ./bin/nonexistent.js");
+      expect(error).toContain("No bin file found at ./bin/also-missing.js");
+    });
+
+    it("should not modify package.json if no fixes are needed", async () => {
+      // First, create a package.json that doesn't need fixing
+      const goodDir = tempDirWithFiles("good-package", {
+        "package.json": JSON.stringify({
+          name: "good-package",
+          version: "1.0.0",
+          description: "Already good package"
+        }, null, 2)
+      });
+
+      try {
+        const beforeContent = await Bun.file(join(goodDir, "package.json")).text();
+        const { code } = await runPmPkg(["fix"], goodDir);
+        expect(code).toBe(0);
+        
+        const afterContent = await Bun.file(join(goodDir, "package.json")).text();
+        expect(afterContent).toBe(beforeContent);
+      } finally {
+        rmSync(goodDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should handle package.json with existing bin files", async () => {
+      // Create a package with an actual bin file
+      const binDir = tempDirWithFiles("bin-test", {
+        "package.json": JSON.stringify({
+          name: "BIN-PACKAGE",
+          version: "1.0.0",
+          bin: {
+            "actualcli": "./bin/real.js"
+          }
+        }, null, 2),
+        "bin/real.js": "#!/usr/bin/env node\nconsole.log('Hello');"
+      });
+
+      try {
+        const { code, error } = await runPmPkg(["fix"], binDir);
+        expect(code).toBe(0);
+        // Should not warn about the real file
+        expect(error).not.toContain("No bin file found at ./bin/real.js");
+        
+        // Should still fix the name
+        const { output: nameOutput } = await runPmPkg(["get", "name"], binDir);
+        expect(nameOutput.trim()).toBe('"bin-package"');
+      } finally {
+        rmSync(binDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should preserve all other package.json fields", async () => {
+      const { code } = await runPmPkg(["fix"], fixTestDir);
+      expect(code).toBe(0);
+
+      // Verify all other fields are preserved
+      const { output: versionOutput } = await runPmPkg(["get", "version"], fixTestDir);
+      expect(versionOutput.trim()).toBe('"1.0.0"');
+
+      const { output: descOutput } = await runPmPkg(["get", "description"], fixTestDir);
+      expect(descOutput.trim()).toBe('"Test package"');
+
+      const { output: depsOutput } = await runPmPkg(["get", "dependencies.react"], fixTestDir);
+      expect(depsOutput.trim()).toBe('"^18.0.0"');
+
+      const { output: binOutput } = await runPmPkg(["get", "bin.mycli"], fixTestDir);
+      expect(binOutput.trim()).toBe('"./bin/nonexistent.js"');
+    });
+
+    it("should handle malformed package.json gracefully", async () => {
+      const malformedDir = tempDirWithFiles("malformed-test", {
+        "package.json": '{"name": "test", invalid}'
+      });
+
+      try {
+        const { code, error } = await runPmPkg(["fix"], malformedDir, false);
+        expect(code).toBe(1);
+        expect(error).toContain("package.json");
+      } finally {
+        rmSync(malformedDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should handle non-object package.json", async () => {
+      const nonObjectDir = tempDirWithFiles("non-object-test", {
+        "package.json": '"this is not an object"'
+      });
+
+      try {
+        const { code, error } = await runPmPkg(["fix"], nonObjectDir, false);
+        expect(code).toBe(1);
+        expect(error).toContain("package.json root must be an object");
+      } finally {
+        rmSync(nonObjectDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should fix multiple issues in one run", async () => {
+      const multiIssueDir = tempDirWithFiles("multi-issue-test", {
+        "package.json": JSON.stringify({
+          name: "MULTIPLE-ISSUES-PACKAGE",
+          version: "1.0.0",
+          bin: {
+            "missing1": "./nonexistent1.js",
+            "missing2": "./nonexistent2.js"
+          }
+        }, null, 2)
+      });
+
+      try {
+        const { code, error } = await runPmPkg(["fix"], multiIssueDir);
+        expect(code).toBe(0);
+
+        // Should fix the name
+        const { output: nameOutput } = await runPmPkg(["get", "name"], multiIssueDir);
+        expect(nameOutput.trim()).toBe('"multiple-issues-package"');
+
+        // Should warn about both missing files
+        expect(error).toContain("No bin file found at ./nonexistent1.js");
+        expect(error).toContain("No bin file found at ./nonexistent2.js");
+      } finally {
+        rmSync(multiIssueDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should not crash on empty bin object", async () => {
+      const emptyBinDir = tempDirWithFiles("empty-bin-test", {
+        "package.json": JSON.stringify({
+          name: "EMPTY-BIN-PACKAGE",
+          version: "1.0.0",
+          bin: {}
+        }, null, 2)
+      });
+
+      try {
+        const { code } = await runPmPkg(["fix"], emptyBinDir);
+        expect(code).toBe(0);
+
+        const { output: nameOutput } = await runPmPkg(["get", "name"], emptyBinDir);
+        expect(nameOutput.trim()).toBe('"empty-bin-package"');
+      } finally {
+        rmSync(emptyBinDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should handle missing package.json file", async () => {
+      const emptyDir = tempDirWithFiles("empty-test", {});
+
+      try {
+        const { code, error } = await runPmPkg(["fix"], emptyDir, false);
+        expect(code).toBe(1);
+        expect(error).toContain("package.json");
+      } finally {
+        rmSync(emptyDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // npm does the actual "" key, but bun right now doesn't support it
+  describe.todo("empty string key compatibility", () => {
+    let emptyKeyDir: string;
+
+    beforeEach(() => {
+      emptyKeyDir = tempDirWithFiles("empty-key-test", {
+        "package.json": JSON.stringify({
+          name: "test-package",
+          version: "1.0.0",
+          "": "empty-key-value"
+        }, null, 2)
+      });
+    });
+
+    afterEach(() => {
+      if (emptyKeyDir) {
+        rmSync(emptyKeyDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should get empty string property key (npm compatibility)", async () => {
+      const { output, code } = await runPmPkg(["get", ""], emptyKeyDir);
+      expect(code).toBe(0);
+      expect(output.trim()).toBe('"empty-key-value"');
+    });
+
+    it("should set empty string property key", async () => {
+      const { code } = await runPmPkg(["set", "=new-empty-value"], emptyKeyDir);
+      expect(code).toBe(0);
+
+      const { output } = await runPmPkg(["get", ""], emptyKeyDir);
+      expect(output.trim()).toBe('"new-empty-value"');
+    });
+
+    it.todo("should delete empty string property key", async () => {
+      const { code } = await runPmPkg(["delete", ""], emptyKeyDir);
+      expect(code).toBe(0);
+
+      const { output } = await runPmPkg(["get", ""], emptyKeyDir);
+      expect(output.trim()).toBe("{}");
+    });
+  });
+});

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -36,7 +36,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 170 },
-  "std.fs.cwd": { reason: "Prefer bun.FD.cwd()", limit: 102 },
+  "std.fs.cwd": { reason: "Prefer bun.FD.cwd()", limit: 103 },
   "std.fs.File": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 62 },
   ".stdFile()": { reason: "Prefer bun.sys + bun.FD instead of std.fs.File. Zig hides 'errno' when Bun wants to match libuv", limit: 18 },
   ".stdDir()": { reason: "Prefer bun.sys + bun.FD instead of std.fs.File. Zig hides 'errno' when Bun wants to match libuv", limit: 40 },


### PR DESCRIPTION
### What does this PR do?

fixes #20855, fixes #9840

<img width="848" height="663" alt="image" src="https://github.com/user-attachments/assets/e6d87e41-8ebd-429d-8f3c-dda840070355" />


<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
