### PR TITLE
docs: Update docs for use prisma with bun

### DIFF
--- a/docs/guides/ecosystem/prisma.md
+++ b/docs/guides/ecosystem/prisma.md
@@ -40,6 +40,7 @@ Open `prisma/schema.prisma` and add a simple `User` model.
 ```prisma-diff#prisma/schema.prisma
   generator client {
     provider = "prisma-client-js"
+    output = "../generated/prisma"
   }
 
   datasource db {
@@ -78,7 +79,7 @@ migrations/
 
 Your database is now in sync with your schema.
 
-✔ Generated Prisma Client (v5.3.1) to ./node_modules/@prisma/client in 41ms
+✔ Generated Prisma Client (v6.11.1) to ./generated/prisma in 41ms
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

I updated the documentation for the Prisma ecosystem guides section. Specifically, added the "output" field to the prisma/schema.prisma file and the output path for the Prisma Client for the "bunx prisma migrate dev --name init" command.
closes #19739 
- [x ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes


