### PR TITLE
Try to deflake bun-install-lifecycle-scripts test

### DIFF
--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -82,7 +82,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -131,7 +131,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -186,7 +186,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -277,7 +277,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -346,7 +346,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -379,7 +379,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -428,7 +428,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -473,7 +473,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -502,7 +502,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -536,7 +536,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -563,7 +563,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -601,7 +601,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -641,7 +641,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -668,7 +668,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -725,7 +725,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -770,7 +770,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -835,7 +835,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -874,7 +874,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cwd: packageDir,
         stdout: "pipe",
         stderr: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         env: testEnv,
       });
 
@@ -914,7 +914,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -953,7 +953,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -985,7 +985,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1022,7 +1022,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1050,7 +1050,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1086,7 +1086,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1130,7 +1130,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cmd: [bunExe(), "install"],
           cwd: packageDir,
           stdout: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           stderr: "pipe",
           env: testEnv,
         });
@@ -1172,7 +1172,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1218,7 +1218,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1267,7 +1267,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1295,7 +1295,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       const dependencies: Record<string, string> = {};
       const dependenciesList: string[] = [];
 
-      for (let i = 0; i < packagesCount; i++) {
+      async function iterate(i) {
         const packageName: string = "stress-test-package-" + i;
         const packageVersion = "1.0." + i;
 
@@ -1303,8 +1303,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         dependenciesList[i] = packageName;
 
         const packagePath = join(packageDir, packageName);
-        await mkdir(packagePath);
-        await writeFile(
+
+        await Bun.write(
           join(packagePath, "package.json"),
           JSON.stringify({
             name: packageName,
@@ -1313,6 +1313,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           }),
         );
       }
+
+      await Promise.all(Array.from({ length: packagesCount }, (_, i) => iterate(i)));
 
       await writeFile(
         packageJson,
@@ -1340,16 +1342,16 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install", "--concurrent-scripts=2"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
 
-      const err = await stderr.text();
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
       expect(err).toContain("Saved lockfile");
       expect(err).not.toContain("not found");
       expect(err).not.toContain("error:");
-      const out = await stdout.text();
       expect(out).not.toContain("Blocked");
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
@@ -1358,7 +1360,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         "",
         "4 packages installed",
       ]);
-      expect(await exited).toBe(0);
+      expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
@@ -1374,16 +1376,16 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
 
-      const err = await stderr.text();
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
       expect(err).toContain("Saved lockfile");
       expect(err).not.toContain("not found");
       expect(err).not.toContain("error:");
-      const out = await stdout.text();
       expect(out).not.toContain("Blocked");
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
@@ -1393,7 +1395,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         "500 packages installed",
       ]);
 
-      expect(await exited).toBe(0);
+      expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
@@ -1421,7 +1423,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1475,7 +1477,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1505,7 +1507,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1549,7 +1551,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1584,7 +1586,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env,
       });
@@ -1627,7 +1629,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1678,7 +1680,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1726,7 +1728,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1776,7 +1778,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });
@@ -1818,7 +1820,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       }));
@@ -1967,7 +1969,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            stdin: "pipe",
+            stdin: "ignore",
             env: testEnv,
           });
 
@@ -2000,7 +2002,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            stdin: "pipe",
+            stdin: "ignore",
             env: testEnv,
           }));
 
@@ -2034,7 +2036,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            stdin: "pipe",
+            stdin: "ignore",
             env: testEnv,
           });
 
@@ -2074,7 +2076,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            stdin: "pipe",
+            stdin: "ignore",
             env: testEnv,
           });
 
@@ -2108,7 +2110,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             cwd: packageDir,
             stdout: "pipe",
             stderr: "pipe",
-            stdin: "pipe",
+            stdin: "ignore",
             env: testEnv,
           }));
 
@@ -2161,7 +2163,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cwd: packageDir,
           stdout: "pipe",
           stderr: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           env: testEnv,
         });
 
@@ -2196,7 +2198,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cwd: packageDir,
           stdout: "pipe",
           stderr: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           env: testEnv,
         }));
 
@@ -2234,7 +2236,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cwd: packageDir,
           stdout: "pipe",
           stderr: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           env: testEnv,
         });
 
@@ -2281,7 +2283,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cwd: packageDir,
           stdout: "pipe",
           stderr: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           env: testEnv,
         }));
 
@@ -2326,7 +2328,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cwd: packageDir,
           stdout: "pipe",
           stderr: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           env: testEnv,
         });
 
@@ -2375,7 +2377,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           cwd: packageDir,
           stdout: "pipe",
           stderr: "pipe",
-          stdin: "pipe",
+          stdin: "ignore",
           env: testEnv,
         }));
 
@@ -2418,7 +2420,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
-        stdin: "pipe",
+        stdin: "ignore",
         stderr: "pipe",
         env: testEnv,
       });


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
