### PR TITLE
Add `NODE_NO_WARNINGS`

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -1411,6 +1411,8 @@ Process::~Process()
 {
 }
 
+extern "C" bool Bun__NODE_NO_WARNINGS();
+
 JSC_DEFINE_HOST_FUNCTION(jsFunction_emitWarning, (JSC::JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
@@ -1425,11 +1427,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitWarning, (JSC::JSGlobalObject * lexicalG
         args.append(value);
         process->wrapped().emit(ident, args);
         return JSValue::encode(jsUndefined());
+    } else if (!Bun__NODE_NO_WARNINGS()) {
+        auto jsArgs = JSValue::encode(value);
+        Bun__ConsoleObject__messageWithTypeAndLevel(reinterpret_cast<Bun::ConsoleObject*>(globalObject->consoleClient().get())->m_client, static_cast<uint32_t>(MessageType::Log), static_cast<uint32_t>(MessageLevel::Warning), globalObject, &jsArgs, 1);
+        RETURN_IF_EXCEPTION(scope, {});
     }
-
-    auto jsArgs = JSValue::encode(value);
-    Bun__ConsoleObject__messageWithTypeAndLevel(reinterpret_cast<Bun::ConsoleObject*>(globalObject->consoleClient().get())->m_client, static_cast<uint32_t>(MessageType::Log), static_cast<uint32_t>(MessageLevel::Warning), globalObject, &jsArgs, 1);
-    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -312,6 +312,10 @@ comptime {
     }
 }
 
+pub export fn Bun__NODE_NO_WARNINGS() callconv(.C) bool {
+    return bun.getRuntimeFeatureFlag(.NODE_NO_WARNINGS);
+}
+
 pub export const Bun__version: [*:0]const u8 = "v" ++ bun.Global.package_json_version;
 pub export const Bun__version_with_sha: [*:0]const u8 = "v" ++ bun.Global.package_json_version_with_sha;
 pub export const Bun__versions_boringssl: [*:0]const u8 = bun.Global.versions.boringssl;

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -36,6 +36,7 @@ pub const RuntimeFeatureFlag = enum {
     BUN_INTERNAL_BUNX_INSTALL,
     BUN_NO_CODESIGN_MACHO_BINARY,
     BUN_TRACE,
+    NODE_NO_WARNINGS,
 };
 
 /// Enable breaking changes for the next major release of Bun

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1555,6 +1555,10 @@ export class VerdaccioRegistry {
       silent,
       // Prefer using a release build of Bun since it's faster
       execPath: isCI ? bunExe() : Bun.which("bun") || bunExe(),
+      env: {
+        ...(bunEnv as any),
+        NODE_NO_WARNINGS: "1",
+      },
     });
 
     this.process.stderr?.on("data", data => {


### PR DESCRIPTION
### What does this PR do?

Add `NODE_NO_WARNINGS`

I don't like that we added any of these to begin with. These warnings are rarely in code controlled by the end-user so for most people it's just noise.

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
