### PR TITLE
Prefer bun.sys.exists over std.posix.access

### DIFF
--- a/src/bun.js/api/server/SSLConfig.zig
+++ b/src/bun.js/api/server/SSLConfig.zig
@@ -241,8 +241,9 @@ pub fn fromJS(vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject, obj: JSC.JSV
         var sliced = try key_file_name.toSlice(global, bun.default_allocator);
         defer sliced.deinit();
         if (sliced.len > 0) {
-            result.key_file_name = try bun.default_allocator.dupeZ(u8, sliced.slice());
-            if (std.posix.system.access(result.key_file_name, std.posix.F_OK) != 0) {
+            const key_file_name_ = try bun.default_allocator.dupeZ(u8, sliced.slice());
+            result.key_file_name = key_file_name_;
+            if (bun.sys.existsAtType(key_file_name_).unwrapOr(.directory) != .file) {
                 return global.throwInvalidArguments("Unable to access keyFile path", .{});
             }
             any = true;
@@ -333,8 +334,9 @@ pub fn fromJS(vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject, obj: JSC.JSV
         var sliced = try cert_file_name.toSlice(global, bun.default_allocator);
         defer sliced.deinit();
         if (sliced.len > 0) {
-            result.cert_file_name = try bun.default_allocator.dupeZ(u8, sliced.slice());
-            if (std.posix.system.access(result.cert_file_name, std.posix.F_OK) != 0) {
+            const cert_file_name_ = try bun.default_allocator.dupeZ(u8, sliced.slice());
+            result.cert_file_name = cert_file_name_;
+            if (bun.sys.existsAtType(cert_file_name_).unwrapOr(.directory) != .file) {
                 return global.throwInvalidArguments("Unable to access certFile path", .{});
             }
             any = true;
@@ -550,8 +552,9 @@ pub fn fromJS(vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject, obj: JSC.JSV
         var sliced = try ca_file_name.toSlice(global, bun.default_allocator);
         defer sliced.deinit();
         if (sliced.len > 0) {
-            result.ca_file_name = try bun.default_allocator.dupeZ(u8, sliced.slice());
-            if (std.posix.system.access(result.ca_file_name, std.posix.F_OK) != 0) {
+            const ca_file_name_ = try bun.default_allocator.dupeZ(u8, sliced.slice());
+            result.ca_file_name = ca_file_name_;
+            if (bun.sys.existsAtType(ca_file_name_).unwrapOr(.directory) != .file) {
                 return global.throwInvalidArguments("Invalid caFile path", .{});
             }
         }
@@ -581,7 +584,7 @@ pub fn fromJS(vm: *JSC.VirtualMachine, global: *JSC.JSGlobalObject, obj: JSC.JSV
             defer sliced.deinit();
             if (sliced.len > 0) {
                 result.dh_params_file_name = try bun.default_allocator.dupeZ(u8, sliced.slice());
-                if (std.posix.system.access(result.dh_params_file_name, std.posix.F_OK) != 0) {
+                if (bun.sys.existsAtType(result.dh_params_file_name).unwrapOr(.directory) != .file) {
                     return global.throwInvalidArguments("Invalid dhParamsFile path", .{});
                 }
             }

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -357,10 +357,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                     for (parents, 0..) |parent_hash, entry_id| {
                                         if (parent_hash == current_hash) {
                                             const affected_path = file_paths[entry_id];
-                                            const was_deleted = check: {
-                                                std.posix.access(affected_path, std.posix.F_OK) catch break :check true;
-                                                break :check false;
-                                            };
+                                            const was_deleted = !bun.sys.exists(affected_path);
                                             if (!was_deleted) continue;
 
                                             affected_buf[affected_i] = affected_path[file_path.len..];

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -655,7 +655,7 @@ pub const UpgradeCommand = struct {
                     defer save_dir_.deleteTree(version_name) catch {};
 
                     if (err == error.FileNotFound) {
-                        if (std.fs.cwd().access(exe, .{})) {
+                        if (!bun.sys.exists(exe)) {
                             // On systems like NixOS, the FileNotFound is actually the system-wide linker,
                             // as they do not have one (most systems have it at a known path). This is how
                             // ChildProcess returns FileNotFound despite the actual
@@ -674,7 +674,7 @@ pub const UpgradeCommand = struct {
                             , .{});
                             Global.exit(1);
                             return;
-                        } else |_| {}
+                        }
                     }
 
                     Output.prettyErrorln("<r><red>error<r><d>:<r> Failed to verify Bun (code: {s})<r>)", .{@errorName(err)});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
