### PR TITLE
[ENG-15008] fix #21086

### DIFF
--- a/src/shell/states/Cmd.zig
+++ b/src/shell/states/Cmd.zig
@@ -420,7 +420,7 @@ fn initSubproc(this: *Cmd) Yield {
 
     var arena = &this.spawn_arena;
     // var arena_allocator = arena.allocator();
-    var spawn_args = Subprocess.SpawnArgs.default(arena, this.base.interpreter.event_loop, false);
+    var spawn_args = Subprocess.SpawnArgs.default(arena, this, this.base.interpreter.event_loop, false);
 
     spawn_args.argv = std.ArrayListUnmanaged(?[*:0]const u8){};
     spawn_args.cmd_parent = this;
@@ -502,7 +502,6 @@ fn initSubproc(this: *Cmd) Yield {
 
         break :args this.args;
     };
-    spawn_args.argv = std.ArrayListUnmanaged(?[*:0]const u8){ .items = args.items, .capacity = args.capacity };
 
     // Fill the env from the export end and cmd local env
     {

--- a/src/shell/states/Cmd.zig
+++ b/src/shell/states/Cmd.zig
@@ -422,11 +422,10 @@ fn initSubproc(this: *Cmd) Yield {
     // var arena_allocator = arena.allocator();
     var spawn_args = Subprocess.SpawnArgs.default(arena, this, this.base.interpreter.event_loop, false);
 
-    spawn_args.argv = std.ArrayListUnmanaged(?[*:0]const u8){};
     spawn_args.cmd_parent = this;
     spawn_args.cwd = this.base.shell.cwdZ();
 
-    const args = args: {
+    {
         this.args.append(null) catch bun.outOfMemory();
 
         log("Cmd(0x{x}, {s}) IO: {}", .{ @intFromPtr(this), if (this.args.items.len > 0) this.args.items[0] orelse "<no args>" else "<no args>", this.io });
@@ -499,9 +498,7 @@ fn initSubproc(this: *Cmd) Yield {
         this.base.allocator().free(first_arg_real);
         const duped = this.base.allocator().dupeZ(u8, bun.span(resolved)) catch bun.outOfMemory();
         this.args.items[0] = duped;
-
-        break :args this.args;
-    };
+    }
 
     // Fill the env from the export end and cmd local env
     {
@@ -600,7 +597,7 @@ fn initRedirections(this: *Cmd, spawn_args: *Subprocess.SpawnArgs) ?Yield {
             },
             .atom => {
                 if (this.redirection_file.items.len == 0) {
-                    return this.writeFailingError("bun: ambiguous redirect: at `{s}`\n", .{spawn_args.argv.items[0] orelse "<unknown>"});
+                    return this.writeFailingError("bun: ambiguous redirect: at `{s}`\n", .{spawn_args.cmd_parent.args.items[0] orelse "<unknown>"});
                 }
                 const path = this.redirection_file.items[0..this.redirection_file.items.len -| 1 :0];
                 log("Expanded Redirect: {s}\n", .{this.redirection_file.items[0..]});

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -51,7 +51,7 @@ pub const ShellSubprocess = struct {
     pub const default_max_buffer_size = 1024 * 1024 * 4;
     pub const Process = bun.spawn.Process;
 
-    cmd_parent: ?*ShellCmd = null,
+    cmd_parent: *ShellCmd,
 
     process: *Process,
 
@@ -73,10 +73,8 @@ pub const ShellSubprocess = struct {
     pub const OutKind = util.OutKind;
 
     pub fn onStaticPipeWriterDone(this: *ShellSubprocess) void {
-        log("Subproc(0x{x}) onStaticPipeWriterDone(cmd=0x{x}))", .{ @intFromPtr(this), if (this.cmd_parent) |cmd| @intFromPtr(cmd) else 0 });
-        if (this.cmd_parent) |cmd| {
-            cmd.bufferedInputClose();
-        }
+        log("Subproc(0x{x}) onStaticPipeWriterDone(cmd=0x{x}))", .{ @intFromPtr(this), @intFromPtr(this.cmd_parent) });
+        this.cmd_parent.bufferedInputClose();
     }
 
     const Writable = union(enum) {
@@ -599,7 +597,7 @@ pub const ShellSubprocess = struct {
 
     pub const SpawnArgs = struct {
         arena: *bun.ArenaAllocator,
-        cmd_parent: ?*ShellCmd = null,
+        cmd_parent: *ShellCmd,
 
         override_env: bool = false,
         env_array: std.ArrayListUnmanaged(?[*:0]const u8) = .{
@@ -614,7 +612,6 @@ pub const ShellSubprocess = struct {
         },
         lazy: bool = false,
         PATH: []const u8,
-        argv: std.ArrayListUnmanaged(?[*:0]const u8),
         detached: bool,
         // ipc_mode: IPCMode,
         // ipc_callback: JSValue,
@@ -673,7 +670,7 @@ pub const ShellSubprocess = struct {
             }
         };
 
-        pub fn default(arena: *bun.ArenaAllocator, event_loop: JSC.EventLoopHandle, comptime is_sync: bool) SpawnArgs {
+        pub fn default(arena: *bun.ArenaAllocator, cmd_parent: *ShellCmd, event_loop: JSC.EventLoopHandle, comptime is_sync: bool) SpawnArgs {
             var out: SpawnArgs = .{
                 .arena = arena,
 
@@ -692,6 +689,7 @@ pub const ShellSubprocess = struct {
                 .PATH = event_loop.env().get("PATH") orelse "",
                 .argv = undefined,
                 .detached = false,
+                .cmd_parent = cmd_parent,
                 // .ipc_mode = IPCMode.none,
                 // .ipc_callback = .zero,
             };
@@ -841,7 +839,7 @@ pub const ShellSubprocess = struct {
             spawn_options.no_sigpipe = no_sigpipe;
         }
 
-        spawn_args.argv.append(allocator, null) catch {
+        spawn_args.cmd_parent.args.append(allocator, null) catch {
             return .{ .err = .{ .custom = bun.default_allocator.dupe(u8, "out of memory") catch bun.outOfMemory() } };
         };
 
@@ -851,7 +849,7 @@ pub const ShellSubprocess = struct {
 
         var spawn_result = switch (bun.spawn.spawnProcess(
             &spawn_options,
-            @ptrCast(spawn_args.argv.items.ptr),
+            @ptrCast(spawn_args.cmd_parent.args.items.ptr),
             @ptrCast(spawn_args.env_array.items.ptr),
         ) catch |err| {
             return .{ .err = .{ .custom = std.fmt.allocPrint(bun.default_allocator, "Failed to spawn process: {s}", .{@errorName(err)}) catch bun.outOfMemory() } };
@@ -945,10 +943,9 @@ pub const ShellSubprocess = struct {
         };
 
         if (exit_code) |code| {
-            if (this.cmd_parent) |cmd| {
-                if (cmd.exit_code == null) {
-                    cmd.onExit(code);
-                }
+            const cmd = this.cmd_parent;
+            if (cmd.exit_code == null) {
+                cmd.onExit(code);
             }
         }
     }
@@ -1218,22 +1215,21 @@ pub const PipeReader = struct {
         log("signalDoneToCmd ({x}: {s}) isDone={any}", .{ @intFromPtr(this), @tagName(this.out_type), this.isDone() });
         if (bun.Environment.allow_assert) assert(this.process != null);
         if (this.process) |proc| {
-            if (proc.cmd_parent) |cmd| {
-                if (this.captured_writer.err) |e| {
-                    if (this.state != .err) {
-                        this.state = .{ .err = e };
-                    }
+            const cmd = proc.cmd_parent;
+            if (this.captured_writer.err) |e| {
+                if (this.state != .err) {
+                    this.state = .{ .err = e };
                 }
-                const e: ?JSC.SystemError = brk: {
-                    if (this.state != .err) break :brk null;
-                    if (this.state.err) |*e| {
-                        e.ref();
-                        break :brk e.*;
-                    }
-                    break :brk null;
-                };
-                return cmd.bufferedOutputClose(this.out_type, e);
             }
+            const e: ?JSC.SystemError = brk: {
+                if (this.state != .err) break :brk null;
+                if (this.state.err) |*e| {
+                    e.ref();
+                    break :brk e.*;
+                }
+                break :brk null;
+            };
+            return cmd.bufferedOutputClose(this.out_type, e);
         }
         return .suspended;
     }

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -687,7 +687,6 @@ pub const ShellSubprocess = struct {
                 },
                 .lazy = false,
                 .PATH = event_loop.env().get("PATH") orelse "",
-                .argv = undefined,
                 .detached = false,
                 .cmd_parent = cmd_parent,
                 // .ipc_mode = IPCMode.none,
@@ -839,7 +838,7 @@ pub const ShellSubprocess = struct {
             spawn_options.no_sigpipe = no_sigpipe;
         }
 
-        spawn_args.cmd_parent.args.append(allocator, null) catch {
+        spawn_args.cmd_parent.args.append(null) catch {
             return .{ .err = .{ .custom = bun.default_allocator.dupe(u8, "out of memory") catch bun.outOfMemory() } };
         };
 

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -556,6 +556,31 @@ it("$npm_package_config_* works", async () => {
   expect(await new Response(p.stdout).text()).toBe(`bar\n`);
 });
 
+it("does not crash after spawning with $ variable", async () => {
+  await Bun.write(
+    join(run_dir, "package.json"),
+    JSON.stringify({
+      scripts: {
+        debug: "bun index.js $hi",
+      },
+    }),
+  );
+
+  const p = spawn({
+    cmd: [bunExe(), "run", "debug"],
+    cwd: run_dir,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: bunEnv,
+  });
+  expect(await p.exited).toBe(1);
+  const out = await p.stdout.text();
+  expect(out).toBe("");
+  const err = await p.stderr.text();
+  expect(err).toBe(
+    '$ bun index.js $hi\nerror: Module not found "index.js"\nerror: script "debug" exited with code 1\n',
+  );
+});
+
 it("should pass arguments correctly in scripts", async () => {
   const dir = tempDirWithFiles("test", {
     "package.json": JSON.stringify({


### PR DESCRIPTION
### What does this PR do?
spawn_args.argv was borrowing the list of args from Cmd.args. Then before spawning the borrowed list is appended to, possibly invalidating the original Cmd.args, leading to crashing on freeing the memory.

fixes #21086 
fixes #20854

most likely fixes #20834
most likely fixes #21044

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually. Added a test but this is a memory bug so it won't repro reliably. 
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
