### PR TITLE
fix #21088 (be more consistent with npm run env vars)

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -830,7 +830,7 @@ pub const RunCommand = struct {
             this_transpiler.runEnvLoader(true) catch {};
         }
 
-        this_transpiler.env.map.putDefault("npm_config_local_prefix", this_transpiler.fs.top_level_dir) catch unreachable;
+        this_transpiler.env.map.put("INIT_CWD", this_transpiler.fs.top_level_dir) catch unreachable;
 
         // we have no way of knowing what version they're expecting without running the node executable
         // running the node executable is too slow
@@ -872,6 +872,10 @@ pub const RunCommand = struct {
                     this_transpiler.env.map.putAssumeCapacity(key, v);
                 }
             }
+
+            this_transpiler.env.map.put("npm_config_local_prefix", package_json.source.path.name.dir) catch unreachable;
+        } else {
+            this_transpiler.env.map.put("npm_config_local_prefix", this_transpiler.fs.top_level_dir) catch unreachable;
         }
 
         return root_dir_info;
@@ -1381,7 +1385,7 @@ pub const RunCommand = struct {
         var this_transpiler: transpiler.Transpiler = undefined;
         const root_dir_info = try configureEnvForRun(ctx, &this_transpiler, null, log_errors, false);
         try configurePathForRun(ctx, root_dir_info, &this_transpiler, &ORIGINAL_PATH, root_dir_info.abs_path, force_using_bun);
-        this_transpiler.env.map.put("npm_command", "run-script") catch unreachable;
+        this_transpiler.env.map.put("npm_command", "run") catch unreachable;
 
         if (!ctx.debug.loaded_bunfig) {
             bun.CLI.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", ctx, .RunCommand) catch {};


### PR DESCRIPTION
### What does this PR do?

fix #21088

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->

made tests & tested behavior with npm
