### PR TITLE
[ENG-15045] add `--linker` and copyfile fallback for isolated installs

### DIFF
--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -566,6 +566,7 @@ src/install/install_binding.zig
 src/install/install.zig
 src/install/integrity.zig
 src/install/isolated_install.zig
+src/install/isolated_install/FileCopier.zig
 src/install/isolated_install/Hardlinker.zig
 src/install/isolated_install/Installer.zig
 src/install/isolated_install/Store.zig

--- a/src/fd.zig
+++ b/src/fd.zig
@@ -546,23 +546,6 @@ pub const FD = packed struct(backing_int) {
         };
     }
 
-    pub fn makeOpenPath(dir: FD, comptime T: type, subpath: []const T) !FD {
-        return switch (T) {
-            u8 => {
-                if (comptime Environment.isWindows) {
-                    return bun.sys.openDirAtWindowsA(dir, subpath, .{ .can_rename_or_delete = false, .create = true, .read_only = false }).unwrap();
-                }
-
-                return FD.fromStdDir(try dir.stdDir().makeOpenPath(subpath, .{ .iterate = true, .access_sub_paths = true }));
-            },
-            u16 => {
-                if (comptime !Environment.isWindows) @compileError("unexpected type");
-                return bun.sys.openDirAtWindows(dir, subpath, .{ .can_rename_or_delete = false, .create = true, .read_only = false }).unwrap();
-            },
-            else => @compileError("unexpected type"),
-        };
-    }
-
     // TODO: make our own version of deleteTree
     pub fn deleteTree(dir: FD, subpath: []const u8) !void {
         try dir.stdDir().deleteTree(subpath);

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -71,7 +71,7 @@ pub const PackageInstall = struct {
         packages_with_blocked_scripts: std.AutoArrayHashMapUnmanaged(TruncatedPackageNameHash, usize) = .{},
     };
 
-    pub const Method = enum {
+    pub const Method = enum(u8) {
         clonefile,
 
         /// Slower than clonefile

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -48,6 +48,7 @@ const shared_params = [_]ParamType{
     clap.parseParam("--save-text-lockfile                  Save a text-based lockfile") catch unreachable,
     clap.parseParam("--omit <dev|optional|peer>...         Exclude 'dev', 'optional', or 'peer' dependencies from install") catch unreachable,
     clap.parseParam("--lockfile-only                       Generate a lockfile without installing dependencies") catch unreachable,
+    clap.parseParam("--linker <STR>                        Linker strategy (one of \"isolated\" or \"hoisted\")") catch unreachable,
     clap.parseParam("-h, --help                            Print this help menu") catch unreachable,
 };
 
@@ -214,6 +215,8 @@ ca_file_name: string = "",
 save_text_lockfile: ?bool = null,
 
 lockfile_only: bool = false,
+
+node_linker: ?Options.NodeLinker = null,
 
 // `bun pm version` options
 git_tag_version: bool = true,
@@ -721,6 +724,10 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     cli.no_summary = args.flag("--no-summary");
     cli.ca = args.options("--ca");
     cli.lockfile_only = args.flag("--lockfile-only");
+
+    if (args.option("--linker")) |linker| {
+        cli.node_linker = .fromStr(linker);
+    }
 
     if (args.option("--cache-dir")) |cache_dir| {
         cli.cache_dir = cache_dir;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -535,6 +535,10 @@ pub fn load(
 
         this.lockfile_only = cli.lockfile_only;
 
+        if (cli.node_linker) |node_linker| {
+            this.node_linker = node_linker;
+        }
+
         const disable_progress_bar = default_disable_progress_bar or cli.no_progress;
 
         if (cli.verbose) {

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -660,7 +660,7 @@ pub fn installIsolatedPackages(
                         continue;
                     }
                     entry_steps[entry_id.get()].store(.done, .monotonic);
-                    installer.onTaskComplete(entry_id, .success);
+                    installer.onTaskComplete(entry_id, .skipped);
                     continue;
                 },
                 .symlink => {

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -618,6 +618,7 @@ pub fn installIsolatedPackages(
             .preallocated_tasks = .init(bun.default_allocator),
             .trusted_dependencies_mutex = .{},
             .trusted_dependencies_from_update_requests = manager.findTrustedDependenciesFromUpdateRequests(),
+            .supported_backend = .init(PackageInstall.supported_method),
         };
 
         // add the pending task count upfront

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -7,9 +7,9 @@ pub const FileCopier = struct {
     pub fn copy(this: *FileCopier, skip_dirnames: []const bun.OSPathSlice) OOM!sys.Maybe(void) {
         var dest_dir = dest_dir: {
             if (comptime Environment.isWindows) {
-                break :dest_dir FD.cwd().stdDir().openDirW(this.dest_subpath.slice(), .{}) catch {
+                break :dest_dir FD.cwd().stdDir().openDirW(this.dest_subpath.sliceZ(), .{}) catch {
                     FD.cwd().makePath(u16, this.dest_subpath.slice()) catch {};
-                    break :dest_dir FD.cwd().stdDir().openDirW(this.dest_subpath.slice(), .{}) catch {
+                    break :dest_dir FD.cwd().stdDir().openDirW(this.dest_subpath.sliceZ(), .{}) catch {
                         unreachable;
                     };
                 };
@@ -53,7 +53,7 @@ pub const FileCopier = struct {
 
                 switch (entry.kind) {
                     .directory => {
-                        if (bun.windows.CreateDirectoryExW(this.src_path.sliceZ(), this.dest_subpath.sliceZ(), null) == null) {
+                        if (bun.windows.CreateDirectoryExW(this.src_path.sliceZ(), this.dest_subpath.sliceZ(), null) == 0) {
                             bun.MakePath.makePath(u16, dest_dir, entry.path) catch {};
                         }
                     },

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -117,14 +117,12 @@ pub const FileCopier = struct {
 
 // @sortImports
 
-const std = @import("std");
-
 const Walker = @import("../../walker_skippable.zig");
 
 const bun = @import("bun");
 const Environment = bun.Environment;
 const FD = bun.FD;
-const OOM = bun.OOM;
-const sys = bun.sys;
-const Output = bun.Output;
 const Global = bun.Global;
+const OOM = bun.OOM;
+const Output = bun.Output;
+const sys = bun.sys;

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -5,19 +5,8 @@ pub const FileCopier = struct {
     dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }),
 
     pub fn copy(this: *FileCopier, skip_dirnames: []const bun.OSPathSlice) OOM!sys.Maybe(void) {
-        var dest_dir = dest_dir: {
-            if (comptime Environment.isWindows) {
-                break :dest_dir FD.cwd().stdDir().openDirW(this.dest_subpath.sliceZ(), .{}) catch {
-                    FD.cwd().makePath(u16, this.dest_subpath.slice()) catch {};
-                    break :dest_dir FD.cwd().stdDir().openDirW(this.dest_subpath.sliceZ(), .{}) catch {
-                        unreachable;
-                    };
-                };
-            }
-
-            break :dest_dir FD.cwd().stdDir().makeOpenPath(this.dest_subpath.slice(), .{}) catch {
-                unreachable;
-            };
+        var dest_dir = bun.MakePath.makeOpenPath(FD.cwd().stdDir(), this.dest_subpath.sliceZ(), .{}) catch {
+            unreachable;
         };
         defer dest_dir.close();
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -16,6 +16,8 @@ pub const Installer = struct {
     tasks: bun.UnboundedQueue(Task, .next) = .{},
     preallocated_tasks: Task.Preallocated,
 
+    supported_backend: std.atomic.Value(PackageInstall.Method),
+
     trusted_dependencies_from_update_requests: std.AutoArrayHashMapUnmanaged(TruncatedPackageNameHash, void),
 
     pub fn deinit(this: *const Installer) void {
@@ -410,31 +412,83 @@ pub const Installer = struct {
                         },
 
                         .folder => {
-                            // the folder does not exist in the cache
+                            // the folder does not exist in the cache. xdev is per folder dependency
                             const folder_dir = switch (bun.openDirForIteration(FD.cwd(), pkg_res.value.folder.slice(string_buf))) {
                                 .result => |fd| fd,
                                 .err => |err| return .failure(.{ .link_package = err }),
                             };
                             defer folder_dir.close();
 
-                            var src: bun.AbsPath(.{ .unit = .os, .sep = .auto }) = .initTopLevelDir();
-                            defer src.deinit();
-                            src.append(pkg_res.value.folder.slice(string_buf));
+                            backend: switch (PackageInstall.Method.hardlink) {
+                                .hardlink => {
+                                    var src: bun.AbsPath(.{ .unit = .os, .sep = .auto }) = .initTopLevelDir();
+                                    defer src.deinit();
+                                    src.append(pkg_res.value.folder.slice(string_buf));
 
-                            var dest: bun.RelPath(.{ .unit = .os, .sep = .auto }) = .init();
-                            defer dest.deinit();
+                                    var dest: bun.RelPath(.{ .unit = .os, .sep = .auto }) = .init();
+                                    defer dest.deinit();
 
-                            installer.appendStorePath(&dest, this.entry_id);
+                                    installer.appendStorePath(&dest, this.entry_id);
 
-                            var hardlinker: Hardlinker = .{
-                                .src_dir = folder_dir,
-                                .src = src,
-                                .dest = dest,
-                            };
+                                    var hardlinker: Hardlinker = .{
+                                        .src_dir = folder_dir,
+                                        .src = src,
+                                        .dest = dest,
+                                    };
 
-                            switch (try hardlinker.link(&.{comptime bun.OSPathLiteral("node_modules")})) {
-                                .result => {},
-                                .err => |err| return .failure(.{ .link_package = err }),
+                                    switch (try hardlinker.link(&.{comptime bun.OSPathLiteral("node_modules")})) {
+                                        .result => {},
+                                        .err => |err| {
+                                            if (err.getErrno() == .XDEV) {
+                                                continue :backend .copyfile;
+                                            }
+                                            return .failure(.{ .link_package = err });
+                                        },
+                                    }
+                                },
+
+                                .copyfile => {
+                                    var src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }) = .init();
+                                    defer src_path.deinit();
+
+                                    if (comptime Environment.isWindows) {
+                                        const src_path_len = bun.windows.GetFinalPathNameByHandleW(
+                                            folder_dir.cast(),
+                                            src_path.buf().ptr,
+                                            src_path.buf().len,
+                                            0,
+                                        );
+
+                                        if (src_path_len == 0) {
+                                            const e = bun.windows.Win32Error.get();
+                                            const err = e.toSystemErrno() orelse .EUNKNOWN;
+                                            return .failure(
+                                                .{ .link_package = .{ .errno = @intFromEnum(err), .syscall = .copyfile } },
+                                            );
+                                        }
+
+                                        src_path.setLength(src_path_len);
+                                    }
+
+                                    var dest: bun.RelPath(.{ .unit = .os, .sep = .auto }) = .init();
+                                    defer dest.deinit();
+                                    installer.appendStorePath(&dest, this.entry_id);
+
+                                    var file_copier: FileCopier = .{
+                                        .src_dir = folder_dir,
+                                        .src_path = src_path,
+                                        .dest_subpath = dest,
+                                    };
+
+                                    switch (try file_copier.copy(&.{})) {
+                                        .result => {},
+                                        .err => |err| {
+                                            return .failure(.{ .link_package = err });
+                                        },
+                                    }
+                                },
+
+                                else => unreachable,
                             }
 
                             continue :next_step this.nextStep(current_step);
@@ -447,89 +501,112 @@ pub const Installer = struct {
 
                     var dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }) = .init();
                     defer dest_subpath.deinit();
-
                     installer.appendStorePath(&dest_subpath, this.entry_id);
 
-                    // link the package
-                    if (comptime Environment.isMac) {
-                        if (install.PackageInstall.supported_method == .clonefile) hardlink_fallback: {
+                    var cached_package_dir: ?FD = null;
+                    defer if (cached_package_dir) |dir| dir.close();
+
+                    backend: switch (installer.supported_backend.load(.monotonic)) {
+                        .clonefile => {
+                            if (comptime !Environment.isMac) {
+                                installer.supported_backend.store(.hardlink, .monotonic);
+                                continue :backend .hardlink;
+                            }
+
                             switch (sys.clonefileat(cache_dir, pkg_cache_dir_subpath.sliceZ(), FD.cwd(), dest_subpath.sliceZ())) {
-                                .result => {
-                                    // success! move to next step
-                                    continue :next_step this.nextStep(current_step);
-                                },
+                                .result => {},
                                 .err => |clonefile_err1| {
                                     switch (clonefile_err1.getErrno()) {
-                                        .XDEV => break :hardlink_fallback,
-                                        .OPNOTSUPP => break :hardlink_fallback,
+                                        .XDEV => {
+                                            installer.supported_backend.store(.copyfile, .monotonic);
+                                            continue :backend .copyfile;
+                                        },
+                                        .OPNOTSUPP => {
+                                            installer.supported_backend.store(.hardlink, .monotonic);
+                                            continue :backend .hardlink;
+                                        },
                                         .NOENT => {
                                             const parent_dest_dir = std.fs.path.dirname(dest_subpath.slice()) orelse {
                                                 return .failure(.{ .link_package = clonefile_err1 });
                                             };
-
                                             FD.cwd().makePath(u8, parent_dest_dir) catch {};
-
                                             switch (sys.clonefileat(cache_dir, pkg_cache_dir_subpath.sliceZ(), FD.cwd(), dest_subpath.sliceZ())) {
-                                                .result => {
-                                                    continue :next_step this.nextStep(current_step);
-                                                },
-                                                .err => |clonefile_err2| {
-                                                    return .failure(.{ .link_package = clonefile_err2 });
-                                                },
+                                                .result => {},
+                                                .err => |clonefile_err2| return .failure(.{ .link_package = clonefile_err2 }),
                                             }
                                         },
                                         else => {
-                                            break :hardlink_fallback;
+                                            installer.supported_backend.store(.hardlink, .monotonic);
+                                            continue :backend .hardlink;
                                         },
                                     }
                                 },
                             }
-                        }
-                    }
 
-                    const cached_package_dir = cached_package_dir: {
-                        if (comptime Environment.isWindows) {
-                            break :cached_package_dir switch (sys.openDirAtWindowsA(
-                                cache_dir,
-                                pkg_cache_dir_subpath.slice(),
-                                .{ .iterable = true, .can_rename_or_delete = false, .read_only = true },
-                            )) {
-                                .result => |dir_fd| dir_fd,
+                            continue :next_step this.nextStep(current_step);
+                        },
+
+                        .hardlink => {
+                            cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
+                                .result => |fd| fd,
                                 .err => |err| {
                                     return .failure(.{ .link_package = err });
                                 },
                             };
-                        }
-                        break :cached_package_dir switch (sys.openat(
-                            cache_dir,
-                            pkg_cache_dir_subpath.sliceZ(),
-                            bun.O.DIRECTORY | bun.O.CLOEXEC | bun.O.RDONLY,
-                            0,
-                        )) {
-                            .result => |fd| fd,
-                            .err => |err| {
-                                return .failure(.{ .link_package = err });
-                            },
-                        };
-                    };
-                    defer cached_package_dir.close();
 
-                    var src: bun.AbsPath(.{ .sep = .auto, .unit = .os }) = .from(cache_dir_path.slice());
-                    defer src.deinit();
-                    src.append(pkg_cache_dir_subpath.slice());
+                            var src: bun.AbsPath(.{ .sep = .auto, .unit = .os }) = .from(cache_dir_path.slice());
+                            defer src.deinit();
+                            src.append(pkg_cache_dir_subpath.slice());
 
-                    var hardlinker: Hardlinker = .{
-                        .src_dir = cached_package_dir,
-                        .src = src,
-                        .dest = dest_subpath,
-                    };
+                            var hardlinker: Hardlinker = .{
+                                .src_dir = cached_package_dir.?,
+                                .src = src,
+                                .dest = dest_subpath,
+                            };
 
-                    switch (try hardlinker.link(&.{})) {
-                        .result => {},
-                        .err => |err| return .failure(.{ .link_package = err }),
+                            switch (try hardlinker.link(&.{})) {
+                                .result => {},
+                                .err => |err| {
+                                    if (err.getErrno() == .XDEV) {
+                                        installer.supported_backend.store(.copyfile, .monotonic);
+                                        continue :backend .copyfile;
+                                    }
+                                    return .failure(.{ .link_package = err });
+                                },
+                            }
+
+                            continue :next_step this.nextStep(current_step);
+                        },
+
+                        // fallthrough copyfile
+                        else => {
+                            cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
+                                .result => |fd| fd,
+                                .err => |err| {
+                                    return .failure(.{ .link_package = err });
+                                },
+                            };
+
+                            var src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }) = .from(cache_dir_path.slice());
+                            defer src_path.deinit();
+                            src_path.append(pkg_cache_dir_subpath.slice());
+
+                            var file_copier: FileCopier = .{
+                                .src_dir = cached_package_dir.?,
+                                .src_path = src_path,
+                                .dest_subpath = dest_subpath,
+                            };
+
+                            switch (try file_copier.copy(&.{})) {
+                                .result => {},
+                                .err => |err| {
+                                    return .failure(.{ .link_package = err });
+                                },
+                            }
+
+                            continue :next_step this.nextStep(current_step);
+                        },
                     }
-
-                    continue :next_step this.nextStep(current_step);
                 },
                 inline .symlink_dependencies => |current_step| {
                     const string_buf = lockfile.buffers.string_bytes.items;
@@ -1109,6 +1186,7 @@ pub const Installer = struct {
 const std = @import("std");
 const Hardlinker = @import("./Hardlinker.zig").Hardlinker;
 const Symlinker = @import("./Symlinker.zig").Symlinker;
+const FileCopier = @import("./FileCopier.zig").FileCopier;
 
 const bun = @import("bun");
 const Environment = bun.Environment;
@@ -1137,3 +1215,4 @@ const invalid_dependency_id = install.invalid_dependency_id;
 
 const Lockfile = install.Lockfile;
 const Package = Lockfile.Package;
+const Walker = @import("../../walker_skippable.zig");

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -455,7 +455,7 @@ pub const Installer = struct {
                                         const src_path_len = bun.windows.GetFinalPathNameByHandleW(
                                             folder_dir.cast(),
                                             src_path.buf().ptr,
-                                            src_path.buf().len,
+                                            @intCast(src_path.buf().len),
                                             0,
                                         );
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1184,9 +1184,9 @@ pub const Installer = struct {
 // @sortImports
 
 const std = @import("std");
+const FileCopier = @import("./FileCopier.zig").FileCopier;
 const Hardlinker = @import("./Hardlinker.zig").Hardlinker;
 const Symlinker = @import("./Symlinker.zig").Symlinker;
-const FileCopier = @import("./FileCopier.zig").FileCopier;
 
 const bun = @import("bun");
 const Environment = bun.Environment;
@@ -1215,4 +1215,3 @@ const invalid_dependency_id = install.invalid_dependency_id;
 
 const Lockfile = install.Lockfile;
 const Package = Lockfile.Package;
-const Walker = @import("../../walker_skippable.zig");

--- a/src/paths/Path.zig
+++ b/src/paths/Path.zig
@@ -398,13 +398,31 @@ pub fn Path(comptime opts: Options) type {
             }
         }
 
-        // pub fn buf(this: *const @This()) []opts.pathUnit() {
-        //     switch (comptime opts.buf_type) {
-        //         .pool => {
-        //             return this._buf.pooled;
-        //         },
-        //     }
-        // }
+        pub fn buf(this: *const @This()) []opts.pathUnit() {
+            switch (comptime opts.buf_type) {
+                .pool => {
+                    return this._buf.pooled;
+                },
+            }
+        }
+
+        pub fn setLength(this: *const @This(), new_length: usize) void {
+            this._buf.setLength(new_length);
+
+            const trimmed = switch (comptime opts.kind) {
+                .abs => trimInput(.abs, this.slice()),
+                .rel => trimInput(.rel, this.slice()),
+                .any => trimmed: {
+                    if (this.isAbsolute()) {
+                        break :trimmed trimInput(.abs, this.slice());
+                    }
+
+                    break :trimmed trimInput(.rel, this.slice());
+                },
+            };
+
+            this._buf.setLength(trimmed.len);
+        }
 
         pub fn len(this: *const @This()) usize {
             switch (comptime opts.buf_type) {

--- a/src/paths/Path.zig
+++ b/src/paths/Path.zig
@@ -406,7 +406,7 @@ pub fn Path(comptime opts: Options) type {
             }
         }
 
-        pub fn setLength(this: *const @This(), new_length: usize) void {
+        pub fn setLength(this: *@This(), new_length: usize) void {
             this._buf.setLength(new_length);
 
             const trimmed = switch (comptime opts.kind) {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,7 +1,8 @@
-import { file, write } from "bun";
+import { file, write, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { existsSync, readlinkSync } from "fs";
-import { VerdaccioRegistry, bunEnv, readdirSorted, runBunInstall } from "harness";
+import { existsSync, readlinkSync, lstatSync } from "fs";
+import { rm } from "fs/promises";
+import { VerdaccioRegistry, bunEnv, readdirSorted, runBunInstall, bunExe } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -343,6 +344,174 @@ describe("isolated workspaces", () => {
   });
 });
 
+for (const backend of ["clonefile", "hardlink", "copyfile"]) {
+  test(`isolated install with backend: ${backend}`, async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ isolated: true });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-backend",
+        dependencies: {
+          "no-deps": "1.0.0",
+          "alias-loop-2": "1.0.0",
+          "alias-loop-1": "1.0.0",
+          "1-peer-dep-a": "1.0.0",
+          "basic-1": "1.0.0",
+          "is-number": "1.0.0",
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--backend", backend],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(await exited).toBe(0);
+    const out = await stdout.text();
+    const err = await stderr.text();
+
+    expect(err).not.toContain("error");
+    expect(err).not.toContain("warning");
+
+    expect(
+      await file(
+        join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps", "package.json"),
+      ).json(),
+    ).toEqual({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+  });
+}
+
+describe("--linker flag", () => {
+  test("can override linker from bunfig", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ isolated: true });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-linker",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+
+    let { exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeTrue();
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    ({ exited } = spawn({
+      cmd: [bunExe(), "install", "--linker", "hoisted"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    }));
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeFalse();
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    ({ exited } = spawn({
+      cmd: [bunExe(), "install", "--linker", "isolated"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    }));
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeTrue();
+  });
+
+  test("works as the only config option", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir();
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-linker",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+
+    let { exited } = spawn({
+      cmd: [bunExe(), "install", "--linker", "isolated"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeTrue();
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    ({ exited } = spawn({
+      cmd: [bunExe(), "install", "--linker", "hoisted"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    }));
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeFalse();
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    ({ exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    }));
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeFalse();
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    ({ exited } = spawn({
+      cmd: [bunExe(), "install", "--linker", "isolated"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    }));
+
+    expect(await exited).toBe(0);
+
+    expect(lstatSync(join(packageDir, "node_modules", "no-deps")).isSymbolicLink()).toBeTrue();
+  });
+});
 test("many transitive dependencies", async () => {
   const { packageJson, packageDir } = await registry.createTestDir({ isolated: true });
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,8 +1,8 @@
-import { file, write, spawn } from "bun";
+import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { existsSync, readlinkSync, lstatSync } from "fs";
+import { existsSync, lstatSync, readlinkSync } from "fs";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, readdirSorted, runBunInstall, bunExe } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();


### PR DESCRIPTION
### What does this PR do?
- Packages will be installed by copying files when hardlink or clonefile received XDEV
- Added `--linker=isolated` and `--linker=hoisted`
- fixes progress bar for isolated installs
- fixes counting installed packages for the install summary
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added tests for install backends and `--linker`
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
