### PR TITLE
PipeReader: remove shrinkAndFree call

### DIFF
--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -225,7 +225,6 @@ const PosixBufferedReader = struct {
 
         bun.assert(!this.flags.is_done);
         this.flags.is_done = true;
-        this._buffer.shrinkAndFree(this._buffer.items.len);
     }
 
     fn closeHandle(this: *PosixBufferedReader) void {
@@ -838,7 +837,6 @@ pub const WindowsBufferedReader = struct {
     fn finish(this: *WindowsBufferedReader) void {
         this.flags.has_inflight_read = false;
         this.flags.is_done = true;
-        this._buffer.shrinkAndFree(this._buffer.items.len);
     }
 
     pub fn done(this: *WindowsBufferedReader) void {


### PR DESCRIPTION
lines first added in https://github.com/oven-sh/bun/pull/20102
occasionally caused an assertion failure on windows in mimalloc
tested locally and it did not regress `test/js/bun/spawn/spawn-noread-leak.test.ts`
seeing if affects `test/js/node/test/parallel/test-child-process-spawnsync-shell.js`
