### PR TITLE
Add support for AI agent environment variables to quiet test output

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1541,7 +1541,7 @@ pub const TestCommand = struct {
         const write_snapshots_success = try jest.Jest.runner.?.snapshots.writeInlineSnapshots();
         try jest.Jest.runner.?.snapshots.writeSnapshotFile();
         var coverage_options = ctx.test_options.coverage;
-        if (reporter.summary().pass > 20) {
+        if (reporter.summary().pass > 20 and !Output.isAIAgent()) {
             if (reporter.summary().skip > 0) {
                 Output.prettyError("\n<r><d>{d} tests skipped:<r>\n", .{reporter.summary().skip});
                 Output.flush();

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1585,7 +1585,7 @@ pub const TestCommand = struct {
             if (ctx.positionals.len < 2) {
                 if (Output.isAIAgent()) {
                     // Be very clear to ai.
-                    Output.errGeneric("0 test files matching **.{{test,spec,_test_,_spec_}}.{{js,ts,jsx,tsx}} found in cwd {}", .{bun.fmt.quote(bun.fs.FileSystem.instance.top_level_dir)});
+                    Output.errGeneric("0 test files matching **{{.test,.spec,_test_,_spec_}}.{{js,ts,jsx,tsx}} in --cwd={}", .{bun.fmt.quote(bun.fs.FileSystem.instance.top_level_dir)});
                 } else {
                     // Be friendlier to humans.
                     Output.prettyErrorln(

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1316,11 +1316,9 @@ pub const TestCommand = struct {
     pub fn exec(ctx: Command.Context) !void {
         Output.is_github_action = Output.isGithubAction();
 
-        if (!Output.isAIAgent()) {
-            // print the version so you know its doing stuff if it takes a sec
-            Output.prettyln("<r><b>bun test <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>", .{});
-            Output.flush();
-        }
+        // print the version so you know its doing stuff if it takes a sec
+        Output.prettyln("<r><b>bun test <r><d>v" ++ Global.package_json_version_with_sha ++ "<r>", .{});
+        Output.flush();
 
         var env_loader = brk: {
             const map = try ctx.allocator.create(DotEnv.Map);

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -36,7 +36,6 @@ pub const RuntimeFeatureFlag = enum {
     BUN_INTERNAL_BUNX_INSTALL,
     BUN_NO_CODESIGN_MACHO_BINARY,
     BUN_TRACE,
-    CLAUDECODE,
     NODE_NO_WARNINGS,
 };
 

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -36,6 +36,7 @@ pub const RuntimeFeatureFlag = enum {
     BUN_INTERNAL_BUNX_INSTALL,
     BUN_NO_CODESIGN_MACHO_BINARY,
     BUN_TRACE,
+    CLAUDECODE,
     NODE_NO_WARNINGS,
 };
 

--- a/src/output.zig
+++ b/src/output.zig
@@ -462,6 +462,55 @@ pub fn isGithubAction() bool {
     return false;
 }
 
+pub fn isAIAgent() bool {
+    const get_is_agent = struct {
+        var value = false;
+        fn evaluate() bool {
+            if (bun.getenvZ("IS_CODE_AGENT")) |env| {
+                return strings.eqlComptime(env, "1");
+            }
+
+            if (isVerbose()) {
+                return false;
+            }
+
+            // Claude Code.
+            if (bun.getenvTruthy("CLAUDECODE")) {
+                return true;
+            }
+
+            // Replit.
+            if (bun.getenvTruthy("REPL_ID")) {
+                return true;
+            }
+
+            // TODO: add environment variable for Gemini
+            // Gemini does not appear to add any environment variables to identify it.
+
+            // TODO: add environment variable for Codex
+            // codex does not appear to add any environment variables to identify it.
+
+            // TODO: add environment variable for Cursor Background Agents
+            // cursor does not appear to add any environment variables to identify it.
+
+            return false;
+        }
+
+        fn setValue() void {
+            value = evaluate();
+        }
+
+        var once = std.once(setValue);
+
+        pub fn isEnabled() bool {
+            once.call();
+            return value;
+        }
+    };
+
+    return get_is_agent.isEnabled();
+}
+
 pub fn isVerbose() bool {
     // Set by Github Actions when a workflow is run using debug mode.
     if (bun.getenvZ("RUNNER_DEBUG")) |value| {

--- a/src/output.zig
+++ b/src/output.zig
@@ -457,7 +457,9 @@ pub inline fn isEmojiEnabled() bool {
 
 pub fn isGithubAction() bool {
     if (bun.getenvZ("GITHUB_ACTIONS")) |value| {
-        return strings.eqlComptime(value, "true");
+        return strings.eqlComptime(value, "true") and
+            // Do not print github annotations for AI agents because that wastes the context window.
+            !isAIAgent();
     }
     return false;
 }

--- a/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
+++ b/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
@@ -1,0 +1,5 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`CLAUDECODE=0 shows normal test output 1`] = `"bun test <version> (<revision>)"`;
+
+exports[`CLAUDECODE=1 shows quiet test output (only failures) 1`] = `"bun test <version> (<revision>)"`;

--- a/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
+++ b/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
@@ -21,7 +21,8 @@ Received: 1
  1 todo
  1 fail
  2 expect() calls
-Ran 4 tests across 1 file."
+Ran 4 tests across 1 file.
+bun test <version> (<revision>)"
 `;
 
 exports[`CLAUDECODE=1 vs CLAUDECODE=0 comparison: normal 1`] = `
@@ -46,7 +47,8 @@ exports[`CLAUDECODE=1 vs CLAUDECODE=0 comparison: quiet 1`] = `
  1 todo
  0 fail
  2 expect() calls
-Ran 4 tests across 1 file."
+Ran 4 tests across 1 file.
+bun test <version> (<revision>)"
 `;
 
 exports[`CLAUDECODE flag handles no test files found: no-tests-normal 1`] = `
@@ -58,4 +60,8 @@ Learn more about bun test: https://bun.com/docs/cli/test
 bun test <version> (<revision>)"
 `;
 
-exports[`CLAUDECODE flag handles no test files found: no-tests-quiet 1`] = `"error: 0 test files matching **.{test,spec,_test_,_spec_}.{js,ts,jsx,tsx} found in cwd "<dir>""`;
+exports[`CLAUDECODE flag handles no test files found: no-tests-quiet 1`] = `
+"error: 0 test files matching **.{test,spec,_test_,_spec_}.{js,ts,jsx,tsx} found in cwd "<dir>"
+
+bun test <version> (<revision>)"
+`;

--- a/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
+++ b/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
@@ -1,5 +1,61 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`CLAUDECODE=0 shows normal test output 1`] = `"bun test <version> (<revision>)"`;
+exports[`CLAUDECODE=1 shows quiet test output (only failures) 1`] = `
+"4 |       test("passing test", () => {
+5 |         expect(1).toBe(1);
+6 |       });
+7 | 
+8 |       test("failing test", () => {
+9 |         expect(1).toBe(2);
+                      ^
+error: expect(received).toBe(expected)
 
-exports[`CLAUDECODE=1 shows quiet test output (only failures) 1`] = `"bun test <version> (<revision>)"`;
+Expected: 2
+Received: 1
+    at <anonymous> (file:NN:NN)
+
+test2.test.js:
+(fail) failing test
+
+ 1 pass
+ 1 skip
+ 1 todo
+ 1 fail
+ 2 expect() calls
+Ran 4 tests across 1 file."
+`;
+
+exports[`CLAUDECODE=1 vs CLAUDECODE=0 comparison: normal 1`] = `
+"test3.test.js:
+(pass) passing test
+(pass) another passing test
+(skip) skipped test
+(todo) todo test
+
+ 2 pass
+ 1 skip
+ 1 todo
+ 0 fail
+ 2 expect() calls
+Ran 4 tests across 1 file.
+bun test <version> (<revision>)"
+`;
+
+exports[`CLAUDECODE=1 vs CLAUDECODE=0 comparison: quiet 1`] = `
+"2 pass
+ 1 skip
+ 1 todo
+ 0 fail
+ 2 expect() calls
+Ran 4 tests across 1 file."
+`;
+
+exports[`CLAUDECODE flag handles no test files found: no-tests-normal 1`] = `
+"No tests found!
+Tests need ".test", "_test_", ".spec" or "_spec_" in the filename (ex: "MyApp.test.ts")
+
+Learn more about bun test: https://bun.com/docs/cli/test
+bun test <version> (<revision>)"
+`;
+
+exports[`CLAUDECODE flag handles no test files found: no-tests-quiet 1`] = `"error: 0 test files matching **.{test,spec,_test_,_spec_}.{js,ts,jsx,tsx} found in cwd "<dir>""`;

--- a/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
+++ b/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
@@ -61,7 +61,7 @@ bun test <version> (<revision>)"
 `;
 
 exports[`CLAUDECODE flag handles no test files found: no-tests-quiet 1`] = `
-"error: 0 test files matching **.{test,spec,_test_,_spec_}.{js,ts,jsx,tsx} found in cwd "<dir>"
+"error: 0 test files matching **{.test,.spec,_test_,_spec_}.{js,ts,jsx,tsx} in --cwd="<dir>"
 
 bun test <version> (<revision>)"
 `;

--- a/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
+++ b/test/cli/test/__snapshots__/claudecode-flag.test.ts.snap
@@ -1,7 +1,8 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`CLAUDECODE=1 shows quiet test output (only failures) 1`] = `
-"4 |       test("passing test", () => {
+"test2.test.js:
+4 |       test("passing test", () => {
 5 |         expect(1).toBe(1);
 6 |       });
 7 | 
@@ -13,8 +14,6 @@ error: expect(received).toBe(expected)
 Expected: 2
 Received: 1
     at <anonymous> (file:NN:NN)
-
-test2.test.js:
 (fail) failing test
 
  1 pass
@@ -52,6 +51,7 @@ Ran 4 tests across 1 file."
 
 exports[`CLAUDECODE flag handles no test files found: no-tests-normal 1`] = `
 "No tests found!
+
 Tests need ".test", "_test_", ".spec" or "_spec_" in the filename (ex: "MyApp.test.ts")
 
 Learn more about bun test: https://bun.com/docs/cli/test

--- a/test/cli/test/claudecode-flag.test.ts
+++ b/test/cli/test/claudecode-flag.test.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles, normalizeBunSnapshot } from "harness";
+import { spawnSync } from "bun";
+
+test("CLAUDECODE=0 shows normal test output", async () => {
+  const dir = tempDirWithFiles("claudecode-test-normal", {
+    "test1.test.js": `
+      import { test, expect } from "bun:test";
+      
+      test("passing test", () => {
+        expect(1).toBe(1);
+      });
+      
+      test("failing test", () => {
+        expect(1).toBe(2);
+      });
+      
+      test.skip("skipped test", () => {
+        expect(1).toBe(1);
+      });
+      
+      test.todo("todo test");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test1.test.js"],
+    env: { ...bunEnv, CLAUDECODE: "0" },
+    cwd: dir,
+  });
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  const output = stderr + stdout;
+  const normalized = normalizeBunSnapshot(output, dir);
+
+  expect(normalized).toMatchSnapshot();
+});
+
+test("CLAUDECODE=1 shows quiet test output (only failures)", async () => {
+  const dir = tempDirWithFiles("claudecode-test-quiet", {
+    "test2.test.js": `
+      import { test, expect } from "bun:test";
+      
+      test("passing test", () => {
+        expect(1).toBe(1);
+      });
+      
+      test("failing test", () => {
+        expect(1).toBe(2);
+      });
+      
+      test.skip("skipped test", () => {
+        expect(1).toBe(1);
+      });
+      
+      test.todo("todo test");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test2.test.js"],
+    env: { ...bunEnv, CLAUDECODE: "1" },
+    cwd: dir,
+  });
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  const output = stderr + stdout;
+  const normalized = normalizeBunSnapshot(output, dir);
+
+  expect(normalized).toMatchSnapshot();
+});
+
+test("CLAUDECODE=1 vs CLAUDECODE=0 comparison", async () => {
+  const dir = tempDirWithFiles("claudecode-test-compare", {
+    "test3.test.js": `
+      import { test, expect } from "bun:test";
+      
+      test("passing test", () => {
+        expect(1).toBe(1);
+      });
+      
+      test("another passing test", () => {
+        expect(2).toBe(2);
+      });
+      
+      test.skip("skipped test", () => {
+        expect(1).toBe(1);
+      });
+      
+      test.todo("todo test");
+    `,
+  });
+
+  // Run with CLAUDECODE=0 (normal output)
+  const result1 = spawnSync({
+    cmd: [bunExe(), "test", "test3.test.js"],
+    env: { ...bunEnv, CLAUDECODE: "0" },
+    cwd: dir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  // Run with CLAUDECODE=1 (quiet output)
+  const result2 = spawnSync({
+    cmd: [bunExe(), "test", "test3.test.js"],
+    env: { ...bunEnv, CLAUDECODE: "1" },
+    cwd: dir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const normalOutput = result1.stderr.toString() + result1.stdout.toString();
+  const quietOutput = result2.stderr.toString() + result2.stdout.toString();
+
+
+  // Normal output should contain pass/skip/todo indicators
+  expect(normalOutput).toContain("(pass)"); // pass indicator
+  expect(normalOutput).toContain("(skip)"); // skip indicator  
+  expect(normalOutput).toContain("(todo)"); // todo indicator
+
+  // Quiet output should NOT contain pass/skip/todo indicators (only failures)
+  expect(quietOutput).not.toContain("(pass)"); // pass indicator
+  expect(quietOutput).not.toContain("(skip)"); // skip indicator
+  expect(quietOutput).not.toContain("(todo)"); // todo indicator
+
+  // Both should contain the summary at the end
+  expect(normalOutput).toContain("2 pass");
+  expect(normalOutput).toContain("1 skip");
+  expect(normalOutput).toContain("1 todo");
+  
+  expect(quietOutput).toContain("2 pass");
+  expect(quietOutput).toContain("1 skip");
+  expect(quietOutput).toContain("1 todo");
+});

--- a/test/cli/test/claudecode-flag.test.ts
+++ b/test/cli/test/claudecode-flag.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles, normalizeBunSnapshot } from "harness";
 import { spawnSync } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
 
 test("CLAUDECODE=0 shows normal test output", async () => {
   const dir = tempDirWithFiles("claudecode-test-normal", {
@@ -29,10 +29,7 @@ test("CLAUDECODE=0 shows normal test output", async () => {
     cwd: dir,
   });
 
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 
   const output = stderr + stdout;
   const normalized = normalizeBunSnapshot(output, dir);
@@ -67,10 +64,7 @@ test("CLAUDECODE=1 shows quiet test output (only failures)", async () => {
     cwd: dir,
   });
 
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 
   const output = stderr + stdout;
   const normalized = normalizeBunSnapshot(output, dir);
@@ -120,10 +114,9 @@ test("CLAUDECODE=1 vs CLAUDECODE=0 comparison", async () => {
   const normalOutput = result1.stderr.toString() + result1.stdout.toString();
   const quietOutput = result2.stderr.toString() + result2.stdout.toString();
 
-
   // Normal output should contain pass/skip/todo indicators
   expect(normalOutput).toContain("(pass)"); // pass indicator
-  expect(normalOutput).toContain("(skip)"); // skip indicator  
+  expect(normalOutput).toContain("(skip)"); // skip indicator
   expect(normalOutput).toContain("(todo)"); // todo indicator
 
   // Quiet output should NOT contain pass/skip/todo indicators (only failures)
@@ -135,7 +128,7 @@ test("CLAUDECODE=1 vs CLAUDECODE=0 comparison", async () => {
   expect(normalOutput).toContain("2 pass");
   expect(normalOutput).toContain("1 skip");
   expect(normalOutput).toContain("1 todo");
-  
+
   expect(quietOutput).toContain("2 pass");
   expect(quietOutput).toContain("1 skip");
   expect(quietOutput).toContain("1 todo");


### PR DESCRIPTION
## Summary

This PR adds support for AI agent environment variables to enable quiet test output in Bun's test runner. When an AI agent is detected through environment variables like `CLAUDECODE=1`, `REPL_ID=1`, or `IS_CODE_AGENT=1`, the test runner reduces verbosity by only showing failures while still maintaining accurate test summary counts.

## Changes

- **Uses existing `Output.isAIAgent()` function** in `src/output.zig` which detects:
  - `CLAUDECODE=1` - Claude Code
  - `REPL_ID=1` - Replit
  - `IS_CODE_AGENT=1` - Generic AI agent flag
  - (Future support for Gemini, Codex, and Cursor background agents)
- **Modified test output functions** in `src/cli/test_command.zig`:
  - `writeTestStatusLine()` - Skip non-failure status indicators in quiet mode
  - `printTestLine()` - Skip non-failure test line output (with full JUnit support)
- **Added comprehensive test suite** with snapshots in `test/cli/test/claudecode-flag.test.ts`

## Behavior

### When AI agent is detected:
- Only test failures are displayed with their full output
- Passing, skipped, and todo test indicators are hidden
- Summary statistics are still shown at the end
- JUnit reporter output remains unaffected
- Error messages are more concise (e.g., "0 test files matching..." instead of friendly hints)

### When no AI agent is detected:
- All test output is shown normally (existing behavior)

## Example Output

**Normal mode (no AI agent):**
```
test.js:
(pass) passing test [1.00ms]
(fail) failing test [2.00ms]
(skip) skipped test
(todo) todo test

 1 pass
 1 skip
 1 todo
 1 fail
```

**Quiet mode (AI agent detected):**
```
test.js:
(fail) failing test [2.00ms]

 1 pass
 1 skip
 1 todo
 1 fail
```

## Test plan

- [x] All existing tests pass
- [x] New comprehensive test suite with snapshots
- [x] Comparison tests between AI agent and normal modes
- [x] Debug build compilation successful
- [x] JUnit reporter functionality preserved
- [x] Summary statistics accuracy maintained

This feature is useful for AI coding assistants where reduced output verbosity improves readability and context efficiency while still providing essential failure information.

🤖 Generated with [Claude Code](https://claude.ai/code)