### PR TITLE
Include `sudo apt update` in CONTRIBUTING.md for Ubuntu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ $ brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool
 ```
 
 ```bash#Ubuntu/Debian
+$ sudo apt update
 $ sudo apt install curl wget lsb-release software-properties-common cargo ccache cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
 ```
 


### PR DESCRIPTION
For those of us who don't use `apt` on a daily basis, it's easy to forget to run this: https://github.com/oven-sh/bun/issues/21144#issuecomment-3086407493

In particular, this avoids an inscrutable error when trying to set up codespace for https://github.com/oven-sh/bun

### What does this PR do?

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes
