### PR TITLE
Update interactive spacing

### DIFF
--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -30,7 +30,6 @@ pub const TerminalHyperlink = struct {
 };
 
 pub const UpdateInteractiveCommand = struct {
-    
     const OutdatedPackage = struct {
         name: []const u8,
         current_version: []const u8,
@@ -598,7 +597,7 @@ pub const UpdateInteractiveCommand = struct {
             } else if (pkg.behavior.optional) {
                 dev_tag_len = 9; // " optional"
             }
-            
+
             max_name_len = @max(max_name_len, pkg.name.len + dev_tag_len);
             max_current_len = @max(max_current_len, pkg.current_version.len);
             max_target_len = @max(max_target_len, pkg.update_version.len);

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -590,8 +590,8 @@ pub const UpdateInteractiveCommand = struct {
         var max_latest_len: usize = "Latest".len;
 
         // Set reasonable limits to prevent excessive column widths
-        const MAX_NAME_WIDTH = 60;
-        const MAX_VERSION_WIDTH = 20;
+        const MAX_NAME_WIDTH = 80;
+        const MAX_VERSION_WIDTH = 30;
 
         for (packages) |pkg| {
             // Include dev tag length in max calculation
@@ -870,8 +870,8 @@ pub const UpdateInteractiveCommand = struct {
                 defer if (package_url.len > 0) bun.default_allocator.free(package_url);
 
                 // Truncate package name if it's too long
-                const display_name = if (pkg.name.len > 60)
-                    try std.fmt.allocPrint(bun.default_allocator, "{s}...", .{pkg.name[0..57]})
+                const display_name = if (pkg.name.len > MAX_NAME_WIDTH)
+                    try std.fmt.allocPrint(bun.default_allocator, "{s}...", .{pkg.name[0..MAX_NAME_WIDTH-3]})
                 else
                     pkg.name;
                 defer if (display_name.ptr != pkg.name.ptr) bun.default_allocator.free(display_name);

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -756,10 +756,11 @@ pub const UpdateInteractiveCommand = struct {
                     // The padding should align with the first character of package names
                     // Package names start at: "    " (4 spaces) + "□ " (2 chars) = 6 chars from left
                     // Headers start at: "  " (2 spaces) + dep_type_text
-                    // So we need to pad: 4 (cursor/space) + 2 (checkbox+space) + max_name_len + 4 (name padding) - dep_type_text_len
-                    // Use safe subtraction to prevent underflow when dep_type_text_len is longer than available space
-                    const base_padding = 4 + 2 + state.max_name_len + 4;
-                    const padding_to_current = if (dep_type_text_len >= base_padding) 1 else base_padding - dep_type_text_len;
+                    // We need the headers to align where the current version column starts
+                    // That's at: 6 (start of names) + max_name_len + 2 (spacing after names) - 2 (header indent) - dep_type_text_len
+                    const total_offset = 6 + state.max_name_len + 2;
+                    const header_start = 2 + dep_type_text_len;
+                    const padding_to_current = if (header_start >= total_offset) 1 else total_offset - header_start;
                     while (j < padding_to_current) : (j += 1) {
                         Output.print(" ", .{});
                     }
@@ -767,7 +768,7 @@ pub const UpdateInteractiveCommand = struct {
                     // Column headers aligned with their columns
                     Output.print("Current", .{});
                     j = 0;
-                    while (j < state.max_current_len - "Current".len + 4) : (j += 1) {
+                    while (j < state.max_current_len - "Current".len + 2) : (j += 1) {
                         Output.print(" ", .{});
                     }
                     Output.print("Target", .{});
@@ -903,19 +904,19 @@ pub const UpdateInteractiveCommand = struct {
                     Output.pretty("<r><d> optional<r>", .{});
                 }
 
-                // Print padding after name (4 spaces as requested)
+                // Print padding after name (2 spaces)
                 var j: usize = 0;
-                while (j < name_padding + 4) : (j += 1) {
+                while (j < name_padding + 2) : (j += 1) {
                     Output.print(" ", .{});
                 }
 
                 // Current version
                 Output.pretty("<r>{s}<r>", .{pkg.current_version});
 
-                // Print padding after current version (4 spaces as requested)
+                // Print padding after current version (2 spaces)
                 const current_padding = if (pkg.current_version.len >= state.max_current_len) 0 else state.max_current_len - pkg.current_version.len;
                 j = 0;
-                while (j < current_padding + 4) : (j += 1) {
+                while (j < current_padding + 2) : (j += 1) {
                     Output.print(" ", .{});
                 }
 

--- a/src/output.zig
+++ b/src/output.zig
@@ -22,10 +22,10 @@ var stdout_stream: Source.StreamType = undefined;
 var stdout_stream_set = false;
 const File = bun.sys.File;
 pub var terminal_size: std.posix.winsize = .{
-    .ws_row = 0,
-    .ws_col = 0,
-    .ws_xpixel = 0,
-    .ws_ypixel = 0,
+    .row = 0,
+    .col = 0,
+    .xpixel = 0,
+    .ypixel = 0,
 };
 
 pub const Source = struct {

--- a/test/cli/__snapshots__/update_interactive_snapshots.test.ts.snap
+++ b/test/cli/__snapshots__/update_interactive_snapshots.test.ts.snap
@@ -1,0 +1,9 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`bun update --interactive snapshots should format mixed package types with proper spacing: update-interactive-formatting 1`] = `"bun update --interactive vX.X.X"`;
+
+exports[`bun update --interactive snapshots should not crash with various package name lengths: update-interactive-no-crash 1`] = `"bun update --interactive vX.X.X"`;
+
+exports[`bun update --interactive snapshots should handle extremely long package names without crashing: update-interactive-long-names 1`] = `"bun update --interactive vX.X.X"`;
+
+exports[`bun update --interactive snapshots should handle complex version strings without crashing: update-interactive-complex-versions 1`] = `"bun update --interactive vX.X.X"`;

--- a/test/cli/update_interactive_snapshots.test.ts
+++ b/test/cli/update_interactive_snapshots.test.ts
@@ -49,10 +49,10 @@ describe("bun update --interactive snapshots", () => {
 
     // Replace version numbers and paths to avoid flakiness
     const normalizedOutput = normalizeOutput(stdout);
-    
+
     // The output should show proper column spacing and formatting
     expect(normalizedOutput).toMatchSnapshot("update-interactive-no-crash");
-    
+
     // Should not crash or have formatting errors
     expect(stderr).not.toContain("panic");
     expect(stderr).not.toContain("underflow");
@@ -88,7 +88,7 @@ describe("bun update --interactive snapshots", () => {
     const stderr = await new Response(result.stderr).text();
 
     const normalizedOutput = normalizeOutput(stdout);
-    
+
     // Should not crash
     expect(normalizedOutput).toMatchSnapshot("update-interactive-long-names");
     expect(stderr).not.toContain("panic");
@@ -124,7 +124,7 @@ describe("bun update --interactive snapshots", () => {
     const stderr = await new Response(result.stderr).text();
 
     const normalizedOutput = normalizeOutput(stdout);
-    
+
     // Should not crash
     expect(normalizedOutput).toMatchSnapshot("update-interactive-complex-versions");
     expect(stderr).not.toContain("panic");
@@ -135,18 +135,18 @@ describe("bun update --interactive snapshots", () => {
 function normalizeOutput(output: string): string {
   // Remove Bun version to avoid test flakiness
   let normalized = output.replace(/bun update --interactive v\d+\.\d+\.\d+[^\n]*/g, "bun update --interactive vX.X.X");
-  
+
   // Normalize any absolute paths
   normalized = normalized.replace(/\/tmp\/[^\/\s]+/g, "/tmp/test-dir");
-  
+
   // Remove ANSI color codes for cleaner snapshots
   normalized = normalized.replace(/\x1b\[[0-9;]*m/g, "");
-  
+
   // Remove progress indicators and timing info
   normalized = normalized.replace(/[\r\n]*\s*\([0-9.]+ms\)/g, "");
-  
+
   // Normalize whitespace
   normalized = normalized.replace(/\r\n/g, "\n");
-  
+
   return normalized.trim();
 }

--- a/test/cli/update_interactive_snapshots.test.ts
+++ b/test/cli/update_interactive_snapshots.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+describe("bun update --interactive snapshots", () => {
+  it("should not crash with various package name lengths", async () => {
+    const dir = tempDirWithFiles("update-interactive-snapshot-test", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: {
+          "short": "1.0.0",
+          "react": "17.0.2",
+          "really-long-package-name-for-testing": "1.0.0",
+          "@scoped/package": "1.0.0",
+          "@organization/extremely-long-scoped-package-name": "1.0.0",
+        },
+        devDependencies: {
+          "dev-pkg": "1.0.0",
+          "super-long-dev-package-name-for-testing": "1.0.0",
+          "typescript": "4.8.0",
+        },
+        peerDependencies: {
+          "peer-pkg": "1.0.0",
+          "very-long-peer-dependency-name": "1.0.0",
+        },
+        optionalDependencies: {
+          "optional-pkg": "1.0.0",
+          "long-optional-dependency-name": "1.0.0",
+        },
+      }),
+    });
+
+    // Test that the command doesn't crash with mixed package lengths
+    const result = await Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive", "--dry-run"],
+      cwd: dir,
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Send 'n' to exit without selecting anything
+    result.stdin.write("n\n");
+    result.stdin.end();
+
+    const stdout = await new Response(result.stdout).text();
+    const stderr = await new Response(result.stderr).text();
+
+    // Replace version numbers and paths to avoid flakiness
+    const normalizedOutput = normalizeOutput(stdout);
+    
+    // The output should show proper column spacing and formatting
+    expect(normalizedOutput).toMatchSnapshot("update-interactive-no-crash");
+    
+    // Should not crash or have formatting errors
+    expect(stderr).not.toContain("panic");
+    expect(stderr).not.toContain("underflow");
+    expect(stderr).not.toContain("overflow");
+  });
+
+  it("should handle extremely long package names without crashing", async () => {
+    const veryLongName = "a".repeat(80);
+    const dir = tempDirWithFiles("update-interactive-long-names", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: {
+          [veryLongName]: "1.0.0",
+          "regular-package": "1.0.0",
+        },
+      }),
+    });
+
+    const result = await Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive", "--dry-run"],
+      cwd: dir,
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    result.stdin.write("n\n");
+    result.stdin.end();
+
+    const stdout = await new Response(result.stdout).text();
+    const stderr = await new Response(result.stderr).text();
+
+    const normalizedOutput = normalizeOutput(stdout);
+    
+    // Should not crash
+    expect(normalizedOutput).toMatchSnapshot("update-interactive-long-names");
+    expect(stderr).not.toContain("panic");
+    expect(stderr).not.toContain("underflow");
+  });
+
+  it("should handle complex version strings without crashing", async () => {
+    const dir = tempDirWithFiles("update-interactive-complex-versions", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: {
+          "package-with-long-version": "1.0.0-alpha.1.2.3.4.5.6.7.8.9.10.11.12",
+          "package-with-prerelease": "1.0.0-beta.1+build.12345",
+          "package-with-short-version": "1.0.0",
+        },
+      }),
+    });
+
+    const result = await Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive", "--dry-run"],
+      cwd: dir,
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    result.stdin.write("n\n");
+    result.stdin.end();
+
+    const stdout = await new Response(result.stdout).text();
+    const stderr = await new Response(result.stderr).text();
+
+    const normalizedOutput = normalizeOutput(stdout);
+    
+    // Should not crash
+    expect(normalizedOutput).toMatchSnapshot("update-interactive-complex-versions");
+    expect(stderr).not.toContain("panic");
+    expect(stderr).not.toContain("underflow");
+  });
+});
+
+function normalizeOutput(output: string): string {
+  // Remove Bun version to avoid test flakiness
+  let normalized = output.replace(/bun update --interactive v\d+\.\d+\.\d+[^\n]*/g, "bun update --interactive vX.X.X");
+  
+  // Normalize any absolute paths
+  normalized = normalized.replace(/\/tmp\/[^\/\s]+/g, "/tmp/test-dir");
+  
+  // Remove ANSI color codes for cleaner snapshots
+  normalized = normalized.replace(/\x1b\[[0-9;]*m/g, "");
+  
+  // Remove progress indicators and timing info
+  normalized = normalized.replace(/[\r\n]*\s*\([0-9.]+ms\)/g, "");
+  
+  // Normalize whitespace
+  normalized = normalized.replace(/\r\n/g, "\n");
+  
+  return normalized.trim();
+}


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
