### PR TITLE
cmake: set nodejs_version statically

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -139,10 +139,10 @@ endif()
 optionx(REVISION STRING "The git revision of the build" DEFAULT ${DEFAULT_REVISION})
 
 # Used in process.version, process.versions.node, napi, and elsewhere
-optionx(NODEJS_VERSION STRING "The version of Node.js to report" DEFAULT "24.3.0")
+setx(NODEJS_VERSION "24.3.0")
 
 # Used in process.versions.modules and compared while loading V8 modules
-optionx(NODEJS_ABI_VERSION STRING "The ABI version of Node.js to report" DEFAULT "137")
+setx(NODEJS_ABI_VERSION "137")
 
 if(APPLE)
   set(DEFAULT_STATIC_SQLITE OFF)


### PR DESCRIPTION
fixes the issue where we change the node version and folks who have an existing `build` folder dont have the cache busted. many components of bun have to move in lock-step when this value change so while it is a build constant it is not readily configurable and expected to work