### PR TITLE
Improve readability in Powershell

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -225,7 +225,7 @@ pub const HelpCommand = struct {
     const cli_helptext_footer =
         \\
         \\Learn more about Bun:            <magenta>https://bun.com/docs<r>
-        \\Join our Discord community:      <blue>https://bun.com/discord<r>
+        \\Join our Discord community:      <b><blue>https://bun.com/discord<r>
         \\
     ;
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1190,12 +1190,12 @@ pub const RunCommand = struct {
         const examples_text =
             \\<b>Examples:<r>
             \\  <d>Run a JavaScript or TypeScript file<r>
-            \\  <b><green>bun run<r> <blue>./index.js<r>
-            \\  <b><green>bun run<r> <blue>./index.tsx<r>
+            \\  <b><green>bun run<r> <b><blue>./index.js<r>
+            \\  <b><green>bun run<r> <b><blue>./index.tsx<r>
             \\
             \\  <d>Run a package.json script<r>
-            \\  <b><green>bun run<r> <blue>dev<r>
-            \\  <b><green>bun run<r> <blue>lint<r>
+            \\  <b><green>bun run<r> <b><blue>dev<r>
+            \\  <b><green>bun run<r> <b><blue>lint<r>
             \\
             \\Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             \\
@@ -1223,7 +1223,7 @@ pub const RunCommand = struct {
                     // Output.prettyln("<r><blue><b>{s}<r> scripts:<r>\n", .{display_name});
                     while (iterator.next()) |entry| {
                         Output.prettyln("\n", .{});
-                        Output.prettyln("  <d>$</r> bun run<r> <blue>{s}<r>\n", .{entry.key_ptr.*});
+                        Output.prettyln("  <d>$</r> bun run<r> <b><blue>{s}<r>\n", .{entry.key_ptr.*});
                         Output.prettyln("  <d>  {s}<r>\n", .{entry.value_ptr.*});
                     }
 


### PR DESCRIPTION
Default blue color was hard to read in Powershell, changed to light blue (same as in commands help section).
I am not sure these are all instances of dark blue text, feel free to add more.

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?

<img width="1919" height="991" alt="Untitled" src="https://github.com/user-attachments/assets/10155d5b-b650-4051-a716-73fa228fd829" />