### PR TITLE
Fix :is() selector bug with compound selectors containing type selectors

### DIFF
--- a/src/css/selectors/selector.zig
+++ b/src/css/selectors/selector.zig
@@ -1511,11 +1511,15 @@ pub fn shouldUnwrapIs(selectors: []const parser.Selector) bool {
 
 fn hasTypeSelector(selector: *const parser.Selector) bool {
     var iter = selector.iterRawParseOrderFrom(0);
-    const first = iter.next();
-
-    if (isNamespace(if (first) |*f| f else null)) return isTypeSelector(if (iter.next()) |*n| n else null);
-
-    return isTypeSelector(if (first) |*f| f else null);
+    
+    // Check all components in the selector to find any type selectors
+    while (iter.next()) |component| {
+        if (isTypeSelector(&component)) {
+            return true;
+        }
+    }
+    
+    return false;
 }
 
 fn isNamespace(component: ?*const parser.Component) bool {

--- a/src/css/selectors/selector.zig
+++ b/src/css/selectors/selector.zig
@@ -1511,14 +1511,14 @@ pub fn shouldUnwrapIs(selectors: []const parser.Selector) bool {
 
 fn hasTypeSelector(selector: *const parser.Selector) bool {
     var iter = selector.iterRawParseOrderFrom(0);
-    
+
     // Check all components in the selector to find any type selectors
     while (iter.next()) |component| {
         if (isTypeSelector(&component)) {
             return true;
         }
     }
-    
+
     return false;
 }
 

--- a/test/regression/issue/21169-is-selector-bug.test.ts
+++ b/test/regression/issue/21169-is-selector-bug.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from "bun:test";
+import { cssTest } from "../../js/bun/css/util";
+
+describe("issue #21169 - :is() selector bug", () => {
+  // Test case for the original bug report
+  test("should not collapse .foo:is(input:checked) to .fooinput:checked", () => {
+    cssTest(
+      ".foo:is(input:checked) { color: red; }",
+      ".foo:is(input:checked) {\n  color: red;\n}",
+    );
+  });
+
+  // Additional test cases for similar compound selectors
+  test("should handle :is() with input:hover", () => {
+    cssTest(
+      ".foo:is(input:hover) { color: blue; }",
+      ".foo:is(input:hover) {\n  color: #00f;\n}",
+    );
+  });
+
+  test("should handle :is() with input.checked", () => {
+    cssTest(
+      ".foo:is(input.checked) { color: purple; }",
+      ".foo:is(input.checked) {\n  color: purple;\n}",
+    );
+  });
+
+  // Test that class-only selectors can still be optimized
+  test("should still optimize class-only :is() selectors", () => {
+    cssTest(
+      ".foo:is(.bar) { color: yellow; }",
+      ".foo.bar {\n  color: #ff0;\n}",
+    );
+  });
+
+  // Test that simple type selectors are preserved
+  test("should preserve simple type selectors in :is()", () => {
+    cssTest(
+      ".foo:is(input) { color: green; }",
+      ".foo:is(input) {\n  color: green;\n}",
+    );
+  });
+
+  // Test multiple selectors in :is() - should work correctly
+  test("should handle multiple selectors in :is()", () => {
+    cssTest(
+      ".foo:is(input:checked, input:valid) { color: orange; }",
+      ".foo:is(input:checked, input:valid) {\n  color: orange;\n}",
+    );
+  });
+
+  // Test :where() - should work correctly (mentioned as workaround)
+  test("should handle :where() selector correctly", () => {
+    cssTest(
+      ".foo:where(input:checked) { color: pink; }",
+      ".foo:where(input:checked) {\n  color: pink;\n}",
+    );
+  });
+});

--- a/test/regression/issue/21169-is-selector-bug.test.ts
+++ b/test/regression/issue/21169-is-selector-bug.test.ts
@@ -4,41 +4,26 @@ import { cssTest } from "../../js/bun/css/util";
 describe("issue #21169 - :is() selector bug", () => {
   // Test case for the original bug report
   test("should not collapse .foo:is(input:checked) to .fooinput:checked", () => {
-    cssTest(
-      ".foo:is(input:checked) { color: red; }",
-      ".foo:is(input:checked) {\n  color: red;\n}",
-    );
+    cssTest(".foo:is(input:checked) { color: red; }", ".foo:is(input:checked) {\n  color: red;\n}");
   });
 
   // Additional test cases for similar compound selectors
   test("should handle :is() with input:hover", () => {
-    cssTest(
-      ".foo:is(input:hover) { color: blue; }",
-      ".foo:is(input:hover) {\n  color: #00f;\n}",
-    );
+    cssTest(".foo:is(input:hover) { color: blue; }", ".foo:is(input:hover) {\n  color: #00f;\n}");
   });
 
   test("should handle :is() with input.checked", () => {
-    cssTest(
-      ".foo:is(input.checked) { color: purple; }",
-      ".foo:is(input.checked) {\n  color: purple;\n}",
-    );
+    cssTest(".foo:is(input.checked) { color: purple; }", ".foo:is(input.checked) {\n  color: purple;\n}");
   });
 
   // Test that class-only selectors can still be optimized
   test("should still optimize class-only :is() selectors", () => {
-    cssTest(
-      ".foo:is(.bar) { color: yellow; }",
-      ".foo.bar {\n  color: #ff0;\n}",
-    );
+    cssTest(".foo:is(.bar) { color: yellow; }", ".foo.bar {\n  color: #ff0;\n}");
   });
 
   // Test that simple type selectors are preserved
   test("should preserve simple type selectors in :is()", () => {
-    cssTest(
-      ".foo:is(input) { color: green; }",
-      ".foo:is(input) {\n  color: green;\n}",
-    );
+    cssTest(".foo:is(input) { color: green; }", ".foo:is(input) {\n  color: green;\n}");
   });
 
   // Test multiple selectors in :is() - should work correctly
@@ -51,9 +36,6 @@ describe("issue #21169 - :is() selector bug", () => {
 
   // Test :where() - should work correctly (mentioned as workaround)
   test("should handle :where() selector correctly", () => {
-    cssTest(
-      ".foo:where(input:checked) { color: pink; }",
-      ".foo:where(input:checked) {\n  color: pink;\n}",
-    );
+    cssTest(".foo:where(input:checked) { color: pink; }", ".foo:where(input:checked) {\n  color: pink;\n}");
   });
 });


### PR DESCRIPTION
## Summary

Fixes issue #21169 where CSS `:is()` selectors containing compound selectors with type selectors were incorrectly parsed, causing malformed CSS output.

### The Problem
- `.foo:is(input:checked)` was incorrectly becoming `.fooinput:checked` (missing space)
- `.foo:is(input:hover)` was incorrectly becoming `.fooinput:hover` (missing space)
- This happened because the `hasTypeSelector` function only checked the first component of a selector

### The Fix
Modified the `hasTypeSelector` function in `src/css/selectors/selector.zig` to check all components in a selector, not just the first one. This prevents compound selectors containing type selectors from being incorrectly unwrapped.

### Test Plan
- [x] Added comprehensive test cases in `test/regression/issue/21169-is-selector-bug.test.ts`
- [x] Verified all new tests pass
- [x] Verified existing CSS tests still pass
- [x] Confirmed that class-only selectors like `.foo:is(.bar)` can still be optimized correctly

🤖 Generated with [Claude Code](https://claude.ai/code)