### PR TITLE
docs: document missing Server#getConnections in node:net compatibility

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -120,7 +120,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:net`](https://nodejs.org/api/net.html)
 
-🟢 Fully implemented.
+🟡 Missing `Server#getConnections`.
 
 ### [`node:perf_hooks`](https://nodejs.org/api/perf_hooks.html)
 


### PR DESCRIPTION
### What does this PR do?

Updates the docs to mention that `node:net` support is missing `Server#getConnections(callback)`. See #4459 (issue repros with latest Bun v1.2.18).

### How did you verify your code works?

Opened the changed file in a markdown viewer.