### PR TITLE
Fix extra bracket in template literal syntax highlighting (#17327)

### DIFF
--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1046,9 +1046,9 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                                     }
 
                                     if (i < text.len and text[i] == '}') {
+                                        try writer.writeAll("}");
                                         i += 1;
                                     }
-                                    try writer.writeAll("}");
                                     text = text[i..];
                                     i = 0;
                                     if (text.len > 0 and text[0] == char) {

--- a/test/regression/issue/17327.test.ts
+++ b/test/regression/issue/17327.test.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { normalizeBunSnapshot } from "harness";
+
+test("issue #17327: extra bracket in error message with colors enabled", async () => {
+  const dir = tempDirWithFiles("17327", {
+    "test.ts": `
+const result = {success:false};
+const err = new Error(\`error: \${JSON.stringify(
+  result
+)}\`);
+throw err;
+    `.trim(),
+  });
+
+  // Test with colors enabled
+  await using coloredProc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: { ...bunEnv, FORCE_COLOR: "1" },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [coloredStdout, coloredStderr] = await Promise.all([
+    new Response(coloredProc.stdout).text(),
+    new Response(coloredProc.stderr).text(),
+  ]);
+
+  const coloredOutput = (coloredStdout + coloredStderr);
+
+  // Test with colors disabled  
+  await using plainProc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: { ...bunEnv, NO_COLOR: "1" },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [plainStdout, plainStderr] = await Promise.all([
+    new Response(plainProc.stdout).text(),
+    new Response(plainProc.stderr).text(),
+  ]);
+
+  const plainOutput = (plainStdout + plainStderr);
+
+  // The error message should contain the correct JSON without extra brackets
+  expect(coloredOutput).toContain('error: {"success":false}');
+  expect(plainOutput).toContain('error: {"success":false}');
+  
+  // The colored output should not contain extra closing brackets after JSON.stringify(
+  // Check for the specific pattern where extra } appears in syntax highlighting
+  expect(coloredOutput).not.toMatch(/stringify.*\(\s*}/);
+  expect(coloredOutput).not.toMatch(/JSON\.stringify\([^)]*\)\s*}/);
+  
+  // Both outputs should contain the same essential error information
+  expect(normalizeBunSnapshot(coloredOutput)).toContain('error: {"success":false}');
+  expect(normalizeBunSnapshot(plainOutput)).toContain('error: {"success":false}');
+});
+
+test("issue #17327: template literal syntax highlighting edge cases", async () => {
+  const dir = tempDirWithFiles("17327-edge", {
+    "nested.ts": `
+const obj = {nested: {deep: true}};
+throw new Error(\`Complex: \${JSON.stringify(obj)}\`);
+    `.trim(),
+    "array.ts": `
+const arr = [1, 2, {inner: "value"}];
+throw new Error(\`Array: \${JSON.stringify(arr)}\`);
+    `.trim(),
+  });
+
+  for (const file of ["nested.ts", "array.ts"]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), file],
+      env: { ...bunEnv, FORCE_COLOR: "1" },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+
+    const output = stdout + stderr;
+    
+    // Should not contain extra brackets in syntax highlighting (avoiding matching legitimate nested JSON)
+    expect(output).not.toMatch(/stringify.*\(\s*}/);
+    expect(output).not.toMatch(/JSON\.stringify\([^)]*\)\s*}/);
+  }
+});

--- a/test/regression/issue/17327.test.ts
+++ b/test/regression/issue/17327.test.ts
@@ -1,6 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
-import { normalizeBunSnapshot } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
 
 test("issue #17327: extra bracket in error message with colors enabled", async () => {
   const dir = tempDirWithFiles("17327", {
@@ -27,9 +26,9 @@ throw err;
     new Response(coloredProc.stderr).text(),
   ]);
 
-  const coloredOutput = (coloredStdout + coloredStderr);
+  const coloredOutput = coloredStdout + coloredStderr;
 
-  // Test with colors disabled  
+  // Test with colors disabled
   await using plainProc = Bun.spawn({
     cmd: [bunExe(), "test.ts"],
     env: { ...bunEnv, NO_COLOR: "1" },
@@ -43,17 +42,17 @@ throw err;
     new Response(plainProc.stderr).text(),
   ]);
 
-  const plainOutput = (plainStdout + plainStderr);
+  const plainOutput = plainStdout + plainStderr;
 
   // The error message should contain the correct JSON without extra brackets
   expect(coloredOutput).toContain('error: {"success":false}');
   expect(plainOutput).toContain('error: {"success":false}');
-  
+
   // The colored output should not contain extra closing brackets after JSON.stringify(
   // Check for the specific pattern where extra } appears in syntax highlighting
   expect(coloredOutput).not.toMatch(/stringify.*\(\s*}/);
   expect(coloredOutput).not.toMatch(/JSON\.stringify\([^)]*\)\s*}/);
-  
+
   // Both outputs should contain the same essential error information
   expect(normalizeBunSnapshot(coloredOutput)).toContain('error: {"success":false}');
   expect(normalizeBunSnapshot(plainOutput)).toContain('error: {"success":false}');
@@ -80,13 +79,10 @@ throw new Error(\`Array: \${JSON.stringify(arr)}\`);
       stderr: "pipe",
     });
 
-    const [stdout, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 
     const output = stdout + stderr;
-    
+
     // Should not contain extra brackets in syntax highlighting (avoiding matching legitimate nested JSON)
     expect(output).not.toMatch(/stringify.*\(\s*}/);
     expect(output).not.toMatch(/JSON\.stringify\([^)]*\)\s*}/);


### PR DESCRIPTION
## Summary

Fixes an issue where the JavaScript syntax highlighter was incorrectly adding an extra closing bracket (`}`) when highlighting template literal interpolations containing `JSON.stringify()` calls in colored terminal output.

## Problem

When running code like this with colors enabled:
```typescript
const result = {success:false};
const err = new Error(`error: ${JSON.stringify(result)}`);
throw err;
```

The error output would show an extra `}` character after `JSON.stringify(`, causing malformed syntax highlighting in the error display.

## Root Cause

The bug was in the template literal parsing code in `src/fmt.zig` where it would always write a closing brace after processing template literal interpolation, even when a closing brace was already found and consumed from the input.

**Before (buggy)**:
```zig
if (i < text.len and text[i] == '}') {
    i += 1;  // consume the brace
}
try writer.writeAll("}");  // always write a brace (BUG\!)
```

**After (fixed)**:
```zig
if (i < text.len and text[i] == '}') {
    try writer.writeAll("}");  // only write if found
    i += 1;  // then consume it
}
```

## Solution

- Only write the closing `}` character when it's actually found in the input
- This ensures the syntax highlighter doesn't add extra brackets to the output
- The fix is minimal and surgical, affecting only the specific case where the bug occurred

## Test plan

- [x] Manual reproduction confirmed the issue existed before the fix
- [x] Manual verification confirmed the extra bracket no longer appears after the fix
- [x] Created comprehensive regression test in `test/regression/issue/17327.test.ts`
- [x] Tested edge cases with nested JSON objects and arrays  
- [x] Verified fix works with both `FORCE_COLOR=1` and `NO_COLOR=1` modes
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.ai/code)