### PR TITLE
Fix beforeAll hooks running for unmatched describe blocks when using test filters

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -925,9 +925,10 @@ pub const DescribeScope = struct {
     pub fn hasRunnableTests(this: *const DescribeScope) bool {
         for (this.tests.items) |test_scope| {
             if (test_scope.tag != .skip and
-                test_scope.tag != .todo and 
+                test_scope.tag != .todo and
                 test_scope.tag != .skipped_because_label and
-                !(test_scope.tag != .only and Jest.runner.?.only)) {
+                !(test_scope.tag != .only and Jest.runner.?.only))
+            {
                 return true;
             }
         }

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -922,6 +922,18 @@ pub const DescribeScope = struct {
         return true;
     }
 
+    pub fn hasRunnableTests(this: *const DescribeScope) bool {
+        for (this.tests.items) |test_scope| {
+            if (test_scope.tag != .skip and
+                test_scope.tag != .todo and 
+                test_scope.tag != .skipped_because_label and
+                !(test_scope.tag != .only and Jest.runner.?.only)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     pub fn push(new: *DescribeScope) void {
         if (new.parent) |scope| {
             if (comptime Environment.allow_assert) {
@@ -1213,7 +1225,7 @@ pub const DescribeScope = struct {
 
         var i: TestRunner.Test.ID = 0;
 
-        if (this.shouldEvaluateScope()) {
+        if (this.shouldEvaluateScope() and this.hasRunnableTests()) {
             if (this.runCallback(globalObject, .beforeAll)) |err| {
                 _ = globalObject.bunVM().uncaughtException(globalObject, err, true);
                 while (i < end) {

--- a/test/regression/issue/21177.fixture.js
+++ b/test/regression/issue/21177.fixture.js
@@ -1,0 +1,15 @@
+describe("False assertion", () => {
+  beforeAll(() => {
+    console.log("Running False assertion tests...");
+  });
+
+  test("false is false", () => {
+    expect(false).toBe(false);
+  });
+});
+
+describe("True assertion", () => {
+  test("true is true", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/test/regression/issue/21177.test.ts
+++ b/test/regression/issue/21177.test.ts
@@ -1,8 +1,8 @@
 // https://github.com/oven-sh/bun/issues/21177
 // beforeAll hooks should not run for describe blocks that have no tests matching the filter
 
-import { test, expect } from "bun:test";
 import { spawn } from "bun";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
@@ -23,13 +23,13 @@ test("beforeAll should not run for unmatched describe blocks when using test fil
   ]);
 
   expect(exitCode).toBe(0);
-  
+
   const output = stdout + stderr;
-  
+
   // The beforeAll hook from "False assertion" describe block should NOT have run
   // because no tests from that block match the filter
   expect(output).not.toContain("Running False assertion tests...");
-  
+
   // The test should have passed
   expect(output).toContain("1 pass");
   expect(output).toContain("1 filtered out");

--- a/test/regression/issue/21177.test.ts
+++ b/test/regression/issue/21177.test.ts
@@ -1,0 +1,36 @@
+// https://github.com/oven-sh/bun/issues/21177
+// beforeAll hooks should not run for describe blocks that have no tests matching the filter
+
+import { test, expect } from "bun:test";
+import { spawn } from "bun";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+test("beforeAll should not run for unmatched describe blocks when using test filters", async () => {
+  const testFile = join(import.meta.dir, "21177.fixture.js");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "test", testFile, "-t", "true is true"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  
+  const output = stdout + stderr;
+  
+  // The beforeAll hook from "False assertion" describe block should NOT have run
+  // because no tests from that block match the filter
+  expect(output).not.toContain("Running False assertion tests...");
+  
+  // The test should have passed
+  expect(output).toContain("1 pass");
+  expect(output).toContain("1 filtered out");
+});


### PR DESCRIPTION
## Summary

Fixes #21177 by ensuring `beforeAll` hooks only run for describe blocks that contain tests matching the filter criteria.

Previously, when using test filters (e.g., `bun test -t "test name"`), `beforeAll` hooks would run for all describe blocks that `shouldEvaluateScope()` returned true for, even if no tests in that block would actually run due to filtering.

## Changes

- Add `hasRunnableTests()` method to `DescribeScope` to check if a describe scope contains tests that will run after filtering
- Modify `runTests()` to only execute `beforeAll` hooks when the scope has runnable tests  
- Add regression test to prevent future regressions

## Test plan

- [x] Added regression test in `test/regression/issue/21177.test.ts` 
- [x] Test passes with the fix (`bun bd test`)
- [x] Test fails without the fix (production `bun test`)
- [x] Manual verification using reproduction case from issue

The fix ensures Jest-compatible behavior where `beforeAll` hooks only run for describe blocks containing tests that match the filter.

🤖 Generated with [Claude Code](https://claude.ai/code)