### PR TITLE
docs: add isolated installs to navigation

### DIFF
--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -184,7 +184,7 @@ export default {
         "Bun's package manager installs all packages into a shared global cache to avoid redundant re-downloads.",
     }),
     page("install/isolated", "Isolated installs", {
-      description: "Create strict dependency isolation similar to pnpm to prevent phantom dependencies.",
+      description: "Create strict dependency isolation, preventing phantom dependencies.",
     }),
     page("install/workspaces", "Workspaces", {
       description: "Bun's package manager supports workspaces and monorepo development workflows.",

--- a/docs/nav.ts
+++ b/docs/nav.ts
@@ -183,6 +183,9 @@ export default {
       description:
         "Bun's package manager installs all packages into a shared global cache to avoid redundant re-downloads.",
     }),
+    page("install/isolated", "Isolated installs", {
+      description: "Create strict dependency isolation similar to pnpm to prevent phantom dependencies.",
+    }),
     page("install/workspaces", "Workspaces", {
       description: "Bun's package manager supports workspaces and monorepo development workflows.",
     }),


### PR DESCRIPTION
## Summary
- Add isolated installs documentation to the Package manager section in `docs/nav.ts`
- Position entry between Global cache and Workspaces for logical flow

## Context
The isolated installs documentation was recently added in #21198 but wasn't included in the navigation. This PR adds the missing navigation entry so users can discover this feature.

🤖 Generated with [Claude Code](https://claude.ai/code)