### PR TITLE
fix(install): prevent race condition in logger from package manager tasks

### DIFF
--- a/test/regression/issue/logger-race-condition.test.ts
+++ b/test/regression/issue/logger-race-condition.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+test("package manager logger race condition fix", async () => {
+  // This test verifies that the logger race condition is fixed
+  // by attempting to trigger simultaneous package installation tasks
+  // that would previously cause a segmentation fault
+  
+  const dir = tempDirWithFiles("logger-race-test", {
+    "package.json": JSON.stringify({
+      name: "test-race-condition",
+      version: "1.0.0",
+      dependencies: {
+        // Multiple small packages to trigger concurrent tasks
+        "is-array": "1.0.1",
+        "is-string": "1.0.4", 
+        "is-number": "7.0.0",
+        "is-boolean": "1.0.1",
+        "is-function": "1.0.1",
+        "is-object": "1.0.1",
+        "is-regexp": "1.0.0",
+        "is-date": "1.0.1"
+      }
+    })
+  });
+
+  // Run install multiple times to increase chance of hitting race condition
+  for (let i = 0; i < 3; i++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: dir,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(), 
+      proc.exited
+    ]);
+
+    // The main assertion is that bun doesn't crash with a segfault
+    // If the race condition exists, this would likely fail
+    expect(exitCode).toBe(0);
+    
+    // Clean up node_modules for next iteration
+    await using rmProc = Bun.spawn({
+      cmd: ["rm", "-rf", "node_modules"],
+      cwd: dir
+    });
+    await rmProc.exited;
+  }
+}, { timeout: 30000 });


### PR DESCRIPTION
## Summary
- Fixes segmentation fault caused by race condition in logger when package manager tasks complete
- Prevents concurrent writes to errorWriter from multiple worker threads
- Collects task logs into manager.log and prints on main thread

## Root Cause
The crash occurred when multiple package manager tasks completed simultaneously and tried to write to `Output.errorWriter()` concurrently. The race condition manifested as a segmentation fault in `simdutf` formatting code:

```
simdutf_impl.cpp.h:5366: simdutf::haswell::\anonymous namespace'::simd::base<...>::operator < /dev/null | 
fmt.zig:896: format
logger.zig:538: writeFormat
logger.zig:1349: printWithEnableAnsiColors
runTasks.zig:487: runTasks  <-- task.log.print(Output.errorWriter())
```

## Solution
Instead of calling `task.log.print(Output.errorWriter())` directly from worker thread completion, the fix:

1. Uses `task.log.appendTo(manager.log)` to collect logs from tasks
2. Prints accumulated logs at the end of `runTasks()` on the main thread
3. Ensures all logging happens on a single thread, eliminating the race condition

## Test Plan
- [x] Added regression test that attempts to trigger concurrent package installations
- [x] Verified debug build compiles and runs without crashes
- [x] Manual testing with simple package installations works correctly
- [x] Crash no longer occurs during package manager operations

🤖 Generated with [Claude Code](https://claude.ai/code)