### PR TITLE
Add comprehensive documentation for bun ci command

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -265,7 +265,7 @@ jobs:
         run: bun run build
 ```
 
-For CI/CD environments that want to enforce reproducible builds on every install, use `bun ci` to fail the build if the package.json is out of sync with the lockfile:
+For CI/CD environments that want to enforce reproducible builds, use `bun ci` to fail the build if the package.json is out of sync with the lockfile:
 
 ```bash
 $ bun ci

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -146,66 +146,17 @@ For more information on Bun's lockfile `bun.lock`, refer to [Package manager > L
 
 ## CI installs
 
-For continuous integration and production environments where reproducible installs are critical, use `bun ci`:
+For CI/CD and production environments, use `bun ci` for reproducible installs:
 
 ```bash
 $ bun ci
 ```
 
-The `bun ci` command is an alias for `bun install --frozen-lockfile`. It will:
-
-- **Install exact versions** specified in the lockfile (`bun.lock`)
-- **Fail if inconsistencies exist** between `package.json` and `bun.lock`
-- **Never update the lockfile** - the lockfile remains read-only
-- **Install all dependency types**: `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies`
-
-This command is equivalent to:
-
-```bash
-$ bun install --frozen-lockfile
-```
+This is equivalent to `bun install --frozen-lockfile`. It installs exact versions from `bun.lock` and fails if `package.json` doesn't match the lockfile.
 
 {% callout type="warning" %}
-**⚠️ Important**: To use `bun ci`, you **must** commit your `bun.lock` file to version control. The lockfile contains the exact resolved versions and integrity hashes that `bun ci` uses to ensure consistent installs across all environments.
+**⚠️ Important**: You must commit `bun.lock` to version control for `bun ci` to work.
 {% /callout %}
-
-### Why commit the lockfile?
-
-Committing `bun.lock` to version control provides two key benefits:
-
-1. **Faster installs**: The lockfile contains pre-resolved dependency trees and integrity hashes, eliminating the need for Bun to resolve versions and verify packages during installation.
-
-2. **Guaranteed consistency**: Every team member and CI environment gets identical dependency versions, preventing "works on my machine" issues caused by different package versions.
-
-### When to use `bun ci`
-
-- **CI/CD pipelines**: Ensures all builds use identical dependency versions
-- **Production deployments**: Guarantees reproducible installs
-- **Team consistency**: Prevents "works on my machine" issues
-- **Docker builds**: Use in Dockerfiles for consistent container builds
-
-### Error conditions
-
-`bun ci` will exit with an error code if:
-
-- No `bun.lock` file exists in the project
-- Dependencies in `package.json` don't match the locked versions
-- Required dependencies cannot be resolved to the exact locked versions
-
-### CI/CD example
-
-```yaml#.github/workflows/test.yml
-name: Test
-on: [push, pull_request]
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4  # Checks out code including bun.lock
-      - uses: oven-sh/setup-bun@v2
-      - run: bun ci  # Uses committed bun.lock for reproducible installs
-      - run: bun test
-```
 
 ## Omitting dependencies
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -144,20 +144,6 @@ $ bun install --frozen-lockfile
 
 For more information on Bun's lockfile `bun.lock`, refer to [Package manager > Lockfile](https://bun.com/docs/install/lockfile).
 
-## CI installs
-
-For CI/CD and production environments, use `bun ci` for reproducible installs:
-
-```bash
-$ bun ci
-```
-
-This is equivalent to `bun install --frozen-lockfile`. It installs exact versions from `bun.lock` and fails if `package.json` doesn't match the lockfile.
-
-{% callout type="warning" %}
-**⚠️ Important**: You must commit `bun.lock` to version control for `bun ci` to work.
-{% /callout %}
-
 ## Omitting dependencies
 
 To omit dev, peer, or optional dependencies use the `--omit` flag.
@@ -259,7 +245,15 @@ linker = "hoisted"
 
 ## CI/CD
 
-Looking to speed up your CI? Use the official [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action to install `bun` in a GitHub Actions pipeline.
+For CI/CD environments, use `bun ci` instead of `bun install` for reproducible builds:
+
+```bash
+$ bun ci
+```
+
+This is equivalent to `bun install --frozen-lockfile`. It installs exact versions from `bun.lock` and fails if `package.json` doesn't match the lockfile. You must commit `bun.lock` to version control.
+
+Use the official [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action to install `bun` in a GitHub Actions pipeline:
 
 ```yaml#.github/workflows/release.yml
 name: bun-types

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -144,6 +144,57 @@ $ bun install --frozen-lockfile
 
 For more information on Bun's lockfile `bun.lock`, refer to [Package manager > Lockfile](https://bun.com/docs/install/lockfile).
 
+## CI installs
+
+For continuous integration and production environments where reproducible installs are critical, use `bun ci`:
+
+```bash
+$ bun ci
+```
+
+The `bun ci` command is an alias for `bun install --frozen-lockfile`. It will:
+
+- **Install exact versions** specified in the lockfile (`bun.lock`)
+- **Fail if inconsistencies exist** between `package.json` and `bun.lock`
+- **Never update the lockfile** - the lockfile remains read-only
+- **Install all dependency types**: `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies`
+
+This command is equivalent to:
+
+```bash
+$ bun install --frozen-lockfile
+```
+
+### When to use `bun ci`
+
+- **CI/CD pipelines**: Ensures all builds use identical dependency versions
+- **Production deployments**: Guarantees reproducible installs
+- **Team consistency**: Prevents "works on my machine" issues
+- **Docker builds**: Use in Dockerfiles for consistent container builds
+
+### Error conditions
+
+`bun ci` will exit with an error code if:
+
+- No `bun.lock` file exists in the project
+- Dependencies in `package.json` don't match the locked versions
+- Required dependencies cannot be resolved to the exact locked versions
+
+### CI/CD example
+
+```yaml#.github/workflows/test.yml
+name: Test
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun ci  # Use bun ci instead of bun install
+      - run: bun test
+```
+
 ## Omitting dependencies
 
 To omit dev, peer, or optional dependencies use the `--omit` flag.
@@ -259,7 +310,7 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
-        run: bun install
+        run: bun ci
       - name: Build app
         run: bun run build
 ```

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -165,6 +165,18 @@ This command is equivalent to:
 $ bun install --frozen-lockfile
 ```
 
+{% callout type="warning" %}
+**⚠️ Important**: To use `bun ci`, you **must** commit your `bun.lock` file to version control. The lockfile contains the exact resolved versions and integrity hashes that `bun ci` uses to ensure consistent installs across all environments.
+{% /callout %}
+
+### Why commit the lockfile?
+
+Committing `bun.lock` to version control provides two key benefits:
+
+1. **Faster installs**: The lockfile contains pre-resolved dependency trees and integrity hashes, eliminating the need for Bun to resolve versions and verify packages during installation.
+
+2. **Guaranteed consistency**: Every team member and CI environment gets identical dependency versions, preventing "works on my machine" issues caused by different package versions.
+
 ### When to use `bun ci`
 
 - **CI/CD pipelines**: Ensures all builds use identical dependency versions
@@ -189,9 +201,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4  # Checks out code including bun.lock
       - uses: oven-sh/setup-bun@v2
-      - run: bun ci  # Use bun ci instead of bun install
+      - run: bun ci  # Uses committed bun.lock for reproducible installs
       - run: bun test
 ```
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -245,15 +245,35 @@ linker = "hoisted"
 
 ## CI/CD
 
-For CI/CD environments, use `bun ci` instead of `bun install` for reproducible builds:
+
+Use the official [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action to install `bun` in a GitHub Actions pipeline:
+
+```yaml#.github/workflows/release.yml
+name: bun-types
+jobs:
+  build:
+    name: build-app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install
+      - name: Build app
+        run: bun run build
+```
+
+For CI/CD environments that want to enforce reproducible builds on every install, use `bun ci` to fail the build if the package.json is out of sync with the lockfile:
 
 ```bash
 $ bun ci
 ```
 
-This is equivalent to `bun install --frozen-lockfile`. It installs exact versions from `bun.lock` and fails if `package.json` doesn't match the lockfile. You must commit `bun.lock` to version control.
+This is equivalent to `bun install --frozen-lockfile`. It installs exact versions from `bun.lock` and fails if `package.json` doesn't match the lockfile. To use `bun ci` or `bun install --frozen-lockfile`, you must commit `bun.lock` to version control.
 
-Use the official [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action to install `bun` in a GitHub Actions pipeline:
+And instead of running `bun install`, run `bun ci`.
 
 ```yaml#.github/workflows/release.yml
 name: bun-types
@@ -271,5 +291,7 @@ jobs:
       - name: Build app
         run: bun run build
 ```
+
+
 
 {% bunCLIUsage command="install" /%}


### PR DESCRIPTION
## Summary

- Add dedicated "CI installs" section explaining `bun ci` as an alias for `bun install --frozen-lockfile`
- Document when to use `bun ci` (CI/CD pipelines, production deployments, team consistency, Docker builds)
- Include detailed error conditions and practical CI/CD workflow examples
- Update existing CI/CD example to use `bun ci` instead of `bun install` for best practices

## Test plan

- [x] Verify documentation renders correctly in markdown
- [x] Confirm placement makes logical sense in the install.md structure
- [x] Ensure examples are practical and follow current best practices

🤖 Generated with [Claude Code](https://claude.ai/code)