### PR TITLE
docs: add comprehensive documentation for bun update --interactive

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -32,7 +32,7 @@ The interface displays packages grouped by dependency type:
     □ react                        17.0.2   18.2.0   18.3.1
     □ lodash                       4.17.20  4.17.21  4.17.21
 
-  devDependencies                  Current  Target   Latest  
+  devDependencies                  Current  Target   Latest
     □ typescript                   4.8.0    5.0.0    5.3.3
     □ @types/node                  16.11.7  18.0.0   20.11.5
 
@@ -41,10 +41,12 @@ The interface displays packages grouped by dependency type:
 ```
 
 **Sections:**
+
 - Packages are grouped under section headers: `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`
 - Each section shows column headers aligned with the package data
 
 **Columns:**
+
 - **Package**: Package name (may have suffix like ` dev`, ` peer`, ` optional` for clarity)
 - **Current**: Currently installed version
 - **Target**: Version that would be installed (respects semver constraints)
@@ -80,8 +82,9 @@ The interface displays packages grouped by dependency type:
 ### Package Grouping
 
 Packages are organized in sections by dependency type:
+
 - **dependencies** - Regular runtime dependencies
-- **devDependencies** - Development dependencies  
+- **devDependencies** - Development dependencies
 - **peerDependencies** - Peer dependencies
 - **optionalDependencies** - Optional dependencies
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -28,16 +28,16 @@ The interface displays packages grouped by dependency type:
 ```
 ? Select packages to update - Space to toggle, Enter to confirm, a to select all, n to select none, i to invert, l to toggle latest
 
-  dependencies                     Current  Target   Latest
-    □ react                        17.0.2   18.2.0   18.3.1
-    □ lodash                       4.17.20  4.17.21  4.17.21
+  dependencies                Current  Target   Latest
+    □ react                   17.0.2   18.2.0   18.3.1
+    □ lodash                  4.17.20  4.17.21  4.17.21
 
-  devDependencies                  Current  Target   Latest
-    □ typescript                   4.8.0    5.0.0    5.3.3
-    □ @types/node                  16.11.7  18.0.0   20.11.5
+  devDependencies             Current  Target   Latest  
+    □ typescript              4.8.0    5.0.0    5.3.3
+    □ @types/node             16.11.7  18.0.0   20.11.5
 
-  optionalDependencies            Current  Target   Latest
-    □ some-optional-package        1.0.0    1.1.0    1.2.0
+  optionalDependencies        Current  Target   Latest
+    □ some-optional-package   1.0.0    1.1.0    1.2.0
 ```
 
 **Sections:**

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -32,7 +32,7 @@ The interface displays packages grouped by dependency type:
     □ react                   17.0.2   18.2.0   18.3.1
     □ lodash                  4.17.20  4.17.21  4.17.21
 
-  devDependencies             Current  Target   Latest  
+  devDependencies             Current  Target   Latest
     □ typescript              4.8.0    5.0.0    5.3.3
     □ @types/node             16.11.7  18.0.0   20.11.5
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -35,6 +35,7 @@ The interface displays packages in a table format:
 ```
 
 **Columns:**
+
 - **Package**: Package name with dependency type (`dev`, `peer`, `optional`)
 - **Current**: Currently installed version
 - **Target**: Version that would be installed (respects semver constraints)
@@ -43,6 +44,7 @@ The interface displays packages in a table format:
 ### Keyboard Controls
 
 **Selection:**
+
 - **Space**: Toggle package selection
 - **Enter**: Confirm selections and update
 - **a/A**: Select all packages
@@ -50,16 +52,18 @@ The interface displays packages in a table format:
 - **i/I**: Invert selection
 
 **Navigation:**
+
 - **↑/↓ Arrow keys** or **j/k**: Move cursor
 - **l/L**: Toggle between target and latest version for current package
 
 **Exit:**
+
 - **Ctrl+C** or **Ctrl+D**: Cancel without updating
 
 ### Visual Indicators
 
 - **☑** Selected packages (will be updated)
-- **□** Unselected packages  
+- **□** Unselected packages
 - **>** Current cursor position
 - **Colors**: Red (major), yellow (minor), green (patch) version changes
 - **Underlined**: Currently selected update target
@@ -67,6 +71,7 @@ The interface displays packages in a table format:
 ### Package Types
 
 The interface groups and labels packages by their dependency type:
+
 - Regular dependencies (no label)
 - `dev` - Development dependencies
 - `peer` - Peer dependencies

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -23,20 +23,29 @@ This launches an interactive terminal interface that shows all outdated packages
 
 ### Interactive Interface
 
-The interface displays packages in a table format:
+The interface displays packages grouped by dependency type:
 
 ```
 ? Select packages to update - Space to toggle, Enter to confirm, a to select all, n to select none, i to invert, l to toggle latest
 
-□ react                    17.0.2   18.2.0   18.3.1
-□ typescript dev           4.8.0    5.0.0    5.3.3
-□ @types/node dev          16.11.7  18.0.0   20.11.5
-□ lodash optional          4.17.20  4.17.21  4.17.21
+  dependencies                     Current  Target   Latest
+    □ react                        17.0.2   18.2.0   18.3.1
+    □ lodash                       4.17.20  4.17.21  4.17.21
+
+  devDependencies                  Current  Target   Latest  
+    □ typescript                   4.8.0    5.0.0    5.3.3
+    □ @types/node                  16.11.7  18.0.0   20.11.5
+
+  optionalDependencies            Current  Target   Latest
+    □ some-optional-package        1.0.0    1.1.0    1.2.0
 ```
 
-**Columns:**
+**Sections:**
+- Packages are grouped under section headers: `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`
+- Each section shows column headers aligned with the package data
 
-- **Package**: Package name with dependency type (`dev`, `peer`, `optional`)
+**Columns:**
+- **Package**: Package name (may have suffix like ` dev`, ` peer`, ` optional` for clarity)
 - **Current**: Currently installed version
 - **Target**: Version that would be installed (respects semver constraints)
 - **Latest**: Latest available version
@@ -68,14 +77,15 @@ The interface displays packages in a table format:
 - **Colors**: Red (major), yellow (minor), green (patch) version changes
 - **Underlined**: Currently selected update target
 
-### Package Types
+### Package Grouping
 
-The interface groups and labels packages by their dependency type:
+Packages are organized in sections by dependency type:
+- **dependencies** - Regular runtime dependencies
+- **devDependencies** - Development dependencies  
+- **peerDependencies** - Peer dependencies
+- **optionalDependencies** - Optional dependencies
 
-- Regular dependencies (no label)
-- `dev` - Development dependencies
-- `peer` - Peer dependencies
-- `optional` - Optional dependencies
+Within each section, individual packages may have additional suffixes (` dev`, ` peer`, ` optional`) for extra clarity.
 
 ## `--latest`
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -10,6 +10,68 @@ To update a specific dependency to the latest version:
 $ bun update [package]
 ```
 
+## `--interactive`
+
+For a more controlled update experience, use the `--interactive` flag to select which packages to update:
+
+```sh
+$ bun update --interactive
+$ bun update -i
+```
+
+This launches an interactive terminal interface that shows all outdated packages with their current and target versions. You can then select which packages to update.
+
+### Interactive Interface
+
+The interface displays packages in a table format:
+
+```
+? Select packages to update - Space to toggle, Enter to confirm, a to select all, n to select none, i to invert, l to toggle latest
+
+□ react                    17.0.2   18.2.0   18.3.1
+□ typescript dev           4.8.0    5.0.0    5.3.3
+□ @types/node dev          16.11.7  18.0.0   20.11.5
+□ lodash optional          4.17.20  4.17.21  4.17.21
+```
+
+**Columns:**
+- **Package**: Package name with dependency type (`dev`, `peer`, `optional`)
+- **Current**: Currently installed version
+- **Target**: Version that would be installed (respects semver constraints)
+- **Latest**: Latest available version
+
+### Keyboard Controls
+
+**Selection:**
+- **Space**: Toggle package selection
+- **Enter**: Confirm selections and update
+- **a/A**: Select all packages
+- **n/N**: Select none
+- **i/I**: Invert selection
+
+**Navigation:**
+- **↑/↓ Arrow keys** or **j/k**: Move cursor
+- **l/L**: Toggle between target and latest version for current package
+
+**Exit:**
+- **Ctrl+C** or **Ctrl+D**: Cancel without updating
+
+### Visual Indicators
+
+- **☑** Selected packages (will be updated)
+- **□** Unselected packages  
+- **>** Current cursor position
+- **Colors**: Red (major), yellow (minor), green (patch) version changes
+- **Underlined**: Currently selected update target
+
+### Package Types
+
+The interface groups and labels packages by their dependency type:
+- Regular dependencies (no label)
+- `dev` - Development dependencies
+- `peer` - Peer dependencies
+- `optional` - Optional dependencies
+
 ## `--latest`
 
 By default, `bun update` will update to the latest version of a dependency that satisfies the version range specified in your `package.json`.
@@ -19,6 +81,8 @@ To update to the latest version, regardless of if it's compatible with the curre
 ```sh
 $ bun update --latest
 ```
+
+In interactive mode, you can toggle individual packages between their target version (respecting semver) and latest version using the **l** key.
 
 For example, with the following `package.json`:
 


### PR DESCRIPTION
## Summary
- Add detailed documentation for the `bun update --interactive` feature to the CLI update docs
- Include usage examples, keyboard controls, visual indicators, and interface overview
- Document integration with the `--latest` flag behavior

## Documentation Added
- **Usage examples**: Basic command syntax and flags
- **Interactive interface**: Example output showing table format with columns explanation
- **Keyboard controls**: Complete reference for selection, navigation, and exit commands
- **Visual indicators**: Explanation of checkboxes, colors, and cursor positioning
- **Package types**: Description of dependency type labels (dev, peer, optional)
- **Integration**: How interactive mode works with `--latest` flag

This documentation covers the comprehensive interactive update functionality that allows users to selectively choose which packages to update through a terminal-based interface.

🤖 Generated with [Claude Code](https://claude.ai/code)