### PR TITLE
Fix CSS error with printing `:is(...)` pseudo class

### DIFF
--- a/src/css/selectors/parser.zig
+++ b/src/css/selectors/parser.zig
@@ -1732,6 +1732,24 @@ pub fn GenericSelector(comptime Impl: type) type {
             return parse(&selector_parser, input);
         }
 
+        pub fn iterRawMatchOrder(this: *const This) RawMatchOrderIterator {
+            return RawMatchOrderIterator{
+                .slice = this.components.items,
+            };
+        }
+
+        const RawMatchOrderIterator = struct {
+            slice: []const GenericComponent(Impl),
+            i: usize = 0,
+
+            pub fn next(this: *@This()) ?GenericComponent(Impl) {
+                if (this.i >= this.slice.len) return null;
+                const result = this.slice[this.i];
+                this.i += 1;
+                return result;
+            }
+        };
+
         /// Returns an iterator over the sequence of simple selectors and
         /// combinators, in parse order (from left to right), starting from
         /// `offset`.

--- a/src/css/selectors/selector.zig
+++ b/src/css/selectors/selector.zig
@@ -1510,7 +1510,7 @@ pub fn shouldUnwrapIs(selectors: []const parser.Selector) bool {
 }
 
 fn hasTypeSelector(selector: *const parser.Selector) bool {
-    var iter = selector.iterRawParseOrderFrom(0);
+    var iter = selector.iterRawMatchOrder();
     const first = iter.next();
 
     if (isNamespace(if (first) |*f| f else null)) return isTypeSelector(if (iter.next()) |*n| n else null);

--- a/test/bundler/css/is-selector-21169.test.ts
+++ b/test/bundler/css/is-selector-21169.test.ts
@@ -12,8 +12,8 @@ describe("css", () => {
     outdir: "/out",
     entryPoints: ["/index.css"],
     onAfterBundle(api) {
-      api.expectFile("/out/index.css").toEqualIgnoringWhitespace(`
-        /* index.css */
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
         .foo:-webkit-any(input:checked) {
           color: red;
         }
@@ -25,6 +25,7 @@ describe("css", () => {
         .foo:is(input:checked) {
           color: red;
         }
+        "
       `);
     },
   });

--- a/test/bundler/css/is-selector-21169.test.ts
+++ b/test/bundler/css/is-selector-21169.test.ts
@@ -1,0 +1,31 @@
+import { itBundled } from "../expectBundled";
+
+describe("css", () => {
+  itBundled("css/is-selector", {
+    files: {
+      "index.css": /* css */ `
+        .foo:is(input:checked) {
+           color: red;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toEqualIgnoringWhitespace(`
+        /* index.css */
+        .foo:-webkit-any(input:checked) {
+          color: red;
+        }
+
+        .foo:-moz-any(input:checked) {
+          color: red;
+        }
+
+        .foo:is(input:checked) {
+          color: red;
+        }
+      `);
+    },
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #21169
