### PR TITLE
Update lol-html to v2.6.0

### DIFF
--- a/cmake/targets/BuildLolHtml.cmake
+++ b/cmake/targets/BuildLolHtml.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     cloudflare/lol-html
   COMMIT
-    67f1d4ffd6b74db7e053fb129dcce620193c180d
+    d64457d9ff0143deef025d5df7e8586092b9afb7
 )
 
 set(LOLHTML_CWD ${VENDOR_PATH}/lolhtml/c-api)

--- a/src/deps/lol-html.zig
+++ b/src/deps/lol-html.zig
@@ -6,6 +6,11 @@ pub const MemorySettings = extern struct {
     max_allowed_memory_usage: usize,
 };
 
+pub const SourceLocationBytes = extern struct {
+    start: usize,
+    end: usize,
+};
+
 inline fn auto_disable() void {
     if (comptime bun.FeatureFlags.disable_lolhtml)
         unreachable;
@@ -313,6 +318,7 @@ pub const TextChunk = opaque {
     extern fn lol_html_text_chunk_is_removed(chunk: *const TextChunk) bool;
     extern fn lol_html_text_chunk_user_data_set(chunk: *const TextChunk, user_data: ?*anyopaque) void;
     extern fn lol_html_text_chunk_user_data_get(chunk: *const TextChunk) ?*anyopaque;
+    extern fn lol_html_text_chunk_source_location_bytes(chunk: *const TextChunk) SourceLocationBytes;
 
     pub const Content = extern struct {
         ptr: [*]const u8,
@@ -383,6 +389,10 @@ pub const TextChunk = opaque {
         auto_disable();
         return @as(?*Type, @ptrCast(@alignCast(this.lol_html_text_chunk_user_data_get())));
     }
+    pub fn getSourceLocationBytes(this: *const TextChunk) SourceLocationBytes {
+        auto_disable();
+        return this.lol_html_text_chunk_source_location_bytes();
+    }
 };
 pub const Element = opaque {
     extern fn lol_html_element_get_attribute(element: *const Element, name: [*]const u8, name_len: usize) HTMLString;
@@ -404,6 +414,7 @@ pub const Element = opaque {
     extern fn lol_html_element_user_data_get(element: *const Element) ?*anyopaque;
     extern fn lol_html_element_add_end_tag_handler(element: *Element, end_tag_handler: lol_html_end_tag_handler_t, user_data: ?*anyopaque) c_int;
     extern fn lol_html_element_clear_end_tag_handlers(element: *Element) void;
+    extern fn lol_html_element_source_location_bytes(element: *const Element) SourceLocationBytes;
 
     pub fn getAttribute(element: *const Element, name: []const u8) HTMLString {
         auto_disable();
@@ -554,6 +565,11 @@ pub const Element = opaque {
     pub fn attributes(element: *const Element) ?*Attribute.Iterator {
         return lol_html_attributes_iterator_get(element);
     }
+
+    pub fn getSourceLocationBytes(element: *const Element) SourceLocationBytes {
+        auto_disable();
+        return lol_html_element_source_location_bytes(element);
+    }
 };
 
 pub const HTMLString = extern struct {
@@ -608,6 +624,7 @@ pub const EndTag = opaque {
     extern fn lol_html_end_tag_remove(end_tag: *EndTag) void;
     extern fn lol_html_end_tag_name_get(end_tag: *const EndTag) HTMLString;
     extern fn lol_html_end_tag_name_set(end_tag: *EndTag, name: [*]const u8, name_len: usize) c_int;
+    extern fn lol_html_end_tag_source_location_bytes(end_tag: *const EndTag) SourceLocationBytes;
 
     pub fn before(end_tag: *EndTag, content: []const u8, is_html: bool) Error!void {
         auto_disable();
@@ -643,6 +660,11 @@ pub const EndTag = opaque {
             -1 => error.Fail,
             else => unreachable,
         };
+    }
+
+    pub fn getSourceLocationBytes(end_tag: *const EndTag) SourceLocationBytes {
+        auto_disable();
+        return lol_html_end_tag_source_location_bytes(end_tag);
     }
 };
 
@@ -684,6 +706,7 @@ pub const Comment = opaque {
     extern fn lol_html_comment_is_removed(comment: *const Comment) bool;
     extern fn lol_html_comment_user_data_set(comment: *const Comment, user_data: ?*anyopaque) void;
     extern fn lol_html_comment_user_data_get(comment: *const Comment) ?*anyopaque;
+    extern fn lol_html_comment_source_location_bytes(comment: *const Comment) SourceLocationBytes;
 
     pub fn getText(comment: *const Comment) HTMLString {
         auto_disable();
@@ -728,6 +751,11 @@ pub const Comment = opaque {
 
     pub const isRemoved = lol_html_comment_is_removed;
     pub const remove = lol_html_comment_remove;
+
+    pub fn getSourceLocationBytes(comment: *const Comment) SourceLocationBytes {
+        auto_disable();
+        return lol_html_comment_source_location_bytes(comment);
+    }
 };
 
 pub const Directive = enum(c_uint) {
@@ -797,6 +825,7 @@ pub const DocType = opaque {
     extern fn lol_html_doctype_user_data_get(doctype: *const DocType) ?*anyopaque;
     extern fn lol_html_doctype_remove(doctype: *DocType) void;
     extern fn lol_html_doctype_is_removed(doctype: *const DocType) bool;
+    extern fn lol_html_doctype_source_location_bytes(doctype: *const DocType) SourceLocationBytes;
 
     pub const Callback = *const fn (*DocType, ?*anyopaque) callconv(.C) Directive;
 
@@ -819,6 +848,10 @@ pub const DocType = opaque {
     pub fn isRemoved(this: *const DocType) bool {
         auto_disable();
         return this.lol_html_doctype_is_removed();
+    }
+    pub fn getSourceLocationBytes(this: *const DocType) SourceLocationBytes {
+        auto_disable();
+        return this.lol_html_doctype_source_location_bytes();
     }
 };
 


### PR DESCRIPTION
## Summary
- Update lol-html dependency from commit 67f1d4f to d64457d (v2.6.0)
- Add new source code location APIs to Zig bindings
- Maintain full backward compatibility

## Changes
- **cmake/targets/BuildLolHtml.cmake**: Updated commit hash to v2.6.0
- **src/deps/lol-html.zig**: Added `SourceLocationBytes` struct and `getSourceLocationBytes()` methods for all HTML element types

## New Features from lol-html v2.6.0
- Source code location tracking for HTML elements, comments, text chunks, doctypes, and end tags
- Performance improvements and code size reductions

## Test plan
- [x] Build completes successfully with `bun bd`
- [x] All HTML rewriter tests pass: `bun bd test test/js/workerd/html-rewriter.test.js` (41 pass, 0 fail)
- [x] No breaking changes to existing APIs

🤖 Generated with [Claude Code](https://claude.ai/code)