### PR TITLE
`bun ci` delete node_modules like `npm ci`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -168,5 +168,5 @@
     "WebKit/WebInspectorUI": true,
   },
   "git.detectSubmodules": false,
-  // "bun.test.customScript": "./build/debug/bun-debug test"
+  "bun.test.customScript": "./build/debug/bun-debug test"
 }

--- a/src/cli/install_command.zig
+++ b/src/cli/install_command.zig
@@ -16,7 +16,7 @@ pub const InstallCommand = struct {
 fn deleteOldNodeModules(fd: bun.FileDescriptor) void {
     var dir = std.fs.Dir{ .fd = fd.cast() };
     var iter = dir.iterate();
-    
+
     while (iter.next() catch null) |entry| {
         if (entry.kind == .directory and std.mem.startsWith(u8, entry.name, ".node_modules_old_")) {
             fd.deleteTree(entry.name) catch {};
@@ -77,9 +77,9 @@ fn installWithCLI(ctx: Command.Context, cli: CommandLineArguments) !void {
         const timestamp = @as(u64, @intCast(std.time.milliTimestamp()));
         var temp_name_buf: [256]u8 = undefined;
         const temp_name = std.fmt.bufPrintZ(&temp_name_buf, ".node_modules_old_{d}", .{timestamp}) catch ".node_modules_old";
-        
+
         _ = bun.sys.renameat(manager.root_dir.fd, "node_modules", manager.root_dir.fd, temp_name);
-        
+
         const delete_thread = std.Thread.spawn(.{}, deleteOldNodeModules, .{manager.root_dir.fd}) catch null;
         if (delete_thread) |thread| {
             thread.detach();

--- a/src/cli/install_command.zig
+++ b/src/cli/install_command.zig
@@ -62,6 +62,10 @@ fn installWithCLI(ctx: Command.Context, cli: CommandLineArguments) !void {
     // and cleanup install/add subcommand usage
     var manager, const original_cwd = try PackageManager.init(ctx, cli, .install);
 
+    if (cli.is_ci_command and subcommand == .install) {
+        manager.root_dir.fd.deleteTree("node_modules") catch {};
+    }
+
     // switch to `bun add <package>`
     if (subcommand == .add) {
         manager.subcommand = .add;

--- a/src/cli/install_command.zig
+++ b/src/cli/install_command.zig
@@ -13,6 +13,17 @@ pub const InstallCommand = struct {
     }
 };
 
+fn deleteOldNodeModules(fd: bun.FileDescriptor) void {
+    var dir = std.fs.Dir{ .fd = fd.cast() };
+    var iter = dir.iterate();
+    
+    while (iter.next() catch null) |entry| {
+        if (entry.kind == .directory and std.mem.startsWith(u8, entry.name, ".node_modules_old_")) {
+            fd.deleteTree(entry.name) catch {};
+        }
+    }
+}
+
 fn install(ctx: Command.Context) !void {
     var cli = try CommandLineArguments.parse(ctx.allocator, .install);
 
@@ -63,7 +74,16 @@ fn installWithCLI(ctx: Command.Context, cli: CommandLineArguments) !void {
     var manager, const original_cwd = try PackageManager.init(ctx, cli, .install);
 
     if (cli.is_ci_command and subcommand == .install) {
-        manager.root_dir.fd.deleteTree("node_modules") catch {};
+        const timestamp = @as(u64, @intCast(std.time.milliTimestamp()));
+        var temp_name_buf: [256]u8 = undefined;
+        const temp_name = std.fmt.bufPrintZ(&temp_name_buf, ".node_modules_old_{d}", .{timestamp}) catch ".node_modules_old";
+        
+        _ = bun.sys.renameat(manager.root_dir.fd, "node_modules", manager.root_dir.fd, temp_name);
+        
+        const delete_thread = std.Thread.spawn(.{}, deleteOldNodeModules, .{manager.root_dir.fd}) catch null;
+        if (delete_thread) |thread| {
+            thread.detach();
+        }
     }
 
     // switch to `bun add <package>`

--- a/src/cli/install_command.zig
+++ b/src/cli/install_command.zig
@@ -18,7 +18,7 @@ fn deleteOldNodeModules(fd: bun.FileDescriptor) void {
     var iter = dir.iterate();
 
     while (iter.next() catch null) |entry| {
-        if (entry.kind == .directory and std.mem.startsWith(u8, entry.name, ".node_modules_old_")) {
+        if (entry.kind == .directory and bun.strings.hasPrefixComptime(entry.name, ".node_modules_old_")) {
             fd.deleteTree(entry.name) catch {};
         }
     }

--- a/src/copy_file.zig
+++ b/src/copy_file.zig
@@ -294,10 +294,11 @@ pub fn copyFileReadWriteLoop(
     }
 }
 
+const debug = bun.Output.scoped(.copy_file, true);
+
 const bun = @import("bun");
 const Environment = bun.Environment;
 const Maybe = bun.sys.Maybe;
-const debug = bun.Output.scoped(.copy_file, true);
 const Platform = bun.analytics.GenerateHeader.GeneratePlatform;
 
 const std = @import("std");

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -174,6 +174,7 @@ positionals: []const string = &[_]string{},
 yarn: bool = false,
 production: bool = false,
 frozen_lockfile: bool = false,
+is_ci_command: bool = false,
 no_save: bool = false,
 dry_run: bool = false,
 force: bool = false,
@@ -715,7 +716,8 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     cli.positionals = args.positionals();
     cli.yarn = args.flag("--yarn");
     cli.production = args.flag("--production");
-    cli.frozen_lockfile = args.flag("--frozen-lockfile") or (cli.positionals.len > 0 and strings.eqlComptime(cli.positionals[0], "ci"));
+    cli.is_ci_command = cli.positionals.len > 0 and strings.eqlComptime(cli.positionals[0], "ci");
+    cli.frozen_lockfile = args.flag("--frozen-lockfile") or cli.is_ci_command;
     cli.no_progress = args.flag("--no-progress");
     cli.dry_run = args.flag("--dry-run");
     cli.global = args.flag("--global");

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -35,7 +35,7 @@ const words: Record<string, { reason: string; limit?: number; regex?: boolean }>
   [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", limit: 230, regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
 
-  "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 170 },
+  "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 171 },
   "std.fs.cwd": { reason: "Prefer bun.FD.cwd()", limit: 103 },
   "std.fs.File": { reason: "Prefer bun.sys + bun.FD instead of std.fs", limit: 62 },
   ".stdFile()": { reason: "Prefer bun.sys + bun.FD instead of std.fs.File. Zig hides 'errno' when Bun wants to match libuv", limit: 18 },


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
