### PR TITLE
bun shell allow `.quiet(true|false)`

### DIFF
--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -112,8 +112,9 @@ declare module "bun" {
        * By default, the shell will write to the current process's stdout and stderr, as well as buffering that output.
        *
        * This configures the shell to only buffer the output.
+       * @param isQuiet - Whether to suppress output. Defaults to true.
        */
-      quiet(): this;
+      quiet(isQuiet?: boolean): this;
 
       /**
        * Read from stdout as a string, line by line

--- a/src/bun.js/api/ShellArgs.classes.ts
+++ b/src/bun.js/api/ShellArgs.classes.ts
@@ -21,7 +21,7 @@ export default [
       },
       setQuiet: {
         fn: "setQuiet",
-        length: 0,
+        length: 1,
       },
     },
   }),

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -175,14 +175,14 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
       }
     }
 
-    #quiet(): this {
+    #quiet(isQuiet: boolean = true): this {
       this.#throwIfRunning();
-      this.#args!.setQuiet();
+      this.#args!.setQuiet(isQuiet);
       return this;
     }
 
-    quiet(): this {
-      return this.#quiet();
+    quiet(isQuiet: boolean | undefined): this {
+      return this.#quiet(isQuiet ?? true);
     }
 
     nothrow(): this {
@@ -196,17 +196,17 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     }
 
     async text(encoding) {
-      const { stdout } = (await this.#quiet()) as ShellOutput;
+      const { stdout } = (await this.#quiet(true)) as ShellOutput;
       return stdout.toString(encoding);
     }
 
     async json() {
-      const { stdout } = (await this.#quiet()) as ShellOutput;
+      const { stdout } = (await this.#quiet(true)) as ShellOutput;
       return JSON.parse(stdout.toString());
     }
 
     async *lines() {
-      const { stdout } = (await this.#quiet()) as ShellOutput;
+      const { stdout } = (await this.#quiet(true)) as ShellOutput;
 
       if (process.platform === "win32") {
         yield* stdout.toString().split(/\r?\n/);
@@ -216,7 +216,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     }
 
     async arrayBuffer() {
-      const { stdout } = (await this.#quiet()) as ShellOutput;
+      const { stdout } = (await this.#quiet(true)) as ShellOutput;
       return stdout.buffer;
     }
 
@@ -225,7 +225,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     }
 
     async blob() {
-      const { stdout } = (await this.#quiet()) as ShellOutput;
+      const { stdout } = (await this.#quiet(true)) as ShellOutput;
       return new Blob([stdout]);
     }
 

--- a/src/shell/ParsedShellScript.zig
+++ b/src/shell/ParsedShellScript.zig
@@ -56,8 +56,9 @@ pub fn setCwd(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: 
     return .js_undefined;
 }
 
-pub fn setQuiet(this: *ParsedShellScript, _: *JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-    this.quiet = true;
+pub fn setQuiet(this: *ParsedShellScript, _: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const arg = callframe.argument(0);
+    this.quiet = arg.toBoolean();
     return .js_undefined;
 }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -195,6 +195,28 @@ describe("bunshell", () => {
     test("cmd subst", async () => {
       await TestBuilder.command`echo $(echo hi)`.quiet().stdout("hi\n").run();
     });
+
+    test.each([
+      { value: undefined, expectedQuiet: true, description: "quiet()" },
+      { value: true, expectedQuiet: true, description: "quiet(true)" },
+      { value: false, expectedQuiet: false, description: "quiet(false)" },
+    ])("$description suppresses output: $expectedQuiet", async ({ value, expectedQuiet }) => {
+      // Test with spawned process to check actual stdout
+      const quietArg = value === undefined ? "" : value.toString();
+      const { stdout, stderr } = Bun.spawnSync(
+        [BUN, "-e", `await Bun.$\`echo "test output"\`.quiet(${quietArg === undefined ? "" : quietArg})`],
+        {
+          env: { BUN_DEBUG_QUIET_LOGS: "1" },
+        },
+      );
+
+      if (expectedQuiet) {
+        expect(stdout.toString()).toBe("");
+      } else {
+        expect(stdout.toString()).toBe("test output\n");
+      }
+      expect(stderr.toString()).toBe("");
+    });
   });
 
   test("failing stmt edgecase", async () => {


### PR DESCRIPTION
### What does this PR do?

fixes https://github.com/oven-sh/bun/issues/17544
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
