### PR TITLE
[STAB-851] rename core dump to `bun-{pid}.core`

### DIFF
--- a/scripts/debug-coredump.ts
+++ b/scripts/debug-coredump.ts
@@ -44,8 +44,8 @@ if (!fs.existsSync(join(dir, "bun-profile")) || !fs.existsSync(join(dir, `bun-${
   await Bun.$`bash -c ${`age -d -i <(echo "$AGE_CORES_IDENTITY")`} < ${cores} | tar -zxvC ${dir}`;
 
   console.log("moving cores out of nested directory");
-  for await (const file of new Bun.Glob("bun-cores-*/bun-*.core").scan(dir)) {
-    fs.renameSync(join(dir, file), join(dir, basename(file)));
+  for await (const file of new Bun.Glob("bun-cores-*/*.core").scan(dir)) {
+    fs.renameSync(join(dir, file), join(dir, `bun-${pid}.core`));
   }
 } else {
   console.log(`already downloaded in ${dir}`);

--- a/scripts/debug-coredump.ts
+++ b/scripts/debug-coredump.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 // usage: bun debug-coredump.ts


### PR DESCRIPTION
### What does this PR do?
Fixes running the script when the crash happens on another thread
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Manually
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
