### PR TITLE
[PKG-513, ENG-19757] `bun install`: fix non-ascii edge case and simplify task lifetimes

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1555,11 +1555,11 @@ fn _resolve(
         return;
     } else if (strings.hasPrefixComptime(specifier, js_ast.Macro.namespaceWithColon)) {
         ret.result = null;
-        ret.path = specifier;
+        ret.path = try bun.default_allocator.dupe(u8, specifier);
         return;
     } else if (strings.hasPrefixComptime(specifier, node_fallbacks.import_path)) {
         ret.result = null;
-        ret.path = specifier;
+        ret.path = try bun.default_allocator.dupe(u8, specifier);
         return;
     } else if (jsc.ModuleLoader.HardcodedModule.Alias.get(specifier, .bun)) |result| {
         ret.result = null;
@@ -1570,12 +1570,12 @@ fn _resolve(
             strings.endsWithComptime(specifier, bun.pathLiteral("/[stdin]"))))
     {
         ret.result = null;
-        ret.path = specifier;
+        ret.path = try bun.default_allocator.dupe(u8, specifier);
         return;
     } else if (strings.hasPrefixComptime(specifier, "blob:")) {
         ret.result = null;
         if (jsc.WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])) {
-            ret.path = specifier;
+            ret.path = try bun.default_allocator.dupe(u8, specifier);
             return;
         } else {
             return error.ModuleNotFound;

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -70,12 +70,9 @@ pub fn runTasks(
 
     if (Ctx == *Store.Installer) {
         const installer: *Store.Installer = extract_ctx;
-        const batch = installer.tasks.popBatch();
+        const batch = installer.task_queue.popBatch();
         var iter = batch.iterator();
         while (iter.next()) |task| {
-            defer {
-                installer.preallocated_tasks.put(task);
-            }
             switch (task.result) {
                 .none => {
                     if (comptime Environment.ci_assert) {

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -620,6 +620,9 @@ pub fn installIsolatedPackages(
         var seen_workspace_ids: std.AutoHashMapUnmanaged(PackageID, void) = .empty;
         defer seen_workspace_ids.deinit(lockfile.allocator);
 
+        const tasks = try manager.allocator.alloc(Store.Installer.Task, store.entries.len);
+        defer manager.allocator.free(tasks);
+
         var installer: Store.Installer = .{
             .lockfile = lockfile,
             .manager = manager,
@@ -628,11 +631,23 @@ pub fn installIsolatedPackages(
             .install_node = if (manager.options.log_level.showProgress()) &install_node else null,
             .scripts_node = if (manager.options.log_level.showProgress()) &scripts_node else null,
             .store = &store,
-            .preallocated_tasks = .init(bun.default_allocator),
+            .tasks = tasks,
             .trusted_dependencies_mutex = .{},
             .trusted_dependencies_from_update_requests = manager.findTrustedDependenciesFromUpdateRequests(),
             .supported_backend = .init(PackageInstall.supported_method),
         };
+
+        for (tasks, 0..) |*task, _entry_id| {
+            const entry_id: Store.Entry.Id = .from(@intCast(_entry_id));
+            task.* = .{
+                .entry_id = entry_id,
+                .installer = &installer,
+                .result = .none,
+
+                .task = .{ .callback = &Store.Installer.Task.callback },
+                .next = null,
+            };
+        }
 
         // add the pending task count upfront
         _ = manager.incrementPendingTasks(@intCast(store.entries.len));

--- a/src/which.zig
+++ b/src/which.zig
@@ -111,18 +111,12 @@ fn searchBin(buf: *bun.WPathBuffer, path_size: usize, check_windows_extensions: 
 fn searchBinInPath(buf: *bun.WPathBuffer, path_buf: *bun.PathBuffer, path: []const u8, bin: []const u8, check_windows_extensions: bool) ?[:0]u16 {
     if (path.len == 0) return null;
     const segment = if (std.fs.path.isAbsolute(path)) (PosixToWinNormalizer.resolveCWDWithExternalBuf(path_buf, path) catch return null) else path;
-    const segment_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf, segment);
+    const segment_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf, bun.strings.withoutTrailingSlash(segment));
 
-    var segment_len = segment.len;
-    var segment_utf16_len = segment_utf16.len;
-    if (buf[segment.len - 1] != std.fs.path.sep) {
-        buf[segment.len] = std.fs.path.sep;
-        segment_len += 1;
-        segment_utf16_len += 1;
-    }
+    buf[segment_utf16.len] = std.fs.path.sep;
 
-    const bin_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf[segment_len..], bin);
-    const path_size = segment_utf16_len + bin_utf16.len;
+    const bin_utf16 = bun.strings.convertUTF8toUTF16InBuffer(buf[segment_utf16.len + 1 ..], bin);
+    const path_size = segment_utf16.len + 1 + bin_utf16.len;
     buf[path_size] = 0;
 
     return searchBin(buf, path_size, check_windows_extensions);

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -73,6 +73,24 @@ for (const flag of ["-e", "--print"]) {
       });
       expect(stdout.toString("utf8")).toEqual(code + "\n");
     });
+
+    test("does not crash in non-latin1 directory", async () => {
+      const dir = join(tmpdirSync(), "eval-test-开始学习");
+      await Bun.write(join(dir, "index.js"), "console.log('hello world')");
+
+      const { stdout, stderr, exitCode } = Bun.spawnSync({
+        cmd: [bunExe(), flag, "import './index.js'"],
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+
+      expect(stderr.toString("utf8")).toBe("");
+      expect(stdout.toString("utf8")).toEqual("hello world\n" + (flag === "--print" ? "undefined\n" : ""));
+      expect(exitCode).toBe(0);
+    });
   });
 }
 

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -160,3 +160,24 @@ test("Bun.which does look in the current directory when given a path with a slas
     process.chdir(cwd);
   }
 });
+
+test("Bun.which can find executables in a non-ascii directory", async () => {
+  const cwd = process.cwd();
+  const dir = tempDirWithFiles("which-non-ascii-开始学习", {
+    "some_program_name": "#!/usr/bin/env sh\necho posix\nexit 0\n",
+    "some_program_name.cmd": "@echo win32\n@exit 0\n",
+  });
+
+  process.chdir(dir);
+  try {
+    if (!isWindows) {
+      await $`chmod +x ./some_program_name`;
+    }
+
+    const suffix = isWindows ? ".cmd" : "";
+    expect(which("./some_program_name")).toBe(join(dir, "some_program_name" + suffix));
+    expect((await $`./some_program_name`.text()).trim()).toBe(isWindows ? "win32" : "posix");
+  } finally {
+    process.chdir(cwd);
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Replaces the preallocated_tasks HiveArray with a fixed-size tasks array allocated per install, and renames the tasks queue to task_queue for clarity. Tasks are now initialized up front and referenced by entry_id, simplifying task lifecycle management and reducing dynamic allocation overhead.

---

Fixes a bug in handling non-ascii directory paths in `Bun.which` on windows.

fixes #21243

---

Fixes a string UAF when importing a module with a non-latin1 file path

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

### How did you verify your code works?
Added a test for both path bugs.
<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
