### PR TITLE
fix(https) fix agent port being rewritten when agent is present with url

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -614,8 +614,7 @@ function ClientRequest(input, options, cb) {
     const urlStr = input;
     try {
       var urlObject = new URL(urlStr);
-    } catch (_err) {
-      void _err;
+    } catch {
       throw $ERR_INVALID_URL(`Invalid URL: ${urlStr}`);
     }
     input = urlToHttpOptions(urlObject);
@@ -634,7 +633,16 @@ function ClientRequest(input, options, cb) {
   } else {
     options = ObjectAssign(input || {}, options);
   }
-
+  {
+    const url = options.url;
+    if (typeof url === "string") {
+      try {
+        options.url = new URL(url);
+      } catch {
+        throw $ERR_INVALID_URL(`Invalid URL: ${url}`);
+      }
+    }
+  }
   this[kTls] = null;
   this[kAbortController] = null;
 
@@ -668,7 +676,7 @@ function ClientRequest(input, options, cb) {
   }
 
   const defaultPort = options.defaultPort || this[kAgent].defaultPort;
-  const port = (this[kPort] = options.port || defaultPort || 80);
+  const port = (this[kPort] = options?.url?.port || options.port || defaultPort || 80);
   this[kUseDefaultPort] = this[kPort] === defaultPort;
   const host =
     (this[kHost] =


### PR DESCRIPTION
### What does this PR do?
When agent was present url port was being ignored so https requests failed when in another port
<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [X] Code changes

### How did you verify your code works?
Tests

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
