### PR TITLE
fix(websocket): prevent double deref crash in handleClose (#21372)

### DIFF
--- a/test/regression/issue/21372-websocket-network-change-crash.test.ts
+++ b/test/regression/issue/21372-websocket-network-change-crash.test.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "bun:test";
+
+// Test for issue #21372: Segmentation fault crash after network is changed
+// This test verifies that the double deref bug in WebSocket handleClose is fixed
+
+test("WebSocket client should handle server-initiated close without double deref", async () => {
+  // Create a server that will close the connection immediately after opening
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      const success = server.upgrade(req);
+      return success ? undefined : new Response("Upgrade failed", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        // Immediately close the connection to trigger handleClose in the client
+        setTimeout(() => {
+          ws.close(1000, "server initiated close");
+        }, 10);
+      },
+      message(ws, message) {
+        // Echo message
+        ws.send(message);
+      },
+    },
+  });
+
+  const port = server.port;
+  
+  try {
+    let closeCount = 0;
+    let errorCount = 0;
+    
+    const promises: Promise<void>[] = [];
+    
+    // Create multiple connections that will be closed by the server
+    // This exercises the handleClose -> dispatchAbruptClose -> deref path
+    for (let i = 0; i < 10; i++) {
+      const promise = new Promise<void>((resolve, reject) => {
+        const client = new WebSocket(`ws://localhost:${port}`);
+        
+        const timeout = setTimeout(() => {
+          reject(new Error(`Connection ${i} timeout`));
+        }, 2000);
+        
+        client.onopen = () => {
+          // Send a message to ensure the connection is fully established
+          client.send(`hello-${i}`);
+        };
+        
+        client.onmessage = (event) => {
+          // Message received, connection is working
+        };
+        
+        client.onclose = (event) => {
+          closeCount++;
+          clearTimeout(timeout);
+          resolve();
+        };
+        
+        client.onerror = (error) => {
+          errorCount++;
+          clearTimeout(timeout);
+          resolve(); // Don't reject, errors are expected during rapid close
+        };
+      });
+      
+      promises.push(promise);
+    }
+    
+    // Wait for all connections to complete
+    await Promise.allSettled(promises);
+    
+    // The test passes if we don't crash with a segfault
+    // We expect some connections to close or error
+    expect(closeCount + errorCount).toBeGreaterThan(0);
+    
+  } finally {
+    server.stop();
+  }
+}, 5000);
+
+test("WebSocket client should handle rapid connection cycles", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      const success = server.upgrade(req);
+      return success ? undefined : new Response("Upgrade failed", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        ws.send("connected");
+      },
+      message(ws, message) {
+        ws.send("pong");
+      },
+    },
+  });
+
+  const port = server.port;
+  
+  try {
+    // Create and close many connections quickly to stress test the cleanup paths
+    for (let i = 0; i < 5; i++) {
+      const client = new WebSocket(`ws://localhost:${port}`);
+      
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, 500);
+        
+        client.onopen = () => {
+          client.send("ping");
+          // Close immediately after opening
+          setTimeout(() => {
+            client.close();
+          }, 10);
+        };
+        
+        client.onclose = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+        
+        client.onerror = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+      });
+    }
+    
+    // If we reach here without crashing, the fix works
+    expect(true).toBe(true);
+    
+  } finally {
+    server.stop();
+  }
+}, 5000);

--- a/test/regression/issue/21372-websocket-network-change-crash.test.ts
+++ b/test/regression/issue/21372-websocket-network-change-crash.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // Test for issue #21372: Segmentation fault crash after network is changed
 // This test verifies that the double deref bug in WebSocket handleClose is fixed
@@ -26,55 +26,54 @@ test("WebSocket client should handle server-initiated close without double deref
   });
 
   const port = server.port;
-  
+
   try {
     let closeCount = 0;
     let errorCount = 0;
-    
+
     const promises: Promise<void>[] = [];
-    
+
     // Create multiple connections that will be closed by the server
     // This exercises the handleClose -> dispatchAbruptClose -> deref path
     for (let i = 0; i < 10; i++) {
       const promise = new Promise<void>((resolve, reject) => {
         const client = new WebSocket(`ws://localhost:${port}`);
-        
+
         const timeout = setTimeout(() => {
           reject(new Error(`Connection ${i} timeout`));
         }, 2000);
-        
+
         client.onopen = () => {
           // Send a message to ensure the connection is fully established
           client.send(`hello-${i}`);
         };
-        
-        client.onmessage = (event) => {
+
+        client.onmessage = event => {
           // Message received, connection is working
         };
-        
-        client.onclose = (event) => {
+
+        client.onclose = event => {
           closeCount++;
           clearTimeout(timeout);
           resolve();
         };
-        
-        client.onerror = (error) => {
+
+        client.onerror = error => {
           errorCount++;
           clearTimeout(timeout);
           resolve(); // Don't reject, errors are expected during rapid close
         };
       });
-      
+
       promises.push(promise);
     }
-    
+
     // Wait for all connections to complete
     await Promise.allSettled(promises);
-    
+
     // The test passes if we don't crash with a segfault
     // We expect some connections to close or error
     expect(closeCount + errorCount).toBeGreaterThan(0);
-    
   } finally {
     server.stop();
   }
@@ -98,15 +97,15 @@ test("WebSocket client should handle rapid connection cycles", async () => {
   });
 
   const port = server.port;
-  
+
   try {
     // Create and close many connections quickly to stress test the cleanup paths
     for (let i = 0; i < 5; i++) {
       const client = new WebSocket(`ws://localhost:${port}`);
-      
-      await new Promise<void>((resolve) => {
+
+      await new Promise<void>(resolve => {
         const timeout = setTimeout(resolve, 500);
-        
+
         client.onopen = () => {
           client.send("ping");
           // Close immediately after opening
@@ -114,22 +113,21 @@ test("WebSocket client should handle rapid connection cycles", async () => {
             client.close();
           }, 10);
         };
-        
+
         client.onclose = () => {
           clearTimeout(timeout);
           resolve();
         };
-        
+
         client.onerror = () => {
           clearTimeout(timeout);
           resolve();
         };
       });
     }
-    
+
     // If we reach here without crashing, the fix works
     expect(true).toBe(true);
-    
   } finally {
     server.stop();
   }


### PR DESCRIPTION
## Summary
- Fixes a double deref bug in WebSocket client's `handleClose` function that caused segmentation faults 
- Adds regression test to prevent similar issues
- Specifically addresses issue #21372 where network changes triggered crashes on Windows

## Root Cause
The crash was caused by a double deref sequence in the WebSocket client cleanup:

1. `handleClose()` calls `clearData()` which unrefs `poll_ref`
2. `handleClose()` calls `dispatchAbruptClose()` which unrefs `poll_ref` **again** and derefs the object
3. `handleClose()` calls `this.deref()` **again**

This created a race condition where the WebSocket object could be freed twice, leading to segmentation faults.

## Solution
- Introduced `dispatchAbruptCloseFromSocketClose()` that handles close events without double unref/deref
- Used this function in `handleClose()` since it already manages cleanup properly
- Added comprehensive test cases to verify the fix

## Test plan
- [x] Added regression test `test/regression/issue/21372-websocket-network-change-crash.test.ts`
- [x] Test verifies server-initiated closes don't cause double deref
- [x] Test verifies rapid connection cycles work correctly
- [ ] Manual testing with network interface changes (requires Windows environment)

🤖 Generated with [Claude Code](https://claude.ai/code)