### PR TITLE
Ensure we handle aborted requests correctly in Rendering API

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -1572,17 +1572,18 @@ pub const DeferredRequest = struct {
 
     /// Deinitializes state by aborting the connection.
     fn abort(this: *DeferredRequest) void {
-        switch (this.handler) {
+        var handler = this.handler;
+        this.handler = .aborted;
+        switch (handler) {
             .server_handler => |*saved| {
-                saved.response.endWithoutBody(true);
-                saved.deinit();
+                saved.ctx.onAbort(saved.response);
+                saved.js_request.deinit();
             },
             .bundled_html_page => |r| {
                 r.response.endWithoutBody(true);
             },
-            .aborted => return,
+            .aborted => {},
         }
-        this.handler = .aborted;
     }
 };
 

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -646,11 +646,10 @@ pub fn deinit(dev: *DevServer) void {
         .next_bundle = {
             var r = dev.next_bundle.requests.first;
             while (r) |request| {
-                defer dev.deferred_request_pool.put(request);
                 // TODO: deinitializing in this state is almost certainly an assertion failure.
                 // This code is shipped in release because it is only reachable by experimenntal server components.
                 bun.debugAssert(request.data.handler != .server_handler);
-                request.data.deinit();
+                defer request.data.deref();
                 r = request.next;
             }
             dev.next_bundle.route_queue.deinit(allocator);
@@ -1088,6 +1087,8 @@ fn deferRequest(
     const method = bun.http.Method.which(req.method()) orelse .POST;
     deferred.data = .{
         .route_bundle_index = route_bundle_index,
+        .dev = dev,
+        .ref_count = .init(),
         .handler = switch (kind) {
             .bundled_html_page => .{ .bundled_html_page = .{ .response = resp, .method = method } },
             .server_handler => .{
@@ -1095,6 +1096,7 @@ fn deferRequest(
             },
         },
     };
+    deferred.data.ref();
     resp.onAborted(*DeferredRequest, DeferredRequest.onAbort, &deferred.data);
     requests_array.prepend(deferred);
 }
@@ -1533,8 +1535,20 @@ pub const DeferredRequest = struct {
     pub const List = std.SinglyLinkedList(DeferredRequest);
     pub const Node = List.Node;
 
+    const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinitImpl, .{});
+
     route_bundle_index: RouteBundle.Index,
     handler: Handler,
+    dev: *DevServer,
+
+    /// This struct can have at most 2 references it:
+    /// - The dev server (`dev.current_bundle.requests`)
+    /// - uws.Response as a user data pointer
+    ref_count: RefCount,
+
+    // expose `ref` and `deref` as public methods
+    pub const ref = RefCount.ref;
+    pub const deref = RefCount.deref;
 
     const Handler = union(enum) {
         /// For a .framework route. This says to call and render the page.
@@ -1560,10 +1574,15 @@ pub const DeferredRequest = struct {
         assert(this.handler == .aborted);
     }
 
+    /// *WARNING*: Do not call this directly, instead call `.deref()`
+    ///
     /// Calling this is only required if the desired handler is going to be avoided,
     /// such as for bundling failures or aborting the server.
     /// Does not free the underlying `DeferredRequest.Node`
-    fn deinit(this: *DeferredRequest) void {
+    fn deinitImpl(this: *DeferredRequest) void {
+        bun.assert(this.ref_count.active_counts == 0);
+
+        defer this.dev.deferred_request_pool.put(@fieldParentPtr("data", this));
         switch (this.handler) {
             .server_handler => |*saved| saved.deinit(),
             .bundled_html_page, .aborted => {},
@@ -1998,8 +2017,8 @@ pub fn finalizeBundle(
             Output.debug("current_bundle.requests.first != null. this leaves pending requests without an error page!", .{});
         }
         while (current_bundle.requests.popFirst()) |node| {
-            defer dev.deferred_request_pool.put(node);
             const req = &node.data;
+            defer req.deref();
             req.abort();
         }
     }
@@ -2505,8 +2524,8 @@ pub fn finalizeBundle(
 
         var inspector_agent = dev.inspector();
         while (current_bundle.requests.popFirst()) |node| {
-            defer dev.deferred_request_pool.put(node);
             const req = &node.data;
+            defer req.deref();
 
             const rb = dev.routeBundlePtr(req.route_bundle_index);
             rb.server_state = .possible_bundling_failures;
@@ -2609,8 +2628,8 @@ pub fn finalizeBundle(
     defer dev.graph_safety_lock.lock();
 
     while (current_bundle.requests.popFirst()) |node| {
-        defer dev.deferred_request_pool.put(node);
         const req = &node.data;
+        defer req.deref();
 
         const rb = dev.routeBundlePtr(req.route_bundle_index);
         rb.server_state = .loaded;
@@ -3952,7 +3971,7 @@ pub fn onPluginsResolved(dev: *DevServer, plugins: ?*Plugin) !void {
 pub fn onPluginsRejected(dev: *DevServer) !void {
     dev.plugin_state = .err;
     while (dev.next_bundle.requests.popFirst()) |item| {
-        defer dev.deferred_request_pool.put(item);
+        defer item.data.deref();
         item.data.abort();
     }
     dev.next_bundle.route_queue.clearRetainingCapacity();

--- a/src/bun.js/api/server/AnyRequestContext.zig
+++ b/src/bun.js/api/server/AnyRequestContext.zig
@@ -199,6 +199,28 @@ pub fn getRequest(self: AnyRequestContext) ?*uws.Request {
     }
 }
 
+pub fn onAbort(self: AnyRequestContext, response: uws.AnyResponse) void {
+    if (self.tagged_pointer.isNull()) {
+        return;
+    }
+
+    switch (self.tagged_pointer.tag()) {
+        @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(HTTPServer.RequestContext))) => {
+            self.tagged_pointer.as(HTTPServer.RequestContext).onAbort(response.TCP);
+        },
+        @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(HTTPSServer.RequestContext))) => {
+            self.tagged_pointer.as(HTTPSServer.RequestContext).onAbort(response.SSL);
+        },
+        @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(DebugHTTPServer.RequestContext))) => {
+            self.tagged_pointer.as(DebugHTTPServer.RequestContext).onAbort(response.TCP);
+        },
+        @field(Pointer.Tag, bun.meta.typeBaseName(@typeName(DebugHTTPSServer.RequestContext))) => {
+            self.tagged_pointer.as(DebugHTTPSServer.RequestContext).onAbort(response.SSL);
+        },
+        else => @panic("Unexpected AnyRequestContext tag"),
+    }
+}
+
 pub fn deref(self: AnyRequestContext) void {
     if (self.tagged_pointer.isNull()) {
         return;

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -1282,8 +1282,9 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
                     res.clearAborted();
                     res.clearOnData();
                 }
-                this.done = true;
                 _ = this.flushNoWait();
+                this.done = true;
+
                 if (this.res) |res| {
                     // is actually fine to call this if the socket is closed because of flushNoWait, the free will be defered by usockets
                     res.endStream(false);

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -825,7 +825,6 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
             // onWritable reset backpressure state to allow flushing
             this.has_backpressure = false;
             if (this.aborted) {
-                this.res = null;
                 this.signal.close(null);
                 this.flushPromise();
                 this.finalize();
@@ -841,7 +840,6 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
             // if we have nothing to write, we are done
             if (chunk.len == 0) {
                 if (this.done) {
-                    this.res = null;
                     this.signal.close(null);
                     this.flushPromise();
                     this.finalize();
@@ -1290,7 +1288,6 @@ pub fn HTTPServerWritable(comptime ssl: bool) type {
                     // is actually fine to call this if the socket is closed because of flushNoWait, the free will be defered by usockets
                     res.endStream(false);
                 }
-                this.res = null;
             }
 
             if (comptime !FeatureFlags.http_buffer_pooling) {


### PR DESCRIPTION
### What does this PR do?

We have to use the existing code for handling aborted requests instead of immediately calling deinit.

Also made the underlying uws.Response an optional pointer to mark when the request has already been aborted to make it clear it's no longer accessible.

### How did you verify your code works?

This needs a test