### PR TITLE
Give us way to know if crashing inside exit handler

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -104,6 +104,7 @@ pub fn isExiting() bool {
 /// Flushes stdout and stderr (in exit/quick_exit callback) and exits with the given code.
 pub fn exit(code: u32) noreturn {
     is_exiting.store(true, .monotonic);
+    _ = @atomicRmw(usize, &bun.analytics.Features.exited, .Add, 1, .monotonic);
 
     // If we are crashing, allow the crash handler to finish it's work.
     bun.crash_handler.sleepForeverIfAnotherThreadIsCrashing();

--- a/src/analytics.zig
+++ b/src/analytics.zig
@@ -110,6 +110,7 @@ pub const Features = struct {
     pub var csrf_verify: usize = 0;
     pub var csrf_generate: usize = 0;
     pub var unsupported_uv_function: usize = 0;
+    pub var exited: usize = 0;
 
     comptime {
         @export(&napi_module_register, .{ .name = "Bun__napi_module_register_count" });


### PR DESCRIPTION
## Summary
- Add `exited: usize = 0` field to analytics Features struct 
- Increment the counter atomically in `Global.exit` when called
- Provides visibility into how often exit is being called

## Test plan
- [x] Syntax check passes for both modified files
- [x] Code compiles without errors

🤖 Generated with [Claude Code](https://claude.ai/code)