### PR TITLE
fix: update hdrhistogram GitHub action workflow

### DIFF
--- a/.github/workflows/update-hdrhistogram.yml
+++ b/.github/workflows/update-hdrhistogram.yml
@@ -55,10 +55,13 @@ jobs:
             echo "Error: Could not fetch SHA for tag $LATEST_TAG"
             exit 1
           fi
-          LATEST_SHA=$(curl -sL "https://api.github.com/repos/HdrHistogram/HdrHistogram_c/git/tags/$LATEST_TAG_SHA" | jq -r '.object.sha')
-          if [ -z "$LATEST_SHA" ] || [ "$LATEST_SHA" = "null" ]; then
-            echo "Error: Could not fetch SHA for tag $LATEST_TAG @ $LATEST_TAG_SHA"
-            exit 1
+          
+          # Try to get commit SHA from tag object (for annotated tags)
+          # If it fails, assume it's a lightweight tag pointing directly to commit
+          LATEST_SHA=$(curl -sL "https://api.github.com/repos/HdrHistogram/HdrHistogram_c/git/tags/$LATEST_TAG_SHA" 2>/dev/null | jq -r '.object.sha // empty')
+          if [ -z "$LATEST_SHA" ]; then
+            # Lightweight tag - SHA points directly to commit
+            LATEST_SHA="$LATEST_TAG_SHA"
           fi
 
           if ! [[ $LATEST_SHA =~ ^[0-9a-f]{40}$ ]]; then
@@ -88,7 +91,7 @@ jobs:
           commit-message: "deps: update hdrhistogram to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update hdrhistogram to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-cares-${{ github.run_number }}
+          branch: deps/update-hdrhistogram-${{ github.run_number }}
           body: |
             ## What does this PR do?
 
@@ -96,4 +99,4 @@ jobs:
 
             Compare: https://github.com/HdrHistogram/HdrHistogram_c/compare/${{ steps.check-version.outputs.current }}...${{ steps.check-version.outputs.latest }}
 
-            Auto-updated by [this workflow](https://github.com/oven-sh/bun/actions/workflows/update-cares.yml)
+            Auto-updated by [this workflow](https://github.com/oven-sh/bun/actions/workflows/update-hdrhistogram.yml)


### PR DESCRIPTION
## Summary

Fixes the broken update hdrhistogram GitHub Action workflow that was failing due to multiple issues.

## Issues Fixed

1. **Tag SHA resolution failure**: The workflow failed when trying to resolve commit SHA from lightweight tags, causing the error "Could not fetch SHA for tag 0.11.8 @ 8dcce8f68512fca460b171bccc3a5afce0048779"
2. **Branch naming bug**: The workflow was creating branches named `deps/update-cares-*` instead of `deps/update-hdrhistogram-*`
3. **Wrong workflow link**: PR body was linking to `update-cares.yml` instead of `update-hdrhistogram.yml`

## Fix Details

- **Improved tag SHA resolution**: Updated logic to handle both lightweight and annotated tags:
  - Try to get commit SHA from tag object (for annotated tags)
  - If that fails, use the tag SHA directly (for lightweight tags)
  - Uses jq's `// empty` operator and proper error handling with `2>/dev/null`
- **Fixed branch naming**: Changed from `deps/update-cares-*` to `deps/update-hdrhistogram-*`
- **Updated workflow link**: Fixed PR body to link to correct workflow file

## Test Plan

- [x] Verified current workflow logs show the exact error being fixed
- [x] Tested API calls locally to confirm the new logic works with latest tag (0.11.8)
- [x] Confirmed the latest tag is a lightweight tag pointing directly to commit

The workflow should now run successfully on the next scheduled execution or manual trigger.

🤖 Generated with [Claude Code](https://claude.ai/code)