### PR TITLE
fix: handle both lightweight and annotated tags in update-lolhtml workflow

### DIFF
--- a/.github/workflows/update-lolhtml.yml
+++ b/.github/workflows/update-lolhtml.yml
@@ -50,15 +50,27 @@ jobs:
             exit 1
           fi
 
-          LATEST_TAG_SHA=$(curl -sL "https://api.github.com/repos/cloudflare/lol-html/git/refs/tags/$LATEST_TAG" | jq -r '.object.sha')
+          # Get the commit SHA that the tag points to
+          # This handles both lightweight tags (direct commit refs) and annotated tags (tag objects)
+          TAG_REF_RESPONSE=$(curl -sL "https://api.github.com/repos/cloudflare/lol-html/git/refs/tags/$LATEST_TAG")
+          LATEST_TAG_SHA=$(echo "$TAG_REF_RESPONSE" | jq -r '.object.sha')
+          TAG_OBJECT_TYPE=$(echo "$TAG_REF_RESPONSE" | jq -r '.object.type')
+          
           if [ -z "$LATEST_TAG_SHA" ] || [ "$LATEST_TAG_SHA" = "null" ]; then
             echo "Error: Could not fetch SHA for tag $LATEST_TAG"
             exit 1
           fi
-          LATEST_SHA=$(curl -sL "https://api.github.com/repos/cloudflare/lol-html/git/tags/$LATEST_TAG_SHA" | jq -r '.object.sha')
-          if [ -z "$LATEST_SHA" ] || [ "$LATEST_SHA" = "null" ]; then
-            echo "Error: Could not fetch SHA for tag $LATEST_TAG @ $LATEST_TAG_SHA"
-            exit 1
+          
+          if [ "$TAG_OBJECT_TYPE" = "tag" ]; then
+            # This is an annotated tag, we need to get the commit it points to
+            LATEST_SHA=$(curl -sL "https://api.github.com/repos/cloudflare/lol-html/git/tags/$LATEST_TAG_SHA" | jq -r '.object.sha')
+            if [ -z "$LATEST_SHA" ] || [ "$LATEST_SHA" = "null" ]; then
+              echo "Error: Could not fetch commit SHA for annotated tag $LATEST_TAG @ $LATEST_TAG_SHA"
+              exit 1
+            fi
+          else
+            # This is a lightweight tag pointing directly to a commit
+            LATEST_SHA="$LATEST_TAG_SHA"
           fi
 
           if ! [[ $LATEST_SHA =~ ^[0-9a-f]{40}$ ]]; then


### PR DESCRIPTION
## Summary

- Fixes the failing update-lolhtml GitHub Action that was unable to handle lightweight Git tags
- The action was failing with "Could not fetch SHA for tag v2.6.0" because it assumed all tags are annotated tag objects
- Updated the workflow to properly handle both lightweight tags (direct commit refs) and annotated tags (tag objects)

## Root Cause

The lolhtml repository uses lightweight tags (like v2.6.0) which point directly to commits, not to tag objects. The original workflow tried to fetch a tag object for every tag, causing failures when the tag was lightweight.

## Solution

The fix adds logic to:
1. Check the tag object type from the Git refs API response
2. For annotated tags: fetch the commit SHA from the tag object (original behavior)
3. For lightweight tags: use the SHA directly from the ref (new behavior)

## Test Plan

- [x] Verified the workflow logic handles both tag types correctly
- [ ] The next scheduled run should succeed (runs weekly on Sundays at 1 AM UTC)
- [ ] Manual workflow dispatch can be used to test immediately

🤖 Generated with [Claude Code](https://claude.ai/code)