### PR TITLE
Fix shell lexer error message handling

### DIFF
--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -11,7 +11,23 @@ test("running a shell script works", async () => {
     cmd: [bunExe(), join(dir, "something.sh")],
     cwd: dir,
     env: bunEnv,
+    stderr: "pipe",
   });
   console.log(stderr.toString("utf8"));
   expect(stdout.toString("utf8")).toEqual("wah\n");
+});
+
+test("invalid syntax reports the error correctly", async () => {
+  const dir = tmpdirSync("bun-shell-test-error");
+  mkdirSync(dir, { recursive: true });
+  const shellScript = `-h)
+  echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`;
+  await Bun.write(join(dir, "scripts", "script.sh"), shellScript);
+  let { stderr } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "scripts", "script.sh")],
+    cwd: dir,
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  expect(stderr.toString("utf8")).toBe("error: Failed to run script.sh due to error Unexpected ')'\n");
 });


### PR DESCRIPTION
## Summary
- Fixed shell lexer to properly store error messages using TextRange instead of direct string slices
- This prevents potential use-after-free issues when error messages are accessed after the lexer's string pool might have been reallocated
- Added test coverage for shell syntax error reporting

## Changes
- Changed `LexError.msg` from `[]const u8` to `Token.TextRange` to store indices into the string pool
- Added `TextRange.slice()` helper method for converting ranges back to string slices
- Updated error message concatenation logic to use the new range-based approach
- Added test to verify syntax errors are reported correctly

## Test plan
- [x] Added test case for invalid shell syntax error reporting
- [x] Existing shell tests continue to pass
- [x] Manual testing of various shell syntax errors

closes BAPI-2232

🤖 Generated with [Claude Code](https://claude.ai/code)