### PR TITLE
Fix bundler cyclic imports with async dependencies

### DIFF
--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -367,22 +367,22 @@ pub const LinkerContext = struct {
             const input_files = this.parse_graph.input_files.items(.source);
             const flags: []JSMeta.Flags = this.graph.meta.items(.flags);
             const css_asts: []?*bun.css.BundlerStyleSheet = this.graph.ast.items(.css);
-            
+
             // Process all files in source index order, like esbuild does
             var source_index: u32 = 0;
             while (source_index < this.graph.files.len) : (source_index += 1) {
-                
+
                 // Skip runtime
                 if (source_index == Index.runtime.get()) continue;
-                
+
                 // Skip if not a JavaScript AST
                 if (source_index >= import_records_list.len) continue;
-                
+
                 // Skip CSS files
                 if (css_asts[source_index] != null) continue;
-                
+
                 const import_records = import_records_list[source_index].slice();
-                
+
                 _ = try this.validateTLA(source_index, tla_keywords, tla_checks, input_files, import_records, flags, import_records_list);
             }
         }

--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -357,6 +357,36 @@ pub const LinkerContext = struct {
             this.checkForMemoryCorruption();
         }
 
+        // Validate top-level await for all files first, like esbuild does.
+        // This must be done before scanImportsAndExports to ensure async
+        // status is properly propagated through cyclic imports.
+        {
+            const import_records_list: []ImportRecord.List = this.graph.ast.items(.import_records);
+            const tla_keywords = this.parse_graph.ast.items(.top_level_await_keyword);
+            const tla_checks = this.parse_graph.ast.items(.tla_check);
+            const input_files = this.parse_graph.input_files.items(.source);
+            const flags: []JSMeta.Flags = this.graph.meta.items(.flags);
+            const css_asts: []?*bun.css.BundlerStyleSheet = this.graph.ast.items(.css);
+            
+            // Process all files in source index order, like esbuild does
+            var source_index: u32 = 0;
+            while (source_index < this.graph.files.len) : (source_index += 1) {
+                
+                // Skip runtime
+                if (source_index == Index.runtime.get()) continue;
+                
+                // Skip if not a JavaScript AST
+                if (source_index >= import_records_list.len) continue;
+                
+                // Skip CSS files
+                if (css_asts[source_index] != null) continue;
+                
+                const import_records = import_records_list[source_index].slice();
+                
+                _ = try this.validateTLA(source_index, tla_keywords, tla_checks, input_files, import_records, flags, import_records_list);
+            }
+        }
+
         try this.scanImportsAndExports();
 
         // Stop now if there were errors

--- a/src/bundler/linker_context/scanImportsAndExports.zig
+++ b/src/bundler/linker_context/scanImportsAndExports.zig
@@ -12,8 +12,6 @@ pub fn scanImportsAndExports(this: *LinkerContext) !void {
         var named_imports: []js_ast.Ast.NamedImports = this.graph.ast.items(.named_imports);
         var flags: []JSMeta.Flags = this.graph.meta.items(.flags);
 
-        const tla_keywords = this.parse_graph.ast.items(.top_level_await_keyword);
-        const tla_checks = this.parse_graph.ast.items(.tla_check);
         const input_files = this.parse_graph.input_files.items(.source);
         const loaders: []const Loader = this.parse_graph.input_files.items(.loader);
 
@@ -80,7 +78,6 @@ pub fn scanImportsAndExports(this: *LinkerContext) !void {
                 continue;
             }
 
-            _ = try this.validateTLA(id, tla_keywords, tla_checks, input_files, import_records, flags, import_records_list);
 
             for (import_records) |record| {
                 if (!record.source_index.isValid()) {

--- a/src/bundler/linker_context/scanImportsAndExports.zig
+++ b/src/bundler/linker_context/scanImportsAndExports.zig
@@ -78,7 +78,6 @@ pub fn scanImportsAndExports(this: *LinkerContext) !void {
                 continue;
             }
 
-
             for (import_records) |record| {
                 if (!record.source_index.isValid()) {
                     continue;

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -3609,6 +3609,64 @@ describe("bundler", () => {
       stdout: "a.js loaded\nEntry value from a",
     },
   });
+  itBundled("default/CyclicImportsWithAsyncDependency", {
+    // Test cyclic imports where one module in the chain uses top-level await
+    // This reproduces the bug where non-async wrappers contain await statements
+    files: {
+      "/entry.js": /* js */ `
+        // Dynamic import to trigger wrapper generation
+        const mod = await import("./AsyncEntryPoint.js");
+        mod.AsyncEntryPoint();
+      `,
+      "/AsyncEntryPoint.js": /* js */ `
+        export async function AsyncEntryPoint() {
+          const { BaseElement } = await import("./BaseElement.js");
+          BaseElement();
+        }
+      `,
+      "/BaseElement.js": /* js */ `
+        import { StoreDependency } from "./StoreDependency.js";
+        import { BaseElementImport } from "./BaseElementImport.js";
+        
+        const depValue = StoreDependency();
+        
+        export const formValue = {
+          key: depValue,
+        };
+        
+        export function BaseElement() {
+          return BaseElementImport();
+        }
+      `,
+      "/BaseElementImport.js": /* js */ `
+        import { SecondElementImport } from "./SecondElementImport.js";
+        export function BaseElementImport() {
+          return SecondElementImport();
+        }
+      `,
+      "/SecondElementImport.js": /* js */ `
+        // This creates the circular dependency
+        import { formValue } from "./BaseElement.js";
+        export function SecondElementImport() {
+          return formValue.key;
+        }
+      `,
+      "/StoreDependency.js": /* js */ `
+        import { somePromise } from "./StoreDependencyAsync.js";
+        
+        export function StoreDependency() {
+          return "A string from StoreFunc" + somePromise;
+        }
+      `,
+      "/StoreDependencyAsync.js": /* js */ `
+        // This top-level await should cause all modules in the cycle to be async
+        export const somePromise = await Promise.resolve("Hello World");
+      `,
+    },
+    format: "esm",
+    // Just test that it compiles without syntax errors
+    compile: true,
+  });
   itBundled("default/TopLevelAwaitWithNestedDynamicImport", {
     // Test nested dynamic imports with top-level await
     files: {

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles, bunExe, bunEnv } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("cyclic imports with async dependencies should generate async wrappers", async () => {
@@ -95,19 +95,19 @@ test("cyclic imports with async dependencies should generate async wrappers", as
   // var init_BaseElement = __esm(() => {
   //   await init_StoreDependency();  // ERROR: await in non-async function
   // });
-  
+
   // All __esm wrappers that contain await should be async
   const esmWrapperRegex = /var\s+(\w+)\s*=\s*__esm\s*\((async\s*)?\(\)\s*=>\s*\{([^}]+)\}/g;
   let match;
-  
+
   while ((match = esmWrapperRegex.exec(bundled)) !== null) {
     const [fullMatch, varName, isAsync, body] = match;
     const hasAwait = body.includes("await ");
-    
+
     if (hasAwait && !isAsync) {
       throw new Error(
         `Found await in non-async wrapper ${varName}:\n${fullMatch}\n\n` +
-        `This indicates the cyclic import async propagation bug is present.`
+          `This indicates the cyclic import async propagation bug is present.`,
       );
     }
   }
@@ -128,6 +128,6 @@ test("cyclic imports with async dependencies should generate async wrappers", as
   ]);
 
   // Should not have syntax errors
-  expect(stderr).not.toContain("await\" can only be used inside an \"async\" function");
+  expect(stderr).not.toContain('await" can only be used inside an "async" function');
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test";
+import { tempDirWithFiles, bunExe, bunEnv } from "harness";
+import { join } from "path";
+
+test("cyclic imports with async dependencies should generate async wrappers", async () => {
+  const dir = tempDirWithFiles("cyclic-imports-async", {
+    "build.ts": `
+      import { build } from "bun";
+      build({
+        entrypoints: ["src/entryBuild.ts"],
+        outdir: "dist",
+        format: "esm",
+        target: "browser",
+        sourcemap: "linked",
+        minify: false,
+      }).then(() => {
+        console.log("Build completed successfully.");
+      }).catch((error) => {
+        console.error("Build failed:", error);
+      })
+    `,
+    "src/entryBuild.ts": `
+      const { AsyncEntryPoint } = await import("./RecursiveDependencies/AsyncEntryPoint");
+      AsyncEntryPoint();
+      export {};
+    `,
+    "src/RecursiveDependencies/AsyncEntryPoint.ts": `
+      export async function AsyncEntryPoint() {
+        const { BaseElement } = await import("./BaseElement");
+        console.log("Launching AsyncEntryPoint", BaseElement());
+      }
+    `,
+    "src/RecursiveDependencies/BaseElement.ts": `
+      import { StoreDependency } from "./StoreDependency";
+      import { BaseElementImport } from "./BaseElementImport";
+      
+      const depValue = StoreDependency();
+      
+      export const formValue = {
+        key: depValue,
+      };
+      
+      export const listValue = {
+        key: depValue + "value",
+      };
+      
+      export function BaseElement() {
+        console.log("BaseElement called", BaseElementImport());
+        return BaseElementImport();
+      }
+    `,
+    "src/RecursiveDependencies/BaseElementImport.ts": `
+      import { SecondElementImport } from "./SecondElementImport";
+      export function BaseElementImport() {
+        console.log("BaseElementImport called", SecondElementImport());
+        return SecondElementImport();
+      }
+    `,
+    "src/RecursiveDependencies/SecondElementImport.ts": `
+      import { formValue } from "./BaseElement";
+      export function SecondElementImport() {
+        console.log("SecondElementImport called", formValue.key);
+        return formValue.key;
+      }
+    `,
+    "src/RecursiveDependencies/StoreDependency.ts": `
+      import { somePromise } from "./StoreDependencyAsync";
+      
+      export function StoreDependency() {
+        return "A string from StoreFunc" + somePromise;
+      }
+    `,
+    "src/RecursiveDependencies/StoreDependencyAsync.ts": `
+      export const somePromise = await Promise.resolve("Hello World");
+    `,
+  });
+
+  // Build the project
+  const buildResult = await Bun.spawn({
+    cmd: [bunExe(), "build.ts"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  await buildResult.exited;
+
+  // Read the bundled output
+  const bundledPath = join(dir, "dist", "entryBuild.js");
+  const bundled = await Bun.file(bundledPath).text();
+
+  // Check that there are no syntax errors like "await" in non-async functions
+  // The bug would manifest as something like:
+  // var init_BaseElement = __esm(() => {
+  //   await init_StoreDependency();  // ERROR: await in non-async function
+  // });
+  
+  // All __esm wrappers that contain await should be async
+  const esmWrapperRegex = /var\s+(\w+)\s*=\s*__esm\s*\((async\s*)?\(\)\s*=>\s*\{([^}]+)\}/g;
+  let match;
+  
+  while ((match = esmWrapperRegex.exec(bundled)) !== null) {
+    const [fullMatch, varName, isAsync, body] = match;
+    const hasAwait = body.includes("await ");
+    
+    if (hasAwait && !isAsync) {
+      throw new Error(
+        `Found await in non-async wrapper ${varName}:\n${fullMatch}\n\n` +
+        `This indicates the cyclic import async propagation bug is present.`
+      );
+    }
+  }
+
+  // Also verify the bundled code can execute without syntax errors
+  const runResult = await Bun.spawn({
+    cmd: [bunExe(), bundledPath],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(runResult.stdout).text(),
+    new Response(runResult.stderr).text(),
+    runResult.exited,
+  ]);
+
+  // Should not have syntax errors
+  expect(stderr).not.toContain("await\" can only be used inside an \"async\" function");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

This PR fixes a bug in Bun's bundler where cyclic imports with async dependencies would produce invalid JavaScript with syntax errors.

## Problem

When modules have cyclic imports and one uses top-level await, the bundler wasn't properly marking all modules in the cycle as async. This resulted in non-async wrapper functions containing `await` statements, causing syntax errors like:

```
error: "await" can only be used inside an "async" function
```

## Solution

The fix matches esbuild's approach by calling `validateTLA` for all files before `scanImportsAndExports` begins. This ensures async status is properly propagated through import chains before dependency resolution.

Key changes:
1. Added a new phase that validates top-level await for all parsed JavaScript files before import/export scanning
2. This matches esbuild's `finishScan` function which processes all files in source index order
3. Ensures the `is_async_or_has_async_dependency` flag is properly set for all modules in cyclic import chains

## Test Plan

- Fixed the reproduction case provided in `/Users/dylan/clones/bun-esm-bug`
- All existing bundler tests pass, including `test/bundler/esbuild/default.test.ts`
- The bundled output now correctly generates async wrapper functions when needed

fixes #21113

🤖 Generated with [Claude Code](https://claude.ai/code)