### PR TITLE
Fix build dependency ordering for cppbind.ts

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -316,6 +316,14 @@ set(BUN_CPP_OUTPUTS
   ${CODEGEN_PATH}/cpp.zig
 )
 
+# Root-level node_modules install needed for @lezer/cpp dependency used by cppbind.ts
+register_bun_install(
+  CWD
+    ${CWD}
+  NODE_MODULES_VARIABLE
+    BUN_ROOT_NODE_MODULES
+)
+
 register_command(
   TARGET
     bun-cppbind
@@ -329,6 +337,7 @@ register_command(
   SOURCES
     ${BUN_JAVASCRIPT_CODEGEN_SOURCES}
     ${BUN_CXX_SOURCES}
+    ${BUN_ROOT_NODE_MODULES}
   OUTPUTS
     ${BUN_CPP_OUTPUTS}
 )


### PR DESCRIPTION
## Summary
Fixes issue #21434 where Bun fails to build the first time because it tries to generate C++ → Zig bindings before installing `@lezer/cpp`.

The problem was that `cppbind.ts` imports `@lezer/cpp`, but the CMake build system was running this script before ensuring that the root-level `node_modules` was installed.

## Changes
- Added `register_bun_install()` call for root directory in `BuildBun.cmake`
- Made `bun-cppbind` target depend on root `node_modules` installation
- This ensures `@lezer/cpp` is available before `cppbind.ts` runs

## Test plan
- [x] Verified the fix works by cleaning `build` and `node_modules` directories
- [x] Confirmed that `ninja bun-cppbind` now runs successfully on first build
- [x] Checked that the dependency chain is correct in the generated `build.ninja`

The build system now correctly:
1. Installs root-level `node_modules` (including `@lezer/cpp`)
2. Then runs the `bun-cppbind` target to generate C++ → Zig bindings

🤖 Generated with [Claude Code](https://claude.ai/code)