### PR TITLE
fix(install): Fix PATH mangling in Windows install.ps1

### DIFF
--- a/src/cli/install.ps1
+++ b/src/cli/install.ps1
@@ -295,7 +295,7 @@ function Install-Bun {
       if (-not $NoPathUpdate) {
         $Path += $BunBin
         Write-Env -Key 'Path' -Value ($Path -join ';')
-        $env:PATH = $Path;
+        $env:PATH = $Path -join ';'
       } else {
         Write-Output "Skipping adding '${BunBin}' to the user's %PATH%`n"
       }


### PR DESCRIPTION
The install script was incorrectly setting $env:PATH by assigning an array directly, which PowerShell converts to a space-separated string instead of the required semicolon-separated format.

This caused the Windows PATH environment variable to be malformed, making installed programs inaccessible.

Fixes #16811

### What does this PR do?

Fixes a bug in the Windows PowerShell install script where `$env:PATH` was being set incorrectly, causing the PATH environment variable to be malformed.

**The Problem:**
- The script assigns an array directly to `$env:PATH`
- PowerShell converts this to a space-separated string instead of semicolon-separated
- This breaks the Windows PATH, making installed programs inaccessible

**The Fix:**
- Changed `$env:PATH = $Path;` to `$env:PATH = $Path -join ';'`
- Now properly creates semicolon-separated PATH entries as required by Windows

### How did you verify your code works?

✅ **Tested the bug reproduction:**
```powershell
$Path = @('C:\Windows', 'C:\Windows\System32', 'C:\test')
$env:PATH = $Path  # WRONG: Results in "C:\Windows C:\Windows\System32 C:\test"
