### PR TITLE
Add asan checks to `HiveArray`

### DIFF
--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -10,6 +10,7 @@ src/allocators/NullableAllocator.zig
 src/analytics.zig
 src/analytics/schema.zig
 src/api/schema.zig
+src/asan.zig
 src/ast.zig
 src/ast/Ast.zig
 src/ast/ASTMemoryAllocator.zig

--- a/src/asan.zig
+++ b/src/asan.zig
@@ -1,0 +1,93 @@
+/// https://github.com/llvm/llvm-project/blob/main/compiler-rt/include/sanitizer/asan_interface.h
+const c = if (bun.Environment.enable_asan) struct {
+    extern fn __asan_poison_memory_region(ptr: *const anyopaque, size: usize) void;
+    extern fn __asan_unpoison_memory_region(ptr: *const anyopaque, size: usize) void;
+    extern fn __asan_address_is_poisoned(ptr: *const anyopaque) bool;
+    extern fn __asan_describe_address(ptr: *const anyopaque) void;
+    extern fn __asan_update_allocation_context(ptr: *const anyopaque) c_int;
+
+    pub fn poison(ptr: *const anyopaque, size: usize) void {
+        __asan_poison_memory_region(ptr, size);
+    }
+    pub fn unpoison(ptr: *const anyopaque, size: usize) void {
+        __asan_unpoison_memory_region(ptr, size);
+    }
+    pub fn isPoisoned(ptr: *const anyopaque) bool {
+        return __asan_address_is_poisoned(ptr);
+    }
+    pub fn describe(ptr: *const anyopaque) void {
+        __asan_describe_address(ptr);
+    }
+    pub fn updateAllocationContext(ptr: *const anyopaque) c_int {
+        return __asan_update_allocation_context(ptr);
+    }
+} else struct {
+    pub fn poison(_: *const anyopaque) void {}
+    pub fn unpoison(_: *const anyopaque) void {}
+    pub fn isPoisoned(_: *const anyopaque) bool {
+        return false;
+    }
+    pub fn describe(_: *const anyopaque) void {}
+    pub fn updateAllocationContext(_: *const anyopaque) c_int {
+        return 0;
+    }
+};
+
+pub const enabled = bun.Environment.enable_asan;
+
+/// Update allocation stack trace for the given allocation to the current stack
+/// trace
+pub fn updateAllocationContext(ptr: *const anyopaque) bool {
+    if (!comptime enabled) return false;
+    return c.updateAllocationContext(ptr) == 1;
+}
+
+/// Describes an address (prints out where it was allocated, freed, stacktraces,
+/// etc.)
+pub fn describe(ptr: *const anyopaque) void {
+    if (!comptime enabled) return;
+    c.describe(ptr);
+}
+
+/// Manually poison a memory region
+///
+/// Useful for making custom allocators asan-aware (for example HiveArray)
+///
+/// *NOT* threadsafe
+pub fn poison(ptr: *const anyopaque, size: usize) void {
+    if (!comptime enabled) return;
+    c.poison(ptr, size);
+}
+
+/// Manually unpoison a memory region
+///
+/// Useful for making custom allocators asan-aware (for example HiveArray)
+///
+/// *NOT* threadsafe
+pub fn unpoison(ptr: *const anyopaque, size: usize) void {
+    if (!comptime enabled) return;
+    c.unpoison(ptr, size);
+}
+
+fn isPoisoned(ptr: *const anyopaque) bool {
+    if (!comptime enabled) return false;
+    return c.isPoisoned(ptr);
+}
+
+pub fn assertPoisoned(ptr: *const anyopaque) void {
+    if (!comptime enabled) return;
+    if (!isPoisoned(ptr)) {
+        c.describe(ptr);
+        @panic("Address is not poisoned");
+    }
+}
+
+pub fn assertUnpoisoned(ptr: *const anyopaque) void {
+    if (!comptime enabled) return;
+    if (isPoisoned(ptr)) {
+        c.describe(ptr);
+        @panic("Address is poisoned");
+    }
+}
+
+const bun = @import("bun");

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3755,6 +3755,8 @@ pub const mach_port = if (Environment.isMac) std.c.mach_port_t else u32;
 
 pub const cpp = @import("cpp").bindings;
 
+pub const asan = @import("./asan.zig");
+
 pub fn contains(item: anytype, list: *const std.ArrayListUnmanaged(@TypeOf(item))) bool {
     const T = @TypeOf(item);
     return switch (T) {

--- a/src/collections/hive_array.zig
+++ b/src/collections/hive_array.zig
@@ -29,21 +29,20 @@ pub fn HiveArray(comptime T: type, comptime capacity: u16) type {
         pub fn get(self: *Self) ?*T {
             const index = self.used.findFirstUnset() orelse return null;
             self.used.set(index);
-            return &self.buffer[index];
+            const ret = &self.buffer[index];
+            bun.asan.unpoison(@ptrCast(ret), @sizeOf(T));
+            return ret;
         }
 
         pub fn at(self: *Self, index: u16) *T {
             assert(index < capacity);
-            return &self.buffer[index];
-        }
-
-        pub fn claim(self: *Self, index: u16) void {
-            assert(index < capacity);
-            assert(!self.used.isSet(index));
-            self.used.set(index);
+            const ret = &self.buffer[index];
+            bun.asan.assertUnpoisoned(@ptrCast(ret));
+            return ret;
         }
 
         pub fn indexOf(self: *const Self, value: *const T) ?u32 {
+            bun.asan.assertUnpoisoned(@ptrCast(value));
             const start = &self.buffer;
             const end = @as([*]const T, @ptrCast(start)) + capacity;
             if (!(@intFromPtr(value) >= @intFromPtr(start) and @intFromPtr(value) < @intFromPtr(end)))
@@ -57,6 +56,7 @@ pub fn HiveArray(comptime T: type, comptime capacity: u16) type {
         }
 
         pub fn in(self: *const Self, value: *const T) bool {
+            bun.asan.assertUnpoisoned(@ptrCast(value));
             const start = &self.buffer;
             const end = @as([*]const T, @ptrCast(start)) + capacity;
             return (@intFromPtr(value) >= @intFromPtr(start) and @intFromPtr(value) < @intFromPtr(end));
@@ -69,6 +69,7 @@ pub fn HiveArray(comptime T: type, comptime capacity: u16) type {
             assert(&self.buffer[index] == value);
 
             value.* = undefined;
+            bun.asan.poison(value, @sizeOf(T));
 
             self.used.unset(index);
             return true;
@@ -88,6 +89,11 @@ pub fn HiveArray(comptime T: type, comptime capacity: u16) type {
             }
 
             pub fn get(self: *This) *T {
+                const value = getImpl(self);
+                return value;
+            }
+
+            fn getImpl(self: *This) *T {
                 if (comptime capacity > 0) {
                     if (self.hive.get()) |value| {
                         return value;


### PR DESCRIPTION
### What does this PR do?

Exposes some asan functions to Zig and makes `HiveArray` use them to report use after frees and such. This works by manually poisoning data allocated in the hive array when it is being `.put()` back, and unpoisoning it when we use it in `.get()`

Note: The asan functions to manually poison and unpoison memory are *not* threadsafe
