### PR TITLE
Fix docs in test.md

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -158,7 +158,7 @@ See [Test > Lifecycle](https://bun.com/docs/test/lifecycle) for complete documen
 
 ## Mocks
 
-Create mock functions with the `mock` function. Mocks are automatically reset between tests.
+Create mock functions with the `mock` function.
 
 ```ts
 import { test, expect, mock } from "bun:test";


### PR DESCRIPTION
Fixes #5391. Jest does not reset mocks between tests, and neither do we. The docs were wrong.