### PR TITLE
Replace allocator isNull() check with an assertion in String.toThreadSafeSlice

### DIFF
--- a/src/string.zig
+++ b/src/string.zig
@@ -759,14 +759,7 @@ pub const String = extern struct {
             if (!this.value.WTFStringImpl.isThreadSafe()) {
                 const slice = this.value.WTFStringImpl.toUTF8(allocator);
 
-                if (slice.allocator.isNull()) {
-                    // this was a WTF-allocated string
-                    // We're going to need to clone it across the threads
-                    // so let's just do that now instead of creating another copy.
-                    return .{
-                        .utf8 = ZigString.Slice.init(allocator, allocator.dupe(u8, slice.slice()) catch bun.outOfMemory()),
-                    };
-                }
+                bun.debugAssert(!slice.allocator.isNull());
 
                 if (comptime bun.Environment.allow_assert) {
                     // bun.assert(!isWTFAllocator(slice.allocator.get().?)); // toUTF8WithoutRef() should never return a WTF allocator


### PR DESCRIPTION
### What does this PR do?

Replaces an if statement with an assertion that the condition is false. The allocator in question should never be null.

### How did you verify your code works?
