### PR TITLE
feat(init): Add VS Code extension recommendations to bun init

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1037,7 +1037,8 @@ const Template = enum {
                 // appear prominently in repos) doesn't show a file path.
                 if (did_create_agent_rule and @"create CLAUDE.md") symlink_cursor_rule: {
                     @"create CLAUDE.md" = false;
-                    bun.makePath(bun.FD.cwd().stdDir(), ".cursor/rules") catch {};
+                    bun.sys.mkdirat(bun.FD.cwd(), ".cursor", 0o755).unwrap() catch {};
+                    bun.sys.mkdirat(bun.FD.cwd(), ".cursor/rules", 0o755).unwrap() catch {};
                     bun.sys.symlinkat(cursor_rule_path_to_claude_md, .cwd(), template_file.path).unwrap() catch break :symlink_cursor_rule;
                     Output.prettyln(" + <r><d>{s} -\\> {s}<r>", .{ template_file.path, asset_path });
                     Output.flush();
@@ -1148,7 +1149,7 @@ const Template = enum {
         // Only create if VS Code or Cursor is installed
         if (isVSCodeInstalled() or isCursorInstalled()) {
             // Create .vscode directory if it doesn't exist
-            bun.makePath(bun.FD.cwd().stdDir(), ".vscode") catch {};
+            bun.sys.mkdirat(bun.FD.cwd(), ".vscode", 0o755).unwrap() catch {};
 
             // Create extensions.json if it doesn't exist
             if (!bun.sys.exists(".vscode/extensions.json")) {
@@ -1169,7 +1170,7 @@ const Template = enum {
         // Only create if VS Code or Cursor is installed and launch.json doesn't exist
         if ((isVSCodeInstalled() or isCursorInstalled()) and !bun.sys.exists(".vscode/launch.json")) {
             // Create .vscode directory if it doesn't exist
-            bun.makePath(bun.FD.cwd().stdDir(), ".vscode") catch {};
+            bun.sys.mkdirat(bun.FD.cwd(), ".vscode", 0o755).unwrap() catch {};
 
             if (template.isReact()) {
                 const react_launch_json =

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1091,7 +1091,7 @@ const Template = enum {
 
         return false;
     }
-    
+
     fn isVSCodeInstalled() bool {
         // Give some way to opt-out.
         if (bun.getenvTruthy("BUN_VSCODE_EXTENSION_DISABLED")) {
@@ -1128,7 +1128,7 @@ const Template = enum {
         if (Environment.isLinux) {
             const pathbuffer = bun.path_buffer_pool.get();
             defer bun.path_buffer_pool.put(pathbuffer);
-            
+
             if (bun.which(pathbuffer, bun.getenvZ("PATH") orelse return false, bun.fs.FileSystem.instance.top_level_dir, "code") != null) {
                 return true;
             }
@@ -1143,36 +1143,36 @@ const Template = enum {
 
         return null;
     }
-    
+
     fn createVSCodeExtensionsJson() void {
         // Only create if VS Code or Cursor is installed
         if (isVSCodeInstalled() or isCursorInstalled()) {
             // Create .vscode directory if it doesn't exist
             bun.makePath(bun.FD.cwd().stdDir(), ".vscode") catch {};
-            
+
             // Create extensions.json if it doesn't exist
             if (!bun.sys.exists(".vscode/extensions.json")) {
-                const extensions_json_content = 
+                const extensions_json_content =
                     \\{
                     \\  "recommendations": [
                     \\    "oven.bun-vscode"
                     \\  ]
                     \\}
                 ;
-                
+
                 InitCommand.Assets.createNew(".vscode/extensions.json", extensions_json_content) catch {};
             }
         }
     }
-    
+
     fn createVSCodeLaunchJson(entry_point: []const u8, template: Template) void {
         // Only create if VS Code or Cursor is installed and launch.json doesn't exist
         if ((isVSCodeInstalled() or isCursorInstalled()) and !bun.sys.exists(".vscode/launch.json")) {
             // Create .vscode directory if it doesn't exist
             bun.makePath(bun.FD.cwd().stdDir(), ".vscode") catch {};
-            
+
             if (template.isReact()) {
-                const react_launch_json = 
+                const react_launch_json =
                     \\{
                     \\  "version": "0.2.0",
                     \\  "configurations": [
@@ -1207,7 +1207,7 @@ const Template = enum {
             } else if (entry_point.len > 0) {
                 // For non-React templates, create a simple launch configuration
                 // Use a generic entry point that works for most cases
-                const simple_launch_json = 
+                const simple_launch_json =
                     \\{
                     \\  "version": "0.2.0",
                     \\  "configurations": [

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -424,7 +424,7 @@ test("bun init creates launch.json for React templates with browser debugging", 
   const launch = JSON.parse(fs.readFileSync(path.join(temp, ".vscode/launch.json"), "utf8"));
   expect(launch.version).toBe("0.2.0");
   expect(launch.configurations).toHaveLength(2);
-  
+
   // Check Bun debugger configuration
   expect(launch.configurations[0]).toMatchObject({
     name: "Debug Bun",
@@ -432,7 +432,7 @@ test("bun init creates launch.json for React templates with browser debugging", 
     request: "launch",
     program: "${workspaceFolder}/src/index.tsx",
   });
-  
+
   // Check Chrome browser debugger configuration
   expect(launch.configurations[1]).toMatchObject({
     name: "Launch Chrome",
@@ -445,16 +445,13 @@ test("bun init creates launch.json for React templates with browser debugging", 
 
 test("bun init does not overwrite existing .vscode/extensions.json", async () => {
   const temp = tmpdirSync();
-  
+
   // Create .vscode directory and existing extensions.json
   fs.mkdirSync(path.join(temp, ".vscode"));
   const existingExtensions = {
     recommendations: ["ms-vscode.vscode-typescript-next"],
   };
-  fs.writeFileSync(
-    path.join(temp, ".vscode/extensions.json"),
-    JSON.stringify(existingExtensions, null, 2)
-  );
+  fs.writeFileSync(path.join(temp, ".vscode/extensions.json"), JSON.stringify(existingExtensions, null, 2));
 
   const out = Bun.spawnSync({
     cmd: [bunExe(), "init", "-y"],
@@ -473,7 +470,7 @@ test("bun init does not overwrite existing .vscode/extensions.json", async () =>
 
 test("bun init does not overwrite existing .vscode/launch.json", async () => {
   const temp = tmpdirSync();
-  
+
   // Create .vscode directory and existing launch.json
   fs.mkdirSync(path.join(temp, ".vscode"));
   const existingLaunch = {
@@ -487,10 +484,7 @@ test("bun init does not overwrite existing .vscode/launch.json", async () => {
       },
     ],
   };
-  fs.writeFileSync(
-    path.join(temp, ".vscode/launch.json"),
-    JSON.stringify(existingLaunch, null, 2)
-  );
+  fs.writeFileSync(path.join(temp, ".vscode/launch.json"), JSON.stringify(existingLaunch, null, 2));
 
   const out = Bun.spawnSync({
     cmd: [bunExe(), "init", "-y"],
@@ -505,7 +499,7 @@ test("bun init does not overwrite existing .vscode/launch.json", async () => {
   // Check that existing launch.json was not overwritten
   const launch = JSON.parse(fs.readFileSync(path.join(temp, ".vscode/launch.json"), "utf8"));
   expect(launch).toEqual(existingLaunch);
-  
+
   // But extensions.json should still be created
   expect(fs.existsSync(path.join(temp, ".vscode/extensions.json"))).toBe(true);
 }, 30_000);

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -4,7 +4,7 @@
   "!= alloc.ptr": 0,
   "!= allocator.ptr": 0,
   ".arguments_old(": 280,
-  ".stdDir()": 40,
+  ".stdDir()": 39,
   ".stdFile()": 18,
   "// autofix": 168,
   ": [a-zA-Z0-9_\\.\\*\\?\\[\\]\\(\\)]+ = undefined,": 230,


### PR DESCRIPTION
## Summary

- Adds automatic VS Code extension recommendations when `bun init` detects VS Code or Cursor
- Creates `.vscode/extensions.json` with `oven.bun-vscode` recommendation for better developer experience
- **NEW**: Creates `.vscode/launch.json` with debugging configurations for the Bun VS Code extension
- Only creates files if VS Code/Cursor is detected and the files don't already exist (non-destructive)
- **NEW**: Comprehensive test suite with 10 new tests covering all functionality

## Changes

### Extension Recommendations
- Added `isVSCodeInstalled()` function with multi-platform detection (macOS, Windows, Linux)
- Added `createVSCodeExtensionsJson()` function to create extension recommendations  
- Supports opt-out via `BUN_VSCODE_EXTENSION_DISABLED` environment variable

### Debugging Configurations  
- **NEW**: Added `createVSCodeLaunchJson()` function to create debugging configurations
- **Basic templates**: Creates Bun debugger configuration for the entry point file
- **React templates**: Creates both Bun debugger AND Chrome browser debugger for port 3000
- Integrated into both basic and React template workflows

### Comprehensive Test Coverage
- **NEW**: Added 10 comprehensive tests in `test/cli/init/init.test.ts`
- Tests VS Code detection via `VSCODE_PID` environment variable
- Tests Cursor detection via `CURSOR_TRACE_ID` environment variable
- Tests no files created when no editor detected
- Tests opt-out via `BUN_VSCODE_EXTENSION_DISABLED`
- Tests launch.json for basic templates (Bun debugger)
- Tests launch.json for React templates (Bun + Chrome debugger)
- Tests non-destructive behavior (preserves existing files)
- Tests both files created together correctly
- Updated existing test snapshots for CLAUDE.md compatibility

## Detection Methods

- **VS Code**: `VSCODE_PID` env var, platform-specific app/executable paths, `which code` on Linux
- **Cursor**: Uses existing detection logic (env vars, app paths)
- **Opt-out**: `BUN_VSCODE_EXTENSION_DISABLED` environment variable

## Debug Configurations Created

### Basic Templates (`index.ts`, etc.)
```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Debug Bun",
      "type": "bun",
      "request": "launch", 
      "program": "${workspaceFolder}/index.ts"
    }
  ]
}
```

### React Templates (`--react`)
```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Debug Bun",
      "type": "bun", 
      "request": "launch",
      "program": "${workspaceFolder}/src/index.tsx"
    },
    {
      "name": "Launch Chrome",
      "type": "chrome",
      "request": "launch", 
      "url": "http://localhost:3000",
      "webRoot": "${workspaceFolder}/src"
    }
  ]
}
```

## Test plan

### Core Functionality
- [x] Creates `.vscode/extensions.json` when VS Code is detected
- [x] Creates `.vscode/extensions.json` when Cursor is detected  
- [x] **NEW**: Creates `.vscode/launch.json` with Bun debugger for basic templates
- [x] **NEW**: Creates `.vscode/launch.json` with Bun + Chrome debugger for React templates
- [x] Does not overwrite existing `.vscode/extensions.json` or `.vscode/launch.json` files
- [x] Does not create files when neither editor is detected
- [x] Works with all template types (blank, React, etc.)
- [x] Files contain correct JSON format with proper debugging configurations

### Test Coverage  
- [x] **10 new automated tests** covering all functionality
- [x] VS Code detection via environment variables
- [x] Cursor detection via environment variables
- [x] Opt-out functionality testing
- [x] Non-destructive behavior verification  
- [x] Template-specific configuration testing
- [x] Integration testing (both files created together)
- [x] Updated existing test snapshots for compatibility

### Manual Verification
- [x] Tested on debug build of Bun
- [x] Verified with `VSCODE_PID` environment variable
- [x] Verified with `CURSOR_TRACE_ID` environment variable
- [x] Verified opt-out with `BUN_VSCODE_EXTENSION_DISABLED`
- [x] Tested basic templates create correct launch.json
- [x] Tested React templates create both debugger configurations
- [x] Verified non-destructive behavior with existing files

🤖 Generated with [Claude Code](https://claude.ai/code)