### PR TITLE
Simplify mimalloc alignment check

### DIFF
--- a/src/allocators/MimallocArena.zig
+++ b/src/allocators/MimallocArena.zig
@@ -72,7 +72,7 @@ pub const supports_posix_memalign = true;
 fn alignedAlloc(heap: *mimalloc.Heap, len: usize, alignment: mem.Alignment) ?[*]u8 {
     log("Malloc: {d}\n", .{len});
 
-    const ptr: ?*anyopaque = if (mimalloc.canUseAlignedAlloc(len, alignment.toByteUnits()))
+    const ptr: ?*anyopaque = if (mimalloc.mustUseAlignedAlloc(alignment))
         mimalloc.mi_heap_malloc_aligned(heap, len, alignment.toByteUnits())
     else
         mimalloc.mi_heap_malloc(heap, len);
@@ -119,7 +119,7 @@ fn free(
     // but its good to have that assertion
     if (comptime Environment.isDebug) {
         assert(mimalloc.mi_is_in_heap_region(buf.ptr));
-        if (mimalloc.canUseAlignedAlloc(buf.len, alignment.toByteUnits()))
+        if (mimalloc.mustUseAlignedAlloc(alignment))
             mimalloc.mi_free_size_aligned(buf.ptr, buf.len, alignment.toByteUnits())
         else
             mimalloc.mi_free_size(buf.ptr, buf.len);

--- a/src/allocators/NullableAllocator.zig
+++ b/src/allocators/NullableAllocator.zig
@@ -30,8 +30,8 @@ pub inline fn get(this: NullableAllocator) ?std.mem.Allocator {
 pub fn free(this: *const NullableAllocator, bytes: []const u8) void {
     if (this.get()) |allocator| {
         if (bun.String.isWTFAllocator(allocator)) {
-            // workaround for https://github.com/ziglang/zig/issues/4298
-            bun.String.StringImplAllocator.free(allocator.ptr, @constCast(bytes), .fromByteUnits(1), 0);
+            // avoid calling `std.mem.Allocator.free` as it sets the memory to undefined
+            allocator.rawFree(@constCast(bytes), .@"1", 0);
             return;
         }
 

--- a/src/allocators/basic.zig
+++ b/src/allocators/basic.zig
@@ -13,7 +13,7 @@ fn mimalloc_free(
     // but its good to have that assertion
     // let's only enable it in debug mode
     if (comptime Environment.isDebug) {
-        if (mimalloc.canUseAlignedAlloc(buf.len, alignment.toByteUnits()))
+        if (mimalloc.mustUseAlignedAlloc(alignment))
             mimalloc.mi_free_size_aligned(buf.ptr, buf.len, alignment.toByteUnits())
         else
             mimalloc.mi_free_size(buf.ptr, buf.len);
@@ -28,7 +28,7 @@ const MimallocAllocator = struct {
         if (comptime Environment.enable_logs)
             log("mi_alloc({d}, {d})", .{ len, alignment.toByteUnits() });
 
-        const ptr: ?*anyopaque = if (mimalloc.canUseAlignedAlloc(len, alignment.toByteUnits()))
+        const ptr: ?*anyopaque = if (mimalloc.mustUseAlignedAlloc(alignment))
             mimalloc.mi_malloc_aligned(len, alignment.toByteUnits())
         else
             mimalloc.mi_malloc(len);
@@ -82,7 +82,7 @@ const ZAllocator = struct {
     fn alignedAlloc(len: usize, alignment: mem.Alignment) ?[*]u8 {
         log("ZAllocator.alignedAlloc: {d}\n", .{len});
 
-        const ptr = if (mimalloc.canUseAlignedAlloc(len, alignment.toByteUnits()))
+        const ptr = if (mimalloc.mustUseAlignedAlloc(alignment))
             mimalloc.mi_zalloc_aligned(len, alignment.toByteUnits())
         else
             mimalloc.mi_zalloc(len);

--- a/src/allocators/mimalloc.zig
+++ b/src/allocators/mimalloc.zig
@@ -203,13 +203,10 @@ pub const MI_SMALL_WSIZE_MAX = @as(c_int, 128);
 pub const MI_SMALL_SIZE_MAX = MI_SMALL_WSIZE_MAX * @import("std").zig.c_translation.sizeof(?*anyopaque);
 pub const MI_ALIGNMENT_MAX = (@as(c_int, 16) * @as(c_int, 1024)) * @as(c_ulong, 1024);
 
-pub fn canUseAlignedAlloc(len: usize, alignment: usize) bool {
-    return alignment > 0 and std.math.isPowerOfTwo(alignment) and !mi_malloc_satisfies_alignment(alignment, len);
-}
 const MI_MAX_ALIGN_SIZE = 16;
-inline fn mi_malloc_satisfies_alignment(alignment: usize, size: usize) bool {
-    return (alignment == @sizeOf(*anyopaque) or
-        (alignment == MI_MAX_ALIGN_SIZE and size >= (MI_MAX_ALIGN_SIZE / 2)));
+
+pub fn mustUseAlignedAlloc(alignment: std.mem.Alignment) bool {
+    return alignment.toByteUnits() > MI_MAX_ALIGN_SIZE;
 }
 
 pub const mi_arena_id_t = ?*anyopaque;


### PR DESCRIPTION
This slightly reduces memory use.

Maximum memory use of `bun test html-rewriter`, averaged across 100 iterations:

* 101975 kB without this change
* 101634 kB with this change

I also tried changing the code to always use the aligned allocation functions, but this slightly increased memory use, to 102160 kB.

(For internal tracking: fixes ENG-19866)
