### PR TITLE
Fix "test failing but passed" arrow pointing to the wrong test

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1646,7 +1646,6 @@ pub const TestRunnerTask = struct {
                 test_.line_number,
             ),
             .fail_because_failing_test_passed => |count| {
-                Output.prettyErrorln("  <d>^<r> <red>this test is marked as failing but it passed.<r> <d>Remove `.failing` if tested behavior now works", .{});
                 Jest.runner.?.reportFailure(
                     test_id,
                     this.source_file_path,
@@ -1656,6 +1655,7 @@ pub const TestRunnerTask = struct {
                     describe,
                     test_.line_number,
                 );
+                Output.prettyErrorln("  <d>^<r> <red>this test is marked as failing but it passed.<r> <d>Remove `.failing` if tested behavior now works", .{});
             },
             .fail_because_expected_has_assertions => {
                 Output.err(error.AssertionError, "received <red>0 assertions<r>, but expected <green>at least one assertion<r> to be called\n", .{});

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -32,7 +32,7 @@ describe("test.failing", () => {
       fail("Expected exit code to be non-zero\n\n" + stderr);
     }
     expect(stderr).toContain(" 2 fail\n");
-    expect(stderr.replaceAll(/ \[\d+ms\]/g, "")).toMatchInlineSnapshot(`
+    expect(stderr.replaceAll(/ \[[\d.]+ms\]/g, "")).toMatchInlineSnapshot(`
       "
       failing-test-passes.fixture.ts:
       (fail) This should fail but it doesnt

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -1,6 +1,6 @@
 import { fail } from "assert";
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { bunExe, bunEnv } from "harness";
 import path from "path";
 
 const fixtureDir = path.join(import.meta.dir, "fixtures");
@@ -24,13 +24,28 @@ describe("test.failing", () => {
   });
 
   it("fails if no error is thrown or promise resolves", async () => {
-    const result = await $.cwd(fixtureDir).nothrow()`${bunExe()} test ./failing-test-passes.fixture.ts`.quiet();
+    const result = await $.cwd(
+      fixtureDir,
+    ).nothrow()`FORCE_COLOR=0 ${bunExe()} test ./failing-test-passes.fixture.ts`.quiet();
     const stderr = result.stderr.toString();
     if (result.exitCode === 0) {
       fail("Expected exit code to be non-zero\n\n" + stderr);
     }
     expect(stderr).toContain(" 2 fail\n");
-    expect(stderr).toContain("this test is marked as failing but it passed");
+    expect(stderr.replaceAll(/ \[\d+ms\]/g, "")).toMatchInlineSnapshot(`
+      "
+      failing-test-passes.fixture.ts:
+      (fail) This should fail but it doesnt [0.24ms]
+        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
+      (fail) This should fail but it doesnt (async) [0.23ms]
+        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
+
+       0 pass
+       2 fail
+       2 expect() calls
+      Ran 2 tests across 1 file. [67.00ms]
+      "
+    `);
   });
 
   it("timeouts still count as failures", async () => {

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -35,15 +35,15 @@ describe("test.failing", () => {
     expect(stderr.replaceAll(/ \[\d+ms\]/g, "")).toMatchInlineSnapshot(`
       "
       failing-test-passes.fixture.ts:
-      (fail) This should fail but it doesnt [0.24ms]
+      (fail) This should fail but it doesnt
         ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
-      (fail) This should fail but it doesnt (async) [0.23ms]
+      (fail) This should fail but it doesnt (async)
         ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
 
        0 pass
        2 fail
        2 expect() calls
-      Ran 2 tests across 1 file. [67.00ms]
+      Ran 2 tests across 1 file.
       "
     `);
   });

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -1,6 +1,6 @@
 import { fail } from "assert";
 import { $ } from "bun";
-import { bunExe, bunEnv } from "harness";
+import { bunExe } from "harness";
 import path from "path";
 
 const fixtureDir = path.join(import.meta.dir, "fixtures");


### PR DESCRIPTION
Before:

```
      failing-test-passes.fixture.ts:
        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
      (fail) This should fail but it doesnt [0.24ms]
        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
      (fail) This should fail but it doesnt (async) [0.23ms]
```

After:

```
      failing-test-passes.fixture.ts:
      (fail) This should fail but it doesnt [0.24ms]
        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
      (fail) This should fail but it doesnt (async) [0.23ms]
        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
```

Adds a snapshot test