### PR TITLE
Delete incorrect assertion in ComptimeStringMap

### DIFF
--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -692,11 +692,11 @@ pub const Init = struct {
             return error.JSError;
         }
 
-        if (try response_init.fastGet(globalThis, .statusText)) |status_text| {
+        if (try response_init.getTruthy(globalThis, "statusText")) |status_text| {
             result.status_text = try bun.String.fromJS(status_text, globalThis);
         }
 
-        if (try response_init.fastGet(globalThis, .method)) |method_value| {
+        if (try response_init.getTruthy(globalThis, "method")) |method_value| {
             if (try Method.fromJS(globalThis, method_value)) |method| {
                 result.method = method;
             }

--- a/src/comptime_string_map.zig
+++ b/src/comptime_string_map.zig
@@ -190,7 +190,7 @@ pub fn ComptimeStringMapWithKeyType(comptime KeyType: type, comptime V: type, co
             return null;
         }
 
-        /// Caller must ensure that the input is a string.
+        /// Throws if toString() throws.
         pub fn fromJS(globalThis: *jsc.JSGlobalObject, input: jsc.JSValue) bun.JSError!?V {
             const str = try bun.String.fromJS(input, globalThis);
             bun.assert(str.tag != .Dead);
@@ -198,7 +198,7 @@ pub fn ComptimeStringMapWithKeyType(comptime KeyType: type, comptime V: type, co
             return getWithEql(str, bun.String.eqlComptime);
         }
 
-        /// Caller must ensure that the input is a string.
+        /// Throws if toString() throws.
         pub fn fromJSCaseInsensitive(globalThis: *jsc.JSGlobalObject, input: jsc.JSValue) bun.JSError!?V {
             const str = try bun.String.fromJS(input, globalThis);
             bun.assert(str.tag != .Dead);

--- a/src/comptime_string_map.zig
+++ b/src/comptime_string_map.zig
@@ -192,12 +192,6 @@ pub fn ComptimeStringMapWithKeyType(comptime KeyType: type, comptime V: type, co
 
         /// Caller must ensure that the input is a string.
         pub fn fromJS(globalThis: *jsc.JSGlobalObject, input: jsc.JSValue) bun.JSError!?V {
-            if (comptime bun.Environment.allow_assert) {
-                if (!input.isString()) {
-                    @panic("ComptimeStringMap.fromJS: input is not a string");
-                }
-            }
-
             const str = try bun.String.fromJS(input, globalThis);
             bun.assert(str.tag != .Dead);
             defer str.deref();
@@ -206,12 +200,6 @@ pub fn ComptimeStringMapWithKeyType(comptime KeyType: type, comptime V: type, co
 
         /// Caller must ensure that the input is a string.
         pub fn fromJSCaseInsensitive(globalThis: *jsc.JSGlobalObject, input: jsc.JSValue) bun.JSError!?V {
-            if (comptime bun.Environment.allow_assert) {
-                if (!input.isString()) {
-                    @panic("ComptimeStringMap.fromJS: input is not a string");
-                }
-            }
-
             const str = try bun.String.fromJS(input, globalThis);
             bun.assert(str.tag != .Dead);
             defer str.deref();

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -99,3 +99,13 @@ test("Response.redirect status code validation", () => {
   expect(Response.redirect("url", 301).status).toBe(301);
   expect(Response.redirect("url", { status: 308 }).status).toBe(308);
 });
+
+test("new Response(123, { statusText: 123 }) does not throw", () => {
+  // @ts-expect-error
+  expect(new Response("123", { statusText: 123 }).statusText).toBe("123");
+});
+
+test("new Response(123, { method: 456 }) does not throw", () => {
+  // @ts-expect-error
+  expect(() => new Response("123", { method: 456 })).not.toThrow();
+});

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (3.48 KB) {
+    "Response (3.82 KB) {
       ok: true,
       url: "",
       status: 200,


### PR DESCRIPTION
### What does this PR do?

Resolves
```js
Bun v1.2.13 ([64ed68c](https://github.com/oven-sh/bun/tree/64ed68c9e0faa7f5224876be8681d2bdc311454b)) on windows x86_64 [TestCommand]

panic: ComptimeStringMap.fromJS: input is not a string

[comptime_string_map.zig:268](https://github.com/oven-sh/bun/blob/64ed68c9e0faa7f5224876be8681d2bdc311454b/src/comptime_string_map.zig#L268): getWithEql
[Response.zig:682](https://github.com/oven-sh/bun/blob/64ed68c9e0faa7f5224876be8681d2bdc311454b/src/bun.js/webcore/Response.zig#L682): init
[Request.zig:679](https://github.com/oven-sh/bun/blob/64ed68c9e0faa7f5224876be8681d2bdc311454b/src/bun.js/webcore/Request.zig#L679): constructInto
[ZigGeneratedClasses.cpp:37976](https://github.com/oven-sh/bun/blob/64ed68c9e0faa7f5224876be8681d2bdc311454b/C:/buildkite-agent/builds/EC2AMAZ-Q4V5GV4/bun/bun/build/release/codegen/ZigGeneratedClasses.cpp#L37976): WebCore::JSRequestConstructor::construct
2 unknown/js code
llint_entry

Features: tsconfig, Bun.stdout, dotenv, jsc
```

### How did you verify your code works?

There is a test.
