### PR TITLE
Fix assertion failure on Windows in resolver

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3755,7 +3755,8 @@ pub const Resolver = struct {
         }
 
         const dir_path = bun.strings.withoutTrailingSlashWindowsPath(Dirname.dirname(path));
-        bun.strings.assertIsValidWindowsPath(u8, dir_path);
+        // Don't validate the path, let our error handling if it is invalid
+        // bun.strings.assertIsValidWindowsPath(u8, dir_path);
 
         const dir_entry: *Fs.FileSystem.RealFS.EntriesOption = rfs.readDirectory(
             dir_path,

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -4225,7 +4225,6 @@ pub const Dirname = struct {
         const root = brk: {
             if (Environment.isWindows) {
                 const root = ResolvePath.windowsFilesystemRoot(path);
-                assert(root.len > 0);
 
                 // Preserve the trailing slash for UNC paths.
                 // Going from `\\server\share\folder` should end up

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3755,7 +3755,6 @@ pub const Resolver = struct {
         }
 
         const dir_path = bun.strings.withoutTrailingSlashWindowsPath(Dirname.dirname(path));
-        // bun.strings.assertIsValidWindowsPath(u8, dir_path);
 
         const dir_entry: *Fs.FileSystem.RealFS.EntriesOption = rfs.readDirectory(
             dir_path,

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3755,7 +3755,6 @@ pub const Resolver = struct {
         }
 
         const dir_path = bun.strings.withoutTrailingSlashWindowsPath(Dirname.dirname(path));
-        // Don't validate the path, let our error handling if it is invalid
         // bun.strings.assertIsValidWindowsPath(u8, dir_path);
 
         const dir_entry: *Fs.FileSystem.RealFS.EntriesOption = rfs.readDirectory(

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -52,4 +52,11 @@ describe("ResolveMessage", () => {
       await import("data:Hello%2C%20World!");
     }).toThrow("Cannot resolve invalid data URL");
   });
+
+  it("doesn't crash", async () => {
+    expect(async () => {
+      // @ts-ignore
+      await import(":://filesystem");
+    }).toThrow("Cannot find module");
+  });
 });


### PR DESCRIPTION
### What does this PR do?

We had `bun.strings.assertIsValidWindowsPath(...)` in the resolver, but we can't do this because the path may come from the user. Instead, let our error handling code handle it.

Also fixes #21065
