### PR TITLE
fix(codegen): use of `kernel.open` or `io.read` or similar sinks with a non-constant value

### DIFF
--- a/src/codegen/generate-unified-source-bundles.rb
+++ b/src/codegen/generate-unified-source-bundles.rb
@@ -382,7 +382,7 @@ end
 
 if $mode == :GenerateXCFilelists
     IO::write($inputXCFilelistPath, $inputSources.sort.join("\n") + "\n") if $inputXCFilelistPath
-    IO::write($outputXCFilelistPath, $outputSources.sort.join("\n") + "\n") if $outputXCFilelistPath
+    File.write($outputXCFilelistPath, $outputSources.sort.join("\n") + "\n") if $outputXCFilelistPath
 end
 
 # We use stdout to report our unified source list to CMake.


### PR DESCRIPTION
https://github.com/oven-sh/bun/blob/ce5152dd7acd721e2c8194741d528540f18e9471/src/codegen/generate-unified-source-bundles.rb#L385-L385

If `kernel.open` is given a file name that starts with a `|` character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to `IO.read`, `IO.write`, `IO.binread`, `IO.binwrite`, IO.foreach, `IO.readlines` and `URI.open`.

---

fix the problem, replace the use of `IO.write` with `File.write` for writing to files. `File.write` does not interpret file paths starting with `|` as shell commands, thus avoiding the command injection vulnerability present in `IO.write`. Specifically, in `src/codegen/generate-unified-source-bundles.rb`, on line 385, change `IO::write($outputXCFilelistPath, ...)` to `File.write($outputXCFilelistPath, ...)`. No additional imports or method definitions are required, as `File` is part of Ruby's standard library.

---

### Recommendation
Use `File.open` instead of `Kernel.open`, as the former does not have this vulnerability. Similarly, use the methods from the `File` class instead of the `IO` class `File.read` instead of `IO.read`. Instead of URI.open use URI(..).open or an HTTP Client.


The following shows code that calls `Kernel.open` on a user-supplied file path.
```rb
require "open-uri"

class UsersController < ActionController::Base
  def create
    filename = params[:filename]
    open(filename) # BAD

    web_page = params[:web_page]
    URI.open(web_page) # BAD - calls `Kernel.open` internally
  end
end
```
Instead, `File.open` should be used, as in the following.
```rb
class UsersController < ActionController::Base
  def create
    filename = params[:filename]
    File.open(filename)

    web_page = params[:web_page]
    Net::HTTP.get(URI.parse(web_page))
  end
end
```
#### References
[Command Injection](https://www.owasp.org/index.php/Command_Injection). [Ruby on Rails Cheat Sheet: Command Injection](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#command-injection)
[Command Injection in RDoc](https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/)