### PR TITLE
ci: increase mac test parallelism to 7

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -568,7 +568,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
     agents: getTestAgent(platform, options),
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    parallelism: unifiedTests ? undefined : os === "darwin" ? 2 : 10,
+    parallelism: unifiedTests ? undefined : os === "darwin" ? 7 : 10,
     timeout_in_minutes: profile === "asan" || os === "windows" ? 45 : 30,
     command:
       os === "windows"


### PR DESCRIPTION
testing this out
job capacity is fixed but this will make individual jobs complete much faster and make a timeout less of an impact