### PR TITLE
Fix Uint8Array types to match new strictness in TypeScript 5.9

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1426,12 +1426,12 @@ interface Blob {
   /**
    * Returns a promise that resolves to the contents of the blob as a Uint8Array (array of bytes) its the same as `new Uint8Array(await blob.arrayBuffer())`
    */
-  bytes(): Promise<Uint8Array>;
+  bytes(): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Returns a readable stream of the blob's contents
    */
-  stream(): ReadableStream<Uint8Array>;
+  stream(): ReadableStream<Uint8Array<ArrayBuffer>>;
 }
 
 declare var Blob: Bun.__internal.UseLibDomIfAvailable<
@@ -1506,14 +1506,14 @@ interface Uint8ArrayConstructor {
       alphabet?: "base64" | "base64url";
       lastChunkHandling?: "loose" | "strict" | "stop-before-partial";
     },
-  ): Uint8Array;
+  ): Uint8Array<ArrayBuffer>;
 
   /**
    * Create a new Uint8Array from a hex encoded string
    * @param hex The hex encoded string to convert to a Uint8Array
    * @returns A new Uint8Array containing the decoded data
    */
-  fromHex(hex: string): Uint8Array;
+  fromHex(hex: string): Uint8Array<ArrayBuffer>;
 }
 
 interface BroadcastChannel extends Bun.__internal.LibEmptyOrBroadcastChannel {}


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-5-9-rc/#lib.d.ts-changes

### What does this PR do?

Updates the return types of the `fromBase64()` static method and `Blob`'s `stream()` and `bytes()` methods to return specifically `Uint8Array<ArrayBuffer>` to match the changes linked above from TypeScript 5.9

### How did you verify your code works?

I have made these changes to bun-types in my own monorepo after TypeScript 5.9 update and the compiler is now happy again
