### PR TITLE
This does NOT return undefined

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -673,7 +673,7 @@ declare module "bun:sqlite" {
     [Symbol.iterator](): IterableIterator<ReturnType>;
 
     /**
-     * Execute the prepared statement. This returns `undefined`.
+     * Execute the prepared statement.
      *
      * @param params optional values to bind to the statement. If omitted, the statement is run with the last bound values or no parameters if there are none.
      *


### PR DESCRIPTION
You updated the types but not the comment in Bun 1.1.14

### What does this PR do?

Removes the sentence "This returns `undefined`." in the SQLite Statement.run function

### How did you verify your code works?

It says this on the website

<img width="787" height="90" alt="Screenshot 2025-08-01 at 2 05 09 PM" src="https://github.com/user-attachments/assets/63259ab3-b5fd-4392-bf69-8e297f4922f2" />
