### PR TITLE
js: remove ERR_INVALID_THIS from ReadableStreamDefaultController

### DIFF
--- a/src/js/builtins/ReadableStreamDefaultController.ts
+++ b/src/js/builtins/ReadableStreamDefaultController.ts
@@ -31,8 +31,6 @@ export function initializeReadableStreamDefaultController(this, stream, underlyi
 }
 
 export function enqueue(this, chunk) {
-  if (!$isReadableStreamDefaultController(this)) throw $ERR_INVALID_THIS("ReadableStreamDefaultController");
-
   if (!$readableStreamDefaultControllerCanCloseOrEnqueue(this)) {
     throw $ERR_INVALID_STATE_TypeError("Controller is already closed");
   }
@@ -41,13 +39,10 @@ export function enqueue(this, chunk) {
 }
 
 export function error(this, err) {
-  if (!$isReadableStreamDefaultController(this)) throw $ERR_INVALID_THIS("ReadableStreamDefaultController");
   $readableStreamDefaultControllerError(this, err);
 }
 
 export function close(this) {
-  if (!$isReadableStreamDefaultController(this)) throw $ERR_INVALID_THIS("ReadableStreamDefaultController");
-
   if (!$readableStreamDefaultControllerCanCloseOrEnqueue(this))
     throw $ERR_INVALID_STATE_TypeError("Controller is already closed");
 


### PR DESCRIPTION
fixes https://github.com/oven-sh/bun/issues/17837