### PR TITLE
Make getIfPropertyValueExistsImpl accept a slice

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3971,9 +3971,9 @@ JSC::EncodedJSValue JSC__JSValue__createObject2(JSC::JSGlobalObject* globalObjec
 // Returns empty for exception, returns deleted if not found.
 // Be careful when handling the return value.
 // Cannot handle numeric index property names! If it is possible that this will be a integer index, use JSC__JSValue__getPropertyValue instead
-JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsImpl(JSC::EncodedJSValue JSValue0,
+[[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsImpl(JSC::EncodedJSValue JSValue0,
     JSC::JSGlobalObject* globalObject,
-    const unsigned char* arg1, uint32_t arg2)
+    const unsigned char* arg1, size_t arg2)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);
     JSValue value = JSC::JSValue::decode(JSValue0);

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -227,7 +227,6 @@ CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntSum(JSC::JSGlobalObject* arg0, 
 CPP_DECL void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
-CPP_DECL JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsImpl(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, const unsigned char* arg2, uint32_t arg3);
 CPP_DECL double JSC__JSValue__getLengthIfPropertyExistsInternal(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__getPrototype(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);

--- a/src/codegen/cppbind.ts
+++ b/src/codegen/cppbind.ts
@@ -14,7 +14,7 @@ To run manually:
 
 1. **nothrow** - Function that never throws exceptions:
    ```cpp
-   [[ZIG_EXPORT(nothrow)]] void hello_world() {
+   extern "C" [[ZIG_EXPORT(nothrow)]] void hello_world() {
        printf("hello world\n");
    }
    ```
@@ -22,7 +22,7 @@ To run manually:
 
 2. **zero_is_throw** - Function returns JSValue, where .zero indicates an exception:
    ```cpp
-   [[ZIG_EXPORT(zero_is_throw)]] JSValue create_object(JSGlobalObject* globalThis) {
+   extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSValue create_object(JSGlobalObject* globalThis) {
        auto scope = DECLARE_THROW_SCOPE();
        // ...
        RETURN_IF_EXCEPTION(scope, {});
@@ -33,7 +33,7 @@ To run manually:
 
 3. **check_slow** - Function that may throw, performs runtime exception checking:
    ```cpp
-   [[ZIG_EXPORT(check_slow)]] void process_data(JSGlobalObject* globalThis) {
+   extern "C" [[ZIG_EXPORT(check_slow)]] void process_data(JSGlobalObject* globalThis) {
        auto scope = DECLARE_THROW_SCOPE();
        // ...
        RETURN_IF_EXCEPTION(scope, );


### PR DESCRIPTION
Previously it accepted `property: anytype` but now it's `[]const u8` because that was the only allowed value, so it makes it easier to see what type it accepts in autocomplete.

Also updates the doc comment, switches it to use ZIG_EXPORT, and updates the cppbind doc comment