### PR TITLE
Fix missing mock.clearAllMocks property

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -56,6 +56,10 @@ declare module "bun:test" {
      * Restore the previous value of mocks.
      */
     restore(): void;
+    /**
+     * Clear all mock calls.
+     */
+    clearAllMocks(): void;
   };
 
   /**

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -462,6 +462,7 @@ pub const Jest = struct {
         module.put(globalObject, ZigString.static("mock"), mockFn);
         mockFn.put(globalObject, ZigString.static("module"), mockModuleFn);
         mockFn.put(globalObject, ZigString.static("restore"), restoreAllMocks);
+        mockFn.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
 
         const jest = JSValue.createEmptyObject(globalObject, 8);
         jest.put(globalObject, ZigString.static("fn"), mockFn);

--- a/test/regression/issue/21437.test.ts
+++ b/test/regression/issue/21437.test.ts
@@ -1,38 +1,38 @@
-import { test, expect, mock } from "bun:test";
+import { expect, mock, test } from "bun:test";
 
 test("mock.clearAllMocks should exist and be callable", () => {
   // Create a mock function
   const mockFn = mock(() => "test");
-  
+
   // Call the mock
   mockFn();
   expect(mockFn).toHaveBeenCalledTimes(1);
-  
+
   // Test that clearAllMocks exists and is callable
   expect(typeof mock.clearAllMocks).toBe("function");
-  
+
   // Call clearAllMocks
   mock.clearAllMocks();
-  
+
   // Verify that the mock was cleared
   expect(mockFn).toHaveBeenCalledTimes(0);
 });
 
 test("mock.clearAllMocks should work the same as jest.clearAllMocks", () => {
   const mockFn = mock(() => "test");
-  
+
   // Call the mock
   mockFn();
   expect(mockFn).toHaveBeenCalledTimes(1);
-  
+
   // Use mock.clearAllMocks
   mock.clearAllMocks();
   expect(mockFn).toHaveBeenCalledTimes(0);
-  
+
   // Call the mock again
   mockFn();
   expect(mockFn).toHaveBeenCalledTimes(1);
-  
+
   // Use jest.clearAllMocks to verify they do the same thing
   jest.clearAllMocks();
   expect(mockFn).toHaveBeenCalledTimes(0);

--- a/test/regression/issue/21437.test.ts
+++ b/test/regression/issue/21437.test.ts
@@ -1,0 +1,39 @@
+import { test, expect, mock } from "bun:test";
+
+test("mock.clearAllMocks should exist and be callable", () => {
+  // Create a mock function
+  const mockFn = mock(() => "test");
+  
+  // Call the mock
+  mockFn();
+  expect(mockFn).toHaveBeenCalledTimes(1);
+  
+  // Test that clearAllMocks exists and is callable
+  expect(typeof mock.clearAllMocks).toBe("function");
+  
+  // Call clearAllMocks
+  mock.clearAllMocks();
+  
+  // Verify that the mock was cleared
+  expect(mockFn).toHaveBeenCalledTimes(0);
+});
+
+test("mock.clearAllMocks should work the same as jest.clearAllMocks", () => {
+  const mockFn = mock(() => "test");
+  
+  // Call the mock
+  mockFn();
+  expect(mockFn).toHaveBeenCalledTimes(1);
+  
+  // Use mock.clearAllMocks
+  mock.clearAllMocks();
+  expect(mockFn).toHaveBeenCalledTimes(0);
+  
+  // Call the mock again
+  mockFn();
+  expect(mockFn).toHaveBeenCalledTimes(1);
+  
+  // Use jest.clearAllMocks to verify they do the same thing
+  jest.clearAllMocks();
+  expect(mockFn).toHaveBeenCalledTimes(0);
+});


### PR DESCRIPTION
## Summary
Fixes #21437 by adding the missing `clearAllMocks` method to the `mock` object.

The `clearAllMocks` function was already implemented in `jest.zig` and available on the `jest` object, but was not exposed on the `mock` object despite being documented in the Bun docs.

## Changes
- Add `clearAllMocks(): void;` to the `mock` object type definition in `test.d.ts`
- Expose the existing `clearAllMocks` function on the `mock` object in `jest.zig`
- Add regression tests to verify the functionality works correctly

## Test plan
- [x] Added regression tests in `test/regression/issue/21437.test.ts`
- [x] Verified TypeScript types are correct
- [x] Verified runtime implementation exposes the function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)