### PR TITLE
sql: support array of strings in SQLHelper

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -82,7 +82,7 @@ class SQLHelper<T> {
   public readonly columns: (keyof T)[];
 
   constructor(value: T, keys?: (keyof T)[]) {
-    if (keys !== undefined && keys.length === 0) {
+    if (keys !== undefined && keys.length === 0 && ($isObject(value[0]) || $isArray(value[0]))) {
       keys = Object.keys(value[0]) as (keyof T)[];
     }
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -11152,6 +11152,27 @@ CREATE TABLE ${table_name} (
       expect(result[1].age).toBe(18);
     });
 
+    test("update helper with IN for strings", async () => {
+      await using sql = postgres({ ...options, max: 1 });
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text, age int)`;
+      const users = [
+        { id: 1, name: "John", age: 30 },
+        { id: 2, name: "Jane", age: 25 },
+        { id: 3, name: "Bob", age: 35 },
+      ];
+      await sql`INSERT INTO ${sql(random_name)} ${sql(users)}`;
+
+      const result =
+        await sql`UPDATE ${sql(random_name)} SET ${sql({ age: 40 })} WHERE name IN ${sql(["John", "Jane"])} RETURNING *`;
+      expect(result[0].id).toBe(1);
+      expect(result[0].name).toBe("John");
+      expect(result[0].age).toBe(40);
+      expect(result[1].id).toBe(2);
+      expect(result[1].name).toBe("Jane");
+      expect(result[1].age).toBe(40);
+    });
+
     test("update helper with IN and column name", async () => {
       await using sql = postgres({ ...options, max: 1 });
       const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");


### PR DESCRIPTION
### What does this PR do?
Support the following:
```javascript
const nom = await sql`SELECT name FROM food WHERE category IN ${sql(['bun', 'baozi', 'xiaolongbao'])}`;
```

Previously, only e.g., `sql([1, 2, 3])` was supported.

To be honest I'm not sure what the semantics of SQLHelper *ought* to be. I'm pretty sure objects ought to be auto-inferred. I'm not sure about arrays, but given the rest of the code in `SQLHelper` trying to read the tea leaves on stringified numeric keys I figured someone cared about this use case. I don't know about other types, but I'm pretty sure that `Object.keys("bun") === [0, 1, 2]` is an oversight and unintended. (Incidentally, the reason numbers previously worked is because `Object.keys(4) === []`). I decided that all non-objects and non-arrays should be treated as not having auto-inferred columns.

Fixes #18637 

### How did you verify your code works?
I wrote a test, but was unable to run it (or any other tests in this file) locally due to Docker struggles. I sure hope it works! 