### PR TITLE
Reduce idle CPU usage in long-running processes

### DIFF
--- a/src/bun.js/bindings/BunJSCEventLoop.cpp
+++ b/src/bun.js/bindings/BunJSCEventLoop.cpp
@@ -12,7 +12,7 @@ static thread_local std::optional<JSC::JSLock::DropAllLocks> drop_all_locks { st
 extern "C" void WTFTimer__runIfImminent(void* bun_vm);
 
 // Safe if VM is nullptr
-extern "C" void Bun__JSC_onBeforeWait(JSC::VM* vm)
+extern "C" int Bun__JSC_onBeforeWait(JSC::VM* vm)
 {
     ASSERT(!drop_all_locks.has_value());
     if (vm) {
@@ -20,11 +20,61 @@ extern "C" void Bun__JSC_onBeforeWait(JSC::VM* vm)
         // sanity check for debug builds to ensure we're not doing a
         // use-after-free here
         ASSERT(vm->refCount() > 0);
-        drop_all_locks.emplace(*vm);
         if (previouslyHadAccess) {
-            vm->heap.releaseAccess();
+
+            // Releasing heap access is a balance between:
+            // 1. CPU usage
+            // 2. Memory usage
+            //
+            // Not releasing heap access causes benchmarks like
+            // https://github.com/oven-sh/bun/pull/14885 to regress due to
+            // finalizers not being called quickly enough.
+            //
+            // Releasing heap access too often causes high idle CPU usage.
+            //
+            // For the following code:
+            // ```
+            // setTimeout(() => {}, 10 * 1000)
+            // ```
+            //
+            // command time -v when with defaultRemainingRunsUntilSkipReleaseAccess = 0:
+            //
+            //   Involuntary context switches: 605
+            //
+            // command time -v when with defaultRemainingRunsUntilSkipReleaseAccess = 5:
+            //
+            //   Involuntary context switches: 350
+            //
+            // command time -v when with defaultRemainingRunsUntilSkipReleaseAccess = 10:
+            //
+            //   Involuntary context switches: 241
+            //
+            // Also comapre the #14885 benchmark with different values.
+            //
+            // The idea here is if you entered JS "recently", running any
+            // finalizers that might've been waiting to be run is a good idea.
+            // But if you haven't, like if the process is just waiting on I/O
+            // then don't bother.
+            static constexpr int defaultRemainingRunsUntilSkipReleaseAccess = 10;
+
+            static thread_local int remainingRunsUntilSkipReleaseAccess = 0;
+
+            // Note: usage of `didEnterVM` in JSC::VM conflicts with Options::validateDFGClobberize
+            // We don't need to use that option, so it should be fine.
+            if (vm->didEnterVM) {
+                vm->didEnterVM = false;
+                remainingRunsUntilSkipReleaseAccess = defaultRemainingRunsUntilSkipReleaseAccess;
+            }
+
+            if (remainingRunsUntilSkipReleaseAccess-- > 0) {
+                drop_all_locks.emplace(*vm);
+                vm->heap.releaseAccess();
+                vm->didEnterVM = false;
+                return 1;
+            }
         }
     }
+    return 0;
 }
 
 extern "C" void Bun__JSC_onAfterWait(JSC::VM* vm)


### PR DESCRIPTION
### What does this PR do?

Releasing heap access causes all the heap helper threads to wake up and lock and then unlock futexes, but it's important to do that to ensure finalizers run quickly.

That means releasing heap access is a balance between:
 1. CPU usage
 2. Memory usage

 Not releasing heap access causes benchmarks like https://github.com/oven-sh/bun/pull/14885 to regress due to finalizers not being called quickly enough.

Releasing heap access too often causes high idle CPU usage.

 For the following code:
 ```
 setTimeout(() => {}, 10 * 1000)
 ```

command time -v when with defaultRemainingRunsUntilSkipReleaseAccess = 0:
>
>   Involuntary context switches: 605
>

command time -v when with defaultRemainingRunsUntilSkipReleaseAccess = 5:
>
>   Involuntary context switches: 350
>

command time -v when with defaultRemainingRunsUntilSkipReleaseAccess = 10:
>
>  Involuntary context switches: 241
>

 Also comapre the #14885 benchmark with different values.

 The idea here is if you entered JS "recently", running any
 finalizers that might've been waiting to be run is a good idea.
 But if you haven't, like if the process is just waiting on I/O
 then don't bother.

### How did you verify your code works?
