### PR TITLE
Report H2FrameParser memory cost more precisely

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4446,10 +4446,6 @@ pub const H2FrameParser = struct {
     }
     pub fn detachFromJS(this: *H2FrameParser, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
         jsc.markBinding(@src());
-        var it = this.streams.valueIterator();
-        while (it.next()) |stream| {
-            stream.freeResources(this, false);
-        }
         this.detach();
         if (this.strong_this.tryGet()) |this_value| {
             js.gc.context.clear(this_value, this.globalThis);

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -767,6 +767,14 @@ pub const H2FrameParser = struct {
             front: usize = 0,
             len: usize = 0,
 
+            pub fn memoryCost(this: *const PendingQueue) usize {
+                var counter: usize = @sizeOf(PendingQueue);
+                for (this.data.items) |*item| {
+                    counter += item.memoryCost();
+                }
+                return counter;
+            }
+
             pub fn deinit(self: *PendingQueue, allocator: Allocator) void {
                 self.front = 0;
                 self.len = 0;
@@ -847,7 +855,19 @@ pub const H2FrameParser = struct {
             pub fn slice(this: *const PendingFrame) []u8 {
                 return this.buffer[this.offset..this.len];
             }
+
+            pub fn memoryCost(this: *const PendingFrame) usize {
+                var counter: usize = @sizeOf(PendingFrame);
+                counter += this.buffer.len;
+                return counter;
+            }
         };
+
+        pub fn memoryCost(this: *const Stream) usize {
+            var counter: usize = @sizeOf(Stream);
+            counter += this.dataFrameQueue.memoryCost();
+            return counter;
+        }
 
         pub fn getPadding(
             this: *Stream,
@@ -1712,6 +1732,18 @@ pub const H2FrameParser = struct {
                 _ = corked._write(bytes);
             }
         }
+    }
+
+    pub fn memoryCost(this: *H2FrameParser) usize {
+        var counter: usize = @sizeOf(H2FrameParser);
+        counter += this.writeBuffer.memoryCost();
+        counter += this.readBuffer.memoryCost();
+        counter += this.streams.capacity() * @sizeOf(u32);
+        var iter = this.streams.valueIterator();
+        while (iter.next()) |stream| {
+            counter += stream.memoryCost();
+        }
+        return counter;
     }
 
     fn registerAutoFlush(this: *H2FrameParser) void {
@@ -4444,6 +4476,18 @@ pub const H2FrameParser = struct {
             hpack.deinit();
             this.hpack = null;
         }
+
+        this.deinitStreams();
+    }
+
+    fn deinitStreams(this: *H2FrameParser) void {
+        var it = this.streams.valueIterator();
+        while (it.next()) |stream| {
+            stream.freeResources(this, true);
+        }
+        var streams = this.streams;
+        defer streams.deinit();
+        this.streams = bun.U32HashMap(Stream).init(bun.default_allocator);
     }
 
     fn deinit(this: *H2FrameParser) void {
@@ -4458,18 +4502,12 @@ pub const H2FrameParser = struct {
         }
         this.detach();
         this.strong_this.deinit();
-        var it = this.streams.valueIterator();
-        while (it.next()) |stream| {
-            stream.freeResources(this, true);
-        }
-        var streams = this.streams;
-        defer streams.deinit();
-        this.streams = bun.U32HashMap(Stream).init(bun.default_allocator);
     }
 
     pub fn finalize(this: *H2FrameParser) void {
         log("finalize", .{});
         this.strong_this.deinit();
+        this.deinitStreams();
         this.deref();
     }
 };

--- a/src/bun.js/api/h2.classes.ts
+++ b/src/bun.js/api/h2.classes.ts
@@ -125,6 +125,7 @@ export default [
     finalize: true,
     construct: true,
     constructNeedsThis: true,
+    memoryCost: true,
     klass: {},
     values: [
       "context",

--- a/src/string/MutableString.zig
+++ b/src/string/MutableString.zig
@@ -22,6 +22,10 @@ pub fn isEmpty(this: *const MutableString) bool {
     return this.list.items.len == 0;
 }
 
+pub fn memoryCost(this: *const MutableString) usize {
+    return this.list.capacity;
+}
+
 pub fn deinit(str: *MutableString) void {
     if (str.list.capacity > 0) {
         str.list.expandToCapacity();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -9,7 +9,13 @@ import tls from "node:tls";
 import { Duplex } from "stream";
 import http2utils from "./helpers";
 import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 const { afterEach, beforeEach, describe, expect, it, createCallCheckCtx } = createTest(import.meta.path);
+
+function getMemorySize(obj) {
+  return estimateShallowMemoryUsageOf(obj[Symbol.for("::bunhttp2native::")]);
+}
+
 function invalidArgTypeHelper(input) {
   if (input === null) return " Received null";
 
@@ -1666,8 +1672,9 @@ it("http2 server handles multiple concurrent requests", async () => {
 
     server.on("listening", () => {
       const port = server.address().port;
-      const client = http2.connect(`http://localhost:${port}`);
 
+      const client = http2.connect(`http://localhost:${port}`);
+      const initialMemorySize = getMemorySize(client);
       client.setMaxListeners(101);
       client.on("goaway", console.log);
 
@@ -1700,6 +1707,9 @@ it("http2 server handles multiple concurrent requests", async () => {
         req.on("data", d => (data += d));
 
         req.on("end", () => {
+          // Test that memoryCost() works.
+          expect(getMemorySize(client)).toBeGreaterThan(initialMemorySize);
+
           expect(body).toBe(data);
         });
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,3 +1,4 @@
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { bunEnv, bunExe, isCI, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import fs from "node:fs";
@@ -9,7 +10,6 @@ import tls from "node:tls";
 import { Duplex } from "stream";
 import http2utils from "./helpers";
 import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
-import { estimateShallowMemoryUsageOf } from "bun:jsc";
 const { afterEach, beforeEach, describe, expect, it, createCallCheckCtx } = createTest(import.meta.path);
 
 function getMemorySize(obj) {


### PR DESCRIPTION
### What does this PR do?

- Report H2FrameParser memory cost more precisely
- Ensure we free the stream data potentially slightly earlier

### How did you verify your code works?

There is a test
