### PR TITLE
Add mode option to Bun.write() for setting file permissions

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1547,12 +1547,12 @@ fn writeStringToFileFast(
             // we deliberately don't use O_TRUNC here
             // it's a perf optimization
             bun.O.WRONLY | bun.O.CREAT | bun.O.NONBLOCK,
-            open_mode,
+            @intCast(open_mode),
         )) {
             .result => |result| {
                 if (comptime !Environment.isWindows) {
                     if (mode) |file_mode| {
-                        _ = bun.sys.fchmod(result, file_mode);
+                        _ = bun.sys.fchmod(result, @intCast(file_mode));
                     }
                 }
                 break :brk result;
@@ -1639,12 +1639,12 @@ fn writeBytesToFileFast(
                 bun.O.WRONLY | bun.O.CREAT | bun.O.NONBLOCK
             else
                 bun.O.WRONLY | bun.O.CREAT,
-            open_mode,
+            @intCast(open_mode),
         )) {
             .result => |result| {
                 if (comptime !Environment.isWindows) {
                     if (mode) |file_mode| {
-                        _ = bun.sys.fchmod(result, file_mode);
+                        _ = bun.sys.fchmod(result, @intCast(file_mode));
                     }
                 }
                 break :brk result;

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -148,7 +148,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
         .path => |path| {
             const options = args.nextEat();
             var mode: ?u32 = null;
-            
+
             // Parse mode from options if present
             if (options) |options_object| {
                 if (options_object.isObject()) {
@@ -159,7 +159,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                     }
                 }
             }
-            
+
             if (path == .fd) {
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
@@ -176,7 +176,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
         .blob => {
             const options = args.nextEat();
             var mode: ?u32 = null;
-            
+
             // Parse mode from options if present
             if (options) |options_object| {
                 if (options_object.isObject()) {
@@ -187,7 +187,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                     }
                 }
             }
-            
+
             return try Blob.writeFileInternal(globalThis, &path_or_blob, data, .{
                 .mkdirp_if_not_exists = false,
                 .extra_options = options,

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -147,14 +147,14 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
     switch (path_or_blob) {
         .path => |path| {
             const options = args.nextEat();
-            var mode: ?u32 = null;
+            var mode: ?bun.Mode = null;
 
             // Parse mode from options if present
             if (options) |options_object| {
                 if (options_object.isObject()) {
                     if (try options_object.getTruthy(globalThis, "mode")) |mode_value| {
                         if (try jsc.Node.modeFromJS(globalThis, mode_value)) |file_mode| {
-                            mode = @intCast(file_mode);
+                            mode = file_mode;
                         }
                     }
                 }
@@ -175,14 +175,14 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
         },
         .blob => {
             const options = args.nextEat();
-            var mode: ?u32 = null;
+            var mode: ?bun.Mode = null;
 
             // Parse mode from options if present
             if (options) |options_object| {
                 if (options_object.isObject()) {
                     if (try options_object.getTruthy(globalThis, "mode")) |mode_value| {
                         if (try jsc.Node.modeFromJS(globalThis, mode_value)) |file_mode| {
-                            mode = @intCast(file_mode);
+                            mode = file_mode;
                         }
                     }
                 }

--- a/src/bun.js/webcore/blob/copy_file.zig
+++ b/src/bun.js/webcore/blob/copy_file.zig
@@ -161,14 +161,14 @@ pub const CopyFile = struct {
                 this.destination_fd = switch (bun.sys.open(
                     dest,
                     open_destination_flags,
-                    this.mode orelse jsc.Node.fs.default_permission,
+                    @intCast(this.mode orelse jsc.Node.fs.default_permission),
                 )) {
                     .result => |result| switch (result.makeLibUVOwnedForSyscall(.open, .close_on_fail)) {
                         .result => |result_fd| blk: {
                             // Set file mode if specified
                             if (comptime !Environment.isWindows) {
                                 if (this.mode) |file_mode| {
-                                    _ = bun.sys.fchmod(result_fd, file_mode);
+                                    _ = bun.sys.fchmod(result_fd, @intCast(file_mode));
                                 }
                             }
                             break :blk result_fd;

--- a/src/bun.js/webcore/blob/copy_file.zig
+++ b/src/bun.js/webcore/blob/copy_file.zig
@@ -18,7 +18,7 @@ pub const CopyFile = struct {
     globalThis: *JSGlobalObject,
 
     mkdirp_if_not_exists: bool = false,
-    mode: ?u32 = null,
+    mode: ?bun.Mode = null,
 
     pub const ResultType = anyerror!SizeType;
 
@@ -32,7 +32,7 @@ pub const CopyFile = struct {
         max_len: SizeType,
         globalThis: *JSGlobalObject,
         mkdirp_if_not_exists: bool,
-        mode: ?u32,
+        mode: ?bun.Mode,
     ) !*CopyFilePromiseTask {
         const read_file = bun.new(CopyFile, CopyFile{
             .store = store,
@@ -161,14 +161,14 @@ pub const CopyFile = struct {
                 this.destination_fd = switch (bun.sys.open(
                     dest,
                     open_destination_flags,
-                    @intCast(this.mode orelse jsc.Node.fs.default_permission),
+                    this.mode orelse jsc.Node.fs.default_permission,
                 )) {
                     .result => |result| switch (result.makeLibUVOwnedForSyscall(.open, .close_on_fail)) {
                         .result => |result_fd| blk: {
                             // Set file mode if specified
                             if (comptime !Environment.isWindows) {
                                 if (this.mode) |file_mode| {
-                                    _ = bun.sys.fchmod(result_fd, @intCast(file_mode));
+                                    _ = bun.sys.fchmod(result_fd, file_mode);
                                 }
                             }
                             break :blk result_fd;

--- a/src/bun.js/webcore/blob/write_file.zig
+++ b/src/bun.js/webcore/blob/write_file.zig
@@ -228,7 +228,7 @@ pub const WriteFile = struct {
         // Set file mode if specified
         if (comptime !Environment.isWindows) {
             if (this.mode) |file_mode| {
-                _ = bun.sys.fchmod(fd, file_mode);
+                _ = bun.sys.fchmod(fd, @intCast(file_mode));
             }
         }
 

--- a/src/bun.js/webcore/blob/write_file.zig
+++ b/src/bun.js/webcore/blob/write_file.zig
@@ -22,7 +22,7 @@ pub const WriteFile = struct {
     could_block: bool = false,
     close_after_io: bool = false,
     mkdirp_if_not_exists: bool = false,
-    mode: ?u32 = null,
+    mode: ?bun.Mode = null,
 
     pub const io_tag = io.Poll.Tag.WriteFile;
 
@@ -78,7 +78,7 @@ pub const WriteFile = struct {
         onWriteFileContext: *anyopaque,
         onCompleteCallback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
-        mode: ?u32,
+        mode: ?bun.Mode,
     ) !*WriteFile {
         const write_file = bun.new(WriteFile, WriteFile{
             .file_blob = file_blob,
@@ -101,7 +101,7 @@ pub const WriteFile = struct {
         context: Context,
         comptime callback: fn (ctx: Context, bytes: WriteFileResultType) void,
         mkdirp_if_not_exists: bool,
-        mode: ?u32,
+        mode: ?bun.Mode,
     ) !*WriteFile {
         const Handler = struct {
             pub fn run(ptr: *anyopaque, bytes: WriteFileResultType) void {
@@ -228,7 +228,7 @@ pub const WriteFile = struct {
         // Set file mode if specified
         if (comptime !Environment.isWindows) {
             if (this.mode) |file_mode| {
-                _ = bun.sys.fchmod(fd, @intCast(file_mode));
+                _ = bun.sys.fchmod(fd, file_mode);
             }
         }
 
@@ -356,7 +356,7 @@ pub const WriteFileWindows = struct {
     onCompleteCallback: WriteFileOnWriteFileCallback,
     onCompleteCtx: *anyopaque,
     mkdirp_if_not_exists: bool = false,
-    mode: ?u32 = null,
+    mode: ?bun.Mode = null,
     uv_bufs: [1]uv.uv_buf_t,
 
     fd: uv.uv_file = -1,
@@ -375,7 +375,7 @@ pub const WriteFileWindows = struct {
         onWriteFileContext: *anyopaque,
         onCompleteCallback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
-        mode: ?u32,
+        mode: ?bun.Mode,
     ) *WriteFileWindows {
         const write_file = WriteFileWindows.new(.{
             .file_blob = file_blob,
@@ -638,7 +638,7 @@ pub const WriteFileWindows = struct {
         context: Context,
         comptime callback: *const fn (ctx: Context, bytes: WriteFileResultType) void,
         mkdirp_if_not_exists: bool,
-        mode: ?u32,
+        mode: ?bun.Mode,
     ) *WriteFileWindows {
         return WriteFileWindows.createWithCtx(
             file_blob,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -533,12 +533,12 @@ if (!isWindows) {
   describe("mode option", () => {
     it("Bun.write() with mode option sets correct file permissions", async () => {
       const filename = path.join(tmpdir(), `mode-test-${Date.now()}.txt`);
-      
+
       // Test mode 0o644 (read/write for owner, read for group/others)
       await Bun.write(filename, "test content", { mode: 0o644 });
       const stats = fs.statSync(filename);
       expect(stats.mode & 0o777).toBe(0o644);
-      
+
       try {
         fs.unlinkSync(filename);
       } catch (e) {}
@@ -546,12 +546,12 @@ if (!isWindows) {
 
     it("Bun.write() with mode option as decimal", async () => {
       const filename = path.join(tmpdir(), `mode-decimal-test-${Date.now()}.txt`);
-      
+
       // Test mode 0o755 as decimal (493)
       await Bun.write(filename, "test content", { mode: 493 });
       const stats = fs.statSync(filename);
       expect(stats.mode & 0o777).toBe(0o755);
-      
+
       try {
         fs.unlinkSync(filename);
       } catch (e) {}
@@ -560,12 +560,12 @@ if (!isWindows) {
     it("Bun.write() with mode option and createPath", async () => {
       const testDir = path.join(tmpdir(), `mode-mkdir-test-${Date.now()}`);
       const filename = path.join(testDir, "test.txt");
-      
+
       // Test mode with createPath
       await Bun.write(filename, "test content", { mode: 0o600, createPath: true });
       const stats = fs.statSync(filename);
       expect(stats.mode & 0o777).toBe(0o600);
-      
+
       try {
         fs.rmSync(testDir, { recursive: true });
       } catch (e) {}
@@ -574,12 +574,12 @@ if (!isWindows) {
     it("blob.write() with mode option", async () => {
       const filename = path.join(tmpdir(), `blob-mode-test-${Date.now()}.txt`);
       const file = Bun.file(filename);
-      
+
       // Test blob write with mode
       await file.write("test content", { mode: 0o640 });
       const stats = fs.statSync(filename);
       expect(stats.mode & 0o777).toBe(0o640);
-      
+
       try {
         fs.unlinkSync(filename);
       } catch (e) {}
@@ -588,15 +588,15 @@ if (!isWindows) {
     it("Bun.write() file to file copy with mode", async () => {
       const sourceFile = path.join(tmpdir(), `source-${Date.now()}.txt`);
       const destFile = path.join(tmpdir(), `dest-mode-${Date.now()}.txt`);
-      
+
       // Create source file
       await Bun.write(sourceFile, "source content");
-      
+
       // Copy with specific mode
       await Bun.write(Bun.file(destFile), Bun.file(sourceFile), { mode: 0o660 });
       const stats = fs.statSync(destFile);
       expect(stats.mode & 0o777).toBe(0o660);
-      
+
       try {
         fs.unlinkSync(sourceFile);
         fs.unlinkSync(destFile);
@@ -606,12 +606,12 @@ if (!isWindows) {
     it("mode validation - should handle edge cases", async () => {
       const filename1 = path.join(tmpdir(), `mode-truncate-test-${Date.now()}.txt`);
       const filename2 = path.join(tmpdir(), `mode-negative-test-${Date.now()}.txt`);
-      
+
       // Test mode > 0o777 gets truncated (like Node.js)
       await Bun.write(filename1, "test", { mode: 0o1644 });
       const stats1 = fs.statSync(filename1);
       expect(stats1.mode & 0o777).toBe(0o644); // 0o1644 & 0o777 = 0o644
-      
+
       // Test negative mode should throw
       try {
         await Bun.write(filename2, "test", { mode: -1 });
@@ -619,7 +619,7 @@ if (!isWindows) {
       } catch (error) {
         expect(error.message).toContain("out of range");
       }
-      
+
       try {
         fs.unlinkSync(filename1);
       } catch (e) {}
@@ -634,11 +634,11 @@ if (!isWindows) {
 
       for (const [type, data] of testCases) {
         const filename = path.join(tmpdir(), `mode-${type}-test-${Date.now()}.txt`);
-        
+
         await Bun.write(filename, data, { mode: 0o622 });
         const stats = fs.statSync(filename);
         expect(stats.mode & 0o777).toBe(0o622);
-        
+
         try {
           fs.unlinkSync(filename);
         } catch (e) {}


### PR DESCRIPTION
## Summary

- Add `mode` option to `Bun.write()` to allow setting file permissions on POSIX systems
- Implementation covers all write code paths including async operations and file copying
- Added comprehensive tests verifying mode setting works correctly

## Implementation Details

This PR implements the `mode` option for `Bun.write()` similar to Node.js `fs.writeFile()`. The implementation includes:

### Core Changes
- **Blob.zig**: Added mode parsing and parameter passing in main write functions
- **write_file.zig**: Updated async file writing to support mode option  
- **copy_file.zig**: Added mode support for file copying operations
- **S3File.zig**: Updated write method to parse and pass mode option

### Key Features
- Mode validation follows Node.js behavior (uses `modeFromJS()` with truncation to 0o777)
- Cross-platform support (POSIX systems only, Windows file permissions work differently)
- Works with all data types (strings, Uint8Array, ArrayBuffer, Blob)
- Compatible with existing options like `createPath`

### Usage Examples
```javascript
// Set read/write for owner, read for others
await Bun.write("file.txt", "content", { mode: 0o644 });

// Set executable permissions
await Bun.write("script.sh", "#\!/bin/bash\necho hello", { mode: 0o755 });

// Works with blob operations  
const file = Bun.file("output.txt");
await file.write("data", { mode: 0o600 });

// Works with file copying
await Bun.write(Bun.file("dest.txt"), Bun.file("source.txt"), { mode: 0o640 });
```

## Test Plan

- ✅ All existing tests pass
- ✅ Added comprehensive mode option tests covering:
  - Basic mode setting with different permission values
  - Blob write operations with mode
  - File copying with mode  
  - Mode with `createPath` option
  - Different data types (string, Uint8Array, ArrayBuffer)
  - Edge case handling (mode truncation, validation)
- ✅ Cross-platform compilation verified with `bun run zig:check-all`

🤖 Generated with [Claude Code](https://claude.ai/code)