### PR TITLE
docs: update node:vm compatibility status

### DIFF
--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -148,7 +148,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:vm`](https://nodejs.org/api/vm.html)
 
-🟡 Core functionality and ES modules are implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`, and `importModuleDynamically` support. Missing `vm.measureMemory`. Some options like `timeout`, `breakOnSigint`, and `cachedData` are partially supported.
+🟡 Core functionality and ES modules are implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`, and `importModuleDynamically` support. Options like `timeout` and `breakOnSigint` are fully supported. Missing `vm.measureMemory` and some `cachedData` functionality.
 
 ### [`node:wasi`](https://nodejs.org/api/wasi.html)
 

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -148,7 +148,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:vm`](https://nodejs.org/api/vm.html)
 
-🟡 Core functionality works, but experimental VM ES modules are not implemented, including `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`,`importModuleDynamically`, and `vm.measureMemory`. Options like `timeout`, `breakOnSigint`, `cachedData` are not implemented yet.
+🟡 Core functionality and ES modules are implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`, and `importModuleDynamically` support. Missing `vm.measureMemory`. Some options like `timeout`, `breakOnSigint`, and `cachedData` are partially supported.
 
 ### [`node:wasi`](https://nodejs.org/api/wasi.html)
 


### PR DESCRIPTION
## Summary
- Update nodejs-apis.md to accurately reflect the current implementation status of node:vm
- Most VM APIs are now implemented, including ES modules support
- Only vm.measureMemory remains unimplemented

## Changes
- Updated documentation to show that `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`, and `importModuleDynamically` are implemented
- Clarified that only `vm.measureMemory` is missing
- Updated description to reflect partial support for options like `timeout`, `breakOnSigint`, and `cachedData`

🤖 Generated with [Claude Code](https://claude.ai/code)