### PR TITLE
support `new Response(html)` for custom headers/status in Bun.serve() routes

### DIFF
--- a/src/bun.js/api/bun/spawn/stdio.zig
+++ b/src/bun.js/api/bun/spawn/stdio.zig
@@ -297,6 +297,9 @@ pub const Stdio = union(enum) {
             },
 
             .Blob, .WTFStringImpl, .InternalBlob => unreachable, // handled above.
+            .HTMLBundle => {
+                return globalThis.throwInvalidArguments("HTMLBundle cannot be used as stdin", .{});
+            },
             .Locked => {
                 if (is_sync) {
                     return globalThis.throwInvalidArguments("ReadableStream cannot be used in sync mode", .{});

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -199,34 +199,31 @@ pub const AnyRoute = union(enum) {
         }
 
         if (argument.as(jsc.WebCore.Response)) |response| {
-            if (response.body.value == .InternalBlob and !response.body.value.InternalBlob.was_string) {
-                const bytes = response.body.value.InternalBlob.bytes.items;
-                if (bytes.len == @sizeOf(*HTMLBundle)) {
-                    const html_bundle_ptr = @as(**HTMLBundle, @ptrCast(@alignCast(bytes.ptr))).*;
-                    const needs_custom = response.init.headers != null or response.statusCode() != 200;
+            if (response.body.value == .HTMLBundle) {
+                const html_bundle = response.body.value.HTMLBundle;
+                const needs_custom = response.init.headers != null or response.statusCode() != 200;
 
-                    if (needs_custom) {
-                        var route = HTMLBundle.Route.init(html_bundle_ptr);
+                if (needs_custom) {
+                    var route = HTMLBundle.Route.init(html_bundle);
 
-                        if (response.init.headers) |headers| {
-                            route.data.custom_headers = bun.http.Headers.from(headers, bun.default_allocator, .{}) catch bun.outOfMemory();
-                        }
+                    if (response.init.headers) |headers| {
+                        route.data.custom_headers = bun.http.Headers.from(headers, bun.default_allocator, .{}) catch bun.outOfMemory();
+                    }
 
-                        const status = response.statusCode();
-                        if (status != 200) {
-                            route.data.custom_status = status;
-                        }
+                    const status = response.statusCode();
+                    if (status != 200) {
+                        route.data.custom_status = status;
+                    }
 
-                        return .{ .html = route };
+                    return .{ .html = route };
+                } else {
+                    const entry = init_ctx.dedupe_html_bundle_map.getOrPut(html_bundle) catch bun.outOfMemory();
+
+                    if (!entry.found_existing) {
+                        entry.value_ptr.* = HTMLBundle.Route.init(html_bundle);
+                        return .{ .html = entry.value_ptr.* };
                     } else {
-                        const entry = init_ctx.dedupe_html_bundle_map.getOrPut(html_bundle_ptr) catch bun.outOfMemory();
-
-                        if (!entry.found_existing) {
-                            entry.value_ptr.* = HTMLBundle.Route.init(html_bundle_ptr);
-                            return .{ .html = entry.value_ptr.* };
-                        } else {
-                            return .{ .html = entry.value_ptr.dupeRef() };
-                        }
+                        return .{ .html = entry.value_ptr.dupeRef() };
                     }
                 }
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -219,7 +219,7 @@ pub const AnyRoute = union(enum) {
 
                         return .{ .html = route };
                     } else {
-                        const route = entry.value_ptr.dupeRef();
+                        var route = HTMLBundle.Route.init(html_bundle_ptr);
 
                         if (response.init.headers) |headers| {
                             route.data.custom_headers = bun.http.Headers.from(headers, bun.default_allocator, .{}) catch bun.outOfMemory();

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1439,6 +1439,12 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     resp.writeHeaderInt("content-length", 0);
                     this.endWithoutBody(this.shouldCloseConnection());
                 },
+                .HTMLBundle => {
+                    // HTMLBundle cannot be used in HEAD response
+                    this.renderMetadata();
+                    resp.writeHeaderInt("content-length", 0);
+                    this.endWithoutBody(this.shouldCloseConnection());
+                },
             }
         }
 

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1325,6 +1325,10 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                 => {
                     break :brk response.body.use();
                 },
+                .HTMLBundle => {
+                    destination_blob.detach();
+                    return globalThis.throwInvalidArguments("HTMLBundle cannot be written to a file", .{});
+                },
                 .Error => |*err_ref| {
                     destination_blob.detach();
                     _ = response.body.value.use();
@@ -1385,6 +1389,10 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                 .Null,
                 => {
                     break :brk request.body.value.use();
+                },
+                .HTMLBundle => {
+                    destination_blob.detach();
+                    return globalThis.throwInvalidArguments("HTMLBundle cannot be written to a file", .{});
                 },
                 .Error => |*err_ref| {
                     destination_blob.detach();

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -268,6 +268,7 @@ pub const Value = union(Tag) {
     Empty,
     Error: ValueError,
     Null,
+    HTMLBundle: *bun.jsc.API.HTMLBundle,
 
     // We may not have all the data yet
     // So we can't know for sure if it's empty or not
@@ -280,6 +281,7 @@ pub const Value = union(Tag) {
             .Blob => this.Blob.size == 0,
             .WTFStringImpl => this.WTFStringImpl.length() == 0,
             .Error, .Locked => false,
+            .HTMLBundle => false,
         };
     }
 
@@ -440,6 +442,7 @@ pub const Value = union(Tag) {
         Empty,
         Error,
         Null,
+        HTMLBundle,
     };
 
     // pub const empty = Value{ .Empty = {} };
@@ -523,6 +526,9 @@ pub const Value = union(Tag) {
                 // TODO: handle error properly
                 return jsc.WebCore.ReadableStream.empty(globalThis);
             },
+            .HTMLBundle => {
+                return globalThis.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
+            },
         }
     }
 
@@ -599,16 +605,9 @@ pub const Value = union(Tag) {
         }
 
         if (value.as(bun.jsc.API.HTMLBundle)) |html_bundle| {
-            const html_bundle_bytes = std.mem.asBytes(&html_bundle);
+            html_bundle.ref();
             return Body.Value{
-                .InternalBlob = .{
-                    .bytes = std.ArrayList(u8){
-                        .items = bun.default_allocator.dupe(u8, html_bundle_bytes) catch bun.outOfMemory(),
-                        .capacity = html_bundle_bytes.len,
-                        .allocator = bun.default_allocator,
-                    },
-                    .was_string = false,
-                },
+                .HTMLBundle = html_bundle,
             };
         }
 
@@ -872,6 +871,7 @@ pub const Value = union(Tag) {
             },
             // .InlineBlob => .{ .InlineBlob = this.InlineBlob },
             .Locked => this.Locked.toAnyBlobAllowPromise() orelse AnyBlob{ .Blob = .{} },
+            .HTMLBundle => .{ .Blob = Blob.initEmpty(undefined) }, // Return empty blob for HTMLBundle
             else => .{ .Blob = Blob.initEmpty(undefined) },
         };
 
@@ -889,6 +889,7 @@ pub const Value = union(Tag) {
             .WTFStringImpl => .{ .WTFStringImpl = this.WTFStringImpl },
             // .InlineBlob => .{ .InlineBlob = this.InlineBlob },
             .Locked => this.Locked.toAnyBlobAllowPromise() orelse AnyBlob{ .Blob = .{} },
+            .HTMLBundle => .{ .Blob = Blob.initEmpty(undefined) }, // Return empty blob for HTMLBundle
             else => .{ .Blob = Blob.initEmpty(undefined) },
         };
 
@@ -976,6 +977,11 @@ pub const Value = union(Tag) {
 
         if (tag == .Error) {
             this.Error.deinit();
+        }
+
+        if (tag == .HTMLBundle) {
+            this.HTMLBundle.deref();
+            this.* = Value{ .Null = {} };
         }
     }
 
@@ -1107,6 +1113,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .HTMLBundle) {
+                return globalObject.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
+            }
+
             if (value.* == .Locked) {
                 if (value.Locked.action != .none or value.Locked.isDisturbed(Type, globalObject, callframe.this())) {
                     return handleBodyAlreadyUsed(globalObject);
@@ -1163,6 +1173,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .HTMLBundle) {
+                return globalObject.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
+            }
+
             if (value.* == .Locked) {
                 if (value.Locked.action != .none or value.Locked.isDisturbed(Type, globalObject, callframe.this())) {
                     return handleBodyAlreadyUsed(globalObject);
@@ -1190,6 +1204,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .HTMLBundle) {
+                return globalObject.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
+            }
+
             if (value.* == .Locked) {
                 if (value.Locked.action != .none or value.Locked.isDisturbed(Type, globalObject, callframe.this())) {
                     return handleBodyAlreadyUsed(globalObject);
@@ -1214,6 +1232,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .HTMLBundle) {
+                return globalObject.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
+            }
+
             if (value.* == .Locked) {
                 if (value.Locked.action != .none or value.Locked.isDisturbed(Type, globalObject, callframe.this())) {
                     return handleBodyAlreadyUsed(globalObject);
@@ -1234,6 +1256,10 @@ pub fn Mixin(comptime Type: type) type {
 
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
+            }
+
+            if (value.* == .HTMLBundle) {
+                return globalObject.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
             }
 
             if (value.* == .Locked) {
@@ -1285,6 +1311,10 @@ pub fn Mixin(comptime Type: type) type {
 
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
+            }
+
+            if (value.* == .HTMLBundle) {
+                return globalObject.throwInvalidArguments("HTMLBundle cannot be used as a Response body", .{});
             }
 
             if (value.* == .Locked) {
@@ -1427,6 +1457,9 @@ pub const ValueBufferer = struct {
             },
             .Locked => {
                 try sink.bufferLockedBodyValue(value);
+            },
+            .HTMLBundle => {
+                return error.UnsupportedBodyType;
             },
         }
     }

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -598,6 +598,20 @@ pub const Value = union(Tag) {
             }
         }
 
+        if (value.as(bun.jsc.API.HTMLBundle)) |html_bundle| {
+            const html_bundle_bytes = std.mem.asBytes(&html_bundle);
+            return Body.Value{
+                .InternalBlob = .{
+                    .bytes = std.ArrayList(u8){
+                        .items = bun.default_allocator.dupe(u8, html_bundle_bytes) catch bun.outOfMemory(),
+                        .capacity = html_bundle_bytes.len,
+                        .allocator = bun.default_allocator,
+                    },
+                    .was_string = false,
+                },
+            };
+        }
+
         value.ensureStillAlive();
 
         if (try jsc.WebCore.ReadableStream.fromJS(value, globalThis)) |readable| {

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -871,7 +871,7 @@ pub const Value = union(Tag) {
             },
             // .InlineBlob => .{ .InlineBlob = this.InlineBlob },
             .Locked => this.Locked.toAnyBlobAllowPromise() orelse AnyBlob{ .Blob = .{} },
-            .HTMLBundle => .{ .Blob = Blob.initEmpty(undefined) }, // Return empty blob for HTMLBundle
+            .HTMLBundle => .{ .Blob = Blob.initEmpty(undefined) },
             else => .{ .Blob = Blob.initEmpty(undefined) },
         };
 
@@ -889,7 +889,7 @@ pub const Value = union(Tag) {
             .WTFStringImpl => .{ .WTFStringImpl = this.WTFStringImpl },
             // .InlineBlob => .{ .InlineBlob = this.InlineBlob },
             .Locked => this.Locked.toAnyBlobAllowPromise() orelse AnyBlob{ .Blob = .{} },
-            .HTMLBundle => .{ .Blob = Blob.initEmpty(undefined) }, // Return empty blob for HTMLBundle
+            .HTMLBundle => .{ .Blob = Blob.initEmpty(undefined) },
             else => .{ .Blob = Blob.initEmpty(undefined) },
         };
 

--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -105,6 +105,7 @@ pub export fn jsFunctionGetCompleteRequestOrResponseBodyValueAsArrayBuffer(globa
             return any_blob.toArrayBufferTransfer(globalObject) catch return .zero;
         },
         .Error, .Locked => return .js_undefined,
+        .HTMLBundle => return .js_undefined,
     }
 }
 

--- a/src/bun.js/webcore/blob/write_file.zig
+++ b/src/bun.js/webcore/blob/write_file.zig
@@ -717,6 +717,13 @@ pub const WriteFileWaitFromLockedValueTask = struct {
                 value.Locked.onReceiveValue = thenWrap;
                 value.Locked.task = this;
             },
+            .HTMLBundle => {
+                file_blob.detach();
+                _ = value.use();
+                this.promise.deinit();
+                bun.destroy(this);
+                promise.reject(globalThis, ZigString.init("HTMLBundle cannot be written to a file").toErrorInstance(globalThis));
+            },
         }
     }
 };

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -60,3 +60,121 @@ console.log(server.port);
 
   proc.kill();
 });
+
+test("many static routes with custom headers/status", async () => {
+  const dir = tempDirWithFiles("html-response-static", {
+    "index.html": /*html*/ `<!DOCTYPE html>
+<html>
+<head>
+  <title>Test Page</title>
+  <script type="module" src="./app.ts"></script>
+</head>
+<body>
+  <h1>Hello from HTMLBundle</h1>
+</body>
+</html>`,
+    "hello.html": /*html*/ `<!DOCTYPE html>
+<html>
+<head>
+  <title>Hello Page</title>
+</head>
+<body>
+  <h1>Hello from HTMLBundle</h1>
+</body>
+</html>`,
+    "app.ts": /*ts*/ `console.log("App loaded");`,
+    "server.ts": /*ts*/ `
+import html from "./index.html";
+import hello from "./hello.html";
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  routes: {
+    "/": new Response(html, {
+      status: 201,
+      headers: {
+        "X-Custom": "custom-value",
+        "X-Test": "test-value"
+      }
+    }),
+    "/home": new Response(html),
+    "/hello": new Response(hello),
+    "/*": new Response(html, {
+      status: 404,
+    })
+  }
+});
+
+console.log(server.port);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+  });
+
+  const reader = proc.stdout.getReader();
+  const { value } = await reader.read();
+  const port = parseInt(new TextDecoder().decode(value).trim());
+
+  {
+    const response = await fetch(`http://localhost:${port}/`);
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("X-Custom")).toBe("custom-value");
+    expect(response.headers.get("X-Test")).toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Test Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/home`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Test Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/hello`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Hello Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/not-found`);
+    expect(response.status).toBe(404);
+
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Test Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  proc.kill();
+});

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("static route with new Response(html) and custom headers/status", async () => {
+  const dir = tempDirWithFiles("html-response-static", {
+    "index.html": /*html*/ `<!DOCTYPE html>
+<html>
+<head>
+  <title>Test Page</title>
+  <script type="module" src="./app.ts"></script>
+</head>
+<body>
+  <h1>Hello from HTMLBundle</h1>
+</body>
+</html>`,
+    "app.ts": /*ts*/ `console.log("App loaded");`,
+    "server.ts": /*ts*/ `
+import html from "./index.html";
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  routes: {
+    "/": new Response(html, {
+      status: 201,
+      headers: {
+        "X-Custom": "custom-value",
+        "X-Test": "test-value"
+      }
+    })
+  }
+});
+
+console.log(server.port);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+  });
+
+  const reader = proc.stdout.getReader();
+  const { value } = await reader.read();
+  const port = parseInt(new TextDecoder().decode(value).trim());
+
+  const response = await fetch(`http://localhost:${port}/`);
+
+  expect(response.status).toBe(201);
+  expect(response.headers.get("X-Custom")).toBe("custom-value");
+  expect(response.headers.get("X-Test")).toBe("test-value");
+  expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+  const text = await response.text();
+  expect(text).toContain("Test Page");
+  expect(text).toContain("Hello from HTMLBundle");
+  expect(text).toMatch(/src="[^"]+\.js"/);
+
+  proc.kill();
+});

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -99,6 +99,12 @@ const server = Bun.serve({
       }
     }),
     "/home": new Response(html),
+    "/haha": new Response(html, {status: 400}),
+    "/index.html": html,
+    "/tea": {
+      GET: new Response(html, {status: 418}),
+      POST: () => new Response("Teapot!!!"),
+    },
     "/hello": new Response(hello),
     "/*": new Response(html, {
       status: 404,
@@ -147,6 +153,62 @@ console.log(server.port);
     expect(text).toContain("Test Page");
     expect(text).toContain("Hello from HTMLBundle");
     expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/index.html`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Test Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/haha`);
+    expect(response.status).toBe(400);
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Test Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/tea`, {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(418);
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/html;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toContain("Test Page");
+    expect(text).toContain("Hello from HTMLBundle");
+    expect(text).toMatch(/src="[^"]+\.js"/);
+  }
+
+  {
+    const response = await fetch(`http://localhost:${port}/tea`, {
+      method: "POST",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Custom")).not.toBe("custom-value");
+    expect(response.headers.get("X-Test")).not.toBe("test-value");
+    expect(response.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
+
+    const text = await response.text();
+    expect(text).toBe("Teapot!!!");
   }
 
   {


### PR DESCRIPTION
### What does this PR do?

one step closer to supporting a simple api in the dynamic `fetch` function, but mainly so user's can set headers and other policies efficiently.

right now it doesn't use the html bundle cache to simplify, but considering its only the status it realistically shouldn't need to be a separate entity


```ts
// example:
import html from "./index.html";
import notFoundHtml from "./404.html";

const server = Bun.serve({
  routes: {
    "/": html,
    "/*": new Response(notFoundHtml, { status: 404 }),
  }
});
```

fixes #19123


### How did you verify your code works?

made tests (note types are kinda broken right now)
