### PR TITLE
refactor: remove unused capturedError variable in ServerPrototype

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1022,7 +1022,6 @@ const ServerPrototype = {
           }
           drainMicrotasks();
 
-          let capturedError;
           let resolveFunction;
           let didFinish = false;
 
@@ -1090,13 +1089,6 @@ const ServerPrototype = {
           }
 
           socket.cork();
-
-          if (capturedError) {
-            handle = undefined;
-            http_res[kCloseCallback] = undefined;
-            http_res.detachSocket(socket);
-            throw capturedError;
-          }
 
           if (handle.finished || didFinish) {
             handle = undefined;


### PR DESCRIPTION
### What does this PR do?

Removes the unused `capturedError` fixing the oxlint error. This variable is never assigned to, hence the block on L1094 can never run.

### How did you verify your code works?

Existing tests