### PR TITLE
ci: lower link-bun agent from c7i.16xlarge to r7i.large

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -326,7 +326,7 @@ function getLinkBunAgent(platform, options) {
   }
 
   return getEc2Agent(platform, options, {
-    instanceType: "r8g.large",
+    instanceType: arch === "aarch64" ? "r8g.large" : "r7i.large",
   });
 }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -310,6 +310,27 @@ function getCppAgent(platform, options) {
 }
 
 /**
+ * @param {Platform} platform
+ * @param {PipelineOptions} options
+ * @returns {string}
+ */
+function getLinkBunAgent(platform, options) {
+  const { os, arch, distro } = platform;
+
+  if (os === "darwin") {
+    return {
+      queue: `build-${os}`,
+      os,
+      arch,
+    };
+  }
+
+  return getEc2Agent(platform, options, {
+    instanceType: "r8g.large",
+  });
+}
+
+/**
  * @returns {Platform}
  */
 function getZigPlatform() {
@@ -502,7 +523,7 @@ function getLinkBunStep(platform, options) {
     key: `${getTargetKey(platform)}-build-bun`,
     label: `${getTargetLabel(platform)} - build-bun`,
     depends_on: [`${getTargetKey(platform)}-build-cpp`, `${getTargetKey(platform)}-build-zig`],
-    agents: getCppAgent(platform, options),
+    agents: getLinkBunAgent(platform, options),
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
     env: {

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -325,8 +325,14 @@ function getLinkBunAgent(platform, options) {
     };
   }
 
+  if (os === "windows") {
+    return getEc2Agent(platform, options, {
+      instanceType: arch === "aarch64" ? "r8g.large" : "r7i.large",
+    });
+  }
+
   return getEc2Agent(platform, options, {
-    instanceType: arch === "aarch64" ? "r8g.large" : "r7i.large",
+    instanceType: arch === "aarch64" ? "r8g.xlarge" : "r7i.xlarge",
   });
 }
 


### PR DESCRIPTION
this instance type was reported to be our 1st most expensive per aws bill

----

before:

x64-linux: 19.5m
arm64-linux: 14m
x64-musl: 16.3m
arm64-musl: 13.3m
x64-windows: 2m

after:

x64-linux: 20.3m
arm64-linux: 15.3m
x64-musl: 16m
arm64-musl: 13.5m
x64-windows: 2.5m