### PR TITLE
shell: fix `$.braces(...)` on unicode inputs, support more deeply nested braces

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -188,6 +188,7 @@ pub const patch = @import("./patch.zig");
 pub const ini = @import("./ini.zig");
 pub const bits = @import("./bits.zig");
 pub const css = @import("./css/css_parser.zig");
+pub const SmallList = css.SmallList;
 pub const csrf = @import("./csrf.zig");
 pub const validators = @import("./bun.js/node/util/validators.zig");
 

--- a/src/css/small_list.zig
+++ b/src/css/small_list.zig
@@ -1,7 +1,7 @@
 /// This is a type whose items can either be heap-allocated (essentially the
 /// same as a BabyList(T)) or inlined in the struct itself.
 ///
-/// This is type is a performance optimizations for avoiding allocations, especially when you know the list
+/// This is type is a performance optimization for avoiding allocations, especially when you know the list
 /// will commonly have N or fewer items.
 ///
 /// The `capacity` field is used to disambiguate between the two states: - When
@@ -163,6 +163,12 @@ pub fn SmallList(comptime T: type, comptime N: comptime_int) type {
 
         pub inline fn last(this: *const @This()) ?*const T {
             const sl = this.slice();
+            if (sl.len == 0) return null;
+            return &sl[sl.len - 1];
+        }
+
+        pub inline fn lastMut(this: *@This()) ?*T {
+            const sl = this.slice_mut();
             if (sl.len == 0) return null;
             return &sl[sl.len - 1];
         }

--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -486,8 +486,6 @@ fn buildExpansionTable(tokens: []Token, table: *std.ArrayList(ExpansionVariant))
 
 pub const Lexer = NewLexer(.ascii);
 
-const BraceLexerError = Allocator.Error;
-
 pub fn NewLexer(comptime encoding: Encoding) type {
     const Chars = NewChars(encoding);
     return struct {
@@ -736,4 +734,6 @@ const assert = bun.assert;
 const std = @import("std");
 const ArrayList = std.ArrayList;
 const t = std.testing;
+
 const Allocator = std.mem.Allocator;
+const BraceLexerError = Allocator.Error;

--- a/src/shell/states/Expansion.zig
+++ b/src/shell/states/Expansion.zig
@@ -223,9 +223,13 @@ pub fn next(this: *Expansion) Yield {
                 defer arena.deinit();
                 const arena_allocator = arena.allocator();
                 const brace_str = this.current_out.items[0..];
-                // FIXME some of these errors aren't alloc errors for example lexer parser errors
-                var lexer_output = Braces.Lexer.tokenize(arena_allocator, brace_str) catch |e| OOM(e);
-                const expansion_count = Braces.calculateExpandedAmount(lexer_output.tokens.items[0..]) catch |e| OOM(e);
+                var lexer_output = if (bun.strings.isAllASCII(brace_str)) lexer_output: {
+                    @branchHint(.likely);
+                    break :lexer_output Braces.Lexer.tokenize(arena_allocator, brace_str) catch bun.outOfMemory();
+                } else lexer_output: {
+                    break :lexer_output Braces.NewLexer(.wtf8).tokenize(arena_allocator, brace_str) catch bun.outOfMemory();
+                };
+                const expansion_count = Braces.calculateExpandedAmount(lexer_output.tokens.items[0..]);
 
                 const stack_max = comptime 16;
                 comptime {

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -7,7 +7,7 @@
   ".stdDir()": 40,
   ".stdFile()": 18,
   "// autofix": 168,
-  ": [a-zA-Z0-9_\\.\\*\\?\\[\\]\\(\\)]+ = undefined,": 229,
+  ": [a-zA-Z0-9_\\.\\*\\?\\[\\]\\(\\)]+ = undefined,": 228,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,
   "@import(\"bun\").": 0,

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -26,4 +26,32 @@ describe("$.braces", () => {
     const result = $.braces(`echo {123,{456,789},abc}`);
     expect(result).toEqual(["echo 123", "echo 456", "echo 789", "echo abc"]);
   });
+
+  test("very deeply nested", () => {
+    const result = $.braces(`{1,{2,{3,{4,{5,{6,{7,{8,{9,{10,{11,{12,{13,{14,{15,{16,{17}}}}}}}}}}}}}}}}}`);
+    expect(result).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+    ]);
+  });
+
+  test("unicode", () => {
+    const result = $.braces(`lol {😂,🫵,🤣}`);
+    expect(result).toEqual(["lol 😂", "lol 🫵", "lol 🤣"]);
+  });
 });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -671,6 +671,11 @@ booga"
         "{a,b,HI{c,e,LMAO{d,f}Q}}{1,2,{3,4},5}",
         "a1 a2 a3 a4 a5 b1 b2 b3 b4 b5 HIc1 HIc2 HIc3 HIc4 HIc5 HIe1 HIe2 HIe3 HIe4 HIe5 HILMAOdQ1 HILMAOdQ2 HILMAOdQ3 HILMAOdQ4 HILMAOdQ5 HILMAOfQ1 HILMAOfQ2 HILMAOfQ3 HILMAOfQ4 HILMAOfQ5",
       );
+
+      doTest(
+        `{1,{2,{3,{4,{5,{6,{7,{8,{9,{10,{11,{12,{13,{14,{15,{16,{17}}}}}}}}}}}}}}}}}`,
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17",
+      );
     });
 
     test("command", async () => {


### PR DESCRIPTION
### What does this PR do?

- Fixes `$.braces(...)` not working properly on non-ascii inputs
- Switches braces code to use `SmallList` to support more deeply nested brace expansion
