### PR TITLE
ci: lower build-cpp agent from 16xlarge to xlarge

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -303,9 +303,7 @@ function getCppAgent(platform, options) {
   }
 
   return getEc2Agent(platform, options, {
-    instanceType: arch === "aarch64" ? "c8g.16xlarge" : "c7i.16xlarge",
-    cpuCount: 32,
-    threadsPerCore: 1,
+    instanceType: arch === "aarch64" ? "c8g.xlarge" : "c7i.xlarge",
   });
 }
 


### PR DESCRIPTION
this instance type was reported to be our 1st most expensive per aws bill

as long as it finishes before build-zig it doesnt affect the total run time