### PR TITLE
ci: lower build-cpp agent from 16xlarge to 4xlarge

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -303,7 +303,7 @@ function getCppAgent(platform, options) {
   }
 
   return getEc2Agent(platform, options, {
-    instanceType: arch === "aarch64" ? "c8g.16xlarge" : "c7i.16xlarge",
+    instanceType: arch === "aarch64" ? "c8g.4xlarge" : "c7i.4xlarge",
     cpuCount: 32,
     threadsPerCore: 1,
   });

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -304,8 +304,6 @@ function getCppAgent(platform, options) {
 
   return getEc2Agent(platform, options, {
     instanceType: arch === "aarch64" ? "c8g.4xlarge" : "c7i.4xlarge",
-    cpuCount: 32,
-    threadsPerCore: 1,
   });
 }
 


### PR DESCRIPTION
this instance type was reported to be our 1st most expensive per aws bill

as long as it finishes before build-zig it doesnt affect the total run time

----

<img width="1512" height="165" alt="image" src="https://github.com/user-attachments/assets/8581f0d6-348c-4be8-98e2-bff8f659b26f" />

<img width="1512" height="163" alt="image" src="https://github.com/user-attachments/assets/cefd5a50-26b2-4dfb-8592-f723874bc461" />

<img width="1512" height="164" alt="image" src="https://github.com/user-attachments/assets/7234cc28-2f7d-4ffa-97c1-67106749dd4e" />

