### PR TITLE
ci: lower linux test agents from xlarge to large

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -381,18 +381,16 @@ function getTestAgent(platform, options) {
     };
   }
 
-  if (arch === "aarch64") {
+  if (os === "windows") {
     return getEc2Agent(platform, options, {
-      instanceType: "c8g.xlarge",
+      instanceType: arch === "aarch64" ? "c8g.xlarge" : "c7i.xlarge",
       cpuCount: 2,
       threadsPerCore: 1,
     });
   }
 
   return getEc2Agent(platform, options, {
-    instanceType: "c7i.xlarge",
-    cpuCount: 2,
-    threadsPerCore: 1,
+    instanceType: arch === "aarch64" ? "c8g.large" : "c7i.large",
   });
 }
 


### PR DESCRIPTION
this lowers linux from 4 cpu / 8gb ram --> 2 cpu / 4 gb ram