### PR TITLE
Fix process.stdout/stderr missing Symbol.asyncIterator

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -55,7 +55,7 @@ export function getStdioWriteStream(
     stream = new fs.WriteStream(null, { autoClose: false, fd, $fastPath: true });
     stream.readable = false;
     stream._type = "fs";
-    
+
     // When stdout/stderr are piped or connected to a socket, they should have Symbol.asyncIterator
     // to match Node.js behavior where they become Duplex streams (Socket)
     // But when redirected to a file, they shouldn't have it

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -34,7 +34,7 @@ export function getStdioWriteStream(
   process: typeof globalThis.process,
   fd: number,
   isTTY: boolean,
-  _fdType: BunProcessStdinFdType,
+  fdType: BunProcessStdinFdType,
 ) {
   $assert(fd === 1 || fd === 2, `Expected fd to be 1 or 2, got ${fd}`);
 
@@ -55,6 +55,17 @@ export function getStdioWriteStream(
     stream = new fs.WriteStream(null, { autoClose: false, fd, $fastPath: true });
     stream.readable = false;
     stream._type = "fs";
+    
+    // When stdout/stderr are piped or connected to a socket, they should have Symbol.asyncIterator
+    // to match Node.js behavior where they become Duplex streams (Socket)
+    // But when redirected to a file, they shouldn't have it
+    if (fdType === BunProcessStdinFdType.pipe || fdType === BunProcessStdinFdType.socket) {
+      stream[Symbol.asyncIterator] = function () {
+        return (async function* () {
+          // stdout/stderr don't produce readable data, so yield nothing
+        })();
+      };
+    }
   }
 
   if (fd === 1 || fd === 2) {

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -157,6 +157,16 @@ Object.defineProperty(WriteStream, "prototype", {
       return require("node:readline").moveCursor(this, dx, dy, cb);
     };
 
+    // Add Symbol.asyncIterator to make tty.WriteStream compatible with code
+    // that expects stdout/stderr to be async iterable (like in Node.js where they're Duplex)
+    WriteStream.prototype[Symbol.asyncIterator] = function () {
+      // Since WriteStream is write-only, we return an empty async iterator
+      // This matches the behavior of Node.js Duplex streams used for stdout/stderr
+      return (async function* () {
+        // stdout/stderr don't produce readable data, so yield nothing
+      })();
+    };
+
     return Real;
   },
   enumerable: true,

--- a/test/regression/issue/test-process-stdout-async-iterator.test.ts
+++ b/test/regression/issue/test-process-stdout-async-iterator.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test";
+
+test("process.stdout and process.stderr have Symbol.asyncIterator for Node.js compatibility", () => {
+  // This is needed for compatibility with tools like execa that check for async iterability
+  // to determine stream capabilities
+  expect(typeof process.stdout[Symbol.asyncIterator]).toBe("function");
+  expect(typeof process.stderr[Symbol.asyncIterator]).toBe("function");
+});
+
+test("process.stdout and process.stderr async iterators work without throwing", async () => {
+  // The iterators should work even though stdout/stderr are write-only
+  // They should just complete immediately without yielding any values
+  const stdoutIterator = process.stdout[Symbol.asyncIterator]();
+  const stdoutResult = await stdoutIterator.next();
+  expect(stdoutResult.done).toBe(true);
+  expect(stdoutResult.value).toBeUndefined();
+
+  const stderrIterator = process.stderr[Symbol.asyncIterator]();
+  const stderrResult = await stderrIterator.next();
+  expect(stderrResult.done).toBe(true);
+  expect(stderrResult.value).toBeUndefined();
+});
+
+test("tty.WriteStream has Symbol.asyncIterator", () => {
+  const tty = require("node:tty");
+  // Create a WriteStream for stdout fd
+  const stream = new tty.WriteStream(1);
+  expect(typeof stream[Symbol.asyncIterator]).toBe("function");
+});

--- a/test/regression/issue/test-process-stdout-async-iterator.test.ts
+++ b/test/regression/issue/test-process-stdout-async-iterator.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("process.stdout and process.stderr have Symbol.asyncIterator for Node.js compatibility", () => {
   // This is needed for compatibility with tools like execa that check for async iterability


### PR DESCRIPTION
## Summary
- Adds `Symbol.asyncIterator` to `process.stdout` and `process.stderr` when they are TTY or pipe/socket streams
- Matches Node.js behavior where these streams are Duplex-like and support async iteration
- Does not add the iterator when streams are redirected to files (matching Node.js SyncWriteStream behavior)

## Test plan
- Added test in `test/regression/issue/test-process-stdout-async-iterator.test.ts`
- Verified the fix works with Claude Code on Linux x64
- Test passes with `bun bd test test/regression/issue/test-process-stdout-async-iterator.test.ts`

Fixes #21704

🤖 Generated with [Claude Code](https://claude.ai/code)