### PR TITLE
Redis PUB/SUB

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -746,7 +746,8 @@ declare module "bun" {
      *
      * Unsubscribing moves the channel back to a normal state out of the
      * subscription state if all channels have been unsubscribed from. For
-     * further details on the subscription state, see {@link subscribe `.subscribe()`}.
+     * further details on the subscription state, see
+     * {@link subscribe `.subscribe()`}.
      */
     unsubscribe(channel: string): Promise<void>;
 
@@ -772,9 +773,9 @@ declare module "bun" {
      * Unsubscribe from all registered Redis channels.
      *
      * The client will automatically re-enable pipelining if it was previously
-     * enabled. Unsubscribing moves the channel back to a normal state out of
-     * the
+     * enabled.
      *
+     * Unsubscribing moves the channel back to a normal state out of the
      * subscription state if all channels have been unsubscribed from. For
      * further details on the subscription state, see
      * {@link subscribe `.subscribe()`}.

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -52,9 +52,10 @@ declare module "bun" {
 
   export namespace RedisClient {
     type KeyLike = string | ArrayBufferView | Blob;
-    type PubSubListener<Message> = (message: Message, channel: string) => void;
-    type StringPubSubListener = PubSubListener<string>;
-    type BufferPubSubListener = PubSubListener<Uint8Array<ArrayBuffer>>;
+    type StringPubSubListener = (message: string, channel: string) => void;
+
+    // Buffer subscriptions are not yet implemented
+    // type BufferPubSubListener = (message: Uint8Array<ArrayBuffer>, channel: string) => void;
   }
 
   export class RedisClient {

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -717,7 +717,7 @@ declare module "bun" {
      * });
      * ```
      */
-    subscribe(channel: string, listener: RedisClient.PubSubListener<string>): Promise<number>;
+    subscribe(channel: string, listener: RedisClient.StringPubSubListener): Promise<number>;
 
     /**
      * Subscribe to multiple Redis channels.
@@ -733,7 +733,7 @@ declare module "bun" {
      * the subscribed channels. The listener will receive the message as the
      * first argument and the channel as the second argument.
      */
-    subscribe(channels: string[], listener: RedisClient.PubSubListener<string>): Promise<number>;
+    subscribe(channels: string[], listener: RedisClient.StringPubSubListener): Promise<number>;
 
     /**
      * Unsubscribe from a singular Redis channel.
@@ -765,7 +765,7 @@ declare module "bun" {
      * referential equality so you must pass the exact same listener instance as
      * when subscribing.
      */
-    unsubscribe(channel: string, listener: RedisClient.PubSubListener<string>): Promise<void>;
+    unsubscribe(channel: string, listener: RedisClient.StringPubSubListener): Promise<void>;
 
     /**
      * Unsubscribe from all registered Redis channels.

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -1,6 +1,4 @@
 declare module "bun" {
-  type SubscriptionListener = (message: string, channel: string) => void;
-
   export interface RedisOptions {
     /**
      * Connection timeout in milliseconds
@@ -54,21 +52,24 @@ declare module "bun" {
 
   export namespace RedisClient {
     type KeyLike = string | ArrayBufferView | Blob;
+    type PubSubListener<Message> = (message: Message, channel: string) => void;
+    type StringPubSubListener = PubSubListener<string>;
+    type BufferPubSubListener = PubSubListener<Uint8Array<ArrayBuffer>>;
   }
 
   export class RedisClient {
     /**
      * Creates a new Redis client
-     * @param url URL to connect to, defaults to process.env.VALKEY_URL, process.env.REDIS_URL, or "valkey://localhost:6379"
+     *
+     * @param url URL to connect to, defaults to `process.env.VALKEY_URL`,
+     * `process.env.REDIS_URL`, or `"valkey://localhost:6379"`
      * @param options Additional options
      *
      * @example
      * ```ts
-     * const valkey = new RedisClient();
-     *
-     * await valkey.set("hello", "world");
-     *
-     * console.log(await valkey.get("hello"));
+     * const redis = new RedisClient();
+     * await redis.set("hello", "world");
+     * console.log(await redis.get("hello"));
      * ```
      */
     constructor(url?: string, options?: RedisOptions);
@@ -90,12 +91,14 @@ declare module "bun" {
 
     /**
      * Callback fired when the client disconnects from the Redis server
+     *
      * @param error The error that caused the disconnection
      */
     onclose: ((this: RedisClient, error: Error) => void) | null;
 
     /**
      * Connect to the Redis server
+     *
      * @returns A promise that resolves when connected
      */
     connect(): Promise<void>;
@@ -154,10 +157,12 @@ declare module "bun" {
     set(key: RedisClient.KeyLike, value: RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<"OK">;
 
     /**
-     * Set key to hold the string value with expiration at a specific Unix timestamp
+     * Set key to hold the string value with expiration at a specific Unix
+     * timestamp
      * @param key The key to set
      * @param value The value to set
-     * @param exat Set the specified Unix time at which the key will expire, in seconds
+     * @param exat Set the specified Unix time at which the key will expire, in
+     * seconds
      * @returns Promise that resolves with "OK" on success
      */
     set(key: RedisClient.KeyLike, value: RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">;
@@ -181,7 +186,8 @@ declare module "bun" {
      * @param key The key to set
      * @param value The value to set
      * @param nx Only set the key if it does not already exist
-     * @returns Promise that resolves with "OK" on success, or null if the key already exists
+     * @returns Promise that resolves with "OK" on success, or null if the key
+     * already exists
      */
     set(key: RedisClient.KeyLike, value: RedisClient.KeyLike, nx: "NX"): Promise<"OK" | null>;
 
@@ -190,7 +196,8 @@ declare module "bun" {
      * @param key The key to set
      * @param value The value to set
      * @param xx Only set the key if it already exists
-     * @returns Promise that resolves with "OK" on success, or null if the key does not exist
+     * @returns Promise that resolves with "OK" on success, or null if the key
+     * does not exist
      */
     set(key: RedisClient.KeyLike, value: RedisClient.KeyLike, xx: "XX"): Promise<"OK" | null>;
 
@@ -198,8 +205,10 @@ declare module "bun" {
      * Set key to hold the string value and return the old value
      * @param key The key to set
      * @param value The value to set
-     * @param get Return the old string stored at key, or null if key did not exist
-     * @returns Promise that resolves with the old value, or null if key did not exist
+     * @param get Return the old string stored at key, or null if key did not
+     * exist
+     * @returns Promise that resolves with the old value, or null if key did not
+     * exist
      */
     set(key: RedisClient.KeyLike, value: RedisClient.KeyLike, get: "GET"): Promise<string | null>;
 
@@ -245,7 +254,8 @@ declare module "bun" {
     /**
      * Determine if a key exists
      * @param key The key to check
-     * @returns Promise that resolves with true if the key exists, false otherwise
+     * @returns Promise that resolves with true if the key exists, false
+     * otherwise
      */
     exists(key: RedisClient.KeyLike): Promise<boolean>;
 
@@ -260,7 +270,8 @@ declare module "bun" {
     /**
      * Get the time to live for a key in seconds
      * @param key The key to get the TTL for
-     * @returns Promise that resolves with the TTL, -1 if no expiry, or -2 if key doesn't exist
+     * @returns Promise that resolves with the TTL, -1 if no expiry, or -2 if
+     * key doesn't exist
      */
     ttl(key: RedisClient.KeyLike): Promise<number>;
 
@@ -284,7 +295,8 @@ declare module "bun" {
      * Check if a value is a member of a set
      * @param key The set key
      * @param member The member to check
-     * @returns Promise that resolves with true if the member exists, false otherwise
+     * @returns Promise that resolves with true if the member exists, false
+     * otherwise
      */
     sismember(key: RedisClient.KeyLike, member: string): Promise<boolean>;
 
@@ -292,7 +304,8 @@ declare module "bun" {
      * Add a member to a set
      * @param key The set key
      * @param member The member to add
-     * @returns Promise that resolves with 1 if the member was added, 0 if it already existed
+     * @returns Promise that resolves with 1 if the member was added, 0 if it
+     * already existed
      */
     sadd(key: RedisClient.KeyLike, member: string): Promise<number>;
 
@@ -300,7 +313,8 @@ declare module "bun" {
      * Remove a member from a set
      * @param key The set key
      * @param member The member to remove
-     * @returns Promise that resolves with 1 if the member was removed, 0 if it didn't exist
+     * @returns Promise that resolves with 1 if the member was removed, 0 if it
+     * didn't exist
      */
     srem(key: RedisClient.KeyLike, member: string): Promise<number>;
 
@@ -314,14 +328,16 @@ declare module "bun" {
     /**
      * Get a random member from a set
      * @param key The set key
-     * @returns Promise that resolves with a random member, or null if the set is empty
+     * @returns Promise that resolves with a random member, or null if the set
+     * is empty
      */
     srandmember(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Remove and return a random member from a set
      * @param key The set key
-     * @returns Promise that resolves with the removed member, or null if the set is empty
+     * @returns Promise that resolves with the removed member, or null if the
+     * set is empty
      */
     spop(key: RedisClient.KeyLike): Promise<string | null>;
 
@@ -388,28 +404,32 @@ declare module "bun" {
     /**
      * Remove and get the first element in a list
      * @param key The list key
-     * @returns Promise that resolves with the first element, or null if the list is empty
+     * @returns Promise that resolves with the first element, or null if the
+     * list is empty
      */
     lpop(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Remove the expiration from a key
      * @param key The key to persist
-     * @returns Promise that resolves with 1 if the timeout was removed, 0 if the key doesn't exist or has no timeout
+     * @returns Promise that resolves with 1 if the timeout was removed, 0 if
+     * the key doesn't exist or has no timeout
      */
     persist(key: RedisClient.KeyLike): Promise<number>;
 
     /**
      * Get the expiration time of a key as a UNIX timestamp in milliseconds
      * @param key The key to check
-     * @returns Promise that resolves with the timestamp, or -1 if the key has no expiration, or -2 if the key doesn't exist
+     * @returns Promise that resolves with the timestamp, or -1 if the key has
+     * no expiration, or -2 if the key doesn't exist
      */
     pexpiretime(key: RedisClient.KeyLike): Promise<number>;
 
     /**
      * Get the time to live for a key in milliseconds
      * @param key The key to check
-     * @returns Promise that resolves with the TTL in milliseconds, or -1 if the key has no expiration, or -2 if the key doesn't exist
+     * @returns Promise that resolves with the TTL in milliseconds, or -1 if the
+     * key has no expiration, or -2 if the key doesn't exist
      */
     pttl(key: RedisClient.KeyLike): Promise<number>;
 
@@ -423,42 +443,48 @@ declare module "bun" {
     /**
      * Get the number of members in a set
      * @param key The set key
-     * @returns Promise that resolves with the cardinality (number of elements) of the set
+     * @returns Promise that resolves with the cardinality (number of elements)
+     * of the set
      */
     scard(key: RedisClient.KeyLike): Promise<number>;
 
     /**
      * Get the length of the value stored in a key
      * @param key The key to check
-     * @returns Promise that resolves with the length of the string value, or 0 if the key doesn't exist
+     * @returns Promise that resolves with the length of the string value, or 0
+     * if the key doesn't exist
      */
     strlen(key: RedisClient.KeyLike): Promise<number>;
 
     /**
      * Get the number of members in a sorted set
      * @param key The sorted set key
-     * @returns Promise that resolves with the cardinality (number of elements) of the sorted set
+     * @returns Promise that resolves with the cardinality (number of elements)
+     * of the sorted set
      */
     zcard(key: RedisClient.KeyLike): Promise<number>;
 
     /**
      * Remove and return members with the highest scores in a sorted set
      * @param key The sorted set key
-     * @returns Promise that resolves with the removed member and its score, or null if the set is empty
+     * @returns Promise that resolves with the removed member and its score, or
+     * null if the set is empty
      */
     zpopmax(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Remove and return members with the lowest scores in a sorted set
      * @param key The sorted set key
-     * @returns Promise that resolves with the removed member and its score, or null if the set is empty
+     * @returns Promise that resolves with the removed member and its score, or
+     * null if the set is empty
      */
     zpopmin(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Get one or multiple random members from a sorted set
      * @param key The sorted set key
-     * @returns Promise that resolves with a random member, or null if the set is empty
+     * @returns Promise that resolves with a random member, or null if the set
+     * is empty
      */
     zrandmember(key: RedisClient.KeyLike): Promise<string | null>;
 
@@ -466,7 +492,8 @@ declare module "bun" {
      * Append a value to a key
      * @param key The key to append to
      * @param value The value to append
-     * @returns Promise that resolves with the length of the string after the append operation
+     * @returns Promise that resolves with the length of the string after the
+     * append operation
      */
     append(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<number>;
 
@@ -474,7 +501,8 @@ declare module "bun" {
      * Set the value of a key and return its old value
      * @param key The key to set
      * @param value The value to set
-     * @returns Promise that resolves with the old value, or null if the key didn't exist
+     * @returns Promise that resolves with the old value, or null if the key
+     * didn't exist
      */
     getset(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<string | null>;
 
@@ -482,7 +510,8 @@ declare module "bun" {
      * Prepend one or multiple values to a list
      * @param key The list key
      * @param value The value to prepend
-     * @returns Promise that resolves with the length of the list after the push operation
+     * @returns Promise that resolves with the length of the list after the push
+     * operation
      */
     lpush(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<number>;
 
@@ -490,7 +519,8 @@ declare module "bun" {
      * Prepend a value to a list, only if the list exists
      * @param key The list key
      * @param value The value to prepend
-     * @returns Promise that resolves with the length of the list after the push operation, or 0 if the list doesn't exist
+     * @returns Promise that resolves with the length of the list after the push
+     * operation, or 0 if the list doesn't exist
      */
     lpushx(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<number>;
 
@@ -498,7 +528,8 @@ declare module "bun" {
      * Add one or more members to a HyperLogLog
      * @param key The HyperLogLog key
      * @param element The element to add
-     * @returns Promise that resolves with 1 if the HyperLogLog was altered, 0 otherwise
+     * @returns Promise that resolves with 1 if the HyperLogLog was altered, 0
+     * otherwise
      */
     pfadd(key: RedisClient.KeyLike, element: string): Promise<number>;
 
@@ -506,7 +537,8 @@ declare module "bun" {
      * Append one or multiple values to a list
      * @param key The list key
      * @param value The value to append
-     * @returns Promise that resolves with the length of the list after the push operation
+     * @returns Promise that resolves with the length of the list after the push
+     * operation
      */
     rpush(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<number>;
 
@@ -514,7 +546,8 @@ declare module "bun" {
      * Append a value to a list, only if the list exists
      * @param key The list key
      * @param value The value to append
-     * @returns Promise that resolves with the length of the list after the push operation, or 0 if the list doesn't exist
+     * @returns Promise that resolves with the length of the list after the push
+     * operation, or 0 if the list doesn't exist
      */
     rpushx(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<number>;
 
@@ -522,7 +555,8 @@ declare module "bun" {
      * Set the value of a key, only if the key does not exist
      * @param key The key to set
      * @param value The value to set
-     * @returns Promise that resolves with 1 if the key was set, 0 if the key was not set
+     * @returns Promise that resolves with 1 if the key was set, 0 if the key
+     * was not set
      */
     setnx(key: RedisClient.KeyLike, value: RedisClient.KeyLike): Promise<number>;
 
@@ -530,14 +564,16 @@ declare module "bun" {
      * Get the score associated with the given member in a sorted set
      * @param key The sorted set key
      * @param member The member to get the score for
-     * @returns Promise that resolves with the score of the member as a string, or null if the member or key doesn't exist
+     * @returns Promise that resolves with the score of the member as a string,
+     * or null if the member or key doesn't exist
      */
     zscore(key: RedisClient.KeyLike, member: string): Promise<string | null>;
 
     /**
      * Get the values of all specified keys
      * @param keys The keys to get
-     * @returns Promise that resolves with an array of values, with null for keys that don't exist
+     * @returns Promise that resolves with an array of values, with null for
+     * keys that don't exist
      */
     mget(...keys: RedisClient.KeyLike[]): Promise<(string | null)[]>;
 
@@ -551,37 +587,46 @@ declare module "bun" {
     /**
      * Return a serialized version of the value stored at the specified key
      * @param key The key to dump
-     * @returns Promise that resolves with the serialized value, or null if the key doesn't exist
+     * @returns Promise that resolves with the serialized value, or null if the
+     * key doesn't exist
      */
     dump(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Get the expiration time of a key as a UNIX timestamp in seconds
+     *
      * @param key The key to check
-     * @returns Promise that resolves with the timestamp, or -1 if the key has no expiration, or -2 if the key doesn't exist
+     * @returns Promise that resolves with the timestamp, or -1 if the key has
+     * no expiration, or -2 if the key doesn't exist
      */
     expiretime(key: RedisClient.KeyLike): Promise<number>;
 
     /**
      * Get the value of a key and delete the key
+     *
      * @param key The key to get and delete
-     * @returns Promise that resolves with the value of the key, or null if the key doesn't exist
+     * @returns Promise that resolves with the value of the key, or null if the
+     * key doesn't exist
      */
     getdel(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Get the value of a key and optionally set its expiration
+     *
      * @param key The key to get
-     * @returns Promise that resolves with the value of the key, or null if the key doesn't exist
+     * @returns Promise that resolves with the value of the key, or null if the
+     * key doesn't exist
      */
     getex(key: RedisClient.KeyLike): Promise<string | null>;
 
     /**
      * Get the value of a key and set its expiration in seconds
+     *
      * @param key The key to get
      * @param ex Set the specified expire time, in seconds
      * @param seconds The number of seconds until expiration
-     * @returns Promise that resolves with the value of the key, or null if the key doesn't exist
+     * @returns Promise that resolves with the value of the key, or null if the
+     * key doesn't exist
      */
     getex(key: RedisClient.KeyLike, ex: "EX", seconds: number): Promise<string | null>;
 
@@ -596,6 +641,7 @@ declare module "bun" {
 
     /**
      * Get the value of a key and set its expiration at a specific Unix timestamp in seconds
+     *
      * @param key The key to get
      * @param exat Set the specified Unix time at which the key will expire, in seconds
      * @param timestampSeconds The Unix timestamp in seconds
@@ -605,6 +651,7 @@ declare module "bun" {
 
     /**
      * Get the value of a key and set its expiration at a specific Unix timestamp in milliseconds
+     *
      * @param key The key to get
      * @param pxat Set the specified Unix time at which the key will expire, in milliseconds
      * @param timestampMilliseconds The Unix timestamp in milliseconds
@@ -614,6 +661,7 @@ declare module "bun" {
 
     /**
      * Get the value of a key and remove its expiration
+     *
      * @param key The key to get
      * @param persist Remove the expiration from the key
      * @returns Promise that resolves with the value of the key, or null if the key doesn't exist
@@ -628,6 +676,7 @@ declare module "bun" {
 
     /**
      *  Ping the server with a message
+     *
      *  @param message The message to send to the server
      *  @returns Promise that resolves with the message if the server is reachable, or throws an error if the server is not reachable
      */
@@ -640,86 +689,94 @@ declare module "bun" {
      * @param message The message to publish.
      *
      * @returns The number of clients that received the message. Note that in a
-     *          cluster this returns the total number of clients in the same
-     *          node.
+     * cluster this returns the total number of clients in the same node.
      */
     publish(channel: string, message: string): Promise<number>;
 
     /**
      * Subscribe to a Redis channel.
      *
+     * Subscribing disables automatic pipelining, so all commands will be
+     * received immediately.
+     *
+     * Subscribing moves the channel to a dedicated subscription state which
+     * prevents most other commands from being executed until unsubscribed. Only
+     * {@link ping `.ping()`}, {@link subscribe `.subscribe()`}, and
+     * {@link unsubscribe `.unsubscribe()`} are legal to invoke in a subscribed
+     * upon channel.
+     *
      * @param channel The channel to subscribe to.
      * @param listener The listener to call when a message is received on the
-     *                 channel. The listener will receive the message as the
-     *                 first argument and the channel as the second argument.
+     * channel. The listener will receive the message as the first argument and
+     * the channel as the second argument.
      *
-     * @example Basic usage
+     * @example
+     * ```ts
      * await client.subscribe("my-channel", (message, channel) => {
      *   console.log(`Received message on ${channel}: ${message}`);
      * });
-     *
-     * @note Subscribing disables automatic pipelining, so all commands will be
-     *       received immediately.
-     * @note Subscribing moves the channel to a dedicated subscription state
-     *       which prevents most other commands from being executed until
-     *       unsubscribed. Only {@see ping}, {@see subscribe}, and {@see unsubscribe} are legal to
-     *       invoke in a subscribed upon channel.
+     * ```
      */
-    subscribe(channel: string, listener: SubscriptionListener): Promise<number>;
+    subscribe(channel: string, listener: RedisClient.PubSubListener<string>): Promise<number>;
 
     /**
      * Subscribe to multiple Redis channels.
      *
-     * @param channels An array of channels to subscribe to.
-     * @param listener The listener to call when a message is received on any
-     *                 of the subscribed channels. The listener will receive
-     *                 the message as the first argument and the channel as the
-     *                 second argument.
+     * Subscribing disables automatic pipelining, so all commands will be
+     * received immediately.
      *
-     * @note Subscribing disables automatic pipelining, so all commands will be
-     *       received immediately.
-     * @note Subscribing moves the channels to a dedicated subscription state
-     *       in which only a limited set of commands can be executed.
+     * Subscribing moves the channels to a dedicated subscription state in which
+     * only a limited set of commands can be executed.
+     *
+     * @param channels An array of channels to subscribe to.
+     * @param listener The listener to call when a message is received on any of
+     * the subscribed channels. The listener will receive the message as the
+     * first argument and the channel as the second argument.
      */
-    subscribe(channels: string[], listener: SubscriptionListener): Promise<number>;
+    subscribe(channels: string[], listener: RedisClient.PubSubListener<string>): Promise<number>;
 
     /**
      * Unsubscribe from a singular Redis channel.
      *
      * @param channel The channel to unsubscribe from.
      *
-     * @note If there are no more channels subscribed to, the client
-     *       automatically re-enables pipelining if it was previously enabled.
-     * @note Unsubscribing moves the channel back to a normal state out of the
-     *       subscription state if all channels have been unsubscribed from.
-     *       For further details on the subscription state, @see subscribe.
+     * If there are no more channels subscribed to, the client automatically
+     * re-enables pipelining if it was previously enabled.
+     *
+     * Unsubscribing moves the channel back to a normal state out of the
+     * subscription state if all channels have been unsubscribed from. For
+     * further details on the subscription state, see {@link subscribe `.subscribe()`}.
      */
     unsubscribe(channel: string): Promise<void>;
 
     /**
      * Remove a listener from a given Redis channel.
      *
+     * If there are no more channels subscribed to, the client automatically
+     * re-enables pipelining if it was previously enabled.
+     *
+     * Unsubscribing moves the channel back to a normal state out of the
+     * subscription state if all channels have been unsubscribed from. For
+     * further details on the subscription state, see
+     * {@link subscribe `.subscribe()`}.
+     *
      * @param channel The channel to unsubscribe from.
      * @param listener The listener to remove. This is tested against
-     *                 referential equality so you must pass the exact same
-     *                 listener instance as when subscribing.
-     *
-     * @note If there are no more channels subscribed to, the client
-     *       automatically re-enables pipelining if it was previously enabled.
-     * @note Unsubscribing moves the channel back to a normal state out of the
-     *       subscription state if all channels have been unsubscribed from.
-     *       For further details on the subscription state, @see subscribe.
+     * referential equality so you must pass the exact same listener instance as
+     * when subscribing.
      */
-    unsubscribe(channel: string, listener: SubscriptionListener): Promise<void>;
+    unsubscribe(channel: string, listener: RedisClient.PubSubListener<string>): Promise<void>;
 
     /**
      * Unsubscribe from all registered Redis channels.
      *
-     * @note The client will automatically re-enable pipelining if it was
-     *       previously enabled.
-     * @note Unsubscribing moves the channel back to a normal state out of the
-     *       subscription state if all channels have been unsubscribed from.
-     *       For further details on the subscription state, @see subscribe.
+     * The client will automatically re-enable pipelining if it was previously
+     * enabled. Unsubscribing moves the channel back to a normal state out of
+     * the
+     *
+     * subscription state if all channels have been unsubscribed from. For
+     * further details on the subscription state, see
+     * {@link subscribe `.subscribe()`}.
      */
     unsubscribe(): Promise<void>;
 
@@ -728,11 +785,13 @@ declare module "bun" {
      *
      * @param channels An array of channels to unsubscribe from.
      *
-     * @note If there are no more channels subscribed to, the client
-     *       automatically re-enables pipelining if it was previously enabled.
-     * @note Unsubscribing moves the channel back to a normal state out of the
-     *       subscription state if all channels have been unsubscribed from.
-     *       For further details on the subscription state, @see subscribe.
+     * If there are no more channels subscribed to, the client automatically
+     * re-enables pipelining if it was previously enabled.
+     *
+     * Unsubscribing moves the channel back to a normal state out of the
+     * subscription state if all channels have been unsubscribed from. For
+     * further details on the subscription state, see
+     * {@link subscribe `.subscribe()`}.
      */
     unsubscribe(channels: string[]): Promise<void>;
 
@@ -740,7 +799,7 @@ declare module "bun" {
      * @brief Create a new RedisClient instance with the same configuration as
      *        the current instance.
      *
-     * @note This will open up a new connection to the Redis server.
+     * This will open up a new connection to the Redis server.
      */
     duplicate(): Promise<RedisClient>;
   }

--- a/src/bun.js/api/valkey.classes.ts
+++ b/src/bun.js/api/valkey.classes.ts
@@ -9,6 +9,7 @@ export default [
     configurable: false,
     JSType: "0b11101110",
     memoryCost: true,
+    hasPendingActivity: true,
     proto: {
       connected: {
         getter: "getConnected",
@@ -228,6 +229,6 @@ export default [
       punsubscribe: { fn: "punsubscribe" },
       pubsub: { fn: "pubsub" },
     },
-    values: ["onconnect", "onclose", "connectionPromise", "hello"],
+    values: ["onconnect", "onclose", "connectionPromise", "hello", "subscriptionCallbackMap"],
   }),
 ];

--- a/src/bun.js/api/valkey.classes.ts
+++ b/src/bun.js/api/valkey.classes.ts
@@ -222,6 +222,7 @@ export default [
       zrank: { fn: "zrank" },
       zrevrank: { fn: "zrevrank" },
       subscribe: { fn: "subscribe" },
+      duplicate: { fn: "duplicate" },
       psubscribe: { fn: "psubscribe" },
       unsubscribe: { fn: "unsubscribe" },
       punsubscribe: { fn: "punsubscribe" },

--- a/src/bun.js/bindings/JSMap.zig
+++ b/src/bun.js/bindings/JSMap.zig
@@ -9,12 +9,17 @@ pub const JSMap = opaque {
         return bun.cpp.JSC__JSMap__set(this, globalObject, key, value);
     }
 
-    pub fn get_(this: *JSMap, globalObject: *JSGlobalObject, key: JSValue) JSValue {
-        return bun.cpp.JSC__JSMap__get_(this, globalObject, key);
-    }
+    extern fn JSC__JSMap__get(*JSMap, *JSGlobalObject, JSValue) JSValue;
 
-    pub fn get(this: *JSMap, globalObject: *JSGlobalObject, key: JSValue) ?JSValue {
-        const value = get_(this, globalObject, key);
+    pub fn get(this: *JSMap, globalObject: *JSGlobalObject, key: JSValue) bun.JSError!?JSValue {
+        var scope: jsc.CatchScope = undefined;
+        scope.init(globalObject, @src());
+        defer scope.deinit();
+
+        const value = JSC__JSMap__get(this, globalObject, key);
+
+        try scope.returnIfException();
+
         if (value == .zero) {
             return null;
         }

--- a/src/bun.js/bindings/JSMap.zig
+++ b/src/bun.js/bindings/JSMap.zig
@@ -15,7 +15,7 @@ pub const JSMap = opaque {
 
     pub fn get(this: *JSMap, globalObject: *JSGlobalObject, key: JSValue) ?JSValue {
         const value = get_(this, globalObject, key);
-        if (value.isEmpty()) {
+        if (value == .zero) {
             return null;
         }
         return value;
@@ -27,6 +27,10 @@ pub const JSMap = opaque {
 
     pub fn remove(this: *JSMap, globalObject: *JSGlobalObject, key: JSValue) bool {
         return bun.cpp.JSC__JSMap__remove(this, globalObject, key);
+    }
+
+    pub fn size(this: *JSMap, globalObject: *JSGlobalObject) usize {
+        return bun.cpp.JSC__JSMap__size(this, globalObject);
     }
 
     pub fn fromJS(value: JSValue) ?*JSMap {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -6422,6 +6422,11 @@ CPP_DECL [[ZIG_EXPORT(nothrow)]] void JSC__JSMap__set(JSC::JSMap* map, JSC::JSGl
     map->set(arg1, JSC::JSValue::decode(JSValue2), JSC::JSValue::decode(JSValue3));
 }
 
+CPP_DECL [[ZIG_EXPORT(nothrow)]] uint32_t JSC__JSMap__size(JSC::JSMap* map, JSC::JSGlobalObject* arg1)
+{
+    return map->size();
+}
+
 CPP_DECL void JSC__VM__setControlFlowProfiler(JSC::VM* vm, bool isEnabled)
 {
     if (isEnabled) {

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -8,7 +8,7 @@
 
 #define AUTO_EXTERN_C extern "C"
 #ifdef WIN32
-  #define AUTO_EXTERN_C_ZIG extern "C" 
+  #define AUTO_EXTERN_C_ZIG extern "C"
 #else
   #define AUTO_EXTERN_C_ZIG extern "C" __attribute__((weak))
 #endif
@@ -129,7 +129,7 @@ CPP_DECL void WebCore__AbortSignal__cleanNativeBindings(WebCore::AbortSignal* ar
 CPP_DECL JSC::EncodedJSValue WebCore__AbortSignal__create(JSC::JSGlobalObject* arg0);
 CPP_DECL WebCore::AbortSignal* WebCore__AbortSignal__fromJS(JSC::EncodedJSValue JSValue0);
 CPP_DECL WebCore::AbortSignal* WebCore__AbortSignal__ref(WebCore::AbortSignal* arg0);
-CPP_DECL WebCore::AbortSignal* WebCore__AbortSignal__signal(WebCore::AbortSignal* arg0, JSC::JSGlobalObject*,  uint8_t abortReason); 
+CPP_DECL WebCore::AbortSignal* WebCore__AbortSignal__signal(WebCore::AbortSignal* arg0, JSC::JSGlobalObject*,  uint8_t abortReason);
 CPP_DECL JSC::EncodedJSValue WebCore__AbortSignal__toJS(WebCore::AbortSignal* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void WebCore__AbortSignal__unref(WebCore::AbortSignal* arg0);
 
@@ -190,6 +190,7 @@ CPP_DECL JSC::EncodedJSValue JSC__JSMap__get_(JSC::JSMap* arg0, JSC::JSGlobalObj
 CPP_DECL bool JSC__JSMap__has(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL bool JSC__JSMap__remove(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__JSMap__set(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2, JSC::EncodedJSValue JSValue3);
+CPP_DECL uint32_t JSC__JSMap__size(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1);
 
 #pragma mark - JSC::JSValue
 

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -186,7 +186,7 @@ CPP_DECL JSC::VM* JSC__JSGlobalObject__vm(JSC::JSGlobalObject* arg0);
 #pragma mark - JSC::JSMap
 
 CPP_DECL JSC::EncodedJSValue JSC__JSMap__create(JSC::JSGlobalObject* arg0);
-CPP_DECL JSC::EncodedJSValue JSC__JSMap__get_(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
+CPP_DECL JSC::EncodedJSValue JSC__JSMap__get(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL bool JSC__JSMap__has(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL bool JSC__JSMap__remove(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__JSMap__set(JSC::JSMap* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2, JSC::EncodedJSValue JSValue3);

--- a/src/deps/uws/us_socket_t.zig
+++ b/src/deps/uws/us_socket_t.zig
@@ -13,7 +13,7 @@ pub const us_socket_t = opaque {
     };
 
     pub fn open(this: *us_socket_t, comptime is_ssl: bool, is_client: bool, ip_addr: ?[]const u8) void {
-        debug("us_socket_open({d}, is_client: {})", .{ @intFromPtr(this), is_client });
+        debug("us_socket_open({p}, is_client: {})", .{ this, is_client });
         const ssl = @intFromBool(is_ssl);
 
         if (ip_addr) |ip| {
@@ -25,22 +25,22 @@ pub const us_socket_t = opaque {
     }
 
     pub fn pause(this: *us_socket_t, ssl: bool) void {
-        debug("us_socket_pause({d})", .{@intFromPtr(this)});
+        debug("us_socket_pause({p})", .{this});
         c.us_socket_pause(@intFromBool(ssl), this);
     }
 
     pub fn @"resume"(this: *us_socket_t, ssl: bool) void {
-        debug("us_socket_resume({d})", .{@intFromPtr(this)});
+        debug("us_socket_resume({p})", .{this});
         c.us_socket_resume(@intFromBool(ssl), this);
     }
 
     pub fn close(this: *us_socket_t, ssl: bool, code: CloseCode) void {
-        debug("us_socket_close({d}, {s})", .{ @intFromPtr(this), @tagName(code) });
+        debug("us_socket_close({p}, {s})", .{ this, @tagName(code) });
         _ = c.us_socket_close(@intFromBool(ssl), this, code, null);
     }
 
     pub fn shutdown(this: *us_socket_t, ssl: bool) void {
-        debug("us_socket_shutdown({d})", .{@intFromPtr(this)});
+        debug("us_socket_shutdown({p})", .{this});
         c.us_socket_shutdown(@intFromBool(ssl), this);
     }
 
@@ -128,25 +128,25 @@ pub const us_socket_t = opaque {
 
     pub fn write(this: *us_socket_t, ssl: bool, data: []const u8) i32 {
         const rc = c.us_socket_write(@intFromBool(ssl), this, data.ptr, @intCast(data.len));
-        debug("us_socket_write({d}, {d}) = {d}", .{ @intFromPtr(this), data.len, rc });
+        debug("us_socket_write({p}, {d}) = {d}", .{ this, data.len, rc });
         return rc;
     }
 
     pub fn writeFd(this: *us_socket_t, data: []const u8, file_descriptor: bun.FD) i32 {
         if (bun.Environment.isWindows) @compileError("TODO: implement writeFd on Windows");
         const rc = c.us_socket_ipc_write_fd(this, data.ptr, @intCast(data.len), file_descriptor.native());
-        debug("us_socket_ipc_write_fd({d}, {d}, {d}) = {d}", .{ @intFromPtr(this), data.len, file_descriptor.native(), rc });
+        debug("us_socket_ipc_write_fd({p}, {d}, {d}) = {d}", .{ this, data.len, file_descriptor.native(), rc });
         return rc;
     }
 
     pub fn write2(this: *us_socket_t, ssl: bool, first: []const u8, second: []const u8) i32 {
         const rc = c.us_socket_write2(@intFromBool(ssl), this, first.ptr, first.len, second.ptr, second.len);
-        debug("us_socket_write2({d}, {d}, {d}) = {d}", .{ @intFromPtr(this), first.len, second.len, rc });
+        debug("us_socket_write2({p}, {d}, {d}) = {d}", .{ this, first.len, second.len, rc });
         return rc;
     }
 
     pub fn rawWrite(this: *us_socket_t, ssl: bool, data: []const u8) i32 {
-        debug("us_socket_raw_write({d}, {d})", .{ @intFromPtr(this), data.len });
+        debug("us_socket_raw_write({p}, {d})", .{ this, data.len });
         return c.us_socket_raw_write(@intFromBool(ssl), this, data.ptr, @intCast(data.len));
     }
 

--- a/src/string/StringBuilder.zig
+++ b/src/string/StringBuilder.zig
@@ -236,6 +236,15 @@ pub fn writable(this: *StringBuilder) []u8 {
     return ptr[this.len..this.cap];
 }
 
+/// Transfer ownership of the underlying memory to a slice.
+///
+/// After calling this, you are responsible for freeing the underlying memory.
+/// This StringBuilder should not be used after calling this function.
+pub fn moveToSlice(this: *StringBuilder, into_slice: *[]u8) void {
+    into_slice.* = this.allocatedSlice();
+    this.* = .{};
+}
+
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 

--- a/src/valkey/ValkeyCommand.zig
+++ b/src/valkey/ValkeyCommand.zig
@@ -137,7 +137,7 @@ pub const Promise = struct {
         self.promise.resolve(globalObject, js_value);
     }
 
-    pub fn reject(self: *Promise, globalObject: *jsc.JSGlobalObject, jsvalue: jsc.JSValue) void {
+    pub fn reject(self: *Promise, globalObject: *jsc.JSGlobalObject, jsvalue: JSError!jsc.JSValue) void {
         self.promise.reject(globalObject, jsvalue);
     }
 
@@ -162,6 +162,7 @@ const protocol = @import("./valkey_protocol.zig");
 const std = @import("std");
 
 const bun = @import("bun");
+const JSError = bun.JSError;
 const jsc = bun.jsc;
 const node = bun.api.node;
 const Slice = jsc.ZigString.Slice;

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -59,7 +59,7 @@ pub const SubscriptionCtx = struct {
     ) !?usize {
         const map = this.subscriptionCallbackMap();
 
-        const existing = map.get(globalObject, channelName);
+        const existing = try map.get(globalObject, channelName);
 
         if (existing == null) {
             // Could not find the channel, nothing to remove.
@@ -109,7 +109,7 @@ pub const SubscriptionCtx = struct {
         const map = this.subscriptionCallbackMap();
 
         var handlers_array: JSValue = undefined;
-        if (map.get(globalObject, channelName)) |existing_handler_arr| {
+        if (try map.get(globalObject, channelName)) |existing_handler_arr| {
             debug("Adding a new receive handler.", .{});
             if (existing_handler_arr.isUndefined()) {
                 // Create a new array if the existing_handler_arr is undefined/null
@@ -130,7 +130,7 @@ pub const SubscriptionCtx = struct {
         map.set(globalObject, channelName, handlers_array);
 
         // TODO(markovejnovic: Remove this debugging junk.
-        const array_readback = map.get(globalObject, channelName);
+        const array_readback = try map.get(globalObject, channelName);
         const count = (try array_readback.?.arrayIterator(globalObject)).len;
         debug("Now have {d} handlers for channel", .{count});
     }
@@ -140,7 +140,7 @@ pub const SubscriptionCtx = struct {
     }
 
     pub fn getCallbacks(this: *Self, globalObject: *jsc.JSGlobalObject, channelName: JSValue) bun.JSError!?JSValue {
-        const result = this.subscriptionCallbackMap().get(globalObject, channelName);
+        const result = try this.subscriptionCallbackMap().get(globalObject, channelName);
         if (result) |r| {
             if (r.isUndefinedOrNull()) {
                 return null;

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -9,7 +9,7 @@ pub const SubscriptionCtx = struct {
 
     pub fn init(parent: *JSValkeyClient, enable_offline_queue: bool, enable_auto_pipelining: bool) Self {
         const callback_map = jsc.JSMap.create(parent.globalObject);
-        ParentJS.gc.set(.subscriptionCallbackMap, parent.this_value.get(), parent.globalObject, callback_map.toJS(parent.globalObject));
+        ParentJS.gc.set(.subscriptionCallbackMap, parent.this_value.get(), parent.globalObject, callback_map);
 
         const self = Self{
             ._parent = parent,

--- a/src/valkey/js_valkey_functions.zig
+++ b/src/valkey/js_valkey_functions.zig
@@ -1,3 +1,19 @@
+fn requireNotSubscriber(this: *const JSValkeyClient, function_name: []const u8) bun.JSError!void {
+    const fmt_string = "RedisClient.{s} cannot be called while in subscriber mode.";
+
+    if (this.isSubscriber()) {
+        return this.globalObject.throw(fmt_string, .{function_name});
+    }
+}
+
+fn requireSubscriber(this: *const JSValkeyClient, function_name: []const u8) bun.JSError!void {
+    const fmt_string = "RedisClient.{s} can only be called while in subscriber mode.";
+
+    if (!this.isSubscriber()) {
+        return this.globalObject.throw(fmt_string, .{function_name});
+    }
+}
+
 pub fn jsSend(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     const command = try callframe.argument(0).toBunString(globalObject);
     defer command.deref();
@@ -41,9 +57,7 @@ pub fn jsSend(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 }
 
 pub fn get(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("get", "key", "string or buffer");
@@ -65,9 +79,7 @@ pub fn get(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: 
 }
 
 pub fn getBuffer(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("getBuffer", "key", "string or buffer");
@@ -89,9 +101,7 @@ pub fn getBuffer(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callf
 }
 
 pub fn set(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const args_view = callframe.arguments();
     var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
@@ -139,9 +149,7 @@ pub fn set(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: 
 }
 
 pub fn incr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("incr", "key", "string or buffer");
@@ -163,9 +171,7 @@ pub fn incr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 }
 
 pub fn decr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("decr", "key", "string or buffer");
@@ -187,9 +193,7 @@ pub fn decr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 }
 
 pub fn exists(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("exists", "key", "string or buffer");
@@ -212,9 +216,7 @@ pub fn exists(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 }
 
 pub fn expire(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("expire", "key", "string or buffer");
@@ -247,9 +249,7 @@ pub fn expire(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 }
 
 pub fn ttl(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("ttl", "key", "string or buffer");
@@ -272,9 +272,7 @@ pub fn ttl(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: 
 
 // Implement srem (remove value from a set)
 pub fn srem(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("srem", "key", "string or buffer");
@@ -301,9 +299,7 @@ pub fn srem(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 
 // Implement srandmember (get random member from set)
 pub fn srandmember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("srandmember", "key", "string or buffer");
@@ -326,9 +322,7 @@ pub fn srandmember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, cal
 
 // Implement smembers (get all members of a set)
 pub fn smembers(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("smembers", "key", "string or buffer");
@@ -351,9 +345,7 @@ pub fn smembers(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfr
 
 // Implement spop (pop a random member from a set)
 pub fn spop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("spop", "key", "string or buffer");
@@ -376,9 +368,7 @@ pub fn spop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 
 // Implement sadd (add member to a set)
 pub fn sadd(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("sadd", "key", "string or buffer");
@@ -405,9 +395,7 @@ pub fn sadd(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 
 // Implement sismember (check if value is member of a set)
 pub fn sismember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("sismember", "key", "string or buffer");
@@ -435,9 +423,7 @@ pub fn sismember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callf
 
 // Implement hmget (get multiple values from hash)
 pub fn hmget(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("hmget", "key", "string or buffer");
@@ -486,9 +472,7 @@ pub fn hmget(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe
 
 // Implement hincrby (increment hash field by integer value)
 pub fn hincrby(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = try callframe.argument(0).toBunString(globalObject);
     defer key.deref();
@@ -520,9 +504,7 @@ pub fn hincrby(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfra
 
 // Implement hincrbyfloat (increment hash field by float value)
 pub fn hincrbyfloat(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = try callframe.argument(0).toBunString(globalObject);
     defer key.deref();
@@ -554,9 +536,7 @@ pub fn hincrbyfloat(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, ca
 
 // Implement hmset (set multiple values in hash)
 pub fn hmset(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const key = try callframe.argument(0).toBunString(globalObject);
     defer key.deref();
@@ -655,9 +635,7 @@ pub fn publish(
     globalObject: *jsc.JSGlobalObject,
     callframe: *jsc.CallFrame,
 ) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
 
     const args_view = callframe.arguments();
     var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
@@ -679,11 +657,7 @@ pub fn publish(
 
     const arg1 = callframe.argument(1);
     if (!arg1.isString()) {
-        return globalObject.throwInvalidArgumentType(
-            "publish",
-            "message",
-            "string or buffer or number",
-        );
+        return globalObject.throwInvalidArgumentType("publish", "message", "string");
     }
     const message = (try fromJS(globalObject, arg1)) orelse unreachable;
     args.appendAssumeCapacity(message);
@@ -724,7 +698,7 @@ pub fn subscribe(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callf
     }
 
     // We now need to register the callback with our subscription context, which may or may not exist.
-    var subscription_ctx = this.getOrCreateSubscriptionCtxEnteringSubscriptionMode(globalObject);
+    var subscription_ctx = this.getOrCreateSubscriptionCtxEnteringSubscriptionMode();
 
     // The first argument given is the channel or may be an array of channels.
     const channelOrMany = callframe.argument(0);
@@ -806,9 +780,7 @@ pub fn unsubscribe(
     callframe: *jsc.CallFrame,
 ) bun.JSError!JSValue {
     // Check if we're in subscription mode
-    if (!this.isSubscriber()) {
-        return globalObject.throw("Not in subscription mode", .{});
-    }
+    try requireSubscriber(this, @src().fn_name);
 
     const args_view = callframe.arguments();
 
@@ -928,280 +900,196 @@ pub fn unsubscribe(
 
 // Wrapper functions that check subscriber mode before delegating to compile-generated functions
 pub fn bitcount(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("bitcount", "BITCOUNT", "key").call(this, globalObject, callframe);
 }
 
 pub fn dump(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("dump", "DUMP", "key").call(this, globalObject, callframe);
 }
 
 pub fn expiretime(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("expiretime", "EXPIRETIME", "key").call(this, globalObject, callframe);
 }
 
 pub fn getdel(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("getdel", "GETDEL", "key").call(this, globalObject, callframe);
 }
 
 pub fn getex(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("getex", "GETEX", "key").call(this, globalObject, callframe);
 }
 
 pub fn hgetall(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("hgetall", "HGETALL", "key").call(this, globalObject, callframe);
 }
 
 pub fn hkeys(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("hkeys", "HKEYS", "key").call(this, globalObject, callframe);
 }
 
 pub fn hlen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("hlen", "HLEN", "key").call(this, globalObject, callframe);
 }
 
 pub fn hvals(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("hvals", "HVALS", "key").call(this, globalObject, callframe);
 }
 
 pub fn keys(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("keys", "KEYS", "key").call(this, globalObject, callframe);
 }
 
 pub fn llen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("llen", "LLEN", "key").call(this, globalObject, callframe);
 }
 
 pub fn lpop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("lpop", "LPOP", "key").call(this, globalObject, callframe);
 }
 
 pub fn persist(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("persist", "PERSIST", "key").call(this, globalObject, callframe);
 }
 
 pub fn pexpiretime(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("pexpiretime", "PEXPIRETIME", "key").call(this, globalObject, callframe);
 }
 
 pub fn pttl(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("pttl", "PTTL", "key").call(this, globalObject, callframe);
 }
 
 pub fn rpop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("rpop", "RPOP", "key").call(this, globalObject, callframe);
 }
 
 pub fn scard(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("scard", "SCARD", "key").call(this, globalObject, callframe);
 }
 
 pub fn strlen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("strlen", "STRLEN", "key").call(this, globalObject, callframe);
 }
 
 pub fn @"type"(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("type", "TYPE", "key").call(this, globalObject, callframe);
 }
 
 pub fn zcard(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("zcard", "ZCARD", "key").call(this, globalObject, callframe);
 }
 
 pub fn zpopmax(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("zpopmax", "ZPOPMAX", "key").call(this, globalObject, callframe);
 }
 
 pub fn zpopmin(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("zpopmin", "ZPOPMIN", "key").call(this, globalObject, callframe);
 }
 
 pub fn zrandmember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("zrandmember", "ZRANDMEMBER", "key").call(this, globalObject, callframe);
 }
 
 pub fn append(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue)"("append", "APPEND", "key", "value").call(this, globalObject, callframe);
 }
 pub fn getset(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue)"("getset", "GETSET", "key", "value").call(this, globalObject, callframe);
 }
 pub fn lpush(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("lpush", "LPUSH").call(this, globalObject, callframe);
 }
 pub fn lpushx(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("lpushx", "LPUSHX").call(this, globalObject, callframe);
 }
 pub fn pfadd(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue)"("pfadd", "PFADD", "key", "value").call(this, globalObject, callframe);
 }
 pub fn rpush(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("rpush", "RPUSH").call(this, globalObject, callframe);
 }
 pub fn rpushx(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("rpushx", "RPUSHX").call(this, globalObject, callframe);
 }
 pub fn setnx(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue)"("setnx", "SETNX", "key", "value").call(this, globalObject, callframe);
 }
 pub fn zscore(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, value: RedisValue)"("zscore", "ZSCORE", "key", "value").call(this, globalObject, callframe);
 }
 
 pub fn del(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, ...args: RedisKey[])"("del", "DEL", "key").call(this, globalObject, callframe);
 }
 pub fn mget(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey, ...args: RedisKey[])"("mget", "MGET", "key").call(this, globalObject, callframe);
 }
 
 pub fn script(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("script", "SCRIPT").call(this, globalObject, callframe);
 }
 pub fn select(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("select", "SELECT").call(this, globalObject, callframe);
 }
 pub fn spublish(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("spublish", "SPUBLISH").call(this, globalObject, callframe);
 }
 pub fn smove(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("smove", "SMOVE").call(this, globalObject, callframe);
 }
 pub fn substr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("substr", "SUBSTR").call(this, globalObject, callframe);
 }
 pub fn hstrlen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("hstrlen", "HSTRLEN").call(this, globalObject, callframe);
 }
 pub fn zrank(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("zrank", "ZRANK").call(this, globalObject, callframe);
 }
 pub fn zrevrank(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
-    if (this.isSubscriber()) {
-        return globalObject.throw("Cannot use in subscriber mode", .{});
-    }
+    try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(...strings: string[])"("zrevrank", "ZREVRANK").call(this, globalObject, callframe);
 }
 
@@ -1210,13 +1098,12 @@ pub fn duplicate(
     globalObject: *jsc.JSGlobalObject,
     callframe: *jsc.CallFrame,
 ) bun.JSError!JSValue {
-    const args_view = callframe.arguments();
-    if (args_view.len != 0) {
-        return globalObject.throwInvalidArguments("duplicate does not take any arguments", .{});
-    }
+    // We ignore the arguments if the user provided any.
+    _ = callframe;
 
-    var new_client: *JSValkeyClient = this.cloneWithoutConnecting();
+    var new_client: *JSValkeyClient = try this.cloneWithoutConnecting();
     var new_client_js = new_client.toJS(globalObject);
+    new_client.this_value = jsc.JSRef.initWeak(new_client_js);
 
     // If the original client is already connected and not manually closed, start connecting the new client.
     if (this.client.status == .connected and !this.client.flags.is_manually_closed) {

--- a/src/valkey/js_valkey_functions.zig
+++ b/src/valkey/js_valkey_functions.zig
@@ -41,6 +41,10 @@ pub fn jsSend(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 }
 
 pub fn get(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("get", "key", "string or buffer");
     };
@@ -61,6 +65,10 @@ pub fn get(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: 
 }
 
 pub fn getBuffer(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("getBuffer", "key", "string or buffer");
     };
@@ -81,6 +89,10 @@ pub fn getBuffer(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callf
 }
 
 pub fn set(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const args_view = callframe.arguments();
     var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
     var args = try std.ArrayList(JSArgument).initCapacity(stack_fallback.get(), args_view.len);
@@ -127,6 +139,10 @@ pub fn set(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: 
 }
 
 pub fn incr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("incr", "key", "string or buffer");
     };
@@ -147,6 +163,10 @@ pub fn incr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 }
 
 pub fn decr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("decr", "key", "string or buffer");
     };
@@ -167,6 +187,10 @@ pub fn decr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 }
 
 pub fn exists(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("exists", "key", "string or buffer");
     };
@@ -188,6 +212,10 @@ pub fn exists(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 }
 
 pub fn expire(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("expire", "key", "string or buffer");
     };
@@ -219,6 +247,10 @@ pub fn expire(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 }
 
 pub fn ttl(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("ttl", "key", "string or buffer");
     };
@@ -240,6 +272,10 @@ pub fn ttl(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: 
 
 // Implement srem (remove value from a set)
 pub fn srem(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("srem", "key", "string or buffer");
     };
@@ -265,6 +301,10 @@ pub fn srem(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 
 // Implement srandmember (get random member from set)
 pub fn srandmember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("srandmember", "key", "string or buffer");
     };
@@ -286,6 +326,10 @@ pub fn srandmember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, cal
 
 // Implement smembers (get all members of a set)
 pub fn smembers(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("smembers", "key", "string or buffer");
     };
@@ -307,6 +351,10 @@ pub fn smembers(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfr
 
 // Implement spop (pop a random member from a set)
 pub fn spop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("spop", "key", "string or buffer");
     };
@@ -328,6 +376,10 @@ pub fn spop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 
 // Implement sadd (add member to a set)
 pub fn sadd(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("sadd", "key", "string or buffer");
     };
@@ -353,6 +405,10 @@ pub fn sadd(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
 
 // Implement sismember (check if value is member of a set)
 pub fn sismember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("sismember", "key", "string or buffer");
     };
@@ -379,6 +435,10 @@ pub fn sismember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callf
 
 // Implement hmget (get multiple values from hash)
 pub fn hmget(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = (try fromJS(globalObject, callframe.argument(0))) orelse {
         return globalObject.throwInvalidArgumentType("hmget", "key", "string or buffer");
     };
@@ -426,6 +486,10 @@ pub fn hmget(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe
 
 // Implement hincrby (increment hash field by integer value)
 pub fn hincrby(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = try callframe.argument(0).toBunString(globalObject);
     defer key.deref();
     const field = try callframe.argument(1).toBunString(globalObject);
@@ -456,6 +520,10 @@ pub fn hincrby(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfra
 
 // Implement hincrbyfloat (increment hash field by float value)
 pub fn hincrbyfloat(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = try callframe.argument(0).toBunString(globalObject);
     defer key.deref();
     const field = try callframe.argument(1).toBunString(globalObject);
@@ -486,6 +554,10 @@ pub fn hincrbyfloat(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, ca
 
 // Implement hmset (set multiple values in hash)
 pub fn hmset(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+
     const key = try callframe.argument(0).toBunString(globalObject);
     defer key.deref();
 
@@ -578,59 +650,591 @@ pub fn ping(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe:
     return promise.toJS();
 }
 
-pub const bitcount = compile.@"(key: RedisKey)"("bitcount", "BITCOUNT", "key").call;
-pub const dump = compile.@"(key: RedisKey)"("dump", "DUMP", "key").call;
-pub const expiretime = compile.@"(key: RedisKey)"("expiretime", "EXPIRETIME", "key").call;
-pub const getdel = compile.@"(key: RedisKey)"("getdel", "GETDEL", "key").call;
-pub const getex = compile.@"(...strings: string[])"("getex", "GETEX").call;
-pub const hgetall = compile.@"(key: RedisKey)"("hgetall", "HGETALL", "key").call;
-pub const hkeys = compile.@"(key: RedisKey)"("hkeys", "HKEYS", "key").call;
-pub const hlen = compile.@"(key: RedisKey)"("hlen", "HLEN", "key").call;
-pub const hvals = compile.@"(key: RedisKey)"("hvals", "HVALS", "key").call;
-pub const keys = compile.@"(key: RedisKey)"("keys", "KEYS", "key").call;
-pub const llen = compile.@"(key: RedisKey)"("llen", "LLEN", "key").call;
-pub const lpop = compile.@"(key: RedisKey)"("lpop", "LPOP", "key").call;
-pub const persist = compile.@"(key: RedisKey)"("persist", "PERSIST", "key").call;
-pub const pexpiretime = compile.@"(key: RedisKey)"("pexpiretime", "PEXPIRETIME", "key").call;
-pub const pttl = compile.@"(key: RedisKey)"("pttl", "PTTL", "key").call;
-pub const rpop = compile.@"(key: RedisKey)"("rpop", "RPOP", "key").call;
-pub const scard = compile.@"(key: RedisKey)"("scard", "SCARD", "key").call;
-pub const strlen = compile.@"(key: RedisKey)"("strlen", "STRLEN", "key").call;
-pub const @"type" = compile.@"(key: RedisKey)"("type", "TYPE", "key").call;
-pub const zcard = compile.@"(key: RedisKey)"("zcard", "ZCARD", "key").call;
-pub const zpopmax = compile.@"(key: RedisKey)"("zpopmax", "ZPOPMAX", "key").call;
-pub const zpopmin = compile.@"(key: RedisKey)"("zpopmin", "ZPOPMIN", "key").call;
-pub const zrandmember = compile.@"(key: RedisKey)"("zrandmember", "ZRANDMEMBER", "key").call;
+pub fn publish(
+    this: *JSValkeyClient,
+    globalObject: *jsc.JSGlobalObject,
+    callframe: *jsc.CallFrame,
+) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
 
-pub const append = compile.@"(key: RedisKey, value: RedisValue)"("append", "APPEND", "key", "value").call;
-pub const getset = compile.@"(key: RedisKey, value: RedisValue)"("getset", "GETSET", "key", "value").call;
-pub const lpush = compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("lpush", "LPUSH").call;
-pub const lpushx = compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("lpushx", "LPUSHX").call;
-pub const pfadd = compile.@"(key: RedisKey, value: RedisValue)"("pfadd", "PFADD", "key", "value").call;
-pub const rpush = compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("rpush", "RPUSH").call;
-pub const rpushx = compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("rpushx", "RPUSHX").call;
-pub const setnx = compile.@"(key: RedisKey, value: RedisValue)"("setnx", "SETNX", "key", "value").call;
-pub const zscore = compile.@"(key: RedisKey, value: RedisValue)"("zscore", "ZSCORE", "key", "value").call;
+    const args_view = callframe.arguments();
+    var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
+    var args = try std.ArrayList(JSArgument).initCapacity(stack_fallback.get(), args_view.len);
+    defer {
+        for (args.items) |*item| {
+            item.deinit();
+        }
+        args.deinit();
+    }
 
-pub const del = compile.@"(key: RedisKey, ...args: RedisKey[])"("del", "DEL", "key").call;
-pub const mget = compile.@"(key: RedisKey, ...args: RedisKey[])"("mget", "MGET", "key").call;
+    const arg0 = callframe.argument(0);
+    if (!arg0.isString()) {
+        return globalObject.throwInvalidArgumentType("publish", "channel", "string");
+    }
+    const channel = (try fromJS(globalObject, arg0)) orelse unreachable;
 
-pub const publish = compile.@"(...strings: string[])"("publish", "PUBLISH").call;
-pub const script = compile.@"(...strings: string[])"("script", "SCRIPT").call;
-pub const select = compile.@"(...strings: string[])"("select", "SELECT").call;
-pub const spublish = compile.@"(...strings: string[])"("spublish", "SPUBLISH").call;
-pub const smove = compile.@"(...strings: string[])"("smove", "SMOVE").call;
-pub const substr = compile.@"(...strings: string[])"("substr", "SUBSTR").call;
-pub const hstrlen = compile.@"(...strings: string[])"("hstrlen", "HSTRLEN").call;
-pub const zrank = compile.@"(...strings: string[])"("zrank", "ZRANK").call;
-pub const zrevrank = compile.@"(...strings: string[])"("zrevrank", "ZREVRANK").call;
-pub const subscribe = compile.@"(...strings: string[])"("subscribe", "SUBSCRIBE").call;
+    args.appendAssumeCapacity(channel);
+
+    const arg1 = callframe.argument(1);
+    if (!arg1.isString()) {
+        return globalObject.throwInvalidArgumentType(
+            "publish",
+            "message",
+            "string or buffer or number",
+        );
+    }
+    const message = (try fromJS(globalObject, arg1)) orelse unreachable;
+    args.appendAssumeCapacity(message);
+
+    const promise = this.send(
+        globalObject,
+        callframe.this(),
+        &.{
+            .command = "PUBLISH",
+            .args = .{ .args = args.items },
+        },
+    ) catch |err| {
+        return protocol.valkeyErrorToJS(globalObject, "Failed to send PUBLISH command", err);
+    };
+
+    return promise.toJS();
+}
+
+pub fn subscribe(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const args_view = callframe.arguments();
+
+    if (args_view.len != 2) {
+        return globalObject.throwInvalidArguments("subscribe requires two arguments", .{});
+    }
+
+    var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
+    var redis_channels = try std.ArrayList(JSArgument).initCapacity(stack_fallback.get(), 1);
+    defer {
+        for (redis_channels.items) |*item| {
+            item.deinit();
+        }
+        redis_channels.deinit();
+    }
+
+    const handler_callback = callframe.argument(1);
+    if (!handler_callback.isCallable()) {
+        return globalObject.throwInvalidArgumentType("subscribe", "listener", "function");
+    }
+
+    // We now need to register the callback with our subscription context, which may or may not exist.
+    var subscription_ctx = this.getOrCreateSubscriptionCtxEnteringSubscriptionMode(globalObject);
+
+    // The first argument given is the channel or may be an array of channels.
+    const channelOrMany = callframe.argument(0);
+    if (channelOrMany.isArray()) {
+        if ((try channelOrMany.getLength(globalObject)) == 0) {
+            return globalObject.throwInvalidArguments("subscribe requires at least one channel", .{});
+        }
+        try redis_channels.ensureTotalCapacity(try channelOrMany.getLength(globalObject));
+
+        var array_iter = try channelOrMany.arrayIterator(globalObject);
+        while (try array_iter.next()) |channel_arg| {
+            const channel = (try fromJS(globalObject, channel_arg)) orelse {
+                return globalObject.throwInvalidArgumentType("subscribe", "channel", "string");
+            };
+            redis_channels.appendAssumeCapacity(channel);
+
+            try subscription_ctx.upsertReceiveHandler(globalObject, channel_arg, handler_callback);
+        }
+    } else if (channelOrMany.isString()) {
+        // It is a single string channel
+        const channel = (try fromJS(globalObject, channelOrMany)) orelse {
+            return globalObject.throwInvalidArgumentType("subscribe", "channel", "string");
+        };
+        redis_channels.appendAssumeCapacity(channel);
+
+        try subscription_ctx.upsertReceiveHandler(globalObject, channelOrMany, handler_callback);
+    } else {
+        return globalObject.throwInvalidArgumentType("subscribe", "channel", "string or array");
+    }
+
+    const command: valkey.Command = .{
+        .command = "SUBSCRIBE",
+        .args = .{ .args = redis_channels.items },
+    };
+    const promise = this.send(
+        globalObject,
+        callframe.this(),
+        &command,
+    ) catch |err| {
+        // If we find an error, we need to clean up the subscription context.
+        this.deleteSubscriptionCtx();
+        return protocol.valkeyErrorToJS(globalObject, "Failed to send SUBSCRIBE command", err);
+    };
+
+    return promise.toJS();
+}
+
+/// Send redis the UNSUBSCRIBE RESP command and clean up anything necessary after the unsubscribe commoand.
+///
+/// The subscription context must exist when calling this function.
+fn sendUnsubscribeRequestAndCleanup(
+    this: *JSValkeyClient,
+    this_js: jsc.JSValue,
+    globalObject: *jsc.JSGlobalObject,
+    redis_channels: []JSArgument,
+) !jsc.JSValue {
+    // Send UNSUBSCRIBE command
+    const command: valkey.Command = .{
+        .command = "UNSUBSCRIBE",
+        .args = .{ .args = redis_channels },
+    };
+    const promise = this.send(
+        globalObject,
+        this_js,
+        &command,
+    ) catch |err| {
+        return protocol.valkeyErrorToJS(globalObject, "Failed to send UNSUBSCRIBE command", err);
+    };
+
+    // We do not delete the subscription context here, but rather when the
+    // onValkeyUnsubscribe callback is invoked.
+
+    return promise.toJS();
+}
+
+pub fn unsubscribe(
+    this: *JSValkeyClient,
+    globalObject: *jsc.JSGlobalObject,
+    callframe: *jsc.CallFrame,
+) bun.JSError!JSValue {
+    // Check if we're in subscription mode
+    if (!this.isSubscriber()) {
+        return globalObject.throw("Not in subscription mode", .{});
+    }
+
+    const args_view = callframe.arguments();
+
+    var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
+    var redis_channels = try std.ArrayList(JSArgument).initCapacity(stack_fallback.get(), 1);
+    defer {
+        for (redis_channels.items) |*item| {
+            item.deinit();
+        }
+        redis_channels.deinit();
+    }
+
+    // If no arguments, unsubscribe from all channels
+    if (args_view.len == 0) {
+        return try sendUnsubscribeRequestAndCleanup(this, callframe.this(), globalObject, redis_channels.items);
+    }
+
+    // The first argument can be a channel or an array of channels
+    const channelOrMany = callframe.argument(0);
+
+    // Get the subscription context
+    if (this._subscription_ctx == null) {
+        return globalObject.throw("Subscription context not found", .{});
+    }
+
+    // Two arguments means .unsubscribe(channel, listener) is invoked.
+    if (callframe.arguments().len == 2) {
+        // In this case, the first argument is a channel string and the second
+        // argument is the handler to remove.
+        if (!channelOrMany.isString()) {
+            return globalObject.throwInvalidArgumentType(
+                "unsubscribe",
+                "channel",
+                "string",
+            );
+        }
+
+        const channel = channelOrMany;
+        const listener_cb = callframe.argument(1);
+
+        if (!listener_cb.isCallable()) {
+            return globalObject.throwInvalidArgumentType(
+                "unsubscribe",
+                "listener",
+                "function",
+            );
+        }
+
+        // Populate the redis_channels list with the single channel to
+        // unsubscribe from. This s important since this list is used to send
+        // the UNSUBSCRIBE command to redis. Without this, we would end up
+        // unsubscribing from all channels.
+        redis_channels.appendAssumeCapacity((try fromJS(globalObject, channel)) orelse {
+            return globalObject.throwInvalidArgumentType("unsubscribe", "channel", "string");
+        });
+
+        const remaining_listeners = this._subscription_ctx.?.removeReceiveHandler(globalObject, channel, listener_cb) catch {
+            return globalObject.throw(
+                "Failed to remove handler for channel {}",
+                .{channel.asString().getZigString(globalObject)},
+            );
+        } orelse {
+            // Listeners weren't present in the first place, so we can return a
+            // resolved promise.
+            const promise = jsc.JSPromise.create(globalObject);
+            promise.resolve(globalObject, .js_undefined);
+            return promise.toJS();
+        };
+
+        // In this case, we only want to send the unsubscribe command to redis if there are no more listeners for this
+        // channel.
+        if (remaining_listeners == 0) {
+            return try sendUnsubscribeRequestAndCleanup(this, callframe.this(), globalObject, redis_channels.items);
+        }
+
+        // Otherwise, in order to keep the API consistent, we need to return a resolved promise.
+        const promise = jsc.JSPromise.create(globalObject);
+        promise.resolve(globalObject, .js_undefined);
+
+        return promise.toJS();
+    }
+
+    if (channelOrMany.isArray()) {
+        if ((try channelOrMany.getLength(globalObject)) == 0) {
+            return globalObject.throwInvalidArguments(
+                "unsubscribe requires at least one channel",
+                .{},
+            );
+        }
+
+        try redis_channels.ensureTotalCapacity(try channelOrMany.getLength(globalObject));
+        // It is an array, so let's iterate over it
+        var array_iter = try channelOrMany.arrayIterator(globalObject);
+        while (try array_iter.next()) |channel_arg| {
+            const channel = (try fromJS(globalObject, channel_arg)) orelse {
+                return globalObject.throwInvalidArgumentType("unsubscribe", "channel", "string");
+            };
+            redis_channels.appendAssumeCapacity(channel);
+            // Clear the handlers for this channel
+            this._subscription_ctx.?.clearReceiveHandlers(globalObject, channel_arg);
+        }
+    } else if (channelOrMany.isString()) {
+        // It is a single string channel
+        const channel = (try fromJS(globalObject, channelOrMany)) orelse {
+            return globalObject.throwInvalidArgumentType("unsubscribe", "channel", "string");
+        };
+        redis_channels.appendAssumeCapacity(channel);
+        // Clear the handlers for this channel
+        this._subscription_ctx.?.clearReceiveHandlers(globalObject, channelOrMany);
+    } else {
+        return globalObject.throwInvalidArgumentType("unsubscribe", "channel", "string or array");
+    }
+
+    // Now send the unsubscribe command and clean up if necessary
+    return try sendUnsubscribeRequestAndCleanup(this, callframe.this(), globalObject, redis_channels.items);
+}
+
+// Wrapper functions that check subscriber mode before delegating to compile-generated functions
+pub fn bitcount(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("bitcount", "BITCOUNT", "key").call(this, globalObject, callframe);
+}
+
+pub fn dump(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("dump", "DUMP", "key").call(this, globalObject, callframe);
+}
+
+pub fn expiretime(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("expiretime", "EXPIRETIME", "key").call(this, globalObject, callframe);
+}
+
+pub fn getdel(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("getdel", "GETDEL", "key").call(this, globalObject, callframe);
+}
+
+pub fn getex(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("getex", "GETEX", "key").call(this, globalObject, callframe);
+}
+
+pub fn hgetall(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("hgetall", "HGETALL", "key").call(this, globalObject, callframe);
+}
+
+pub fn hkeys(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("hkeys", "HKEYS", "key").call(this, globalObject, callframe);
+}
+
+pub fn hlen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("hlen", "HLEN", "key").call(this, globalObject, callframe);
+}
+
+pub fn hvals(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("hvals", "HVALS", "key").call(this, globalObject, callframe);
+}
+
+pub fn keys(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("keys", "KEYS", "key").call(this, globalObject, callframe);
+}
+
+pub fn llen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("llen", "LLEN", "key").call(this, globalObject, callframe);
+}
+
+pub fn lpop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("lpop", "LPOP", "key").call(this, globalObject, callframe);
+}
+
+pub fn persist(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("persist", "PERSIST", "key").call(this, globalObject, callframe);
+}
+
+pub fn pexpiretime(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("pexpiretime", "PEXPIRETIME", "key").call(this, globalObject, callframe);
+}
+
+pub fn pttl(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("pttl", "PTTL", "key").call(this, globalObject, callframe);
+}
+
+pub fn rpop(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("rpop", "RPOP", "key").call(this, globalObject, callframe);
+}
+
+pub fn scard(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("scard", "SCARD", "key").call(this, globalObject, callframe);
+}
+
+pub fn strlen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("strlen", "STRLEN", "key").call(this, globalObject, callframe);
+}
+
+pub fn @"type"(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("type", "TYPE", "key").call(this, globalObject, callframe);
+}
+
+pub fn zcard(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("zcard", "ZCARD", "key").call(this, globalObject, callframe);
+}
+
+pub fn zpopmax(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("zpopmax", "ZPOPMAX", "key").call(this, globalObject, callframe);
+}
+
+pub fn zpopmin(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("zpopmin", "ZPOPMIN", "key").call(this, globalObject, callframe);
+}
+
+pub fn zrandmember(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey)"("zrandmember", "ZRANDMEMBER", "key").call(this, globalObject, callframe);
+}
+
+pub fn append(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue)"("append", "APPEND", "key", "value").call(this, globalObject, callframe);
+}
+pub fn getset(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue)"("getset", "GETSET", "key", "value").call(this, globalObject, callframe);
+}
+pub fn lpush(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("lpush", "LPUSH").call(this, globalObject, callframe);
+}
+pub fn lpushx(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("lpushx", "LPUSHX").call(this, globalObject, callframe);
+}
+pub fn pfadd(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue)"("pfadd", "PFADD", "key", "value").call(this, globalObject, callframe);
+}
+pub fn rpush(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("rpush", "RPUSH").call(this, globalObject, callframe);
+}
+pub fn rpushx(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue, ...args: RedisValue)"("rpushx", "RPUSHX").call(this, globalObject, callframe);
+}
+pub fn setnx(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue)"("setnx", "SETNX", "key", "value").call(this, globalObject, callframe);
+}
+pub fn zscore(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, value: RedisValue)"("zscore", "ZSCORE", "key", "value").call(this, globalObject, callframe);
+}
+
+pub fn del(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, ...args: RedisKey[])"("del", "DEL", "key").call(this, globalObject, callframe);
+}
+pub fn mget(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(key: RedisKey, ...args: RedisKey[])"("mget", "MGET", "key").call(this, globalObject, callframe);
+}
+
+pub fn script(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("script", "SCRIPT").call(this, globalObject, callframe);
+}
+pub fn select(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("select", "SELECT").call(this, globalObject, callframe);
+}
+pub fn spublish(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("spublish", "SPUBLISH").call(this, globalObject, callframe);
+}
+pub fn smove(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("smove", "SMOVE").call(this, globalObject, callframe);
+}
+pub fn substr(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("substr", "SUBSTR").call(this, globalObject, callframe);
+}
+pub fn hstrlen(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("hstrlen", "HSTRLEN").call(this, globalObject, callframe);
+}
+pub fn zrank(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("zrank", "ZRANK").call(this, globalObject, callframe);
+}
+pub fn zrevrank(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.isSubscriber()) {
+        return globalObject.throw("Cannot use in subscriber mode", .{});
+    }
+    return compile.@"(...strings: string[])"("zrevrank", "ZREVRANK").call(this, globalObject, callframe);
+}
+
+pub fn duplicate(
+    this: *JSValkeyClient,
+    globalObject: *jsc.JSGlobalObject,
+    callframe: *jsc.CallFrame,
+) bun.JSError!JSValue {
+    const args_view = callframe.arguments();
+    if (args_view.len != 0) {
+        return globalObject.throwInvalidArguments("duplicate does not take any arguments", .{});
+    }
+
+    var new_client: *JSValkeyClient = this.cloneWithoutConnecting();
+    var new_client_js = new_client.toJS(globalObject);
+
+    // If the original client is already connected and not manually closed, start connecting the new client.
+    if (this.client.status == .connected and !this.client.flags.is_manually_closed) {
+        new_client.client.flags.connection_promise_returns_client = true;
+        new_client_js.protect();
+        return try new_client.doConnect(globalObject, new_client_js);
+    }
+
+    // Otherwise, we create a dummy promise to yield the unconnected client.
+    const promise = jsc.JSPromise.create(globalObject);
+    promise.resolve(globalObject, new_client_js);
+    return promise.toJS();
+}
+
 pub const psubscribe = compile.@"(...strings: string[])"("psubscribe", "PSUBSCRIBE").call;
-pub const unsubscribe = compile.@"(...strings: string[])"("unsubscribe", "UNSUBSCRIBE").call;
 pub const punsubscribe = compile.@"(...strings: string[])"("punsubscribe", "PUNSUBSCRIBE").call;
 pub const pubsub = compile.@"(...strings: string[])"("pubsub", "PUBSUB").call;
 
-// publish(channel: RedisValue, message: RedisValue)
 // script(subcommand: "LOAD", script: RedisValue)
 // select(index: number | string)
 // spublish(shardchannel: RedisValue, message: RedisValue)

--- a/src/valkey/js_valkey_functions.zig
+++ b/src/valkey/js_valkey_functions.zig
@@ -895,7 +895,6 @@ pub fn unsubscribe(
     return try sendUnsubscribeRequestAndCleanup(this, callframe.this(), globalObject, redis_channels.items);
 }
 
-// Wrapper functions that check subscriber mode before delegating to compile-generated functions
 pub fn bitcount(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     try requireNotSubscriber(this, @src().fn_name);
     return compile.@"(key: RedisKey)"("bitcount", "BITCOUNT", "key").call(this, globalObject, callframe);
@@ -918,7 +917,7 @@ pub fn getdel(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callfram
 
 pub fn getex(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     try requireNotSubscriber(this, @src().fn_name);
-    return compile.@"(key: RedisKey)"("getex", "GETEX", "key").call(this, globalObject, callframe);
+    return compile.@"(...strings: string[])"("getex", "GETEX").call(this, globalObject, callframe);
 }
 
 pub fn hgetall(this: *JSValkeyClient, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -279,6 +279,7 @@ pub const ValkeyClient = struct {
                     .meta = command.meta,
                     .promise = command.promise,
                 }) catch |err| bun.handleOom(err);
+                this.parent().updateHasPendingActivity();
 
                 total += 1;
                 total_bytelength += command.serialized_data.len;
@@ -289,6 +290,7 @@ pub const ValkeyClient = struct {
         bun.handleOom(this.write_buffer.byte_list.ensureUnusedCapacity(this.allocator, total_bytelength));
         for (pipelineable_commands) |*command| {
             bun.handleOom(this.write_buffer.write(this.allocator, command.serialized_data));
+            this.parent().updateHasPendingActivity();
             // Free the serialized data since we've copied it to the write buffer
             this.allocator.free(command.serialized_data);
         }
@@ -374,6 +376,7 @@ pub const ValkeyClient = struct {
         if (wrote > 0) {
             this.write_buffer.consume(@intCast(wrote));
         }
+        this.parent().updateHasPendingActivity();
         return this.write_buffer.len() > 0;
     }
 
@@ -435,6 +438,7 @@ pub const ValkeyClient = struct {
     pub fn failWithJSValue(this: *ValkeyClient, globalThis: *jsc.JSGlobalObject, jsvalue: jsc.JSValue) void {
         this.status = .failed;
         rejectAllPendingCommands(&this.in_flight, &this.queue, globalThis, this.allocator, jsvalue);
+        this.parent().updateHasPendingActivity();
 
         if (!this.connectionReady()) {
             this.flags.is_manually_closed = true;
@@ -483,6 +487,7 @@ pub const ValkeyClient = struct {
         debug("reconnect in {d}ms (attempt {d}/{d})", .{ delay_ms, this.retry_attempts, this.max_retries });
 
         this.status = .disconnected;
+        this.parent().updateHasPendingActivity();
         this.flags.is_reconnecting = true;
         this.flags.is_authenticated = false;
         this.flags.is_selecting_db_internal = false;
@@ -518,6 +523,8 @@ pub const ValkeyClient = struct {
                 // Without auto pipelining, wait for in-flight to empty before draining
                 _ = this.drain();
             }
+
+            this.parent().updateHasPendingActivity();
         }
 
         _ = this.flushData();
@@ -530,6 +537,7 @@ pub const ValkeyClient = struct {
         // Path 1: Buffer already has data, append and process from buffer
         if (this.read_buffer.remaining().len > 0) {
             this.read_buffer.write(this.allocator, data) catch @panic("failed to write to read buffer");
+            this.parent().updateHasPendingActivity();
 
             // Process as many complete messages from the buffer as possible
             while (true) {
@@ -562,6 +570,7 @@ pub const ValkeyClient = struct {
                 }
 
                 this.read_buffer.consume(@truncate(bytes_consumed));
+                this.parent().updateHasPendingActivity();
 
                 var value_to_handle = value; // Use temp var for defer
                 this.handleResponse(&value_to_handle) catch |err| {
@@ -693,6 +702,7 @@ pub const ValkeyClient = struct {
             .SimpleString => |str| {
                 if (std.mem.eql(u8, str, "OK")) {
                     this.status = .connected;
+                    this.parent().updateHasPendingActivity();
                     this.flags.is_authenticated = true;
                     this.onValkeyConnect(value);
                     return;
@@ -726,6 +736,7 @@ pub const ValkeyClient = struct {
 
                 // Authentication successful via HELLO
                 this.status = .connected;
+                this.parent().updateHasPendingActivity();
                 this.flags.is_authenticated = true;
                 this.onValkeyConnect(value);
                 return;
@@ -953,6 +964,7 @@ pub const ValkeyClient = struct {
             .meta = offline_cmd.meta,
             .promise = offline_cmd.promise,
         }) catch |err| bun.handleOom(err);
+        this.parent().updateHasPendingActivity();
         const data = offline_cmd.serialized_data;
 
         if (this.connectionReady() and this.write_buffer.remaining().len == 0) {
@@ -965,6 +977,7 @@ pub const ValkeyClient = struct {
             if (unwritten.len > 0) {
                 // Handle incomplete write.
                 bun.handleOom(this.write_buffer.write(this.allocator, unwritten));
+                this.parent().updateHasPendingActivity();
             }
 
             return true;
@@ -1029,6 +1042,7 @@ pub const ValkeyClient = struct {
 
         // Add to queue with command type
         try this.in_flight.writeItem(cmd_pair);
+        this.parent().updateHasPendingActivity();
 
         _ = this.flushData();
     }
@@ -1073,6 +1087,7 @@ pub const ValkeyClient = struct {
         this.unregisterAutoFlusher();
         if (this.status == .connected or this.status == .connecting) {
             this.status = .disconnected;
+            this.parent().updateHasPendingActivity();
             this.close();
         }
     }
@@ -1085,6 +1100,7 @@ pub const ValkeyClient = struct {
     /// Write data to the socket buffer
     fn write(this: *ValkeyClient, data: []const u8) !usize {
         try this.write_buffer.write(this.allocator, data);
+        this.parent().updateHasPendingActivity();
         return data.len;
     }
 

--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -3,7 +3,6 @@
 // This file contains the core Valkey client implementation with protocol handling
 
 pub const ValkeyContext = @import("./ValkeyContext.zig");
-const ValkeyCommand = @import("./ValkeyCommand.zig");
 
 /// Connection flags to track Valkey client state
 pub const ConnectionFlags = struct {
@@ -1133,6 +1132,7 @@ pub const ValkeyClient = struct {
 // Auto-pipelining
 const debug = bun.Output.scoped(.Redis, .visible);
 
+const ValkeyCommand = @import("./ValkeyCommand.zig");
 const protocol = @import("./valkey_protocol.zig");
 const std = @import("std");
 

--- a/test/integration/bun-types/fixture/redis.ts
+++ b/test/integration/bun-types/fixture/redis.ts
@@ -1,0 +1,33 @@
+import { expectType } from "./utilities";
+
+expectType(Bun.redis.publish("hello", "world")).is<Promise<number>>();
+
+const copy = await Bun.redis.duplicate();
+expectType(copy.connected).is<boolean>();
+expectType(copy).is<Bun.RedisClient>();
+
+const listener: Bun.RedisClient.StringPubSubListener = (message, channel) => {
+  expectType(message).is<string>();
+  expectType(channel).is<string>();
+};
+
+const bufferListener: Bun.RedisClient.BufferPubSubListener = (message, channel) => {
+  expectType(message).is<Uint8Array<ArrayBuffer>>();
+  expectType(channel).is<string>();
+};
+
+Bun.redis.subscribe("hello", listener);
+
+// @ts-expect-error cannot buffer subscribe without buffer mode (not implemented yet)
+Bun.redis.subscribe("hello", bufferListener);
+
+expectType(
+  copy.subscribe("hello", message => {
+    expectType(message).is<string>();
+  }),
+).is<Promise<number>>();
+
+await copy.unsubscribe();
+await copy.unsubscribe("hello");
+
+expectType(copy.unsubscribe("hello", () => {})).is<Promise<void>>();

--- a/test/integration/bun-types/fixture/redis.ts
+++ b/test/integration/bun-types/fixture/redis.ts
@@ -10,16 +10,14 @@ const listener: Bun.RedisClient.StringPubSubListener = (message, channel) => {
   expectType(message).is<string>();
   expectType(channel).is<string>();
 };
-
-const bufferListener: Bun.RedisClient.BufferPubSubListener = (message, channel) => {
-  expectType(message).is<Uint8Array<ArrayBuffer>>();
-  expectType(channel).is<string>();
-};
-
 Bun.redis.subscribe("hello", listener);
 
-// @ts-expect-error cannot buffer subscribe without buffer mode (not implemented yet)
-Bun.redis.subscribe("hello", bufferListener);
+// Buffer subscriptions are not yet implemented
+// const bufferListener: Bun.RedisClient.BufferPubSubListener = (message, channel) => {
+//   expectType(message).is<Uint8Array<ArrayBuffer>>();
+//   expectType(channel).is<string>();
+// };
+// Bun.redis.subscribe("hello", bufferListener);
 
 expectType(
   copy.subscribe("hello", message => {

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -455,9 +455,10 @@ import { tmpdir } from "os";
  * Create a new client with specific connection type
  */
 export function createClient(
-    connectionType: ConnectionType = ConnectionType.TCP,
-    customOptions = {},
-    dbId: number | undefined = undefined,
+  connectionType: ConnectionType = ConnectionType.TCP,
+  hostUrl: string | undefined = undefined,
+  customOptions = {},
+  dbId: number | undefined = undefined,
 ) {
   let url: string;
   const mkUrl = (baseUrl: string) => dbId ? `${baseUrl}/${dbId}`: baseUrl;
@@ -467,42 +468,42 @@ export function createClient(
 
   switch (connectionType) {
     case ConnectionType.TCP:
-      url = mkUrl(DEFAULT_REDIS_URL);
+      url = hostUrl || mkUrl(DEFAULT_REDIS_URL);
       options = {
         ...DEFAULT_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.TLS:
-      url = mkUrl(TLS_REDIS_URL);
+      url = hostUrl || mkUrl(TLS_REDIS_URL);
       options = {
         ...TLS_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.UNIX:
-      url = mkUrl(UNIX_REDIS_URL);
+      url = hostUrl || mkUrl(UNIX_REDIS_URL);
       options = {
         ...UNIX_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.AUTH:
-      url = mkUrl(AUTH_REDIS_URL);
+      url = hostUrl || mkUrl(AUTH_REDIS_URL);
       options = {
         ...AUTH_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.READONLY:
-      url = mkUrl(READONLY_REDIS_URL);
+      url = hostUrl || mkUrl(READONLY_REDIS_URL);
       options = {
         ...READONLY_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.WRITEONLY:
-      url = mkUrl(WRITEONLY_REDIS_URL);
+      url = hostUrl || mkUrl(WRITEONLY_REDIS_URL);
       options = {
         ...WRITEONLY_REDIS_OPTIONS,
         ...customOptions,

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -765,6 +765,14 @@ async function getRedisContainerName(): Promise<string> {
 
 /**
  * Restart the Redis container to simulate connection drop
+ *
+ * Restarts the container identified by the test harness and waits briefly for it
+ * to come back online (approximately 2 seconds). Use this to simulate a server
+ * restart or connection drop during tests.
+ *
+ * @returns A promise that resolves when the restart and short wait complete.
+ * @throws If the Docker restart command exits with a non-zero code; the error
+ *         message includes the container's stderr output.
  */
 export async function restartRedisContainer(): Promise<void> {
   const containerName = await getRedisContainerName();
@@ -788,4 +796,11 @@ export async function restartRedisContainer(): Promise<void> {
   await delay(2000);
 
   console.log(`Redis container restarted: ${containerName}`);
+}
+
+/**
+ * @returns true or false with approximately equal probability
+ */
+export function randomCoinFlip(): boolean {
+  return Math.floor(Math.random() * 2) == 0;
 }

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -456,7 +456,6 @@ import { tmpdir } from "os";
  */
 export function createClient(
   connectionType: ConnectionType = ConnectionType.TCP,
-  hostUrl: string | undefined = undefined,
   customOptions = {},
   dbId: number | undefined = undefined,
 ) {
@@ -468,42 +467,42 @@ export function createClient(
 
   switch (connectionType) {
     case ConnectionType.TCP:
-      url = hostUrl || mkUrl(DEFAULT_REDIS_URL);
+      url = mkUrl(DEFAULT_REDIS_URL);
       options = {
         ...DEFAULT_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.TLS:
-      url = hostUrl || mkUrl(TLS_REDIS_URL);
+      url = mkUrl(TLS_REDIS_URL);
       options = {
         ...TLS_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.UNIX:
-      url = hostUrl || mkUrl(UNIX_REDIS_URL);
+      url = mkUrl(UNIX_REDIS_URL);
       options = {
         ...UNIX_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.AUTH:
-      url = hostUrl || mkUrl(AUTH_REDIS_URL);
+      url = mkUrl(AUTH_REDIS_URL);
       options = {
         ...AUTH_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.READONLY:
-      url = hostUrl || mkUrl(READONLY_REDIS_URL);
+      url = mkUrl(READONLY_REDIS_URL);
       options = {
         ...READONLY_REDIS_OPTIONS,
         ...customOptions,
       };
       break;
     case ConnectionType.WRITEONLY:
-      url = hostUrl || mkUrl(WRITEONLY_REDIS_URL);
+      url = mkUrl(WRITEONLY_REDIS_URL);
       options = {
         ...WRITEONLY_REDIS_OPTIONS,
         ...customOptions,

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,5 +1,5 @@
 import { randomUUIDv7, RedisClient, sleep } from "bun";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   ConnectionType,
   createClient,
@@ -244,7 +244,9 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
 
       await redis.subscribe(testChannel, () => {});
 
-      expect(() => redis.set(testKey, testValue)).toThrow("RedisClient.prototype.set cannot be called while in subscriber mode");
+      expect(() => redis.set(testKey, testValue)).toThrow(
+        "RedisClient.prototype.set cannot be called while in subscriber mode",
+      );
 
       // Clean up subscription
       await redis.unsubscribe(testChannel);
@@ -503,7 +505,9 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
       await redis.subscribe(channel, () => {});
 
       // Should fail in subscription mode
-      expect(() => redis.set(testKey, testValue)).toThrow("RedisClient.prototype.set cannot be called while in subscriber mode.");
+      expect(() => redis.set(testKey, testValue)).toThrow(
+        "RedisClient.prototype.set cannot be called while in subscriber mode.",
+      );
 
       // Unsubscribe from all channels
       await redis.unsubscribe(channel);

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -2,14 +2,13 @@ import { randomUUIDv7, RedisClient, sleep } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
   ConnectionType,
-  DEFAULT_REDIS_URL,
   createClient,
   ctx,
+  DEFAULT_REDIS_URL,
   expectType,
   isEnabled,
   randomCoinFlip,
 } from "./test-utils";
-import {c} from "cli/run/cjs-defineProperty-fixture.cjs";
 
 describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
   beforeEach(async () => {
@@ -572,11 +571,15 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
       const subscriber = await connectedRedis();
 
       let messageCount1 = 0;
-      const listener1 = () => { messageCount1++; };
+      const listener1 = () => {
+        messageCount1++;
+      };
       await subscriber.subscribe(channel, listener1);
 
       let messageCount2 = 0;
-      const listener2 = () => { messageCount2++; };
+      const listener2 = () => {
+        messageCount2++;
+      };
       await subscriber.subscribe(channel, listener2);
 
       await redis.publish(channel, "message1");
@@ -670,7 +673,6 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
 
       duplicate.close?.();
     });
-
 
     test("should allow duplicate to work independently from original", async () => {
       const redis = new RedisClient(DEFAULT_REDIS_URL);

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -4,21 +4,23 @@ import {
   ConnectionType,
   createClient,
   ctx,
-  DEFAULT_REDIS_URL,
+  //DEFAULT_REDIS_URL,
   expectType,
   isEnabled,
   randomCoinFlip,
 } from "./test-utils";
 
 describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
-  beforeEach(async () => {
-    if (ctx.redis?.connected) {
-      ctx.redis.close?.();
-    }
-    ctx.redis = createClient(ConnectionType.TCP);
+  //beforeEach(async () => {
+  //  if (ctx.redis?.connected) {
+  //    ctx.redis.close?.();
+  //  }
+  //  ctx.redis = createClient(ConnectionType.TCP);
 
-    await ctx.redis.send("FLUSHALL", ["SYNC"]);
-  });
+  //  await ctx.redis.send("FLUSHALL", ["SYNC"]);
+  //});
+
+  const DEFAULT_REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
 
   const connectedRedis = async () => {
     const redis = new RedisClient(DEFAULT_REDIS_URL);
@@ -242,7 +244,7 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
 
       await redis.subscribe(testChannel, () => {});
 
-      expect(() => redis.set(testKey, testValue)).toThrow("RedisClient.set cannot be called while in subscriber mode");
+      expect(() => redis.set(testKey, testValue)).toThrow("RedisClient.prototype.set cannot be called while in subscriber mode");
 
       // Clean up subscription
       await redis.unsubscribe(testChannel);
@@ -501,7 +503,7 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
       await redis.subscribe(channel, () => {});
 
       // Should fail in subscription mode
-      expect(() => redis.set(testKey, testValue)).toThrow("RedisClient.set cannot be called while in subscriber mode.");
+      expect(() => redis.set(testKey, testValue)).toThrow("RedisClient.prototype.set cannot be called while in subscriber mode.");
 
       // Unsubscribe from all channels
       await redis.unsubscribe(channel);
@@ -527,7 +529,7 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
       const channel = "never-subscribed-channel";
 
       expect(() => redis.unsubscribe(channel)).toThrow(
-        "RedisClient.unsubscribe can only be called while in subscriber mode.",
+        "RedisClient.prototype.unsubscribe can only be called while in subscriber mode.",
       );
     });
 

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,6 +1,15 @@
-import { randomUUIDv7, RedisClient } from "bun";
+import { randomUUIDv7, RedisClient, sleep } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
-import { ConnectionType, createClient, ctx, DEFAULT_REDIS_URL, expectType, isEnabled } from "./test-utils";
+import {
+  ConnectionType,
+  DEFAULT_REDIS_URL,
+  createClient,
+  ctx,
+  expectType,
+  isEnabled,
+  randomCoinFlip,
+} from "./test-utils";
+import {c} from "cli/run/cjs-defineProperty-fixture.cjs";
 
 describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
   beforeEach(async () => {
@@ -11,6 +20,12 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
 
     await ctx.redis.send("FLUSHALL", ["SYNC"]);
   });
+
+  const connectedRedis = async () => {
+    const redis = new RedisClient("redis://localhost:6379");
+    await redis.connect();
+    return redis;
+  };
 
   describe("Basic Operations", () => {
     test("should set and get strings", async () => {
@@ -207,6 +222,568 @@ describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
 
       const valueAfterStop = await ctx.redis.get(TEST_KEY);
       expect(valueAfterStop).toBe(TEST_VALUE);
+    });
+  });
+
+  describe("PUB/SUB", () => {
+    const testChannel = "test-channel";
+    const testKey = "test-key";
+    const testValue = "test-value";
+    const testMessage = "test-message";
+    const flushTimeoutMs = 300;
+
+    test("publishing to a channel does not fail", async () => {
+      const redis = await connectedRedis();
+      // no subs
+      expect(await redis.publish(testChannel, testMessage)).toBe(0);
+    });
+
+    test("setting in subscriber mode gracefully fails", async () => {
+      const redis = await connectedRedis();
+
+      await redis.subscribe(testChannel, () => {});
+
+      expect(() => redis.set(testKey, testValue)).toThrow("Cannot use in subscriber mode");
+
+      // Clean up subscription
+      await redis.unsubscribe(testChannel);
+    });
+
+    test("setting after unsubscribing works", async () => {
+      const redis = await connectedRedis();
+
+      await redis.subscribe(testChannel, () => {});
+      await redis.unsubscribe(testChannel);
+
+      expect(redis.set(testKey, testValue)).resolves.toEqual("OK");
+    });
+
+    test("subscribing to a channel receives messages", async () => {
+      const TEST_MESSAGE_COUNT = 128;
+      const redis = await connectedRedis();
+      const subscriber = await connectedRedis();
+
+      var receiveCount = 0;
+      await subscriber.subscribe(testChannel, (message, channel) => {
+        receiveCount++;
+        expect(channel).toBe(testChannel);
+        expect(message).toBe(testMessage);
+      });
+
+      Array.from({ length: TEST_MESSAGE_COUNT }).forEach(async () => {
+        expect(await redis.publish(testChannel, testMessage)).toBe(1);
+      });
+
+      // Wait a little bit just to ensure all the messages are flushed.
+      await sleep(flushTimeoutMs);
+
+      expect(receiveCount).toBe(TEST_MESSAGE_COUNT);
+
+      await subscriber.unsubscribe(testChannel);
+    });
+
+    test("messages are received in order", async () => {
+      const TEST_MESSAGE_COUNT = 1024;
+      const redis = await connectedRedis();
+      const subscriber = await connectedRedis();
+
+      var receivedMessages: string[] = [];
+      await subscriber.subscribe(testChannel, message => {
+        receivedMessages.push(message);
+      });
+
+      var sentMessages: string[] = [];
+      Array.from({ length: TEST_MESSAGE_COUNT }).forEach(async () => {
+        const message = randomUUIDv7();
+        expect(await redis.publish(testChannel, message)).toBe(1);
+        sentMessages.push(message);
+      });
+
+      // Wait a little bit just to ensure all the messages are flushed.
+      await sleep(flushTimeoutMs);
+
+      expect(receivedMessages.length).toBe(sentMessages.length);
+      expect(receivedMessages).toEqual(sentMessages);
+
+      await subscriber.unsubscribe(testChannel);
+    });
+
+    test("subscribing to multiple channels receives messages", async () => {
+      const TEST_MESSAGE_COUNT = 128;
+      const redis = await connectedRedis();
+      const subscriber = await connectedRedis();
+
+      const channels = [testChannel, "another-test-channel"];
+
+      var receivedMessages: { [channel: string]: string[] } = {};
+      await subscriber.subscribe(channels, (message, channel) => {
+        receivedMessages[channel] = receivedMessages[channel] || [];
+        receivedMessages[channel].push(message);
+      });
+
+      var sentMessages: { [channel: string]: string[] } = {};
+      for (let i = 0; i < TEST_MESSAGE_COUNT; i++) {
+        const channel = channels[randomCoinFlip() ? 0 : 1];
+        const message = randomUUIDv7();
+
+        expect(await redis.publish(channel, message)).toBe(1);
+
+        sentMessages[channel] = sentMessages[channel] || [];
+        sentMessages[channel].push(message);
+      }
+
+      // Wait a little bit just to ensure all the messages are flushed.
+      await sleep(flushTimeoutMs);
+
+      // Check that we received messages on both channels
+      expect(Object.keys(receivedMessages).sort()).toEqual(Object.keys(sentMessages).sort());
+
+      // Check messages match for each channel
+      for (const channel of channels) {
+        if (sentMessages[channel]) {
+          expect(receivedMessages[channel]).toEqual(sentMessages[channel]);
+        }
+      }
+
+      await subscriber.unsubscribe(channels);
+    });
+
+    test("unsubscribing from specific channels while remaining subscribed to others", async () => {
+      const channel1 = "channel-1";
+      const channel2 = "channel-2";
+      const channel3 = "channel-3";
+
+      const redis = await connectedRedis();
+      const subscriber = await connectedRedis();
+
+      let receivedMessages: { [channel: string]: string[] } = {};
+
+      // Subscribe to three channels
+      await subscriber.subscribe([channel1, channel2, channel3], (message, channel) => {
+        receivedMessages[channel] = receivedMessages[channel] || [];
+        receivedMessages[channel].push(message);
+      });
+
+      // Send initial messages to all channels
+      expect(await redis.publish(channel1, "msg1-before")).toBe(1);
+      expect(await redis.publish(channel2, "msg2-before")).toBe(1);
+      expect(await redis.publish(channel3, "msg3-before")).toBe(1);
+
+      await sleep(flushTimeoutMs);
+
+      // Unsubscribe from channel2
+      await subscriber.unsubscribe(channel2);
+
+      // Send messages after unsubscribing from channel2
+      expect(await redis.publish(channel1, "msg1-after")).toBe(1);
+      expect(await redis.publish(channel2, "msg2-after")).toBe(0);
+      expect(await redis.publish(channel3, "msg3-after")).toBe(1);
+
+      await sleep(flushTimeoutMs);
+
+      // Check we received messages only on subscribed channels
+      expect(receivedMessages[channel1]).toEqual(["msg1-before", "msg1-after"]);
+      expect(receivedMessages[channel2]).toEqual(["msg2-before"]); // No "msg2-after"
+      expect(receivedMessages[channel3]).toEqual(["msg3-before", "msg3-after"]);
+
+      await subscriber.unsubscribe([channel1, channel3]);
+    });
+
+    test("subscribing to the same channel multiple times", async () => {
+      const redis = await connectedRedis();
+      const subscriber = await connectedRedis();
+      const channel = "duplicate-channel";
+
+      let callCount = 0;
+      const listener = () => {
+        callCount++;
+      };
+
+      let callCount2 = 0;
+      const listener2 = () => {
+        callCount2++;
+      };
+
+      // Subscribe to the same channel twice
+      await subscriber.subscribe(channel, listener);
+      await subscriber.subscribe(channel, listener2);
+
+      // Publish a single message
+      expect(await redis.publish(channel, "test-message")).toBe(1);
+
+      await sleep(flushTimeoutMs);
+
+      // Both listeners should have been called once.
+      expect(callCount).toBe(1);
+      expect(callCount2).toBe(1);
+
+      await subscriber.unsubscribe(channel);
+    });
+
+    test("empty string messages", async () => {
+      const redis = await connectedRedis();
+      const channel = "empty-message-channel";
+      const subscriber = await connectedRedis();
+
+      let receivedMessage: string | undefined = undefined;
+      await subscriber.subscribe(channel, message => {
+        receivedMessage = message;
+      });
+
+      expect(await redis.publish(channel, "")).toBe(1);
+      await sleep(flushTimeoutMs);
+
+      expect(receivedMessage).not.toBeUndefined();
+      expect(receivedMessage!).toBe("");
+
+      await subscriber.unsubscribe(channel);
+    });
+
+    test("special characters in channel names", async () => {
+      const redis = await connectedRedis();
+      const subscriber = await connectedRedis();
+
+      const specialChannels = [
+        "channel:with:colons",
+        "channel with spaces",
+        "channel-with-unicode-😀",
+        "channel[with]brackets",
+        "channel@with#special$chars",
+      ];
+
+      for (const channel of specialChannels) {
+        let received = false;
+        await subscriber.subscribe(channel, () => {
+          received = true;
+        });
+
+        expect(await redis.publish(channel, "test")).toBe(1);
+        await sleep(flushTimeoutMs);
+
+        expect(received).toBe(true);
+        await subscriber.unsubscribe(channel);
+      }
+    });
+
+    test("ping works in subscription mode", async () => {
+      const redis = await connectedRedis();
+      const channel = "ping-test-channel";
+
+      await redis.subscribe(channel, () => {});
+
+      // Ping should work in subscription mode
+      const pong = await redis.ping();
+      expect(pong).toBe("PONG");
+
+      const customPing = await redis.ping("hello");
+      expect(customPing).toBe("hello");
+
+      await redis.unsubscribe(channel);
+    });
+
+    test("publish does not work from a subscribed client", async () => {
+      const redis = await connectedRedis();
+      const channel = "self-publish-channel";
+
+      await redis.subscribe(channel, () => {});
+
+      // Publishing from the same client should work
+      expect(async () => redis.publish(channel, "self-published")).toThrow();
+      await sleep(flushTimeoutMs);
+
+      await redis.unsubscribe(channel);
+    });
+
+    test("complete unsubscribe restores normal command mode", async () => {
+      const redis = await connectedRedis();
+      const channel = "restore-test-channel";
+      const testKey = "restore-test-key";
+
+      await redis.subscribe(channel, () => {});
+
+      // Should fail in subscription mode
+      expect(() => redis.set(testKey, testValue)).toThrow("Cannot use in subscriber mode");
+
+      // Unsubscribe from all channels
+      await redis.unsubscribe(channel);
+
+      // Should work after unsubscribing
+      const result = await redis.set(testKey, "value");
+      expect(result).toBe("OK");
+
+      const value = await redis.get(testKey);
+      expect(value).toBe("value");
+    });
+
+    test("publishing without subscribers succeeds", async () => {
+      const redis = await connectedRedis();
+      const channel = "no-subscribers-channel";
+
+      // Publishing without subscribers should not throw
+      expect(await redis.publish(channel, "message")).toBe(0);
+    });
+
+    test("unsubscribing from non-subscribed channels", async () => {
+      const redis = await connectedRedis();
+      const channel = "never-subscribed-channel";
+
+      expect(() => redis.unsubscribe(channel)).toThrow("Not in subscription mode");
+    });
+
+    test("callback errors don't crash the client", async () => {
+      const redis = await connectedRedis();
+      const channel = "error-callback-channel";
+
+      const subscriber = await connectedRedis();
+
+      let messageCount = 0;
+      await subscriber.subscribe(channel, () => {
+        messageCount++;
+        if (messageCount === 2) {
+          throw new Error("Intentional callback error");
+        }
+      });
+
+      // Send multiple messages
+      expect(await redis.publish(channel, "message1")).toBe(1);
+      expect(await redis.publish(channel, "message2")).toBe(1);
+      expect(await redis.publish(channel, "message3")).toBe(1);
+
+      await sleep(flushTimeoutMs);
+
+      expect(messageCount).toBe(3);
+
+      await subscriber.unsubscribe(channel);
+    });
+
+    test("subscriptions return correct counts", async () => {
+      const subscriber = await connectedRedis();
+
+      expect(await subscriber.subscribe("chan1", () => {})).toBe(1);
+      expect(await subscriber.subscribe("chan2", () => {})).toBe(2);
+
+      await subscriber.unsubscribe();
+    });
+
+    test("unsubscribing from listeners", async () => {
+      const redis = await connectedRedis();
+      const channel = "error-callback-channel";
+
+      const subscriber = await connectedRedis();
+
+      let messageCount1 = 0;
+      const listener1 = () => { messageCount1++; };
+      await subscriber.subscribe(channel, listener1);
+
+      let messageCount2 = 0;
+      const listener2 = () => { messageCount2++; };
+      await subscriber.subscribe(channel, listener2);
+
+      await redis.publish(channel, "message1");
+
+      await sleep(flushTimeoutMs);
+
+      expect(messageCount1).toBe(1);
+      expect(messageCount2).toBe(1);
+
+      await subscriber.unsubscribe(channel, listener2);
+
+      await redis.publish(channel, "message1");
+
+      await sleep(flushTimeoutMs);
+
+      expect(messageCount1).toBe(2);
+      expect(messageCount2).toBe(1);
+
+      await subscriber.unsubscribe();
+
+      await redis.publish(channel, "message1");
+
+      await sleep(flushTimeoutMs);
+
+      expect(messageCount1).toBe(2);
+      expect(messageCount2).toBe(1);
+    });
+  });
+
+  describe("duplicate()", () => {
+    test("should create duplicate of unconnected client that remains unconnected", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+      expect(redis.connected).toBe(false);
+
+      const duplicate = await redis.duplicate();
+      expect(duplicate.connected).toBe(false);
+      expect(duplicate).not.toBe(redis);
+    });
+
+    test("should create duplicate of connected client that gets connected", async () => {
+      const redis = await connectedRedis();
+
+      const duplicate = await redis.duplicate();
+
+      expect(duplicate.connected).toBe(true);
+      expect(duplicate).not.toBe(redis);
+
+      // Both should work independently
+      await redis.set("test-original", "original-value");
+      await duplicate.set("test-duplicate", "duplicate-value");
+
+      expect(await redis.get("test-duplicate")).toBe("duplicate-value");
+      expect(await duplicate.get("test-original")).toBe("original-value");
+
+      duplicate.close();
+    });
+
+    test("should create duplicate of manually closed client that remains closed", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+      await redis.connect();
+      redis.close?.();
+      expect(redis.connected).toBe(false);
+
+      const duplicate = await redis.duplicate();
+      expect(duplicate.connected).toBe(false);
+    });
+
+    test("should reject when duplicate() is called with arguments", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+
+      expect(() => {
+        // @ts-expect-error - Testing invalid usage
+        redis.duplicate("invalid-arg");
+      }).toThrow("duplicate does not take any arguments");
+    });
+
+    test("should preserve connection configuration in duplicate", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+      await redis.connect();
+
+      const duplicate = await redis.duplicate();
+
+      // Both clients should be able to perform the same operations
+      const testKey = `duplicate-config-test-${randomUUIDv7().substring(0, 8)}`;
+      const testValue = "test-value";
+
+      await redis.set(testKey, testValue);
+      const retrievedValue = await duplicate.get(testKey);
+
+      expect(retrievedValue).toBe(testValue);
+
+      duplicate.close?.();
+    });
+
+
+    test("should allow duplicate to work independently from original", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+      await redis.connect();
+
+      const duplicate = await redis.duplicate();
+
+      // Close original, duplicate should still work
+      redis.close?.();
+
+      const testKey = `independent-test-${randomUUIDv7().substring(0, 8)}`;
+      const testValue = "independent-value";
+
+      await duplicate.set(testKey, testValue);
+      const retrievedValue = await duplicate.get(testKey);
+
+      expect(retrievedValue).toBe(testValue);
+
+      duplicate.close?.();
+    });
+
+    test("should handle duplicate of client in subscriber mode", async () => {
+      const redis = await connectedRedis();
+      const testChannel = "test-subscriber-duplicate";
+
+      // Put original client in subscriber mode
+      await redis.subscribe(testChannel, () => {});
+
+      const duplicate = await redis.duplicate();
+
+      // Duplicate should not be in subscriber mode
+      expect(() => duplicate.set("test-key", "test-value")).not.toThrow();
+
+      await redis.unsubscribe(testChannel);
+      duplicate.close?.();
+    });
+
+    test("should create multiple duplicates from same client", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+      await redis.connect();
+
+      const duplicate1 = await redis.duplicate();
+      const duplicate2 = await redis.duplicate();
+      const duplicate3 = await redis.duplicate();
+
+      // All should be connected
+      expect(duplicate1.connected).toBe(true);
+      expect(duplicate2.connected).toBe(true);
+      expect(duplicate3.connected).toBe(true);
+
+      // All should work independently
+      const testKey = `multi-duplicate-test-${randomUUIDv7().substring(0, 8)}`;
+      await duplicate1.set(`${testKey}-1`, "value-1");
+      await duplicate2.set(`${testKey}-2`, "value-2");
+      await duplicate3.set(`${testKey}-3`, "value-3");
+
+      expect(await duplicate1.get(`${testKey}-1`)).toBe("value-1");
+      expect(await duplicate2.get(`${testKey}-2`)).toBe("value-2");
+      expect(await duplicate3.get(`${testKey}-3`)).toBe("value-3");
+
+      // Cross-check: each duplicate can read what others wrote
+      expect(await duplicate1.get(`${testKey}-2`)).toBe("value-2");
+      expect(await duplicate2.get(`${testKey}-3`)).toBe("value-3");
+      expect(await duplicate3.get(`${testKey}-1`)).toBe("value-1");
+
+      duplicate1.close?.();
+      duplicate2.close?.();
+      duplicate3.close?.();
+      redis.close?.();
+    });
+
+    test("should duplicate client that failed to connect", async () => {
+      // Create client with invalid credentials to force connection failure
+      const url = new URL(DEFAULT_REDIS_URL);
+      url.username = "invaliduser";
+      url.password = "invalidpassword";
+      const failedRedis = new RedisClient(url.toString());
+
+      // Try to connect and expect it to fail
+      let connectionFailed = false;
+      try {
+        await failedRedis.connect();
+      } catch {
+        connectionFailed = true;
+      }
+
+      expect(connectionFailed).toBe(true);
+      expect(failedRedis.connected).toBe(false);
+
+      // Duplicate should also remain unconnected
+      const duplicate = await failedRedis.duplicate();
+      expect(duplicate.connected).toBe(false);
+    });
+
+    test("should handle duplicate timing with concurrent operations", async () => {
+      const redis = new RedisClient(DEFAULT_REDIS_URL);
+      await redis.connect();
+
+      // Start some operations on the original client
+      const testKey = `concurrent-test-${randomUUIDv7().substring(0, 8)}`;
+      const originalOperation = redis.set(testKey, "original-value");
+
+      // Create duplicate while operation is in flight
+      const duplicate = await redis.duplicate();
+
+      // Wait for original operation to complete
+      await originalOperation;
+
+      // Duplicate should be able to read the value
+      expect(await duplicate.get(testKey)).toBe("original-value");
+
+      duplicate.close?.();
+      redis.close?.();
     });
   });
 });

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -2,9 +2,9 @@ import { randomUUIDv7, RedisClient, sleep } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
   ConnectionType,
-  DEFAULT_REDIS_URL,
   createClient,
   ctx,
+  DEFAULT_REDIS_URL,
   expectType,
   isEnabled,
   randomCoinFlip,

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -4,23 +4,21 @@ import {
   ConnectionType,
   createClient,
   ctx,
-  //DEFAULT_REDIS_URL,
+  DEFAULT_REDIS_URL,
   expectType,
   isEnabled,
   randomCoinFlip,
 } from "./test-utils";
 
 describe.skipIf(!isEnabled)("Valkey Redis Client", () => {
-  //beforeEach(async () => {
-  //  if (ctx.redis?.connected) {
-  //    ctx.redis.close?.();
-  //  }
-  //  ctx.redis = createClient(ConnectionType.TCP);
+  beforeEach(async () => {
+    if (ctx.redis?.connected) {
+      ctx.redis.close?.();
+    }
+    ctx.redis = createClient(ConnectionType.TCP);
 
-  //  await ctx.redis.send("FLUSHALL", ["SYNC"]);
-  //});
-
-  const DEFAULT_REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+    await ctx.redis.send("FLUSHALL", ["SYNC"]);
+  });
 
   const connectedRedis = async () => {
     const redis = new RedisClient(DEFAULT_REDIS_URL);

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,10 +1,10 @@
 import { randomUUIDv7, RedisClient, sleep } from "bun";
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import {
   ConnectionType,
+  DEFAULT_REDIS_URL,
   createClient,
   ctx,
-  DEFAULT_REDIS_URL,
   expectType,
   isEnabled,
   randomCoinFlip,


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to introduce PUB/SUB functionality to the built-in Redis client. Based on the fact that the current Redis API does not appear to have compatibility with `io-redis` or `redis-node`, I've decided to do away with existing APIs and API compatibility with these existing libraries.

I have decided to base my implementation on the [`redis-node` pub/sub API](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md).



### How did you verify your code works?

I've written a set of unit tests to hopefully catch the major use-cases of this feature. They all appear to pass:

<img width="368" height="71" alt="image" src="https://github.com/user-attachments/assets/36527386-c8fe-47f6-b69a-a11d4b614fa0" />


#### Future Improvements

I would have a lot more confidence in our Redis implementation if we tested it with a test suite running over a network which emulates a high network failure rate. There are large amounts of edge cases that are worthwhile to grab, but I think we can roll that out in a future PR.

### Future Tasks

- [ ] Tests over flaky network
- [ ] Use the custom private members over `_<member>`.