### PR TITLE
Reduce false negatives in `ban-words.test.ts` for undefined struct fields

### DIFF
--- a/scripts/github-metrics.ts
+++ b/scripts/github-metrics.ts
@@ -41,10 +41,11 @@ async function getReleaseInfo(tag: string): Promise<ReleaseInfo> {
  */
 async function countCompletedIssues(sinceDate: string): Promise<{ count: number; issues: number[] }> {
   try {
-    const result = await $`gh issue list --state closed --search "closed:>=${sinceDate} reason:completed" --limit 1000 --json number,closedAt,stateReason`.json() as Issue[];
-    
+    const result =
+      (await $`gh issue list --state closed --search "closed:>=${sinceDate} reason:completed" --limit 1000 --json number,closedAt,stateReason`.json()) as Issue[];
+
     const completedIssues = result.filter(issue => issue.stateReason === "COMPLETED");
-    
+
     return {
       count: completedIssues.length,
       issues: completedIssues.map(issue => issue.number),
@@ -59,7 +60,7 @@ async function countCompletedIssues(sinceDate: string): Promise<{ count: number;
  */
 async function getIssueReactions(issueNumber: number): Promise<number> {
   try {
-    const reactions = await $`gh api "repos/oven-sh/bun/issues/${issueNumber}/reactions"`.json() as Reaction[];
+    const reactions = (await $`gh api "repos/oven-sh/bun/issues/${issueNumber}/reactions"`.json()) as Reaction[];
     return reactions.filter(r => ["+1", "heart", "hooray", "rocket"].includes(r.content)).length;
   } catch {
     return 0;
@@ -71,18 +72,19 @@ async function getIssueReactions(issueNumber: number): Promise<number> {
  */
 async function getCommentReactions(issueNumber: number): Promise<number> {
   try {
-    const comments = await $`gh api "repos/oven-sh/bun/issues/${issueNumber}/comments"`.json() as Comment[];
-    
+    const comments = (await $`gh api "repos/oven-sh/bun/issues/${issueNumber}/comments"`.json()) as Comment[];
+
     let totalReactions = 0;
     for (const comment of comments) {
       try {
-        const reactions = await $`gh api "repos/oven-sh/bun/issues/comments/${comment.id}/reactions"`.json() as Reaction[];
+        const reactions =
+          (await $`gh api "repos/oven-sh/bun/issues/comments/${comment.id}/reactions"`.json()) as Reaction[];
         totalReactions += reactions.filter(r => ["+1", "heart", "hooray", "rocket"].includes(r.content)).length;
       } catch {
         // Skip if we can't get reactions for this comment
       }
     }
-    
+
     return totalReactions;
   } catch {
     return 0;
@@ -94,28 +96,30 @@ async function getCommentReactions(issueNumber: number): Promise<number> {
  */
 async function countReactions(issueNumbers: number[], verbose = false): Promise<number> {
   let totalReactions = 0;
-  
+
   for (const issueNumber of issueNumbers) {
     if (verbose) {
       console.log(`Processing issue #${issueNumber}...`);
     }
-    
+
     const [issueReactions, commentReactions] = await Promise.all([
       getIssueReactions(issueNumber),
       getCommentReactions(issueNumber),
     ]);
-    
+
     const issueTotal = issueReactions + commentReactions;
     totalReactions += issueTotal;
-    
+
     if (verbose && issueTotal > 0) {
-      console.log(`  Issue #${issueNumber}: ${issueReactions} issue + ${commentReactions} comment = ${issueTotal} total`);
+      console.log(
+        `  Issue #${issueNumber}: ${issueReactions} issue + ${commentReactions} comment = ${issueTotal} total`,
+      );
     }
-    
+
     // Small delay to avoid rate limiting
     await Bun.sleep(50);
   }
-  
+
   return totalReactions;
 }
 
@@ -126,41 +130,40 @@ async function main() {
   const args = process.argv.slice(2);
   const releaseTag = args[0];
   const verbose = args.includes("--verbose") || args.includes("-v");
-  
+
   if (!releaseTag) {
     console.error("Usage: bun run scripts/github-metrics.ts <release-tag> [--verbose]");
     console.error("Example: bun run scripts/github-metrics.ts bun-v1.2.19");
     process.exit(1);
   }
-  
+
   try {
     console.log(`📊 Collecting GitHub metrics since ${releaseTag}...`);
-    
+
     // Get release date
     const releaseInfo = await getReleaseInfo(releaseTag);
     const releaseDate = releaseInfo.publishedAt.split("T")[0]; // Extract date part
-    
+
     if (verbose) {
       console.log(`📅 Release date: ${releaseDate}`);
     }
-    
+
     // Count completed issues
     console.log("🔍 Counting completed issues...");
     const { count: issueCount, issues: issueNumbers } = await countCompletedIssues(releaseDate);
-    
+
     // Count reactions
     console.log("👍 Counting positive reactions...");
     const reactionCount = await countReactions(issueNumbers, verbose);
-    
+
     // Display results
     console.log("\n📈 Results:");
     console.log(`Issues closed as completed since ${releaseTag}: ${issueCount}`);
     console.log(`Total positive reactions (👍❤️🎉🚀): ${reactionCount}`);
-    
+
     if (issueCount > 0) {
       console.log(`Average reactions per completed issue: ${(reactionCount / issueCount).toFixed(1)}`);
     }
-    
   } catch (error) {
     console.error("❌ Error:", error.message);
     process.exit(1);

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -7,7 +7,7 @@
   ".stdDir()": 40,
   ".stdFile()": 18,
   "// autofix": 168,
-  ": [a-zA-Z0-9_\\.\\*\\?\\[\\]\\(\\)]+ = undefined,": 228,
+  ": [^=]+= undefined,$": 261,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,
   "@import(\"bun\").": 0,

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -31,7 +31,7 @@ const words: Record<string, { reason: string; regex?: boolean }> = {
   "== alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
   "!= alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
 
-  [String.raw`: [a-zA-Z0-9_\.\*\?\[\]\(\)]+ = undefined,`]: { reason: "Do not default a struct field to undefined", regex: true },
+  ": [^=]+= undefined,$": { reason: "Do not default a struct field to undefined", regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs" },
@@ -69,7 +69,7 @@ for (const source of sources) {
       if (source.startsWith("src" + path.sep + "codegen")) continue;
       const content = await file(source).text();
       for (const word of words_keys) {
-        let regex = words[word].regex ? new RegExp(word, "g") : undefined;
+        let regex = words[word].regex ? new RegExp(word, "gm") : undefined;
         const did_match = regex ? regex.test(content) : content.includes(word);
         if (regex) regex.lastIndex = 0;
         if (did_match) {


### PR DESCRIPTION
`ban-words.test.ts` attempts to detect places where a struct field is given a default value of `undefined`, but it fails to detect cases like the following:

```zig
foo: *Foo align(1) = undefined,
bar: [16 * 64]Bar = undefined,
baz: Baz(u8, true) = undefined,
```

This PR updates the check to detect more occurrences, while still avoiding (as far as I can tell) the inclusion of any false positives.

(For internal tracking: fixes STAB-971)