### PR TITLE
fix "File URL path must be an absolute path" error on windows when using `fileURLToPath`

### DIFF
--- a/src/bun.js/bindings/PathInlines.h
+++ b/src/bun.js/bindings/PathInlines.h
@@ -27,11 +27,12 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
         if (len < 1)
             return false;
         const auto bytes = input.span8().data();
-        if (IS_SLASH(bytes[0]))
+        // On Windows, paths starting with / are not absolute paths
+        // They need to be resolved relative to the current drive
+        // Only paths with drive letters (C:\) or UNC paths (\\) are absolute
+        if (len >= 3 && IS_LETTER(bytes[0]) && bytes[1] == ':' && IS_SLASH(bytes[2]))
             return true;
-        if (len < 2)
-            return false;
-        if (IS_LETTER(bytes[0]) && bytes[1] == ':' && IS_SLASH(bytes[2]))
+        if (len >= 2 && IS_SLASH(bytes[0]) && IS_SLASH(bytes[1]))
             return true;
         return false;
     } else {
@@ -39,11 +40,12 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
         if (len < 1)
             return false;
         const auto bytes = input.span16().data();
-        if (IS_SLASH(bytes[0]))
+        // On Windows, paths starting with / are not absolute paths
+        // They need to be resolved relative to the current drive
+        // Only paths with drive letters (C:\) or UNC paths (\\) are absolute
+        if (len >= 3 && IS_LETTER(bytes[0]) && bytes[1] == ':' && IS_SLASH(bytes[2]))
             return true;
-        if (len < 2)
-            return false;
-        if (IS_LETTER(bytes[0]) && bytes[1] == ':' && IS_SLASH(bytes[2]))
+        if (len >= 2 && IS_SLASH(bytes[0]) && IS_SLASH(bytes[1]))
             return true;
         return false;
     }

--- a/test/regression/issue/issue-18748-fileURLToPath-windows.test.ts
+++ b/test/regression/issue/issue-18748-fileURLToPath-windows.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test";
+import { isWindows } from "harness";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+test("fileURLToPath should handle paths starting with / correctly on all platforms", () => {
+  const testPaths = ["/test", "/@test", "/node_modules/test", "/@solid-refresh"];
+
+  for (const testPath of testPaths) {
+    const url = pathToFileURL(testPath);
+
+    if (isWindows) {
+      expect(url.href).toMatch(/^file:\/\/\/[A-Z]:\//);
+    } else {
+      expect(url.href).toBe(`file://${testPath}`);
+    }
+
+    const result = fileURLToPath(url);
+
+    if (isWindows) {
+      expect(result).toMatch(/^[A-Z]:\\/);
+      expect(result.toLowerCase()).toContain(testPath.replace(/\//g, "\\").toLowerCase());
+    } else {
+      expect(result).toBe(testPath);
+    }
+  }
+});
+
+test.if(isWindows)("Windows absolute paths should still work correctly", () => {
+  const absolutePaths = ["C:\\test", "C:\\Users\\test", "D:\\Projects\\myapp", "\\\\server\\share\\file"];
+
+  for (const absolutePath of absolutePaths) {
+    const url = pathToFileURL(absolutePath);
+    const result = fileURLToPath(url);
+
+    expect(result).toBe(absolutePath);
+  }
+});

--- a/test/regression/issue/issue-18748-fileURLToPath-windows.test.ts
+++ b/test/regression/issue/issue-18748-fileURLToPath-windows.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { isWindows } from "harness";
-import { pathToFileURL, fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 test("fileURLToPath should handle paths starting with / correctly on all platforms", () => {
   const testPaths = ["/test", "/@test", "/node_modules/test", "/@solid-refresh"];


### PR DESCRIPTION
### What does this PR do?'

fixes #18748

### How did you verify your code works?

made tests & ran on windows
