### PR TITLE
Add import.meta.env.* inlining support

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -475,12 +475,12 @@ pub const Loader = struct {
             var process_env_iter = to_string.iterator();
             while (process_env_iter.next()) |entry| {
                 const process_key = entry.key_ptr.*;
-                
+
                 // Check if this is a process.env key
                 if (process_key.len > "process.env.".len and strings.eqlComptime(process_key[0.."process.env.".len], "process.env.")) {
                     const var_name = process_key["process.env.".len..];
                     const meta_key = try std.fmt.allocPrint(allocator, "import.meta.env.{s}", .{var_name});
-                    
+
                     // Copy the define value
                     _ = try to_string.getOrPutValue(meta_key, entry.value_ptr.*);
                 }


### PR DESCRIPTION
## Summary

This PR adds support for inlining `import.meta.env.*` environment variables during bundling, similar to how `process.env.*` is currently inlined.

### Changes

- **Environment variable inlining**: `import.meta.env.*` patterns are now inlined when using `--env=inline` or `--env=prefix*` flags
- **Framework support**: Framework defaults now support `import.meta.env.*` keys in addition to `process.env.*` keys  
- **Comprehensive tests**: Added tests for all inlining modes including inline, disable, prefix matching, and mixed usage scenarios

### Implementation

The implementation works by:
1. Processing `process.env.*` defines as before using existing logic
2. Creating corresponding `import.meta.env.*` defines by copying from the `process.env.*` defines
3. Supporting framework defaults that use `import.meta.env.*` prefixes

### Test Coverage

New tests verify:
- ✅ `import.meta.env.*` inlining in `--env=inline` mode
- ✅ No inlining in `--env=disable` mode  
- ✅ Prefix-based inlining with `--env=prefix*` patterns
- ✅ Mixed usage of both `process.env.*` and `import.meta.env.*` in the same bundle
- ✅ Tests fail with current stable bun (demonstrating the feature gap)

### Why This Matters

Many modern frontend frameworks (Vite, Next.js, etc.) use `import.meta.env.*` for environment variables. This change brings Bun's environment variable inlining support to parity with these tools, improving build-time optimization for applications using `import.meta.env`.

🤖 Generated with [Claude Code](https://claude.ai/code)