### PR TITLE
Add owned pointer types

### DIFF
--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -707,6 +707,9 @@ src/Progress.zig
 src/ptr.zig
 src/ptr/Cow.zig
 src/ptr/CowSlice.zig
+src/ptr/owned.zig
+src/ptr/owned/maybe.zig
+src/ptr/owned/meta.zig
 src/ptr/ref_count.zig
 src/ptr/tagged_pointer.zig
 src/ptr/weak_ptr.zig

--- a/src/ptr.zig
+++ b/src/ptr.zig
@@ -5,6 +5,12 @@ pub const CowSlice = @import("./ptr/CowSlice.zig").CowSlice;
 pub const CowSliceZ = @import("./ptr/CowSlice.zig").CowSliceZ;
 pub const CowString = CowSlice(u8);
 
+pub const owned = @import("./ptr/owned.zig");
+pub const Owned = owned.Owned;
+pub const OwnedWithOpts = owned.OwnedWithOpts;
+pub const MaybeOwned = owned.MaybeOwned;
+pub const MaybeOwnedWithOpts = owned.MaybeOwnedWithOpts;
+
 pub const ref_count = @import("./ptr/ref_count.zig");
 pub const RefCount = ref_count.RefCount;
 pub const ThreadSafeRefCount = ref_count.ThreadSafeRefCount;

--- a/src/ptr/owned.zig
+++ b/src/ptr/owned.zig
@@ -1,0 +1,228 @@
+/// Options for `OwnedWithOpts`.
+pub const Options = struct {
+    // Whether to call `deinit` on the data before freeing it, if such a method exists.
+    deinit: bool = true,
+};
+
+/// An owned pointer or slice.
+///
+/// This type is a wrapper around a pointer or slice of type `Pointer`, and the allocator that was
+/// used to allocate the memory. Calling `deinit` on this type first calls `deinit` on the
+/// underlying data, and then frees the memory.
+///
+/// `Pointer` can be a single-item pointer, a slice, or an optional version of either of those;
+/// e.g., `Owned(*u8)`, `Owned([]u8)`, `Owned(?*u8)`, or `Owned(?[]u8)`.
+///
+/// Use the `alloc*` functions to create an `Owned(Pointer)` by allocating memory, or use
+/// `fromRawOwned` to create one from a raw pointer and allocator. Use `get` to access the inner
+/// pointer, and call `deinit` to free the memory. If `Pointer` is optional, use `initNull` to
+/// create a null `Owned(Pointer)`.
+pub fn Owned(comptime Pointer: type) type {
+    return OwnedWithOpts(Pointer, .{});
+}
+
+/// Like `Owned`, but takes explicit options.
+///
+/// `Owned(Pointer)` is simply an alias of `OwnedWithOpts(Pointer, .{})`.
+pub fn OwnedWithOpts(comptime Pointer: type, comptime options: Options) type {
+    const info = PointerInfo.parse(Pointer);
+    const NonOptionalPointer = info.NonOptionalPointer;
+    const Child = info.Child;
+
+    return struct {
+        const Self = @This();
+
+        unsafe_raw_pointer: Pointer,
+        unsafe_allocator: Allocator,
+
+        pub const Unmanaged = OwnedUnmanaged(Pointer, options);
+
+        pub const alloc = switch (info.kind()) {
+            .single => struct {
+                /// Allocate memory for a single value and initialize it with `value`.
+                pub fn alloc(allocator: Allocator, value: Child) Allocator.Error!Self {
+                    const data = try allocator.create(Child);
+                    data.* = value;
+                    return .{
+                        .unsafe_raw_pointer = data,
+                        .unsafe_allocator = allocator,
+                    };
+                }
+            },
+            .slice => struct {
+                /// Allocate memory for `count` elements, and initialize every element with `elem`.
+                pub fn alloc(allocator: Allocator, count: usize, elem: Child) Allocator.Error!Self {
+                    const data = try allocator.alloc(Child, count);
+                    @memset(data, elem);
+                    return .{
+                        .unsafe_raw_pointer = data,
+                        .unsafe_allocator = allocator,
+                    };
+                }
+            },
+        }.alloc;
+
+        /// Create an `Owned(Pointer)` by allocating memory and performing a shallow copy of `data`.
+        pub fn allocDupe(data: NonOptionalPointer, allocator: Allocator) Allocator.Error!Self {
+            return switch (comptime info.kind()) {
+                .single => .alloc(allocator, data.*),
+                .slice => .fromRawOwned(try allocator.dupe(Child, data), allocator),
+            };
+        }
+
+        /// Create an `Owned(Pointer)` from a raw pointer and allocator.
+        ///
+        /// Requirements:
+        ///
+        /// * `data` must have been allocated by `allocator`.
+        /// * `data` must not be freed for the life of the `Owned(Pointer)`.
+        pub fn fromRawOwned(data: NonOptionalPointer, allocator: Allocator) Self {
+            return .{
+                .unsafe_raw_pointer = data,
+                .unsafe_allocator = allocator,
+            };
+        }
+
+        /// Deinitialize the pointer or slice, freeing its memory.
+        ///
+        /// By default, this will first call `deinit` on the data itself, if such a method exists.
+        /// (For slices, this will call `deinit` on every element in this slice.) This behavior can
+        /// be disabled in `options`.
+        pub fn deinit(self: Self) void {
+            const data = if (comptime info.isOptional())
+                self.unsafe_raw_pointer orelse return
+            else
+                self.unsafe_raw_pointer;
+            if (comptime options.deinit and std.meta.hasFn(Child, "deinit")) {
+                switch (comptime info.kind()) {
+                    .single => data.deinit(),
+                    .slice => for (data) |*elem| elem.deinit(),
+                }
+            }
+            switch (comptime info.kind()) {
+                .single => self.unsafe_allocator.destroy(data),
+                .slice => self.unsafe_allocator.free(data),
+            }
+        }
+
+        /// Returns the inner pointer or slice.
+        pub fn get(self: if (info.isConst()) Self else *Self) Pointer {
+            return self.unsafe_raw_pointer;
+        }
+
+        /// Returns a const version of the inner pointer or slice.
+        ///
+        /// This method is not provided if the pointer is already const; use `get` in that case.
+        pub const getConst = if (!info.isConst()) struct {
+            pub fn getConst(self: Self) AddConst(Pointer) {
+                return self.unsafe_raw_pointer;
+            }
+        }.getConst;
+
+        /// Converts an `Owned(Pointer)` into its constituent parts, a raw pointer and an allocator.
+        ///
+        /// Do not use `self` or call `deinit` after calling this method.
+        pub const intoRawOwned = switch (info.isOptional()) {
+            // Regular, non-optional pointer (e.g., `*u8`, `[]u8`).
+            false => struct {
+                pub fn intoRawOwned(self: Self) struct { Pointer, Allocator } {
+                    return .{ self.unsafe_raw_pointer, self.unsafe_allocator };
+                }
+            },
+            // Optional pointer (e.g., `?*u8`, `?[]u8`).
+            true => struct {
+                pub fn intoRawOwned(self: Self) ?struct { NonOptionalPointer, Allocator } {
+                    return .{ self.unsafe_raw_pointer orelse return null, self.unsafe_allocator };
+                }
+            },
+        }.intoRawOwned;
+
+        /// Return a null `Owned(Pointer)`. This method is provided only if `Pointer` is an
+        /// optional type.
+        ///
+        /// It is permitted, but not required, to call `deinit` on the returned value.
+        pub const initNull = if (info.isOptional()) struct {
+            pub fn initNull() Self {
+                return .{
+                    .unsafe_raw_pointer = null,
+                    .unsafe_allocator = undefined,
+                };
+            }
+        }.initNull;
+
+        /// If this pointer is non-null, convert it to an `Owned(NonOptionalPointer)`, and set
+        /// this pointer to null. Otherwise, do nothing and return null.
+        ///
+        /// This method is provided only if `Pointer` is an optional type.
+        ///
+        /// It is permitted, but not required, to call deinit on `self` after calling this method.
+        pub const take = if (info.isOptional()) struct {
+            pub fn take(self: *Self) ?Owned(NonOptionalPointer) {
+                const data = self.unsafe_raw_pointer orelse return null;
+                const allocator = self.unsafe_allocator;
+                self.* = .initNull();
+                return .fromRawOwned(data, allocator);
+            }
+        }.take;
+
+        /// Convert this owned pointer into an unmanaged variant that doesn't store the allocator.
+        pub fn toUnmanaged(self: Self) Unmanaged {
+            return .{
+                .unsafe_raw_pointer = self.unsafe_raw_pointer,
+            };
+        }
+    };
+}
+
+/// An unmanaged version of `Owned(Pointer)` that doesn't store the allocator.
+pub fn OwnedUnmanaged(comptime Pointer: type, comptime options: Options) type {
+    const info = PointerInfo.parse(Pointer);
+
+    return struct {
+        const Self = @This();
+
+        unsafe_raw_pointer: Pointer,
+
+        /// Convert this unmanaged owned pointer back into a managed version.
+        ///
+        /// `allocator` must be the allocator that was used to allocate the pointer.
+        pub fn toManaged(self: Self, allocator: Allocator) OwnedWithOpts(Pointer, options) {
+            const data = if (comptime info.isOptional())
+                self.unsafe_raw_pointer orelse return .initNull()
+            else
+                self.unsafe_raw_pointer;
+            return .fromRawOwned(data, allocator);
+        }
+
+        /// Deinitialize the pointer or slice. See `Owned.deinit` for more information.
+        ///
+        /// `allocator` must be the allocator that was used to allocate the pointer.
+        pub fn deinit(self: Self, allocator: Allocator) void {
+            self.toManaged(allocator).deinit();
+        }
+
+        /// Returns the inner pointer or slice.
+        pub fn get(self: if (info.isConst()) Self else *Self) Pointer {
+            return self.unsafe_raw_pointer;
+        }
+
+        /// Returns a const version of the inner pointer or slice.
+        ///
+        /// This method is not provided if the pointer is already const; use `get` in that case.
+        pub const getConst = if (!info.isConst()) struct {
+            pub fn getConst(self: Self) AddConst(Pointer) {
+                return self.unsafe_raw_pointer;
+            }
+        }.getConst;
+    };
+}
+
+pub const MaybeOwned = @import("./owned/maybe.zig").MaybeOwned;
+pub const MaybeOwnedWithOpts = @import("./owned/maybe.zig").MaybeOwned;
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const meta = @import("./owned/meta.zig");
+const AddConst = meta.AddConst;
+const PointerInfo = meta.PointerInfo;

--- a/src/ptr/owned/maybe.zig
+++ b/src/ptr/owned/maybe.zig
@@ -75,20 +75,9 @@ pub fn MaybeOwnedWithOpts(comptime Pointer: type, comptime options: Options) typ
         }
 
         /// Returns the inner pointer or slice.
-        pub const get = switch (info.isConst()) {
-            // Non-const pointer (e.g., `*u8`, `[]u8`).
-            false => struct {
-                pub fn get(self: *Self) Pointer {
-                    return self.unsafe_raw_pointer;
-                }
-            },
-            // Const pointer (e.g., `*const u8`, `[]const u8`).
-            true => struct {
-                pub fn get(self: Self) Pointer {
-                    return self.unsafe_raw_pointer;
-                }
-            },
-        }.get;
+        pub fn get(self: if (info.isConst()) Self else *Self) Pointer {
+            return self.unsafe_raw_pointer;
+        }
 
         /// Returns a const version of the inner pointer or slice.
         ///

--- a/src/ptr/owned/maybe.zig
+++ b/src/ptr/owned/maybe.zig
@@ -1,0 +1,154 @@
+/// A possibly owned pointer or slice.
+///
+/// Memory held by this type is either owned or borrowed. If owned, this type also holds the
+/// allocator used to allocate the memory, and calling `deinit` on this type will call `deinit` on
+/// the underlying data and then free the memory. If the memory is borrowed, `deinit` is a no-op.
+///
+/// `Pointer` can be a single-item pointer, a slice, or an optional version of either of those;
+/// e.g., `MaybeOwned(*u8)`, `MaybeOwned([]u8)`, `MaybeOwned(?*u8)`, or `MaybeOwned(?[]u8)`.
+///
+/// Use `fromOwned` or `fromBorrowed` to create a `MaybeOwned(Pointer)`. Use `get` to access the
+/// inner pointer, and call `deinit` when done with the data. (It's best practice to always call
+/// `deinit`, even if the data is borrowed. It's a no-op in that case but doing so will help prevent
+/// leaks.) If `Pointer` is optional, use `initNull` to create a null `MaybeOwned(Pointer)`.
+pub fn MaybeOwned(comptime Pointer: type) type {
+    return MaybeOwnedWithOpts(Pointer, .{});
+}
+
+/// Like `MaybeOwned`, but takes explicit options.
+///
+/// `MaybeOwned(Pointer)` is simply an alias of `MaybeOwnedWithOpts(Pointer, .{})`.
+pub fn MaybeOwnedWithOpts(comptime Pointer: type, comptime options: Options) type {
+    const info = PointerInfo.parse(Pointer);
+    const NonOptionalPointer = info.NonOptionalPointer;
+
+    return struct {
+        const Self = @This();
+
+        unsafe_raw_pointer: Pointer,
+        unsafe_allocator: NullableAllocator,
+
+        /// Create a `MaybeOwned(Pointer)` from an `Owned(Pointer)`.
+        ///
+        /// Don't use `owned` (including calling `deinit`) after calling this method.
+        pub fn fromOwned(owned: OwnedWithOpts(Pointer, options)) Self {
+            const data, const allocator = if (comptime info.isOptional())
+                owned.intoRawOwned() orelse return .initNull()
+            else
+                owned.intoRawOwned();
+            return .{
+                .unsafe_raw_pointer = data,
+                .unsafe_allocator = .init(allocator),
+            };
+        }
+
+        /// Create a `MaybeOwned(Pointer)` from a raw owned pointer or slice.
+        ///
+        /// Requirements:
+        ///
+        /// * `data` must have been allocated by `allocator`.
+        /// * `data` must not be freed for the life of the `MaybeOwned`.
+        pub fn fromRawOwned(data: NonOptionalPointer, allocator: Allocator) Self {
+            return .fromOwned(.fromRawOwned(data, allocator));
+        }
+
+        /// Create a `MaybeOwned(Pointer)` from borrowed slice or pointer.
+        pub fn fromBorrowed(data: NonOptionalPointer) Self {
+            return .{
+                .unsafe_raw_pointer = data,
+                .unsafe_allocator = .init(null),
+            };
+        }
+
+        /// Deinitialize the pointer or slice, freeing its memory if owned.
+        ///
+        /// By default, if the data is owned, `deinit` will first be called on the data itself.
+        /// See `Owned.deinit` for more information.
+        pub fn deinit(self: Self) void {
+            const data, const maybe_allocator = if (comptime info.isOptional())
+                self.intoRaw() orelse return
+            else
+                self.intoRaw();
+            if (maybe_allocator) |allocator| {
+                OwnedWithOpts(Pointer, options).fromRawOwned(data, allocator).deinit();
+            }
+        }
+
+        /// Returns the inner pointer or slice.
+        pub const get = switch (info.isConst()) {
+            // Non-const pointer (e.g., `*u8`, `[]u8`).
+            false => struct {
+                pub fn get(self: *Self) Pointer {
+                    return self.unsafe_raw_pointer;
+                }
+            },
+            // Const pointer (e.g., `*const u8`, `[]const u8`).
+            true => struct {
+                pub fn get(self: Self) Pointer {
+                    return self.unsafe_raw_pointer;
+                }
+            },
+        }.get;
+
+        /// Returns a const version of the inner pointer or slice.
+        ///
+        /// This method is not provided if the pointer is already const; use `get` in that case.
+        pub const getConst = if (!info.isConst()) struct {
+            pub fn getConst(self: Self) AddConst(Pointer) {
+                return self.unsafe_raw_pointer;
+            }
+        }.getConst;
+
+        /// Converts a `MaybeOwned(Pointer)` into its constituent parts, a raw pointer and an
+        /// optional allocator.
+        ///
+        /// Do not use `self` or call `deinit` after calling this method.
+        pub const intoRaw = switch (info.isOptional()) {
+            // Regular, non-optional pointer (e.g., `*u8`, `[]u8`).
+            false => struct {
+                pub fn intoRaw(self: Self) struct { Pointer, ?Allocator } {
+                    return .{ self.unsafe_raw_pointer, self.unsafe_allocator.get() };
+                }
+            },
+            // Optional pointer (e.g., `?*u8`, `?[]u8`).
+            true => struct {
+                pub fn intoRaw(self: Self) ?struct { NonOptionalPointer, ?Allocator } {
+                    return .{
+                        self.unsafe_raw_pointer orelse return null,
+                        self.unsafe_allocator.get(),
+                    };
+                }
+            },
+        }.intoRaw;
+
+        /// Returns whether or not the memory is owned.
+        pub fn isOwned(self: Self) bool {
+            return !self.unsafe_allocator.isNull();
+        }
+
+        /// Return a null `MaybeOwned(Pointer)`. This method is provided only if `Pointer` is an
+        /// optional type.
+        ///
+        /// It is permitted, but not required, to call `deinit` on the returned value.
+        pub const initNull = if (info.isOptional()) struct {
+            pub fn initNull() Self {
+                return .{
+                    .unsafe_raw_pointer = null,
+                    .unsafe_allocator = undefined,
+                };
+            }
+        }.initNull;
+    };
+}
+
+const bun = @import("bun");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const NullableAllocator = bun.allocators.NullableAllocator;
+
+const meta = @import("./meta.zig");
+const AddConst = meta.AddConst;
+const PointerInfo = meta.PointerInfo;
+
+const Options = bun.ptr.owned.Options;
+const OwnedWithOpts = bun.ptr.owned.OwnedWithOpts;

--- a/src/ptr/owned/meta.zig
+++ b/src/ptr/owned/meta.zig
@@ -1,3 +1,5 @@
+//! Private utilities used in the implementation of `Owned` and `MaybeOwned`.
+
 pub const PointerInfo = struct {
     const Self = @This();
 

--- a/src/ptr/owned/meta.zig
+++ b/src/ptr/owned/meta.zig
@@ -1,0 +1,90 @@
+pub const PointerInfo = struct {
+    const Self = @This();
+
+    /// A possibly optional slice or single-item pointer type.
+    /// E.g., `*u8`, `[]u8`, `?*u8`, `?[]u8`.
+    Pointer: type,
+
+    /// If `Pointer` is an optional pointer, this is the non-optional equivalent. Otherwise, this
+    /// is the same as `Pointer`.
+    ///
+    /// For example, if `Pointer` is `?[]u8`, this is `[]u8`.
+    NonOptionalPointer: type,
+
+    /// The type of data stored by the pointer, i.e., the type obtained by dereferencing a
+    /// single-item pointer or accessing an element of a slice.
+    ///
+    /// For example, if `Pointer` is `?[]u8`, this is `u8`.
+    Child: type,
+
+    pub fn kind(self: Self) enum { single, slice } {
+        return switch (@typeInfo(self.NonOptionalPointer).pointer.size) {
+            .one => .single,
+            .slice => .slice,
+            else => @compileError("unreachable"),
+        };
+    }
+
+    pub fn isOptional(self: Self) bool {
+        return @typeInfo(self.Pointer) == .optional;
+    }
+
+    pub fn isConst(self: Self) bool {
+        return @typeInfo(self.NonOptionalPointer).pointer.is_const;
+    }
+
+    pub fn parse(comptime Pointer: type) Self {
+        const NonOptionalPointer = switch (@typeInfo(Pointer)) {
+            .optional => |opt| opt.child,
+            else => Pointer,
+        };
+
+        const pointer_info = switch (@typeInfo(NonOptionalPointer)) {
+            .pointer => |ptr| ptr,
+            else => {
+                @compileError("type must be a (possibly optional) slice or single-item pointer");
+            },
+        };
+        const Child = pointer_info.child;
+
+        switch (pointer_info.size) {
+            .one, .slice => {},
+            else => @compileError("only slices and single-item pointers are supported"),
+        }
+
+        if (pointer_info.is_volatile) {
+            @compileError("volatile pointers not supported");
+        }
+        if (pointer_info.alignment != @alignOf(Child)) {
+            @compileError("non-default alignment not supported");
+        }
+        if (pointer_info.is_allowzero) {
+            @compileError("allowzero not supported");
+        }
+        if (pointer_info.sentinel_ptr != null) {
+            @compileError("sentinel-terminated pointers not supported");
+        }
+
+        return .{
+            .Pointer = Pointer,
+            .NonOptionalPointer = NonOptionalPointer,
+            .Child = Child,
+        };
+    }
+};
+
+pub fn AddConst(Pointer: type) type {
+    var type_info = @typeInfo(Pointer);
+    switch (type_info) {
+        .pointer => |*ptr| {
+            ptr.is_const = true;
+        },
+        .optional => |*opt| {
+            opt.child = AddConst(opt.child);
+        },
+        // Technically this function accepts things like `?????[]u8`, but `PointerInfo.parse`
+        // verifies that's not the case.
+        else => @compileError("`Pointer` must be a (possibly optional) pointer or slice"),
+    }
+    return @Type(type_info);
+}


### PR DESCRIPTION
Add an owned pointer type—a wrapper around a pointer and an allocator.

`Owned(*Foo)` and `Owned([]Foo)` contain both the pointer/slice and the allocator that was used to allocate it. Calling `deinit` on these types first calls `Foo.deinit` and then frees the memory. This makes it easier to remember to free the memory, and hard to accidentally free it with the wrong allocator.

Optional pointers are also supported (`Owned(?*Foo)`, `Owned(?[]Foo)`), and an unmanaged variant which doesn't store the allocator (`Owned(*Foo).Unmanaged`) is available for cases where space efficiency is a concern.

A `MaybeOwned` type is also provided for representing data that could be owned or borrowed. If the data is owned, `MaybeOwned.deinit` works like `Owned.deinit`; otherwise, it's a no-op.

(For internal tracking: fixes STAB-920, STAB-921)