### PR TITLE
fix regression in node:crypto with lowercase rsa-sha keys

### DIFF
--- a/src/bun.js/bindings/ncrypto.cpp
+++ b/src/bun.js/bindings/ncrypto.cpp
@@ -1913,6 +1913,25 @@ const EVP_MD* getDigestByName(const WTF::StringView name, bool ignoreSHA512_224)
         return EVP_md5();
     }
 
+    if (WTF::startsWithIgnoringASCIICase(name, "rsa-sha"_s)) {
+        auto bits = name.substring(7);
+        if (WTF::equalIgnoringASCIICase(bits, "1"_s)) {
+            return EVP_sha1();
+        }
+        if (WTF::equalIgnoringASCIICase(bits, "224"_s)) {
+            return EVP_sha224();
+        }
+        if (WTF::equalIgnoringASCIICase(bits, "256"_s)) {
+            return EVP_sha256();
+        }
+        if (WTF::equalIgnoringASCIICase(bits, "384"_s)) {
+            return EVP_sha384();
+        }
+        if (WTF::equalIgnoringASCIICase(bits, "512"_s)) {
+            return EVP_sha512();
+        }
+    }
+
     if (WTF::startsWithIgnoringASCIICase(name, "sha"_s)) {
         auto remain = name.substring(3);
         if (remain.startsWith('-')) {

--- a/test/js/node/crypto/crypto-sign-regression.test.ts
+++ b/test/js/node/crypto/crypto-sign-regression.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { sign, constants } from "crypto";
+import { expect, test } from "bun:test";
+import { constants, sign } from "crypto";
 
 const DUMMY_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
 MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMx5bEJhDzwNBG1m

--- a/test/js/node/crypto/crypto-sign-regression.test.ts
+++ b/test/js/node/crypto/crypto-sign-regression.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "bun:test";
+import { sign, constants } from "crypto";
+
+const DUMMY_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMx5bEJhDzwNBG1m
+mIYn/V1HMK9g8WTVaHym4F4iPcTdZ4RYUrMa/xOUwPMAfrOJdf3joSUFWBx3ZPdW
+hrvpqjmcmgoYDRJzZwVKJ1uqTko6Anm3gplWl6JP3nGOL9Vt5K5xAJWif5fHPfCx
+LA2p/SnJDNmcyOWURUCRVCDlZgJRAgMBAAECgYEAt8a+ZZ7EyY1NmGJo3dMdZnPw
+rwArlhw08CwwZorSB5mTS6Dym2W9MsU08nNUbVs0AIBRumtmOReaWK+dI1GtmsT+
+/5YOrE8aU9xcTgMzZjr9AjI9cSc5J9etqqTjUplKfC5Ay0WBhPlx66MPAcTsq/u/
+IdPYvhvgXuJm6X3oDP0CQQDllIopSYXW+EzfpsdTsY1dW+xKM90NA7hUFLbIExwc
+vL9dowJcNvPNtOOA8Zrt0guVz0jZU/wPYZhvAm2/ab93AkEA5AFCfcAXrfC2lnDe
+9G5x/DGaB5jAsQXi9xv+/QECyAN3wzSlQNAZO8MaNr2IUpKuqMfxl0sPJSsGjOMY
+e8aOdwJBAIM7U3aiVmU5bgfyN8J5ncsd/oWz+8mytK0rYgggFFPA+Mq3oWPA7cBK
+hDly4hLLnF+4K3Y/cbgBG7do9f8SnaUCQQCLvfXpqp0Yv4q4487SUwrLff8gns+i
+76+uslry5/azbeSuIIsUETcV+LsNR9bQfRRNX9ZDWv6aUid+nAU6f3R7AkAFoONM
+mr4hjSGiU1o91Duatf4tny1Hp/hw2VoZAb5zxAlMtMifDg4Aqg4XFgptST7IUzTN
+K3P7zdJ30gregvjI
+-----END PRIVATE KEY-----`;
+
+test("crypto.sign() supports all RSA digest variants", () => {
+  const message = Buffer.from("test message");
+
+  const digests = [
+    "rsa-sha1",
+    "RSA-SHA1",
+    "rsa-sha224",
+    "RSA-SHA224",
+    "rsa-sha256",
+    "RSA-SHA256",
+    "rsa-sha384",
+    "RSA-SHA384",
+    "rsa-sha512",
+    "RSA-SHA512",
+  ];
+
+  for (const digest of digests) {
+    const signature = sign(digest, message, {
+      key: DUMMY_PRIVATE_KEY,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+    });
+    expect(signature).toBeInstanceOf(Buffer);
+    expect(signature.length).toBeGreaterThan(0);
+  }
+});

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -265,16 +265,11 @@ describe("createHash", () => {
     "ripemd160withrsa",
     "rsa-md5",
     "rsa-ripemd160",
-    "rsa-sha1",
     "rsa-sha1-2",
-    "rsa-sha224",
-    "rsa-sha256",
     "rsa-sha3-224",
     "rsa-sha3-256",
     "rsa-sha3-384",
     "rsa-sha3-512",
-    "rsa-sha384",
-    "rsa-sha512",
     "rsa-sha512/224",
     "rsa-sha512/256",
     "rsa-sm3",
@@ -294,13 +289,14 @@ describe("createHash", () => {
   for (const name_ in nodeValues) {
     const name = name_.toLowerCase();
     const is_unsupported = unsupported.includes(name);
+    const v = nodeValues[name] || nodeValues[name_];
 
     it(`${name} - "Hello World"`, () => {
       if (is_unsupported) {
         expect(() => {
           const hash = crypto.createHash(name);
           hash.update("Hello World");
-          expect(hash.digest("hex")).toBe(nodeValues[name].value);
+          expect(hash.digest("hex")).toBe(v.value);
         }).toThrow(Error(`Digest method not supported`));
       } else {
         const hash = crypto.createHash(name);
@@ -309,8 +305,8 @@ describe("createHash", () => {
         // testing copy to be sure boringssl workarounds for blake2b256/512,
         // ripemd160, sha3-<n>, and shake128/256 are working.
         const copy = hash.copy();
-        expect(hash.digest("hex")).toBe(nodeValues[name].value);
-        expect(copy.digest("hex")).toBe(nodeValues[name].value);
+        expect(hash.digest("hex")).toBe(v.value);
+        expect(copy.digest("hex")).toBe(v.value);
 
         expect(() => {
           hash.copy();
@@ -326,12 +322,12 @@ describe("createHash", () => {
         expect(() => {
           const hash = crypto.createHash(name);
           hash.update("Hello World");
-          expect(hash.digest()).toEqual(Buffer.from(nodeValues[name].value, "hex"));
+          expect(hash.digest()).toEqual(Buffer.from(v.value, "hex"));
         }).toThrow(Error(`Digest method not supported`));
       } else {
         const hash = crypto.createHash(name);
         hash.update("Hello World");
-        expect(hash.digest()).toEqual(Buffer.from(nodeValues[name].value, "hex"));
+        expect(hash.digest()).toEqual(Buffer.from(v.value, "hex"));
       }
     });
   }


### PR DESCRIPTION
### What does this PR do?

there was a regression in 1.2.5 where it stopped supporting lowercase veriants of the crypto keys. This broke the `mailauth` lib and proabibly many more.

simple code:
```ts
import { sign, constants } from 'crypto';

const DUMMY_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----\r\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMx5bEJhDzwNBG1m\r\nmIYn/V1HMK9g8WTVaHym4F4iPcTdZ4RYUrMa/xOUwPMAfrOJdf3joSUFWBx3ZPdW\r\nhrvpqjmcmgoYDRJzZwVKJ1uqTko6Anm3gplWl6JP3nGOL9Vt5K5xAJWif5fHPfCx\r\nLA2p/SnJDNmcyOWURUCRVCDlZgJRAgMBAAECgYEAt8a+ZZ7EyY1NmGJo3dMdZnPw\r\nrwArlhw08CwwZorSB5mTS6Dym2W9MsU08nNUbVs0AIBRumtmOReaWK+dI1GtmsT+\r\n/5YOrE8aU9xcTgMzZjr9AjI9cSc5J9etqqTjUplKfC5Ay0WBhPlx66MPAcTsq/u/\r\nIdPYvhvgXuJm6X3oDP0CQQDllIopSYXW+EzfpsdTsY1dW+xKM90NA7hUFLbIExwc\r\nvL9dowJcNvPNtOOA8Zrt0guVz0jZU/wPYZhvAm2/ab93AkEA5AFCfcAXrfC2lnDe\r\n9G5x/DGaB5jAsQXi9xv+/QECyAN3wzSlQNAZO8MaNr2IUpKuqMfxl0sPJSsGjOMY\r\ne8aOdwJBAIM7U3aiVmU5bgfyN8J5ncsd/oWz+8mytK0rYgggFFPA+Mq3oWPA7cBK\r\nhDly4hLLnF+4K3Y/cbgBG7do9f8SnaUCQQCLvfXpqp0Yv4q4487SUwrLff8gns+i\r\n76+uslry5/azbeSuIIsUETcV+LsNR9bQfRRNX9ZDWv6aUid+nAU6f3R7AkAFoONM\r\nmr4hjSGiU1o91Duatf4tny1Hp/hw2VoZAb5zxAlMtMifDg4Aqg4XFgptST7IUzTN\r\nK3P7zdJ30gregvjI\r\n-----END PRIVATE KEY-----`;

sign('rsa-sha256', Buffer.from('message'), {
    key: DUMMY_PRIVATE_KEY,
    padding: constants.RSA_PKCS1_PSS_PADDING,
});
// would throw invalid digest
```

### How did you verify your code works?

made test
