### PR TITLE
Fix signal handler compatibility with Go-based native modules

### DIFF
--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -517,7 +517,7 @@ extern "C" void bun_initialize_process()
         memset(&sa, 0, sizeof(sa));
         sigemptyset(&sa.sa_mask);
 
-        sa.sa_flags = SA_RESETHAND;
+        sa.sa_flags = SA_RESETHAND | SA_ONSTACK;
         sa.sa_handler = onExitSignal;
 
         sigaction(SIGTERM, &sa, nullptr);
@@ -838,7 +838,7 @@ extern "C" void Bun__registerSignalsForForwarding()
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = SA_RESETHAND;
+    sa.sa_flags = SA_RESETHAND | SA_ONSTACK;
     sa.sa_handler = [](int sig) {
         if (Bun__currentSyncPID == 0) {
             Bun__pendingSignalToSend = sig;


### PR DESCRIPTION
This PR adds the SA_ONSTACK flag to signal handlers to fix compatibility with Go-based native modules.

## Problem

Bun currently hangs when loading native modules built with Go because of a signal handling conflict. Go's runtime uses signals for its preemptive scheduler and expects signal handlers to run on an alternate stack. Without the SA_ONSTACK flag, this causes an infinite loop of signal delivery.

## Solution

Add SA_ONSTACK flag to signal handler setups in c-bindings.cpp. This is a standard requirement when interfacing with Go code.

## Root Cause Analysis

Through debugging with strace, I identified that Go-based native modules trigger an infinite loop of SIGPWR signals. This happens because:
1. Go's runtime uses SIGPWR for thread preemption
2. Go expects signal handlers to run on an alternate stack (SA_ONSTACK)
3. Without this flag, the signal handler interferes with Go's runtime state

## Node.js Comparison

Interestingly, Node.js does NOT use SA_ONSTACK in its signal handling:
- https://github.com/nodejs/node/blob/main/deps/uv/src/unix/signal.c#L235 - Node.js only uses `SA_RESTART` and optionally `SA_RESETHAND`

Yet Node.js works correctly with Go-based native modules. This suggests Bun's signal handling may be more aggressive or installed at different timing than Node.js, making SA_ONSTACK necessary for Bun specifically.

## Go Requirements

Go's runtime requires SA_ONSTACK for proper signal handling:
- https://github.com/golang/go/blob/master/src/runtime/os_linux.go#L330-L335 - Go sets `SA_SIGINFO | SA_ONSTACK | SA_RESTORER | SA_RESTART`
- https://github.com/golang/go/blob/master/src/runtime/signal_unix.go#L254-L263 - `setsigstack` function ensures SA_ONSTACK is set

## Code to Reproduce

```javascript
const asherah = require('asherah');

async function test() {
  await asherah.setup(JSON.stringify({
    KMS: 'static',
    Metastore: 'memory',
    ServiceName: 'test',
    ProductID: 'test'
  }));
  
  const encrypted = await asherah.encrypt_string('partition', 'data');
  console.log('Success\!', encrypted);
}

test();
```

This change enables the entire ecosystem of Go-based native modules to work with Bun.