### PR TITLE
fix: Use the correct default lib path in bun-types integration test

### DIFF
--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath, $ as Shell } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { cp, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
@@ -80,6 +80,8 @@ async function diagnose(
     options?: Partial<ts.CompilerOptions>;
     /** Specify extra files to include in the build */
     files?: Record<string, string>;
+    /** Extra (absolute) paths for files to include (useful for loading lib) */
+    include?: string[];
   } = {},
 ) {
   const tsconfig = config.options ?? {};
@@ -101,6 +103,10 @@ async function diagnose(
     }
   }
 
+  if (config.include) {
+    files.push(...config.include);
+  }
+
   const options: ts.CompilerOptions = {
     ...DEFAULT_COMPILER_OPTIONS,
     ...tsconfig,
@@ -113,23 +119,22 @@ async function diagnose(
   const host: ts.LanguageServiceHost = {
     getScriptFileNames: () => files,
     getScriptVersion: () => "0",
-    getScriptSnapshot: fileName => {
+    getScriptSnapshot: absolutePath => {
       if (extraFiles) {
-        const relativePath = relative(fixtureDir, fileName);
+        const relativePath = relative(fixtureDir, absolutePath);
         if (relativePath in extraFiles) {
           return ts.ScriptSnapshot.fromString(extraFiles[relativePath]);
         }
       }
 
-      if (!existsSync(fileName)) {
-        return undefined;
-      }
-
-      return ts.ScriptSnapshot.fromString(readFileSync(fileName).toString());
+      return ts.ScriptSnapshot.fromString(readFileSync(absolutePath).toString());
     },
     getCurrentDirectory: () => fixtureDir,
     getCompilationSettings: () => options,
-    getDefaultLibFileName: options => ts.getDefaultLibFilePath(options),
+    getDefaultLibFileName: options => {
+      const defaultLibFileName = ts.getDefaultLibFileName(options);
+      return join(fixtureDir, "node_modules", "typescript", "lib", defaultLibFileName);
+    },
     fileExists: ts.sys.fileExists,
     readFile: ts.sys.readFile,
     readDirectory: ts.sys.readDirectory,
@@ -349,46 +354,46 @@ describe("@types/bun integration test", () => {
           "Argument of type '{ headers: { \"x-bun\": string; }; }' is not assignable to parameter of type 'number'.",
         code: 2345,
       },
+      // {
+      //   line: "spawn.ts:62:38",
+      //   message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
+      //   code: 2339,
+      // },
+      // {
+      //   line: "spawn.ts:107:38",
+      //   message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
+      //   code: 2339,
+      // },
       {
-        line: "spawn.ts:62:38",
-        message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
-        code: 2339,
-      },
-      {
-        line: "spawn.ts:107:38",
-        message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
-        code: 2339,
-      },
-      {
-        line: "streams.ts:16:3",
+        line: "streams.ts:18:3",
         message: "No overload matches this call.",
         code: 2769,
       },
       {
-        line: "streams.ts:18:16",
+        line: "streams.ts:20:16",
         message: "Property 'write' does not exist on type 'ReadableByteStreamController'.",
         code: 2339,
       },
-      {
-        line: "streams.ts:44:19",
-        message: "Property 'json' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        code: 2339,
-      },
-      {
-        line: "streams.ts:45:19",
-        message: "Property 'bytes' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        code: 2339,
-      },
-      {
-        line: "streams.ts:46:19",
-        message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        code: 2339,
-      },
-      {
-        line: "streams.ts:47:19",
-        message: "Property 'blob' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        code: 2339,
-      },
+      // {
+      //   line: "streams.ts:44:19",
+      //   message: "Property 'json' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+      //   code: 2339,
+      // },
+      // {
+      //   line: "streams.ts:45:19",
+      //   message: "Property 'bytes' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+      //   code: 2339,
+      // },
+      // {
+      //   line: "streams.ts:46:19",
+      //   message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+      //   code: 2339,
+      // },
+      // {
+      //   line: "streams.ts:47:19",
+      //   message: "Property 'blob' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+      //   code: 2339,
+      // },
       {
         line: "websocket.ts:25:5",
         message: "Object literal may only specify known properties, and 'protocols' does not exist in type 'string[]'.",

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -80,8 +80,6 @@ async function diagnose(
     options?: Partial<ts.CompilerOptions>;
     /** Specify extra files to include in the build */
     files?: Record<string, string>;
-    /** Extra (absolute) paths for files to include (useful for loading lib) */
-    include?: string[];
   } = {},
 ) {
   const tsconfig = config.options ?? {};
@@ -101,10 +99,6 @@ async function diagnose(
         files.push(absolutePath);
       }
     }
-  }
-
-  if (config.include) {
-    files.push(...config.include);
   }
 
   const options: ts.CompilerOptions = {
@@ -354,16 +348,16 @@ describe("@types/bun integration test", () => {
           "Argument of type '{ headers: { \"x-bun\": string; }; }' is not assignable to parameter of type 'number'.",
         code: 2345,
       },
-      // {
-      //   line: "spawn.ts:62:38",
-      //   message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
-      //   code: 2339,
-      // },
-      // {
-      //   line: "spawn.ts:107:38",
-      //   message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
-      //   code: 2339,
-      // },
+      {
+        line: "spawn.ts:62:38",
+        message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
+        code: 2339,
+      },
+      {
+        line: "spawn.ts:107:38",
+        message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
+        code: 2339,
+      },
       {
         line: "streams.ts:18:3",
         message: "No overload matches this call.",
@@ -374,26 +368,26 @@ describe("@types/bun integration test", () => {
         message: "Property 'write' does not exist on type 'ReadableByteStreamController'.",
         code: 2339,
       },
-      // {
-      //   line: "streams.ts:44:19",
-      //   message: "Property 'json' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-      //   code: 2339,
-      // },
-      // {
-      //   line: "streams.ts:45:19",
-      //   message: "Property 'bytes' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-      //   code: 2339,
-      // },
-      // {
-      //   line: "streams.ts:46:19",
-      //   message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-      //   code: 2339,
-      // },
-      // {
-      //   line: "streams.ts:47:19",
-      //   message: "Property 'blob' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-      //   code: 2339,
-      // },
+      {
+        line: "streams.ts:46:19",
+        message: "Property 'json' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+        code: 2339,
+      },
+      {
+        line: "streams.ts:47:19",
+        message: "Property 'bytes' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+        code: 2339,
+      },
+      {
+        line: "streams.ts:48:19",
+        message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+        code: 2339,
+      },
+      {
+        line: "streams.ts:49:19",
+        message: "Property 'blob' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
+        code: 2339,
+      },
       {
         line: "websocket.ts:25:5",
         message: "Object literal may only specify known properties, and 'protocols' does not exist in type 'string[]'.",

--- a/test/integration/bun-types/fixture/streams.ts
+++ b/test/integration/bun-types/fixture/streams.ts
@@ -1,9 +1,11 @@
 import { expectType } from "./utilities";
 
-new ReadableStream({
+new ReadableStream<string>({
   start(controller) {
     controller.enqueue("hello");
     controller.enqueue("world");
+    // @ts-expect-error
+    controller.enqueue(2);
     controller.close();
   },
 });


### PR DESCRIPTION
### What does this PR do?

We should be loading the library files from the fixture directory, not from the Bun repo's test/node_modules folder. We might have differing versions of TypeScript installed in the fixture and in the repo, so this helps find issues earlier by always ensuring we have the latest version

This is something I just noticed which could be causing issues in the future (and actually already was while I was messing with something just now)

### How did you verify your code works?

bun-types integration test passes
