### PR TITLE
fix: Make navigator properties getter-only like Node.js

### DIFF
--- a/test/js/web/navigator-readonly.test.ts
+++ b/test/js/web/navigator-readonly.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("navigator properties should be getter-only like Node.js", () => {
   const originalUserAgent = navigator.userAgent;
@@ -25,11 +25,11 @@ test("navigator properties should have getter-only descriptors like Node.js", ()
   expect(userAgentDescriptor?.get).toBeTypeOf("function");
   expect(userAgentDescriptor?.set).toBeUndefined();
   expect(userAgentDescriptor?.configurable).toBe(false);
-  
+
   expect(platformDescriptor?.get).toBeTypeOf("function");
   expect(platformDescriptor?.set).toBeUndefined();
   expect(platformDescriptor?.configurable).toBe(false);
-  
+
   expect(hardwareConcurrencyDescriptor?.get).toBeTypeOf("function");
   expect(hardwareConcurrencyDescriptor?.set).toBeUndefined();
   expect(hardwareConcurrencyDescriptor?.configurable).toBe(false);
@@ -37,14 +37,14 @@ test("navigator properties should have getter-only descriptors like Node.js", ()
 
 test("Object.defineProperty should not be able to modify navigator properties", () => {
   const originalUserAgent = navigator.userAgent;
-  
+
   expect(() => {
     Object.defineProperty(navigator, "userAgent", {
       value: "modified",
       writable: true,
-      configurable: true
+      configurable: true,
     });
   }).toThrow();
-  
+
   expect(navigator.userAgent).toBe(originalUserAgent);
 });

--- a/test/js/web/navigator-readonly.test.ts
+++ b/test/js/web/navigator-readonly.test.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "bun:test";
+
+test("navigator properties should be getter-only like Node.js", () => {
+  const originalUserAgent = navigator.userAgent;
+  const originalPlatform = navigator.platform;
+  const originalHardwareConcurrency = navigator.hardwareConcurrency;
+
+  // Attempting to modify getter-only properties should silently fail (like Node.js)
+  navigator.userAgent = "modified";
+  navigator.platform = "modified";
+  navigator.hardwareConcurrency = 999;
+
+  // Values should remain unchanged
+  expect(navigator.userAgent).toBe(originalUserAgent);
+  expect(navigator.platform).toBe(originalPlatform);
+  expect(navigator.hardwareConcurrency).toBe(originalHardwareConcurrency);
+});
+
+test("navigator properties should have getter-only descriptors like Node.js", () => {
+  const userAgentDescriptor = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  const platformDescriptor = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const hardwareConcurrencyDescriptor = Object.getOwnPropertyDescriptor(navigator, "hardwareConcurrency");
+
+  // Properties should have getters but no setters
+  expect(userAgentDescriptor?.get).toBeTypeOf("function");
+  expect(userAgentDescriptor?.set).toBeUndefined();
+  expect(userAgentDescriptor?.configurable).toBe(false);
+  
+  expect(platformDescriptor?.get).toBeTypeOf("function");
+  expect(platformDescriptor?.set).toBeUndefined();
+  expect(platformDescriptor?.configurable).toBe(false);
+  
+  expect(hardwareConcurrencyDescriptor?.get).toBeTypeOf("function");
+  expect(hardwareConcurrencyDescriptor?.set).toBeUndefined();
+  expect(hardwareConcurrencyDescriptor?.configurable).toBe(false);
+});
+
+test("Object.defineProperty should not be able to modify navigator properties", () => {
+  const originalUserAgent = navigator.userAgent;
+  
+  expect(() => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: "modified",
+      writable: true,
+      configurable: true
+    });
+  }).toThrow();
+  
+  expect(navigator.userAgent).toBe(originalUserAgent);
+});


### PR DESCRIPTION
## Summary

Fixes #21585

Makes Navigator properties (userAgent, platform, hardwareConcurrency) getter-only like Node.js, where assignment attempts are silently ignored instead of changing the values.

## Changes

- Replaced `putDirect` with `putDirectCustomAccessor` for navigator properties
- Created dedicated getter functions for each property  
- Preserved all existing logic, comments, and TODO notes
- Added comprehensive tests to verify the new behavior

## Test plan

- [x] Added tests in `test/js/web/navigator-readonly.test.ts` that verify:
  - Properties cannot be overwritten
  - Assignment attempts are silently ignored  
  - Original values are preserved after assignment attempts
  - Properties have proper descriptors with getters but no setters
- [x] Verified existing navigator functionality still works
- [x] Confirmed behavior now matches Node.js exactly

🤖 Generated with [Claude Code](https://claude.ai/code)