### PR TITLE
feat: add GitHub Action to auto-label Claude PRs

### DIFF
--- a/.github/workflows/auto-label-claude-prs.yml
+++ b/.github/workflows/auto-label-claude-prs.yml
@@ -1,0 +1,24 @@
+name: Auto-label Claude PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    if: github.event.pull_request.user.login == 'robobun'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Add claude label to PRs from robobun
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['claude']
+            });


### PR DESCRIPTION
## Summary

- Adds a GitHub Action that automatically applies the 'claude' label to PRs created by robobun user
- Triggers on `pull_request` `opened` events
- Only runs for PRs created by the `robobun` user account
- Uses `github-script` action to add the label

## Test plan

- [x] Created the workflow file with proper permissions
- [ ] Test by creating a new PR with robobun user (will happen automatically on next Claude PR)
- [ ] Verify the label gets applied automatically

This ensures all future Claude-generated PRs are properly labeled for tracking and organization.

🤖 Generated with [Claude Code](https://claude.ai/code)