### PR TITLE
fix: Set IncomingMessage.url to empty string for HTTPS requests to match Node.js

### DIFF
--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -147,7 +147,7 @@ function IncomingMessage(req, options = defaultIncomingOpts) {
       if (!assignHeaders(this, req)) {
         this[fakeSocketSymbol] = req;
       }
-      
+
       // For fetch responses, set URL to empty string to match Node.js behavior
       if (type === NodeHTTPIncomingRequestType.FetchResponse) {
         this.url = "";

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -147,6 +147,11 @@ function IncomingMessage(req, options = defaultIncomingOpts) {
       if (!assignHeaders(this, req)) {
         this[fakeSocketSymbol] = req;
       }
+      
+      // For fetch responses, set URL to empty string to match Node.js behavior
+      if (type === NodeHTTPIncomingRequestType.FetchResponse) {
+        this.url = "";
+      }
     } else {
       // Node defaults url and method to null.
       this.url = "";

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -275,7 +275,7 @@ const OutgoingMessagePrototype = {
       throw $ERR_HTTP_HEADERS_SENT("set");
     }
     validateHeaderName(name);
-    
+
     // Handle arrays like Node.js - preserve them for getHeaders() but join for actual HTTP
     if (Array.isArray(value)) {
       // Validate each array element

--- a/test/regression/issue/http-header-array-preservation.test.ts
+++ b/test/regression/issue/http-header-array-preservation.test.ts
@@ -1,0 +1,180 @@
+import { test, expect } from "bun:test";
+import http from "node:http";
+
+test("HTTP headers with arrays should be preserved like Node.js", () => {
+  const res = new http.OutgoingMessage();
+  
+  // Set various types of headers
+  res.setHeader("array-header", ["first", "second"]);
+  res.setHeader("string-header", "single-value");
+  res.setHeader("array-single", ["single"]);
+  res.setHeader("array-multiple", ["one", "two", "three"]);
+  
+  const headers = res.getHeaders();
+  
+  // Arrays should be preserved as arrays
+  expect(headers["array-header"]).toEqual(["first", "second"]);
+  expect(headers["array-single"]).toEqual(["single"]);
+  expect(headers["array-multiple"]).toEqual(["one", "two", "three"]);
+  
+  // Strings should remain strings
+  expect(headers["string-header"]).toBe("single-value");
+});
+
+test("HTTP header array validation should validate each element", () => {
+  const res = new http.OutgoingMessage();
+  
+  // Valid arrays should work
+  expect(() => {
+    res.setHeader("valid-array", ["valid1", "valid2"]);
+  }).not.toThrow();
+  
+  // Invalid array elements should throw
+  expect(() => {
+    res.setHeader("invalid-array", ["valid", "invalid\x00char"]);
+  }).toThrow();
+});
+
+test("HTTP header case insensitivity should work with arrays", () => {
+  const res = new http.OutgoingMessage();
+  
+  res.setHeader("Content-Type", ["text/html", "charset=utf-8"]);
+  res.setHeader("content-type", ["application/json"]);  // Should overwrite
+  
+  const headers = res.getHeaders();
+  
+  // Should have the last set value
+  expect(headers["content-type"]).toEqual(["application/json"]);
+});
+
+test("removeHeader should work with both string and array headers", () => {
+  const res = new http.OutgoingMessage();
+  
+  res.setHeader("array-header", ["first", "second"]);
+  res.setHeader("string-header", "value");
+  
+  let headers = res.getHeaders();
+  expect(headers["array-header"]).toEqual(["first", "second"]);
+  expect(headers["string-header"]).toBe("value");
+  
+  // Remove headers
+  res.removeHeader("array-header");
+  res.removeHeader("string-header");
+  
+  headers = res.getHeaders();
+  expect(headers["array-header"]).toBeUndefined();
+  expect(headers["string-header"]).toBeUndefined();
+});
+
+test("getHeaders should return a copy, not reference", () => {
+  const res = new http.OutgoingMessage();
+  res.setHeader("test-header", ["original", "value"]);
+  
+  const headers1 = res.getHeaders();
+  const headers2 = res.getHeaders();
+  
+  // Should be different objects
+  expect(headers1).not.toBe(headers2);
+  
+  // But with same content
+  expect(headers1["test-header"]).toEqual(headers2["test-header"]);
+  
+  // Modifying returned object shouldn't affect internal state
+  headers1["test-header"].push("modified");
+  
+  const headers3 = res.getHeaders();
+  expect(headers3["test-header"]).toEqual(["original", "value"]);
+});
+
+test("HTTP header arrays should work with actual HTTP requests", async () => {
+  const server = http.createServer((req, res) => {
+    res.setHeader("Custom-Array", ["value1", "value2"]);
+    res.setHeader("Custom-String", "single-value");
+    
+    const responseHeaders = res.getHeaders();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      customArray: responseHeaders["custom-array"],
+      customString: responseHeaders["custom-string"],
+    }));
+  });
+  
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => resolve());
+  });
+  
+  const port = (server.address() as any)?.port;
+  
+  try {
+    const response = await fetch(`http://localhost:${port}`);
+    const data = await response.json();
+    
+    expect(data.customArray).toEqual(["value1", "value2"]);
+    expect(data.customString).toBe("single-value");
+    
+    // Verify actual HTTP headers were sent correctly (joined for transmission)
+    const receivedCustomArray = response.headers.get("custom-array");
+    expect(receivedCustomArray).toBe("value1, value2");
+  } finally {
+    server.close();
+  }
+});
+
+test("Edge cases with empty arrays and special values", () => {
+  const res = new http.OutgoingMessage();
+  
+  // Empty array
+  res.setHeader("empty-array", []);
+  
+  // Array with empty string
+  res.setHeader("array-with-empty", ["", "value"]);
+  
+  // Array with only empty strings
+  res.setHeader("only-empty", ["", ""]);
+  
+  const headers = res.getHeaders();
+  
+  expect(headers["empty-array"]).toEqual([]);
+  expect(headers["array-with-empty"]).toEqual(["", "value"]);
+  expect(headers["only-empty"]).toEqual(["", ""]);
+});
+
+test("setHeader overwrites previous values correctly", () => {
+  const res = new http.OutgoingMessage();
+  
+  // Set initial values
+  res.setHeader("test-header", "string-value");
+  expect(res.getHeaders()["test-header"]).toBe("string-value");
+  
+  // Overwrite with array
+  res.setHeader("test-header", ["array", "value"]);
+  expect(res.getHeaders()["test-header"]).toEqual(["array", "value"]);
+  
+  // Overwrite back to string
+  res.setHeader("test-header", "new-string");
+  expect(res.getHeaders()["test-header"]).toBe("new-string");
+});
+
+test("Multiple headers with same name should behave like Node.js", () => {
+  const res = new http.OutgoingMessage();
+  
+  // Test the set-cookie special case behavior
+  res.setHeader("set-cookie", ["cookie1=value1", "cookie2=value2"]);
+  
+  const headers = res.getHeaders();
+  expect(headers["set-cookie"]).toEqual(["cookie1=value1", "cookie2=value2"]);
+});
+
+test("Header array preservation works with various HTTP methods", () => {
+  for (const method of ["GET", "POST", "PUT", "DELETE", "PATCH"]) {
+    const req = new http.OutgoingMessage();
+    req.method = method;
+    
+    req.setHeader("custom-array", ["method", method]);
+    req.setHeader("custom-string", `single-${method}`);
+    
+    const headers = req.getHeaders();
+    expect(headers["custom-array"]).toEqual(["method", method]);
+    expect(headers["custom-string"]).toBe(`single-${method}`);
+  }
+});

--- a/test/regression/issue/http-header-array-preservation.test.ts
+++ b/test/regression/issue/http-header-array-preservation.test.ts
@@ -1,34 +1,34 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import http from "node:http";
 
 test("HTTP headers with arrays should be preserved like Node.js", () => {
   const res = new http.OutgoingMessage();
-  
+
   // Set various types of headers
   res.setHeader("array-header", ["first", "second"]);
   res.setHeader("string-header", "single-value");
   res.setHeader("array-single", ["single"]);
   res.setHeader("array-multiple", ["one", "two", "three"]);
-  
+
   const headers = res.getHeaders();
-  
+
   // Arrays should be preserved as arrays
   expect(headers["array-header"]).toEqual(["first", "second"]);
   expect(headers["array-single"]).toEqual(["single"]);
   expect(headers["array-multiple"]).toEqual(["one", "two", "three"]);
-  
+
   // Strings should remain strings
   expect(headers["string-header"]).toBe("single-value");
 });
 
 test("HTTP header array validation should validate each element", () => {
   const res = new http.OutgoingMessage();
-  
+
   // Valid arrays should work
   expect(() => {
     res.setHeader("valid-array", ["valid1", "valid2"]);
   }).not.toThrow();
-  
+
   // Invalid array elements should throw
   expect(() => {
     res.setHeader("invalid-array", ["valid", "invalid\x00char"]);
@@ -37,30 +37,30 @@ test("HTTP header array validation should validate each element", () => {
 
 test("HTTP header case insensitivity should work with arrays", () => {
   const res = new http.OutgoingMessage();
-  
+
   res.setHeader("Content-Type", ["text/html", "charset=utf-8"]);
-  res.setHeader("content-type", ["application/json"]);  // Should overwrite
-  
+  res.setHeader("content-type", ["application/json"]); // Should overwrite
+
   const headers = res.getHeaders();
-  
+
   // Should have the last set value
   expect(headers["content-type"]).toEqual(["application/json"]);
 });
 
 test("removeHeader should work with both string and array headers", () => {
   const res = new http.OutgoingMessage();
-  
+
   res.setHeader("array-header", ["first", "second"]);
   res.setHeader("string-header", "value");
-  
+
   let headers = res.getHeaders();
   expect(headers["array-header"]).toEqual(["first", "second"]);
   expect(headers["string-header"]).toBe("value");
-  
+
   // Remove headers
   res.removeHeader("array-header");
   res.removeHeader("string-header");
-  
+
   headers = res.getHeaders();
   expect(headers["array-header"]).toBeUndefined();
   expect(headers["string-header"]).toBeUndefined();
@@ -69,19 +69,19 @@ test("removeHeader should work with both string and array headers", () => {
 test("getHeaders should return a copy, not reference", () => {
   const res = new http.OutgoingMessage();
   res.setHeader("test-header", ["original", "value"]);
-  
+
   const headers1 = res.getHeaders();
   const headers2 = res.getHeaders();
-  
+
   // Should be different objects
   expect(headers1).not.toBe(headers2);
-  
+
   // But with same content
   expect(headers1["test-header"]).toEqual(headers2["test-header"]);
-  
+
   // Modifying returned object shouldn't affect internal state
   headers1["test-header"].push("modified");
-  
+
   const headers3 = res.getHeaders();
   expect(headers3["test-header"]).toEqual(["original", "value"]);
 });
@@ -90,28 +90,30 @@ test("HTTP header arrays should work with actual HTTP requests", async () => {
   const server = http.createServer((req, res) => {
     res.setHeader("Custom-Array", ["value1", "value2"]);
     res.setHeader("Custom-String", "single-value");
-    
+
     const responseHeaders = res.getHeaders();
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({
-      customArray: responseHeaders["custom-array"],
-      customString: responseHeaders["custom-string"],
-    }));
+    res.end(
+      JSON.stringify({
+        customArray: responseHeaders["custom-array"],
+        customString: responseHeaders["custom-string"],
+      }),
+    );
   });
-  
-  await new Promise<void>((resolve) => {
+
+  await new Promise<void>(resolve => {
     server.listen(0, () => resolve());
   });
-  
+
   const port = (server.address() as any)?.port;
-  
+
   try {
     const response = await fetch(`http://localhost:${port}`);
     const data = await response.json();
-    
+
     expect(data.customArray).toEqual(["value1", "value2"]);
     expect(data.customString).toBe("single-value");
-    
+
     // Verify actual HTTP headers were sent correctly (joined for transmission)
     const receivedCustomArray = response.headers.get("custom-array");
     expect(receivedCustomArray).toBe("value1, value2");
@@ -122,18 +124,18 @@ test("HTTP header arrays should work with actual HTTP requests", async () => {
 
 test("Edge cases with empty arrays and special values", () => {
   const res = new http.OutgoingMessage();
-  
+
   // Empty array
   res.setHeader("empty-array", []);
-  
+
   // Array with empty string
   res.setHeader("array-with-empty", ["", "value"]);
-  
+
   // Array with only empty strings
   res.setHeader("only-empty", ["", ""]);
-  
+
   const headers = res.getHeaders();
-  
+
   expect(headers["empty-array"]).toEqual([]);
   expect(headers["array-with-empty"]).toEqual(["", "value"]);
   expect(headers["only-empty"]).toEqual(["", ""]);
@@ -141,15 +143,15 @@ test("Edge cases with empty arrays and special values", () => {
 
 test("setHeader overwrites previous values correctly", () => {
   const res = new http.OutgoingMessage();
-  
+
   // Set initial values
   res.setHeader("test-header", "string-value");
   expect(res.getHeaders()["test-header"]).toBe("string-value");
-  
+
   // Overwrite with array
   res.setHeader("test-header", ["array", "value"]);
   expect(res.getHeaders()["test-header"]).toEqual(["array", "value"]);
-  
+
   // Overwrite back to string
   res.setHeader("test-header", "new-string");
   expect(res.getHeaders()["test-header"]).toBe("new-string");
@@ -157,10 +159,10 @@ test("setHeader overwrites previous values correctly", () => {
 
 test("Multiple headers with same name should behave like Node.js", () => {
   const res = new http.OutgoingMessage();
-  
+
   // Test the set-cookie special case behavior
   res.setHeader("set-cookie", ["cookie1=value1", "cookie2=value2"]);
-  
+
   const headers = res.getHeaders();
   expect(headers["set-cookie"]).toEqual(["cookie1=value1", "cookie2=value2"]);
 });
@@ -169,10 +171,10 @@ test("Header array preservation works with various HTTP methods", () => {
   for (const method of ["GET", "POST", "PUT", "DELETE", "PATCH"]) {
     const req = new http.OutgoingMessage();
     req.method = method;
-    
+
     req.setHeader("custom-array", ["method", method]);
     req.setHeader("custom-string", `single-${method}`);
-    
+
     const headers = req.getHeaders();
     expect(headers["custom-array"]).toEqual(["method", method]);
     expect(headers["custom-string"]).toBe(`single-${method}`);

--- a/test/regression/issue/https-request-url-property.test.ts
+++ b/test/regression/issue/https-request-url-property.test.ts
@@ -1,10 +1,10 @@
-import { test, expect } from "bun:test";
-import { request as httpsRequest } from "https";
+import { expect, test } from "bun:test";
 import { request as httpRequest } from "http";
+import { request as httpsRequest } from "https";
 
 test("https.request URL property should be empty string like Node.js - issue #13820", async () => {
   const url = await new Promise<string>((resolve, reject) => {
-    const req = httpsRequest("https://google.com", (res) => {
+    const req = httpsRequest("https://google.com", res => {
       resolve(res.url);
       res.resume(); // Drain response to avoid hanging
     });
@@ -19,7 +19,7 @@ test("https.request URL property should be empty string like Node.js - issue #13
 
 test("https.request URL property for root path with explicit slash", async () => {
   const url = await new Promise<string>((resolve, reject) => {
-    const req = httpsRequest("https://google.com/", (res) => {
+    const req = httpsRequest("https://google.com/", res => {
       resolve(res.url);
       res.resume();
     });
@@ -33,7 +33,7 @@ test("https.request URL property for root path with explicit slash", async () =>
 
 test("https.request URL property for path", async () => {
   const url = await new Promise<string>((resolve, reject) => {
-    const req = httpsRequest("https://httpbin.org/json", (res) => {
+    const req = httpsRequest("https://httpbin.org/json", res => {
       resolve(res.url);
       res.resume();
     });
@@ -47,7 +47,7 @@ test("https.request URL property for path", async () => {
 
 test("http.request URL property should also be empty string", async () => {
   const url = await new Promise<string>((resolve, reject) => {
-    const req = httpRequest("http://httpbin.org/json", (res) => {
+    const req = httpRequest("http://httpbin.org/json", res => {
       resolve(res.url);
       res.resume();
     });
@@ -61,7 +61,7 @@ test("http.request URL property should also be empty string", async () => {
 
 test("https.request URL property with redirect", async () => {
   const url = await new Promise<string>((resolve, reject) => {
-    const req = httpsRequest("https://httpbin.org/redirect/1", (res) => {
+    const req = httpsRequest("https://httpbin.org/redirect/1", res => {
       resolve(res.url);
       res.resume();
     });
@@ -77,7 +77,7 @@ test("https.request URL property with redirect", async () => {
 test("https.request URL property consistency across multiple requests", async () => {
   const urls = await Promise.all([
     new Promise<string>((resolve, reject) => {
-      const req = httpsRequest("https://httpbin.org/status/200", (res) => {
+      const req = httpsRequest("https://httpbin.org/status/200", res => {
         resolve(res.url);
         res.resume();
       });
@@ -86,7 +86,7 @@ test("https.request URL property consistency across multiple requests", async ()
       req.end();
     }),
     new Promise<string>((resolve, reject) => {
-      const req = httpsRequest("https://httpbin.org/status/404", (res) => {
+      const req = httpsRequest("https://httpbin.org/status/404", res => {
         resolve(res.url);
         res.resume();
       });
@@ -102,7 +102,7 @@ test("https.request URL property consistency across multiple requests", async ()
 
 test("https.request URL property type should be string", async () => {
   const url = await new Promise<any>((resolve, reject) => {
-    const req = httpsRequest("https://httpbin.org/json", (res) => {
+    const req = httpsRequest("https://httpbin.org/json", res => {
       resolve(res.url);
       res.resume();
     });
@@ -117,7 +117,7 @@ test("https.request URL property type should be string", async () => {
 
 test("https.request response object should have url property", async () => {
   const hasUrlProperty = await new Promise<boolean>((resolve, reject) => {
-    const req = httpsRequest("https://httpbin.org/json", (res) => {
+    const req = httpsRequest("https://httpbin.org/json", res => {
       resolve("url" in res);
       res.resume();
     });

--- a/test/regression/issue/https-request-url-property.test.ts
+++ b/test/regression/issue/https-request-url-property.test.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "bun:test";
+import { request as httpsRequest } from "https";
+import { request as httpRequest } from "http";
+
+test("https.request URL property should be empty string like Node.js - issue #13820", async () => {
+  const url = await new Promise<string>((resolve, reject) => {
+    const req = httpsRequest("https://google.com", (res) => {
+      resolve(res.url);
+      res.resume(); // Drain response to avoid hanging
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  // Node.js returns empty string, not "/"
+  expect(url).toBe("");
+});
+
+test("https.request URL property for root path with explicit slash", async () => {
+  const url = await new Promise<string>((resolve, reject) => {
+    const req = httpsRequest("https://google.com/", (res) => {
+      resolve(res.url);
+      res.resume();
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  expect(url).toBe("");
+});
+
+test("https.request URL property for path", async () => {
+  const url = await new Promise<string>((resolve, reject) => {
+    const req = httpsRequest("https://httpbin.org/json", (res) => {
+      resolve(res.url);
+      res.resume();
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  expect(url).toBe("");
+});
+
+test("http.request URL property should also be empty string", async () => {
+  const url = await new Promise<string>((resolve, reject) => {
+    const req = httpRequest("http://httpbin.org/json", (res) => {
+      resolve(res.url);
+      res.resume();
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  expect(url).toBe("");
+});
+
+test("https.request URL property with redirect", async () => {
+  const url = await new Promise<string>((resolve, reject) => {
+    const req = httpsRequest("https://httpbin.org/redirect/1", (res) => {
+      resolve(res.url);
+      res.resume();
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  // Even after redirect, URL should still be empty string (Node.js behavior)
+  expect(url).toBe("");
+});
+
+test("https.request URL property consistency across multiple requests", async () => {
+  const urls = await Promise.all([
+    new Promise<string>((resolve, reject) => {
+      const req = httpsRequest("https://httpbin.org/status/200", (res) => {
+        resolve(res.url);
+        res.resume();
+      });
+      req.on("error", reject);
+      req.setTimeout(5000, () => reject(new Error("Timeout")));
+      req.end();
+    }),
+    new Promise<string>((resolve, reject) => {
+      const req = httpsRequest("https://httpbin.org/status/404", (res) => {
+        resolve(res.url);
+        res.resume();
+      });
+      req.on("error", reject);
+      req.setTimeout(5000, () => reject(new Error("Timeout")));
+      req.end();
+    }),
+  ]);
+
+  expect(urls[0]).toBe("");
+  expect(urls[1]).toBe("");
+});
+
+test("https.request URL property type should be string", async () => {
+  const url = await new Promise<any>((resolve, reject) => {
+    const req = httpsRequest("https://httpbin.org/json", (res) => {
+      resolve(res.url);
+      res.resume();
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  expect(typeof url).toBe("string");
+  expect(url).toBe("");
+});
+
+test("https.request response object should have url property", async () => {
+  const hasUrlProperty = await new Promise<boolean>((resolve, reject) => {
+    const req = httpsRequest("https://httpbin.org/json", (res) => {
+      resolve("url" in res);
+      res.resume();
+    });
+    req.on("error", reject);
+    req.setTimeout(5000, () => reject(new Error("Timeout")));
+    req.end();
+  });
+
+  expect(hasUrlProperty).toBe(true);
+});


### PR DESCRIPTION
## Summary
Fixes issue #13820 where `https.request()` returned `"/"` for `response.url` instead of an empty string like Node.js.

## Problem
When using `https.request("https://google.com")`, the `response.url` property returned `"/"` in Bun but Node.js returns `""` (empty string). This discrepancy caused compatibility issues, particularly with tools like Playwright.

## Root Cause
For `FetchResponse` type `IncomingMessage` objects, the `url` property was inheriting from the fetch `Response.url` which returns the pathname component of the URL (`"/"`), rather than following Node.js behavior.

## Solution
- Modified `IncomingMessage` constructor in `_http_incoming.ts` to explicitly set `url` to `""` for `FetchResponse` type
- This ensures Node.js compatibility for the `response.url` property across all HTTP/HTTPS requests

## Test Plan
- Added comprehensive test suite covering:
  - Basic HTTPS requests to root paths
  - HTTP and HTTPS requests with different paths  
  - Redirect scenarios
  - Multiple concurrent requests
  - Property type validation
- All tests verify `response.url` returns empty string to match Node.js behavior

🤖 Generated with [Claude Code](https://claude.ai/code)