### PR TITLE
Fix Error.prepareStackTrace segfault when called with insufficient arguments

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2645,6 +2645,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
         return {};
     }
 
+    if (!callSites) {
+        throwTypeError(lexicalGlobalObject, scope, "Second argument must be an array of call sites"_s);
+        return {};
+    }
+
     JSValue result = formatStackTraceToJSValue(vm, globalObject, lexicalGlobalObject, errorObject, callSites, jsUndefined());
 
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/regression/issue/21815.test.ts
+++ b/test/regression/issue/21815.test.ts
@@ -5,6 +5,9 @@ test("Error.prepareStackTrace called without second parameter should not crash",
   // This test is for issue #21815
   // The command `Error.prepareStackTrace(e)` was causing a segmentation fault 
   // due to missing validation of the second parameter (callSites array)
+  // 
+  // Node.js throws: "Cannot read properties of undefined (reading 'length')"
+  // Bun now throws: "Second argument must be an array of call sites" (clearer message)
   
   const code = `
 const e = new Error();
@@ -35,5 +38,31 @@ process.exit(1);
   expect(exitCode).toBe(0);
   expect(stdout).toContain("Caught error:");
   expect(stdout).toContain("Second argument must be an array of call sites");
+  expect(stderr).toBe("");
+});
+
+test("Error.prepareStackTrace with custom function should work like Node.js", async () => {
+  // Custom prepareStackTrace functions should work normally, even with missing parameters
+  const code = `
+Error.prepareStackTrace = (err, stack) => "Custom: " + err.message;
+const e = new Error("test");
+console.log("Result:", Error.prepareStackTrace(e)); // Missing second param should be OK
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("Result: Custom: test");
   expect(stderr).toBe("");
 });

--- a/test/regression/issue/21815.test.ts
+++ b/test/regression/issue/21815.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Error.prepareStackTrace called without second parameter should not crash", async () => {
+  // This test is for issue #21815
+  // The command `Error.prepareStackTrace(e)` was causing a segmentation fault 
+  // due to missing validation of the second parameter (callSites array)
+  
+  const code = `
+const e = new Error();
+try {
+  Error.prepareStackTrace(e);
+} catch (err) {
+  console.log("Caught error:", err.message);
+  process.exit(0);
+}
+console.log("No error thrown - this is unexpected");
+process.exit(1);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // The command should execute successfully without crashing
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("Caught error:");
+  expect(stdout).toContain("Second argument must be an array of call sites");
+  expect(stderr).toBe("");
+});

--- a/test/regression/issue/21815.test.ts
+++ b/test/regression/issue/21815.test.ts
@@ -1,14 +1,14 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Error.prepareStackTrace called without second parameter should not crash", async () => {
   // This test is for issue #21815
-  // The command `Error.prepareStackTrace(e)` was causing a segmentation fault 
+  // The command `Error.prepareStackTrace(e)` was causing a segmentation fault
   // due to missing validation of the second parameter (callSites array)
-  // 
+  //
   // Node.js throws: "Cannot read properties of undefined (reading 'length')"
   // Bun now throws: "Second argument must be an array of call sites" (clearer message)
-  
+
   const code = `
 const e = new Error();
 try {
@@ -28,11 +28,7 @@ process.exit(1);
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // The command should execute successfully without crashing
   expect(exitCode).toBe(0);
@@ -56,11 +52,7 @@ console.log("Result:", Error.prepareStackTrace(e)); // Missing second param shou
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("Result: Custom: test");


### PR DESCRIPTION
## Summary

Fixes a critical segmentation fault when `Error.prepareStackTrace()` is called without the required second parameter (callSites array).

- **Issue**: Calling `Error.prepareStackTrace(error)` without the second parameter caused segfault at address 0x4
- **Root Cause**: Missing parameter validation in `jsFunctionDefaultErrorPrepareStackTrace` function
- **Solution**: Added proper validation with clear error message

## Before

```javascript
const e = new Error();
Error.prepareStackTrace(e); // Segmentation fault at address 0x4
```

## After

```javascript
const e = new Error();
Error.prepareStackTrace(e); // TypeError: Second argument must be an array of call sites
```

## Node.js Compatibility

Node.js also has issues with this case but throws: `"Cannot read properties of undefined (reading 'length')"`. 
Bun's error message is clearer and more descriptive while maintaining the same behavior (throwing TypeError).

## Changes

- Added parameter validation in `jsFunctionDefaultErrorPrepareStackTrace` 
- Enhanced error handling with descriptive message
- Maintains compatibility with custom `prepareStackTrace` functions
- Added comprehensive regression tests

## Test Coverage

- ✅ Prevents segmentation fault
- ✅ Throws proper TypeError with clear message  
- ✅ Custom `prepareStackTrace` functions continue to work normally
- ✅ Regression test included

Fixes #21815

🤖 Generated with [Claude Code](https://claude.ai/code)