### PR TITLE
fix: Use correct MIME type for CSS files in Bun.build outputs

### DIFF
--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -368,7 +368,7 @@ pub fn toJS(
             var build_output = bun.new(jsc.API.BuildArtifact, .{
                 .blob = jsc.WebCore.Blob.initWithStore(file_blob, globalObject),
                 .hash = this.hash,
-                .loader = this.input_loader,
+                .loader = this.loader,
                 .output_kind = this.output_kind,
                 .path = bun.default_allocator.dupe(u8, copy.pathname) catch @panic("Failed to allocate path"),
             });
@@ -406,7 +406,7 @@ pub fn toJS(
             build_output.* = jsc.API.BuildArtifact{
                 .blob = jsc.WebCore.Blob.initWithStore(file_blob, globalObject),
                 .hash = this.hash,
-                .loader = this.input_loader,
+                .loader = this.loader,
                 .output_kind = this.output_kind,
                 .path = bun.default_allocator.dupe(u8, path_to_use) catch @panic("Failed to allocate path"),
             };
@@ -428,7 +428,7 @@ pub fn toJS(
             build_output.* = jsc.API.BuildArtifact{
                 .blob = blob,
                 .hash = this.hash,
-                .loader = this.input_loader,
+                .loader = this.loader,
                 .output_kind = this.output_kind,
                 .path = owned_pathname orelse bun.default_allocator.dupe(u8, this.src_path.text) catch unreachable,
             };

--- a/src/bundler/linker_context/writeOutputFilesToDisk.zig
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.zig
@@ -317,7 +317,7 @@ pub fn writeOutputFilesToDisk(
                 .js,
             .hash = chunk.template.placeholder.hash,
             .output_kind = output_kind,
-            .loader = .js,
+            .loader = chunk.content.loader(),
             .source_map_index = source_map_index,
             .bytecode_index = bytecode_index,
             .size = @as(u32, @truncate(code_result.buffer.len)),

--- a/test/regression/issue/20131.test.ts
+++ b/test/regression/issue/20131.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("CSS file has correct MIME type in Bun.build result", async () => {
+  const dir = tempDirWithFiles("css-mime-type-test", {
+    "styles.css": `.test { color: red; }`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/styles.css`],
+    outdir: `${dir}/out`,
+  });
+
+  expect(result.outputs).toHaveLength(1);
+  expect(result.outputs[0].type).toBe("text/css;charset=utf-8");
+  expect(result.outputs[0].kind).toBe("asset");
+});
+
+test("CSS file has correct MIME type in Bun.build result (in-memory)", async () => {
+  const dir = tempDirWithFiles("css-mime-type-test-memory", {
+    "styles.css": `.test { color: blue; }`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/styles.css`],
+    // No outdir = in-memory build
+  });
+
+  expect(result.outputs).toHaveLength(1);
+  expect(result.outputs[0].type).toBe("text/css;charset=utf-8");
+  expect(result.outputs[0].kind).toBe("asset");
+});

--- a/test/regression/issue/20131.test.ts
+++ b/test/regression/issue/20131.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
 
 test("CSS file has correct MIME type in Bun.build result", async () => {
   const dir = tempDirWithFiles("css-mime-type-test", {


### PR DESCRIPTION
## Summary
- Fixes CSS files returning incorrect MIME type in Bun.build() outputs
- Changes "text/javascript;charset=utf-8" to correct "text/css;charset=utf-8"
- Adds regression test to prevent future issues

## Root Cause
The bug was caused by two issues:
1. `BuildArtifact` objects used `input_loader` (which defaults to `.js`) instead of the actual output `loader` in `OutputFile.zig`
2. The `loader` field was hardcoded to `.js` in `writeOutputFilesToDisk.zig` instead of using `chunk.content.loader()`

## Changes
- Fixed `BuildArtifact` creation in `src/OutputFile.zig` to use `this.loader` instead of `this.input_loader`
- Fixed hardcoded `.js` loader in `src/bundler/linker_context/writeOutputFilesToDisk.zig`
- Added regression test in `test/regression/issue/20131.test.ts`

## Test plan
- [x] Verified CSS files now return correct MIME type in both file output and in-memory builds
- [x] Added regression tests that cover both scenarios
- [x] All existing tests continue to pass

Fixes #20131

🤖 Generated with [Claude Code](https://claude.ai/code)