### PR TITLE
Don't run the "Date" header timer every second all the time

### DIFF
--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -135,6 +135,7 @@ src/bun.js/api/server/StaticRoute.zig
 src/bun.js/api/server/WebSocketServerContext.zig
 src/bun.js/api/streams.classes.zig
 src/bun.js/api/Timer.zig
+src/bun.js/api/Timer/DateHeaderTimer.zig
 src/bun.js/api/Timer/EventLoopTimer.zig
 src/bun.js/api/Timer/ImmediateObject.zig
 src/bun.js/api/Timer/TimeoutObject.zig

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -30,13 +30,17 @@ extern void __attribute((__noreturn__)) Bun__panic(const char* message, size_t l
 #define BUN_PANIC(message) Bun__panic(message, sizeof(message) - 1)
 #endif
 
+extern void Bun__internal_ensureDateHeaderTimerIsEnabled(struct us_loop_t *loop);
+
 void sweep_timer_cb(struct us_internal_callback_t *cb);
 
 void us_internal_enable_sweep_timer(struct us_loop_t *loop) {
-    if (loop->data.sweep_timer_count == 0) {
-        us_timer_set(loop->data.sweep_timer, (void (*)(struct us_timer_t *)) sweep_timer_cb, LIBUS_TIMEOUT_GRANULARITY * 1000, LIBUS_TIMEOUT_GRANULARITY * 1000);
-    }
     loop->data.sweep_timer_count++;
+    if (loop->data.sweep_timer_count == 1) {
+        us_timer_set(loop->data.sweep_timer, (void (*)(struct us_timer_t *)) sweep_timer_cb, LIBUS_TIMEOUT_GRANULARITY * 1000, LIBUS_TIMEOUT_GRANULARITY * 1000);
+        Bun__internal_ensureDateHeaderTimerIsEnabled(loop);
+    }
+    
 }
 
 void us_internal_disable_sweep_timer(struct us_loop_t *loop) {

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -82,19 +82,6 @@ private:
 
     static Loop *create(void *hint) {
         Loop *loop = ((Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData)))->init();
-
-        /* We also need some timers (should live off the one 4 second timer rather) */
-        LoopData *loopData = (LoopData *) us_loop_ext((struct us_loop_t *) loop);
-        loopData->dateTimer = us_create_timer((struct us_loop_t *) loop, 1, sizeof(LoopData *));
-        loopData->updateDate();
-
-        memcpy(us_timer_ext(loopData->dateTimer), &loopData, sizeof(LoopData *));
-        us_timer_set(loopData->dateTimer, [](struct us_timer_t *t) {
-            LoopData *loopData;
-            memcpy(&loopData, us_timer_ext(t), sizeof(LoopData *));
-            loopData->updateDate();
-        }, 1000, 1000);
-
         return loop;
     }
 
@@ -146,10 +133,7 @@ public:
     /* Freeing the default loop should be done once */
     void free() {
         LoopData *loopData = (LoopData *) us_loop_ext((us_loop_t *) this);
-
-        /* Stop and free dateTimer first */
-        us_timer_close(loopData->dateTimer, 1);
-
+        
         loopData->~LoopData();
         /* uSockets will track whether this loop is owned by us or a borrowed alien loop */
         us_loop_free((us_loop_t *) this);

--- a/packages/bun-uws/src/LoopData.h
+++ b/packages/bun-uws/src/LoopData.h
@@ -151,8 +151,6 @@ public:
     ZlibContext *zlibContext = nullptr;
     InflationStream *inflationStream = nullptr;
     DeflationStream *deflationStream = nullptr;
-
-    us_timer_t *dateTimer;
 };
 
 }

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -310,7 +310,11 @@ pub const VMHolder = struct {
 };
 
 pub inline fn get() *VirtualMachine {
-    return VMHolder.vm.?;
+    return getOrNull().?;
+}
+
+pub inline fn getOrNull() ?*VirtualMachine {
+    return VMHolder.vm;
 }
 
 pub fn getMainThreadVM() ?*VirtualMachine {

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -46,6 +46,9 @@ pub const All = struct {
         }
     } = .{},
 
+    /// Updates the "Date" header.
+    date_header_timer: DateHeaderTimer = .{},
+
     pub fn init() @This() {
         return .{
             .thread_id = std.Thread.getCurrentId(),
@@ -197,6 +200,27 @@ pub const All = struct {
     pub fn getNextID() callconv(.C) i32 {
         VirtualMachine.get().timer.last_id +%= 1;
         return VirtualMachine.get().timer.last_id;
+    }
+
+    fn isDateTimerActive(this: *const All) bool {
+        return this.date_header_timer.event_loop_timer.state == .ACTIVE;
+    }
+
+    pub fn updateDateHeaderTimerIfNecessary(this: *All, loop: *const uws.Loop, vm: *VirtualMachine) void {
+        if (loop.shouldEnableDateHeaderTimer()) {
+            if (!this.isDateTimerActive()) {
+                this.date_header_timer.enable(
+                    vm,
+                    // Be careful to avoid adding extra calls to bun.timespec.now()
+                    // when it's not needed.
+                    &bun.timespec.now(),
+                );
+            }
+        } else {
+            // don't un-schedule it here.
+            // it's better to wake up an extra 1 time after a second idle
+            // than to have to check a date potentially on every single HTTP request.
+        }
     }
 
     pub fn getTimeout(this: *All, spec: *timespec, vm: *VirtualMachine) bool {
@@ -571,6 +595,8 @@ pub const ID = extern struct {
 /// A timer created by WTF code and invoked by Bun's event loop
 pub const WTFTimer = @import("./Timer/WTFTimer.zig");
 
+pub const DateHeaderTimer = @import("./Timer/DateHeaderTimer.zig");
+
 pub const internal_bindings = struct {
     /// Node.js has some tests that check whether timers fire at the right time. They check this
     /// with the internal binding `getLibuvNow()`, which returns an integer in milliseconds. This
@@ -605,3 +631,4 @@ const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSValue = jsc.JSValue;
 const VirtualMachine = jsc.VirtualMachine;
+const uws = bun.uws;

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -624,6 +624,7 @@ const Environment = bun.Environment;
 const JSError = bun.JSError;
 const assert = bun.assert;
 const timespec = bun.timespec;
+const uws = bun.uws;
 const heap = bun.io.heap;
 const uv = bun.windows.libuv;
 
@@ -631,4 +632,3 @@ const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSValue = jsc.JSValue;
 const VirtualMachine = jsc.VirtualMachine;
-const uws = bun.uws;

--- a/src/bun.js/api/Timer/DateHeaderTimer.zig
+++ b/src/bun.js/api/Timer/DateHeaderTimer.zig
@@ -1,0 +1,80 @@
+/// DateHeaderTimer manages the periodic updating of the "Date" header in Bun.serve().
+///
+/// This timer ensures that HTTP responses include an up-to-date Date header by
+/// updating the date every second when there are active connections.
+///
+/// Behavior:
+/// - When sweep_timer_count > 0 (active connections), the timer should be running
+/// - When sweep_timer_count = 0 (no connections), the timer doesn't get rescheduled.
+/// - If the timer was already running, no changes are made.
+/// - If the timer was not running and needs to start:
+///   - If the last update was > 1 second ago, update the date immediately and schedule next update
+///   - If the last update was < 1 second ago, just schedule the next update
+///
+/// Note that we only check for potential updates ot this timer once per event loop tick.
+const DateHeaderTimer = @This();
+
+event_loop_timer: jsc.API.Timer.EventLoopTimer = .{
+    .tag = .DateHeaderTimer,
+    .next = .epoch,
+},
+
+/// Schedule the "Date"" header timer.
+///
+/// The logic handles two scenarios:
+/// 1. If the timer was recently updated (< 1 second ago), just reschedule it
+/// 2. If the timer is stale (> 1 second since last update), update the date immediately and reschedule
+pub fn enable(this: *DateHeaderTimer, vm: *VirtualMachine, now: *const bun.timespec) void {
+    bun.debugAssert(this.event_loop_timer.state != .ACTIVE);
+
+    const last_update = this.event_loop_timer.next;
+    const elapsed = now.duration(&last_update).ms();
+
+    // If the last update was more than 1 second ago, the date is stale
+    if (elapsed >= std.time.ms_per_s) {
+        // Update the date immediately since it's stale
+        log("updating stale timer & rescheduling for 1 second later", .{});
+
+        // updateDate() is an expensive function.
+        vm.uwsLoop().updateDate();
+
+        vm.timer.update(&this.event_loop_timer, &now.addMs(std.time.ms_per_s));
+    } else {
+        // The date was updated recently, just reschedule for the next second
+        log("rescheduling timer", .{});
+        vm.timer.insert(&this.event_loop_timer);
+    }
+}
+
+pub fn run(this: *DateHeaderTimer, vm: *VirtualMachine) void {
+    this.event_loop_timer.state = .FIRED;
+    const loop = vm.uwsLoop();
+    const now = bun.timespec.now();
+
+    // Record when we last ran it.
+    this.event_loop_timer.next = now;
+    log("run", .{});
+
+    // updateDate() is an expensive function.
+    loop.updateDate();
+
+    if (loop.internal_loop_data.sweep_timer_count > 0) {
+        // Reschedule it automatically for 1 second later.
+        this.event_loop_timer.next = now.addMs(std.time.ms_per_s);
+        vm.timer.insert(&this.event_loop_timer);
+    }
+}
+
+pub export fn Bun__internal_ensureDateHeaderTimerIsEnabled(loop: *uws.Loop) callconv(.C) void {
+    if (jsc.VirtualMachine.getOrNull()) |vm| {
+        vm.timer.updateDateHeaderTimerIfNecessary(loop, vm);
+    }
+}
+
+const bun = @import("bun");
+const jsc = bun.jsc;
+const VirtualMachine = jsc.VirtualMachine;
+const std = @import("std");
+
+const uws = bun.uws;
+const log = bun.Output.scoped(.DateHeaderTimer, .visible);

--- a/src/bun.js/api/Timer/DateHeaderTimer.zig
+++ b/src/bun.js/api/Timer/DateHeaderTimer.zig
@@ -71,10 +71,12 @@ pub export fn Bun__internal_ensureDateHeaderTimerIsEnabled(loop: *uws.Loop) call
     }
 }
 
-const bun = @import("bun");
-const jsc = bun.jsc;
-const VirtualMachine = jsc.VirtualMachine;
+const log = bun.Output.scoped(.DateHeaderTimer, .visible);
+
 const std = @import("std");
 
+const bun = @import("bun");
 const uws = bun.uws;
-const log = bun.Output.scoped(.DateHeaderTimer, .visible);
+
+const jsc = bun.jsc;
+const VirtualMachine = jsc.VirtualMachine;

--- a/src/bun.js/api/Timer/EventLoopTimer.zig
+++ b/src/bun.js/api/Timer/EventLoopTimer.zig
@@ -65,6 +65,7 @@ pub const Tag = if (Environment.isWindows) enum {
     DevServerSweepSourceMaps,
     DevServerMemoryVisualizerTick,
     AbortSignalTimeout,
+    DateHeaderTimer,
 
     pub fn Type(comptime T: Tag) type {
         return switch (T) {
@@ -86,6 +87,7 @@ pub const Tag = if (Environment.isWindows) enum {
             .DevServerMemoryVisualizerTick,
             => bun.bake.DevServer,
             .AbortSignalTimeout => jsc.WebCore.AbortSignal.Timeout,
+            .DateHeaderTimer => jsc.API.Timer.DateHeaderTimer,
         };
     }
 } else enum {
@@ -105,6 +107,7 @@ pub const Tag = if (Environment.isWindows) enum {
     DevServerSweepSourceMaps,
     DevServerMemoryVisualizerTick,
     AbortSignalTimeout,
+    DateHeaderTimer,
 
     pub fn Type(comptime T: Tag) type {
         return switch (T) {
@@ -125,6 +128,7 @@ pub const Tag = if (Environment.isWindows) enum {
             .DevServerMemoryVisualizerTick,
             => bun.bake.DevServer,
             .AbortSignalTimeout => jsc.WebCore.AbortSignal.Timeout,
+            .DateHeaderTimer => jsc.API.Timer.DateHeaderTimer,
         };
     }
 };
@@ -192,6 +196,11 @@ pub fn fire(self: *Self, now: *const timespec, vm: *VirtualMachine) Arm {
         .AbortSignalTimeout => {
             const timeout = @as(*jsc.WebCore.AbortSignal.Timeout, @fieldParentPtr("event_loop_timer", self));
             timeout.run(vm);
+            return .disarm;
+        },
+        .DateHeaderTimer => {
+            const date_header_timer = @as(*jsc.API.Timer.DateHeaderTimer, @fieldParentPtr("event_loop_timer", self));
+            date_header_timer.run(vm);
             return .disarm;
         },
         inline else => |t| {

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -326,8 +326,8 @@ pub fn usocketsLoop(this: *const EventLoop) *uws.Loop {
 }
 
 pub fn autoTick(this: *EventLoop) void {
-    var loop = this.usocketsLoop();
-    var ctx = this.virtual_machine;
+    const loop = this.usocketsLoop();
+    const ctx = this.virtual_machine;
 
     this.tickImmediateTasks(ctx);
     if (comptime Environment.isPosix) {
@@ -349,6 +349,8 @@ pub fn autoTick(this: *EventLoop) void {
             loop.unrefCount(pending_unref);
         }
     }
+
+    ctx.timer.updateDateHeaderTimerIfNecessary(loop, ctx);
 
     this.runImminentGCTimer();
 
@@ -378,8 +380,8 @@ pub fn autoTick(this: *EventLoop) void {
 }
 
 pub fn tickPossiblyForever(this: *EventLoop) void {
-    var ctx = this.virtual_machine;
-    var loop = this.usocketsLoop();
+    const ctx = this.virtual_machine;
+    const loop = this.usocketsLoop();
 
     if (comptime Environment.isPosix) {
         const pending_unref = ctx.pending_unref_counter;
@@ -428,6 +430,8 @@ pub fn autoTickActive(this: *EventLoop) void {
             loop.unrefCount(pending_unref);
         }
     }
+
+    ctx.timer.updateDateHeaderTimerIfNecessary(loop, ctx);
 
     if (loop.isActive()) {
         this.processGCTimer();

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -23,6 +23,11 @@ using TCPWebSocket = uWS::WebSocket<false, true, void *>;
 extern "C"
 {
 
+  void uws_loop_date_header_timer_update(us_loop_t *loop) {
+    uWS::LoopData *loopData = uWS::Loop::data(loop);
+    loopData->updateDate();
+  }
+
   uws_app_t *uws_create_app(int ssl, struct us_bun_socket_context_options_t options)
   {
     if (ssl)

--- a/src/deps/uws/InternalLoopData.zig
+++ b/src/deps/uws/InternalLoopData.zig
@@ -29,6 +29,10 @@ pub const InternalLoopData = extern struct {
         return this.recv_buf[0..LIBUS_RECV_BUFFER_LENGTH];
     }
 
+    pub fn shouldEnableDateHeaderTimer(this: *const InternalLoopData) bool {
+        return this.sweep_timer_count > 0;
+    }
+
     pub fn setParentEventLoop(this: *InternalLoopData, parent: jsc.EventLoopHandle) void {
         switch (parent) {
             .js => |ptr| {

--- a/src/deps/uws/Loop.zig
+++ b/src/deps/uws/Loop.zig
@@ -31,6 +31,10 @@ pub const PosixLoop = extern struct {
         c.uws_res_clear_corked_socket(this);
     }
 
+    pub fn updateDate(this: *PosixLoop) void {
+        c.uws_loop_date_header_timer_update(this);
+    }
+
     pub fn iterationNumber(this: *const PosixLoop) u64 {
         return this.internal_loop_data.iteration_nr;
     }
@@ -157,6 +161,10 @@ pub const PosixLoop = extern struct {
     pub fn run(this: *PosixLoop) void {
         c.us_loop_run(this);
     }
+
+    pub fn shouldEnableDateHeaderTimer(this: *const PosixLoop) bool {
+        return this.internal_loop_data.shouldEnableDateHeaderTimer();
+    }
 };
 
 pub const WindowsLoop = extern struct {
@@ -168,6 +176,10 @@ pub const WindowsLoop = extern struct {
     is_default: c_int,
     pre: *uv.uv_prepare_t,
     check: *uv.uv_check_t,
+
+    pub fn shouldEnableDateHeaderTimer(this: *const WindowsLoop) bool {
+        return this.internal_loop_data.shouldEnableDateHeaderTimer();
+    }
 
     pub fn uncork(this: *PosixLoop) void {
         c.uws_res_clear_corked_socket(this);
@@ -245,6 +257,10 @@ pub const WindowsLoop = extern struct {
         c.uws_loop_defer(this, user_data, Handler.callback);
     }
 
+    pub fn updateDate(this: *Loop) void {
+        c.uws_loop_date_header_timer_update(this);
+    }
+
     fn NewHandler(comptime UserType: type, comptime callback_fn: fn (UserType) void) type {
         return struct {
             loop: *Loop,
@@ -287,6 +303,7 @@ const c = struct {
     pub extern fn uws_get_loop_with_native(*anyopaque) *WindowsLoop;
     pub extern fn uws_loop_defer(loop: *Loop, ctx: *anyopaque, cb: *const (fn (ctx: *anyopaque) callconv(.C) void)) void;
     pub extern fn uws_res_clear_corked_socket(loop: *Loop) void;
+    pub extern fn uws_loop_date_header_timer_update(loop: *Loop) void;
 };
 
 const log = bun.Output.scoped(.Loop, .visible);

--- a/test/js/bun/http/bun-serve-date.test.ts
+++ b/test/js/bun/http/bun-serve-date.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "bun:test";
+
+test("Date header is not updated every request", async () => {
+  const twoSecondsAgo = new Date(Date.now() - 2 * 1000);
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("OK");
+    },
+  });
+
+  // Make multiple requests in quick succession
+  const responses = await Promise.all([
+    fetch(server.url),
+    fetch(server.url),
+    fetch(server.url),
+    fetch(server.url),
+    fetch(server.url),
+  ]);
+
+  // All responses should have the same Date header since they were made within the same second
+  const dates = responses.map(r => r.headers.get("Date"));
+  const uniqueDates = new Set(dates);
+
+  // Should only have 1 unique date value since all requests were made rapidly
+  expect(uniqueDates.size).toBe(1);
+  expect(dates[0]).toBeTruthy();
+
+  for (const delay of [250, 250, 250, 250, 250]) {
+    await Bun.sleep(delay);
+    const laterResponses = await Promise.all([
+      fetch(server.url),
+      fetch(server.url),
+      fetch(server.url),
+      fetch(server.url),
+      fetch(server.url),
+    ]);
+    const laterDates = laterResponses.map(r => r.headers.get("Date"));
+    const laterUniqueDates = new Set(laterDates);
+    expect(laterUniqueDates.size).toBe(1);
+    uniqueDates.add([...laterUniqueDates][0]);
+  }
+
+  // There should only really be two, but I don't trust timers to be SUPER accurate.
+  expect(uniqueDates.size).toBeLessThan(4);
+
+  for (const date of [...uniqueDates]) {
+    const d = new Date(date!);
+    const stamp = d.getTime();
+    expect(Number.isFinite(stamp)).toBe(true);
+    expect(stamp).toBeGreaterThan(0);
+    expect(stamp).toBeGreaterThan(twoSecondsAgo.getTime());
+    expect(stamp).toBeLessThan(Date.now() + 100);
+  }
+});

--- a/test/js/bun/http/bun-serve-date.test.ts
+++ b/test/js/bun/http/bun-serve-date.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("Date header is not updated every request", async () => {
   const twoSecondsAgo = new Date(Date.now() - 2 * 1000);


### PR DESCRIPTION
### What does this PR do?

Only reschedule the Date header while there are in-flight incoming HTTP requests.

Update the Date header if, at the time we reschedule it, it is now stale.

Goal: don't wake up Bun's process on every second when we're idly doing nothing.

| Metric | this branch | main |
|--------|--------------------------|-------------------|
| **task-clock** | **35.24 msec** 🟢 | **102.79 msec** |
| **context-switches** | 619 🟢 | 1,699 |
| **cpu-migrations** | 11 🟢| 35 |
| **page-faults** | 2,173 | 2,174 |
| **cpu_atom/instructions** | **109,904,685 (1.76 insn/cycle)** 🟢 | **67,880,002 (0.55 insn/cycle)** |
| **cpu_core/instructions** | **87,183,124 (1.07 insn/cycle)** 🟢 | **32,939,500 (0.44 insn/cycle)** |
| **cpu_atom/cycles** | 62,527,125 (1.774 GHz) 🔻 | 122,448,620 (1.191 GHz) |
| **cpu_core/cycles** | 81,651,366 (2.317 GHz) 🟢 | 75,584,111 (0.735 GHz) |
| **cpu_atom/branches** | 9,632,460 (273.338 M/sec) 🔻 | 12,119,616 (117.909 M/sec) |
| **cpu_core/branches** | 17,417,756 (494.259 M/sec) 🟢 | 6,901,859 (67.147 M/sec) |
| **cpu_atom/branch-misses** | 192,013 (1.99%) 🟢 | 1,735,446 (14.32%) |
| **cpu_core/branch-misses** | 473,567 (2.72%) 🟢 | 499,907 (7.24%) |
| **TopdownL1 (cpu_core)** | 31.4% backend_bound<br>11.7% bad_speculation<br>36.0% frontend_bound 🔻<br>20.9% retiring<br>34.1% bad_speculation<br>41.9% retiring<br>0.0% backend_bound<br>24.0% frontend_bound 🔻 | 21.3% backend_bound<br>9.6% bad_speculation<br>56.2% frontend_bound<br>12.9% retiring<br>-20.0% bad_speculation<br>55.2% retiring<br>26.2% backend_bound<br>38.6% frontend_bound |
| **time elapsed** | 1000.0219 s | 1000.0107 s |
| **user time** | — | 0.042667 s |
| **sys time** | — | 0.060309 s |

### How did you verify your code works?

Added a test