### PR TITLE
feat(types): add decompress to fetch()

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1890,23 +1890,6 @@ interface BunFetchRequestInit extends RequestInit {
   unix?: string;
 
   /**
-   * Set the highWaterMark for the response stream buffer.
-   * This controls the size of the internal buffer used when reading the response body.
-   * Larger values can improve performance for large responses at the cost of memory.
-   * This is a custom property that is not part of the Fetch API specification.
-   *
-   * @default 16384 (16KB)
-   * @example
-   * ```js
-   * // Use a 64KB buffer for better throughput with large files
-   * const response = await fetch("https://example.com/large-file.zip", {
-   *   highWaterMark: 65536
-   * });
-   * ```
-   */
-  highWaterMark?: number;
-
-  /**
    * Control automatic decompression of the response body.
    * When set to `false`, the response body will not be automatically decompressed,
    * and the `Content-Encoding` header will be preserved. This can improve performance

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1888,6 +1888,42 @@ interface BunFetchRequestInit extends RequestInit {
    * ```
    */
   unix?: string;
+
+  /**
+   * Set the highWaterMark for the response stream buffer.
+   * This controls the size of the internal buffer used when reading the response body.
+   * Larger values can improve performance for large responses at the cost of memory.
+   * This is a custom property that is not part of the Fetch API specification.
+   * 
+   * @default 16384 (16KB)
+   * @example
+   * ```js
+   * // Use a 64KB buffer for better throughput with large files
+   * const response = await fetch("https://example.com/large-file.zip", {
+   *   highWaterMark: 65536
+   * });
+   * ```
+   */
+  highWaterMark?: number;
+
+  /**
+   * Control automatic decompression of the response body.
+   * When set to `false`, the response body will not be automatically decompressed,
+   * and the `Content-Encoding` header will be preserved. This can improve performance
+   * when you need to handle compressed data manually or forward it as-is.
+   * This is a custom property that is not part of the Fetch API specification.
+   * 
+   * @default true
+   * @example
+   * ```js
+   * // Disable automatic decompression for a proxy server
+   * const response = await fetch("https://example.com/api", {
+   *   decompress: false
+   * });
+   * // response.headers.get('content-encoding') might be 'gzip' or 'br'
+   * ```
+   */
+  decompress?: boolean;
 }
 
 /**

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1894,7 +1894,7 @@ interface BunFetchRequestInit extends RequestInit {
    * This controls the size of the internal buffer used when reading the response body.
    * Larger values can improve performance for large responses at the cost of memory.
    * This is a custom property that is not part of the Fetch API specification.
-   * 
+   *
    * @default 16384 (16KB)
    * @example
    * ```js
@@ -1912,7 +1912,7 @@ interface BunFetchRequestInit extends RequestInit {
    * and the `Content-Encoding` header will be preserved. This can improve performance
    * when you need to handle compressed data manually or forward it as-is.
    * This is a custom property that is not part of the Fetch API specification.
-   * 
+   *
    * @default true
    * @example
    * ```js


### PR DESCRIPTION
## What
Add TypeScript definition for the `decompress` option in `fetch()`.

## Why
This option works at runtime but requires `@ts-ignore` in TypeScript:

**Before:**
```ts
// @ts-ignore  
decompress: false
```

**After:**
```ts
decompress: false
```

## How
Added the decompress property to BunFetchRequestInit interface with JSDoc documentation.