### PR TITLE
fix toBeCloseTo missing incrementExpectCallCounter

### DIFF
--- a/src/bun.js/test/expect/toBeCloseTo.zig
+++ b/src/bun.js/test/expect/toBeCloseTo.zig
@@ -85,7 +85,7 @@ const jsc = bun.jsc;
 const CallFrame = bun.jsc.CallFrame;
 const JSGlobalObject = bun.jsc.JSGlobalObject;
 const JSValue = bun.jsc.JSValue;
+const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;
 
 const Expect = bun.jsc.Expect.Expect;
 const getSignature = Expect.getSignature;
-const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;

--- a/src/bun.js/test/expect/toBeCloseTo.zig
+++ b/src/bun.js/test/expect/toBeCloseTo.zig
@@ -5,6 +5,8 @@ pub fn toBeCloseTo(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
     const thisArguments = callFrame.arguments_old(2);
     const arguments = thisArguments.ptr[0..thisArguments.len];
 
+    incrementExpectCallCounter();
+
     if (arguments.len < 1) {
         return globalThis.throwInvalidArguments("toBeCloseTo() requires at least 1 argument. Expected value must be a number", .{});
     }
@@ -86,3 +88,4 @@ const JSValue = bun.jsc.JSValue;
 
 const Expect = bun.jsc.Expect.Expect;
 const getSignature = Expect.getSignature;
+const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;

--- a/src/bun.js/test/expect/toBeValidDate.zig
+++ b/src/bun.js/test/expect/toBeValidDate.zig
@@ -32,7 +32,7 @@ const jsc = bun.jsc;
 const CallFrame = bun.jsc.CallFrame;
 const JSGlobalObject = bun.jsc.JSGlobalObject;
 const JSValue = bun.jsc.JSValue;
+const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;
 
 const Expect = bun.jsc.Expect.Expect;
 const getSignature = Expect.getSignature;
-const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;

--- a/src/bun.js/test/expect/toBeValidDate.zig
+++ b/src/bun.js/test/expect/toBeValidDate.zig
@@ -4,7 +4,7 @@ pub fn toBeValidDate(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Cal
     const thisValue = callFrame.this();
     const value: JSValue = try this.getValue(globalThis, thisValue, "toBeValidDate", "");
 
-    bun.jsc.Expect.active_test_expectation_counter.actual += 1;
+    incrementExpectCallCounter();
 
     const not = this.flags.not;
     var pass = (value.isDate() and !std.math.isNan(value.getUnixTimestamp()));
@@ -35,3 +35,4 @@ const JSValue = bun.jsc.JSValue;
 
 const Expect = bun.jsc.Expect.Expect;
 const getSignature = Expect.getSignature;
+const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;

--- a/src/bun.js/test/expect/toContainEqual.zig
+++ b/src/bun.js/test/expect/toContainEqual.zig
@@ -108,7 +108,7 @@ const jsc = bun.jsc;
 const CallFrame = bun.jsc.CallFrame;
 const JSGlobalObject = bun.jsc.JSGlobalObject;
 const JSValue = bun.jsc.JSValue;
+const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;
 
 const Expect = bun.jsc.Expect.Expect;
 const getSignature = Expect.getSignature;
-const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;

--- a/src/bun.js/test/expect/toContainEqual.zig
+++ b/src/bun.js/test/expect/toContainEqual.zig
@@ -12,7 +12,7 @@ pub fn toContainEqual(
         return globalThis.throwInvalidArguments("toContainEqual() takes 1 argument", .{});
     }
 
-    bun.jsc.Expect.active_test_expectation_counter.actual += 1;
+    incrementExpectCallCounter();
 
     const expected = arguments[0];
     expected.ensureStillAlive();
@@ -111,3 +111,4 @@ const JSValue = bun.jsc.JSValue;
 
 const Expect = bun.jsc.Expect.Expect;
 const getSignature = Expect.getSignature;
+const incrementExpectCallCounter = bun.jsc.Expect.incrementExpectCallCounter;

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -1,4 +1,5 @@
 import { file, Glob } from "bun";
+import { readdirSync } from "fs";
 import path from "path";
 
 // prettier-ignore
@@ -129,6 +130,22 @@ describe("banned words", () => {
       } else if (count.length < limit) {
         throw new Error(
           `Instances of banned word ${JSON.stringify(word)} reduced from ${limit} to ${count.length}\nUpdate limit by running \`bun ./test/internal/ban-words.test.ts\`\n`,
+        );
+      }
+    });
+  }
+});
+
+describe("required words", () => {
+  const expectDir = "src/bun.js/test/expect";
+  const files = readdirSync(expectDir);
+  for (const file of files) {
+    if (!file.endsWith(".zig") || file.startsWith(".") || file === "toHaveReturnedTimes.zig") continue;
+    test(file, async () => {
+      const content = await Bun.file(path.join(expectDir, file)).text();
+      if (!content.includes("incrementExpectCallCounter")) {
+        throw new Error(
+          `${expectDir}/${file} is missing string "incrementExpectCallCounter"\nAll expect() functions must call incrementExpectCallCounter()`,
         );
       }
     });


### PR DESCRIPTION
Fixes #11367. Also enforces that all expect functions must use incrementExpectCallCounter and migrates two from incrementing active_test_expectation_counter manually