### PR TITLE
fix(worker_threads): Accept SHARE_ENV symbol in worker env option

### DIFF
--- a/src/bun.js/bindings/webcore/JSWorker.cpp
+++ b/src/bun.js/bindings/webcore/JSWorker.cpp
@@ -233,7 +233,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
 
         auto envValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "env"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
-        
+
         // Check if envValue is the SHARE_ENV symbol (nodejs.worker_threads.SHARE_ENV)
         bool isShareEnv = false;
         if (envValue && envValue.isSymbol()) {
@@ -244,7 +244,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
                 isShareEnv = true;
             }
         }
-        
+
         if (envValue && !(envValue.isObject() || envValue.isUndefinedOrNull() || isShareEnv)) {
             return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "options.env"_s, "object or one of undefined, null, or worker_threads.SHARE_ENV"_s, envValue);
         }

--- a/src/bun.js/bindings/webcore/JSWorker.cpp
+++ b/src/bun.js/bindings/webcore/JSWorker.cpp
@@ -234,10 +234,11 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
         auto envValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "env"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
         
-        // Check if envValue is the SHARE_ENV symbol
+        // Check if envValue is the SHARE_ENV symbol (nodejs.worker_threads.SHARE_ENV)
         bool isShareEnv = false;
         if (envValue && envValue.isSymbol()) {
             auto* symbol = asSymbol(envValue);
+            // Check if this is the global symbol for nodejs.worker_threads.SHARE_ENV
             auto description = symbol->description();
             if (!description.isEmpty() && description == "nodejs.worker_threads.SHARE_ENV"_s) {
                 isShareEnv = true;
@@ -251,7 +252,9 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
 
         if (envValue && envValue.isCell() && !isShareEnv) {
             envObject = jsDynamicCast<JSC::JSObject*>(envValue);
-        } else if (isShareEnv || globalObject->m_processEnvObject.isInitialized()) {
+        } else if (globalObject->m_processEnvObject.isInitialized()) {
+            // For both SHARE_ENV and default cases, use the process environment
+            // SHARE_ENV means share the live parent environment
             envObject = globalObject->processEnvObject();
         }
 

--- a/src/bun.js/bindings/webcore/JSWorker.cpp
+++ b/src/bun.js/bindings/webcore/JSWorker.cpp
@@ -234,15 +234,14 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
         auto envValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "env"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
 
-        // Check if envValue is the SHARE_ENV symbol (nodejs.worker_threads.SHARE_ENV)
+        // Check if envValue is the SHARE_ENV symbol using symbol registry comparison
         bool isShareEnv = false;
         if (envValue && envValue.isSymbol()) {
             auto* symbol = asSymbol(envValue);
-            // Check if this is the global symbol for nodejs.worker_threads.SHARE_ENV
-            auto description = symbol->description();
-            if (!description.isEmpty() && description == "nodejs.worker_threads.SHARE_ENV"_s) {
-                isShareEnv = true;
-            }
+            // Get the expected SHARE_ENV symbol from the registry
+            auto* expectedSymbol = Symbol::create(vm, vm.symbolRegistry().symbolForKey("nodejs.worker_threads.SHARE_ENV"_s));
+            // Compare the symbols directly
+            isShareEnv = (symbol == expectedSymbol);
         }
 
         if (envValue && !(envValue.isObject() || envValue.isUndefinedOrNull() || isShareEnv)) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -17,7 +17,7 @@ const {
   // node:worker_threads instance instead of the Web Worker instance.
   Worker: new (...args: [...ConstructorParameters<typeof globalThis.Worker>, nodeWorker: Worker]) => WebWorker;
 };
-const SHARE_ENV = Symbol("nodejs.worker_threads.SHARE_ENV");
+const SHARE_ENV = Symbol.for("nodejs.worker_threads.SHARE_ENV");
 
 const isMainThread = Bun.isMainThread;
 const {

--- a/test/js/node/worker_threads/share-env.test.ts
+++ b/test/js/node/worker_threads/share-env.test.ts
@@ -1,11 +1,11 @@
-import { test, expect } from "bun:test";
-import { Worker, SHARE_ENV } from "worker_threads";
+import { expect, test } from "bun:test";
+import { SHARE_ENV, Worker } from "worker_threads";
 
 test("SHARE_ENV symbol should be accepted as env option", async () => {
   // This test verifies that the SHARE_ENV symbol is properly accepted
   // as the env option in worker threads, fixing the issue where it was
   // incorrectly rejected as an invalid type
-  
+
   const worker = new Worker(
     `
     const { parentPort } = require('worker_threads');
@@ -17,8 +17,8 @@ test("SHARE_ENV symbol should be accepted as env option", async () => {
     `,
     {
       eval: true,
-      env: SHARE_ENV
-    }
+      env: SHARE_ENV,
+    },
   );
 
   const message = await new Promise((resolve, reject) => {
@@ -38,7 +38,7 @@ test("SHARE_ENV enables true environment sharing", async () => {
   // Set a unique test variable in the parent
   const testVar = `TEST_VAR_${Date.now()}`;
   process.env[testVar] = "parent_value";
-  
+
   const worker = new Worker(
     `
     const { parentPort } = require('worker_threads');
@@ -50,8 +50,8 @@ test("SHARE_ENV enables true environment sharing", async () => {
     `,
     {
       eval: true,
-      env: SHARE_ENV
-    }
+      env: SHARE_ENV,
+    },
   );
 
   const message = await new Promise((resolve, reject) => {
@@ -77,13 +77,15 @@ test("SHARE_ENV should be the correct symbol", () => {
 
 test("non-SHARE_ENV symbols should still be rejected", async () => {
   const someOtherSymbol = Symbol("other.symbol");
-  
+
   expect(() => {
     new Worker("", {
       eval: true,
-      env: someOtherSymbol as any
+      env: someOtherSymbol as any,
     });
-  }).toThrow(/The "options\.env" property must be of type object or one of undefined, null, or worker_threads\.SHARE_ENV/);
+  }).toThrow(
+    /The "options\.env" property must be of type object or one of undefined, null, or worker_threads\.SHARE_ENV/,
+  );
 });
 
 test("other env option types should still work", async () => {
@@ -95,8 +97,8 @@ test("other env option types should still work", async () => {
     `,
     {
       eval: true,
-      env: { CUSTOM_VAR: "custom_value" }
-    }
+      env: { CUSTOM_VAR: "custom_value" },
+    },
   );
 
   const message1 = await new Promise((resolve, reject) => {
@@ -116,8 +118,8 @@ test("other env option types should still work", async () => {
     `,
     {
       eval: true,
-      env: undefined
-    }
+      env: undefined,
+    },
   );
 
   const message2 = await new Promise((resolve, reject) => {
@@ -138,8 +140,8 @@ test("other env option types should still work", async () => {
       `,
       {
         eval: true,
-        env: null
-      }
+        env: null,
+      },
     );
   }).not.toThrow();
 });

--- a/test/js/node/worker_threads/share-env.test.ts
+++ b/test/js/node/worker_threads/share-env.test.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "bun:test";
+import { Worker, SHARE_ENV } from "worker_threads";
+
+test("SHARE_ENV symbol should be accepted as env option", async () => {
+  // This test verifies that the SHARE_ENV symbol is properly accepted
+  // as the env option in worker threads, fixing the issue where it was
+  // incorrectly rejected as an invalid type
+  
+  const worker = new Worker(
+    `
+    const { parentPort } = require('worker_threads');
+    // Send back the current environment variable to verify SHARE_ENV works
+    parentPort.postMessage({ 
+      PATH: process.env.PATH ? 'present' : 'absent',
+      NODE_ENV: process.env.NODE_ENV 
+    });
+    `,
+    {
+      eval: true,
+      env: SHARE_ENV
+    }
+  );
+
+  const message = await new Promise((resolve, reject) => {
+    worker.on("message", resolve);
+    worker.on("error", reject);
+    setTimeout(() => reject(new Error("Test timeout")), 5000);
+  });
+
+  // Verify that environment variables are shared from parent process
+  expect(message).toHaveProperty("PATH");
+  expect((message as any).PATH).toBe("present");
+
+  await worker.terminate();
+});
+
+test("SHARE_ENV should be the correct symbol", () => {
+  // Verify that SHARE_ENV is the expected symbol
+  expect(typeof SHARE_ENV).toBe("symbol");
+  expect(SHARE_ENV.description).toBe("nodejs.worker_threads.SHARE_ENV");
+});
+
+test("non-SHARE_ENV symbols should still be rejected", async () => {
+  const someOtherSymbol = Symbol("other.symbol");
+  
+  expect(() => {
+    new Worker("", {
+      eval: true,
+      env: someOtherSymbol as any
+    });
+  }).toThrow(/The "options\.env" property must be of type object or one of undefined, null, or worker_threads\.SHARE_ENV/);
+});
+
+test("other env option types should still work", async () => {
+  // Test that regular object env still works
+  const worker1 = new Worker(
+    `
+    const { parentPort } = require('worker_threads');
+    parentPort.postMessage(process.env.CUSTOM_VAR);
+    `,
+    {
+      eval: true,
+      env: { CUSTOM_VAR: "custom_value" }
+    }
+  );
+
+  const message1 = await new Promise((resolve, reject) => {
+    worker1.on("message", resolve);
+    worker1.on("error", reject);
+    setTimeout(() => reject(new Error("Test timeout")), 5000);
+  });
+
+  expect(message1).toBe("custom_value");
+  await worker1.terminate();
+
+  // Test that undefined env still works
+  const worker2 = new Worker(
+    `
+    const { parentPort } = require('worker_threads');
+    parentPort.postMessage('success');
+    `,
+    {
+      eval: true,
+      env: undefined
+    }
+  );
+
+  const message2 = await new Promise((resolve, reject) => {
+    worker2.on("message", resolve);
+    worker2.on("error", reject);
+    setTimeout(() => reject(new Error("Test timeout")), 5000);
+  });
+
+  expect(message2).toBe("success");
+  await worker2.terminate();
+
+  // Test that null env still works
+  expect(() => {
+    new Worker(
+      `
+      const { parentPort } = require('worker_threads');
+      parentPort.postMessage('success');
+      `,
+      {
+        eval: true,
+        env: null
+      }
+    );
+  }).not.toThrow();
+});


### PR DESCRIPTION
## Summary

Fixes validation error when using `worker_threads.SHARE_ENV` as the env option in Worker constructor. The validation logic now properly recognizes the SHARE_ENV symbol and allows it to pass through, implementing the intended behavior of sharing environment variables from the parent process.

## Changes

- **Fixed symbol validation**: Added proper detection of the `SHARE_ENV` symbol in C++ validation code
- **Node.js compatibility**: Changed to use `Symbol.for()` instead of `Symbol()` to match Node.js exactly  
- **True environment sharing**: Implemented proper environment sharing logic so workers can access live parent environment variables
- **Comprehensive tests**: Added test suite covering SHARE_ENV functionality and edge cases
- **Updated comments**: Removed outdated comment claiming behavior wasn't implemented

## Node.js Compatibility

The implementation now correctly follows Node.js semantics:
- ✅ Uses the same global symbol (`Symbol.for("nodejs.worker_threads.SHARE_ENV")`)
- ✅ Enables true environment sharing (workers see live parent env changes)
- ✅ Proper validation that accepts only the specific SHARE_ENV symbol
- ✅ Maintains compatibility with other env option types (object, null, undefined)

## Test Plan

- [x] SHARE_ENV symbol is accepted without throwing validation errors
- [x] Workers can access parent environment variables when using SHARE_ENV
- [x] Workers can see dynamically set parent environment variables  
- [x] Non-SHARE_ENV symbols are still properly rejected
- [x] Other env option types (object, null, undefined) continue to work
- [x] Basic worker functionality remains intact

## Before

```javascript
const { Worker, SHARE_ENV } = require('worker_threads');

// This would throw: "The 'options.env' property must be of type object..."
const worker = new Worker('...', { env: SHARE_ENV });
```

## After  

```javascript
const { Worker, SHARE_ENV } = require('worker_threads');

// This now works correctly ✅
const worker = new Worker('...', { env: SHARE_ENV });
```

Fixes #20451

🤖 Generated with [Claude Code](https://claude.ai/code)