### PR TITLE
Fix xxhash64 to support seeds larger than u32.

### DIFF
--- a/src/bun.js/api/HashObject.zig
+++ b/src/bun.js/api/HashObject.zig
@@ -13,7 +13,7 @@ pub const xxHash32 = hashWrap(struct {
     }
 });
 pub const xxHash64 = hashWrap(struct {
-    pub fn hash(seed: u32, bytes: []const u8) u64 {
+    pub fn hash(seed: u64, bytes: []const u8) u64 {
         // sidestep .hash taking in anytype breaking ArgTuple
         // downstream by forcing a type signature on the input
         return std.hash.XxHash64.hash(seed, bytes);

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -44,6 +44,9 @@ it(`Bun.hash.xxHash64()`, () => {
   gcTick();
   expect(Bun.hash.xxHash64(new TextEncoder().encode("hello world"))).toBe(0x45ab6734b21e6968n);
   gcTick();
+  // Test with seed larger than u32
+  expect(Bun.hash.xxHash64("", 16269921104521594740n)).toBe(3224619365169652240n);
+  gcTick();
 });
 it(`Bun.hash.xxHash3()`, () => {
   expect(Bun.hash.xxHash3("hello world")).toBe(0xd447b1ea40e6988bn);


### PR DESCRIPTION
### What does this PR do?

Hopefully fix https://github.com/oven-sh/bun/issues/21879

### How did you verify your code works?

Added a test with a seed larger than u32.

The test vector is from this tiny test I wrote to rule out upstream zig as the culprit:

```zig
const std = @import("std");
const testing = std.testing;
test "xxhash64 of short string with custom seed" {
    const input = "";
    const seed: u64 = 16269921104521594740;
    const hash = std.hash.XxHash64.hash(seed, input);
    const expected_hash: u64 = 3224619365169652240;
    try testing.expect(hash == expected_hash);
}
```
