### PR TITLE
Add --user-agent flag to customize HTTP request User-Agent header

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -108,6 +108,7 @@ pub const runtime_params_ = [_]ParamType{
     clap.parseParam("--no-addons                       Throw an error if process.dlopen is called, and disable export condition \"node-addons\"") catch unreachable,
     clap.parseParam("--unhandled-rejections <STR>      One of \"strict\", \"throw\", \"warn\", \"none\", or \"warn-with-error-code\"") catch unreachable,
     clap.parseParam("--console-depth <NUMBER>          Set the default depth for console.log object inspection (default: 2)") catch unreachable,
+    clap.parseParam("--user-agent <STR>               Set the default User-Agent header for HTTP requests") catch unreachable,
 };
 
 pub const auto_or_run_params = [_]ParamType{
@@ -635,6 +636,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             } else {
                 bun.http.max_http_header_size = size;
             }
+        }
+
+        if (args.option("--user-agent")) |user_agent| {
+            bun.http.overridden_default_user_agent = user_agent;
         }
 
         ctx.debug.offline_mode_setting = if (args.flag("--prefer-offline"))

--- a/src/http.zig
+++ b/src/http.zig
@@ -528,13 +528,10 @@ else
     accept_encoding_header_compression;
 
 fn getUserAgentHeader() picohttp.Header {
-    return picohttp.Header{ 
-        .name = "User-Agent", 
-        .value = if (overridden_default_user_agent.len > 0) 
-            overridden_default_user_agent 
-        else 
-            Global.user_agent 
-    };
+    return picohttp.Header{ .name = "User-Agent", .value = if (overridden_default_user_agent.len > 0)
+        overridden_default_user_agent
+    else
+        Global.user_agent };
 }
 
 pub fn headerStr(this: *const HTTPClient, ptr: api.StringPointer) string {

--- a/src/http.zig
+++ b/src/http.zig
@@ -15,6 +15,8 @@ comptime {
     @export(&max_http_header_size, .{ .name = "BUN_DEFAULT_MAX_HTTP_HEADER_SIZE" });
 }
 
+pub var overridden_default_user_agent: []const u8 = "";
+
 const print_every = 0;
 var print_every_i: usize = 0;
 
@@ -525,7 +527,15 @@ const accept_encoding_header = if (FeatureFlags.disable_compression_in_http_clie
 else
     accept_encoding_header_compression;
 
-const user_agent_header = picohttp.Header{ .name = "User-Agent", .value = Global.user_agent };
+fn getUserAgentHeader() picohttp.Header {
+    return picohttp.Header{ 
+        .name = "User-Agent", 
+        .value = if (overridden_default_user_agent.len > 0) 
+            overridden_default_user_agent 
+        else 
+            Global.user_agent 
+    };
+}
 
 pub fn headerStr(this: *const HTTPClient, ptr: api.StringPointer) string {
     return this.header_buf[ptr.offset..][0..ptr.length];
@@ -619,7 +629,7 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     }
 
     if (!override_user_agent) {
-        request_headers_buf[header_count] = user_agent_header;
+        request_headers_buf[header_count] = getUserAgentHeader();
         header_count += 1;
     }
 

--- a/test/cli/user-agent.test.ts
+++ b/test/cli/user-agent.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+describe("--user-agent flag", () => {
+  test("custom user agent is sent in HTTP requests", async () => {
+    const customUserAgent = "MyCustomUserAgent/1.0";
+    
+    const testScript = `
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    const userAgent = request.headers.get("User-Agent");
+    if (userAgent === "${customUserAgent}") {
+      process.exit(0); // SUCCESS
+    } else {
+      process.exit(1); // FAIL
+    }
+  },
+});
+
+// Make request to self
+try {
+  await fetch(\`http://localhost:\${server.port}/test\`);
+} catch (error) {
+  process.exit(1);
+}
+`;
+
+    const dir = tempDirWithFiles("user-agent-test", {
+      "test.js": testScript,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--user-agent", customUserAgent, "test.js"],
+      env: bunEnv,
+      cwd: dir,
+    });
+
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+
+  test("default user agent is used when --user-agent is not specified", async () => {
+    const testScript = `
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    const userAgent = request.headers.get("User-Agent");
+    // Default Bun user agent should contain "Bun/"
+    if (userAgent && userAgent.includes("Bun/")) {
+      process.exit(0); // SUCCESS
+    } else {
+      process.exit(1); // FAIL
+    }
+  },
+});
+
+// Make request to self
+try {
+  await fetch(\`http://localhost:\${server.port}/test\`);
+} catch (error) {
+  process.exit(1);
+}
+`;
+
+    const dir = tempDirWithFiles("user-agent-default-test", {
+      "test.js": testScript,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test.js"],
+      env: bunEnv,
+      cwd: dir,
+    });
+
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/user-agent.test.ts
+++ b/test/cli/user-agent.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 describe("--user-agent flag", () => {
   test("custom user agent is sent in HTTP requests", async () => {
     const customUserAgent = "MyCustomUserAgent/1.0";
-    
+
     const testScript = `
 const server = Bun.serve({
   port: 0,


### PR DESCRIPTION
## Summary
- Adds `--user-agent` CLI flag to allow customizing the default User-Agent header for HTTP requests
- Maintains backward compatibility with existing default behavior
- Includes comprehensive tests

## Test plan
- [x] Added unit tests for both custom and default user-agent behavior
- [x] Tested manually with external HTTP service (httpbin.org)
- [x] Verified existing tests still pass

@thdxr I built this for you! 🎉

🤖 Generated with [Claude Code](https://claude.ai/code)