### PR TITLE
Replace ShimmedStdin and ShimmedStdioOutStream with standard streams

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1133,12 +1133,12 @@ class ChildProcess extends EventEmitter {
 
             if (!stdin) {
               // This can happen if the process was already killed.
-              const stream = new Writable({ 
+              const stream = new Writable({
                 write(chunk, encoding, callback) {
                   // Gracefully handle writes - stream acts as if it's ended
                   if (callback) callback();
                   return false;
-                }
+                },
               });
               // Mark as destroyed to indicate it's not usable
               stream.destroy();
@@ -1151,12 +1151,12 @@ class ChildProcess extends EventEmitter {
           case "inherit":
             return null;
           case "destroyed": {
-            const stream = new Writable({ 
+            const stream = new Writable({
               write(chunk, encoding, callback) {
                 // Gracefully handle writes - stream acts as if it's ended
                 if (callback) callback();
                 return false;
-              }
+              },
             });
             // Mark as destroyed to indicate it's not usable
             stream.destroy();
@@ -1660,7 +1660,6 @@ class Control extends EventEmitter {
     super();
   }
 }
-
 
 //------------------------------------------------------------------------------
 // Section 5. Validators

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1,6 +1,5 @@
 // Hardcoded module "node:child_process"
 const EventEmitter = require("node:events");
-const { Readable, Writable } = require("node:stream");
 const OsModule = require("node:os");
 const { kHandle } = require("internal/shared");
 const {
@@ -1133,6 +1132,7 @@ class ChildProcess extends EventEmitter {
 
             if (!stdin) {
               // This can happen if the process was already killed.
+              const { Writable } = require("node:stream");
               const stream = new Writable({
                 write(chunk, encoding, callback) {
                   // Gracefully handle writes - stream acts as if it's ended
@@ -1151,6 +1151,7 @@ class ChildProcess extends EventEmitter {
           case "inherit":
             return null;
           case "destroyed": {
+            const { Writable } = require("node:stream");
             const stream = new Writable({
               write(chunk, encoding, callback) {
                 // Gracefully handle writes - stream acts as if it's ended
@@ -1175,6 +1176,7 @@ class ChildProcess extends EventEmitter {
             const value = handle?.[fdToStdioName(i as 1 | 2)!];
             // This can happen if the process was already killed.
             if (!value) {
+              const { Readable } = require("node:stream");
               const stream = new Readable({ read() {} });
               // Mark as destroyed to indicate it's not usable
               stream.destroy();
@@ -1188,6 +1190,7 @@ class ChildProcess extends EventEmitter {
             return pipe;
           }
           case "destroyed": {
+            const { Readable } = require("node:stream");
             const stream = new Readable({ read() {} });
             // Mark as destroyed to indicate it's not usable
             stream.destroy();


### PR DESCRIPTION
## Summary

Fixes #21704

Replace custom `ShimmedStdin` and `ShimmedStdioOutStream` classes with proper Node.js `Readable`/`Writable` streams that are immediately destroyed. This provides better compatibility and standards compliance while maintaining the same graceful error handling behavior.

## Changes

- ✂️ **Remove shimmed classes**: Delete `ShimmedStdin` and `ShimmedStdioOutStream` (~40 lines of code)
- 🔄 **Replace with standard streams**: 
  - `ShimmedStdin` → destroyed `Writable` stream with graceful write handling
  - `ShimmedStdioOutStream` → destroyed `Readable` stream
- 🛡️ **Maintain compatibility**: Streams return `false` for writes and handle operations gracefully without throwing errors
- ✅ **Standards compliant**: Uses proper Node.js stream inheritance and behavior

## Technical Details

The new implementation creates streams that are immediately destroyed using `.destroy()`, which properly marks them as unusable while still providing the expected stream interface. The `Writable` streams include a custom `write()` method that always returns `false` and calls callbacks to prevent hanging, matching the original shimmed behavior.

## Test plan

- [x] Verified basic child_process functionality works
- [x] Tested error cases (non-existent processes, killed processes)
- [x] Confirmed graceful handling of writes to destroyed streams
- [x] Validated stream state properties (`.destroyed`, `.readable`, etc.)
- [x] Ensured no exceptions are thrown during normal operation

🤖 Generated with [Claude Code](https://claude.ai/code)