### PR TITLE
install.sh: check if on riscv64, and if so bail out

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -73,6 +73,9 @@ case $platform in
 'MINGW64'*)
     target=windows-x64
     ;;
+'Linux riscv64')
+    error 'Not supported on riscv64'
+    ;;
 'Linux x86_64' | *)
     target=linux-x64
     ;;


### PR DESCRIPTION
### What does this PR do?

Solves https://github.com/oven-sh/bun/issues/21923

So: if on riscv64, bail out, and do not install the x86-64 version of bun

### How did you verify your code works?

On my RISCV system:

```
git clone https://github.com/sanderjo/bun.git sjo-oven-sh-bun
cd sjo-oven-sh-bun/
git branch -a
git checkout origin/detect_and_refuse_riscv64
grep -irn riscv64 src/cli/install.sh 
```
Yes, correct. And then:

```
sander@riscv:~/git/sjo-oven-sh-bun$ bash src/cli/install.sh
error: Not supported on riscv64
sander@riscv:~/git/sjo-oven-sh-bun$
```

Good.
