### PR TITLE
Add string fast path for postMessage and structuredClone

### DIFF
--- a/bench/string-fastpath.mjs
+++ b/bench/string-fastpath.mjs
@@ -1,0 +1,56 @@
+// Benchmark for string fast path optimization in postMessage and structuredClone
+
+import { bench, run } from "mitata";
+
+// Test strings of different sizes
+const strings = {
+  small: "Hello world",
+  medium: "Hello World!!!".repeat(1024).split("").join(""),
+  large: "Hello World!!!".repeat(1024).repeat(1024).split("").join(""),
+};
+
+console.log("String fast path benchmark");
+console.log("Comparing pure strings (fast path) vs objects containing strings (traditional)");
+console.log("For structuredClone, pure strings should have constant time regardless of size.");
+console.log("");
+
+// Benchmark structuredClone with pure strings (uses fast path)
+bench("structuredClone small string (fast path)", () => {
+  structuredClone(strings.small);
+});
+
+bench("structuredClone medium string (fast path)", () => {
+  structuredClone(strings.medium);
+});
+
+bench("structuredClone large string (fast path)", () => {
+  structuredClone(strings.large);
+});
+
+// Benchmark structuredClone with objects containing strings (traditional path)
+bench("structuredClone object with small string", () => {
+  structuredClone({ str: strings.small });
+});
+
+bench("structuredClone object with medium string", () => {
+  structuredClone({ str: strings.medium });
+});
+
+bench("structuredClone object with large string", () => {
+  structuredClone({ str: strings.large });
+});
+
+// Multiple string cloning benchmark
+bench("structuredClone 100 small strings", () => {
+  for (let i = 0; i < 100; i++) {
+    structuredClone(strings.small);
+  }
+});
+
+bench("structuredClone 100 small objects", () => {
+  for (let i = 0; i < 100; i++) {
+    structuredClone({ str: strings.small });
+  }
+});
+
+await run();

--- a/bench/string-postmessage.mjs
+++ b/bench/string-postmessage.mjs
@@ -1,0 +1,77 @@
+// Benchmark for string fast path optimization in postMessage with Workers
+
+import { bench, run } from "mitata";
+import { Worker, isMainThread, parentPort } from "node:worker_threads";
+
+// Test strings of different sizes
+const strings = {
+  small: "Hello world",
+  medium: Buffer.alloc("Hello World!!!".length * 1024, "Hello World!!!").toString(),
+  large: Buffer.alloc("Hello World!!!".length * 1024 * 256, "Hello World!!!").toString(),
+};
+
+let worker;
+let receivedCount = new Int32Array(new SharedArrayBuffer(4));
+let sentCount = 0;
+
+function createWorker() {
+  const workerCode = `
+    import { parentPort, workerData } from "node:worker_threads";
+
+    let int = workerData;
+
+    parentPort?.on("message", data => {
+      Atomics.add(int, 0, 1);
+    });
+  `;
+
+  worker = new Worker(workerCode, { eval: true, workerData: receivedCount });
+
+  worker.on("message", confirmationId => {});
+
+  worker.on("error", error => {
+    console.error("Worker error:", error);
+  });
+}
+
+// Initialize worker before running benchmarks
+createWorker();
+
+function fmt(int) {
+  if (int < 1000) {
+    return `${int} chars`;
+  }
+
+  if (int < 100000) {
+    return `${(int / 1024) | 0} KB`;
+  }
+
+  return `${(int / 1024 / 1024) | 0} MB`;
+}
+
+// Benchmark postMessage with pure strings (uses fast path)
+bench("postMessage(" + fmt(strings.small.length) + " string)", async () => {
+  sentCount++;
+  worker.postMessage(strings.small);
+});
+
+bench("postMessage(" + fmt(strings.medium.length) + " string)", async () => {
+  sentCount++;
+  worker.postMessage(strings.medium);
+});
+
+bench("postMessage(" + fmt(strings.large.length) + " string)", async () => {
+  sentCount++;
+  worker.postMessage(strings.large);
+});
+
+await run();
+
+await new Promise(resolve => setTimeout(resolve, 5000));
+
+if (receivedCount[0] !== sentCount) {
+  throw new Error("Expected " + receivedCount[0] + " to equal " + sentCount);
+}
+
+// Cleanup worker
+worker?.terminate();

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION aa4997abc9126f5a7557c9ecb7e8104779d87ec4)
+  set(WEBKIT_VERSION a73e665a39b281c5ccab93fac70194a5188351ff)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION a73e665a39b281c5ccab93fac70194a5188351ff)
+  set(WEBKIT_VERSION 53385bda2d2270223ac66f7b021a4aec3dd6df75)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -521,7 +521,7 @@ pub const JSBundler = struct {
         }
 
         var plugins: ?*Plugin = null;
-        const config = try Config.fromJS(globalThis, arguments[0], &plugins, globalThis.allocator());
+        const config = try Config.fromJS(globalThis, arguments[0], &plugins, bun.default_allocator);
 
         return bun.BundleV2.generateFromJavaScript(
             config,

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -459,7 +459,7 @@ export default [
     finalize: true,
     estimatedSize: true,
     // inspectCustom: true,
-    structuredClone: { transferable: false, tag: 251 },
+    structuredClone: { transferable: false, tag: 251, storable: false },
     JSType: "0b11101110",
     klass: {
       isBlockList: {

--- a/src/bun.js/api/sourcemap.classes.ts
+++ b/src/bun.js/api/sourcemap.classes.ts
@@ -27,6 +27,5 @@ export default [
     constructNeedsThis: true,
     memoryCost: true,
     estimatedSize: true,
-    structuredClone: false,
   }),
 ];

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -195,8 +195,7 @@ BunString fromJS(JSC::JSGlobalObject* globalObject, JSValue value)
 extern "C" [[ZIG_EXPORT(nothrow)]] void BunString__toThreadSafe(BunString* str)
 {
     if (str->tag == BunStringTag::WTFStringImpl) {
-        Ref<WTF::StringImpl> impl = *str->impl.wtf;
-        impl = Bun::toCrossThreadShareable(impl);
+        auto impl = str->impl.wtf->isolatedCopy();
         if (impl.ptr() != str->impl.wtf) {
             str->impl.wtf = &impl.leakRef();
         }
@@ -288,7 +287,7 @@ bool isCrossThreadShareable(const WTF::String& string)
 
     auto* impl = string.impl();
 
-    // 1) Never share atomics/symbols - they have special thread-unsafe behavior
+    // 1) Never share AtomStringImpl/symbols - they have special thread-unsafe behavior
     if (impl->isAtom() || impl->isSymbol())
         return false;
 
@@ -322,7 +321,7 @@ WTF::String toCrossThreadShareable(const WTF::String& string)
 
     auto* impl = string.impl();
 
-    // 1) Never share atomics/symbols - they have special thread-unsafe behavior
+    // 1) Never share AtomStringImpl/symbols - they have special thread-unsafe behavior
     if (impl->isAtom() || impl->isSymbol())
         return string.isolatedCopy();
 

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -302,7 +302,7 @@ bool isCrossThreadShareable(const WTF::String& string)
 Ref<WTF::StringImpl> toCrossThreadShareable(Ref<WTF::StringImpl> impl)
 {
     if (impl->isAtom() || impl->isSymbol())
-        return impl;
+        return impl->isolatedCopy();
 
     if (impl->bufferOwnership() == StringImpl::BufferSubstring)
         return impl->isolatedCopy();

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -310,6 +310,7 @@ Ref<WTF::StringImpl> toCrossThreadShareable(Ref<WTF::StringImpl> impl)
     // 3) Ensure we won't lazily touch hash/flags on the consumer thread
     // Force hash computation on this thread before sharing
     impl->hash();
+    impl->setNeverAtomize();
 
     return impl;
 }
@@ -332,6 +333,7 @@ WTF::String toCrossThreadShareable(const WTF::String& string)
     // 3) Ensure we won't lazily touch hash/flags on the consumer thread
     // Force hash computation on this thread before sharing
     const_cast<StringImpl*>(impl)->hash();
+    const_cast<StringImpl*>(impl)->setNeverAtomize();
 
     return string;
 }

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -292,7 +292,7 @@ bool isCrossThreadShareable(const WTF::String& string)
     if (impl->isAtom() || impl->isSymbol())
         return false;
 
-    // 2) Don't share slices or external buffers that might have ownership issues
+    // 2) Don't share slices
     if (impl->bufferOwnership() == StringImpl::BufferSubstring)
         return false;
 
@@ -306,6 +306,10 @@ Ref<WTF::StringImpl> toCrossThreadShareable(Ref<WTF::StringImpl> impl)
 
     if (impl->bufferOwnership() == StringImpl::BufferSubstring)
         return impl->isolatedCopy();
+
+    // 3) Ensure we won't lazily touch hash/flags on the consumer thread
+    // Force hash computation on this thread before sharing
+    impl->hash();
 
     return impl;
 }
@@ -321,7 +325,7 @@ WTF::String toCrossThreadShareable(const WTF::String& string)
     if (impl->isAtom() || impl->isSymbol())
         return string.isolatedCopy();
 
-    // 2) Don't share slices or external buffers that might have ownership issues
+    // 2) Don't share slices
     if (impl->bufferOwnership() == StringImpl::BufferSubstring)
         return string.isolatedCopy();
 

--- a/src/bun.js/bindings/BunString.h
+++ b/src/bun.js/bindings/BunString.h
@@ -58,5 +58,6 @@ public:
 
 bool isCrossThreadShareable(const WTF::String& string);
 WTF::String toCrossThreadShareable(const WTF::String& string);
+Ref<WTF::StringImpl> toCrossThreadShareable(Ref<WTF::StringImpl> impl);
 
 }

--- a/src/bun.js/bindings/BunString.h
+++ b/src/bun.js/bindings/BunString.h
@@ -55,4 +55,8 @@ public:
         return std::span(reinterpret_cast<const char*>(m_view.span8().data()), m_view.length());
     }
 };
+
+bool isCrossThreadShareable(const WTF::String& string);
+WTF::String toCrossThreadShareable(const WTF::String& string);
+
 }

--- a/src/bun.js/bindings/IPC.cpp
+++ b/src/bun.js/bindings/IPC.cpp
@@ -2,12 +2,13 @@
 #include "headers-handwritten.h"
 #include "BunBuiltinNames.h"
 #include "WebCoreJSBuiltins.h"
+#include "ZigGlobalObject.h"
 
-extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCSerialize(JSC::JSGlobalObject* global, JSC::EncodedJSValue message, JSC::EncodedJSValue handle)
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCSerialize(Zig::GlobalObject* global, JSC::EncodedJSValue message, JSC::EncodedJSValue handle)
 {
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSFunction* serializeFunction = JSC::JSFunction::create(vm, global, WebCore::ipcSerializeCodeGenerator(vm), global);
+    JSC::JSFunction* serializeFunction = global->m_ipcSerializeFunction.getInitializedOnMainThread(global);
     JSC::CallData callData = JSC::getCallData(serializeFunction);
 
     JSC::MarkedArgumentBuffer args;
@@ -19,11 +20,11 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCSerialize(JSC::J
     return JSC::JSValue::encode(result);
 }
 
-extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCParse(JSC::JSGlobalObject* global, JSC::EncodedJSValue target, JSC::EncodedJSValue serialized, JSC::EncodedJSValue fd)
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCParse(Zig::GlobalObject* global, JSC::EncodedJSValue target, JSC::EncodedJSValue serialized, JSC::EncodedJSValue fd)
 {
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSFunction* parseFunction = JSC::JSFunction::create(vm, global, WebCore::ipcParseHandleCodeGenerator(vm), global);
+    JSC::JSFunction* parseFunction = global->m_ipcParseHandleFunction.getInitializedOnMainThread(global);
     JSC::CallData callData = JSC::getCallData(parseFunction);
 
     JSC::MarkedArgumentBuffer args;

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -2168,7 +2168,7 @@ pub const JSValue = enum(i64) {
         return bun.jsc.fromJSHostCall(global, @src(), Bun__JSValue__deserialize, .{ global, bytes.ptr, bytes.len });
     }
 
-    extern fn Bun__serializeJSValue(global: *jsc.JSGlobalObject, value: JSValue, forTransfer: bool) SerializedScriptValue.External;
+    extern fn Bun__serializeJSValue(global: *jsc.JSGlobalObject, value: JSValue, flags: u8) SerializedScriptValue.External;
     extern fn Bun__SerializedScriptSlice__free(*anyopaque) void;
 
     pub const SerializedScriptValue = struct {
@@ -2186,10 +2186,20 @@ pub const JSValue = enum(i64) {
         }
     };
 
+    pub const SerializedFlags = packed struct(u8) {
+        forTransfer: bool = false,
+        forCrossProcess: bool = false,
+        _padding: u6 = 0,
+    };
+
     /// Throws a JS exception and returns null if the serialization fails, otherwise returns a SerializedScriptValue.
     /// Must be freed when you are done with the bytes.
-    pub inline fn serialize(this: JSValue, global: *JSGlobalObject, forTransfer: bool) bun.JSError!SerializedScriptValue {
-        const value = try bun.jsc.fromJSHostCallGeneric(global, @src(), Bun__serializeJSValue, .{ global, this, forTransfer });
+    pub inline fn serialize(this: JSValue, global: *JSGlobalObject, flags: SerializedFlags) bun.JSError!SerializedScriptValue {
+        var flags_u8: u8 = 0;
+        if (flags.forTransfer) flags_u8 |= 1 << 0;
+        if (flags.forCrossProcess) flags_u8 |= 1 << 1;
+
+        const value = try bun.jsc.fromJSHostCallGeneric(global, @src(), Bun__serializeJSValue, .{ global, this, flags_u8 });
         return .{ .data = value.bytes.?[0..value.size], .handle = value.handle.? };
     }
 

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -2187,8 +2187,8 @@ pub const JSValue = enum(i64) {
     };
 
     pub const SerializedFlags = packed struct(u8) {
-        forTransfer: bool = false,
-        forCrossProcess: bool = false,
+        forCrossProcessTransfer: bool = false,
+        forStorage: bool = false,
         _padding: u6 = 0,
     };
 
@@ -2196,8 +2196,8 @@ pub const JSValue = enum(i64) {
     /// Must be freed when you are done with the bytes.
     pub inline fn serialize(this: JSValue, global: *JSGlobalObject, flags: SerializedFlags) bun.JSError!SerializedScriptValue {
         var flags_u8: u8 = 0;
-        if (flags.forTransfer) flags_u8 |= 1 << 0;
-        if (flags.forCrossProcess) flags_u8 |= 1 << 1;
+        if (flags.forCrossProcessTransfer) flags_u8 |= 1 << 0;
+        if (flags.forStorage) flags_u8 |= 1 << 1;
 
         const value = try bun.jsc.fromJSHostCallGeneric(global, @src(), Bun__serializeJSValue, .{ global, this, flags_u8 });
         return .{ .data = value.bytes.?[0..value.size], .handle = value.handle.? };

--- a/src/bun.js/bindings/Serialization.cpp
+++ b/src/bun.js/bindings/Serialization.cpp
@@ -32,7 +32,7 @@ extern "C" SerializedValueSlice Bun__serializeJSValue(JSGlobalObject* globalObje
     Vector<RefPtr<MessagePort>> dummyPorts;
     auto forStorage = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForCrossProcess)) ? SerializationForStorage::Yes : SerializationForStorage::No;
     auto context = SerializationContext::Default;
-    auto forTransferEnum = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForTransfer)) ? SerializationForTransfer::Yes : SerializationForTransfer::No;
+    auto forTransferEnum = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForTransfer)) ? SerializationForCrossProcessTransfer::Yes : SerializationForCrossProcessTransfer::No;
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTFMove(transferList), dummyPorts, forStorage, context, forTransferEnum);
 
     EXCEPTION_ASSERT(!!scope.exception() == serialized.hasException());

--- a/src/bun.js/bindings/Serialization.cpp
+++ b/src/bun.js/bindings/Serialization.cpp
@@ -17,8 +17,8 @@ struct SerializedValueSlice {
 
 enum class SerializedFlags : uint8_t {
     None = 0,
-    ForTransfer = 1 << 0,
-    ForCrossProcess = 1 << 1,
+    ForCrossProcessTransfer = 1 << 0,
+    ForStorage = 1 << 1,
 };
 
 /// Returns a "slice" that also contains a pointer to the SerializedScriptValue. Must be freed by the caller
@@ -30,9 +30,9 @@ extern "C" SerializedValueSlice Bun__serializeJSValue(JSGlobalObject* globalObje
 
     Vector<JSC::Strong<JSC::JSObject>> transferList;
     Vector<RefPtr<MessagePort>> dummyPorts;
-    auto forStorage = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForCrossProcess)) ? SerializationForStorage::Yes : SerializationForStorage::No;
+    auto forStorage = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForStorage)) ? SerializationForStorage::Yes : SerializationForStorage::No;
     auto context = SerializationContext::Default;
-    auto forTransferEnum = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForTransfer)) ? SerializationForCrossProcessTransfer::Yes : SerializationForCrossProcessTransfer::No;
+    auto forTransferEnum = (static_cast<uint8_t>(flags) & static_cast<uint8_t>(SerializedFlags::ForCrossProcessTransfer)) ? SerializationForCrossProcessTransfer::Yes : SerializationForCrossProcessTransfer::No;
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTFMove(transferList), dummyPorts, forStorage, context, forTransferEnum);
 
     EXCEPTION_ASSERT(!!scope.exception() == serialized.hasException());

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3898,6 +3898,15 @@ uint8_t GlobalObject::drainMicrotasks()
 {
     auto& vm = this->vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);
+#if ASSERT_ENABLED
+    if (auto* exception = scope.exception()) {
+        scope.clearException();
+        Bun__reportError(this, JSValue::encode(exception));
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        throwScope.throwException(this, exception);
+        throwScope.release();
+    }
+#endif
     scope.assertNoExceptionExceptTermination();
 
     if (auto nextTickQueue = this->m_nextTickQueue.get()) {

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3866,7 +3866,12 @@ uint8_t GlobalObject::drainMicrotasks()
 
 #if ASSERT_ENABLED
         scope.clearException();
+        // We should not have an exception here.
+        // But it's an easy mistake to make.
+        // Let's log it so that we can debug this.
         Bun__reportError(this, JSValue::encode(exception));
+
+        // And re-throw it to preserve the production behavior.
         auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwScope.throwException(this, exception);
         throwScope.release();

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3327,6 +3327,14 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(AsyncContextFrame::createStructure(init.vm, init.owner));
         });
 
+    m_ipcParseHandleFunction.initLater([](const LazyProperty<JSC::JSGlobalObject, JSC::JSFunction>::Initializer& init) {
+        init.set(JSC::JSFunction::create(init.vm, init.owner, WebCore::ipcParseHandleCodeGenerator(init.vm), init.owner));
+    });
+
+    m_ipcSerializeFunction.initLater([](const LazyProperty<JSC::JSGlobalObject, JSC::JSFunction>::Initializer& init) {
+        init.set(JSC::JSFunction::create(init.vm, init.owner, WebCore::ipcSerializeCodeGenerator(init.vm), init.owner));
+    });
+
     m_JSFileSinkClassStructure.initLater(
         [](LazyClassStructure::Initializer& init) {
             auto* prototype = createJSSinkPrototype(init.vm, init.global, WebCore::SinkID::FileSink);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -627,7 +627,9 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSFloat64Array>, m_statFsValues)                                    \
     V(public, LazyPropertyOfGlobalObject<JSBigInt64Array>, m_bigintStatFsValues)                             \
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMDontContextify)                                    \
-    V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMUseMainContextDefaultLoader)
+    V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMUseMainContextDefaultLoader)                       \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcSerializeFunction)                                \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)
 
 #define DECLARE_GLOBALOBJECT_GC_MEMBER(visibility, T, name) \
     visibility:                                             \

--- a/src/bun.js/bindings/ZigGlobalObject.lut.txt
+++ b/src/bun.js/bindings/ZigGlobalObject.lut.txt
@@ -20,7 +20,7 @@
   setImmediate                    functionSetImmediate                                 Function 1
   setInterval                     functionSetInterval                                  Function 1
   setTimeout                      functionSetTimeout                                   Function 1
-  structuredClone                 functionStructuredClone                              Function 2
+  structuredClone                 WebCore::jsFunctionStructuredClone                    Function 2
   
   global                          GlobalObject_getGlobalThis                           PropertyCallback
   

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -890,7 +890,7 @@ public:
         WasmMemoryHandleArray& wasmMemoryHandles,
 #endif
         Vector<uint8_t>& out, SerializationContext context, ArrayBufferContentsArray& sharedBuffers,
-        SerializationForStorage forStorage, SerializationForTransfer forTransfer)
+        SerializationForStorage forStorage, SerializationForCrossProcessTransfer forTransfer)
     {
         CloneSerializer serializer(lexicalGlobalObject, messagePorts, arrayBuffers,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
@@ -992,7 +992,7 @@ private:
         WasmModuleArray& wasmModules,
         WasmMemoryHandleArray& wasmMemoryHandles,
 #endif
-        Vector<uint8_t>& out, SerializationContext context, ArrayBufferContentsArray& sharedBuffers, SerializationForStorage forStorage, SerializationForTransfer forTransfer)
+        Vector<uint8_t>& out, SerializationContext context, ArrayBufferContentsArray& sharedBuffers, SerializationForStorage forStorage, SerializationForCrossProcessTransfer forTransfer)
         : CloneBase(lexicalGlobalObject)
         , m_buffer(out)
         , m_emptyIdentifier(Identifier::fromString(lexicalGlobalObject->vm(), emptyString()))
@@ -1951,7 +1951,7 @@ private:
             auto _cloneable = StructuredCloneableSerialize::fromJS(value);
             if (_cloneable) {
                 auto cloneable = _cloneable.value();
-                const bool isTransferCompatible = m_forTransfer == SerializationForTransfer::Yes ? cloneable.isForTransfer : true;
+                const bool isTransferCompatible = m_forTransfer == SerializationForCrossProcessTransfer::Yes ? cloneable.isForTransfer : true;
                 const bool isStorageCompatible = m_forStorage == SerializationForStorage::Yes ? cloneable.isForStorage : true;
                 if (!isTransferCompatible || !isStorageCompatible) {
                     write(ObjectTag);
@@ -2563,7 +2563,7 @@ private:
     Vector<RefPtr<WebCodecsVideoFrame>>& m_serializedVideoFrames;
 #endif
     SerializationForStorage m_forStorage;
-    SerializationForTransfer m_forTransfer;
+    SerializationForCrossProcessTransfer m_forTransfer;
 };
 
 SYSV_ABI void SerializedScriptValue::writeBytesForBun(CloneSerializer* ctx, const uint8_t* data, uint32_t size)
@@ -5739,7 +5739,7 @@ static bool canDetachRTCDataChannels(const Vector<Ref<RTCDataChannel>>& channels
 }
 #endif
 
-RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSC::JSGlobalObject& globalObject, JSC::JSValue value, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext serializationContext, SerializationForTransfer forTransfer)
+RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSC::JSGlobalObject& globalObject, JSC::JSValue value, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext serializationContext, SerializationForCrossProcessTransfer forTransfer)
 {
     Vector<RefPtr<MessagePort>> dummyPorts;
     auto result = create(globalObject, value, {}, dummyPorts, forStorage, throwExceptions, serializationContext, forTransfer);
@@ -5754,13 +5754,13 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSC::JSGlobalObject&
 //     return create(globalObject, value, WTFMove(transferList), messagePorts, forStorage, SerializationErrorMode::NonThrowing, serializationContext);
 // }
 
-ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& globalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<RefPtr<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationContext serializationContext, SerializationForTransfer forTransfer)
+ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& globalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<RefPtr<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationContext serializationContext, SerializationForCrossProcessTransfer forTransfer)
 {
     return create(globalObject, value, WTFMove(transferList), messagePorts, forStorage, SerializationErrorMode::Throwing, serializationContext, forTransfer);
 }
 
 // ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& lexicalGlobalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext context)
-ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& lexicalGlobalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<RefPtr<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext context, SerializationForTransfer forTransfer)
+ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& lexicalGlobalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<RefPtr<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext context, SerializationForCrossProcessTransfer forTransfer)
 {
     VM& vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -5768,6 +5768,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     // Fast path optimization: for postMessage/structuredClone with pure strings and no transfers
     if ((context == SerializationContext::WorkerPostMessage || context == SerializationContext::WindowPostMessage || context == SerializationContext::Default)
         && forStorage == SerializationForStorage::No
+        && forTransfer == SerializationForCrossProcessTransfer::No
         && transferList.isEmpty()
         && messagePorts.isEmpty()
         && value.isString()) {

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -6114,15 +6114,15 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
 
 JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, SerializationErrorMode throwExceptions, bool* didFail)
 {
+    VM& vm = lexicalGlobalObject.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     // Fast path for string-only values - avoid deserialization overhead
     if (m_isStringFastPath) {
         if (didFail)
             *didFail = false;
-        return jsString(lexicalGlobalObject.vm(), m_fastPathString);
+        return jsString(vm, m_fastPathString);
     }
 
-    VM& vm = lexicalGlobalObject.vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
     DeserializationResult result = CloneDeserializer::deserialize(&lexicalGlobalObject, globalObject, messagePorts
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         ,

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.h
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.h
@@ -75,7 +75,7 @@ enum class SerializationContext { Default,
     WindowPostMessage };
 enum class SerializationForStorage : bool { No,
     Yes };
-enum class SerializationForTransfer : bool { No,
+enum class SerializationForCrossProcessTransfer : bool { No,
     Yes };
 
 using ArrayBufferContentsArray = Vector<JSC::ArrayBufferContents>;
@@ -92,10 +92,10 @@ public:
     static SYSV_ABI void writeBytesForBun(CloneSerializer*, const uint8_t*, uint32_t);
     static SYSV_ABI bool isTransferable(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
 
-    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default, SerializationForTransfer = SerializationForTransfer::No);
+    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default, SerializationForCrossProcessTransfer = SerializationForCrossProcessTransfer::No);
     // WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);
 
-    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default, SerializationForTransfer = SerializationForTransfer::No);
+    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default, SerializationForCrossProcessTransfer = SerializationForCrossProcessTransfer::No);
 
     static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject& globalObject, JSC::JSValue value) { return create(globalObject, value, SerializationForStorage::Yes); }
 
@@ -154,7 +154,7 @@ private:
     //         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& = {}, Vector<WebCodecsVideoFrameData>&& = {}
     // #endif
     //     );
-    static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext, SerializationForTransfer);
+    static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext, SerializationForCrossProcessTransfer);
     WEBCORE_EXPORT SerializedScriptValue(Vector<unsigned char>&&, std::unique_ptr<ArrayBufferContentsArray>&& = nullptr
 #if ENABLE(WEB_RTC)
         ,

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.h
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.h
@@ -101,6 +101,9 @@ public:
 
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(StringView);
 
+    // Fast path for postMessage with pure strings
+    static Ref<SerializedScriptValue> createStringFastPath(const String& string);
+
     static Ref<SerializedScriptValue> nullValue();
 
     WEBCORE_EXPORT JSC::JSValue deserialize(JSC::JSGlobalObject&, JSC::JSGlobalObject*, SerializationErrorMode = SerializationErrorMode::Throwing, bool* didFail = nullptr);
@@ -200,6 +203,9 @@ private:
 #endif
     );
 
+    // Constructor for string fast path
+    explicit SerializedScriptValue(const String& fastPathString);
+
     size_t computeMemoryCost() const;
 
     Vector<unsigned char> m_data;
@@ -221,6 +227,11 @@ private:
     Vector<WebCodecsVideoFrameData> m_serializedVideoFrames;
 #endif
     // Vector<URLKeepingBlobAlive> m_blobHandles;
+
+    // Fast path for postMessage with pure strings - avoids serialization overhead
+    String m_fastPathString;
+    bool m_isStringFastPath { false };
+
     size_t m_memoryCost { 0 };
 };
 

--- a/src/bun.js/bindings/webcore/StructuredClone.cpp
+++ b/src/bun.js/bindings/webcore/StructuredClone.cpp
@@ -195,7 +195,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced, (JSC::JSGlobalObject
         }
     }
 
-    SerializationForTransfer forTransfer = isForTransfer ? SerializationForTransfer::Yes : SerializationForTransfer::No;
+    SerializationForCrossProcessTransfer forTransfer = isForTransfer ? SerializationForCrossProcessTransfer::Yes : SerializationForCrossProcessTransfer::No;
     SerializationForStorage forStorage = isForStorage ? SerializationForStorage::Yes : SerializationForStorage::No;
 
     Vector<JSC::Strong<JSC::JSObject>> transferList;

--- a/src/bun.js/bindings/webcore/StructuredClone.cpp
+++ b/src/bun.js/bindings/webcore/StructuredClone.cpp
@@ -30,6 +30,8 @@
 #include "JSDOMBinding.h"
 #include "JSDOMExceptionHandling.h"
 #include <JavaScriptCore/JSTypedArrays.h>
+#include "SerializedScriptValue.h"
+#include "MessagePort.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -112,6 +114,117 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject * globalObjec
 
     throwTypeError(globalObject, scope, "structuredClone not implemented for non-ArrayBuffer / non-ArrayBufferView"_s);
     return {};
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredClone, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() == 0) {
+        throwTypeError(globalObject, throwScope, "structuredClone requires 1 argument"_s);
+        return {};
+    }
+
+    JSC::JSValue value = callFrame->argument(0);
+    JSC::JSValue options = callFrame->argument(1);
+
+    Vector<JSC::Strong<JSC::JSObject>> transferList;
+
+    if (options.isObject()) {
+        JSC::JSObject* optionsObject = options.getObject();
+        JSC::JSValue transferListValue = optionsObject->get(globalObject, vm.propertyNames->transfer);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (transferListValue.isObject()) {
+            JSC::JSObject* transferListObject = transferListValue.getObject();
+            if (auto* transferListArray = jsDynamicCast<JSC::JSArray*>(transferListObject)) {
+                for (unsigned i = 0; i < transferListArray->length(); i++) {
+                    JSC::JSValue transferListValue = transferListArray->get(globalObject, i);
+                    RETURN_IF_EXCEPTION(throwScope, {});
+                    if (transferListValue.isObject()) {
+                        JSC::JSObject* transferListObject = transferListValue.getObject();
+                        transferList.append(JSC::Strong<JSC::JSObject>(vm, transferListObject));
+                    }
+                }
+            }
+        }
+    }
+
+    Vector<RefPtr<MessagePort>> ports;
+    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTFMove(transferList), ports);
+    if (serialized.hasException()) {
+        WebCore::propagateException(*globalObject, throwScope, serialized.releaseException());
+        RELEASE_AND_RETURN(throwScope, {});
+    }
+    throwScope.assertNoException();
+
+    JSValue deserialized = serialized.releaseReturnValue()->deserialize(*globalObject, globalObject, ports);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    return JSValue::encode(deserialized);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (callFrame->argumentCount() < 4) {
+        throwTypeError(globalObject, throwScope, "structuredCloneAdvanced requires 3 arguments"_s);
+        return {};
+    }
+
+    JSC::JSValue value = callFrame->argument(0);
+    JSC::JSValue transferListValue = callFrame->argument(1);
+    bool isForTransfer = callFrame->argument(2).toBoolean(globalObject);
+    bool isForStorage = callFrame->argument(3).toBoolean(globalObject);
+    JSC::JSValue serializationContextValue = callFrame->argument(4);
+
+    SerializationContext serializationContext = SerializationContext::Default;
+    if (serializationContextValue.isString()) {
+        if (serializationContextValue.getString(globalObject) == "worker"_s) {
+            serializationContext = SerializationContext::WorkerPostMessage;
+        } else if (serializationContextValue.getString(globalObject) == "window"_s) {
+            serializationContext = SerializationContext::WindowPostMessage;
+        } else if (serializationContextValue.getString(globalObject) == "postMessage"_s) {
+            serializationContext = SerializationContext::WindowPostMessage;
+        } else if (serializationContextValue.getString(globalObject) == "default"_s) {
+            serializationContext = SerializationContext::Default;
+        } else {
+            throwTypeError(globalObject, throwScope, "invalid serialization context"_s);
+        }
+    }
+
+    SerializationForTransfer forTransfer = isForTransfer ? SerializationForTransfer::Yes : SerializationForTransfer::No;
+    SerializationForStorage forStorage = isForStorage ? SerializationForStorage::Yes : SerializationForStorage::No;
+
+    Vector<JSC::Strong<JSC::JSObject>> transferList;
+
+    if (transferListValue.isObject()) {
+        JSC::JSObject* transferListObject = transferListValue.getObject();
+        if (auto* transferListArray = jsDynamicCast<JSC::JSArray*>(transferListObject)) {
+            for (unsigned i = 0; i < transferListArray->length(); i++) {
+                JSC::JSValue transferListValue = transferListArray->get(globalObject, i);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                if (transferListValue.isObject()) {
+                    transferList.append(JSC::Strong<JSC::JSObject>(vm, transferListValue.getObject()));
+                }
+            }
+        }
+    }
+
+    Vector<RefPtr<MessagePort>> ports;
+    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTFMove(transferList), ports, forStorage, serializationContext, forTransfer);
+    if (serialized.hasException()) {
+        WebCore::propagateException(*globalObject, throwScope, serialized.releaseException());
+        RELEASE_AND_RETURN(throwScope, {});
+    }
+    throwScope.assertNoException();
+
+    JSValue deserialized = serialized.releaseReturnValue()->deserialize(*globalObject, globalObject, ports);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    return JSValue::encode(deserialized);
 }
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/StructuredClone.h
+++ b/src/bun.js/bindings/webcore/StructuredClone.h
@@ -36,5 +36,6 @@ namespace WebCore {
 
 JSC_DECLARE_HOST_FUNCTION(cloneArrayBuffer);
 JSC_DECLARE_HOST_FUNCTION(structuredCloneForStream);
-
+JSC_DECLARE_HOST_FUNCTION(jsFunctionStructuredClone);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced);
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -248,7 +248,7 @@ ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue m
 
     MessageWithMessagePorts messageWithMessagePorts { serialized.releaseReturnValue(), disentangledPorts.releaseReturnValue() };
 
-    this->postTaskToWorkerGlobalScope([message = messageWithMessagePorts](auto& context) mutable {
+    this->postTaskToWorkerGlobalScope([message = WTFMove(messageWithMessagePorts)](auto& context) mutable {
         Zig::GlobalObject* globalObject = jsCast<Zig::GlobalObject*>(context.jsGlobalObject());
 
         auto ports = MessagePort::entanglePorts(context, WTFMove(message.transferredPorts));

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -118,11 +118,10 @@ const advanced = struct {
 
     pub fn serialize(writer: *bun.io.StreamBuffer, global: *jsc.JSGlobalObject, value: JSValue, is_internal: IsInternal) !usize {
         const serialized = try value.serialize(global, .{
-            // You can't do transfer() across processes. That does not work.
-            .forTransfer = false,
+            // IPC sends across process.
+            .forCrossProcessTransfer = true,
 
-            // This is for cross-process serialization, so it must go through the Storage version.
-            .forCrossProcess = true,
+            .forStorage = false,
         });
         defer serialized.deinit();
 

--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -1081,8 +1081,7 @@ fn handleIPCMessage(send_queue: *SendQueue, message: DecodedIPCMessage, globalTh
                 if (!ack) return;
 
                 // Get file descriptor and clear it
-                const fd = send_queue.incoming_fd.?;
-                send_queue.incoming_fd = null;
+                const fd: bun.FD = bun.take(&send_queue.incoming_fd).?;
 
                 const target: bun.jsc.JSValue = switch (send_queue.owner) {
                     .subprocess => |subprocess| subprocess.this_jsvalue,

--- a/src/bun.js/modules/BunJSCModule.h
+++ b/src/bun.js/modules/BunJSCModule.h
@@ -777,7 +777,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSerialize,
 
     Vector<JSC::Strong<JSC::JSObject>> transferList;
     Vector<RefPtr<MessagePort>> dummyPorts;
-    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTFMove(transferList), dummyPorts);
+    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTFMove(transferList), dummyPorts, SerializationForStorage::Yes);
     EXCEPTION_ASSERT(serialized.hasException() == !!throwScope.exception());
     if (serialized.hasException()) {
         WebCore::propagateException(*globalObject, throwScope, serialized.releaseException());

--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -23,7 +23,7 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callFrame: *jsc.CallFrame) b
     return ptr;
 }
 
-// **Cross-thread**
+/// May be called from any thread.
 pub fn estimatedSize(this: *@This()) usize {
     return (@sizeOf(@This()) + this.estimated_size.load(.seq_cst)) / this.ref_count.get();
 }

--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -11,6 +11,9 @@ globalThis: *jsc.JSGlobalObject,
 da_rules: std.ArrayList(Rule),
 mutex: bun.Mutex = .{},
 
+/// We cannot lock/unlock a mutex
+estimated_size: std.atomic.Value(u32) = .init(0),
+
 pub fn constructor(globalThis: *jsc.JSGlobalObject, callFrame: *jsc.CallFrame) bun.JSError!*@This() {
     _ = callFrame;
     const ptr = @This().new(.{
@@ -20,10 +23,9 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callFrame: *jsc.CallFrame) b
     return ptr;
 }
 
+// **Cross-thread**
 pub fn estimatedSize(this: *@This()) usize {
-    this.mutex.lock();
-    defer this.mutex.unlock();
-    return @sizeOf(@This()) + (@sizeOf(Rule) * this.da_rules.items.len);
+    return (@sizeOf(@This()) + this.estimated_size.load(.seq_cst)) / this.ref_count.get();
 }
 
 pub fn finalize(this: *@This()) void {
@@ -42,8 +44,6 @@ pub fn isBlockList(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) b
 }
 
 pub fn addAddress(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-    this.mutex.lock();
-    defer this.mutex.unlock();
     const arguments = callframe.argumentsAsArray(2);
     const address_js, var family_js = arguments;
     if (family_js.isUndefined()) family_js = bun.String.static("ipv4").toJS(globalThis);
@@ -52,13 +52,15 @@ pub fn addAddress(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *j
         try validators.validateString(globalThis, family_js, "family", .{});
         break :blk (try SocketAddress.initFromAddrFamily(globalThis, address_js, family_js))._addr;
     };
+
+    this.mutex.lock();
+    defer this.mutex.unlock();
     try this.da_rules.insert(0, .{ .addr = address });
+    _ = this.estimated_size.fetchAdd(@sizeOf(Rule), .monotonic);
     return .js_undefined;
 }
 
 pub fn addRange(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-    this.mutex.lock();
-    defer this.mutex.unlock();
     const arguments = callframe.argumentsAsArray(3);
     const start_js, const end_js, var family_js = arguments;
     if (family_js.isUndefined()) family_js = bun.String.static("ipv4").toJS(globalThis);
@@ -72,18 +74,19 @@ pub fn addRange(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc
         try validators.validateString(globalThis, family_js, "family", .{});
         break :blk (try SocketAddress.initFromAddrFamily(globalThis, end_js, family_js))._addr;
     };
-    if (_compare(start, end)) |ord| {
+    if (_compare(&start, &end)) |ord| {
         if (ord.compare(.gt)) {
             return globalThis.throwInvalidArgumentValueCustom("start", start_js, "must come before end");
         }
     }
+    this.mutex.lock();
+    defer this.mutex.unlock();
     try this.da_rules.insert(0, .{ .range = .{ .start = start, .end = end } });
+    _ = this.estimated_size.fetchAdd(@sizeOf(Rule), .monotonic);
     return .js_undefined;
 }
 
 pub fn addSubnet(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-    this.mutex.lock();
-    defer this.mutex.unlock();
     const arguments = callframe.argumentsAsArray(3);
     const network_js, const prefix_js, var family_js = arguments;
     if (family_js.isUndefined()) family_js = bun.String.static("ipv4").toJS(globalThis);
@@ -98,17 +101,18 @@ pub fn addSubnet(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *js
         std.posix.AF.INET6 => prefix = @intCast(try validators.validateInt32(globalThis, prefix_js, "prefix", .{}, 0, 128)),
         else => {},
     }
+    this.mutex.lock();
+    defer this.mutex.unlock();
     try this.da_rules.insert(0, .{ .subnet = .{ .network = network, .prefix = prefix } });
+    _ = this.estimated_size.fetchAdd(@sizeOf(Rule), .monotonic);
     return .js_undefined;
 }
 
 pub fn check(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-    this.mutex.lock();
-    defer this.mutex.unlock();
     const arguments = callframe.argumentsAsArray(2);
     const address_js, var family_js = arguments;
     if (family_js.isUndefined()) family_js = bun.String.static("ipv4").toJS(globalThis);
-    const address = if (address_js.as(SocketAddress)) |sa| sa._addr else blk: {
+    const address = &(if (address_js.as(SocketAddress)) |sa| sa._addr else blk: {
         try validators.validateString(globalThis, address_js, "address", .{});
         try validators.validateString(globalThis, family_js, "family", .{});
         break :blk (SocketAddress.initFromAddrFamily(globalThis, address_js, family_js) catch |err| {
@@ -116,19 +120,21 @@ pub fn check(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.Ca
             globalThis.clearException();
             return .jsBoolean(false);
         })._addr;
-    };
-    for (this.da_rules.items) |item| {
-        switch (item) {
-            .addr => |a| {
+    });
+    this.mutex.lock();
+    defer this.mutex.unlock();
+    for (this.da_rules.items) |*item| {
+        switch (item.*) {
+            .addr => |*a| {
                 const order = _compare(address, a) orelse continue;
                 if (order.compare(.eq)) return .jsBoolean(true);
             },
-            .range => |r| {
-                const os = _compare(address, r.start) orelse continue;
-                const oe = _compare(address, r.end) orelse continue;
+            .range => |*r| {
+                const os = _compare(address, &r.start) orelse continue;
+                const oe = _compare(address, &r.end) orelse continue;
                 if (os.compare(.gte) and oe.compare(.lte)) return .jsBoolean(true);
             },
-            .subnet => |s| {
+            .subnet => |*s| {
                 if (address.as_v4()) |ip_addr| if (s.network.as_v4()) |subnet_addr| {
                     if (s.prefix == 32) if (ip_addr == subnet_addr) (return .jsBoolean(true)) else continue;
                     const one: u32 = 1;
@@ -154,28 +160,30 @@ pub fn check(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.Ca
 }
 
 pub fn rules(this: *@This(), globalThis: *jsc.JSGlobalObject) bun.JSError!jsc.JSValue {
+
+    // GC must be able to visit
+    var array = try jsc.JSArray.createEmpty(globalThis, 0);
+
     this.mutex.lock();
     defer this.mutex.unlock();
-    var list = std.ArrayList(jsc.JSValue).initCapacity(bun.default_allocator, this.da_rules.items.len) catch bun.outOfMemory();
-    defer list.deinit();
-    for (this.da_rules.items) |rule| {
-        switch (rule) {
-            .addr => |a| {
+    for (this.da_rules.items) |*rule| {
+        switch (rule.*) {
+            .addr => |*a| {
                 var buf: [SocketAddress.inet.INET6_ADDRSTRLEN]u8 = @splat(0);
-                list.appendAssumeCapacity(try bun.String.createFormatForJS(globalThis, "Address: {s} {s}", .{ a.family().upper(), a.fmt(&buf) }));
+                try array.push(globalThis, try bun.String.createFormatForJS(globalThis, "Address: {s} {s}", .{ a.family().upper(), a.fmt(&buf) }));
             },
-            .range => |r| {
+            .range => |*r| {
                 var buf_s: [SocketAddress.inet.INET6_ADDRSTRLEN]u8 = @splat(0);
                 var buf_e: [SocketAddress.inet.INET6_ADDRSTRLEN]u8 = @splat(0);
-                list.appendAssumeCapacity(try bun.String.createFormatForJS(globalThis, "Range: {s} {s}-{s}", .{ r.start.family().upper(), r.start.fmt(&buf_s), r.end.fmt(&buf_e) }));
+                try array.push(globalThis, try bun.String.createFormatForJS(globalThis, "Range: {s} {s}-{s}", .{ r.start.family().upper(), r.start.fmt(&buf_s), r.end.fmt(&buf_e) }));
             },
-            .subnet => |s| {
+            .subnet => |*s| {
                 var buf: [SocketAddress.inet.INET6_ADDRSTRLEN]u8 = @splat(0);
-                list.appendAssumeCapacity(try bun.String.createFormatForJS(globalThis, "Subnet: {s} {s}/{d}", .{ s.network.family().upper(), s.network.fmt(&buf), s.prefix }));
+                try array.push(globalThis, try bun.String.createFormatForJS(globalThis, "Subnet: {s} {s}/{d}", .{ s.network.family().upper(), s.network.fmt(&buf), s.prefix }));
             },
         }
     }
-    return jsc.JSArray.create(globalThis, list.items);
+    return array;
 }
 
 pub fn onStructuredCloneSerialize(this: *@This(), globalThis: *jsc.JSGlobalObject, ctx: *anyopaque, writeBytes: *const fn (*anyopaque, ptr: [*]const u8, len: u32) callconv(jsc.conv) void) void {
@@ -216,13 +224,13 @@ pub const Rule = union(enum) {
     subnet: struct { network: sockaddr, prefix: u8 },
 };
 
-fn _compare(l: sockaddr, r: sockaddr) ?std.math.Order {
+fn _compare(l: *const sockaddr, r: *const sockaddr) ?std.math.Order {
     if (l.as_v4()) |l_4| if (r.as_v4()) |r_4| return std.math.order(@byteSwap((l_4)), @byteSwap((r_4)));
-    if (l.sin.family == std.posix.AF.INET6 and r.sin.family == std.posix.AF.INET6) return _compare_ipv6(l.sin6, r.sin6);
+    if (l.sin.family == std.posix.AF.INET6 and r.sin.family == std.posix.AF.INET6) return _compare_ipv6(&l.sin6, &r.sin6);
     return null;
 }
 
-fn _compare_ipv6(l: sockaddr.in6, r: sockaddr.in6) std.math.Order {
+fn _compare_ipv6(l: *const sockaddr.in6, r: *const sockaddr.in6) std.math.Order {
     return std.math.order(@byteSwap((@as(u128, @bitCast(l.addr)))), @byteSwap((@as(u128, @bitCast(r.addr)))));
 }
 

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -2707,7 +2707,7 @@ pub fn getWriter(
                 .path = ZigString.Slice.fromUTF8NeverFree(
                     store.data.file.pathlike.path.slice(),
                 ).cloneIfNeeded(
-                    globalThis.allocator(),
+                    bun.default_allocator,
                 ) catch bun.outOfMemory(),
             };
         }
@@ -4390,7 +4390,7 @@ pub const Internal = struct {
 
     pub fn toStringOwned(this: *@This(), globalThis: *jsc.JSGlobalObject) JSValue {
         const bytes_without_bom = strings.withoutUTF8BOM(this.bytes.items);
-        if (strings.toUTF16Alloc(globalThis.allocator(), bytes_without_bom, false, false) catch &[_]u16{}) |out| {
+        if (strings.toUTF16Alloc(bun.default_allocator, bytes_without_bom, false, false) catch &[_]u16{}) |out| {
             const return_value = ZigString.toExternalU16(out.ptr, out.len, globalThis);
             return_value.ensureStillAlive();
             this.deinit();

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -572,7 +572,7 @@ pub fn constructInto(globalThis: *jsc.JSGlobalObject, arguments: []const jsc.JSV
         if (value_type == .DOMWrapper) {
             if (value.asDirect(Request)) |request| {
                 if (values_to_try.len == 1) {
-                    try request.cloneInto(&req, globalThis.allocator(), globalThis, fields.contains(.url));
+                    try request.cloneInto(&req, bun.default_allocator, globalThis, fields.contains(.url));
                     success = true;
                     return req;
                 }

--- a/src/bun.js/webcore/TextDecoder.zig
+++ b/src/bun.js/webcore/TextDecoder.zig
@@ -203,7 +203,7 @@ fn decodeSlice(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, buffer_slice
             //
             // It's not clear why we couldn't jusst use Latin1 here, but tests failures proved it necessary.
             const out_length = strings.elementLengthLatin1IntoUTF16([]const u8, buffer_slice);
-            const bytes = try globalThis.allocator().alloc(u16, out_length);
+            const bytes = try bun.default_allocator.alloc(u16, out_length);
 
             const out = strings.copyLatin1IntoUTF16([]u16, bytes, []const u8, buffer_slice);
             return ZigString.toExternalU16(bytes.ptr, out.written, globalThis);

--- a/src/bun.js/webcore/response.classes.ts
+++ b/src/bun.js/webcore/response.classes.ts
@@ -139,7 +139,7 @@ export default [
 
       // TODO: fix this.
       // We should support it unless i'ts a file descriptor.
-      storable: false,
+      storable: true,
     },
     estimatedSize: true,
     values: ["stream"],

--- a/src/bun.js/webcore/response.classes.ts
+++ b/src/bun.js/webcore/response.classes.ts
@@ -138,7 +138,7 @@ export default [
       tag: 254,
 
       // TODO: fix this.
-      // We should support it unless i'ts a file descriptor.
+      // We should support it unless it's a file descriptor.
       storable: true,
     },
     estimatedSize: true,

--- a/src/bun.js/webcore/response.classes.ts
+++ b/src/bun.js/webcore/response.classes.ts
@@ -133,7 +133,7 @@ export default [
     JSType: "0b11101110",
     klass: {},
     configurable: false,
-    structuredClone: { transferable: false, tag: 254 },
+    structuredClone: { transferable: false, tag: 254, storable: true },
     estimatedSize: true,
     values: ["stream"],
     overridesToJS: true,

--- a/src/bun.js/webcore/response.classes.ts
+++ b/src/bun.js/webcore/response.classes.ts
@@ -133,7 +133,14 @@ export default [
     JSType: "0b11101110",
     klass: {},
     configurable: false,
-    structuredClone: { transferable: false, tag: 254, storable: true },
+    structuredClone: {
+      transferable: false,
+      tag: 254,
+
+      // TODO: fix this.
+      // We should support it unless i'ts a file descriptor.
+      storable: false,
+    },
     estimatedSize: true,
     values: ["stream"],
     overridesToJS: true,

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -42,7 +42,7 @@ const JS_DIR = path.join(CMAKE_BUILD_ROOT, "js");
 const t = new Bun.Transpiler({ loader: "tsx" });
 
 let start = performance.now();
-const silent = process.env.BUN_SILENT === "1";
+const silent = process.env.BUN_SILENT === "1" || process.env.CLAUDECODE;
 function markVerbose(log: string) {
   const now = performance.now();
   console.log(`${log} (${(now - start).toFixed(0)}ms)`);

--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -212,7 +212,7 @@ export class ClassDefinition {
 
   configurable?: boolean;
   enumerable?: boolean;
-  structuredClone?: { transferable: boolean; tag: number };
+  structuredClone?: { transferable: boolean; tag: number; storable: boolean };
   inspectCustom?: boolean;
 
   callbacks?: Record<string, string>;

--- a/src/codegen/cppbind.ts
+++ b/src/codegen/cppbind.ts
@@ -798,21 +798,22 @@ async function main() {
   const resultSourceLinksContents = resultSourceLinks.join("\n");
   if ((await readFileOrEmpty(resultSourceLinksFilePath)) !== resultSourceLinksContents) {
     await Bun.write(resultSourceLinksFilePath, resultSourceLinksContents);
+    const now = Date.now();
+    const sin = Math.round(((Math.sin((now / 1000) * 1) + 1) / 2) * 0);
+    if (process.env.CI) {
+      console.log(
+        " ".repeat(sin) +
+          (errors.length > 0 ? "✗" : "✓") +
+          " cppbind.ts generated bindings to " +
+          resultFilePath +
+          (errors.length > 0 ? " with errors" : "") +
+          " in " +
+          (now - start) +
+          "ms",
+      );
+    }
   }
 
-  const now = Date.now();
-  const sin = Math.round(((Math.sin((now / 1000) * 1) + 1) / 2) * 0);
-
-  console.log(
-    " ".repeat(sin) +
-      (errors.length > 0 ? "✗" : "✓") +
-      " cppbind.ts generated bindings to " +
-      resultFilePath +
-      (errors.length > 0 ? " with errors" : "") +
-      " in " +
-      (now - start) +
-      "ms",
-  );
   if (errors.length > 0) {
     process.exit(1);
   }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2567,10 +2567,13 @@ class StructuredCloneableSerialize {
     CppStructuredCloneableSerializeFunction cppWriteBytes;
     ZigStructuredCloneableSerializeFunction zigFunction;
 
-    uint8_t tag;
+    uint8_t tag = 0;
 
     // the type from zig
-    void* impl;
+    void* impl = nullptr;
+
+    bool isForTransfer = false;
+    bool isForStorage = false;
 
     static std::optional<StructuredCloneableSerialize> fromJS(JSC::JSValue);
     void write(CloneSerializer* serializer, JSC::JSGlobalObject* globalObject)
@@ -2601,7 +2604,7 @@ function writeCppSerializers() {
       return StructuredCloneableSerialize { .cppWriteBytes = SerializedScriptValue::writeBytesForBun, .zigFunction = ${symbolName(
         klass.name,
         "onStructuredCloneSerialize",
-      )}, .tag = ${klass.structuredClone.tag}, .impl = result->wrapped() };
+      )}, .tag = ${klass.structuredClone.tag}, .impl = result->wrapped(), .isForTransfer = ${!!klass.structuredClone.transferable}, .isForStorage = ${!!klass.structuredClone.storable} };
     }
     `;
   }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -195,7 +195,7 @@ interface setSocketOptionsFn {
 export const setSocketOptions: setSocketOptionsFn = $newZigFunction("socket.zig", "jsSetSocketOptions", 3);
 export const structuredCloneAdvanced: (
   value: any,
-  transferList?: any[],
+  transferList: any[],
   forTransfer: boolean,
   forStorage: boolean,
   serializationContext: "worker" | "window" | "postMessage" | "default",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -194,4 +194,10 @@ interface setSocketOptionsFn {
 
 export const setSocketOptions: setSocketOptionsFn = $newZigFunction("socket.zig", "jsSetSocketOptions", 3);
 type SerializationContext = "worker" | "window" | "postMessage" | "default";
-export const structuredCloneAdvanced: (value: any, transferList: any[], forTransfer: boolean, forStorage: boolean, serializationContext: SerializationContext) => any = $newCppFunction("StructuredClone.cpp", "jsFunctionStructuredCloneAdvanced", 5);
+export const structuredCloneAdvanced: (
+  value: any,
+  transferList: any[],
+  forTransfer: boolean,
+  forStorage: boolean,
+  serializationContext: SerializationContext,
+) => any = $newCppFunction("StructuredClone.cpp", "jsFunctionStructuredCloneAdvanced", 5);

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -193,3 +193,10 @@ interface setSocketOptionsFn {
 }
 
 export const setSocketOptions: setSocketOptionsFn = $newZigFunction("socket.zig", "jsSetSocketOptions", 3);
+export const structuredCloneAdvanced: (
+  value: any,
+  transferList?: any[],
+  forTransfer: boolean,
+  forStorage: boolean,
+  serializationContext: "worker" | "window" | "postMessage" | "default",
+) => any = $newCppFunction("StructuredClone.cpp", "jsFunctionStructuredCloneAdvanced", 5);

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -193,10 +193,5 @@ interface setSocketOptionsFn {
 }
 
 export const setSocketOptions: setSocketOptionsFn = $newZigFunction("socket.zig", "jsSetSocketOptions", 3);
-export const structuredCloneAdvanced: (
-  value: any,
-  transferList: any[],
-  forTransfer: boolean,
-  forStorage: boolean,
-  serializationContext: "worker" | "window" | "postMessage" | "default",
-) => any = $newCppFunction("StructuredClone.cpp", "jsFunctionStructuredCloneAdvanced", 5);
+type SerializationContext = "worker" | "window" | "postMessage" | "default";
+export const structuredCloneAdvanced: (value: any, transferList: any[], forTransfer: boolean, forStorage: boolean, serializationContext: SerializationContext) => any = $newCppFunction("StructuredClone.cpp", "jsFunctionStructuredCloneAdvanced", 5);

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -269,7 +269,7 @@ export function tempDirWithFilesAnon(filesOrAbsolutePathToCopyFolderFrom: Direct
   return base;
 }
 
-export function bunRun(file: string, env?: Record<string, string> | NodeJS.ProcessEnv) {
+export function bunRun(file: string, env?: Record<string, string> | NodeJS.ProcessEnv, dump = false) {
   var path = require("path");
   const result = Bun.spawnSync([bunExe(), file], {
     cwd: path.dirname(file),
@@ -278,11 +278,14 @@ export function bunRun(file: string, env?: Record<string, string> | NodeJS.Proce
       NODE_ENV: undefined,
       ...env,
     },
+    stdin: "ignore",
+    stdout: !dump ? "pipe" : "inherit",
+    stderr: !dump ? "pipe" : "inherit",
   });
-  if (!result.success) throw new Error(result.stderr.toString("utf8"));
+  if (!result.success) throw new Error(String(result.stderr) + "\n" + String(result.stdout));
   return {
-    stdout: result.stdout.toString("utf8").trim(),
-    stderr: result.stderr.toString("utf8").trim(),
+    stdout: String(result.stdout ?? "").trim(),
+    stderr: String(result.stderr ?? "").trim(),
   };
 }
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -282,7 +282,14 @@ export function bunRun(file: string, env?: Record<string, string> | NodeJS.Proce
     stdout: !dump ? "pipe" : "inherit",
     stderr: !dump ? "pipe" : "inherit",
   });
-  if (!result.success) throw new Error(String(result.stderr) + "\n" + String(result.stdout));
+  if (!result.success) {
+    if (dump) {
+      throw new Error(
+        "exited with code " + result.exitCode + (result.signalCode ? `signal: ${result.signalCode}` : ""),
+      );
+    }
+    throw new Error(String(result.stderr) + "\n" + String(result.stdout));
+  }
   return {
     stdout: String(result.stdout ?? "").trim(),
     stderr: String(result.stderr ?? "").trim(),

--- a/test/js/bun/jsc/string-noAtomize.test.ts
+++ b/test/js/bun/jsc/string-noAtomize.test.ts
@@ -1,0 +1,27 @@
+// @bun
+const { describe, expect, it, test } = Bun.jest(import.meta.path);
+
+test("string no atomize should work", () => {
+  var str = "hello";
+  if (structuredClone(str) !== str) {
+    throw new Error("FAIL");
+  }
+
+  var obj = {};
+  for (var i = 0; i < 10000; i++) {
+    obj[str] = str;
+  }
+
+  if (Object.getOwnPropertyNames(obj).length !== 1) {
+    throw new Error("FAIL");
+  }
+
+  var obj2 = {};
+  for (var i = 0; i < 10000; i++) {
+    obj2[str] = Object.getOwnPropertyNames(obj)[0];
+  }
+
+  if (structuredClone(Object.getOwnPropertyNames(obj2)[0]) !== str) {
+    throw new Error("FAIL");
+  }
+});

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -49,6 +49,11 @@ if (cluster.isPrimary) {
   worker.on("online", function () {
     worker.send({ file });
   });
+  worker.on("exit", function (code, signal) {
+    if (code !== 0) {
+      process.exit(code);
+    }
+  });
   worker.on("message", function (data) {
     worker.kill();
     const { file } = data;
@@ -62,6 +67,10 @@ if (cluster.isPrimary) {
   process.on("message", msg => {
     console.log("W", msg);
     process.send!(msg);
+  });
+  process.on("uncaughtExceptionMonitor", (error) => {
+    console.error(error);
+    process.exit(1);
   });
 }
 `,
@@ -84,6 +93,11 @@ if (cluster.isPrimary) {
   worker.on("online", function () {
     worker.send({ blocklist });
   });
+  worker.on("exit", function (code, signal) {
+    if (code !== 0) {
+      process.exit(code);
+    }
+  });
   worker.on("message", function (data) {
     worker.kill();
     const { blocklist } = data;
@@ -95,7 +109,11 @@ if (cluster.isPrimary) {
 } else {
   process.on("message", msg => {
     console.log("W", msg);
-    process.send!(msg);
+    process.send!(msg); 
+  });
+  process.on("uncaughtExceptionMonitor", (error) => {
+    console.error(error);
+    process.exit(1);
   });
 }
 `,

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -30,7 +30,7 @@ if (cluster.isPrimary) {
 }
 `,
   });
-  bunRun(joinP(dir, "index.ts"), bunEnv);
+  bunRun(joinP(dir, "index.ts"), bunEnv, true);
 });
 
 test("cloneable and non-transferable not-equals (BunFile)", () => {
@@ -66,7 +66,7 @@ if (cluster.isPrimary) {
 }
 `,
   });
-  bunRun(joinP(dir, "index.ts"), bunEnv);
+  bunRun(joinP(dir, "index.ts"), bunEnv, true);
 });
 
 test("cloneable and non-transferable not-equals (net.BlockList)", () => {
@@ -100,5 +100,5 @@ if (cluster.isPrimary) {
 }
 `,
   });
-  bunRun(joinP(dir, "index.ts"), bunEnv);
+  bunRun(joinP(dir, "index.ts"), bunEnv, true);
 });

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Structured Clone Fast Path", () => {
+  test("structuredClone should use a constant amount of memory for string inputs", () => {
+    // Create a 100KB string to test fast path
+    const largeString = Buffer.alloc(512 * 1024).toString();
+    for (let i = 0; i < 100; i++) {
+      structuredClone(largeString);
+    }
+    const rss = process.memoryUsage.rss();
+    for (let i = 0; i < 10000; i++) {
+      structuredClone(largeString);
+    }
+    const rss2 = process.memoryUsage.rss();
+    const delta = rss2 - rss;
+    expect(delta).toBeLessThan(1024 * 1024);
+  });
+});

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,246 +1,282 @@
 import { openSync } from "fs";
 import { join } from "path";
+import { serialize, deserialize } from "bun:jsc";
+import { bunExe } from "js/bun/shell/test_builder";
+import { bunEnv } from "harness";
+function jscSerializeRoundtrip(value: any) {
+  const serialized = serialize(value);
+  const cloned = deserialize(serialized);
+  return cloned;
+}
 
-describe("structured clone", () => {
-  let primitives_tests = [
-    { description: "primitive undefined", value: undefined },
-    { description: "primitive null", value: null },
-    { description: "primitive true", value: true },
-    { description: "primitive false", value: false },
-    { description: "primitive string, empty string", value: "" },
-    { description: "primitive string, lone high surrogate", value: "\uD800" },
-    { description: "primitive string, lone low surrogate", value: "\uDC00" },
-    { description: "primitive string, NUL", value: "\u0000" },
-    { description: "primitive string, astral character", value: "\uDBFF\uDFFD" },
-    { description: "primitive number, 0.2", value: 0.2 },
-    { description: "primitive number, 0", value: 0 },
-    { description: "primitive number, -0", value: -0 },
-    { description: "primitive number, NaN", value: NaN },
-    { description: "primitive number, Infinity", value: Infinity },
-    { description: "primitive number, -Infinity", value: -Infinity },
-    { description: "primitive number, 9007199254740992", value: 9007199254740992 },
-    { description: "primitive number, -9007199254740992", value: -9007199254740992 },
-    { description: "primitive number, 9007199254740994", value: 9007199254740994 },
-    { description: "primitive number, -9007199254740994", value: -9007199254740994 },
-    { description: "primitive BigInt, 0n", value: 0n },
-    { description: "primitive BigInt, -0n", value: -0n },
-    { description: "primitive BigInt, -9007199254740994000n", value: -9007199254740994000n },
-    {
-      description: "primitive BigInt, -9007199254740994000900719925474099400090071992547409940009007199254740994000n",
-      value: -9007199254740994000900719925474099400090071992547409940009007199254740994000n,
-    },
-  ];
-  for (let { description, value } of primitives_tests) {
-    test(description, () => {
-      const cloned = structuredClone(value);
-      expect(cloned).toBe(value);
-    });
-  }
+function jscSerializeRoundtripCrossProcess(original: any) {
+  const serialized = serialize(original);
 
-  test("Array with primitives", () => {
-    const input = [
-      undefined,
-      null,
-      true,
-      false,
-      "",
-      "\uD800",
-      "\uDC00",
-      "\u0000",
-      "\uDBFF\uDFFD",
-      0.2,
-      0,
-      -0,
-      NaN,
-      Infinity,
-      -Infinity,
-      9007199254740992,
-      -9007199254740992,
-      9007199254740994,
-      -9007199254740994,
-      -12n,
-      -0n,
-      0n,
+  const result = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+    import {deserialize, serialize} from "bun:jsc";
+    const serialized = deserialize(await Bun.stdin.bytes());
+    const cloned = serialize(serialized);
+    process.stdout.write(cloned);
+    `,
+    ],
+    env: bunEnv,
+    stdin: serialized,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  return deserialize(result.stdout);
+}
+
+for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSerializeRoundtripCrossProcess]) {
+  describe(structuredCloneFn.name, () => {
+    let primitives_tests = [
+      { description: "primitive undefined", value: undefined },
+      { description: "primitive null", value: null },
+      { description: "primitive true", value: true },
+      { description: "primitive false", value: false },
+      { description: "primitive string, empty string", value: "" },
+      { description: "primitive string, lone high surrogate", value: "\uD800" },
+      { description: "primitive string, lone low surrogate", value: "\uDC00" },
+      { description: "primitive string, NUL", value: "\u0000" },
+      { description: "primitive string, astral character", value: "\uDBFF\uDFFD" },
+      { description: "primitive number, 0.2", value: 0.2 },
+      { description: "primitive number, 0", value: 0 },
+      { description: "primitive number, -0", value: -0 },
+      { description: "primitive number, NaN", value: NaN },
+      { description: "primitive number, Infinity", value: Infinity },
+      { description: "primitive number, -Infinity", value: -Infinity },
+      { description: "primitive number, 9007199254740992", value: 9007199254740992 },
+      { description: "primitive number, -9007199254740992", value: -9007199254740992 },
+      { description: "primitive number, 9007199254740994", value: 9007199254740994 },
+      { description: "primitive number, -9007199254740994", value: -9007199254740994 },
+      { description: "primitive BigInt, 0n", value: 0n },
+      { description: "primitive BigInt, -0n", value: -0n },
+      { description: "primitive BigInt, -9007199254740994000n", value: -9007199254740994000n },
+      {
+        description: "primitive BigInt, -9007199254740994000900719925474099400090071992547409940009007199254740994000n",
+        value: -9007199254740994000900719925474099400090071992547409940009007199254740994000n,
+      },
     ];
-    const cloned = structuredClone(input);
-    expect(cloned).toBeInstanceOf(Array);
-    expect(cloned).not.toBe(input);
-    expect(cloned.length).toEqual(input.length);
-    for (const x in input) {
-      expect(cloned[x]).toBe(input[x]);
-    }
-  });
-  test("Object with primitives", () => {
-    const input: any = {
-      undefined: undefined,
-      null: null,
-      true: true,
-      false: false,
-      empty: "",
-      "high surrogate": "\uD800",
-      "low surrogate": "\uDC00",
-      nul: "\u0000",
-      astral: "\uDBFF\uDFFD",
-      "0.2": 0.2,
-      "0": 0,
-      "-0": -0,
-      NaN: NaN,
-      Infinity: Infinity,
-      "-Infinity": -Infinity,
-      "9007199254740992": 9007199254740992,
-      "-9007199254740992": -9007199254740992,
-      "9007199254740994": 9007199254740994,
-      "-9007199254740994": -9007199254740994,
-      "-12n": -12n,
-      "-0n": -0n,
-      "0n": 0n,
-    };
-    const cloned = structuredClone(input);
-    expect(cloned).toBeInstanceOf(Object);
-    expect(cloned).not.toBeInstanceOf(Array);
-    expect(cloned).not.toBe(input);
-    for (const x in input) {
-      expect(cloned[x]).toBe(input[x]);
-    }
-  });
-
-  test("map", () => {
-    const input = new Map();
-    input.set("a", 1);
-    input.set("b", 2);
-    input.set("c", 3);
-    const cloned = structuredClone(input);
-    expect(cloned).toBeInstanceOf(Map);
-    expect(cloned).not.toBe(input);
-    expect(cloned.size).toEqual(input.size);
-    for (const [key, value] of input) {
-      expect(cloned.get(key)).toBe(value);
-    }
-  });
-
-  test("set", () => {
-    const input = new Set();
-    input.add("a");
-    input.add("b");
-    input.add("c");
-    const cloned = structuredClone(input);
-    expect(cloned).toBeInstanceOf(Set);
-    expect(cloned).not.toBe(input);
-    expect(cloned.size).toEqual(input.size);
-    for (const value of input) {
-      expect(cloned.has(value)).toBe(true);
-    }
-  });
-
-  describe("bun blobs work", () => {
-    test("simple", async () => {
-      const blob = new Blob(["hello"], { type: "application/octet-stream" });
-      const cloned = structuredClone(blob);
-      await compareBlobs(blob, cloned);
-    });
-    test("empty", async () => {
-      const emptyBlob = new Blob([], { type: "" });
-      const clonedEmpty = structuredClone(emptyBlob);
-      await compareBlobs(emptyBlob, clonedEmpty);
-    });
-    test("empty with type", async () => {
-      const emptyBlob = new Blob([], { type: "application/octet-stream" });
-      const clonedEmpty = structuredClone(emptyBlob);
-      await compareBlobs(emptyBlob, clonedEmpty);
-    });
-    test("unknown type", async () => {
-      const blob = new Blob(["hello type"], { type: "this is type" });
-      const cloned = structuredClone(blob);
-      await compareBlobs(blob, cloned);
-    });
-    test("file from path", async () => {
-      const blob = Bun.file(join(import.meta.dir, "example.txt"));
-      const cloned = structuredClone(blob);
-      expect(cloned.lastModified).toBe(blob.lastModified);
-      expect(cloned.name).toBe(blob.name);
-    });
-    test("file from fd", async () => {
-      const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-      const blob = Bun.file(fd);
-      const cloned = structuredClone(blob);
-      expect(cloned.lastModified).toBe(blob.lastModified);
-      expect(cloned.name).toBe(blob.name);
-    });
-    describe("dom file", async () => {
-      test("without lastModified", async () => {
-        const file = new File(["hi"], "example.txt", { type: "text/plain" });
-        expect(file.lastModified).toBeGreaterThan(0);
-        expect(file.name).toBe("example.txt");
-        expect(file.size).toBe(2);
-        const cloned = structuredClone(file);
-        expect(cloned.lastModified).toBe(file.lastModified);
-        expect(cloned.name).toBe(file.name);
-        expect(cloned.size).toBe(file.size);
+    for (let { description, value } of primitives_tests) {
+      test(description, () => {
+        const cloned = structuredCloneFn(value);
+        expect(cloned).toBe(value);
       });
-      test("with lastModified", async () => {
-        const file = new File(["hi"], "example.txt", { type: "text/plain", lastModified: 123 });
-        expect(file.lastModified).toBe(123);
-        expect(file.name).toBe("example.txt");
-        expect(file.size).toBe(2);
-        const cloned = structuredClone(file);
-        expect(cloned.lastModified).toBe(123);
-        expect(cloned.name).toBe(file.name);
-        expect(cloned.size).toBe(file.size);
+    }
+
+    test("Array with primitives", () => {
+      const input = [
+        undefined,
+        null,
+        true,
+        false,
+        "",
+        "\uD800",
+        "\uDC00",
+        "\u0000",
+        "\uDBFF\uDFFD",
+        0.2,
+        0,
+        -0,
+        NaN,
+        Infinity,
+        -Infinity,
+        9007199254740992,
+        -9007199254740992,
+        9007199254740994,
+        -9007199254740994,
+        -12n,
+        -0n,
+        0n,
+      ];
+      const cloned = structuredCloneFn(input);
+      expect(cloned).toBeInstanceOf(Array);
+      expect(cloned).not.toBe(input);
+      expect(cloned.length).toEqual(input.length);
+      for (const x in input) {
+        expect(cloned[x]).toBe(input[x]);
+      }
+    });
+    test("Object with primitives", () => {
+      const input: any = {
+        undefined: undefined,
+        null: null,
+        true: true,
+        false: false,
+        empty: "",
+        "high surrogate": "\uD800",
+        "low surrogate": "\uDC00",
+        nul: "\u0000",
+        astral: "\uDBFF\uDFFD",
+        "0.2": 0.2,
+        "0": 0,
+        "-0": -0,
+        NaN: NaN,
+        Infinity: Infinity,
+        "-Infinity": -Infinity,
+        "9007199254740992": 9007199254740992,
+        "-9007199254740992": -9007199254740992,
+        "9007199254740994": 9007199254740994,
+        "-9007199254740994": -9007199254740994,
+        "-12n": -12n,
+        "-0n": -0n,
+        "0n": 0n,
+      };
+      const cloned = structuredCloneFn(input);
+      expect(cloned).toBeInstanceOf(Object);
+      expect(cloned).not.toBeInstanceOf(Array);
+      expect(cloned).not.toBe(input);
+      for (const x in input) {
+        expect(cloned[x]).toBe(input[x]);
+      }
+    });
+
+    test("map", () => {
+      const input = new Map();
+      input.set("a", 1);
+      input.set("b", 2);
+      input.set("c", 3);
+      const cloned = structuredCloneFn(input);
+      expect(cloned).toBeInstanceOf(Map);
+      expect(cloned).not.toBe(input);
+      expect(cloned.size).toEqual(input.size);
+      for (const [key, value] of input) {
+        expect(cloned.get(key)).toBe(value);
+      }
+    });
+
+    test("set", () => {
+      const input = new Set();
+      input.add("a");
+      input.add("b");
+      input.add("c");
+      const cloned = structuredCloneFn(input);
+      expect(cloned).toBeInstanceOf(Set);
+      expect(cloned).not.toBe(input);
+      expect(cloned.size).toEqual(input.size);
+      for (const value of input) {
+        expect(cloned.has(value)).toBe(true);
+      }
+    });
+
+    describe("bun blobs work", () => {
+      test("simple", async () => {
+        const blob = new Blob(["hello"], { type: "application/octet-stream" });
+        const cloned = structuredCloneFn(blob);
+        await compareBlobs(blob, cloned);
+      });
+      test("empty", async () => {
+        const emptyBlob = new Blob([], { type: "" });
+        const clonedEmpty = structuredCloneFn(emptyBlob);
+        await compareBlobs(emptyBlob, clonedEmpty);
+      });
+      test("empty with type", async () => {
+        const emptyBlob = new Blob([], { type: "application/octet-stream" });
+        const clonedEmpty = structuredCloneFn(emptyBlob);
+        await compareBlobs(emptyBlob, clonedEmpty);
+      });
+      test("unknown type", async () => {
+        const blob = new Blob(["hello type"], { type: "this is type" });
+        const cloned = structuredCloneFn(blob);
+        await compareBlobs(blob, cloned);
+      });
+      test("file from path", async () => {
+        const blob = Bun.file(join(import.meta.dir, "example.txt"));
+        const cloned = structuredCloneFn(blob);
+        expect(cloned.lastModified).toBe(blob.lastModified);
+        expect(cloned.name).toBe(blob.name);
+        expect(cloned.size).toBe(blob.size);
+      });
+      test("file from fd", async () => {
+        const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+        const blob = Bun.file(fd);
+        const cloned = structuredCloneFn(blob);
+        expect(cloned.lastModified).toBe(blob.lastModified);
+        expect(cloned.name).toBe(blob.name);
+        expect(cloned.size).toBe(blob.size);
+      });
+      describe("dom file", async () => {
+        test("without lastModified", async () => {
+          const file = new File(["hi"], "example.txt", { type: "text/plain" });
+          expect(file.lastModified).toBeGreaterThan(0);
+          expect(file.name).toBe("example.txt");
+          expect(file.size).toBe(2);
+          const cloned = structuredCloneFn(file);
+          expect(cloned.lastModified).toBe(file.lastModified);
+          expect(cloned.name).toBe(file.name);
+          expect(cloned.size).toBe(file.size);
+        });
+        test("with lastModified", async () => {
+          const file = new File(["hi"], "example.txt", { type: "text/plain", lastModified: 123 });
+          expect(file.lastModified).toBe(123);
+          expect(file.name).toBe("example.txt");
+          expect(file.size).toBe(2);
+          const cloned = structuredCloneFn(file);
+          expect(cloned.lastModified).toBe(123);
+          expect(cloned.name).toBe(file.name);
+          expect(cloned.size).toBe(file.size);
+        });
+      });
+      test("unpaired high surrogate (invalid utf-8)", async () => {
+        const blob = createBlob(encode_cesu8([0xd800]));
+        const cloned = structuredCloneFn(blob);
+        await compareBlobs(blob, cloned);
+      });
+      test("unpaired low surrogate (invalid utf-8)", async () => {
+        const blob = createBlob(encode_cesu8([0xdc00]));
+        const cloned = structuredCloneFn(blob);
+        await compareBlobs(blob, cloned);
+      });
+      test("paired surrogates (invalid utf-8)", async () => {
+        const blob = createBlob(encode_cesu8([0xd800, 0xdc00]));
+        const cloned = structuredCloneFn(blob);
+        await compareBlobs(blob, cloned);
       });
     });
-    test("unpaired high surrogate (invalid utf-8)", async () => {
-      const blob = createBlob(encode_cesu8([0xd800]));
-      const cloned = structuredClone(blob);
-      await compareBlobs(blob, cloned);
-    });
-    test("unpaired low surrogate (invalid utf-8)", async () => {
-      const blob = createBlob(encode_cesu8([0xdc00]));
-      const cloned = structuredClone(blob);
-      await compareBlobs(blob, cloned);
-    });
-    test("paired surrogates (invalid utf-8)", async () => {
-      const blob = createBlob(encode_cesu8([0xd800, 0xdc00]));
-      const cloned = structuredClone(blob);
-      await compareBlobs(blob, cloned);
-    });
-  });
 
-  describe("net.BlockList works", () => {
-    test("simple", () => {
-      const net = require("node:net");
-      const blocklist = new net.BlockList();
-      blocklist.addAddress("123.123.123.123");
-      const newlist = structuredClone(blocklist);
-      expect(newlist.check("123.123.123.123")).toBeTrue();
-      expect(!newlist.check("123.123.123.124")).toBeTrue();
-      newlist.addAddress("123.123.123.124");
-      expect(blocklist.check("123.123.123.124")).toBeTrue();
-      expect(newlist.check("123.123.123.124")).toBeTrue();
-    });
-  });
+    if (structuredCloneFn === structuredClone) {
+      describe("net.BlockList works", () => {
+        test("simple", () => {
+          const net = require("node:net");
+          const blocklist = new net.BlockList();
+          blocklist.addAddress("123.123.123.123");
+          const newlist = structuredCloneFn(blocklist);
+          expect(newlist.check("123.123.123.123")).toBeTrue();
+          expect(!newlist.check("123.123.123.124")).toBeTrue();
+          newlist.addAddress("123.123.123.124");
+          expect(blocklist.check("123.123.123.124")).toBeTrue();
+          expect(newlist.check("123.123.123.124")).toBeTrue();
+        });
+      });
 
-  describe("transferables", () => {
-    test("ArrayBuffer", () => {
-      const buffer = Uint8Array.from([1]).buffer;
-      const cloned = structuredClone(buffer, { transfer: [buffer] });
-      expect(buffer.byteLength).toBe(0);
-      expect(cloned.byteLength).toBe(1);
-    });
-    test("A detached ArrayBuffer cannot be transferred", () => {
-      const buffer = new ArrayBuffer(2);
-      structuredClone(buffer, { transfer: [buffer] });
-      expect(() => {
-        structuredClone(buffer, { transfer: [buffer] });
-      }).toThrow(DOMException);
-    });
-    test("Transferring a non-transferable platform object fails", () => {
-      const blob = new Blob();
-      expect(() => {
-        structuredClone(blob, { transfer: [blob] });
-      }).toThrow(DOMException);
-    });
+      describe("transferables", () => {
+        test("ArrayBuffer", () => {
+          const buffer = Uint8Array.from([1]).buffer;
+          const cloned = structuredCloneFn(buffer, { transfer: [buffer] });
+          expect(buffer.byteLength).toBe(0);
+          expect(cloned.byteLength).toBe(1);
+        });
+        test("A detached ArrayBuffer cannot be transferred", () => {
+          const buffer = new ArrayBuffer(2);
+          structuredCloneFn(buffer, { transfer: [buffer] });
+          expect(() => {
+            structuredCloneFn(buffer, { transfer: [buffer] });
+          }).toThrow(DOMException);
+        });
+        test("Transferring a non-transferable platform object fails", () => {
+          const blob = new Blob();
+          expect(() => {
+            structuredCloneFn(blob, { transfer: [blob] });
+          }).toThrow(DOMException);
+        });
+      });
+    }
   });
-});
+}
 
 async function compareBlobs(original: Blob, cloned: Blob) {
   expect(cloned).toBeInstanceOf(Blob);

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,8 +1,8 @@
+import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { join } from "path";
-import { serialize, deserialize } from "bun:jsc";
-import { bunExe } from "js/bun/shell/test_builder";
 import { bunEnv } from "harness";
+import { bunExe } from "js/bun/shell/test_builder";
+import { join } from "path";
 function jscSerializeRoundtrip(value: any) {
   const serialized = serialize(value);
   const cloned = deserialize(serialized);

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -1,5 +1,5 @@
 import { structuredCloneAdvanced } from "bun:internal-for-testing";
-import { serialize, deserialize } from "bun:jsc";
+import { deserialize, serialize } from "bun:jsc";
 import { bunEnv, bunExe } from "harness";
 
 enum TransferMode {

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -1,0 +1,106 @@
+import { structuredCloneAdvanced } from "bun:internal-for-testing";
+
+enum TransferMode {
+  no = 0,
+  yes_in_transfer_list = 1,
+  yes_but_not_in_transfer_list = 2,
+}
+
+const testTypes = [
+  {
+    name: "ArrayBuffer (transferable)",
+    createValue: () => {
+      const buf = Uint8Array.from([21, 11, 96, 126, 243, 128, 164]);
+      return buf.buffer.transfer();
+    },
+    isTransferable: true,
+    expectedAfterClone: (original: ArrayBuffer, cloned: any, isTransfer: TransferMode, isStorage: boolean) => {
+      expect(cloned).toBeInstanceOf(ArrayBuffer);
+      expect(new Uint8Array(cloned)).toStrictEqual(new Uint8Array([21, 11, 96, 126, 243, 128, 164]));
+      if (isTransfer === TransferMode.yes_in_transfer_list) {
+        // Original should be detached after transfer
+        expect(original.byteLength).toBe(0);
+      }
+    },
+  },
+  {
+    name: "BunFile (cloneable, non-transferable)",
+    createValue: () => Bun.file(import.meta.filename),
+    isTransferable: false,
+    expectedAfterClone: (original: any, cloned: any, isTransfer: TransferMode, isStorage: boolean) => {
+      expect(original).toBeInstanceOf(Blob);
+      expect(original.name).toEqual(import.meta.filename);
+      expect(original.type).toEqual("text/javascript;charset=utf-8");
+
+      if (isTransfer || isStorage) {
+        // Non-transferable types should yield an empty object when transferred
+        expect(cloned).toBeEmptyObject();
+      } else {
+        // When not stored or transferred, BunFile maintains its properties
+        expect(cloned.name).toBe(original.name);
+        expect(cloned.type).toBe(original.type);
+      }
+    },
+  },
+  {
+    name: "net.BlockList (cloneable, non-transferable)",
+    createValue: () => {
+      const { BlockList } = require("net");
+      const blocklist = new BlockList();
+      blocklist.addAddress("123.123.123.123");
+      return blocklist;
+    },
+    isTransferable: false,
+    expectedAfterClone: (original: any, cloned: any, isTransfer: TransferMode, isStorage: boolean) => {
+      if (isStorage || isTransfer !== TransferMode.no) {
+        // BlockList loses its internal state when stored
+        expect(cloned.rules).toBeUndefined();
+        expect(cloned).toBeEmptyObject();
+      } else {
+        // When not stored or transferred, BlockList maintains its properties
+        expect(cloned).toHaveProperty("rules");
+        expect(cloned.check("123.123.123.123")).toBe(true);
+      }
+    },
+  },
+];
+
+const contexts = ["default", "worker", "window"] as const;
+const transferModes = [
+  TransferMode.yes_but_not_in_transfer_list,
+  TransferMode.yes_in_transfer_list,
+  TransferMode.no,
+] as const;
+const storageModes = [true, false] as const;
+
+for (const testType of testTypes) {
+  for (const context of contexts) {
+    for (const isForTransfer of transferModes) {
+      for (const isForStorage of storageModes) {
+        test(`${testType.name} - context: ${context}, transfer: ${TransferMode[isForTransfer]}, storage: ${isForStorage}`, () => {
+          const original = testType.createValue();
+
+          if (isForTransfer === TransferMode.yes_in_transfer_list) {
+            // Test with transfer list (even for non-transferable types)
+            const transferList = [original];
+            if (!testType.isTransferable) {
+              expect(() =>
+                structuredCloneAdvanced(original, transferList, !!isForTransfer, isForStorage, context),
+              ).toThrowError("The object can not be cloned.");
+            } else {
+              const cloned = structuredCloneAdvanced(original, transferList, !!isForTransfer, isForStorage, context);
+              testType.expectedAfterClone(original, cloned, isForTransfer, isForStorage);
+            }
+          } else if (isForTransfer === TransferMode.yes_but_not_in_transfer_list) {
+            const cloned = structuredCloneAdvanced(original, [], !!isForTransfer, isForStorage, context);
+            testType.expectedAfterClone(original, cloned, isForTransfer, isForStorage);
+          } else {
+            // Test without transfer list
+            const cloned = structuredCloneAdvanced(original, [], !!isForTransfer, isForStorage, context);
+            testType.expectedAfterClone(original, cloned, isForTransfer, isForStorage);
+          }
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements a string fast path optimization for `postMessage` and `structuredClone` operations that provides significant performance improvements for string-only data transfer, along with various bug fixes and infrastructure improvements.

## Key Performance Improvements

**postMessage with Workers:**
- **Small strings (11 chars):** ~5% faster (572ns vs 599ns)
- **Medium strings (14KB):** **~2.7x faster** (528ns vs 1.40μs) 
- **Large strings (3MB):** **~660x faster** (540ns vs 356μs)

**Compared to Node.js postMessage:**
- Similar performance for small strings
- Competitive for medium strings  
- **~455x faster** for large strings (540ns vs 245μs)

## Implementation Details

The optimization adds a **string fast path** that bypasses full structured cloning serialization when:
- Input is a pure string (`value.isString()`)
- No transfer list or message ports are involved
- Not being stored persistently

### Core Changes

**String Thread-Safety Utilities (`BunString.cpp/h`):**
- `isCrossThreadShareable()` - Checks if string can be safely shared across threads
- `toCrossThreadShareable()` - Converts strings to thread-safe form via `isolatedCopy()`
- Handles edge cases: atoms, symbols, substring slices, external buffers

**Serialization Fast Path (`SerializedScriptValue.cpp`):**
- New `m_fastPathString` field stores string data directly
- Bypasses full object serialization machinery for pure strings
- Creates isolated copies for cross-thread safety

**Deserialization Fast Path:**
- Directly returns JSString from stored string data
- Avoids parsing serialized byte streams

**Updated Flags System (`JSValue.zig`, `Serialization.cpp`):**
- Replaces boolean `forTransfer` with structured `SerializedFlags`
- Supports `forCrossProcessTransfer` and `forStorage` distinctions

**Structured Clone Infrastructure:**
- Moved `structuredClone` implementation to dedicated `StructuredClone.cpp`
- Added `jsFunctionStructuredCloneAdvanced` for testing with custom flags
- Improved class serialization compatibility checks (`isForTransfer`, `isForStorage`)

**IPC Improvements (`ipc.zig`):**
- Fixed race conditions in `SendQueue` by deferring cleanup to next tick
- Proper fd ownership handling with `bun.take()`
- Cached IPC serialize/parse functions for better performance

**BlockList Thread Safety Fixes (`BlockList.zig`):**
- Fixed potential deadlocks by moving mutex locking inside methods
- Added atomic `estimated_size` counter to avoid lock during GC
- Corrected pointer handling in comparison functions
- Improved GC safety in `rules()` method

## Benchmark Results

```
❯ bun-21926 bench/string-postmessage.mjs  # This branch
postMessage(11 chars string)  572.24 ns/iter
postMessage(14 KB string)     527.55 ns/iter  ← ~2.7x faster
postMessage(3 MB string)      539.70 ns/iter  ← ~660x faster

❯ bun-1.2.20 bench/string-postmessage.mjs  # Previous
postMessage(11 chars string)  598.76 ns/iter
postMessage(14 KB string)       1.40 µs/iter
postMessage(3 MB string)      356.38 µs/iter

❯ node bench/string-postmessage.mjs       # Node.js comparison  
postMessage(11 chars string)  569.63 ns/iter
postMessage(14 KB string)       1.46 µs/iter
postMessage(3 MB string)      245.46 µs/iter
```

**Key insight:** The fast path achieves **constant time performance** regardless of string size (~540ns), while traditional serialization scales linearly with data size.

## Test Coverage

**New Tests:**
- `test/js/web/structured-clone-fastpath.test.ts` - Fast path memory usage validation
- `test/js/web/workers/structuredClone-classes.test.ts` - Comprehensive class serialization tests
  - Tests ArrayBuffer transferability 
  - Tests BunFile cloning with storage/transfer restrictions
  - Tests net.BlockList cloning behavior
  - Validates different serialization contexts (default, worker, window)

**Enhanced Tests:**
- `test/js/web/workers/structured-clone.test.ts` - Multi-function testing
  - Tests `structuredClone`, `jscSerializeRoundtrip`, and cross-process serialization
  - Validates consistency across different serialization paths
- `test/js/node/cluster.test.ts` - Better error handling and debugging

**Benchmarks:**
- `bench/string-postmessage.mjs` - Worker postMessage performance comparison
- `bench/string-fastpath.mjs` - Fast path vs traditional serialization comparison

## Bug Fixes

**BlockList Threading Issues:**
- Fixed potential deadlocks when multiple threads access BlockList simultaneously
- Moved mutex locks inside methods rather than holding across entire function calls
- Added atomic size tracking for GC compatibility
- Fixed comparison function pointer handling

**IPC Race Conditions:**
- Fixed race condition where `SendQueue._onAfterIPCClosed()` could be called on wrong thread
- Deferred cleanup operations to next tick using task queue
- Improved file descriptor ownership with proper `bun.take()` usage

**Structured Clone Compatibility:**
- Enhanced class serialization with proper transfer/storage mode checking
- Fixed edge cases where non-transferable objects were incorrectly handled
- Added better error reporting for unsupported clone operations

## Technical Notes

- Thread safety ensured via `String.isolatedCopy()` for cross-VM transfers
- Memory cost calculation updated to account for string references
- Maintains full compatibility with existing structured clone semantics
- Does not affect object serialization or transfer lists
- Proper cleanup and error handling throughout IPC pipeline