### PR TITLE
Call JSC::VM::notifyNeedTermination on process.exit in a Web Worker

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2742,6 +2742,10 @@ extern "C" napi_status napi_call_function(napi_env env, napi_value recv,
 
     JSValue res = AsyncContextFrame::call(globalObject, funcValue, thisValue, args);
 
+    if (env->isVMTerminating()) {
+        return napi_set_last_error(env, napi_pending_exception);
+    }
+
     if (result) {
         if (res.isEmpty()) {
             *result = toNapi(JSC::jsUndefined(), globalObject);

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -555,7 +555,7 @@ pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
 
     if (this.vm) |vm| {
         vm.eventLoop().wakeup();
-        // TODO(@190n) notifyNeedTermination
+        vm.jsc_vm.notifyNeedTermination();
     }
 
     // TODO(@190n) delete

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -555,7 +555,7 @@ pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
 
     if (this.vm) |vm| {
         vm.eventLoop().wakeup();
-        vm.jsc_vm.notifyNeedTermination();
+        vm.global.requestTermination();
     }
 
     // TODO(@190n) delete


### PR DESCRIPTION
### What does this PR do?

Calling `process.exit` inside a Web Worker now immediately notifies the VM that it needs to terminate. Previously, `napi_call_function` would return success in a Web Worker even if the JS code called `process.exit`. Now it'll return `napi_pending_exception`.

### How did you verify your code works?

Ran Node's NAPI tests (`node-api/test_worker_terminate/test.js` now passes) in addition to our own NAPI tests.