### PR TITLE
Fix undici Client.request() returning undefined

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -269,7 +269,27 @@ class Pool extends Dispatcher {
 }
 class BalancedPool extends Dispatcher {}
 class Client extends Dispatcher {
-  request() {}
+  #url
+  
+  constructor(url, options = {}) {
+    super();
+    this.#url = url;
+  }
+  
+  async request(options = {}) {
+    // If path is provided, resolve it against the base URL
+    let requestUrl = this.#url;
+    if (options.path) {
+      if (typeof this.#url === 'string') {
+        requestUrl = new URL(options.path, this.#url).toString();
+      } else {
+        requestUrl = new URL(options.path, this.#url);
+      }
+    }
+    
+    // Call the global request function with the resolved URL
+    return await request(requestUrl, options);
+  }
 }
 
 class DispatcherBase extends EventEmitter {}

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -269,24 +269,24 @@ class Pool extends Dispatcher {
 }
 class BalancedPool extends Dispatcher {}
 class Client extends Dispatcher {
-  #url
-  
+  #url;
+
   constructor(url, options = {}) {
     super();
     this.#url = url;
   }
-  
+
   async request(options = {}) {
     // If path is provided, resolve it against the base URL
     let requestUrl = this.#url;
     if (options.path) {
-      if (typeof this.#url === 'string') {
+      if (typeof this.#url === "string") {
         requestUrl = new URL(options.path, this.#url).toString();
       } else {
         requestUrl = new URL(options.path, this.#url);
       }
     }
-    
+
     // Call the global request function with the resolved URL
     return await request(requestUrl, options);
   }

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { request } from "undici";
+import { request, Client } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -154,5 +154,50 @@ describe("undici", () => {
     //   const json = (await body.json()) as { form: { foo: string } };
     //   expect(json.form.foo).toBe("bar");
     // });
+  });
+
+  describe("Client", () => {
+    it("should create a client with a base URL and make requests", async () => {
+      const client = new Client(hostUrl);
+      const { body, statusCode } = await client.request({
+        path: "/get",
+        method: "GET",
+      });
+      
+      expect(statusCode).toBe(200);
+      expect(body).toBeDefined();
+      const json = (await body.json()) as { url: string };
+      expect(json.url).toBe(`${hostUrl}/get`);
+    });
+
+    it("should handle relative paths correctly", async () => {
+      const client = new Client(hostUrl);
+      const { body, statusCode } = await client.request({
+        path: "/headers",
+        method: "GET",
+        headers: {
+          "x-test": "client-test"
+        }
+      });
+      
+      expect(statusCode).toBe(200);
+      expect(body).toBeDefined();
+      const json = (await body.json()) as { headers: { "x-test": string } };
+      expect(json.headers["x-test"]).toBe("client-test");
+    });
+
+    it("should work with POST requests", async () => {
+      const client = new Client(hostUrl);
+      const { body, statusCode } = await client.request({
+        path: "/post",
+        method: "POST",
+        body: "test body",
+      });
+      
+      expect(statusCode).toBe(201);
+      expect(body).toBeDefined();
+      const json = (await body.json()) as { data: string };
+      expect(json.data).toBe("test body");
+    });
   });
 });

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { request, Client } from "undici";
+import { Client, request } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -163,7 +163,7 @@ describe("undici", () => {
         path: "/get",
         method: "GET",
       });
-      
+
       expect(statusCode).toBe(200);
       expect(body).toBeDefined();
       const json = (await body.json()) as { url: string };
@@ -176,10 +176,10 @@ describe("undici", () => {
         path: "/headers",
         method: "GET",
         headers: {
-          "x-test": "client-test"
-        }
+          "x-test": "client-test",
+        },
       });
-      
+
       expect(statusCode).toBe(200);
       expect(body).toBeDefined();
       const json = (await body.json()) as { headers: { "x-test": string } };
@@ -193,7 +193,7 @@ describe("undici", () => {
         method: "POST",
         body: "test body",
       });
-      
+
       expect(statusCode).toBe(201);
       expect(body).toBeDefined();
       const json = (await body.json()) as { data: string };


### PR DESCRIPTION
## Summary
Fixes the undici `Client` class's `request()` method returning `undefined` instead of a proper response object.

## Problem
The undici `Client` class had an empty `request()` method implementation, causing `client.request()` calls to return `undefined` instead of the expected response object with status code, headers, and body.

## Solution
- Added constructor to `Client` class to accept and store base URL
- Implemented proper `request()` method that resolves relative paths against the base URL
- Delegates to the existing global `request()` function for actual HTTP handling

## Test Plan
- [x] Added comprehensive test cases for Client class
- [x] Verified GET requests work correctly
- [x] Verified POST requests work correctly  
- [x] Verified header handling works correctly
- [x] Confirmed original reproduction case from issue works

## Changes
- `src/js/thirdparty/undici.js`: Updated Client class implementation
- `test/js/first_party/undici/undici.test.ts`: Added Client-specific tests

Closes #21944

🤖 Generated with [Claude Code](https://claude.ai/code)