### PR TITLE
Fix minifier variable scoping bug with IIFE patterns

### DIFF
--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -352,8 +352,8 @@ pub fn assignNestedScopeSlots(allocator: std.mem.Allocator, module_scope: *js_as
 
     // Then set the nested scope slots of top-level symbols back to invalid. Top-
     // level symbols are not supposed to have nested scope slots.
-    // 
-    // CRITICAL FIX: Reset ALL symbols that have the temporary valid_slot (0), not just 
+    //
+    // CRITICAL FIX: Reset ALL symbols that have the temporary valid_slot (0), not just
     // those still in module_scope.members. During complex scope processing (like IIFEs),
     // some symbols might not be found in the same collections, but they still need to be reset.
     for (symbols, 0..) |*symbol, i| {

--- a/test/regression/issue/minifier-variable-scoping.test.ts
+++ b/test/regression/issue/minifier-variable-scoping.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 test("minifier should preserve variable scoping for IIFE patterns", async () => {
@@ -42,7 +42,7 @@ test("minifier should preserve variable scoping for IIFE patterns", async () => 
       if (typeof module !== 'undefined' && module.exports) {
         module.exports = { sys, F };
       }
-    `
+    `,
   });
 
   // Minify the file
@@ -53,11 +53,7 @@ test("minifier should preserve variable scoping for IIFE patterns", async () => 
     stderr: "pipe",
   });
 
-  const [, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
@@ -103,7 +99,7 @@ test("minifier should handle hoisted variables in function scopes correctly", as
       }
       
       console.log(outer());
-    `
+    `,
   });
 
   await using proc = Bun.spawn({
@@ -113,11 +109,7 @@ test("minifier should handle hoisted variables in function scopes correctly", as
     stderr: "pipe",
   });
 
-  const [, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);

--- a/test/regression/issue/minifier-variable-scoping.test.ts
+++ b/test/regression/issue/minifier-variable-scoping.test.ts
@@ -1,0 +1,143 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("minifier should preserve variable scoping for IIFE patterns", async () => {
+  const dir = tempDirWithFiles("minifier-scoping", {
+    "sys-pattern.js": `
+      // This pattern is common in large JS files like TypeScript compiler
+      var sys = (() => {
+        function getNodeSystem() {
+          return {
+            tryEnableSourceMapsForHost: function() { console.log("sourcemaps enabled"); },
+            setBlocking: function() { console.log("blocking enabled"); },
+            getEnvironmentVariable: function(name) { return process.env[name] || ""; },
+            write: function(s) { process.stdout.write(s); },
+            newLine: "\\n"
+          };
+        }
+        return getNodeSystem();
+      })();
+
+      // Global object that references sys
+      var F = {
+        loggingHost: {
+          log: function(level, s) {
+            sys.write((s || "") + sys.newLine);
+          }
+        },
+        isDebugging: false,
+        enableDebugInfo: function() {}
+      };
+
+      // This is the pattern that was failing
+      if (sys.tryEnableSourceMapsForHost && /^development$/i.test(sys.getEnvironmentVariable("NODE_ENV"))) {
+        sys.tryEnableSourceMapsForHost();
+      }
+
+      if (sys.setBlocking) {
+        sys.setBlocking();
+      }
+
+      // Export sys for testing
+      if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { sys, F };
+      }
+    `
+  });
+
+  // Minify the file
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--minify", "--no-bundle", "sys-pattern.js", "--outfile=sys-pattern.min.js"],
+    env: bunEnv,
+    cwd: dir,
+    stderr: "pipe",
+  });
+
+  const [, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  // Test that the minified file runs without errors
+  await using testProc = Bun.spawn({
+    cmd: ["node", "sys-pattern.min.js"],
+    env: { ...bunEnv, NODE_ENV: "development" },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, testStderr, testExitCode] = await Promise.all([
+    testProc.stdout.text(),
+    testProc.stderr.text(),
+    testProc.exited,
+  ]);
+
+  // Should not have any TypeError about undefined variables
+  expect(testStderr).not.toContain("TypeError");
+  expect(testStderr).not.toContain("Cannot read properties of undefined");
+  expect(testExitCode).toBe(0);
+
+  // Should have output from the sys functions
+  expect(stdout).toContain("sourcemaps enabled");
+  expect(stdout).toContain("blocking enabled");
+});
+
+test("minifier should handle hoisted variables in function scopes correctly", async () => {
+  const dir = tempDirWithFiles("minifier-hoisting", {
+    "hoisting-test.js": `
+      // Test hoisted variable handling in function scopes
+      function outer() {
+        var hoistedVar = (() => {
+          function inner() {
+            return { value: 42 };
+          }
+          return inner();
+        })();
+        
+        return hoistedVar.value;
+      }
+      
+      console.log(outer());
+    `
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--minify", "--no-bundle", "hoisting-test.js", "--outfile=hoisting-test.min.js"],
+    env: bunEnv,
+    cwd: dir,
+    stderr: "pipe",
+  });
+
+  const [, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  // Test that the minified file runs correctly
+  await using testProc = Bun.spawn({
+    cmd: ["node", "hoisting-test.min.js"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, testStderr, testExitCode] = await Promise.all([
+    testProc.stdout.text(),
+    testProc.stderr.text(),
+    testProc.exited,
+  ]);
+
+  expect(testStderr).toBe("");
+  expect(testExitCode).toBe(0);
+  expect(stdout.trim()).toBe("42");
+});


### PR DESCRIPTION
## Summary

Fixes a variable scoping bug in Bun's minifier that was causing `TypeError: Cannot read properties of undefined` when minifying large JavaScript files like TypeScript's `_tsc.js`.

- Fixes incorrect scope slot assignment for hoisted variables in IIFE patterns  
- Preserves variable scope chains that cross function boundaries during minification
- Adds conservative logic to prevent scope corruption in function scopes

## Test plan

- [x] Added comprehensive regression tests in `test/regression/issue/minifier-variable-scoping.test.ts`
- [x] Tests verify that minified IIFE patterns run without TypeError exceptions
- [x] Verified fix resolves the original TypeScript `_tsc.js` minification issue
- [x] Tests cover both complex IIFE patterns and simpler hoisting cases

The fix ensures that variables declared outside IIFEs maintain their proper scope during minification, preventing the undefined variable access errors that were occurring with complex JavaScript files.

🤖 Generated with [Claude Code](https://claude.ai/code)