### PR TITLE
Fix UTF-16 encoding crash with odd-length byte arrays

### DIFF
--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -131,10 +131,10 @@ pub fn toBunStringFromOwnedSlice(input: []u8, encoding: Encoding) bun.String {
                 bun.default_allocator.free(input);
                 return bun.String.empty;
             }
-            
+
             // If input length is odd, truncate to the nearest even length
             const usable_len = if (input.len % 2 != 0) input.len - 1 else input.len;
-            
+
             if (usable_len == 0) {
                 bun.default_allocator.free(input);
                 return bun.String.empty;

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -127,7 +127,7 @@ pub fn toBunStringFromOwnedSlice(input: []u8, encoding: Encoding) bun.String {
         },
         .ucs2, .utf16le => {
             // Avoid incomplete characters - if input length is 0 or odd, handle gracefully
-            const usable_len = if (input.len % 2 != 0) input.len -| 1 else input.len;
+            const usable_len = if (input.len % 2 != 0) input.len - 1 else input.len;
 
             if (usable_len == 0) {
                 bun.default_allocator.free(input);

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -126,13 +126,21 @@ pub fn toBunStringFromOwnedSlice(input: []u8, encoding: Encoding) bun.String {
             return bun.String.createExternalGloballyAllocated(.latin1, input);
         },
         .ucs2, .utf16le => {
-            // Avoid incomplete characters
-            if (input.len / 2 == 0) {
+            // Avoid incomplete characters - if input length is 0 or odd, handle gracefully
+            if (input.len == 0) {
+                bun.default_allocator.free(input);
+                return bun.String.empty;
+            }
+            
+            // If input length is odd, truncate to the nearest even length
+            const usable_len = if (input.len % 2 != 0) input.len - 1 else input.len;
+            
+            if (usable_len == 0) {
                 bun.default_allocator.free(input);
                 return bun.String.empty;
             }
 
-            const as_u16 = std.mem.bytesAsSlice(u16, input);
+            const as_u16 = std.mem.bytesAsSlice(u16, input[0..usable_len]);
             return bun.String.createExternalGloballyAllocated(.utf16, @alignCast(as_u16));
         },
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -127,13 +127,7 @@ pub fn toBunStringFromOwnedSlice(input: []u8, encoding: Encoding) bun.String {
         },
         .ucs2, .utf16le => {
             // Avoid incomplete characters - if input length is 0 or odd, handle gracefully
-            if (input.len == 0) {
-                bun.default_allocator.free(input);
-                return bun.String.empty;
-            }
-
-            // If input length is odd, truncate to the nearest even length
-            const usable_len = if (input.len % 2 != 0) input.len - 1 else input.len;
+            const usable_len = if (input.len % 2 != 0) input.len -| 1 else input.len;
 
             if (usable_len == 0) {
                 bun.default_allocator.free(input);

--- a/test/regression/issue/utf16-encoding-crash.test.ts
+++ b/test/regression/issue/utf16-encoding-crash.test.ts
@@ -10,23 +10,20 @@ const testCases = [
     expectedLength: 0,
     expectedString: "",
   },
+
+  // It needs to be big enough to trigger the code path that dynamically allocates the arraybuffer
+  // so at least 256 KB.
   {
-    name: "3 bytes",
-    bytes: [0x41, 0x42, 0x43],
-    expectedLength: 1,
-    expectedString: "䉁", // 0x4241 in UTF-16le (little endian)
-  },
-  {
-    name: "5 bytes",
-    bytes: [0x41, 0x00, 0x42, 0x00, 0x43],
-    expectedLength: 2,
-    expectedString: "AB", // 0x0041, 0x0042 in UTF-16le
-  },
-  {
-    name: "7 bytes",
-    bytes: [0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x44],
-    expectedLength: 3,
-    expectedString: "ABC", // 0x0041, 0x0042, 0x0043 in UTF-16le
+    name: "large buffer - 256KB + 1",
+    bytes: (() => {
+      const buffer = Buffer.allocUnsafe(256 * 1024 + 1);
+      for (let i = 0; i < buffer.length; i++) {
+        buffer[i] = i % 2 === 0 ? 0x41 : 0x00;
+      }
+      return buffer;
+    })(),
+    expectedLength: 128 * 1024,
+    expectedString: "A".repeat(128 * 1024),
   },
 ];
 

--- a/test/regression/issue/utf16-encoding-crash.test.ts
+++ b/test/regression/issue/utf16-encoding-crash.test.ts
@@ -2,57 +2,68 @@ import { expect, test } from "bun:test";
 import fs from "fs";
 import { tempDirWithFiles } from "harness";
 
-test("fs.readFile with utf16le encoding should not crash on odd-length files", () => {
-  // Create a temporary directory with files containing odd numbers of bytes
-  const dir = tempDirWithFiles("utf16-crash-test", {
-    "three-bytes.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes - should trigger the crash
-    "five-bytes.bin": Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45]), // 5 bytes
-    "seven-bytes.bin": Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]), // 7 bytes
+// Test cases that verify Bun's UTF-16le behavior matches Node.js exactly
+const testCases = [
+  {
+    name: "1 byte",
+    bytes: [0x41],
+    expectedLength: 0,
+    expectedString: "",
+  },
+  {
+    name: "3 bytes", 
+    bytes: [0x41, 0x42, 0x43],
+    expectedLength: 1,
+    expectedString: "䉁", // 0x4241 in UTF-16le (little endian)
+  },
+  {
+    name: "5 bytes",
+    bytes: [0x41, 0x00, 0x42, 0x00, 0x43],
+    expectedLength: 2,
+    expectedString: "AB", // 0x0041, 0x0042 in UTF-16le
+  },
+  {
+    name: "7 bytes",
+    bytes: [0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x44],
+    expectedLength: 3,
+    expectedString: "ABC", // 0x0041, 0x0042, 0x0043 in UTF-16le
+  },
+];
+
+test("fs.readFile with utf16le encoding matches Node.js behavior for all byte lengths", () => {
+  const files: Record<string, Buffer> = {};
+  
+  // Create test files for each case
+  testCases.forEach((testCase, i) => {
+    files[`test-${i}.bin`] = Buffer.from(testCase.bytes);
   });
+  
+  const dir = tempDirWithFiles("utf16-node-compatibility", files);
 
-  // This should not crash with "exact division produced remainder"
-  expect(() => {
-    fs.readFileSync(`${dir}/three-bytes.bin`, "utf16le");
-  }).not.toThrow();
-
-  expect(() => {
-    fs.readFileSync(`${dir}/five-bytes.bin`, "utf16le");
-  }).not.toThrow();
-
-  expect(() => {
-    fs.readFileSync(`${dir}/seven-bytes.bin`, "utf16le");
-  }).not.toThrow();
+  testCases.forEach((testCase, i) => {
+    const filePath = `${dir}/test-${i}.bin`;
+    
+    // Test that reading doesn't crash
+    expect(() => {
+      fs.readFileSync(filePath, "utf16le");
+    }).not.toThrow();
+    
+    // Test that result matches expected Node.js behavior
+    const result = fs.readFileSync(filePath, "utf16le");
+    expect(result.length).toBe(testCase.expectedLength);
+    expect(result).toBe(testCase.expectedString);
+  });
 });
 
-test("fs.readFile with ucs2 encoding should not crash on odd-length files", () => {
-  // Create a temporary directory with files containing odd numbers of bytes
-  const dir = tempDirWithFiles("ucs2-crash-test", {
-    "three-bytes.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes - should trigger the crash
+test("fs.readFile with ucs2 encoding matches utf16le behavior", () => {
+  const dir = tempDirWithFiles("ucs2-compatibility", {
+    "test.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes
   });
 
-  // This should not crash with "exact division produced remainder"
-  expect(() => {
-    fs.readFileSync(`${dir}/three-bytes.bin`, "ucs2");
-  }).not.toThrow();
-});
-
-test("fs.readFile with utf16le encoding should handle single byte gracefully", () => {
-  const dir = tempDirWithFiles("utf16-single-test", {
-    "one-byte.bin": Buffer.from([0x41]), // 1 byte - should return empty
-  });
-
-  // Single byte should return empty string, not crash
-  const result = fs.readFileSync(`${dir}/one-byte.bin`, "utf16le");
-  expect(result).toBe("");
-});
-
-test("fs.readFile with utf16le encoding should truncate odd-length files correctly", () => {
-  const dir = tempDirWithFiles("utf16-truncate-test", {
-    // 5 bytes: [0x41, 0x00, 0x42, 0x00, 0x43] should become "AB" (first 4 bytes as 2 UTF-16 chars)
-    "five-bytes.bin": Buffer.from([0x41, 0x00, 0x42, 0x00, 0x43]),
-  });
-
-  // Should truncate the last odd byte and return the valid UTF-16 content
-  const result = fs.readFileSync(`${dir}/five-bytes.bin`, "utf16le");
-  expect(result).toBe("AB"); // First 4 bytes as UTF-16LE: A (0x41, 0x00) + B (0x42, 0x00)
+  const utf16leResult = fs.readFileSync(`${dir}/test.bin`, "utf16le");
+  const ucs2Result = fs.readFileSync(`${dir}/test.bin`, "ucs2");
+  
+  // ucs2 and utf16le should behave identically
+  expect(ucs2Result.length).toBe(utf16leResult.length);
+  expect(ucs2Result).toBe(utf16leResult);
 });

--- a/test/regression/issue/utf16-encoding-crash.test.ts
+++ b/test/regression/issue/utf16-encoding-crash.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test";
+import { tempDirWithFiles } from "harness";
+import fs from "fs";
+
+test("fs.readFile with utf16le encoding should not crash on odd-length files", () => {
+  // Create a temporary directory with files containing odd numbers of bytes
+  const dir = tempDirWithFiles("utf16-crash-test", {
+    "three-bytes.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes - should trigger the crash
+    "five-bytes.bin": Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45]), // 5 bytes
+    "seven-bytes.bin": Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]), // 7 bytes
+  });
+  
+  // This should not crash with "exact division produced remainder"
+  expect(() => {
+    fs.readFileSync(`${dir}/three-bytes.bin`, "utf16le");
+  }).not.toThrow();
+  
+  expect(() => {
+    fs.readFileSync(`${dir}/five-bytes.bin`, "utf16le");
+  }).not.toThrow();
+  
+  expect(() => {
+    fs.readFileSync(`${dir}/seven-bytes.bin`, "utf16le");
+  }).not.toThrow();
+});
+
+test("fs.readFile with ucs2 encoding should not crash on odd-length files", () => {
+  // Create a temporary directory with files containing odd numbers of bytes
+  const dir = tempDirWithFiles("ucs2-crash-test", {
+    "three-bytes.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes - should trigger the crash
+  });
+  
+  // This should not crash with "exact division produced remainder"
+  expect(() => {
+    fs.readFileSync(`${dir}/three-bytes.bin`, "ucs2");
+  }).not.toThrow();
+});
+
+test("fs.readFile with utf16le encoding should handle single byte gracefully", () => {
+  const dir = tempDirWithFiles("utf16-single-test", {
+    "one-byte.bin": Buffer.from([0x41]), // 1 byte - should return empty
+  });
+  
+  // Single byte should return empty string, not crash
+  const result = fs.readFileSync(`${dir}/one-byte.bin`, "utf16le");
+  expect(result).toBe("");
+});
+
+test("fs.readFile with utf16le encoding should truncate odd-length files correctly", () => {
+  const dir = tempDirWithFiles("utf16-truncate-test", {
+    // 5 bytes: [0x41, 0x00, 0x42, 0x00, 0x43] should become "AB" (first 4 bytes as 2 UTF-16 chars)
+    "five-bytes.bin": Buffer.from([0x41, 0x00, 0x42, 0x00, 0x43]),
+  });
+  
+  // Should truncate the last odd byte and return the valid UTF-16 content
+  const result = fs.readFileSync(`${dir}/five-bytes.bin`, "utf16le");
+  expect(result).toBe("AB"); // First 4 bytes as UTF-16LE: A (0x41, 0x00) + B (0x42, 0x00)
+});

--- a/test/regression/issue/utf16-encoding-crash.test.ts
+++ b/test/regression/issue/utf16-encoding-crash.test.ts
@@ -11,7 +11,7 @@ const testCases = [
     expectedString: "",
   },
   {
-    name: "3 bytes", 
+    name: "3 bytes",
     bytes: [0x41, 0x42, 0x43],
     expectedLength: 1,
     expectedString: "䉁", // 0x4241 in UTF-16le (little endian)
@@ -32,22 +32,22 @@ const testCases = [
 
 test("fs.readFile with utf16le encoding matches Node.js behavior for all byte lengths", () => {
   const files: Record<string, Buffer> = {};
-  
+
   // Create test files for each case
   testCases.forEach((testCase, i) => {
     files[`test-${i}.bin`] = Buffer.from(testCase.bytes);
   });
-  
+
   const dir = tempDirWithFiles("utf16-node-compatibility", files);
 
   testCases.forEach((testCase, i) => {
     const filePath = `${dir}/test-${i}.bin`;
-    
+
     // Test that reading doesn't crash
     expect(() => {
       fs.readFileSync(filePath, "utf16le");
     }).not.toThrow();
-    
+
     // Test that result matches expected Node.js behavior
     const result = fs.readFileSync(filePath, "utf16le");
     expect(result.length).toBe(testCase.expectedLength);
@@ -62,7 +62,7 @@ test("fs.readFile with ucs2 encoding matches utf16le behavior", () => {
 
   const utf16leResult = fs.readFileSync(`${dir}/test.bin`, "utf16le");
   const ucs2Result = fs.readFileSync(`${dir}/test.bin`, "ucs2");
-  
+
   // ucs2 and utf16le should behave identically
   expect(ucs2Result.length).toBe(utf16leResult.length);
   expect(ucs2Result).toBe(utf16leResult);

--- a/test/regression/issue/utf16-encoding-crash.test.ts
+++ b/test/regression/issue/utf16-encoding-crash.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { expect, test } from "bun:test";
 import fs from "fs";
+import { tempDirWithFiles } from "harness";
 
 test("fs.readFile with utf16le encoding should not crash on odd-length files", () => {
   // Create a temporary directory with files containing odd numbers of bytes
@@ -9,16 +9,16 @@ test("fs.readFile with utf16le encoding should not crash on odd-length files", (
     "five-bytes.bin": Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45]), // 5 bytes
     "seven-bytes.bin": Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]), // 7 bytes
   });
-  
+
   // This should not crash with "exact division produced remainder"
   expect(() => {
     fs.readFileSync(`${dir}/three-bytes.bin`, "utf16le");
   }).not.toThrow();
-  
+
   expect(() => {
     fs.readFileSync(`${dir}/five-bytes.bin`, "utf16le");
   }).not.toThrow();
-  
+
   expect(() => {
     fs.readFileSync(`${dir}/seven-bytes.bin`, "utf16le");
   }).not.toThrow();
@@ -29,7 +29,7 @@ test("fs.readFile with ucs2 encoding should not crash on odd-length files", () =
   const dir = tempDirWithFiles("ucs2-crash-test", {
     "three-bytes.bin": Buffer.from([0x41, 0x42, 0x43]), // 3 bytes - should trigger the crash
   });
-  
+
   // This should not crash with "exact division produced remainder"
   expect(() => {
     fs.readFileSync(`${dir}/three-bytes.bin`, "ucs2");
@@ -40,7 +40,7 @@ test("fs.readFile with utf16le encoding should handle single byte gracefully", (
   const dir = tempDirWithFiles("utf16-single-test", {
     "one-byte.bin": Buffer.from([0x41]), // 1 byte - should return empty
   });
-  
+
   // Single byte should return empty string, not crash
   const result = fs.readFileSync(`${dir}/one-byte.bin`, "utf16le");
   expect(result).toBe("");
@@ -51,7 +51,7 @@ test("fs.readFile with utf16le encoding should truncate odd-length files correct
     // 5 bytes: [0x41, 0x00, 0x42, 0x00, 0x43] should become "AB" (first 4 bytes as 2 UTF-16 chars)
     "five-bytes.bin": Buffer.from([0x41, 0x00, 0x42, 0x00, 0x43]),
   });
-  
+
   // Should truncate the last odd byte and return the valid UTF-16 content
   const result = fs.readFileSync(`${dir}/five-bytes.bin`, "utf16le");
   expect(result).toBe("AB"); // First 4 bytes as UTF-16LE: A (0x41, 0x00) + B (0x42, 0x00)


### PR DESCRIPTION
## Summary
- Fixes a panic: "exact division produced remainder" that occurs when reading files with odd number of bytes using utf16le/ucs2 encoding
- The crash happened in `encoding.zig:136` when `std.mem.bytesAsSlice(u16, input)` was called on a byte slice with odd length
- Fixed by properly checking for odd-length input and truncating to the nearest even length

## Test plan
- Added regression tests in `test/regression/issue/utf16-encoding-crash.test.ts`
- Tests verify that reading files with odd byte counts doesn't crash
- Tests verify correct truncation behavior matches Node.js expectations
- Verified edge cases (0, 1 byte inputs) return empty strings

## Root Cause
The original code checked `if (input.len / 2 == 0)` which only caught 0 and 1-byte inputs, but `std.mem.bytesAsSlice(u16, input)` panics on any odd-length input (3, 5, 7, etc. bytes).

## Fix Details
- Changed condition to check `input.len % 2 != 0` for any odd length
- Truncate odd-length inputs to the nearest even length for valid UTF-16 processing
- Handle edge cases by returning empty string for 0 or 1-byte inputs

🤖 Generated with [Claude Code](https://claude.ai/code)