### PR TITLE
Fix shell rm issues with dir links and ./ prefix

### DIFF
--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -830,7 +830,7 @@ pub const ShellRmTask = struct {
             return Maybe(void).initErr(Syscall.Error.fromCode(bun.sys.E.ISDIR, .TODO).withPath(bun.handleOom(bun.default_allocator.dupeZ(u8, dir_task.path))));
         }
 
-        const flags = bun.O.DIRECTORY | bun.O.RDONLY;
+        const flags = bun.O.DIRECTORY | bun.O.RDONLY | bun.O.NOFOLLOW;
         const fd = switch (ShellSyscall.openat(dirfd, path, flags, 0)) {
             .result => |fd| fd,
             .err => |e| {

--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -830,7 +830,7 @@ pub const ShellRmTask = struct {
             return Maybe(void).initErr(Syscall.Error.fromCode(bun.sys.E.ISDIR, .TODO).withPath(bun.handleOom(bun.default_allocator.dupeZ(u8, dir_task.path))));
         }
 
-        const flags = bun.O.DIRECTORY | bun.O.RDONLY | bun.O.NOFOLLOW;
+        const flags = bun.O.DIRECTORY | bun.O.RDONLY | if (bun.Environment.isWindows) bun.O.NOFOLLOW else 0;
         const fd = switch (ShellSyscall.openat(dirfd, path, flags, 0)) {
             .result => |fd| fd,
             .err => |e| {

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -173,6 +173,11 @@ pub fn toWPathNormalized(wbuf: []u16, utf8: []const u8) [:0]u16 {
 
     var path_to_use = normalizeSlashesOnly(renormalized, utf8, '\\');
 
+    // is there a current-dir prefix ".\\"? Let's remove it before converting to UTF-16
+    if (path_to_use.len > 2 and std.mem.startsWith(u8, path_to_use, ".\\")) {
+        path_to_use = path_to_use[2..];
+    }
+
     // is there a trailing slash? Let's remove it before converting to UTF-16
     if (path_to_use.len > 3 and bun.path.isSepAny(path_to_use[path_to_use.len - 1])) {
         path_to_use = path_to_use[0 .. path_to_use.len - 1];

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -189,13 +189,13 @@ pub fn toWPathNormalized(wbuf: []u16, utf8: []const u8) [:0]u16 {
 pub fn toWPathNormalized16(wbuf: []u16, path: []const u16) [:0]u16 {
     var path_to_use = normalizeSlashesOnlyT(u16, wbuf, path, '\\', true);
 
-    // is there a current-dir prefix ".\\"? Let's remove it before converting to UTF-16
+    // is there a current-dir prefix ".\\"? Let's remove it before further processing
     const curdirPrefix: [2]u16 = .{ '.', '\\' };
     if (path_to_use.len > 2 and std.mem.startsWith(u16, path_to_use, &curdirPrefix)) {
         path_to_use = path_to_use[2..];
     }
 
-    // is there a trailing slash? Let's remove it before converting to UTF-16
+    // is there a trailing slash? Let's remove it before further processing
     if (path_to_use.len > 3 and bun.path.isSepAnyT(u16, path_to_use[path_to_use.len - 1])) {
         path_to_use = path_to_use[0 .. path_to_use.len - 1];
     }
@@ -211,12 +211,12 @@ pub fn toPathNormalized(buf: []u8, utf8: []const u8) [:0]const u8 {
 
     var path_to_use = normalizeSlashesOnly(renormalized, utf8, '\\');
 
-    // is there a current-dir prefix ".\\"? Let's remove it before converting to UTF-16
+    // is there a current-dir prefix ".\\"? Let's remove it before further processing
     if (path_to_use.len > 2 and std.mem.startsWith(u8, path_to_use, ".\\")) {
         path_to_use = path_to_use[2..];
     }
 
-    // is there a trailing slash? Let's remove it before converting to UTF-16
+    // is there a trailing slash? Let's remove it before further processing
     if (path_to_use.len > 3 and bun.path.isSepAny(path_to_use[path_to_use.len - 1])) {
         path_to_use = path_to_use[0 .. path_to_use.len - 1];
     }

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -189,6 +189,12 @@ pub fn toWPathNormalized(wbuf: []u16, utf8: []const u8) [:0]u16 {
 pub fn toWPathNormalized16(wbuf: []u16, path: []const u16) [:0]u16 {
     var path_to_use = normalizeSlashesOnlyT(u16, wbuf, path, '\\', true);
 
+    // is there a current-dir prefix ".\\"? Let's remove it before converting to UTF-16
+    const curdirPrefix: [2]u16 = .{ '.', '\\' };
+    if (path_to_use.len > 2 and std.mem.startsWith(u16, path_to_use, &curdirPrefix)) {
+        path_to_use = path_to_use[2..];
+    }
+
     // is there a trailing slash? Let's remove it before converting to UTF-16
     if (path_to_use.len > 3 and bun.path.isSepAnyT(u16, path_to_use[path_to_use.len - 1])) {
         path_to_use = path_to_use[0 .. path_to_use.len - 1];
@@ -204,6 +210,11 @@ pub fn toPathNormalized(buf: []u8, utf8: []const u8) [:0]const u8 {
     defer bun.path_buffer_pool.put(renormalized);
 
     var path_to_use = normalizeSlashesOnly(renormalized, utf8, '\\');
+
+    // is there a current-dir prefix ".\\"? Let's remove it before converting to UTF-16
+    if (path_to_use.len > 2 and std.mem.startsWith(u8, path_to_use, ".\\")) {
+        path_to_use = path_to_use[2..];
+    }
 
     // is there a trailing slash? Let's remove it before converting to UTF-16
     if (path_to_use.len > 3 and bun.path.isSepAny(path_to_use[path_to_use.len - 1])) {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -162,7 +162,7 @@ foo/
       "sub_dir": {},
     };
 
-    const tempdir = tempDirWithFiles("rmdir", files);
+    const tempdir = tempDirWithFiles("rmsymlinks", files);
 
     // Create file symlink and remove it
     {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -192,7 +192,7 @@ foo/
       expect(await fileExists(`${tempdir}/sub_dir/file_symlink.txt`)).toBeTrue();
       expect(await fileExists(`${tempdir}/sub_dir/dir_symlink`)).toBeTrue();
       expect(await fileExists(`${tempdir}/sub_dir/dir_symlink/file.txt`)).toBeTrue();
-      await $`rm -r ./sub_dir`.cwd(`${tempdir}`);
+      await $`rm -r ./sub_dir`.cwd(tempdir);
       expect(await fileExists(`${tempdir}/sub_dir`)).toBeFalse();
       expect(await fileExists(`${tempdir}/keep_dir`)).toBeTrue();
       expect(await fileExists(`${tempdir}/keep_dir/file.txt`)).toBeTrue();


### PR DESCRIPTION
### What does this PR do?
It fixes 2 issues in shell `rm -rf`:
1. Symbolic directory links are no longer followed: #20633
2. The prefix `./` can be used: #13523

### How did you verify your code works?

I added some automated tests.

For manual testing i used a bash script in git-bash and ensured that the file `temp/keep/file.txt` still existed and the `temp/node_modules` folder is fully removed.

```bash
#!/bin/env bash

rm -rf temp
mkdir -p temp/keep temp/node_modules
touch temp/keep/file.txt temp/node_modules/some_package.txt
cp -R temp/keep temp/node_modules/copy
pwsh -c 'New-Item -ItemType SymbolicLink temp\node_modules\link -Target "$(Get-Location)\temp\keep"'
pwsh -c 'D:\github\bun\build\debug\bun-debug.exe exec "rm -rf ./temp/node_modules"'
```