### PR TITLE
Improve output clarity for bun update command

### DIFF
--- a/src/install/lockfile/printer/tree_printer.zig
+++ b/src/install/lockfile/printer/tree_printer.zig
@@ -400,9 +400,8 @@ pub fn print(
             .none, .dir => {
                 printed_installed_update_request = true;
 
-                // Determine if this package was updated or newly added
                 const was_updated = manager.updating_packages.contains(package_name);
-                const action_word = if (was_updated) "updated" else "added";
+                const action_word = if (was_updated) "updated" else "installed";
 
                 const fmt = comptime Output.prettyFmt("<r><green>{s}<r> <b>{s}<r><d>@{}<r>\n", enable_ansi_colors);
 
@@ -426,9 +425,8 @@ pub fn print(
                 };
 
                 {
-                    // Determine if this package was updated or newly added
                     const was_updated = manager.updating_packages.contains(package_name);
-                    const action_word = if (was_updated) "updated" else "added";
+                    const action_word = if (was_updated) "updated" else "installed";
 
                     const fmt = comptime Output.prettyFmt("<r><green>{s}<r> {s}<r><d>@{}<r> with binaries:\n", enable_ansi_colors);
 

--- a/src/install/lockfile/printer/tree_printer.zig
+++ b/src/install/lockfile/printer/tree_printer.zig
@@ -400,11 +400,16 @@ pub fn print(
             .none, .dir => {
                 printed_installed_update_request = true;
 
-                const fmt = comptime Output.prettyFmt("<r><green>installed<r> <b>{s}<r><d>@{}<r>\n", enable_ansi_colors);
+                // Determine if this package was updated or newly added
+                const was_updated = manager.updating_packages.contains(package_name);
+                const action_word = if (was_updated) "updated" else "added";
+                
+                const fmt = comptime Output.prettyFmt("<r><green>{s}<r> <b>{s}<r><d>@{}<r>\n", enable_ansi_colors);
 
                 try writer.print(
                     fmt,
                     .{
+                        action_word,
                         package_name,
                         resolved[package_id].fmt(string_buf, .posix),
                     },
@@ -421,11 +426,16 @@ pub fn print(
                 };
 
                 {
-                    const fmt = comptime Output.prettyFmt("<r><green>installed<r> {s}<r><d>@{}<r> with binaries:\n", enable_ansi_colors);
+                    // Determine if this package was updated or newly added
+                    const was_updated = manager.updating_packages.contains(package_name);
+                    const action_word = if (was_updated) "updated" else "added";
+                    
+                    const fmt = comptime Output.prettyFmt("<r><green>{s}<r> {s}<r><d>@{}<r> with binaries:\n", enable_ansi_colors);
 
                     try writer.print(
                         fmt,
                         .{
+                            action_word,
                             package_name,
                             resolved[package_id].fmt(string_buf, .posix),
                         },

--- a/src/install/lockfile/printer/tree_printer.zig
+++ b/src/install/lockfile/printer/tree_printer.zig
@@ -403,7 +403,7 @@ pub fn print(
                 // Determine if this package was updated or newly added
                 const was_updated = manager.updating_packages.contains(package_name);
                 const action_word = if (was_updated) "updated" else "added";
-                
+
                 const fmt = comptime Output.prettyFmt("<r><green>{s}<r> <b>{s}<r><d>@{}<r>\n", enable_ansi_colors);
 
                 try writer.print(
@@ -429,7 +429,7 @@ pub fn print(
                     // Determine if this package was updated or newly added
                     const was_updated = manager.updating_packages.contains(package_name);
                     const action_word = if (was_updated) "updated" else "added";
-                    
+
                     const fmt = comptime Output.prettyFmt("<r><green>{s}<r> {s}<r><d>@{}<r> with binaries:\n", enable_ansi_colors);
 
                     try writer.print(

--- a/src/install/lockfile/printer/tree_printer.zig
+++ b/src/install/lockfile/printer/tree_printer.zig
@@ -400,8 +400,10 @@ pub fn print(
             .none, .dir => {
                 printed_installed_update_request = true;
 
-                const was_updated = manager.updating_packages.contains(package_name);
-                const action_word = if (was_updated) "updated" else "installed";
+                const action_word = if (manager.subcommand == .update)
+                    (if (manager.updating_packages.contains(package_name)) "updated" else "added")
+                else
+                    "installed";
 
                 const fmt = comptime Output.prettyFmt("<r><green>{s}<r> <b>{s}<r><d>@{}<r>\n", enable_ansi_colors);
 
@@ -425,8 +427,10 @@ pub fn print(
                 };
 
                 {
-                    const was_updated = manager.updating_packages.contains(package_name);
-                    const action_word = if (was_updated) "updated" else "installed";
+                    const action_word = if (manager.subcommand == .update)
+                        (if (manager.updating_packages.contains(package_name)) "updated" else "added")
+                    else
+                        "installed";
 
                     const fmt = comptime Output.prettyFmt("<r><green>{s}<r> {s}<r><d>@{}<r> with binaries:\n", enable_ansi_colors);
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5210,7 +5210,7 @@ describe("update", () => {
       expect(out).toEqual([
         expect.stringContaining("bun update v1."),
         "",
-        "installed no-deps@1.0.1",
+        "updated no-deps@1.0.1",
         "",
         expect.stringContaining("done"),
         "",
@@ -5230,7 +5230,7 @@ describe("update", () => {
       expect(out).toEqual([
         expect.stringContaining("bun update v1."),
         "",
-        "installed no-deps@2.0.0",
+        "updated no-deps@2.0.0",
         "",
         "1 package installed",
       ]);
@@ -5570,10 +5570,10 @@ describe("update", () => {
     expect(out).toEqual([
       expect.stringContaining("bun update v1."),
       "",
-      "installed what-bin@1.5.0 with binaries:",
+      "updated what-bin@1.5.0 with binaries:",
       " - what-bin",
-      "installed uses-what-bin@1.5.0",
-      "installed a-dep@1.0.5",
+      "updated uses-what-bin@1.5.0",
+      "updated a-dep@1.0.5",
       "",
       "3 packages installed",
     ]);
@@ -5617,7 +5617,7 @@ describe("update", () => {
     expect(out).toEqual([
       expect.stringContaining("bun update v1."),
       "",
-      "installed a-dep@1.0.10",
+      "updated a-dep@1.0.10",
       "",
       expect.stringMatching(/(\[\d+\.\d+m?s\])/),
       "",
@@ -5663,7 +5663,7 @@ describe("update", () => {
         expect(out).toEqual([
           expect.stringContaining("bun update v1."),
           "",
-          args ? "installed a-dep@1.0.10" : expect.stringContaining("+ a-dep@1.0.10"),
+          args ? "updated a-dep@1.0.10" : expect.stringContaining("+ a-dep@1.0.10"),
           "",
           "1 package installed",
         ]);
@@ -5733,7 +5733,7 @@ describe("update", () => {
     expect(out).toEqual([
       expect.stringContaining("bun update v1."),
       "",
-      "installed no-deps@1.0.0",
+      "updated no-deps@1.0.0",
       "",
       expect.stringMatching(/(\[\d+\.\d+m?s\])/),
       "",
@@ -5749,7 +5749,7 @@ describe("update", () => {
     expect(out).toEqual([
       expect.stringContaining("bun update v1."),
       "",
-      "installed no-deps@2.0.0",
+      "added no-deps@2.0.0",
       "",
       "1 package installed",
     ]);
@@ -5783,7 +5783,7 @@ describe("update", () => {
     expect(out).toEqual([
       expect.stringContaining("bun update v1."),
       "",
-      "installed no-deps@1.1.0",
+      "updated no-deps@1.1.0",
       "",
       "1 package installed",
     ]);

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -420,15 +420,15 @@ it("should support catalog versions in update", async () => {
 
 it("should show 'updated' for packages that existed and 'added' for new packages during update", async () => {
   const urls: string[] = [];
-  
+
   // Test when running update on non-existent package (simulates the scenario from the issue)
   const registry = {
     "0.0.3": {},
     latest: "0.0.3",
   };
   setHandler(dummyRegistry(urls, registry));
-  
-  // Start with empty package.json  
+
+  // Start with empty package.json
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
@@ -436,7 +436,7 @@ it("should show 'updated' for packages that existed and 'added' for new packages
       dependencies: {},
     }),
   );
-  
+
   const {
     stdout: stdout1,
     stderr: stderr1,
@@ -448,10 +448,10 @@ it("should show 'updated' for packages that existed and 'added' for new packages
     stderr: "pipe",
     env,
   });
-  
+
   expect(await exited1).toBe(0);
   const out1 = await new Response(stdout1).text();
-  
+
   // When updating a package that doesn't exist, it should show "added"
   expect(out1).toContain("added baz@0.0.3");
   // Should NOT show "installed" or "updated"


### PR DESCRIPTION
## Summary

- Improves output clarity in `bun update` command
- Shows "added" for new packages vs "updated" for existing packages
- Prevents confusion when packages are unintentionally installed during updates

## Problem

When running `bun update` on packages that don't exist in package.json, the output shows "installed" which is identical to the output for packages that were actually updated, making it difficult to distinguish between updated and newly added packages.

## Solution

Modified the tree printer to check `manager.updating_packages` to determine if a package was already tracked for updates:

- **"updated"** for packages that existed in package.json and got updated
- **"added"** for packages that were newly installed during the update command

## Test plan

- [x] All existing `bun update` tests pass
- [x] New test verifies correct output for newly added packages during update

🤖 Generated with [Claude Code](https://claude.ai/code)