### PR TITLE
Disable postMessage optimization when string is < 256 chars

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -325,7 +325,7 @@ Ref<WTF::StringImpl> toCrossThreadShareable(Ref<WTF::StringImpl> impl)
 WTF::String toCrossThreadShareable(const WTF::String& string)
 {
     if (string.length() < kMinCrossThreadShareableLength)
-        return string;
+        return string.isolatedCopy();
 
     auto* impl = string.impl();
 


### PR DESCRIPTION
### What does this PR do?

Disable postMessage optimization when string is < 256 chars

If you're going to potentially use these strings as a property or identifier, which is much more likely for short strings than long strings, we shouldn't ban atomizing them and the cost of cloning isn't so much in that case

### How did you verify your code works?
