### PR TITLE
docs: fix link for bun:jsc

### DIFF
--- a/docs/runtime/bun-apis.md
+++ b/docs/runtime/bun-apis.md
@@ -200,7 +200,7 @@ Click the link in the right column to jump to the associated documentation.
 ---
 
 - Low-level / Internals
-- `Bun.mmap`, `Bun.gc`, `Bun.generateHeapSnapshot`, [`bun:jsc`](https://bun.com/docs/api/bun-jsc)
+- `Bun.mmap`, `Bun.gc`, `Bun.generateHeapSnapshot`, [`bun:jsc`](https://bun.sh/reference/bun/jsc)
 
 ---
 

--- a/docs/runtime/bun-apis.md
+++ b/docs/runtime/bun-apis.md
@@ -200,7 +200,7 @@ Click the link in the right column to jump to the associated documentation.
 ---
 
 - Low-level / Internals
-- `Bun.mmap`, `Bun.gc`, `Bun.generateHeapSnapshot`, [`bun:jsc`](https://bun.sh/reference/bun/jsc)
+- `Bun.mmap`, `Bun.gc`, `Bun.generateHeapSnapshot`, [`bun:jsc`](https://bun.com/reference/bun/jsc)
 
 ---
 


### PR DESCRIPTION
easy fix to https://x.com/kiritotwt1/status/1958452541718458513/photo/1 as it's generated of the types so should be accurate documentation. in future it could be better done like what it may have been once upon a time

(this doesn't fix the error, but it fixes the broken link)