### PR TITLE
Fix struct size assertion in Bake dev server

### DIFF
--- a/src/bake/DevServer/IncrementalGraph.zig
+++ b/src/bake/DevServer/IncrementalGraph.zig
@@ -182,14 +182,9 @@ pub fn IncrementalGraph(side: bake.Side) type {
                 };
 
                 comptime {
-                    if (!Environment.ci_assert) {
-                        // On Windows, struct padding can cause size to be larger than expected
-                        // Allow for platform-specific padding while ensuring reasonable bounds
-                        const expected_size = @sizeOf(u64) * 5; // 40 bytes
-                        const actual_size = @sizeOf(@This());
-                        if (actual_size < expected_size or actual_size > expected_size + 16) {
-                            @compileError(std.fmt.comptimePrint("Struct size {} is outside expected range [{}, {}]", .{ actual_size, expected_size, expected_size + 16 }));
-                        }
+                    // Debug and ReleaseSafe builds add a tag to untagged unions
+                    if (!Environment.allow_assert) {
+                        bun.assert_eql(@sizeOf(@This()), @sizeOf(u64) * 5);
                         bun.assert_eql(@alignOf(@This()), @alignOf([*]u8));
                     }
                 }

--- a/src/bake/DevServer/PackedMap.zig
+++ b/src/bake/DevServer/PackedMap.zig
@@ -80,6 +80,7 @@ pub fn quotedContents(self: *const @This()) []u8 {
 }
 
 comptime {
+    // `ci_assert` builds add a `safety.ThreadLock`
     if (!Environment.ci_assert) {
         assert_eql(@sizeOf(@This()), @sizeOf(usize) * 7);
         assert_eql(@alignOf(@This()), @alignOf(usize));


### PR DESCRIPTION
Followup to #22049: I'm pretty sure “platform-specific padding” on Windows is a hallucination. I think this is due to ReleaseSafe adding tags to untagged unions.

(For internal tracking: fixes STAB-1057)