### PR TITLE
Add 'none' option to util.styleText

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -202,6 +202,7 @@ function styleText(format, text) {
     let left = "";
     let right = "";
     for (const key of format) {
+      if (key === 'none') continue;
       const formatCodes = inspect.colors[key];
       if (formatCodes == null) {
         validateOneOf(key, "format", ObjectKeys(inspect.colors));
@@ -211,6 +212,10 @@ function styleText(format, text) {
     }
 
     return `${left}${text}${right}`;
+  }
+
+  if (format === 'none') {
+    return text;
   }
 
   let formatCodes = inspect.colors[format];

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -197,8 +197,9 @@ var toUSVString = input => {
 
 function styleText(format, text) {
   validateString(text, "text");
+  if (!$isJSArray(format)) format = [format];
 
-  if ($isJSArray(format)) {
+  {
     let left = "";
     let right = "";
     for (const key of format) {
@@ -212,10 +213,6 @@ function styleText(format, text) {
     }
 
     return `${left}${text}${right}`;
-  }
-
-  if (format === "none") {
-    return text;
   }
 
   let formatCodes = inspect.colors[format];

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -197,9 +197,8 @@ var toUSVString = input => {
 
 function styleText(format, text) {
   validateString(text, "text");
-  if (!$isJSArray(format)) format = [format];
 
-  {
+  if ($isJSArray(format)) {
     let left = "";
     let right = "";
     for (const key of format) {
@@ -213,6 +212,10 @@ function styleText(format, text) {
     }
 
     return `${left}${text}${right}`;
+  }
+
+  if (format === "none") {
+    return text;
   }
 
   let formatCodes = inspect.colors[format];

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -202,7 +202,7 @@ function styleText(format, text) {
     let left = "";
     let right = "";
     for (const key of format) {
-      if (key === 'none') continue;
+      if (key === "none") continue;
       const formatCodes = inspect.colors[key];
       if (formatCodes == null) {
         validateOneOf(key, "format", ObjectKeys(inspect.colors));
@@ -214,7 +214,7 @@ function styleText(format, text) {
     return `${left}${text}${right}`;
   }
 
-  if (format === 'none') {
+  if (format === "none") {
     return text;
   }
 

--- a/test/js/node/test/parallel/test-util-styletext.js
+++ b/test/js/node/test/parallel/test-util-styletext.js
@@ -41,3 +41,8 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
 });
+
+assert.strictEqual(util.styleText('none', 'test'), 'test');
+assert.strictEqual(util.styleText(['none'], 'test'), 'test');
+assert.strictEqual(util.styleText(['none', 'red'], 'test'), '\u001b[31mtest\u001b[39m');
+assert.strictEqual(util.styleText(['red', 'none'], 'test'), '\u001b[31mtest\u001b[39m');


### PR DESCRIPTION
## Summary
Add support for the special format value `'none'` in `util.styleText()` which applies no additional styling to the text. This brings Bun's Node.js compatibility layer in line with Node.js behavior.

## Changes Made
- **Single format support**: `util.styleText('none', 'text')` returns the text with no styling applied
- **Array format support**: `'none'` values in format arrays are skipped, allowing other formats to be applied normally
- **Comprehensive tests**: Added tests covering single format usage, array usage, and mixed format scenarios
- **Backward compatibility**: All existing functionality preserved and error handling unchanged

## Test Plan
- [x] Added comprehensive test cases for the `'none'` format option
- [x] Verified all existing `util.styleText` tests continue to pass
- [x] Tested error handling for invalid formats still works correctly
- [x] Verified mixed usage scenarios (e.g., `['none', 'red', 'bold']`)
- [x] Confirmed edge cases like multiple `'none'` values work as expected

## Examples
```js
const util = require('util');

// Single format - returns text unchanged
util.styleText('none', 'hello') // => 'hello'

// Array format - skips 'none', applies other formats
util.styleText(['none'], 'hello') // => 'hello'  
util.styleText(['none', 'red'], 'hello') // => '\u001b[31mhello\u001b[39m'
util.styleText(['bold', 'none', 'red'], 'hello') // => '\u001b[1m\u001b[31mhello\u001b[39m\u001b[22m'
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Node.js patch: https://github.com/nodejs/node/commit/73471bdb6aae0f94d3978722b5335afd39c61bbc