### PR TITLE
fix(Bun.SQL) delay postgres promise resolve for prepared statements

### DIFF
--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1453,12 +1453,7 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
             debug("-> {s}", .{cmd.command_tag.slice()});
             defer this.updateRef();
 
-            if (request.flags.simple) {
-                // simple queries can have multiple commands
-                request.onResult(cmd.command_tag.slice(), this.globalObject, this.js_value, false);
-            } else {
-                request.onResult(cmd.command_tag.slice(), this.globalObject, this.js_value, true);
-            }
+            request.onResult(cmd.command_tag.slice(), this.globalObject, this.js_value, false);
         },
         .BindComplete => {
             try reader.eatMessage(protocol.BindComplete);


### PR DESCRIPTION
### What does this PR do?
fixes https://github.com/oven-sh/bun/issues/21945
### How did you verify your code works?
Run the code bellow and will be way harder the encounter the same problem (I got it 1 times after 10 tries the same effect as Bun.sleep mentioned before)

```ts
const sql = new Bun.SQL("postgres://localhost");
using conn1 = await sql.reserve();
using conn2 = await sql.reserve();

await sql`DROP TABLE IF EXISTS test1`;
await sql`CREATE TABLE IF NOT EXISTS test1 (
id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
uuid UUID NOT NULL
)`;
await sql`INSERT INTO test1 (uuid) VALUES (gen_random_uuid())`;
type Row = {
  id: number;
  uuid: string;
};

for (let i = 0; i < 100_000; i++) {
  const [original]: Array<Row> = await conn1`SELECT id, uuid FROM test1 LIMIT 1`;

  const [updated]: Array<Row> =
    await conn1`UPDATE test1 SET uuid = gen_random_uuid() WHERE id = ${original.id} RETURNING id, uuid`;

  const [retrieved]: Array<Row> = await conn2`SELECT id, uuid FROM test1 WHERE id = ${original.id}`;

  if (retrieved.uuid !== updated.uuid) {
    console.log("Expected retrieved and updated to match", retrieved, updated, i);
    break;
  }
}

```
