### PR TITLE
Fix poll fd bug where stderr fd was incorrectly set to stdout fd

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -2201,7 +2201,7 @@ pub const sync = struct {
 
             if (out_fds_to_wait_for[1] != bun.invalid_fd) {
                 poll_fds.len += 1;
-                poll_fds[poll_fds.len - 1].fd = @intCast(out_fds_to_wait_for[0].cast());
+                poll_fds[poll_fds.len - 1].fd = @intCast(out_fds_to_wait_for[1].cast());
             }
 
             if (poll_fds.len == 0) {


### PR DESCRIPTION
## Summary
Fixes a bug in the internal `bun.spawnSync` implementation where stderr's poll file descriptor was incorrectly set to stdout's fd when polling both streams.

## The Bug
In `/src/bun.js/api/bun/process.zig` line 2204, when setting up the poll file descriptor array for stderr, the code incorrectly used `out_fds_to_wait_for[0]` (stdout) instead of `out_fds_to_wait_for[1]` (stderr).

This meant:
- stderr's fd was never actually polled
- stdout's fd was polled twice
- Could cause stderr data to be lost or incomplete
- Could potentially cause hangs when reading from stderr

## Impact
This bug only affects Bun's internal CLI commands that use `bun.spawnSync` with both stdout and stderr piped (like `bun create`, `bun upgrade`, etc.). The JavaScript `spawnSync` API uses a different code path and is not affected.

## The Fix
Changed line 2204 from:
```zig
poll_fds[poll_fds.len - 1].fd = @intCast(out_fds_to_wait_for[0].cast());
```
to:
```zig
poll_fds[poll_fds.len - 1].fd = @intCast(out_fds_to_wait_for[1].cast());
```

🤖 Generated with [Claude Code](https://claude.ai/code)