### PR TITLE
Fix ShellError reference in documentation example

### DIFF
--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -211,7 +211,7 @@ declare module "bun" {
      * try {
      *   const result = await $`exit 1`;
      * } catch (error) {
-     *   if (error instanceof ShellError) {
+     *   if (error instanceof $.ShellError) {
      *     console.log(error.exitCode); // 1
      *   }
      * }


### PR DESCRIPTION
### What does this PR do?
ShellError is not exported from bun or available globally and need to use `$.ShellError` to use it. So updated the jsdoc to mention it properly

### How did you verify your code works?
This pr only changes jsdoc so no test/verification is needed