### PR TITLE
Add --tolerate-republish flag to bun publish command

### DIFF
--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -82,6 +82,16 @@ The `--dry-run` flag can be used to simulate the publish process without actuall
 $ bun publish --dry-run
 ```
 
+### `--tolerate-republish`
+
+The `--tolerate-republish` flag makes `bun publish` exit with code 0 instead of code 1 when attempting to republish over an existing version number. This is useful in automated workflows where republishing the same version might occur and should not be treated as an error.
+
+```sh
+$ bun publish --tolerate-republish
+```
+
+Without this flag, attempting to publish a version that already exists will result in an error and exit code 1. With this flag, the command will exit successfully even when trying to republish an existing version.
+
 ### `--gzip-level`
 
 Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball path argument. Values range from `0` to `9` (default is `9`).

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -452,7 +452,7 @@ pub const PublishCommand = struct {
     };
 
     fn checkPackageVersionExists(
-        allocator: std.mem.Allocator, 
+        allocator: std.mem.Allocator,
         package_name: string,
         version: string,
         registry: *const Npm.Registry.Scope,
@@ -461,32 +461,32 @@ pub const PublishCommand = struct {
         defer url_buf.deinit();
         const registry_url = strings.withoutTrailingSlash(registry.url.href);
         const encoded_name = bun.fmt.dependencyUrl(package_name);
-        
+
         url_buf.writer().print("{s}/{s}/{s}", .{ registry_url, encoded_name, version }) catch return false;
-        
+
         const package_version_url = URL.parse(url_buf.items);
-        
-        var response_buf = MutableString.init(allocator, 64) catch return false;  
+
+        var response_buf = MutableString.init(allocator, 64) catch return false;
         defer response_buf.deinit();
 
         var headers = http.HeaderBuilder{};
         headers.count("accept", "application/json");
-        
+
         if (registry.token.len > 0) {
             var auth_buf = std.ArrayList(u8).init(allocator);
             defer auth_buf.deinit();
             auth_buf.writer().print("Bearer {s}", .{registry.token}) catch return false;
             headers.count("authorization", auth_buf.items);
         } else if (registry.auth.len > 0) {
-            var auth_buf = std.ArrayList(u8).init(allocator);  
+            var auth_buf = std.ArrayList(u8).init(allocator);
             defer auth_buf.deinit();
             auth_buf.writer().print("Basic {s}", .{registry.auth}) catch return false;
             headers.count("authorization", auth_buf.items);
         }
-        
+
         headers.allocate(allocator) catch return false;
         headers.append("accept", "application/json");
-        
+
         if (registry.token.len > 0) {
             var auth_buf = std.ArrayList(u8).init(allocator);
             defer auth_buf.deinit();

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -334,7 +334,7 @@ pub const PublishCommand = struct {
                 Global.crash();
             };
 
-            publish(false, &context, cli.tolerate_republish) catch |err| {
+            publish(false, &context) catch |err| {
                 switch (err) {
                     error.OutOfMemory => bun.outOfMemory(),
                     error.NeedAuth => {
@@ -381,7 +381,7 @@ pub const PublishCommand = struct {
         // TODO: read this into memory
         _ = bun.sys.unlink(context.abs_tarball_path);
 
-        publish(true, &context, cli.tolerate_republish) catch |err| {
+        publish(true, &context) catch |err| {
             switch (err) {
                 error.OutOfMemory => bun.outOfMemory(),
                 error.NeedAuth => {
@@ -471,7 +471,6 @@ pub const PublishCommand = struct {
     pub fn publish(
         comptime directory_publish: bool,
         ctx: *const Context(directory_publish),
-        tolerate_republish: bool,
     ) PublishError!void {
         const registry = ctx.manager.scopeForPackageName(ctx.package_name);
 
@@ -483,6 +482,7 @@ pub const PublishCommand = struct {
         // When --tolerate-republish is enabled, we should check if package version already exists
         // BEFORE doing any expensive work (packing, uploading, etc.) by making a GET request
         // to the registry API. For now, we use the reactive approach below.
+        const tolerate_republish = ctx.manager.options.publish_config.tolerate_republish;
 
         // continues from `printSummary`
         Output.pretty(

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -472,14 +472,13 @@ pub const PublishCommand = struct {
         var headers = http.HeaderBuilder{};
         headers.count("accept", "application/json");
 
+        var auth_buf = std.ArrayList(u8).init(allocator);
+        defer auth_buf.deinit();
+
         if (registry.token.len > 0) {
-            var auth_buf = std.ArrayList(u8).init(allocator);
-            defer auth_buf.deinit();
             auth_buf.writer().print("Bearer {s}", .{registry.token}) catch return false;
             headers.count("authorization", auth_buf.items);
         } else if (registry.auth.len > 0) {
-            var auth_buf = std.ArrayList(u8).init(allocator);
-            defer auth_buf.deinit();
             auth_buf.writer().print("Basic {s}", .{registry.auth}) catch return false;
             headers.count("authorization", auth_buf.items);
         }
@@ -488,13 +487,11 @@ pub const PublishCommand = struct {
         headers.append("accept", "application/json");
 
         if (registry.token.len > 0) {
-            var auth_buf = std.ArrayList(u8).init(allocator);
-            defer auth_buf.deinit();
+            auth_buf.clearRetainingCapacity();
             auth_buf.writer().print("Bearer {s}", .{registry.token}) catch return false;
             headers.append("authorization", auth_buf.items);
         } else if (registry.auth.len > 0) {
-            var auth_buf = std.ArrayList(u8).init(allocator);
-            defer auth_buf.deinit();
+            auth_buf.clearRetainingCapacity();
             auth_buf.writer().print("Basic {s}", .{registry.auth}) catch return false;
             headers.append("authorization", auth_buf.items);
         }

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -158,6 +158,7 @@ const publish_params: []const ParamType = &(shared_params ++ [_]ParamType{
     clap.parseParam("--otp <STR>                            Provide a one-time password for authentication") catch unreachable,
     clap.parseParam("--auth-type <STR>                      Specify the type of one-time password authentication (default is 'web')") catch unreachable,
     clap.parseParam("--gzip-level <STR>                     Specify a custom compression level for gzip. Default is 9.") catch unreachable,
+    clap.parseParam("--tolerate-republish                   Don't exit with code 1 when republishing over an existing version number") catch unreachable,
 });
 
 const why_params: []const ParamType = &(shared_params ++ [_]ParamType{
@@ -217,6 +218,8 @@ patch: PatchOpts = .{ .nothing = .{} },
 registry: string = "",
 
 publish_config: Options.PublishConfig = .{},
+
+tolerate_republish: bool = false,
 
 ca: []const string = &.{},
 ca_file_name: string = "",
@@ -605,6 +608,9 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Publish a pre-existing package tarball with tag 'next'.<r>
                 \\  <b><green>bun publish<r> <cyan>--tag next<r> <blue>./path/to/tarball.tgz<r>
                 \\
+                \\  <d>Publish without failing when republishing over an existing version.<r>
+                \\  <b><green>bun publish<r> <cyan>--tolerate-republish<r>
+                \\
                 \\Full documentation is available at <magenta>https://bun.com/docs/cli/publish<r>.
                 \\
             ;
@@ -860,6 +866,8 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
                 Global.crash();
             };
         }
+
+        cli.tolerate_republish = args.flag("--tolerate-republish");
     }
 
     // link and unlink default to not saving, all others default to

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -79,6 +79,7 @@ pub const PublishConfig = struct {
     tag: string = "",
     otp: string = "",
     auth_type: ?AuthType = null,
+    tolerate_republish: bool = false,
 };
 
 pub const Access = enum {
@@ -636,6 +637,7 @@ pub fn load(
         if (cli.publish_config.auth_type) |auth_type| {
             this.publish_config.auth_type = auth_type;
         }
+        this.publish_config.tolerate_republish = cli.tolerate_republish;
 
         if (cli.ca.len > 0) {
             this.ca = cli.ca;

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -875,7 +875,7 @@ describe("--tolerate-republish", async () => {
     expect(err).toContain("403") || expect(err).toContain("already exists") || expect(err).toContain("cannot publish");
   });
 
-  test("republishing with --tolerate-republish checks registry proactively and skips", async () => {
+  test("republishing with --tolerate-republish skips when version exists", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();
     const bunfig = await registry.authBunfig("republish-tolerate");
     const pkgJson = {
@@ -894,14 +894,14 @@ describe("--tolerate-republish", async () => {
     expect(exitCode).toBe(0);
     expect(out).toContain("+ republish-test-2@1.0.0");
 
-    // Second publish with --tolerate-republish should check registry and skip (Yarn's approach)
+    // Second publish with --tolerate-republish should skip
     ({ out, err, exitCode } = await publish(env, packageDir, "--tolerate-republish"));
     expect(exitCode).toBe(0);
     expect(err).toContain("warning: Registry already knows about version 1.0.0; skipping.");
     expect(err).not.toContain("error:");
   });
 
-  test("republishing tarball with --tolerate-republish checks registry and skips", async () => {
+  test("republishing tarball with --tolerate-republish skips when version exists", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();
     const bunfig = await registry.authBunfig("republish-tarball");
     const pkgJson = {
@@ -923,7 +923,7 @@ describe("--tolerate-republish", async () => {
     expect(exitCode).toBe(0);
     expect(out).toContain("+ republish-test-3@1.0.0");
 
-    // Second publish with --tolerate-republish should proactively check and skip
+    // Second publish with --tolerate-republish should skip
     ({ out, err, exitCode } = await publish(env, packageDir, "./republish-test-3-1.0.0.tgz", "--tolerate-republish"));
     expect(exitCode).toBe(0);
     expect(err).toContain("warning: Registry already knows about version 1.0.0; skipping.");

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -875,7 +875,7 @@ describe("--tolerate-republish", async () => {
     expect(err).toContain("403") || expect(err).toContain("already exists") || expect(err).toContain("cannot publish");
   });
 
-  test("republishing with --tolerate-republish skips and succeeds", async () => {
+  test("republishing with --tolerate-republish checks registry proactively and skips", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();
     const bunfig = await registry.authBunfig("republish-tolerate");
     const pkgJson = {
@@ -894,14 +894,14 @@ describe("--tolerate-republish", async () => {
     expect(exitCode).toBe(0);
     expect(out).toContain("+ republish-test-2@1.0.0");
 
-    // Second publish with --tolerate-republish should skip and succeed
+    // Second publish with --tolerate-republish should check registry and skip (Yarn's approach)
     ({ out, err, exitCode } = await publish(env, packageDir, "--tolerate-republish"));
     expect(exitCode).toBe(0);
     expect(err).toContain("warning: Registry already knows about version 1.0.0; skipping.");
     expect(err).not.toContain("error:");
   });
 
-  test("republishing tarball with --tolerate-republish skips and succeeds", async () => {
+  test("republishing tarball with --tolerate-republish checks registry and skips", async () => {
     const { packageDir, packageJson } = await registry.createTestDir();
     const bunfig = await registry.authBunfig("republish-tarball");
     const pkgJson = {
@@ -923,7 +923,7 @@ describe("--tolerate-republish", async () => {
     expect(exitCode).toBe(0);
     expect(out).toContain("+ republish-test-3@1.0.0");
 
-    // Second publish with --tolerate-republish should skip and succeed
+    // Second publish with --tolerate-republish should proactively check and skip
     ({ out, err, exitCode } = await publish(env, packageDir, "./republish-test-3-1.0.0.tgz", "--tolerate-republish"));
     expect(exitCode).toBe(0);
     expect(err).toContain("warning: Registry already knows about version 1.0.0; skipping.");

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -857,7 +857,7 @@ describe("--tolerate-republish", async () => {
       name: "republish-test-1",
       version: "1.0.0",
     };
-    
+
     await Promise.all([
       rm(join(registry.packagesPath, "republish-test-1"), { recursive: true, force: true }),
       write(join(packageDir, "bunfig.toml"), bunfig),
@@ -882,7 +882,7 @@ describe("--tolerate-republish", async () => {
       name: "republish-test-2",
       version: "1.0.0",
     };
-    
+
     await Promise.all([
       rm(join(registry.packagesPath, "republish-test-2"), { recursive: true, force: true }),
       write(join(packageDir, "bunfig.toml"), bunfig),
@@ -908,7 +908,7 @@ describe("--tolerate-republish", async () => {
       name: "republish-test-3",
       version: "1.0.0",
     };
-    
+
     await Promise.all([
       rm(join(registry.packagesPath, "republish-test-3"), { recursive: true, force: true }),
       write(join(packageDir, "bunfig.toml"), bunfig),


### PR DESCRIPTION
This flag allows `bun publish` to exit with code 0 instead of code 1 when attempting to republish over an existing version number. This is useful in automated workflows where republishing the same version might occur and should not be treated as an error.

Changes:
- Add --tolerate-republish CLI flag parsing
- Implement republish error detection and tolerance logic
- Add help text and usage examples
- Add comprehensive test coverage
- Update CLI documentation

### What does this PR do?

### How did you verify your code works?
