### PR TITLE
[bun:sqlite] Add sqlite-type symbol for Database

### DIFF
--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -339,6 +339,7 @@ class Statement {
 }
 
 const cachedCount = Symbol.for("Bun.Database.cache.count");
+const sqliteTypeSymbol = Symbol.for("sqlite-type");
 
 class Database implements SqliteTypes.Database {
   constructor(
@@ -435,6 +436,14 @@ class Database implements SqliteTypes.Database {
 
   get inTransaction() {
     return SQL.isInTransaction(this.#handle);
+  }
+
+  // Mark the Database prototype with a symbol to identify it as a bun-specific sqlite database.
+  // This is useful for the package author to detect which sqlite implementation is being used.
+  // Reference:
+  //   https://github.com/oven-sh/bun/pull/22109
+  get [sqliteTypeSymbol]() {
+    return "bun:sqlite";
   }
 
   static open(filename, options) {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -8,6 +8,18 @@ import path from "path";
 
 const tmpbase = tmpdir() + path.sep;
 
+describe("sqlite-type symbol", () => {
+  it("should have the sqlite-type symbol with value 'bun:sqlite'", () => {
+    const db = new Database(":memory:");
+    const sqliteTypeSymbol = Symbol.for("sqlite-type");
+
+    expect(sqliteTypeSymbol in db).toBe(true);
+    expect(db[sqliteTypeSymbol]).toBe("bun:sqlite");
+
+    db.close();
+  });
+});
+
 describe("as", () => {
   it("should return an implementation of the class", () => {
     const db = new Database(":memory:");


### PR DESCRIPTION
### What does this PR do?

Related: https://github.com/nodejs/node/commit/d1eabcb044a448ea2ff106fb1ec3814341867235
Related: https://github.com/nodejs/node/pull/59405
Related: https://github.com/better-auth/better-auth/pull/3869

Nowadays, there are tons of database packages, like sqlite3, sqlite, better-sqlite, bun:sqlite... Checking the difference from them is pretty hard.
instanceof is not good, since the developer will still need to import the module, which is costly.
 I think we should provide a symbol to distinguish different SQLite classes, at least nodejs could make the first step

This symbol could help with lots of duplicate properties checking, like https://github.com/kysely-org/kysely, https://github.com/knex/knex

It helps the library author to write an adapter for a different SQLite library. Right now, the library is checking the prototype method to determine whether it's node:sqlite, bun:sqlite, or better-sqlite... It was a lot of performance, and it's not stable as the API could change

https://github.com/better-auth/better-auth/blob/375e9f3ced6f3842c133f4cae689cb2a604ba94a/packages/better-auth/src/adapters/kysely-adapter/dialect.ts#L53-L109

I hope there's an easy way. like a symbol tag, to determine the user's land SQLite lib

### How did you verify your code works?

Adding tests