### PR TITLE
improve(MySQL) optimize queue to skip running queries

### DIFF
--- a/src/sql/mysql/MySQLConnection.zig
+++ b/src/sql/mysql/MySQLConnection.zig
@@ -658,7 +658,12 @@ fn advance(this: *@This()) void {
                 }
             },
             .binding, .running, .partial_response => {
-                offset += 1;
+                const total_requests_running = this.pipelined_requests + this.nonpipelinable_requests;
+                if (offset < total_requests_running) {
+                    offset += total_requests_running;
+                } else {
+                    offset += 1;
+                }
                 continue;
             },
             .success => {


### PR DESCRIPTION
### What does this PR do?
optimize advance method
after this optimizations
100k req the query bellow in 1 connection takes 792ms instead of 6s
```sql
SELECT CAST(1 AS UNSIGNED) AS x
```
1mi req of the query bellow with 10 connections takes 57.41s - 62.5s instead of 162.50s, mysql2 takes 1516.94s for comparison
```sql
SELECT * FROM users_bun_bench LIMIT 100
```

### How did you verify your code works?
Tested and benchmarked + CI