### PR TITLE
fix version tag infer: return tarball for gitlab tarball urls

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -662,6 +662,10 @@ pub const Version = struct {
                                 if (isGitHubRepoPath(path)) return .github;
                             }
 
+                            if (isTarball(url)) {
+                                return .tarball;
+                            }
+
                             if (strings.indexOfChar(url, '.')) |dot| {
                                 if (Repository.Hosts.has(url[0..dot])) return .git;
                             }

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -9,7 +9,7 @@
   ".stdDir()": 41,
   ".stdFile()": 18,
   "// autofix": 168,
-  ": [^=]+= undefined,$": 260,
+  ": [^=]+= undefined,$": 259,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,
   "@import(\"bun\").": 0,
@@ -37,7 +37,7 @@
   "std.fs.cwd": 104,
   "std.log": 1,
   "std.mem.indexOfAny(u8": 0,
-  "std.unicode": 33,
+  "std.unicode": 27,
   "undefined != ": 0,
   "undefined == ": 0,
   "usingnamespace": 0


### PR DESCRIPTION
GitLab package registry URLs like
`https://gitlab.example.com/api/v4/projects/1/packages/npm/@group/repo/-/@group/repo-x.y.y.tgz` were incorrectly inferred as `git` type due to hostname pattern matching.

These URLs now correctly resolve as `tarball` type.

### What does this PR do?

Fixes #22153

### How did you verify your code works?

Create a project with npm and install a tarball dependency from Gitlab repository

```sh
mkdir bun-gitlab-tarball-bug
cd bun-gitlab-tarball-bug
echo @gitlab-org:registry=https://gitlab.com/api/v4/projects/46519181/packages/npm/ >> .npmrc
npm i @gitlab-org/gitlab-lsp
```

Then check if `package-lock.json` migration works:

```sh
bun install
```
