### PR TITLE
Fix argv handling for standalone binaries - remove extra executable name (#22157)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -659,8 +659,8 @@ pub const Command = struct {
                     };
                     global_cli_ctx = &context_data;
 
-                    // If no compile_exec_argv, set offset normally
-                    offset_for_passthrough = if (bun.argv.len > 1) 1 else 0;
+                    // If no compile_exec_argv, skip executable name if present
+                    offset_for_passthrough = @min(1, bun.argv.len);
 
                     break :brk global_cli_ctx;
                 };

--- a/test/integration/vite-build/vite-build.test.ts
+++ b/test/integration/vite-build/vite-build.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import fs from "fs";
-import { bunExe, bunEnv as env, tmpdirSync, isASAN } from "harness";
+import { bunExe, bunEnv as env, isASAN, tmpdirSync } from "harness";
 import path from "path";
 
 const ASAN_MULTIPLIER = isASAN ? 3 : 1;

--- a/test/regression/issue/22157.test.ts
+++ b/test/regression/issue/22157.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv, tempDirWithFiles } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 // Regression test for https://github.com/oven-sh/bun/issues/22157
 // Compiled binaries were including executable name in process.argv
@@ -27,7 +27,7 @@ test("issue 22157: compiled binary should not include executable name in process
     stdout: "pipe",
     stderr: "pipe",
   });
-  
+
   await compileProc.exited;
 
   // Run the compiled binary - should not throw
@@ -39,18 +39,15 @@ test("issue 22157: compiled binary should not include executable name in process
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([
-    runProc.stdout.text(),
-    runProc.exited,
-  ]);
+  const [stdout, exitCode] = await Promise.all([runProc.stdout.text(), runProc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("SUCCESS");
-  
+
   // Verify process.argv structure
   const argvMatch = stdout.match(/\[.*?\]/);
   expect(argvMatch).toBeTruthy();
-  
+
   const processArgv = JSON.parse(argvMatch![0]);
   expect(processArgv).toHaveLength(2);
   expect(processArgv[0]).toBe("bun");
@@ -85,21 +82,18 @@ test("issue 22157: compiled binary with user args should pass them correctly", a
     stdout: "pipe",
     stderr: "pipe",
   });
-  
+
   await compileProc.exited;
 
   await using runProc = Bun.spawn({
     cmd: ["./test-binary", "arg1", "arg2"],
-    cwd: dir, 
+    cwd: dir,
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([
-    runProc.stdout.text(),
-    runProc.exited,
-  ]);
+  const [stdout, exitCode] = await Promise.all([runProc.stdout.text(), runProc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("SUCCESS");

--- a/test/regression/issue/22157.test.ts
+++ b/test/regression/issue/22157.test.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv, tempDirWithFiles } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/22157
+// Compiled binaries were including executable name in process.argv
+test("issue 22157: compiled binary should not include executable name in process.argv", async () => {
+  const dir = tempDirWithFiles("22157-basic", {
+    "index.js": /* js */ `
+      import { parseArgs } from "node:util"
+      
+      console.log(JSON.stringify(process.argv));
+      
+      // This should work - no extra executable name should cause parseArgs to throw
+      parseArgs({
+        args: process.argv.slice(2),
+      });
+      
+      console.log("SUCCESS");
+    `,
+  });
+
+  // Compile the binary
+  await using compileProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "--outfile=test-binary", "./index.js"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  
+  await compileProc.exited;
+
+  // Run the compiled binary - should not throw
+  await using runProc = Bun.spawn({
+    cmd: ["./test-binary"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("SUCCESS");
+  
+  // Verify process.argv structure
+  const argvMatch = stdout.match(/\[.*?\]/);
+  expect(argvMatch).toBeTruthy();
+  
+  const processArgv = JSON.parse(argvMatch![0]);
+  expect(processArgv).toHaveLength(2);
+  expect(processArgv[0]).toBe("bun");
+  expect(processArgv[1]).toContain("/$bunfs/root/");
+});
+
+test("issue 22157: compiled binary with user args should pass them correctly", async () => {
+  const dir = tempDirWithFiles("22157-args", {
+    "index.js": /* js */ `
+      console.log(JSON.stringify(process.argv));
+      
+      // Expect: ["bun", "/$bunfs/root/...", "arg1", "arg2"]
+      if (process.argv.length !== 4) {
+        console.error("Expected 4 argv items, got", process.argv.length);
+        process.exit(1);
+      }
+      
+      if (process.argv[2] !== "arg1" || process.argv[3] !== "arg2") {
+        console.error("User args not correct");
+        process.exit(1);
+      }
+      
+      console.log("SUCCESS");
+    `,
+  });
+
+  await using compileProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "--outfile=test-binary", "./index.js"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  
+  await compileProc.exited;
+
+  await using runProc = Bun.spawn({
+    cmd: ["./test-binary", "arg1", "arg2"],
+    cwd: dir, 
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("SUCCESS");
+});

--- a/test/regression/issue/22157.test.ts
+++ b/test/regression/issue/22157.test.ts
@@ -54,7 +54,8 @@ test("issue 22157: compiled binary should not include executable name in process
   const processArgv = JSON.parse(argvMatch![0]);
   expect(processArgv).toHaveLength(2);
   expect(processArgv[0]).toBe("bun");
-  expect(processArgv[1]).toContain("/$bunfs/root/");
+  // Windows uses "B:/~BUN/root/", Unix uses "/$bunfs/root/"
+  expect(processArgv[1]).toMatch(/(\$bunfs|~BUN).*root/);
 });
 
 test("issue 22157: compiled binary with user args should pass them correctly", async () => {
@@ -62,7 +63,7 @@ test("issue 22157: compiled binary with user args should pass them correctly", a
     "index.js": /* js */ `
       console.log(JSON.stringify(process.argv));
       
-      // Expect: ["bun", "/$bunfs/root/...", "arg1", "arg2"]
+      // Expect: ["bun", "/$bunfs/root/..." or "B:/~BUN/root/...", "arg1", "arg2"]
       if (process.argv.length !== 4) {
         console.error("Expected 4 argv items, got", process.argv.length);
         process.exit(1);


### PR DESCRIPTION
## Summary

Fixes an issue where compiled standalone binaries included an extra executable name argument in `process.argv`, breaking code that uses `node:util.parseArgs()` with `process.argv.slice(2)`.

## Problem

When running a compiled binary, `process.argv` incorrectly included the executable name as a third argument:

```bash
./my-app
# process.argv = ["bun", "/$bunfs/root/my-app", "./my-app"]  # BUG
```

This caused `parseArgs()` to fail with "Unexpected argument" errors, breaking previously valid code.

## Solution

Fixed the `offset_for_passthrough` calculation in `cli.zig` to always skip the executable name for standalone binaries, ensuring `process.argv` only contains the runtime name and script path:

```bash  
./my-app
# process.argv = ["bun", "/$bunfs/root/my-app"]  # FIXED
```

## Test plan

- [x] Added regression test in `test/regression/issue/22157.test.ts`
- [x] Verified existing exec-argv functionality still works correctly  
- [x] Manual testing confirms the fix resolves the parseArgs issue

Fixes #22157

🤖 Generated with [Claude Code](https://claude.ai/code)