### PR TITLE
node:util: move deprecate to internal file so its faster to import

### DIFF
--- a/cmake/sources/JavaScriptSources.txt
+++ b/cmake/sources/JavaScriptSources.txt
@@ -97,6 +97,7 @@ src/js/internal/tls.ts
 src/js/internal/tty.ts
 src/js/internal/url.ts
 src/js/internal/util/colors.ts
+src/js/internal/util/deprecate.ts
 src/js/internal/util/inspect.d.ts
 src/js/internal/util/inspect.js
 src/js/internal/util/mime.ts

--- a/src/js/internal/util/deprecate.ts
+++ b/src/js/internal/util/deprecate.ts
@@ -1,0 +1,45 @@
+const { validateString } = require("internal/validators");
+
+const codesWarned = new Set();
+
+function getDeprecationWarningEmitter(code, msg, deprecated, shouldEmitWarning = () => true) {
+  let warned = false;
+  return function () {
+    if (!warned && shouldEmitWarning()) {
+      warned = true;
+      if (code !== undefined) {
+        if (!codesWarned.has(code)) {
+          process.emitWarning(msg, "DeprecationWarning", code, deprecated);
+          codesWarned.add(code);
+        }
+      } else {
+        process.emitWarning(msg, "DeprecationWarning", deprecated);
+      }
+    }
+  };
+}
+
+function deprecate(fn, msg, code) {
+  // Lazy-load to avoid a circular dependency.
+  if (code !== undefined) validateString(code, "code");
+
+  const emitDeprecationWarning = getDeprecationWarningEmitter(code, msg, deprecated);
+
+  function deprecated(...args) {
+    if (!process.noDeprecation) {
+      emitDeprecationWarning();
+    }
+    if (new.target) {
+      return Reflect.construct(fn, args, new.target);
+    }
+    return fn.$apply(this, args);
+  }
+
+  // The wrapper will keep the same prototype as fn to maintain prototype chain
+  Object.setPrototypeOf(deprecated, fn);
+  return deprecated;
+}
+
+export default {
+  deprecate,
+};

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -1,6 +1,6 @@
 const { Stream } = require("internal/stream");
 const { isUint8Array, validateString } = require("internal/validators");
-const { deprecate } = require("node:util");
+const { deprecate } = require("internal/util/deprecate");
 const ObjectDefineProperty = Object.defineProperty;
 const ObjectKeys = Object.keys;
 const {

--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -975,7 +975,7 @@ var CallTracker;
 Object.defineProperty(assert, "CallTracker", {
   get() {
     if (CallTracker === undefined) {
-      const { deprecate } = require("node:util");
+      const { deprecate } = require("internal/util/deprecate");
       CallTracker = deprecate(require("internal/assert/calltracker"), "assert.CallTracker is deprecated.", "DEP0173");
     }
     return CallTracker;

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -57,7 +57,7 @@ const { isIP } = require("node:net");
 
 const EventEmitter = require("node:events");
 
-const { deprecate } = require("node:util");
+const { deprecate } = require("internal/util/deprecate");
 
 const SymbolDispose = Symbol.dispose;
 const SymbolAsyncDispose = Symbol.asyncDispose;

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -5,6 +5,7 @@ const utl = require("internal/util/inspect");
 const { promisify } = require("internal/promisify");
 const { validateString, validateOneOf } = require("internal/validators");
 const { MIMEType, MIMEParams } = require("internal/util/mime");
+const { deprecate } = require("internal/util/deprecate");
 
 const internalErrorName = $newZigFunction("node_util_binding.zig", "internalErrorName", 1);
 const parseEnv = $newZigFunction("node_util_binding.zig", "parseEnv", 1);
@@ -30,46 +31,6 @@ const inspect = utl.inspect;
 const formatWithOptions = utl.formatWithOptions;
 const format = utl.format;
 const stripVTControlCharacters = utl.stripVTControlCharacters;
-
-const codesWarned = new Set();
-
-function getDeprecationWarningEmitter(code, msg, deprecated, shouldEmitWarning = () => true) {
-  let warned = false;
-  return function () {
-    if (!warned && shouldEmitWarning()) {
-      warned = true;
-      if (code !== undefined) {
-        if (!codesWarned.has(code)) {
-          process.emitWarning(msg, "DeprecationWarning", code, deprecated);
-          codesWarned.add(code);
-        }
-      } else {
-        process.emitWarning(msg, "DeprecationWarning", deprecated);
-      }
-    }
-  };
-}
-
-function deprecate(fn, msg, code) {
-  // Lazy-load to avoid a circular dependency.
-  if (code !== undefined) validateString(code, "code");
-
-  const emitDeprecationWarning = getDeprecationWarningEmitter(code, msg, deprecated);
-
-  function deprecated(...args) {
-    if (!process.noDeprecation) {
-      emitDeprecationWarning();
-    }
-    if (new.target) {
-      return Reflect.construct(fn, args, new.target);
-    }
-    return fn.$apply(this, args);
-  }
-
-  // The wrapper will keep the same prototype as fn to maintain prototype chain
-  Object.setPrototypeOf(deprecated, fn);
-  return deprecated;
-}
 
 var debugs = {};
 var debugEnvRegex = /^$/;


### PR DESCRIPTION
pulled out of https://github.com/oven-sh/bun/pull/21809

importing `node:util` is very slow because it includes `inspect`