### PR TITLE
Make `BoundedArray` more compact, shrink `Data` in `sql` from 32 bytes to 24 bytes

### DIFF
--- a/cmake/sources/ZigSources.txt
+++ b/cmake/sources/ZigSources.txt
@@ -491,6 +491,7 @@ src/codegen/process_windows_translate_c.zig
 src/collections.zig
 src/collections/baby_list.zig
 src/collections/bit_set.zig
+src/collections/BoundedArray.zig
 src/collections/hive_array.zig
 src/collections/multi_array_list.zig
 src/compile_target.zig

--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -222,7 +222,7 @@ pub fn HTMLProcessor(
             var builder = lol.HTMLRewriter.Builder.init();
             defer builder.deinit();
 
-            var selectors: std.BoundedArray(*lol.HTMLSelector, tag_handlers.len + if (visit_document_tags) 3 else 0) = .{};
+            var selectors: bun.BoundedArray(*lol.HTMLSelector, tag_handlers.len + if (visit_document_tags) 3 else 0) = .{};
             defer for (selectors.slice()) |selector| {
                 selector.deinit();
             };

--- a/src/bake/FrameworkRouter.zig
+++ b/src/bake/FrameworkRouter.zig
@@ -816,7 +816,7 @@ pub fn insert(
 pub const MatchedParams = struct {
     pub const max_count = 64;
 
-    params: std.BoundedArray(Entry, max_count),
+    params: bun.BoundedArray(Entry, max_count),
 
     pub const Entry = struct {
         key: []const u8,
@@ -874,7 +874,7 @@ const PatternParseError = error{InvalidRoutePattern};
 /// Non-allocating single message log, specialized for the messages from the route pattern parsers.
 /// DevServer uses this to special-case the printing of these messages to highlight the offending part of the filename
 pub const TinyLog = struct {
-    msg: std.BoundedArray(u8, 512 + std.fs.max_path_bytes),
+    msg: bun.BoundedArray(u8, 512 + @min(std.fs.max_path_bytes, 4096)),
     cursor_at: u32,
     cursor_len: u32,
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -415,6 +415,7 @@ pub const BabyList = collections.BabyList;
 pub const OffsetList = collections.OffsetList;
 pub const bit_set = collections.bit_set;
 pub const HiveArray = collections.HiveArray;
+pub const BoundedArray = collections.BoundedArray;
 
 pub const ByteList = BabyList(u8);
 pub const OffsetByteList = OffsetList(u8);

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.zig
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.zig
@@ -49,7 +49,7 @@ pub fn generateCodeForFileInChunkJS(
 
         const inner = stmts.all_stmts.items[0..main_stmts_len];
 
-        var clousure_args = std.BoundedArray(G.Arg, 3).fromSlice(&.{
+        var clousure_args = bun.BoundedArray(G.Arg, 3).fromSlice(&.{
             .{ .binding = Binding.alloc(temp_allocator, B.Identifier{
                 .ref = hmr_api_ref,
             }, Logger.Loc.Empty) },

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -142,8 +142,8 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
                 try endTag.before(slice, true);
         }
 
-        fn getHeadTags(this: *@This(), allocator: std.mem.Allocator) std.BoundedArray([]const u8, 2) {
-            var array: std.BoundedArray([]const u8, 2) = .{};
+        fn getHeadTags(this: *@This(), allocator: std.mem.Allocator) bun.BoundedArray([]const u8, 2) {
+            var array: bun.BoundedArray([]const u8, 2) = .{};
             // Put CSS before JS to reduce changes of flash of unstyled content
             if (this.chunk.getCSSChunkForHTML(this.chunks)) |css_chunk| {
                 const link_tag = bun.handleOom(std.fmt.allocPrintZ(allocator, "<link rel=\"stylesheet\" crossorigin href=\"{s}\">", .{css_chunk.unique_key}));

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -711,7 +711,7 @@ pub const BunxCommand = struct {
             package_json.writeAll("{}\n") catch {};
         }
 
-        var args = std.BoundedArray([]const u8, 8).fromSlice(&.{
+        var args = bun.BoundedArray([]const u8, 8).fromSlice(&.{
             try bun.selfExePath(),
             "add",
             install_param,

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -616,7 +616,7 @@ pub const CommandLineReporter = struct {
         file_reporter: ?FileReporter,
         line_number: u32,
     ) void {
-        var scopes_stack = std.BoundedArray(*jest.DescribeScope, 64).init(0) catch unreachable;
+        var scopes_stack = bun.BoundedArray(*jest.DescribeScope, 64).init(0) catch unreachable;
         var parent_ = parent;
 
         while (parent_) |scope| {

--- a/src/collections.zig
+++ b/src/collections.zig
@@ -3,3 +3,4 @@ pub const BabyList = @import("./collections/baby_list.zig").BabyList;
 pub const OffsetList = @import("./collections/baby_list.zig").OffsetList;
 pub const bit_set = @import("./collections/bit_set.zig");
 pub const HiveArray = @import("./collections/hive_array.zig").HiveArray;
+pub const BoundedArray = @import("./collections/BoundedArray.zig").BoundedArray;

--- a/src/collections/BoundedArray.zig
+++ b/src/collections/BoundedArray.zig
@@ -40,13 +40,9 @@ pub fn BoundedArrayAligned(
     return struct {
         const Self = @This();
         buffer: [buffer_capacity]T align(alignment.toByteUnits()) = undefined,
-        len: Int = 0,
+        len: Length = 0,
 
-        pub const Int = switch (buffer_capacity) {
-            0...255 => u8,
-            256...std.math.maxInt(u16) => u16,
-            else => @compileError("BoundedArray buffer_capacity must be less than 64 KiB"),
-        };
+        const Length = std.math.ByteAlignedInt(std.math.IntFittingRange(0, buffer_capacity));
 
         pub const Buffer = @FieldType(Self, "buffer");
 

--- a/src/collections/BoundedArray.zig
+++ b/src/collections/BoundedArray.zig
@@ -1,0 +1,310 @@
+/// Removed from the Zig standard library in https://github.com/ziglang/zig/pull/24699/
+///
+/// Modifications:
+/// - `len` is a field of integer-size instead of usize. This reduces memory usage.
+///
+/// A structure with an array and a length, that can be used as a slice.
+///
+/// Useful to pass around small arrays whose exact size is only known at
+/// runtime, but whose maximum size is known at comptime, without requiring
+/// an `Allocator`.
+///
+/// ```zig
+/// var actual_size = 32;
+/// var a = try BoundedArray(u8, 64).init(actual_size);
+/// var slice = a.slice(); // a slice of the 64-byte array
+/// var a_clone = a; // creates a copy - the structure doesn't use any internal pointers
+/// ```
+pub fn BoundedArray(comptime T: type, comptime buffer_capacity: usize) type {
+    return BoundedArrayAligned(T, std.mem.Alignment.fromByteUnits(@alignOf(T)), buffer_capacity);
+}
+
+/// A structure with an array, length and alignment, that can be used as a
+/// slice.
+///
+/// Useful to pass around small explicitly-aligned arrays whose exact size is
+/// only known at runtime, but whose maximum size is known at comptime, without
+/// requiring an `Allocator`.
+/// ```zig
+//  var a = try BoundedArrayAligned(u8, 16, 2).init(0);
+//  try a.append(255);
+//  try a.append(255);
+//  const b = @ptrCast(*const [1]u16, a.constSlice().ptr);
+//  try testing.expectEqual(@as(u16, 65535), b[0]);
+/// ```
+pub fn BoundedArrayAligned(
+    comptime T: type,
+    comptime alignment: Alignment,
+    comptime buffer_capacity: usize,
+) type {
+    return struct {
+        const Self = @This();
+        buffer: [buffer_capacity]T align(alignment.toByteUnits()) = undefined,
+        len: Int = 0,
+
+        pub const Int = switch (buffer_capacity) {
+            0...255 => u8,
+            256...std.math.maxInt(u16) => u16,
+            else => @compileError("BoundedArray buffer_capacity must be less than 64 KiB"),
+        };
+
+        pub const Buffer = @FieldType(Self, "buffer");
+
+        /// Set the actual length of the slice.
+        /// Returns error.Overflow if it exceeds the length of the backing array.
+        pub fn init(len: usize) error{Overflow}!Self {
+            if (len > buffer_capacity) return error.Overflow;
+            return Self{ .len = @intCast(len) };
+        }
+
+        /// View the internal array as a slice whose size was previously set.
+        pub fn slice(self: anytype) switch (@TypeOf(&self.buffer)) {
+            *align(alignment.toByteUnits()) [buffer_capacity]T => []align(alignment.toByteUnits()) T,
+            *align(alignment.toByteUnits()) const [buffer_capacity]T => []align(alignment.toByteUnits()) const T,
+            else => unreachable,
+        } {
+            return self.buffer[0..self.len];
+        }
+
+        /// View the internal array as a constant slice whose size was previously set.
+        pub fn constSlice(self: *const Self) []align(alignment.toByteUnits()) const T {
+            return self.slice();
+        }
+
+        /// Adjust the slice's length to `len`.
+        /// Does not initialize added items if any.
+        pub fn resize(self: *Self, len: usize) error{Overflow}!void {
+            if (len > buffer_capacity) return error.Overflow;
+            self.len = len;
+        }
+
+        /// Remove all elements from the slice.
+        pub fn clear(self: *Self) void {
+            self.len = 0;
+        }
+
+        /// Copy the content of an existing slice.
+        pub fn fromSlice(m: []const T) error{Overflow}!Self {
+            var list = try init(m.len);
+            @memcpy(list.slice(), m);
+            return list;
+        }
+
+        /// Return the element at index `i` of the slice.
+        pub fn get(self: Self, i: usize) T {
+            return self.constSlice()[i];
+        }
+
+        /// Set the value of the element at index `i` of the slice.
+        pub fn set(self: *Self, i: usize, item: T) void {
+            self.slice()[i] = item;
+        }
+
+        /// Return the maximum length of a slice.
+        pub fn capacity(self: Self) usize {
+            return self.buffer.len;
+        }
+
+        /// Check that the slice can hold at least `additional_count` items.
+        pub fn ensureUnusedCapacity(self: Self, additional_count: usize) error{Overflow}!void {
+            if (self.len + additional_count > buffer_capacity) {
+                return error.Overflow;
+            }
+        }
+
+        /// Increase length by 1, returning a pointer to the new item.
+        pub fn addOne(self: *Self) error{Overflow}!*T {
+            try self.ensureUnusedCapacity(1);
+            return self.addOneAssumeCapacity();
+        }
+
+        /// Increase length by 1, returning pointer to the new item.
+        /// Asserts that there is space for the new item.
+        pub fn addOneAssumeCapacity(self: *Self) *T {
+            assert(self.len < buffer_capacity);
+            self.len += 1;
+            return &self.slice()[self.len - 1];
+        }
+
+        /// Resize the slice, adding `n` new elements, which have `undefined` values.
+        /// The return value is a pointer to the array of uninitialized elements.
+        pub fn addManyAsArray(self: *Self, comptime n: usize) error{Overflow}!*align(alignment.toByteUnits()) [n]T {
+            const prev_len = self.len;
+            try self.resize(@as(usize, self.len) + n);
+            return self.slice()[prev_len..][0..n];
+        }
+
+        /// Resize the slice, adding `n` new elements, which have `undefined` values.
+        /// The return value is a slice pointing to the uninitialized elements.
+        pub fn addManyAsSlice(self: *Self, n: usize) error{Overflow}![]align(alignment.toByteUnits()) T {
+            const prev_len = self.len;
+            try self.resize(self.len + n);
+            return self.slice()[prev_len..][0..n];
+        }
+
+        /// Remove and return the last element from the slice, or return `null` if the slice is empty.
+        pub fn pop(self: *Self) ?T {
+            if (self.len == 0) return null;
+            const item = self.get(self.len - 1);
+            self.len -= 1;
+            return item;
+        }
+
+        /// Return a slice of only the extra capacity after items.
+        /// This can be useful for writing directly into it.
+        /// Note that such an operation must be followed up with a
+        /// call to `resize()`
+        pub fn unusedCapacitySlice(self: *Self) []align(alignment.toByteUnits()) T {
+            return self.buffer[self.len..];
+        }
+
+        /// Insert `item` at index `i` by moving `slice[n .. slice.len]` to make room.
+        /// This operation is O(N).
+        pub fn insert(
+            self: *Self,
+            i: usize,
+            item: T,
+        ) error{Overflow}!void {
+            if (i > self.len) {
+                return error.Overflow;
+            }
+            _ = try self.addOne();
+            var s = self.slice();
+            mem.copyBackwards(T, s[i + 1 .. s.len], s[i .. s.len - 1]);
+            self.buffer[i] = item;
+        }
+
+        /// Insert slice `items` at index `i` by moving `slice[i .. slice.len]` to make room.
+        /// This operation is O(N).
+        pub fn insertSlice(self: *Self, i: usize, items: []const T) error{Overflow}!void {
+            try self.ensureUnusedCapacity(items.len);
+            self.len += @intCast(items.len);
+            mem.copyBackwards(T, self.slice()[i + items.len .. self.len], self.constSlice()[i .. self.len - items.len]);
+            @memcpy(self.slice()[i..][0..items.len], items);
+        }
+
+        /// Replace range of elements `slice[start..][0..len]` with `new_items`.
+        /// Grows slice if `len < new_items.len`.
+        /// Shrinks slice if `len > new_items.len`.
+        pub fn replaceRange(
+            self: *Self,
+            start: usize,
+            len: usize,
+            new_items: []const T,
+        ) error{Overflow}!void {
+            const after_range = start + len;
+            var range = self.slice()[start..after_range];
+
+            if (range.len == new_items.len) {
+                @memcpy(range[0..new_items.len], new_items);
+            } else if (range.len < new_items.len) {
+                const first = new_items[0..range.len];
+                const rest = new_items[range.len..];
+                @memcpy(range[0..first.len], first);
+                try self.insertSlice(after_range, rest);
+            } else {
+                @memcpy(range[0..new_items.len], new_items);
+                const after_subrange = start + new_items.len;
+                for (self.constSlice()[after_range..], 0..) |item, i| {
+                    self.slice()[after_subrange..][i] = item;
+                }
+                self.len = @intCast(@as(usize, self.len) - @as(usize, len) - @as(usize, new_items.len));
+            }
+        }
+
+        /// Extend the slice by 1 element.
+        pub fn append(self: *Self, item: T) error{Overflow}!void {
+            const new_item_ptr = try self.addOne();
+            new_item_ptr.* = item;
+        }
+
+        /// Extend the slice by 1 element, asserting the capacity is already
+        /// enough to store the new item.
+        pub fn appendAssumeCapacity(self: *Self, item: T) void {
+            const new_item_ptr = self.addOneAssumeCapacity();
+            new_item_ptr.* = item;
+        }
+
+        /// Remove the element at index `i`, shift elements after index
+        /// `i` forward, and return the removed element.
+        /// Asserts the slice has at least one item.
+        /// This operation is O(N).
+        pub fn orderedRemove(self: *Self, i: usize) T {
+            const newlen = self.len - 1;
+            if (newlen == i) return self.pop().?;
+            const old_item = self.get(i);
+            for (self.slice()[i..newlen], 0..) |*b, j| b.* = self.get(i + 1 + j);
+            self.set(newlen, undefined);
+            self.len = newlen;
+            return old_item;
+        }
+
+        /// Remove the element at the specified index and return it.
+        /// The empty slot is filled from the end of the slice.
+        /// This operation is O(1).
+        pub fn swapRemove(self: *Self, i: usize) T {
+            if (self.len - 1 == i) return self.pop().?;
+            const old_item = self.get(i);
+            self.set(i, self.pop().?);
+            return old_item;
+        }
+
+        /// Append the slice of items to the slice.
+        pub fn appendSlice(self: *Self, items: []const T) error{Overflow}!void {
+            try self.ensureUnusedCapacity(items.len);
+            self.appendSliceAssumeCapacity(items);
+        }
+
+        /// Append the slice of items to the slice, asserting the capacity is already
+        /// enough to store the new items.
+        pub fn appendSliceAssumeCapacity(self: *Self, items: []const T) void {
+            const old_len = self.len;
+            const new_len: usize = old_len + @as(usize, items.len);
+            self.len = @intCast(new_len);
+            @memcpy(self.slice()[old_len..][0..items.len], items);
+        }
+
+        /// Append a value to the slice `n` times.
+        /// Allocates more memory as necessary.
+        pub fn appendNTimes(self: *Self, value: T, n: usize) error{Overflow}!void {
+            const old_len = self.len;
+            try self.resize(old_len + n);
+            @memset(self.slice()[old_len..self.len], value);
+        }
+
+        /// Append a value to the slice `n` times.
+        /// Asserts the capacity is enough.
+        pub fn appendNTimesAssumeCapacity(self: *Self, value: T, n: usize) void {
+            const old_len: usize = self.len;
+            const new_len: usize = old_len + @as(usize, n);
+            self.len = @intCast(new_len);
+            assert(self.len <= buffer_capacity);
+            @memset(self.slice()[old_len..self.len], value);
+        }
+
+        pub const Writer = if (T != u8)
+            @compileError("The Writer interface is only defined for BoundedArray(u8, ...) " ++
+                "but the given type is BoundedArray(" ++ @typeName(T) ++ ", ...)")
+        else
+            std.io.GenericWriter(*Self, error{Overflow}, appendWrite);
+
+        /// Initializes a writer which will write into the array.
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
+
+        /// Same as `appendSlice` except it returns the number of bytes written, which is always the same
+        /// as `m.len`. The purpose of this function existing is to match `std.io.GenericWriter` API.
+        fn appendWrite(self: *Self, m: []const u8) error{Overflow}!usize {
+            try self.appendSlice(m);
+            return m.len;
+        }
+    };
+}
+
+const bun = @import("bun");
+const std = @import("std");
+const assert = bun.assert;
+const mem = std.mem;
+const testing = std.testing;
+const Alignment = std.mem.Alignment;

--- a/src/collections/BoundedArray.zig
+++ b/src/collections/BoundedArray.zig
@@ -303,8 +303,10 @@ pub fn BoundedArrayAligned(
 }
 
 const bun = @import("bun");
-const std = @import("std");
 const assert = bun.assert;
-const mem = std.mem;
+
+const std = @import("std");
 const testing = std.testing;
+
+const mem = std.mem;
 const Alignment = std.mem.Alignment;

--- a/src/collections/BoundedArray.zig
+++ b/src/collections/BoundedArray.zig
@@ -16,7 +16,7 @@
 /// var a_clone = a; // creates a copy - the structure doesn't use any internal pointers
 /// ```
 pub fn BoundedArray(comptime T: type, comptime buffer_capacity: usize) type {
-    return BoundedArrayAligned(T, std.mem.Alignment.fromByteUnits(@alignOf(T)), buffer_capacity);
+    return BoundedArrayAligned(T, .fromByteUnits(@alignOf(T)), buffer_capacity);
 }
 
 /// A structure with an array, length and alignment, that can be used as a

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -175,7 +175,7 @@ pub fn crashHandler(
     if (bun.Environment.isDebug)
         bun.Output.disableScopedDebugWriter();
 
-    var trace_str_buf = std.BoundedArray(u8, 1024){};
+    var trace_str_buf = bun.BoundedArray(u8, 1024){};
 
     nosuspend switch (panic_stage) {
         0 => {
@@ -1434,7 +1434,7 @@ fn report(url: []const u8) void {
                 // .hStdOutput = bun.FD.stdout().native(),
                 // .hStdError = bun.FD.stderr().native(),
             };
-            var cmd_line = std.BoundedArray(u16, 4096){};
+            var cmd_line = bun.BoundedArray(u16, 4096){};
             cmd_line.appendSliceAssumeCapacity(std.unicode.utf8ToUtf16LeStringLiteral("powershell -ExecutionPolicy Bypass -Command \"try{Invoke-RestMethod -Uri '"));
             {
                 const encoded = bun.strings.convertUTF8toUTF16InBuffer(cmd_line.unusedCapacitySlice(), url);
@@ -1468,7 +1468,7 @@ fn report(url: []const u8) void {
                 bun.getcwd(&buf2) catch return,
                 "curl",
             ) orelse return;
-            var cmd_line = std.BoundedArray(u8, 4096){};
+            var cmd_line = bun.BoundedArray(u8, 4096){};
             cmd_line.appendSlice(url) catch return;
             cmd_line.appendSlice("/ack") catch return;
             cmd_line.append(0) catch return;
@@ -1866,7 +1866,7 @@ pub const js_bindings = struct {
 
     pub fn jsGetFeaturesAsVLQ(global: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
         const bits = bun.analytics.packedFeatures();
-        var buf = std.BoundedArray(u8, 16){};
+        var buf = bun.BoundedArray(u8, 16){};
         writeU64AsTwoVLQs(buf.writer(), @bitCast(bits)) catch {
             // there is definitely enough space in the bounded array
             unreachable;

--- a/src/glob/match.zig
+++ b/src/glob/match.zig
@@ -31,7 +31,7 @@ const Brace = struct {
     open_brace_idx: u32,
     branch_idx: u32,
 };
-const BraceStack = std.BoundedArray(Brace, 10);
+const BraceStack = bun.BoundedArray(Brace, 10);
 
 pub const MatchResult = enum {
     no_match,

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -408,7 +408,7 @@ pub const LoadResult = struct {
 var resolver_Mutex: Mutex = undefined;
 var resolver_Mutex_loaded: bool = false;
 
-const BinFolderArray = std.BoundedArray(string, 128);
+const BinFolderArray = bun.BoundedArray(string, 128);
 var bin_folders: BinFolderArray = undefined;
 var bin_folders_lock: Mutex = .{};
 var bin_folders_loaded: bool = false;
@@ -4165,7 +4165,7 @@ pub const Resolver = struct {
                     break :brk null;
                 };
                 if (info.tsconfig_json) |tsconfig_json| {
-                    var parent_configs = try std.BoundedArray(*TSConfigJSON, 64).init(0);
+                    var parent_configs = try bun.BoundedArray(*TSConfigJSON, 64).init(0);
                     try parent_configs.append(tsconfig_json);
                     var current = tsconfig_json;
                     while (current.extends.len > 0) {

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -785,7 +785,7 @@ pub const S3Credentials = struct {
                 const canonical = brk_canonical: {
                     var stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
                     const allocator = stack_fallback.get();
-                    var query_parts: std.BoundedArray([]const u8, 10) = .{};
+                    var query_parts: bun.BoundedArray([]const u8, 10) = .{};
 
                     // Add parameters in alphabetical order: Content-MD5, X-Amz-Acl, X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-Security-Token, X-Amz-SignedHeaders, x-amz-storage-class
 
@@ -836,7 +836,7 @@ pub const S3Credentials = struct {
                 // Build final URL with query parameters in alphabetical order to match canonical request
                 var url_stack_fallback = std.heap.stackFallback(512, bun.default_allocator);
                 const url_allocator = url_stack_fallback.get();
-                var url_query_parts: std.BoundedArray([]const u8, 10) = .{};
+                var url_query_parts: bun.BoundedArray([]const u8, 10) = .{};
 
                 // Add parameters in alphabetical order: Content-MD5, X-Amz-Acl, X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-Security-Token, X-Amz-SignedHeaders, x-amz-storage-class, X-Amz-Signature
 

--- a/src/sql/mysql/protocol/EncodeInt.zig
+++ b/src/sql/mysql/protocol/EncodeInt.zig
@@ -1,6 +1,6 @@
 // Length-encoded integer encoding/decoding
-pub fn encodeLengthInt(value: u64) std.BoundedArray(u8, 9) {
-    var array: std.BoundedArray(u8, 9) = .{};
+pub fn encodeLengthInt(value: u64) bun.BoundedArray(u8, 9) {
+    var array: bun.BoundedArray(u8, 9) = .{};
     if (value < 0xfb) {
         array.len = 1;
         array.buffer[0] = @intCast(value);
@@ -71,3 +71,4 @@ pub fn decodeLengthInt(bytes: []const u8) ?struct { value: u64, bytes_read: usiz
 }
 
 const std = @import("std");
+const bun = @import("bun");

--- a/src/sql/mysql/protocol/EncodeInt.zig
+++ b/src/sql/mysql/protocol/EncodeInt.zig
@@ -70,5 +70,4 @@ pub fn decodeLengthInt(bytes: []const u8) ?struct { value: u64, bytes_read: usiz
     }
 }
 
-const std = @import("std");
 const bun = @import("bun");

--- a/src/sql/shared/Data.zig
+++ b/src/sql/shared/Data.zig
@@ -2,8 +2,10 @@
 pub const Data = union(enum) {
     owned: bun.ByteList,
     temporary: []const u8,
-    inline_storage: std.BoundedArray(u8, 15),
+    inline_storage: InlineStorage,
     empty: void,
+
+    pub const InlineStorage = bun.BoundedArray(u8, 15);
 
     pub const Empty: Data = .{ .empty = {} };
 
@@ -13,7 +15,7 @@ pub const Data = union(enum) {
         }
 
         if (possibly_inline_bytes.len <= 15) {
-            var inline_storage = std.BoundedArray(u8, 15){};
+            var inline_storage = InlineStorage{};
             @memcpy(inline_storage.buffer[0..possibly_inline_bytes.len], possibly_inline_bytes);
             inline_storage.len = @truncate(possibly_inline_bytes.len);
             return .{ .inline_storage = inline_storage };

--- a/src/string/immutable.zig
+++ b/src/string/immutable.zig
@@ -1546,11 +1546,11 @@ const LineRange = struct {
     start: u32,
     end: u32,
 };
-pub fn indexOfLineRanges(text: []const u8, target_line: u32, comptime line_range_count: usize) std.BoundedArray(LineRange, line_range_count) {
+pub fn indexOfLineRanges(text: []const u8, target_line: u32, comptime line_range_count: usize) bun.BoundedArray(LineRange, line_range_count) {
     const remaining = text;
     if (remaining.len == 0) return .{};
 
-    var ranges = std.BoundedArray(LineRange, line_range_count){};
+    var ranges = bun.BoundedArray(LineRange, line_range_count){};
 
     var current_line: u32 = 0;
     const first_newline_or_nonascii_i = strings.indexOfNewlineOrNonASCIICheckStart(text, 0, true) orelse {
@@ -1644,7 +1644,7 @@ pub fn indexOfLineRanges(text: []const u8, target_line: u32, comptime line_range
         };
 
         if (ranges.len == line_range_count and current_line <= target_line) {
-            var new_ranges = std.BoundedArray(LineRange, line_range_count){};
+            var new_ranges = bun.BoundedArray(LineRange, line_range_count){};
             new_ranges.appendSliceAssumeCapacity(ranges.slice()[1..]);
             ranges = new_ranges;
         }
@@ -1658,7 +1658,7 @@ pub fn indexOfLineRanges(text: []const u8, target_line: u32, comptime line_range
     }
 
     if (ranges.len == line_range_count and current_line <= target_line) {
-        var new_ranges = std.BoundedArray(LineRange, line_range_count){};
+        var new_ranges = bun.BoundedArray(LineRange, line_range_count){};
         new_ranges.appendSliceAssumeCapacity(ranges.slice()[1..]);
         ranges = new_ranges;
     }
@@ -1667,10 +1667,10 @@ pub fn indexOfLineRanges(text: []const u8, target_line: u32, comptime line_range
 }
 
 /// Get N lines from the start of the text
-pub fn getLinesInText(text: []const u8, line: u32, comptime line_range_count: usize) ?std.BoundedArray([]const u8, line_range_count) {
+pub fn getLinesInText(text: []const u8, line: u32, comptime line_range_count: usize) ?bun.BoundedArray([]const u8, line_range_count) {
     const ranges = indexOfLineRanges(text, line, line_range_count);
     if (ranges.len == 0) return null;
-    var results = std.BoundedArray([]const u8, line_range_count){};
+    var results = bun.BoundedArray([]const u8, line_range_count){};
     results.len = ranges.len;
 
     for (results.slice()[0..ranges.len], ranges.slice()) |*chunk, range| {

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -10,7 +10,7 @@
   ".stdDir()": 41,
   ".stdFile()": 18,
   "// autofix": 168,
-  ": [^=]+= undefined,$": 259,
+  ": [^=]+= undefined,$": 260,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,
   "@import(\"bun\").": 0,


### PR DESCRIPTION
### What does this PR do?

- Instead of storing `len` in `BoundedArray` as a `usize`, store it as either a `u8` or ` u16` depending on the `buffer_capacity`
- Copy-paste `BoundedArray` from the standard library into Bun's codebase as it was removed in https://github.com/ziglang/zig/pull/24699/files#diff-cbd8cbbc17583cb9ea5cc0f711ce0ad447b446e62ea5ddbe29274696dce89e4f and we will probably continue using it

### How did you verify your code works?

Ran `bun run zig:check`