### PR TITLE
Hide private fields in typeInfo

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -62,7 +62,7 @@ jobs:
           (
             ZIG_TEMP=$(mktemp -d)
             echo "[zig] Downloading Zig (musl build)..."
-            wget -q -O "$ZIG_TEMP/zig.zip" https://github.com/oven-sh/zig/releases/download/autobuild-ebe0cdac3170b0462a39caff4d1d7252b608e98d/bootstrap-x86_64-linux-musl.zip
+            wget -q -O "$ZIG_TEMP/zig.zip" https://github.com/oven-sh/zig/releases/download/autobuild-e0b7c318f318196c5f81fdf3423816a7b5bb3112/bootstrap-x86_64-linux-musl.zip
             unzip -q -d "$ZIG_TEMP" "$ZIG_TEMP/zig.zip"
             export PATH="$ZIG_TEMP/bootstrap-x86_64-linux-musl:$PATH"
             echo "[zig] Running zig fmt..."

--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -20,7 +20,7 @@ else()
   unsupported(CMAKE_SYSTEM_NAME)
 endif()
 
-set(ZIG_COMMIT "ebe0cdac3170b0462a39caff4d1d7252b608e98d")
+set(ZIG_COMMIT "e0b7c318f318196c5f81fdf3423816a7b5bb3112")
 optionx(ZIG_TARGET STRING "The zig target to use" DEFAULT ${DEFAULT_ZIG_TARGET})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
https://github.com/oven-sh/zig/compare/ebe0cdac3170b0462a39caff4d1d7252b608e98d..e0b7c318f318196c5f81fdf3423816a7b5bb3112

It hides it in typeInfo even in the current file, unlike private declarations which are only hidden in other files.

This allows you to formatted print a type with private fields, but the private fields are not shown. The alternative would be to allow accessing private fields through `@field()` but that looked like it was going to be more complicated (need to add an argument to structFieldVal/structFieldPtr which are called by fieldVal/fieldPtr which have 36 callsites)