### PR TITLE
Fix the curl installation command for zsh

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,8 +11,8 @@ Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1. Us
 
 {% codetabs %}
 
-```bash#macOS/Linux_(curl)
-$ curl -fsSL https://bun.com/install | bash # for macOS, Linux, and WSL
+```bash#macOS/Linux/WSL_(curl)
+$ curl -fsSL https://bun.com/install | bash
 # to install a specific version
 $ curl -fsSL https://bun.com/install | bash -s "bun-v$BUN_LATEST_VERSION"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1. Us
 
 {% codetabs %}
 
-```bash#macOS/Linux/WSL_(curl)
+```bash#curl_(macOS/Linux/WSL)
 $ curl -fsSL https://bun.com/install | bash
 # to install a specific version
 $ curl -fsSL https://bun.com/install | bash -s "bun-v$BUN_LATEST_VERSION"
@@ -304,8 +304,8 @@ If you need to remove Bun from your system, use the following commands.
 
 {% codetabs %}
 
-```bash#macOS/Linux_(curl)
-$ rm -rf ~/.bun # for macOS, Linux, and WSL
+```bash#curl_(macOS/Linux/WSL)
+$ rm -rf ~/.bun
 ```
 
 ```powershell#Windows


### PR DESCRIPTION
### What does this PR do?
Fix the curl installation command for `zsh`.

the comment causes the installation command to fail with this error: 
```bash: #: No such file or directory```

<img width="1286" height="156" alt="CleanShot 2025-08-30 at 21 55 46@2x" src="https://github.com/user-attachments/assets/1771786b-1fff-48e4-a62f-28fbaa7e0c4f" />

I removed the comment because I didn't find it useful, the tab title is explanatory.

before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/f470529b-0fe1-4eee-b48b-675a8e18f121" />
after:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b8b33616-cf87-4d97-9530-85840e496aa7" />


I would even change it to `curl (MacOS/Linux/curl)` to be aligned with the other tabs 
EDIT: Done that as the rabbit said


### How did you verify your code works?
It's docs change (trust me bro)
