### PR TITLE
Prevent describe() and lifecycle hooks from being called inside test() blocks

### DIFF
--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -1932,12 +1932,12 @@ inline fn createScope(
 
     const allocator = bun.default_allocator;
     const parent = DescribeScope.active.?;
-    
+
     // Prevent describe blocks from being nested inside test blocks
     if (!is_test and parent.current_test_id != TestRunner.Test.null_id) {
         return globalThis.throwPretty("describe() cannot be called inside a test(). Test structure functions must be called at the top level.", .{});
     }
-    
+
     const label = brk: {
         if (description == .zero) {
             break :brk "";


### PR DESCRIPTION
## Summary

Prevent `describe()` blocks and lifecycle hooks (`beforeEach`, `afterEach`, `beforeAll`, `afterAll`) from being nested inside `test()` blocks, matching Jest behavior and maintaining proper test isolation.

## Simple Implementation

Uses existing `DescribeScope.current_test_id` field to detect when a test is executing:
- Check `parent.current_test_id != TestRunner.Test.null_id` 
- No complex thread-local storage or concurrency concerns
- Leverages existing test execution tracking infrastructure

## Changes

- Add checks in `createScope()` to prevent `describe()` calls during test execution
- Add checks in `createCallback()` to prevent lifecycle hooks during test execution  
- Add comprehensive tests to verify both restrictions work correctly

## Test Results

✅ **Normal describe nesting still works** (describe inside describe)  
✅ **Hooks work properly at top level** (outside test functions)  
✅ **Proper error messages** for both describe and hook violations  
✅ **Jest compatibility** - matches Jest's "Hooks cannot be defined inside tests" behavior

## Rationale

**Why restrict describe blocks?**
- Just like `test()` inside `test()`, it doesn't make logical sense
- Prevents common testing mistakes
- Maintains consistent test structure

**Why restrict lifecycle hooks?**  
- **Jest compatibility**: Jest throws "Hooks cannot be defined inside tests"
- **Test isolation**: Hooks defined inside tests pollute ALL subsequent tests
- **Predictable behavior**: Hooks should set up test context, not be defined within tests

## Error Messages

**For describe blocks:**
```
describe() cannot be called inside a test(). Test structure functions must be called at the top level.
```

**For lifecycle hooks:**
```
beforeEach() cannot be called inside a test(). Lifecycle hooks must be called at the top level.
```

## Implementation Details

The solution is elegantly simple:

```zig
// Check existing test execution state in parent DescribeScope  
if (parent.current_test_id != TestRunner.Test.null_id) {
    // We're inside a test execution - block the call
}
```

This reuses Bun's existing test execution tracking without adding complexity, making it:
- **Lightweight** - just a pointer comparison
- **Reliable** - uses the same mechanism that tracks test execution  
- **Future-proof** - no global state or concurrency concerns
- **Maintainable** - minimal code footprint

🤖 Generated with [Claude Code](https://claude.ai/code)