### PR TITLE
Gate async hooks warning behind an env var

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,8 +40,8 @@
     },
   },
   "overrides": {
-    "bun-types": "workspace:packages/bun-types",
     "@types/bun": "workspace:packages/@types/bun",
+    "bun-types": "workspace:packages/bun-types",
   },
   "packages": {
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -324,7 +324,7 @@ class AsyncResource {
 function createWarning(message, isCreateHook?: boolean) {
   let warned = false;
   var wrapped = function (arg1?) {
-    if (warned) return;
+    if (warned || (!Bun.env.BUN_FEATURE_FLAG_VERBOSE_WARNINGS && (warned = true))) return;
 
     const known_supported_modules = [
       // the following do not actually need async_hooks to work properly


### PR DESCRIPTION
### What does this PR do?

The async_hooks warning is mostly just noise. There's no action you can take. And React is now using this to track the error.stack of every single promise with a no-op if it's not in use, so let's be silent about this by default instead of noisy.

### How did you verify your code works?
