### PR TITLE
Fix panic when installing global packages with --trust and existing trusted dependencies

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -401,7 +401,11 @@ pub fn edit(
         };
 
         if (options.add_trusted_dependencies) {
-            for (manager.trusted_deps_to_add_to_package_json.items, 0..) |trusted_package_name, i| {
+            // Iterate backwards to avoid index issues when removing items
+            var i: usize = manager.trusted_deps_to_add_to_package_json.items.len;
+            while (i > 0) {
+                i -= 1;
+                const trusted_package_name = manager.trusted_deps_to_add_to_package_json.items[i];
                 for (original_trusted_dependencies.items.slice()) |item| {
                     if (item.data == .e_string) {
                         if (item.data.e_string.eql(string, trusted_package_name)) {


### PR DESCRIPTION
## Summary

Fixes index out of bounds panic in `PackageJSONEditor` when removing duplicate trusted dependencies.

The issue occurred when iterating over `trusted_deps_to_add_to_package_json.items` with a `for` loop and calling `swapRemove()` during iteration. The `for` loop captures the array length at the start, but `swapRemove()` modifies the array length, causing the loop to access indices that are now out of bounds.

## Root Cause

In `PackageJSONEditor.zig:408`, the code was:

```zig
for (manager.trusted_deps_to_add_to_package_json.items, 0..) |trusted_package_name, i| {
    // ... find duplicate logic ...
    allocator.free(manager.trusted_deps_to_add_to_package_json.swapRemove(i));
}
```

When `swapRemove(i)` is called, it removes the element and decreases the array length, but the `for` loop continues with the original captured length, leading to index out of bounds.

## Solution

Changed to iterate backwards using a `while` loop:

```zig
var i: usize = manager.trusted_deps_to_add_to_package_json.items.len;
while (i > 0) {
    i -= 1;
    // ... same logic ...
    allocator.free(manager.trusted_deps_to_add_to_package_json.swapRemove(i));
}
```

Backwards iteration is safe because removing elements doesn't affect indices we haven't processed yet.

## Test Plan

Manually tested the reproduction case:
```bash
# This command previously panicked, now works
bun install -g --trust @google/gemini-cli
```

Fixes #22261

🤖 Generated with [Claude Code](https://claude.ai/code)