### PR TITLE
ai slop

### DIFF
--- a/src/bun.js/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/bun.js/bindings/node/crypto/CryptoSignJob.cpp
@@ -349,6 +349,14 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
             ERR::CRYPTO_INVALID_DIGEST(scope, globalObject, algorithmView);
             return {};
         }
+    } else {
+        // When no algorithm is specified, use a default for RSA keys
+        // Ed25519/Ed448 (one-shot variants) don't need a digest
+        if (keyObject.asymmetricKey().isRsaVariant()) {
+            // Use SHA256 as default for RSA keys when no algorithm is specified
+            // This matches Node.js behavior for crypto.verify with null algorithm
+            digest = Digest::FromName("SHA256"_s);
+        }
     }
 
     if (mode == Mode::Verify) {

--- a/test/regression/issue/11029-crypto-verify-null-algorithm.test.ts
+++ b/test/regression/issue/11029-crypto-verify-null-algorithm.test.ts
@@ -1,0 +1,135 @@
+import { test, expect } from "bun:test";
+import crypto from "crypto";
+
+// Regression test for issue #11029
+// crypto.verify() should support null/undefined algorithm parameter
+test("crypto.verify with null algorithm should work for RSA keys", () => {
+  // Generate RSA key pair
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+
+  const data = Buffer.from("test data");
+
+  // Sign with null algorithm (should use default SHA256 for RSA)
+  const signature = crypto.sign(null, data, privateKey);
+  expect(signature).toBeInstanceOf(Buffer);
+
+  // Verify with null algorithm should succeed
+  const isVerified = crypto.verify(null, data, publicKey, signature);
+  expect(isVerified).toBe(true);
+
+  // Verify with wrong data should fail
+  const wrongData = Buffer.from("wrong data");
+  const isVerifiedWrong = crypto.verify(null, wrongData, publicKey, signature);
+  expect(isVerifiedWrong).toBe(false);
+});
+
+test("crypto.verify with undefined algorithm should work for RSA keys", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+
+  const data = Buffer.from("test data");
+  const signature = crypto.sign(undefined, data, privateKey);
+
+  // Verify with undefined algorithm
+  const isVerified = crypto.verify(undefined, data, publicKey, signature);
+  expect(isVerified).toBe(true);
+});
+
+test("crypto.verify with null algorithm should work for Ed25519 keys", () => {
+  // Generate Ed25519 key pair (one-shot variant that doesn't need digest)
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519", {
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+
+  const data = Buffer.from("test data");
+
+  // Ed25519 should work with null algorithm (no digest needed)
+  const signature = crypto.sign(null, data, privateKey);
+  expect(signature).toBeInstanceOf(Buffer);
+
+  const isVerified = crypto.verify(null, data, publicKey, signature);
+  expect(isVerified).toBe(true);
+});
+
+test("crypto.verify cross-verification between null and explicit SHA256", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+
+  const data = Buffer.from("test data");
+
+  // Sign with SHA256
+  const signatureSHA256 = crypto.sign("SHA256", data, privateKey);
+
+  // Should be able to verify with null (defaults to SHA256 for RSA)
+  const isVerifiedWithNull = crypto.verify(null, data, publicKey, signatureSHA256);
+  expect(isVerifiedWithNull).toBe(true);
+
+  // Sign with null
+  const signatureNull = crypto.sign(null, data, privateKey);
+
+  // Should be able to verify with explicit SHA256
+  const isVerifiedWithSHA256 = crypto.verify("SHA256", data, publicKey, signatureNull);
+  expect(isVerifiedWithSHA256).toBe(true);
+});
+
+test("crypto.createVerify should also work with RSA keys", () => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+
+  const data = Buffer.from("test data");
+
+  // Create signature using createSign
+  const signer = crypto.createSign("SHA256");
+  signer.update(data);
+  const signature = signer.sign(privateKey);
+
+  // Verify using createVerify
+  const verifier = crypto.createVerify("SHA256");
+  verifier.update(data);
+  const isVerified = verifier.verify(publicKey, signature);
+  expect(isVerified).toBe(true);
+});

--- a/test/regression/issue/11029-crypto-verify-null-algorithm.test.ts
+++ b/test/regression/issue/11029-crypto-verify-null-algorithm.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import crypto from "crypto";
 
 // Regression test for issue #11029


### PR DESCRIPTION
## Summary
Fixes #11029 - `crypto.verify()` now correctly handles null/undefined algorithm parameter for RSA keys, matching Node.js behavior.

## Problem
When calling `crypto.verify()` with a null or undefined algorithm parameter, Bun was throwing an error:
```
error: error:06000077:public key routines:OPENSSL_internal:NO_DEFAULT_DIGEST
```

## Solution
The fix detects when no algorithm is specified and the key is an RSA variant, then uses SHA256 as the default digest algorithm. This matches the OpenSSL v3 behavior where SHA256 is the default digest for RSA keys.

For Ed25519/Ed448 keys (one-shot variants), no digest is needed and null is correctly passed through to BoringSSL.

## OpenSSL v3 Implementation Details
In OpenSSL v3 (used by Node.js), when `EVP_DigestSignInit` or `EVP_DigestVerifyInit` is called with a NULL digest for RSA keys:

1. **crypto/evp/m_sigver.c:215-220**: When digest is NULL, OpenSSL calls `evp_keymgmt_util_get_deflt_digest_name()` to get the default digest
2. **crypto/evp/keymgmt_lib.c:533-571**: This function queries the key provider for `OSSL_PKEY_PARAM_DEFAULT_DIGEST`
3. **providers/implementations/keymgmt/rsa_kmgmt.c:54**: RSA_DEFAULT_MD is defined as "SHA256"
4. **providers/implementations/keymgmt/rsa_kmgmt.c:351-355**: RSA keys return SHA256 as their default digest

BoringSSL does not have this automatic default mechanism, so this fix explicitly provides SHA256 as the default to achieve OpenSSL-compatible behavior.

## Test plan
- Added comprehensive regression test in `test/regression/issue/11029-crypto-verify-null-algorithm.test.ts`
- Tests cover:
  - RSA keys with null/undefined algorithm
  - Ed25519 keys with null algorithm  
  - Cross-verification between null and explicit SHA256
  - createVerify() compatibility
- All tests pass and behavior matches Node.js

🤖 Generated with [Claude Code](https://claude.ai/code)