### PR TITLE
chore: add @foundry-rs/forge to trusted-dependencies

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -40,6 +40,12 @@
 @ffprobe-installer/linux-ia32
 @ffprobe-installer/linux-x64
 @fingerprintjs/fingerprintjs-pro-react
+@foundry-rs/forge
+@foundry-rs/forge-darwin-arm64
+@foundry-rs/forge-darwin-amd64
+@foundry-rs/forge-linux-arm64
+@foundry-rs/forge-linux-amd64
+@foundry-rs/forge-win32-amd64
 @ghaiklor/x509
 @go-task/cli
 @injectivelabs/sdk-ts


### PR DESCRIPTION
### What does this PR do?

Adds `@foundry-rs` packages to trusted dependencies.

https://github.com/foundry-rs/foundry

### How did you verify your code works?

N/A