### PR TITLE
Refactor Buffer.concat to use spans and improve error handling

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -884,6 +884,9 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
 
     if (byteLength == 0) {
         RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
+    } else if (byteLength > MAX_ARRAY_BUFFER_SIZE) [[unlikely]] {
+        throwRangeError(lexicalGlobalObject, throwScope, makeString("JavaScriptCore typed arrays are currently limited to "_s, MAX_ARRAY_BUFFER_SIZE, " bytes. To use an array this large, use an ArrayBuffer instead. If this is causing issues for you, please file an issue in Bun's GitHub repository."_s));
+        return {};
     }
 
     JSC::JSUint8Array* outBuffer = byteLength <= availableLength
@@ -896,21 +899,17 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         allocBuffer(lexicalGlobalObject, byteLength);
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    size_t remain = byteLength;
-    auto* head = outBuffer->typedVector();
-    const int arrayLengthI = args.size();
-    for (int i = 0; i < arrayLengthI && remain > 0; i++) {
+    auto output = outBuffer->typedSpan();
+    const size_t arrayLengthI = args.size();
+    for (size_t i = 0; i < arrayLengthI && output.size() > 0; i++) {
         auto* bufferView = JSC::jsCast<JSC::JSArrayBufferView*>(args.at(i));
-        size_t length = std::min(remain, bufferView->byteLength());
+        auto source = bufferView->span();
+        size_t length = std::min(output.size(), source.size());
 
         ASSERT_WITH_MESSAGE(length > 0, "length should be greater than 0. This should be checked before appending to the MarkedArgumentBuffer.");
 
-        auto* source = bufferView->vector();
-        ASSERT(source);
-        memcpy(head, source, length);
-
-        remain -= length;
-        head += length;
+        memcpy(output.data(), source.data(), length);
+        output = output.subspan(length);
     }
 
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(outBuffer));

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -908,7 +908,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
 
         ASSERT_WITH_MESSAGE(length > 0, "length should be greater than 0. This should be checked before appending to the MarkedArgumentBuffer.");
 
-        memcpy(output.data(), source.data(), length);
+        WTF::memcpySpan(output.first(length), source.first(length));
         output = output.subspan(length);
     }
 

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -1,13 +1,52 @@
 import { expect, test } from "bun:test";
 
-test("Buffer.concat throws OutOfMemoryError", () => {
+test("Buffer.concat throws RangeError for too large buffers", () => {
   const bufferToUse = Buffer.allocUnsafe(1024 * 1024 * 64);
   const buffers = new Array(1024);
   for (let i = 0; i < buffers.length; i++) {
     buffers[i] = bufferToUse;
   }
 
-  expect(() => Buffer.concat(buffers)).toThrow(/out of memory/i);
+  expect(() => Buffer.concat(buffers)).toThrow(/JavaScriptCore typed arrays are currently limited to/);
+});
+
+test("Buffer.concat works with normal sized buffers", () => {
+  const buf1 = Buffer.from("hello");
+  const buf2 = Buffer.from(" ");
+  const buf3 = Buffer.from("world");
+  const result = Buffer.concat([buf1, buf2, buf3]);
+  expect(result.toString()).toBe("hello world");
+});
+
+test("Buffer.concat with totalLength parameter", () => {
+  const buf1 = Buffer.from("hello");
+  const buf2 = Buffer.from(" ");
+  const buf3 = Buffer.from("world");
+  
+  // Test with exact length
+  const result1 = Buffer.concat([buf1, buf2, buf3], 11);
+  expect(result1.toString()).toBe("hello world");
+  
+  // Test with larger length (should pad with zeros)
+  const result2 = Buffer.concat([buf1, buf2, buf3], 15);
+  expect(result2.length).toBe(15);
+  expect(result2.toString("utf8", 0, 11)).toBe("hello world");
+  
+  // Test with smaller length (should truncate)
+  const result3 = Buffer.concat([buf1, buf2, buf3], 5);
+  expect(result3.toString()).toBe("hello");
+});
+
+test("Buffer.concat with empty array", () => {
+  const result = Buffer.concat([]);
+  expect(result.length).toBe(0);
+});
+
+test("Buffer.concat with single buffer", () => {
+  const buf = Buffer.from("test");
+  const result = Buffer.concat([buf]);
+  expect(result.toString()).toBe("test");
+  expect(result).not.toBe(buf); // Should be a copy
 });
 
 test("Bun.concatArrayBuffers throws OutOfMemoryError", () => {

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -22,16 +22,16 @@ test("Buffer.concat with totalLength parameter", () => {
   const buf1 = Buffer.from("hello");
   const buf2 = Buffer.from(" ");
   const buf3 = Buffer.from("world");
-  
+
   // Test with exact length
   const result1 = Buffer.concat([buf1, buf2, buf3], 11);
   expect(result1.toString()).toBe("hello world");
-  
+
   // Test with larger length (should pad with zeros)
   const result2 = Buffer.concat([buf1, buf2, buf3], 15);
   expect(result2.length).toBe(15);
   expect(result2.toString("utf8", 0, 11)).toBe("hello world");
-  
+
   // Test with smaller length (should truncate)
   const result3 = Buffer.concat([buf1, buf2, buf3], 5);
   expect(result3.toString()).toBe("hello");


### PR DESCRIPTION
## Summary

This PR refactors the `Buffer.concat` implementation to use modern C++ spans for safer memory operations and adds proper error handling for oversized buffers.

## Changes

- **Use spans instead of raw pointers**: Replaced pointer arithmetic with `typedSpan()` and `span()` methods for safer memory access
- **Add MAX_ARRAY_BUFFER_SIZE check**: Added explicit check with a descriptive error message when attempting to create buffers larger than JavaScriptCore's limit (4GB)
- **Improve loop logic**: Changed loop counter from `int` to `size_t` and simplified the iteration using span sizes
- **Enhanced test coverage**: Updated tests to verify the new error message and added comprehensive test cases for various Buffer.concat scenarios

## Test Plan

All existing tests pass, plus added new tests:
- ✅ Error handling for oversized buffers
- ✅ Normal buffer concatenation
- ✅ totalLength parameter handling (exact, larger, smaller)
- ✅ Empty array handling
- ✅ Single buffer handling

```bash
./build/debug/bun-debug test test/js/node/buffer-concat.test.ts
# Result: 6 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.ai/code)