### PR TITLE
 fix(install): Respect NODE_ENV when loading .env files

### DIFF
--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -785,7 +785,7 @@ pub fn init(
     };
 
     try env.loadProcess();
-    try env.load(entries_option.entries, &[_][]u8{}, .production, false);
+    try env.loadRuntime(entries_option.entries, &[_][]u8{}, env.getSuffixFromEnv(), false);
 
     initializeStore();
     if (bun.getenvZ("XDG_CONFIG_HOME") orelse bun.getenvZ(bun.DotEnv.home_env)) |data_dir| {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1040,7 +1040,7 @@ pub const Printer = struct {
         };
 
         try env_loader.loadProcess();
-        try env_loader.load(entries_option.entries, &[_][]u8{}, .production, false);
+        try env_loader.loadRuntime(entries_option.entries, &[_][]u8{}, env_loader.getSuffixFromEnv(), false);
         var log = logger.Log.init(allocator);
         try options.load(
             allocator,

--- a/test/regression/issue/bun-install-node-env.test.ts
+++ b/test/regression/issue/bun-install-node-env.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import { tempDirWithFiles, bunExe, bunEnv } from "harness";
 import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 const testDir = tempDirWithFiles("bun-install-node-env", {
   "package.json": JSON.stringify({
@@ -10,7 +10,7 @@ const testDir = tempDirWithFiles("bun-install-node-env", {
   ".env.development": "DEVELOPMENT_VAR=false",
   ".env.production": "PRODUCTION_VAR=production_value",
   ".env.test": "TEST_VAR=test_value",
-  "bunfig.toml": "[run]\nsilent = false"
+  "bunfig.toml": "[run]\nsilent = false",
 });
 
 test("bun install respects NODE_ENV=development", async () => {
@@ -22,10 +22,7 @@ test("bun install respects NODE_ENV=development", async () => {
     stderr: "pipe",
   });
 
-  const [exitCode, output] = await Promise.all([
-    exited,
-    new Response(stderr).text(),
-  ]);
+  const [exitCode, output] = await Promise.all([exited, new Response(stderr).text()]);
 
   expect(exitCode).toBe(0);
   // Should load .env.development, not .env.production
@@ -42,10 +39,7 @@ test("bun install respects NODE_ENV=production", async () => {
     stderr: "pipe",
   });
 
-  const [exitCode, output] = await Promise.all([
-    exited,
-    new Response(stderr).text(),
-  ]);
+  const [exitCode, output] = await Promise.all([exited, new Response(stderr).text()]);
 
   expect(exitCode).toBe(0);
   // Should load .env.production
@@ -61,10 +55,7 @@ test("bun install respects NODE_ENV=test", async () => {
     stderr: "pipe",
   });
 
-  const [exitCode, output] = await Promise.all([
-    exited,
-    new Response(stderr).text(),
-  ]);
+  const [exitCode, output] = await Promise.all([exited, new Response(stderr).text()]);
 
   expect(exitCode).toBe(0);
   // Should load .env.test
@@ -80,10 +71,7 @@ test("bun install defaults to production when NODE_ENV is not set", async () => 
     stderr: "pipe",
   });
 
-  const [exitCode, output] = await Promise.all([
-    exited,
-    new Response(stderr).text(),
-  ]);
+  const [exitCode, output] = await Promise.all([exited, new Response(stderr).text()]);
 
   expect(exitCode).toBe(0);
   // Should default to .env.production
@@ -99,10 +87,7 @@ test("bun install respects BUN_ENV over NODE_ENV", async () => {
     stderr: "pipe",
   });
 
-  const [exitCode, output] = await Promise.all([
-    exited,
-    new Response(stderr).text(),
-  ]);
+  const [exitCode, output] = await Promise.all([exited, new Response(stderr).text()]);
 
   expect(exitCode).toBe(0);
   // BUN_ENV should take precedence over NODE_ENV

--- a/test/regression/issue/bun-install-node-env.test.ts
+++ b/test/regression/issue/bun-install-node-env.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test";
+import { tempDirWithFiles, bunExe, bunEnv } from "harness";
+import { spawn } from "bun";
+
+const testDir = tempDirWithFiles("bun-install-node-env", {
+  "package.json": JSON.stringify({
+    name: "test-package",
+    version: "1.0.0",
+  }),
+  ".env.development": "DEVELOPMENT_VAR=false",
+  ".env.production": "PRODUCTION_VAR=production_value",
+  ".env.test": "TEST_VAR=test_value",
+  "bunfig.toml": "[run]\nsilent = false"
+});
+
+test("bun install respects NODE_ENV=development", async () => {
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    env: { ...bunEnv, NODE_ENV: "development" },
+    cwd: testDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, output] = await Promise.all([
+    exited,
+    new Response(stderr).text(),
+  ]);
+
+  expect(exitCode).toBe(0);
+  // Should load .env.development, not .env.production
+  expect(output).toContain(".env.development");
+  expect(output).not.toContain(".env.production");
+});
+
+test("bun install respects NODE_ENV=production", async () => {
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: testDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, output] = await Promise.all([
+    exited,
+    new Response(stderr).text(),
+  ]);
+
+  expect(exitCode).toBe(0);
+  // Should load .env.production
+  expect(output).toContain(".env.production");
+});
+
+test("bun install respects NODE_ENV=test", async () => {
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    env: { ...bunEnv, NODE_ENV: "test" },
+    cwd: testDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, output] = await Promise.all([
+    exited,
+    new Response(stderr).text(),
+  ]);
+
+  expect(exitCode).toBe(0);
+  // Should load .env.test
+  expect(output).toContain(".env.test");
+});
+
+test("bun install defaults to production when NODE_ENV is not set", async () => {
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv, // NODE_ENV not set
+    cwd: testDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, output] = await Promise.all([
+    exited,
+    new Response(stderr).text(),
+  ]);
+
+  expect(exitCode).toBe(0);
+  // Should default to .env.production
+  expect(output).toContain(".env.production");
+});
+
+test("bun install respects BUN_ENV over NODE_ENV", async () => {
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    env: { ...bunEnv, NODE_ENV: "production", BUN_ENV: "development" },
+    cwd: testDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, output] = await Promise.all([
+    exited,
+    new Response(stderr).text(),
+  ]);
+
+  expect(exitCode).toBe(0);
+  // BUN_ENV should take precedence over NODE_ENV
+  expect(output).toContain(".env.development");
+  expect(output).not.toContain(".env.production");
+});


### PR DESCRIPTION
### What does this PR do?
This pull request addresses a inconsistency where `bun install` has never recognized the `NODE_ENV` environment variable. This was in contrast to other bun commands (like `bun run`, etc.), which correctly handle `NODE_ENV`.

The primary issue was that `bun install` would ignore the `NODE_ENV` setting, leading to incorrect environment configurations during the dependency installation phase, my `bunfig.toml` would load incorrect configurations for that environment, also leading to publishing issues in my end. It would default to loading variables from `.env.production` even when `NODE_ENV` was explicitly set to `development`.

This commit corrects the behavior of `bun install` to ensure it properly respects the `NODE_ENV` variable, loading the appropriate `.env` file just like other commands in the Bun toolkit. This change eliminates a key source of confusion and ensures a consistent, predictable experience across the entire CLI.

### How did you verify your code works?
   - `NODE_ENV=development bun install` now correctly loads `.env.development`.
   - `NODE_ENV=test bun install` now correctly loads `.env.test`.
   - `NODE_ENV=production bun install` continues to correctly load `.env.production`.
   - `bun install` continues to correctly load `.env.production`.
   - There's a new regression test: `test/regression/issue/bun-install-node-env.test.ts`
