### PR TITLE
Use `phys_footprint` instead of `resident_size` for process.memoryUsage.rss() on macOS

### DIFF
--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -210,7 +210,7 @@ describe.skipIf(isBroken && isIntelMacOS)("files transpiled and loaded don't lea
     expect(exitCode).toBe(0);
   }, 60000);
 
-  test.only("via require() with a lot of function calls", async () => {
+  test("via require() with a lot of function calls", async () => {
     let text = "function i() { return 1; }\n";
     for (let i = 0; i < 20000; i++) {
       text += `i();\n`;


### PR DESCRIPTION
### What does this PR do?

### How did you verify your code works?
