### PR TITLE
Update javascript-uuid.md

### DIFF
--- a/docs/guides/util/javascript-uuid.md
+++ b/docs/guides/util/javascript-uuid.md
@@ -6,7 +6,7 @@ Use `crypto.randomUUID()` to generate a UUID v4. This API works in Bun, Node.js,
 
 ```ts
 crypto.randomUUID();
-// => "123e4567-e89b-12d3-a456-426614174000"
+// => "123e4567-e89b-42d3-a456-426614174000"
 ```
 
 ---


### PR DESCRIPTION
based on UUID version 4 regex:
^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
crypto.randomUUID function's output at third slot must always start with digit 4 

### What does this PR do?
fixes a sample output of code in markdown file where new output is compatible with UUID version 4

### How did you verify your code works?
calling crypto.randomUUID a bunch of times and comparing changes.