### PR TITLE
Fix coverage accuracy for single-byte basic blocks

### DIFF
--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -457,7 +457,7 @@ pub const ByteRangeMapping = struct {
 
                 const has_executed = block.hasExecuted or block.executionCount > 0;
 
-                for (min..max) |byte_offset| {
+                for (min..(max + 1)) |byte_offset| {
                     const new_line_index = LineOffsetTable.findIndex(line_starts, .{ .start = @intCast(byte_offset) }) orelse continue;
                     const line_start_byte_offset = line_starts[new_line_index];
                     if (line_start_byte_offset >= byte_offset) {
@@ -494,7 +494,7 @@ pub const ByteRangeMapping = struct {
                 var min_line: u32 = std.math.maxInt(u32);
                 var max_line: u32 = 0;
 
-                for (min..max) |byte_offset| {
+                for (min..(max + 1)) |byte_offset| {
                     const new_line_index = LineOffsetTable.findIndex(line_starts, .{ .start = @intCast(byte_offset) }) orelse continue;
                     const line_start_byte_offset = line_starts[new_line_index];
                     if (line_start_byte_offset >= byte_offset) {
@@ -546,7 +546,7 @@ pub const ByteRangeMapping = struct {
                 var max_line: u32 = 0;
                 const has_executed = block.hasExecuted or block.executionCount > 0;
 
-                for (min..max) |byte_offset| {
+                for (min..(max + 1)) |byte_offset| {
                     const new_line_index = LineOffsetTable.findIndex(line_starts, .{ .start = @intCast(byte_offset) }) orelse continue;
                     const line_start_byte_offset = line_starts[new_line_index];
                     if (line_start_byte_offset >= byte_offset) {
@@ -589,7 +589,7 @@ pub const ByteRangeMapping = struct {
                 var min_line: u32 = std.math.maxInt(u32);
                 var max_line: u32 = 0;
 
-                for (min..max) |byte_offset| {
+                for (min..(max + 1)) |byte_offset| {
                     const new_line_index = LineOffsetTable.findIndex(line_starts, .{ .start = @intCast(byte_offset) }) orelse continue;
                     const line_start_byte_offset = line_starts[new_line_index];
                     if (line_start_byte_offset >= byte_offset) {


### PR DESCRIPTION
### What does this PR do?

Bun's code coverage was incorrectly skipping single-byte basic blocks reported by JSC's control flow profiler. JSC reports basic block ranges as inclusive (e.g., `[69-70]`), but Bun was processing them using Zig's exclusive range operator (`69..70`). When a basic block had the same start and end byte offset, the exclusive range would process zero iterations, causing those blocks to be completely ignored during coverage calculation. This led to false positive coverage reports, particularly for switch statement case branches and try-catch error handling paths that compile to minimal bytecode.

This PR fixes the issue by changing `for (min..max)` to `for (min..(max + 1))` in four locations within `src/sourcemap/CodeCoverage.zig` to properly handle JSC's inclusive ranges. The fix ensures that single-byte ranges like `[69-70]` now correctly process both byte 69 and byte 70.

### How did you verify your code works?

Added regression tests that verify specific line numbers are correctly marked as uncovered.

