### PR TITLE
Add --stream flag for workspace script execution

### DIFF
--- a/docs/cli/filter.md
+++ b/docs/cli/filter.md
@@ -71,6 +71,33 @@ bun --filter '*' dev
 Both commands will be run in parallel, and you will see a nice terminal UI showing their respective outputs:
 ![Terminal Output](https://github.com/oven-sh/bun/assets/48869301/2a103e42-9921-4c33-948f-a1ad6e6bac71)
 
+### Output options
+
+By default, when running scripts with `--filter` in a terminal, Bun displays a formatted UI that elides long output to keep the display manageable. You can control this behavior with these flags:
+
+#### `--elide-lines <number>`
+
+Controls how many lines of output are shown for each package (default: 10). Set to 0 to show all output:
+
+```bash
+# Show only 5 lines of output per package
+bun --filter '*' --elide-lines 5 test
+
+# Show all output (no eliding)
+bun --filter '*' --elide-lines 0 test
+```
+
+#### `--stream`
+
+Stream logs immediately without buffering or eliding. This is useful when you want to see real-time output from all packages, similar to pnpm's `--stream` flag:
+
+```bash
+# Stream all output immediately
+bun --filter '*' --stream dev
+```
+
+Note: `--stream` and `--elide-lines` cannot be used together. When `--stream` is enabled, output is written directly to stdout without package name prefixes or formatting.
+
 ### Running scripts in workspaces
 
 Filters respect your [workspace configuration](https://bun.com/docs/install/workspaces): If you have a `package.json` file that specifies which packages are part of the workspace,

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -165,6 +165,7 @@ bun run --filter 'ba*' <script>
 will execute `<script>` in both `bar` and `baz`, but not in `foo`.
 
 When using `--filter`, you can control the output display with:
+
 - `--elide-lines <number>`: Limit the number of output lines shown per package (default: 10, use 0 for no limit)
 - `--stream`: Stream output immediately without buffering or formatting (similar to pnpm's `--stream`)
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -164,6 +164,10 @@ bun run --filter 'ba*' <script>
 
 will execute `<script>` in both `bar` and `baz`, but not in `foo`.
 
+When using `--filter`, you can control the output display with:
+- `--elide-lines <number>`: Limit the number of output lines shown per package (default: 10, use 0 for no limit)
+- `--stream`: Stream output immediately without buffering or formatting (similar to pnpm's `--stream`)
+
 Find more details in the docs page for [filter](https://bun.com/docs/cli/filter#running-scripts-with-filter).
 
 ## `bun run -` to pipe code from stdin

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -419,6 +419,7 @@ pub const Command = struct {
             env_behavior: api.DotEnvBehavior = .disable,
             env_prefix: []const u8 = "",
             elide_lines: ?usize = null,
+            stream_logs: bool = false,
             // Compile options
             compile: bool = false,
             compile_target: Cli.CompileTarget = .{},

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -401,7 +401,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 };
             }
         }
-        
+
         ctx.bundler_options.stream_logs = args.flag("--stream");
     }
 
@@ -1144,7 +1144,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 };
             }
         }
-        
+
         ctx.bundler_options.stream_logs = args.flag("--stream");
 
         if (opts.define) |define| {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -123,6 +123,7 @@ pub const auto_only_params = [_]ParamType{
     // clap.parseParam("--all") catch unreachable,
     clap.parseParam("--silent                          Don't print the script command") catch unreachable,
     clap.parseParam("--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines.") catch unreachable,
+    clap.parseParam("--stream                          Stream logs immediately without buffering or eliding. Similar to pnpm's --stream flag") catch unreachable,
     clap.parseParam("-v, --version                     Print version and exit") catch unreachable,
     clap.parseParam("--revision                        Print version with revision and exit") catch unreachable,
 } ++ auto_or_run_params;
@@ -131,6 +132,7 @@ pub const auto_params = auto_only_params ++ runtime_params_ ++ transpiler_params
 pub const run_only_params = [_]ParamType{
     clap.parseParam("--silent                          Don't print the script command") catch unreachable,
     clap.parseParam("--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines.") catch unreachable,
+    clap.parseParam("--stream                          Stream logs immediately without buffering or eliding. Similar to pnpm's --stream flag") catch unreachable,
 } ++ auto_or_run_params;
 pub const run_params = run_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -399,6 +401,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 };
             }
         }
+        
+        ctx.bundler_options.stream_logs = args.flag("--stream");
     }
 
     if (cmd == .TestCommand) {
@@ -1140,6 +1144,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 };
             }
         }
+        
+        ctx.bundler_options.stream_logs = args.flag("--stream");
 
         if (opts.define) |define| {
             if (define.keys.len > 0)

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -560,12 +560,12 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
         Output.prettyErrorln("<r><red>error<r>: --stream and --elide-lines cannot be used together", .{});
         Global.exit(1);
     }
-    
+
     // When --stream is set, disable pretty output
     if (state.stream_logs) {
         state.pretty_output = false;
     }
-    
+
     // Check if elide-lines is used in a non-terminal environment
     if (ctx.bundler_options.elide_lines != null and !state.pretty_output) {
         Output.prettyErrorln("<r><red>error<r>: --elide-lines is only supported in terminal environments", .{});

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -543,11 +543,11 @@ describe("bun", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      
+
       const td = new TextDecoder();
       const reader = proc.stdout.getReader();
       let output = "";
-      
+
       // Prove we get a chunk before the process exits (streaming)
       let firstChunk: Uint8Array | null = null;
       const first = await Promise.race([
@@ -563,16 +563,16 @@ describe("bun", () => {
         })(),
       ]);
       expect(first).toBe("chunk");
-      
+
       // Drain remaining output
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
         output += td.decode(value);
       }
-      
+
       const exitCode = await proc.exited;
-      
+
       // In stream mode, output should not have package name prefixes
       expect(output).toMatch(/pkg1-line1/);
       expect(output).toMatch(/pkg1-line2/);


### PR DESCRIPTION
## Summary

This PR implements a `--stream` flag for `bun run` that provides immediate, unbuffered output when running scripts across workspace packages, similar to pnpm's `--stream` flag.

## Problem

Users have reported difficulty with the current log display in workspaces:
- Logs are buffered and elided by default (limited to 10 lines)
- Real-time output is not available without workarounds
- This makes it hard to monitor long-running processes or debug timing issues

## Solution

Added a `--stream` flag that:
- Streams output immediately without buffering
- Bypasses the eliding UI completely
- Writes directly to stdout for real-time visibility
- Works with both `bun run --filter` and `bun --filter` (auto command)

## Changes

- **CLI**: Added `--stream` flag to run and auto command parameters
- **Runtime**: Modified `filter_run.zig` to handle streaming output mode
- **Validation**: Added check to prevent conflicting use of `--stream` and `--elide-lines`
- **Tests**: Added comprehensive test coverage for all streaming scenarios
- **Docs**: Updated filter.md and run.md with the new flag documentation

## Usage

```bash
# Stream output from all workspace packages
bun run --filter "*" --stream dev

# Works with specific package patterns
bun run --filter "pkg-*" --stream test

# Also works with auto command
bun --filter "*" --stream run build
```

## Test Coverage

Added tests for:
- Basic streaming functionality
- Conflict with `--elide-lines` flag
- Dependency ordering preservation
- Pre/post script lifecycle
- Error handling
- Auto command compatibility

All tests pass successfully.

## Documentation

Updated both `docs/cli/filter.md` and `docs/cli/run.md` to document:
- The new `--stream` flag and its purpose
- Usage examples
- Comparison to pnpm's similar feature
- Incompatibility with `--elide-lines`

This addresses user feedback about needing better real-time log visibility in workspace environments.

🤖 Generated with [Claude Code](https://claude.ai/code)