### PR TITLE
fix(buffer): use correct constructor for `buffer.isAscii`

### DIFF
--- a/src/bun.js/modules/NodeBufferModule.h
+++ b/src/bun.js/modules/NodeBufferModule.h
@@ -210,7 +210,7 @@ DEFINE_NATIVE_MODULE(NodeBuffer)
 
     put(JSC::Identifier::fromString(vm, "resolveObjectURL"_s), resolveObjectURL);
 
-    put(JSC::Identifier::fromString(vm, "isAscii"_s), JSC::JSFunction::create(vm, globalObject, 1, "isAscii"_s, jsBufferConstructorFunction_isAscii, ImplementationVisibility::Public, NoIntrinsic, jsBufferConstructorFunction_isUtf8));
+    put(JSC::Identifier::fromString(vm, "isAscii"_s), JSC::JSFunction::create(vm, globalObject, 1, "isAscii"_s, jsBufferConstructorFunction_isAscii, ImplementationVisibility::Public, NoIntrinsic, jsBufferConstructorFunction_isAscii));
 
     put(JSC::Identifier::fromString(vm, "isUtf8"_s), JSC::JSFunction::create(vm, globalObject, 1, "isUtf8"_s, jsBufferConstructorFunction_isUtf8, ImplementationVisibility::Public, NoIntrinsic, jsBufferConstructorFunction_isUtf8));
 }

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -193,6 +193,7 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(isAscii(new Buffer(""))).toBeTrue();
         expect(isAscii(new Buffer([32, 32, 128]))).toBeFalse();
         expect(isAscii(new Buffer("What did the 🦊 say?"))).toBeFalse();
+        expect(new isAscii(new Buffer("What did the 🦊 say?"))).toBeFalse();
         expect(isAscii(new Buffer("").buffer)).toBeTrue();
         expect(isAscii(new Buffer([32, 32, 128]).buffer)).toBeFalse();
       });


### PR DESCRIPTION
### What does this PR do?
The constructor was using `isUtf8` instead of `isAscii`.

Instead of this change maybe we should remove the constructors for `isAscii` and `isUtf8`. It looks like we do this for most native functions, but would be more breaking than correcting the current bug.
### How did you verify your code works?
Added a test