### PR TITLE
Fix: Socket.write() fails with Uint8Array

### DIFF
--- a/src/js/internal/streams/legacy.ts
+++ b/src/js/internal/streams/legacy.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 const EE = require("node:events");
+const { isArrayBufferView, isUint8Array } = require("node:util/types");
 
 const ReflectOwnKeys = Reflect.ownKeys;
 const ArrayIsArray = Array.isArray;
@@ -112,6 +113,13 @@ function prependListener(emitter, event, fn) {
   else if (ArrayIsArray(emitter._events[event])) emitter._events[event].unshift(fn);
   else emitter._events[event] = [fn, emitter._events[event]];
 }
+
+// Add helper methods to Stream
+Stream._isArrayBufferView = isArrayBufferView;
+Stream._isUint8Array = isUint8Array;
+Stream._uint8ArrayToBuffer = function _uint8ArrayToBuffer(chunk) {
+  return new $Buffer(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+};
 
 export default { Stream, prependListener } as unknown as {
   Stream: typeof import("node:stream").Stream;

--- a/test/js/bun/stream/direct-readable-stream.test.tsx
+++ b/test/js/bun/stream/direct-readable-stream.test.tsx
@@ -93,8 +93,7 @@ const fixtures = [
     "<span>Hello World!</span>😋L😋l😋L😋",
     <>
       <span>Hello World!</span>
-      😋L😋l😋L😋
-{" "}
+      😋L😋l😋L😋{" "}
     </>,
   ],
 ] as const;

--- a/test/js/bun/stream/direct-readable-stream.test.tsx
+++ b/test/js/bun/stream/direct-readable-stream.test.tsx
@@ -94,6 +94,7 @@ const fixtures = [
     <>
       <span>Hello World!</span>
       😋L😋l😋L😋
+{" "}
     </>,
   ],
 ] as const;

--- a/test/js/bun/stream/direct-readable-stream.test.tsx
+++ b/test/js/bun/stream/direct-readable-stream.test.tsx
@@ -93,7 +93,7 @@ const fixtures = [
     "<span>Hello World!</span>😋L😋l😋L😋",
     <>
       <span>Hello World!</span>
-      😋L😋l😋L😋{" "}
+      😋L😋l😋L😋
     </>,
   ],
 ] as const;

--- a/test/regression/issue/22481.test.ts
+++ b/test/regression/issue/22481.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test";
+import { createConnection, createServer } from "node:net";
+
+test("client socket can write Uint8Array (issue #22481)", async () => {
+  const server = createServer(socket => {
+    socket.on("data", data => {
+      // Echo back what we received
+      socket.write(data);
+      socket.end();
+    });
+  });
+
+  await new Promise<void>(resolve => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const port = (server.address() as any).port;
+
+  const testData = "Hello from Uint8Array!";
+  const u8 = new Uint8Array(testData.split("").map(x => x.charCodeAt(0)));
+
+  // Test with Uint8Array
+  {
+    const received = await new Promise<string>((resolve, reject) => {
+      const client = createConnection(port, "127.0.0.1", () => {
+        // Write Uint8Array directly
+        client.write(u8, err => {
+          if (err) reject(err);
+        });
+      });
+
+      let data = "";
+      client.on("data", chunk => {
+        data += chunk.toString();
+      });
+
+      client.on("end", () => {
+        resolve(data);
+      });
+
+      client.on("error", reject);
+    });
+
+    expect(received).toBe(testData);
+  }
+
+  // Test with Buffer.from(Uint8Array) for comparison
+  {
+    const received = await new Promise<string>((resolve, reject) => {
+      const client = createConnection(port, "127.0.0.1", () => {
+        // Write Buffer created from Uint8Array
+        client.write(Buffer.from(u8), err => {
+          if (err) reject(err);
+        });
+      });
+
+      let data = "";
+      client.on("data", chunk => {
+        data += chunk.toString();
+      });
+
+      client.on("end", () => {
+        resolve(data);
+      });
+
+      client.on("error", reject);
+    });
+
+    expect(received).toBe(testData);
+  }
+
+  // Test with other TypedArrays (Float32Array view)
+  {
+    const float32 = new Float32Array([1.5, 2.5]);
+    const u8view = new Uint8Array(float32.buffer);
+
+    const received = await new Promise<Buffer>((resolve, reject) => {
+      const client = createConnection(port, "127.0.0.1", () => {
+        client.write(u8view, err => {
+          if (err) reject(err);
+        });
+      });
+
+      const chunks: Buffer[] = [];
+      client.on("data", chunk => {
+        chunks.push(chunk);
+      });
+
+      client.on("end", () => {
+        resolve(Buffer.concat(chunks));
+      });
+
+      client.on("error", reject);
+    });
+
+    // Check that we received the same bytes back
+    expect(received).toEqual(Buffer.from(u8view));
+  }
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- Fixes #22481 where `Socket.write()` was throwing "Stream._isArrayBufferView is not a function" when passed a Uint8Array
- The helper methods were being added to the wrong Stream export
- Now adds them directly to the Stream constructor in `internal/streams/legacy.ts` where they're actually used

## Test plan
- Added regression test in `test/regression/issue/22481.test.ts`
- Test verifies that sockets can write Uint8Array, Buffer, and other TypedArray views
- All tests pass with the fix

🤖 Generated with [Claude Code](https://claude.ai/code)