### PR TITLE
Fix tsconfig resolution in Bun.build

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1808,6 +1808,10 @@ pub const BundleV2 = struct {
                         config.dir.sliceWithSentinel()
                     else
                         null,
+                    .tsconfig_override = if (config.tsconfig_override.list.items.len > 0)
+                        config.tsconfig_override.slice()
+                    else
+                        null,
                     .inject = &.{},
                     .external = config.external.keys(),
                     .main_fields = &.{},

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -4171,7 +4171,7 @@ pub const Resolver = struct {
                         }
                     }
                 }
-            } else if (parent == null) {
+            } else {
                 tsconfig_path = r.opts.tsconfig_override.?;
             }
 

--- a/test/bundler/bundler_tsconfig.test.ts
+++ b/test/bundler/bundler_tsconfig.test.ts
@@ -1,0 +1,84 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  itBundled("tsconfig/TsconfigParameterWithBaseUrl", {
+    files: {
+      "/src/entry.ts": /* ts */ `
+        import helper from "utils/helper";
+        helper();
+      `,
+      "/src/utils/helper.ts": /* ts */ `
+        export default function helper() {
+          console.log("helper called");
+        }
+      `,
+      "/tsconfig.custom.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: "./src",
+        },
+      }),
+    },
+    tsconfig: "/tsconfig.custom.json",
+    run: {
+      stdout: "helper called",
+    },
+  });
+
+  itBundled("tsconfig/TsconfigParameterOverridesDefault", {
+    files: {
+      "/src/entry.ts": /* ts */ `
+        import helper from "lib/helper";
+        helper();
+      `,
+      "/src/lib/helper.ts": /* ts */ `
+        export default function helper() {
+          console.log("custom tsconfig used");
+        }
+      `,
+      "/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: "./wrong",
+        },
+      }),
+      "/tsconfig.custom.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: "./src",
+        },
+      }),
+    },
+    tsconfig: "/tsconfig.custom.json",
+    run: {
+      stdout: "custom tsconfig used",
+    },
+  });
+
+  itBundled("tsconfig/TsconfigParameterWithExtends", {
+    files: {
+      "/src/entry.ts": /* ts */ `
+        import helper from "utils/helper";
+        helper();
+      `,
+      "/src/utils/helper.ts": /* ts */ `
+        export default function helper() {
+          console.log("extends works");
+        }
+      `,
+      "/tsconfig.base.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: "./src",
+        },
+      }),
+      "/tsconfig.custom.json": JSON.stringify({
+        extends: "./tsconfig.base.json",
+        compilerOptions: {
+          strict: true,
+        },
+      }),
+    },
+    tsconfig: "/tsconfig.custom.json",
+    run: {
+      stdout: "extends works",
+    },
+  });
+});

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -213,6 +213,7 @@ export interface BundlerTestInput {
   unsupportedJSFeatures?: string[];
   /** if set to true or false, create or edit tsconfig.json to set compilerOptions.useDefineForClassFields */
   useDefineForClassFields?: boolean;
+  tsconfig?: string;
   sourceMap?: "inline" | "external" | "linked" | "none" | "linked";
   plugins?: BunPlugin[] | ((builder: PluginBuilder) => void | Promise<void>);
   install?: string[];
@@ -1064,6 +1065,7 @@ function expectBundled(
           splitting,
           target,
           bytecode,
+          tsconfig: opts.tsconfig ? path.join(root, opts.tsconfig) : undefined,
           publicPath,
           emitDCEAnnotations,
           ignoreDCEAnnotations,


### PR DESCRIPTION
### What does this PR do?

I encountered an issue where `Bun.build` did not respect the `tsconfig` parameter, even though `bun build --tsconfig-override=…` worked correctly. This PR fixes `tsconfig` resolution for `Bun.build` and makes it fail when the specified `tsconfig` file does not exist, matching the CLI behavior.

I believe I identified two issues with `tsconfig` resolution:

1. The `tsconfig_override` parameter was not set in `bundle_v2.zig`.
2. `resolver.zig` loaded the override only when parent == null (top-level dir). In a warm VM, parent DirInfo is often cached, so that condition didn’t fire and the override was silently ignored. I changed the resolver to load the `tsconfig` override unconditionally.

### How did you verify your code works?

This PR adds `bundler_tsconfig.test.ts` and and new tests in `bun-build-api.test.ts`. These test verify that bun’s build command functions as expected when run with a `tsconfig` override. I further verified that these tests correctly fail when run against the `main` branch of bun.