### PR TITLE
fix: explicitly set main fields for bundler

### DIFF
--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -808,6 +808,7 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
       "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
     },
+    mainFields: ["module", "main"],
     run: {
       stdout: "main main",
     },
@@ -832,6 +833,7 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
       "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
     },
+    mainFields: ["module", "main"],
     run: {
       stdout: "main\nmain",
     },
@@ -880,6 +882,7 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/demo-pkg/index.js": `module.exports = 'index'`,
       "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
     },
+    mainFields: ["module", "main"],
     run: {
       stdout: "index\nindex",
     },


### PR DESCRIPTION
### What does this PR do?

Related to #3056

I know this issue has been assigned to @dylan-conway a while ago, and there is no much update since. Thus, I believe this is a low-priority nice-to-have fix, and might try to a bold attempt to try fixing it.

### How did you verify your code works?

Before the change, running this test file ended up with failure on `DualPackageHazardImportAndRequireSameFile`
```.ts
runtime failed file: /tmp/bun-build-tests/bun-3dgqck/packagejson/DualPackageHazardImportAndRequireSameFile/out.js
stdout output:
module main
---
expected stdout:
main main
---
1655 |               console.log(`---`);
1656 |               console.log(`expected ${name}:`);
1657 |               console.log(expected);
1658 |               console.log(`---`);
1659 |             }
1660 |             expect(result).toBe(expected);
                                  ^
error: expect(received).toBe(expected)

Expected: "main main"
Received: "module main"

      at <anonymous> (/home/linux/Work/self/bun/test/bundler/expectBundled.ts:1660:28)
      at <anonymous> (/home/linux/Work/self/bun/test/bundler/expectBundled.ts:576:11)
✗ bundler > packagejson/DualPackageHazardImportAndRequireSameFile [23.00ms]
```

Where the out.js content is following:
```.js
var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);

// Users/user/project/node_modules/demo-pkg/main.js
var require_main = __commonJS((exports, module) => {
  module.exports = "main";
});

// Users/user/project/node_modules/demo-pkg/module.js
var module_default = "module";

// Users/user/project/src/entry.js
console.log(module_default, require_main());
```

After explicitly setting up `mainFields`, the above testcase passed.