### PR TITLE
feat: support overriding Host, Sec-WebSocket-Key, and Sec-WebSocket-Protocol headers in WebSocket client

### DIFF
--- a/test/js/web/websocket/websocket-custom-headers.test.ts
+++ b/test/js/web/websocket/websocket-custom-headers.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, nodeExe } from "harness";
 import * as path from "node:path";
 
@@ -51,15 +51,15 @@ describe("WebSocket custom headers", () => {
   it("should send custom Host header", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     const ws = new WebSocket(url.href, {
       headers: {
         "Host": "custom-host.example.com:8080",
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -69,25 +69,25 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     expect(headers.host).toBe("custom-host.example.com:8080");
     ws.close();
   });
-  
+
   it("should reject invalid Sec-WebSocket-Key and generate a valid one", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     // Invalid keys that should be rejected
     const invalidKeys = [
-      "not-base64!@#",  // Invalid base64
-      "dG9vc2hvcnQ=",   // Valid base64 but decodes to 8 bytes, not 16
+      "not-base64!@#", // Invalid base64
+      "dG9vc2hvcnQ=", // Valid base64 but decodes to 8 bytes, not 16
       btoa("toolongkeytoolongkey"), // Valid base64 but decodes to >16 bytes
     ];
-    
+
     for (const invalidKey of invalidKeys) {
       const ws = new WebSocket(url.href, {
         headers: {
@@ -95,9 +95,9 @@ describe("WebSocket custom headers", () => {
         },
       });
       clients.push(ws);
-      
+
       const headerPromise = new Promise<any>((res, rej) => {
-        ws.onmessage = (event) => {
+        ws.onmessage = event => {
           try {
             const data = JSON.parse(event.data);
             if (data.type === "headers") {
@@ -109,7 +109,7 @@ describe("WebSocket custom headers", () => {
         };
         ws.onerror = rej;
       });
-      
+
       const headers = await headerPromise;
       // Should have generated a new valid key instead of using the invalid one
       expect(headers["sec-websocket-key"]).not.toBe(invalidKey);
@@ -119,24 +119,24 @@ describe("WebSocket custom headers", () => {
       ws.close();
     }
   });
-  
+
   it("should send custom Sec-WebSocket-Key header", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     // Generate a valid base64-encoded 16-byte key
     const keyBytes = new Uint8Array(16);
     crypto.getRandomValues(keyBytes);
     const customKey = btoa(String.fromCharCode(...keyBytes));
-    
+
     const ws = new WebSocket(url.href, {
       headers: {
         "Sec-WebSocket-Key": customKey,
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -146,26 +146,26 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     expect(headers["sec-websocket-key"]).toBe(customKey);
     ws.close();
   });
-  
+
   it("should send custom Sec-WebSocket-Protocol header", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     const ws = new WebSocket(url.href, {
       headers: {
         "Sec-WebSocket-Protocol": "custom-protocol, another-protocol",
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -175,18 +175,18 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     expect(headers["sec-websocket-protocol"]).toBe("custom-protocol, another-protocol");
     ws.close();
   });
-  
+
   it("should override protocol header when both protocols array and header are provided", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     const ws = new WebSocket(url.href, {
       protocols: ["proto1", "proto2"],
       headers: {
@@ -194,8 +194,8 @@ describe("WebSocket custom headers", () => {
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -205,23 +205,23 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     // The custom header should override the protocols array
     expect(headers["sec-websocket-protocol"]).toBe("custom-protocol");
     ws.close();
   });
-  
+
   it("should send multiple custom headers", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     const keyBytes = new Uint8Array(16);
     crypto.getRandomValues(keyBytes);
     const customKey = btoa(String.fromCharCode(...keyBytes));
-    
+
     const ws = new WebSocket(url.href, {
       headers: {
         "Host": "multi-header.example.com",
@@ -231,8 +231,8 @@ describe("WebSocket custom headers", () => {
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -242,9 +242,9 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     expect(headers.host).toBe("multi-header.example.com");
     expect(headers["sec-websocket-key"]).toBe(customKey);
@@ -252,11 +252,11 @@ describe("WebSocket custom headers", () => {
     expect(headers["x-custom-header"]).toBe("custom-value");
     ws.close();
   });
-  
+
   it("should reject CRLF injection in header values", async () => {
     const url = await createHeaderEchoServer();
-    
-    // Test with CRLF injection attempt - this should be rejected  
+
+    // Test with CRLF injection attempt - this should be rejected
     expect(() => {
       new WebSocket(url.href, {
         headers: {
@@ -265,11 +265,11 @@ describe("WebSocket custom headers", () => {
       });
     }).toThrow("Header 'X-Test-Header' has invalid value");
   });
-  
+
   it("should allow headers with special but valid characters", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     // These should be allowed according to HTTP spec
     const ws = new WebSocket(url.href, {
       headers: {
@@ -277,8 +277,8 @@ describe("WebSocket custom headers", () => {
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -288,18 +288,18 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     expect(headers["x-special-chars"]).toContain("value with spaces");
     ws.close();
   });
-  
+
   it("should handle empty header values correctly", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     const ws = new WebSocket(url.href, {
       headers: {
         "X-Empty-Header": "",
@@ -307,8 +307,8 @@ describe("WebSocket custom headers", () => {
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -318,11 +318,11 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
-    
+
     // Check X-Empty-Header: should either be filtered out or have empty value
     if ("x-empty-header" in headers) {
       expect(headers["x-empty-header"]).toBe("");
@@ -330,7 +330,7 @@ describe("WebSocket custom headers", () => {
       // Header was filtered out, which is also acceptable
       expect(headers["x-empty-header"]).toBeUndefined();
     }
-    
+
     // Check X-Whitespace-Header: should either be filtered out, trimmed to empty, or have the exact whitespace
     if ("x-whitespace-header" in headers) {
       // Whitespace might be preserved or trimmed - both are acceptable
@@ -339,25 +339,25 @@ describe("WebSocket custom headers", () => {
       // Header was filtered out, which is also acceptable
       expect(headers["x-whitespace-header"]).toBeUndefined();
     }
-    
+
     ws.close();
   });
-  
+
   it("should not override system headers like Connection or Upgrade", async () => {
     const url = await createHeaderEchoServer();
     const { promise, resolve, reject } = Promise.withResolvers<any>();
-    
+
     const ws = new WebSocket(url.href, {
       headers: {
-        "Connection": "close",  // Should be ignored
-        "Upgrade": "http/2.0",   // Should be ignored
-        "Sec-WebSocket-Version": "8",  // Should be ignored
+        "Connection": "close", // Should be ignored
+        "Upgrade": "http/2.0", // Should be ignored
+        "Sec-WebSocket-Version": "8", // Should be ignored
         "X-Custom": "allowed",
       },
     });
     clients.push(ws);
-    
-    ws.onmessage = (event) => {
+
+    ws.onmessage = event => {
       try {
         const data = JSON.parse(event.data);
         if (data.type === "headers") {
@@ -367,9 +367,9 @@ describe("WebSocket custom headers", () => {
         reject(e);
       }
     };
-    
+
     ws.onerror = reject;
-    
+
     const headers = await promise;
     // These should remain as WebSocket requires
     expect(headers.connection.toLowerCase()).toContain("upgrade");

--- a/test/js/web/websocket/websocket-custom-headers.test.ts
+++ b/test/js/web/websocket/websocket-custom-headers.test.ts
@@ -1,0 +1,322 @@
+import type { Subprocess } from "bun";
+import { spawn } from "bun";
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { bunEnv, bunExe, nodeExe } from "harness";
+import * as path from "node:path";
+
+let servers: Subprocess[] = [];
+let clients: WebSocket[] = [];
+
+function cleanUp() {
+  for (const client of clients) {
+    client.terminate?.();
+  }
+  for (const server of servers) {
+    server.kill();
+  }
+  clients = [];
+  servers = [];
+}
+
+beforeEach(cleanUp);
+afterEach(cleanUp);
+
+async function createHeaderEchoServer(): Promise<URL> {
+  const pathname = path.join(import.meta.dir, "./websocket-server-echo-headers-simple.mjs");
+  const { promise, resolve, reject } = Promise.withResolvers<URL>();
+  const server = spawn({
+    cmd: [nodeExe() ?? bunExe(), pathname],
+    cwd: import.meta.dir,
+    env: bunEnv,
+    stdout: "inherit",
+    stderr: "inherit",
+    serialization: "json",
+    ipc(message) {
+      const url = message?.href;
+      if (url) {
+        try {
+          resolve(new URL(url));
+        } catch (error) {
+          reject(error);
+        }
+      }
+    },
+  });
+
+  servers.push(server);
+  return await promise;
+}
+
+describe("WebSocket custom headers", () => {
+  it("should send custom Host header", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "Host": "custom-host.example.com:8080",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    expect(headers.host).toBe("custom-host.example.com:8080");
+    ws.close();
+  });
+  
+  it("should send custom Sec-WebSocket-Key header", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    // Generate a valid base64-encoded 16-byte key
+    const keyBytes = new Uint8Array(16);
+    crypto.getRandomValues(keyBytes);
+    const customKey = btoa(String.fromCharCode(...keyBytes));
+    
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "Sec-WebSocket-Key": customKey,
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    expect(headers["sec-websocket-key"]).toBe(customKey);
+    ws.close();
+  });
+  
+  it("should send custom Sec-WebSocket-Protocol header", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "Sec-WebSocket-Protocol": "custom-protocol, another-protocol",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    expect(headers["sec-websocket-protocol"]).toBe("custom-protocol, another-protocol");
+    ws.close();
+  });
+  
+  it("should override protocol header when both protocols array and header are provided", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    const ws = new WebSocket(url.href, {
+      protocols: ["proto1", "proto2"],
+      headers: {
+        "Sec-WebSocket-Protocol": "custom-protocol",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    // The custom header should override the protocols array
+    expect(headers["sec-websocket-protocol"]).toBe("custom-protocol");
+    ws.close();
+  });
+  
+  it("should send multiple custom headers", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    const keyBytes = new Uint8Array(16);
+    crypto.getRandomValues(keyBytes);
+    const customKey = btoa(String.fromCharCode(...keyBytes));
+    
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "Host": "multi-header.example.com",
+        "Sec-WebSocket-Key": customKey,
+        "Sec-WebSocket-Protocol": "multi-proto",
+        "X-Custom-Header": "custom-value",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    expect(headers.host).toBe("multi-header.example.com");
+    expect(headers["sec-websocket-key"]).toBe(customKey);
+    expect(headers["sec-websocket-protocol"]).toBe("multi-proto");
+    expect(headers["x-custom-header"]).toBe("custom-value");
+    ws.close();
+  });
+  
+  it("should reject CRLF injection in header values", async () => {
+    const url = await createHeaderEchoServer();
+    
+    // Test with CRLF injection attempt - this should be rejected  
+    expect(() => {
+      new WebSocket(url.href, {
+        headers: {
+          "X-Test-Header": "value\r\nInjected-Header: bad",
+        },
+      });
+    }).toThrow("Header 'X-Test-Header' has invalid value");
+  });
+  
+  it("should allow headers with special but valid characters", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    // These should be allowed according to HTTP spec
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "X-Special-Chars": "value with spaces and !@#$%^&*()_+-=[]{}|;:',.<>?/`~",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    expect(headers["x-special-chars"]).toContain("value with spaces");
+    ws.close();
+  });
+  
+  it("should handle empty header values correctly", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "X-Empty-Header": "",
+        "X-Whitespace-Header": "  ",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    // Empty headers should either be filtered out or passed through
+    // The validation function should reject truly empty values
+    ws.close();
+  });
+  
+  it("should not override system headers like Connection or Upgrade", async () => {
+    const url = await createHeaderEchoServer();
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    
+    const ws = new WebSocket(url.href, {
+      headers: {
+        "Connection": "close",  // Should be ignored
+        "Upgrade": "http/2.0",   // Should be ignored
+        "Sec-WebSocket-Version": "8",  // Should be ignored
+        "X-Custom": "allowed",
+      },
+    });
+    clients.push(ws);
+    
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "headers") {
+          resolve(data.headers);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    
+    ws.onerror = reject;
+    
+    const headers = await promise;
+    // These should remain as WebSocket requires
+    expect(headers.connection.toLowerCase()).toContain("upgrade");
+    expect(headers.upgrade.toLowerCase()).toBe("websocket");
+    expect(headers["sec-websocket-version"]).toBe("13");
+    expect(headers["x-custom"]).toBe("allowed");
+    ws.close();
+  });
+});

--- a/test/js/web/websocket/websocket-server-echo-headers-simple.mjs
+++ b/test/js/web/websocket/websocket-server-echo-headers-simple.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { createServer } from "http";
+import crypto from "crypto";
+
+const port = 0;
+
+function generateAccept(key) {
+  return crypto
+    .createHash("sha1")
+    .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    .digest("base64");
+}
+
+const server = createServer();
+
+let connectedSocket = null;
+let requestHeaders = {};
+
+server.on("upgrade", (request, socket, head) => {
+  // Store the headers
+  requestHeaders = request.headers;
+  
+  const key = request.headers["sec-websocket-key"];
+  const accept = generateAccept(key);
+  
+  // Build response headers
+  let responseHeaders = [
+    "HTTP/1.1 101 Switching Protocols",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Accept: ${accept}`,
+  ];
+  
+  // Echo back the protocol if provided
+  if (request.headers["sec-websocket-protocol"]) {
+    // Just echo back the first protocol
+    const protocols = request.headers["sec-websocket-protocol"].split(",")[0].trim();
+    responseHeaders.push(`Sec-WebSocket-Protocol: ${protocols}`);
+  }
+  
+  responseHeaders.push("", ""); // Empty line to end headers
+  
+  socket.write(responseHeaders.join("\r\n"));
+  
+  connectedSocket = socket;
+  
+  // Send headers as first message (simple text frame)
+  const message = JSON.stringify({
+    type: "headers",
+    headers: requestHeaders,
+  });
+  
+  // Simple WebSocket text frame
+  const messageBuffer = Buffer.from(message);
+  
+  // Handle payload length encoding
+  let frame;
+  if (messageBuffer.length < 126) {
+    frame = Buffer.allocUnsafe(2 + messageBuffer.length);
+    frame[0] = 0x81; // FIN + text opcode
+    frame[1] = messageBuffer.length; // Payload length (no masking for server)
+    messageBuffer.copy(frame, 2);
+  } else if (messageBuffer.length < 65536) {
+    frame = Buffer.allocUnsafe(4 + messageBuffer.length);
+    frame[0] = 0x81; // FIN + text opcode
+    frame[1] = 126; // Extended payload length (16-bit)
+    frame.writeUInt16BE(messageBuffer.length, 2);
+    messageBuffer.copy(frame, 4);
+  } else {
+    // For very large messages (unlikely in our test)
+    frame = Buffer.allocUnsafe(10 + messageBuffer.length);
+    frame[0] = 0x81; // FIN + text opcode
+    frame[1] = 127; // Extended payload length (64-bit)
+    frame.writeBigUInt64BE(BigInt(messageBuffer.length), 2);
+    messageBuffer.copy(frame, 10);
+  }
+  
+  socket.write(frame);
+  
+  socket.on("data", (data) => {
+    // Simple echo - just bounce back any frames we receive
+    // This is not a full WebSocket implementation but enough for testing
+    if (data[0] === 0x88) {
+      // Close frame
+      socket.end();
+    }
+  });
+  
+  socket.on("error", (err) => {
+    console.error("Socket error:", err);
+  });
+});
+
+server.listen(port, () => {
+  const { port } = server.address();
+  const url = `ws://localhost:${port}`;
+  
+  if (process.send) {
+    process.send({ href: url });
+  } else {
+    console.log(url);
+  }
+});
+
+process.on("SIGTERM", () => {
+  if (connectedSocket) {
+    connectedSocket.end();
+  }
+  server.close();
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

Adds support for overriding special WebSocket headers (`Host`, `Sec-WebSocket-Key`, and `Sec-WebSocket-Protocol`) via the headers option when creating a WebSocket connection.

## Changes

- Modified `WebSocketUpgradeClient.zig` to check for and use user-provided special headers
- Added header value validation to prevent CRLF injection attacks
- Updated the NonUTF8Headers struct to automatically filter duplicate headers
- When a custom `Sec-WebSocket-Protocol` header is provided, it properly updates the subprotocols list for validation

## Implementation Details

The implementation adds minimal code by:
1. Using the existing `NonUTF8Headers` struct's methods to find valid header overrides
2. Automatically filtering out WebSocket-specific headers in the format method to prevent duplication
3. Maintaining a single, clean code path in `buildRequestBody()`

## Testing

Added comprehensive tests in `websocket-custom-headers.test.ts` that verify:
- Custom Host header support
- Custom Sec-WebSocket-Key header support  
- Custom Sec-WebSocket-Protocol header support
- Header override behavior when both protocols array and header are provided
- CRLF injection prevention
- Protection of system headers (Connection, Upgrade, etc.)
- Support for additional custom headers

All existing WebSocket tests continue to pass, ensuring backward compatibility.

## Security

The implementation includes validation to:
- Reject header values with control characters (preventing CRLF injection)
- Prevent users from overriding critical system headers like Connection and Upgrade
- Validate header values according to RFC 7230 specifications

## Use Cases

This feature enables:
- Testing WebSocket servers with specific header requirements
- Connecting through proxies that require custom Host headers
- Implementing custom WebSocket subprotocol negotiation
- Debugging WebSocket connections with specific keys

Fixes #[issue_number]