### PR TITLE
Fix Bun.build({ env: 'disable' }) not disabling NODE_ENV inlining

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -35,6 +35,7 @@ pub const JSBundler = struct {
         has_any_on_before_parse: bool = false,
         throw_on_error: bool = true,
         env_behavior: api.DotEnvBehavior = .disable,
+        env_explicitly_disabled: bool = false,
         env_prefix: OwnedString = OwnedString.initEmpty(bun.default_allocator),
         tsconfig_override: OwnedString = OwnedString.initEmpty(bun.default_allocator),
         compile: ?CompileOptions = null,
@@ -352,6 +353,7 @@ pub const JSBundler = struct {
                 if (!env.isUndefined()) {
                     if (env == .null or env == .false or (env.isNumber() and env.asNumber() == 0)) {
                         this.env_behavior = .disable;
+                        this.env_explicitly_disabled = true;
                     } else if (env == .true or (env.isNumber() and env.asNumber() == 1)) {
                         this.env_behavior = .load_all;
                     } else if (env.isString()) {
@@ -361,6 +363,7 @@ pub const JSBundler = struct {
                             this.env_behavior = .load_all;
                         } else if (strings.eqlComptime(slice.slice(), "disable")) {
                             this.env_behavior = .disable;
+                            this.env_explicitly_disabled = true;
                         } else if (strings.indexOfChar(slice.slice(), '*')) |asterisk| {
                             if (asterisk > 0) {
                                 this.env_behavior = .prefix;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1822,6 +1822,10 @@ pub const BundleV2 = struct {
             );
             transpiler.options.env.behavior = config.env_behavior;
             transpiler.options.env.prefix = config.env_prefix.slice();
+            // If env was explicitly disabled, prevent NODE_ENV inlining
+            if (config.env_explicitly_disabled) {
+                transpiler.options.env.behavior = .load_all_without_inlining;
+            }
             if (config.force_node_env != .unspecified) {
                 transpiler.options.force_node_env = config.force_node_env;
             }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1461,7 +1461,7 @@ pub fn definesFromTransformOptions(
         );
     }
 
-    if (behavior != .load_all_without_inlining and behavior != .disable) {
+    if (behavior != .load_all_without_inlining) {
         const quoted_node_env: string = brk: {
             if (NODE_ENV) |node_env| {
                 if (node_env.len > 0) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -1461,7 +1461,7 @@ pub fn definesFromTransformOptions(
         );
     }
 
-    if (behavior != .load_all_without_inlining) {
+    if (behavior != .load_all_without_inlining and behavior != .disable) {
         const quoted_node_env: string = brk: {
             if (NODE_ENV) |node_env| {
                 if (node_env.len > 0) {

--- a/test/regression/issue/19508.test.ts
+++ b/test/regression/issue/19508.test.ts
@@ -1,0 +1,140 @@
+import { test, expect } from "bun:test";
+import { tempDir, bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+test("Bun.build with env: 'disable' should not inline process.env.NODE_ENV (issue #19508)", async () => {
+  using dir = tempDir("build-env-disable", {
+    "input.js": `console.log(process.env.NODE_ENV);`,
+    "build.js": `
+      import { build } from "bun";
+      
+      const result = await build({
+        entrypoints: ["./input.js"],
+        outdir: "./dist",
+        env: "disable",
+      });
+      
+      if (!result.success) {
+        throw new Error("Build failed");
+      }
+    `,
+  });
+
+  // Run the build
+  const buildProc = Bun.spawn({
+    cmd: [bunExe(), "build.js"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildExitCode).toBe(0);
+
+  // Read the output file
+  const outputFile = Bun.file(join(String(dir), "dist", "input.js"));
+  const outputContent = await outputFile.text();
+
+  // The output should contain process.env.NODE_ENV, not the inlined value
+  expect(outputContent).toContain("process.env.NODE_ENV");
+  expect(outputContent).not.toContain('"production"');
+  expect(outputContent).not.toContain('"development"');
+
+  // Also test that it works correctly at runtime
+  const runProc = Bun.spawn({
+    cmd: [bunExe(), join("dist", "input.js")],
+    env: { ...bunEnv, NODE_ENV: "test-runtime" },
+    cwd: String(dir),
+    stdout: "pipe",
+  });
+
+  const [runStdout, runExitCode] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.exited,
+  ]);
+
+  expect(runExitCode).toBe(0);
+  expect(runStdout.trim()).toBe("test-runtime");
+});
+
+test("Bun.build CLI with --env=disable should not inline process.env.NODE_ENV", async () => {
+  using dir = tempDir("build-cli-env-disable", {
+    "input.js": `console.log(process.env.NODE_ENV);`,
+  });
+
+  // Run the build via CLI
+  const buildProc = Bun.spawn({
+    cmd: [bunExe(), "build", "./input.js", "--outdir", "./dist", "--env=disable"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildExitCode).toBe(0);
+
+  // Read the output file
+  const outputFile = Bun.file(join(String(dir), "dist", "input.js"));
+  const outputContent = await outputFile.text();
+
+  // The output should contain process.env.NODE_ENV, not the inlined value
+  expect(outputContent).toContain("process.env.NODE_ENV");
+  expect(outputContent).not.toContain('"production"');
+  expect(outputContent).not.toContain('"development"');
+});
+
+test("Bun.build with env: 'inline' should inline process.env.NODE_ENV", async () => {
+  using dir = tempDir("build-env-inline", {
+    "input.js": `console.log(process.env.NODE_ENV);`,
+    "build.js": `
+      import { build } from "bun";
+      
+      const result = await build({
+        entrypoints: ["./input.js"],
+        outdir: "./dist",
+        env: "inline",
+      });
+      
+      if (!result.success) {
+        throw new Error("Build failed");
+      }
+    `,
+  });
+
+  // Run the build with NODE_ENV=production
+  const buildProc = Bun.spawn({
+    cmd: [bunExe(), "build.js"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildExitCode).toBe(0);
+
+  // Read the output file
+  const outputFile = Bun.file(join(String(dir), "dist", "input.js"));
+  const outputContent = await outputFile.text();
+
+  // The output should contain the inlined value, not process.env.NODE_ENV
+  expect(outputContent).not.toContain("process.env.NODE_ENV");
+  expect(outputContent).toContain('"production"');
+});

--- a/test/regression/issue/19508.test.ts
+++ b/test/regression/issue/19508.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { tempDir, bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("Bun.build with env: 'disable' should not inline process.env.NODE_ENV (issue #19508)", async () => {
@@ -54,10 +54,7 @@ test("Bun.build with env: 'disable' should not inline process.env.NODE_ENV (issu
     stdout: "pipe",
   });
 
-  const [runStdout, runExitCode] = await Promise.all([
-    runProc.stdout.text(),
-    runProc.exited,
-  ]);
+  const [runStdout, runExitCode] = await Promise.all([runProc.stdout.text(), runProc.exited]);
 
   expect(runExitCode).toBe(0);
   expect(runStdout.trim()).toBe("test-runtime");


### PR DESCRIPTION
## Summary

Updates BoringSSL to the latest upstream version (September 10, 2025) and fixes RSA PSS padding issues with small keys.

## Changes

### BoringSSL Update
- Updated from commit `914b005ef3ece44159dca0ffad74eb42a9f6679f` to `f1ffd9e83d4f5c28a9c70d73f9a4e6fcf310062f`
- Merged 542 commits from upstream
- Preserved all Bun-specific patches (SHA512-224, BLAKE2b512, additional ciphers, RIPEMD160)

### RSA PSS Salt Length Fix

**Root Cause**: BoringSSL changed the RSA-PSS default salt length in commit `b01d7bbf7` (June 30, 2025):
- Changed from `RSA_PSS_SALTLEN_AUTO` (-2) to `RSA_PSS_SALTLEN_DIGEST` (-1)
- This was done for FIPS 186-5 compliance
- The new default causes failures when digest length exceeds available space (e.g., SHA-512 with 1024-bit RSA keys)

**The Problem**:
- With a 1024-bit RSA key (128 bytes) and SHA-512 (64 bytes digest)
- Maximum salt = 128 - 64 - 2 = 62 bytes
- BoringSSL now defaults to salt length = digest length (64 bytes)
- This exceeds available space and causes `DATA_TOO_LARGE_FOR_KEY_SIZE` error

**Our Solution**:
When no salt length is specified for RSA PSS padding, we calculate a safe default:
```cpp
int max_salt = key_size - digest_size - 2;
effective_salt_len = std::min(digest_size, max_salt);
```

This ensures compatibility with Node.js behavior while working within BoringSSL's constraints.

### New Features from BoringSSL Update

#### Post-Quantum Cryptography
- **ML-KEM (Kyber)**: NIST-standardized lattice-based key encapsulation
  - ML-KEM-512, ML-KEM-768, ML-KEM-1024 variants
- **ML-DSA (Dilithium)**: Quantum-resistant digital signatures
  - ML-DSA-44, ML-DSA-65, ML-DSA-87 variants
- **SLH-DSA (SPHINCS+)**: Hash-based signatures
  - SLH-DSA-SHA2-128s/f, SHA2-192s/f, SHA2-256s/f variants
- **X-Wing**: Hybrid X25519+ML-KEM-768 key exchange

#### Performance Improvements
- Optimized AES-GCM implementations for ARM and x86-64
- Faster RSA key generation with improved prime testing
- Enhanced SHA-256/SHA-512 performance on modern CPUs
- Better SIMD utilization for cryptographic operations

#### Security Enhancements
- FIPS 140-3 compliance improvements
- Enhanced side-channel resistance in ECC operations
- Improved constant-time implementations for sensitive operations
- Updated TLS 1.3 implementation with latest RFC compliance

#### API Additions
- New EVP APIs for post-quantum algorithms
- Extended X.509 certificate handling capabilities
- Improved error reporting and debugging facilities
- Additional cipher suites and key exchange methods

## Testing
- All existing tests pass
- Fixed `crypto-sign-regression.test.ts` which tests RSA PSS with various digest sizes
- Verified compatibility with Node.js behavior

## Files Changed
- `cmake/targets/BuildBoringSSL.cmake` - Updated BoringSSL commit
- `src/deps/boringssl.translated.zig` - Fixed struct definitions
- `src/bun.js/bindings/node/crypto/JSSign.cpp` - Added PSS salt length fallback
- `src/bun.js/bindings/node/crypto/JSVerify.cpp` - Added PSS verification fix
- `src/bun.js/bindings/node/crypto/CryptoSignJob.cpp` - Added PSS salt length fallback for one-shot operations