### PR TITLE
Fix PostgreSQL StringBuilder assertion failure with empty error messages

### DIFF
--- a/src/sql/postgres/protocol/ErrorResponse.zig
+++ b/src/sql/postgres/protocol/ErrorResponse.zig
@@ -133,7 +133,7 @@ pub fn toJS(this: ErrorResponse, globalObject: *jsc.JSGlobalObject) JSValue {
     const routine_slice = if (routine.isEmpty()) null else routine.byteSlice();
 
     const error_message = if (b.len > 0) b.allocatedSlice()[0..b.len] else "";
-    
+
     return createPostgresError(globalObject, error_message, .{
         .code = error_code,
         .errno = errno,

--- a/src/sql/postgres/protocol/ErrorResponse.zig
+++ b/src/sql/postgres/protocol/ErrorResponse.zig
@@ -132,7 +132,9 @@ pub fn toJS(this: ErrorResponse, globalObject: *jsc.JSGlobalObject) JSValue {
     const line_slice = if (line.isEmpty()) null else line.byteSlice();
     const routine_slice = if (routine.isEmpty()) null else routine.byteSlice();
 
-    return createPostgresError(globalObject, b.allocatedSlice()[0..b.len], .{
+    const error_message = if (b.len > 0) b.allocatedSlice()[0..b.len] else "";
+    
+    return createPostgresError(globalObject, error_message, .{
         .code = error_code,
         .errno = errno,
         .detail = detail_slice,

--- a/test/regression/issue/postgres-stringbuilder-assertion-aggressive.test.ts
+++ b/test/regression/issue/postgres-stringbuilder-assertion-aggressive.test.ts
@@ -1,13 +1,12 @@
-import { test, expect } from "bun:test";
 import { SQL } from "bun";
+import { expect, test } from "bun:test";
 import net from "net";
-import { bunEnv, bunExe } from "harness";
 
 test("PostgreSQL StringBuilder assertion - aggressive empty error test", async () => {
   const server = net.createServer(socket => {
     // Immediately send an error response with completely empty fields
     // This is more likely to trigger the assertion
-    socket.write(createPostgresPacket('E', Buffer.from("\0"))); // Terminator only
+    socket.write(createPostgresPacket("E", Buffer.from("\0"))); // Terminator only
     socket.destroy();
   });
 
@@ -26,14 +25,14 @@ test("PostgreSQL StringBuilder assertion - aggressive empty error test", async (
       sql`SELECT ${i}`.catch(err => {
         // We expect errors, just checking for crashes
         return null;
-      })
+      }),
     );
   }
-  
+
   await Promise.all(promises);
   await sql.close();
   server.close();
-  
+
   // If we get here without crashing, the test passes
   expect(true).toBe(true);
 });

--- a/test/regression/issue/postgres-stringbuilder-assertion-aggressive.test.ts
+++ b/test/regression/issue/postgres-stringbuilder-assertion-aggressive.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test";
+import { SQL } from "bun";
+import net from "net";
+import { bunEnv, bunExe } from "harness";
+
+test("PostgreSQL StringBuilder assertion - aggressive empty error test", async () => {
+  const server = net.createServer(socket => {
+    // Immediately send an error response with completely empty fields
+    // This is more likely to trigger the assertion
+    socket.write(createPostgresPacket('E', Buffer.from("\0"))); // Terminator only
+    socket.destroy();
+  });
+
+  await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as net.AddressInfo).port;
+
+  const sql = new SQL({
+    url: `postgres://test@127.0.0.1:${port}/test`,
+    max: 10,
+    connection_timeout: 0.1,
+  });
+
+  const promises = [];
+  for (let i = 0; i < 20; i++) {
+    promises.push(
+      sql`SELECT ${i}`.catch(err => {
+        // We expect errors, just checking for crashes
+        return null;
+      })
+    );
+  }
+  
+  await Promise.all(promises);
+  await sql.close();
+  server.close();
+  
+  // If we get here without crashing, the test passes
+  expect(true).toBe(true);
+});
+
+function createPostgresPacket(type: string, data: Buffer): Buffer {
+  const len = data.length + 4;
+  const header = Buffer.alloc(5);
+  header.write(type, 0);
+  header.writeInt32BE(len, 1);
+  return Buffer.concat([header, data]);
+}


### PR DESCRIPTION
## Summary
- Fixed a debug build assertion failure in PostgreSQL error handling when all error message fields are empty
- Added safety check before calling `StringBuilder.allocatedSlice()` to handle zero-length messages
- Added regression test to prevent future occurrences

## The Problem
When PostgreSQL sends an error response with completely empty message fields, the `ErrorResponse.toJS` function would:
1. Calculate `b.cap` but end up with `b.len = 0` (no actual content)
2. Call `b.allocatedSlice()[0..b.len]` unconditionally
3. Trigger an assertion in `StringBuilder.allocatedSlice()` that requires `cap > 0`

This only affected debug builds since the assertion is compiled out in release builds.

## The Fix
Check if `b.len > 0` before calling `allocatedSlice()`. If there's no content, use an empty string instead.

## Test Plan
- [x] Added regression test that triggers the exact crash scenario
- [x] Verified test crashes without the fix (debug build)
- [x] Verified test passes with the fix
- [x] Confirmed release builds were not affected

🤖 Generated with [Claude Code](https://claude.ai/code)