### PR TITLE
Fix linear_fifo

### DIFF
--- a/src/linear_fifo.zig
+++ b/src/linear_fifo.zig
@@ -123,6 +123,7 @@ pub fn LinearFifo(
         pub fn ensureTotalCapacity(self: *Self, size: usize) !void {
             if (self.buf.len >= size) return;
             if (buffer_type == .Dynamic) {
+                self.realign();
                 const new_size = if (powers_of_two) math.ceilPowerOfTwo(usize, size) catch return error.OutOfMemory else size;
                 const buf = try self.allocator.alloc(T, new_size);
                 if (self.count > 0) {


### PR DESCRIPTION
There was a bug with `append append shift append append append shift shift`

I couldn't remove it entirely because we add two new methods 'peekItemMut' and 'orderedRemoveItem' that are not in the stdlib version.