### PR TITLE
feat(http): Add partial support for HTTP CONNECT method and 'connect' event

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -551,7 +551,8 @@ namespace uWS
                 return ConsumeRequestLineResult::shortRead();
             }
 
-            if (data[0] == 32 && (__builtin_expect(data[1] == '/', 1) || isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1)) [[likely]] {
+            if (data[0] == 32 && (__builtin_expect(data[1] == '/', 1) || isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1 || 
+                    ((data - start) == 7 && memcmp(start, "CONNECT", 7) == 0))) [[likely]] {
                 header.key = {start, (size_t) (data - start)};
                 data++;
                 if(!isValidMethod(header.key, useStrictMethodValidation)) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -593,7 +593,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           if (server.listenerCount("connect") > 0) {
             // For CONNECT, emit the event and let the handler respond
             server.emit("connect", http_req, socket, kEmptyBuffer);
-            
+
             // Don't assign the socket to a response for CONNECT
             // The handler should write the raw response
           } else {
@@ -1018,8 +1018,8 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       // Try to write directly to the socket handle
       try {
         // Convert string to buffer if needed
-        if (typeof chunk === 'string') {
-          chunk = Buffer.from(chunk, encoding || 'utf8');
+        if (typeof chunk === "string") {
+          chunk = Buffer.from(chunk, encoding || "utf8");
         }
         // Write raw data
         handle.write(chunk);

--- a/test/regression/issue/16372-http-connect-event-minimal.test.ts
+++ b/test/regression/issue/16372-http-connect-event-minimal.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "bun:test";
+import { createServer } from "node:http";
+import net from "node:net";
+
+test("node:http server emits 'connect' event for CONNECT method", async () => {
+  let connectEventEmitted = false;
+  let receivedRequest = null;
+  
+  const server = createServer();
+  
+  server.on("connect", (req, socket, head) => {
+    connectEventEmitted = true;
+    receivedRequest = {
+      method: req.method,
+      url: req.url,
+    };
+    // Note: Raw socket writing is not fully implemented yet
+    // This test only verifies the event is emitted
+    socket.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    });
+  });
+
+  const port = (server.address() as any).port;
+
+  // Send CONNECT request
+  const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+    client.write("CONNECT github.com:443 HTTP/1.1\r\n");
+    client.write("Host: github.com:443\r\n");
+    client.write("\r\n");
+  });
+
+  await new Promise<void>((resolve) => {
+    client.on("end", () => {
+      resolve();
+    });
+    client.on("error", () => {
+      resolve();
+    });
+    
+    // Timeout to prevent hanging
+    setTimeout(() => {
+      client.destroy();
+      resolve();
+    }, 1000);
+  });
+
+  // Verify the connect event was emitted with correct data
+  expect(connectEventEmitted).toBe(true);
+  expect(receivedRequest).not.toBeNull();
+  expect(receivedRequest?.method).toBe("CONNECT");
+  expect(receivedRequest?.url).toBe("github.com:443");
+
+  server.close();
+  client.destroy();
+});

--- a/test/regression/issue/16372-http-connect-event-minimal.test.ts
+++ b/test/regression/issue/16372-http-connect-event-minimal.test.ts
@@ -1,13 +1,13 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { createServer } from "node:http";
 import net from "node:net";
 
 test("node:http server emits 'connect' event for CONNECT method", async () => {
   let connectEventEmitted = false;
   let receivedRequest = null;
-  
+
   const server = createServer();
-  
+
   server.on("connect", (req, socket, head) => {
     connectEventEmitted = true;
     receivedRequest = {
@@ -19,7 +19,7 @@ test("node:http server emits 'connect' event for CONNECT method", async () => {
     socket.end();
   });
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     server.listen(0, "127.0.0.1", () => {
       resolve();
     });
@@ -34,14 +34,14 @@ test("node:http server emits 'connect' event for CONNECT method", async () => {
     client.write("\r\n");
   });
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     client.on("end", () => {
       resolve();
     });
     client.on("error", () => {
       resolve();
     });
-    
+
     // Timeout to prevent hanging
     setTimeout(() => {
       client.destroy();

--- a/test/regression/issue/16372-http-connect-event.test.ts
+++ b/test/regression/issue/16372-http-connect-event.test.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { createServer } from "node:http";
+import net from "node:net";
+
+test("node:http server should emit 'connect' event for CONNECT method", async () => {
+  let connectCalled = false;
+  
+  const server = createServer();
+  
+  server.on("connect", (req, socket, head) => {
+    connectCalled = true;
+    // Respond with 200 Connection Established
+    socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+    socket.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    });
+  });
+
+  const port = (server.address() as any).port;
+
+  // Create a client connection and send CONNECT request
+  const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+    client.write("CONNECT github.com:443 HTTP/1.1\r\n");
+    client.write("Host: github.com:443\r\n");
+    client.write("Proxy-Connection: Keep-Alive\r\n");
+    client.write("\r\n");
+  });
+
+  let response = "";
+  client.on("data", (data) => {
+    response += data.toString();
+  });
+
+  await new Promise<void>((resolve) => {
+    client.on("end", () => {
+      resolve();
+    });
+  });
+
+  // Verify the connect event was called
+  expect(connectCalled).toBe(true);
+  
+  // Verify proper response
+  expect(response).toContain("200 Connection Established");
+
+  server.close();
+  client.destroy();
+});
+
+test("node:http server should respond with 400 if no connect handler", async () => {
+  const server = createServer();
+  
+  // No connect event handler - should return 400
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    });
+  });
+
+  const port = (server.address() as any).port;
+
+  // Create a client connection and send CONNECT request
+  const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+    client.write("CONNECT github.com:443 HTTP/1.1\r\n");
+    client.write("Host: github.com:443\r\n");
+    client.write("\r\n");
+  });
+
+  let response = "";
+  client.on("data", (data) => {
+    response += data.toString();
+  });
+
+  await new Promise<void>((resolve) => {
+    client.on("end", () => {
+      resolve();
+    });
+    client.on("error", () => {
+      // Connection might be closed early
+      resolve();
+    });
+  });
+
+  // Should get 400 or 405 response
+  expect(response).toMatch(/HTTP\/1\.1 (400|405)/);
+
+  server.close();
+  client.destroy();
+});

--- a/test/regression/issue/16372-http-connect-event.test.ts
+++ b/test/regression/issue/16372-http-connect-event.test.ts
@@ -1,13 +1,12 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
 import { createServer } from "node:http";
 import net from "node:net";
 
 test("node:http server should emit 'connect' event for CONNECT method", async () => {
   let connectCalled = false;
-  
+
   const server = createServer();
-  
+
   server.on("connect", (req, socket, head) => {
     connectCalled = true;
     // Respond with 200 Connection Established
@@ -15,7 +14,7 @@ test("node:http server should emit 'connect' event for CONNECT method", async ()
     socket.end();
   });
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     server.listen(0, "127.0.0.1", () => {
       resolve();
     });
@@ -32,11 +31,11 @@ test("node:http server should emit 'connect' event for CONNECT method", async ()
   });
 
   let response = "";
-  client.on("data", (data) => {
+  client.on("data", data => {
     response += data.toString();
   });
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     client.on("end", () => {
       resolve();
     });
@@ -44,7 +43,7 @@ test("node:http server should emit 'connect' event for CONNECT method", async ()
 
   // Verify the connect event was called
   expect(connectCalled).toBe(true);
-  
+
   // Verify proper response
   expect(response).toContain("200 Connection Established");
 
@@ -54,10 +53,10 @@ test("node:http server should emit 'connect' event for CONNECT method", async ()
 
 test("node:http server should respond with 400 if no connect handler", async () => {
   const server = createServer();
-  
+
   // No connect event handler - should return 400
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     server.listen(0, "127.0.0.1", () => {
       resolve();
     });
@@ -73,11 +72,11 @@ test("node:http server should respond with 400 if no connect handler", async () 
   });
 
   let response = "";
-  client.on("data", (data) => {
+  client.on("data", data => {
     response += data.toString();
   });
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     client.on("end", () => {
       resolve();
     });


### PR DESCRIPTION
## Summary

This PR adds partial support for the HTTP CONNECT method in the node:http server, fixing #16372 where the 'connect' event was never emitted for CONNECT requests.

## The Problem

The HTTP CONNECT method is used for establishing HTTP tunnels, primarily for HTTPS proxy connections. Node.js emits a special 'connect' event when receiving CONNECT requests, allowing servers to handle HTTP tunneling. Bun was not emitting this event at all.

The root cause was twofold:
1. **uWebSockets parser rejection**: The HTTP parser was rejecting CONNECT requests because they have a different URL format (`CONNECT host:port HTTP/1.1` instead of `GET /path HTTP/1.1`)
2. **Missing event handling**: Even if the request made it through, there was no code to detect CONNECT method and emit the appropriate event

## What This PR Does

### 1. Modified uWebSockets Parser (`packages/bun-uws/src/HttpParser.h`)
- Added special handling for CONNECT method in the request line parser
- The parser now accepts URLs that don't start with `/` or `http://` when the method is CONNECT
- This allows `CONNECT example.com:443 HTTP/1.1` format to be parsed correctly

### 2. Added CONNECT Event Handling (`src/js/node/_http_server.ts`)
- Added detection for CONNECT method in `onNodeHTTPRequest`
- When CONNECT is detected and there are 'connect' event listeners, it emits the event
- Falls back to 400 Bad Request if no connect handler is registered

### 3. Added Tests
- `test/regression/issue/16372-http-connect-event-minimal.test.ts`: Verifies the 'connect' event is emitted with correct request data
- `test/regression/issue/16372-http-connect-event.test.ts`: More comprehensive test (currently has issues with socket writing)

## Known Limitations & Uncertainties

⚠️ **This is where I need guidance** - I'm not entirely sure this is the right approach, and there are significant limitations:

### 1. **Raw Socket Writing Doesn't Work Properly**
The biggest issue is that after the 'connect' event is emitted, the socket should be able to write raw TCP data for tunneling. However:
- The `NodeHTTPServerSocket._write()` method was empty (just `{}`)
- When I tried implementing it, I ran into issues with the handle
- The underlying `handle.write()` still adds HTTP framing instead of writing raw data
- Writing `"HTTP/1.1 200 Connection Established\r\n\r\n"` gets transformed into a full HTTP response with headers

### 2. **Architectural Mismatch**
The fundamental issue seems to be that Bun's HTTP server is built on uWebSockets, which is designed for HTTP/WebSocket protocols, not raw TCP tunneling. CONNECT requires:
- Initial HTTP parsing for the CONNECT request
- Sending a raw TCP response (200 Connection Established)
- Switching to raw TCP tunnel mode (no more HTTP framing)
- Bidirectional raw data proxying

This doesn't fit well with how uWebSockets handles connections.

### 3. **Incomplete Implementation**
Currently:
- ✅ CONNECT requests are parsed
- ✅ The 'connect' event is emitted
- ❌ Socket writing doesn't work properly for the tunnel response
- ❌ Raw TCP tunneling after the handshake isn't implemented
- ❌ The socket can't properly read/write raw data after CONNECT

### 4. **Questions About the Implementation**

1. **Is modifying uWebSockets the right approach?** I added a special case for CONNECT in the parser, but this feels hacky.

2. **How should we handle the socket?** The NodeHTTPServerSocket doesn't have proper access to the underlying TCP socket for raw writes.

3. **Should we use a different approach entirely?** Maybe CONNECT handling needs to bypass uWebSockets somehow?

4. **What about the response handle?** The `handle.write()` method seems to always apply HTTP framing. Is there a way to write raw data?

5. **Socket lifecycle**: After CONNECT, the socket should be removed from HTTP processing and become a raw TCP tunnel. How do we achieve this?

## Testing

```bash
# This test passes - verifies the event is emitted
bun test test/regression/issue/16372-http-connect-event-minimal.test.ts

# This test has issues - socket writing doesn't work properly
bun test test/regression/issue/16372-http-connect-event.test.ts

# Basic HTTP still works
bun test test/js/node/http/node-http.test.ts
```

## Request for Review

@cirospaciari - I'd really appreciate your review and guidance on this. I feel like I'm fighting against the architecture here, and there might be a better approach I'm missing. Specifically:

1. Is modifying the uWebSockets parser acceptable for this use case?
2. How can we properly implement raw socket writing for CONNECT tunneling?
3. Should CONNECT be handled at a different layer entirely?
4. Is there existing infrastructure for switching from HTTP to raw TCP that I missed?

The current implementation at least makes the 'connect' event fire (fixing the immediate issue in #16372), but it's not a complete solution for HTTP tunneling.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>