### PR TITLE
Fix glob match not working on absolute file path without glob pattern

### DIFF
--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -446,7 +446,7 @@ pub fn GlobWalker_(
                                 .err => |e| {
                                     if (e.getErrno() == bun.sys.E.NOTDIR) {
                                         // This means that the glob pattern is an absolute file path
-                                        const directory_idx = bun.strings.lastIndexOfChar(this.walker.pattern, std.fs.path.sep);
+                                        const directory_idx = ResolvePath.lastIndexOfSep(this.walker.pattern);
                                         path_without_special_syntax =
                                             if (directory_idx) |idx| path_without_special_syntax[0 .. idx + 1] else if (!bun.Environment.isWindows) "/" else ResolvePath.windowsFilesystemRoot(this.walker.cwd);
                                         starting_component_idx -= 1;

--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -446,7 +446,7 @@ pub fn GlobWalker_(
                                 .err => |e| {
                                     if (e.getErrno() == bun.sys.E.NOTDIR) {
                                         // This means that the glob pattern is an absolute file path
-                                        const directory_idx = std.mem.lastIndexOfScalar(u8, this.walker.pattern, if (bun.Environment.isWindows) '\\' else '/');
+                                        const directory_idx = bun.strings.lastIndexOfChar(this.walker.pattern, std.fs.path.sep);
                                         path_without_special_syntax =
                                             if (directory_idx) |idx| path_without_special_syntax[0 .. idx + 1] else if (!bun.Environment.isWindows) "/" else ResolvePath.windowsFilesystemRoot(this.walker.cwd);
                                         starting_component_idx -= 1;

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -650,6 +650,17 @@ describe("absolute path pattern", async () => {
     expect(entries.sort()).toEqual(files.slice(0, files.length - 1).sort());
   });
 
+  test("absolute file path", async () => {
+    const tmpdir = tmpdirSync();
+    const file = `${tmpdir}${path.sep}foo`;
+
+    await Bun.$`touch ${file}`;
+
+    const glob = new Glob(file);
+    const entries = await Array.fromAsync(glob.scan());
+    expect(entries.sort()).toEqual([file]);
+  });
+
   test("non-special path as first component", async () => {
     const glob = new Glob("/**lol");
     const entries = await Array.fromAsync(glob.scan({ onlyFiles: false }));


### PR DESCRIPTION
### What does this PR do?

Fixes:
- https://github.com/oven-sh/bun/issues/16709

Fix edge case where glob do not match absolute path without glob patterns.

### How did you verify your code works?

- Added a failing test to avoid regression
- Tested a few edge cases on my local machine, but I only have access to an x86_64-linux machine. Should work on macOS & Windows tho