### PR TITLE
Add ban-words check for underscore-prefixed Zig struct fields

### DIFF
--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -17,6 +17,7 @@
   "EXCEPTION_ASSERT(!scope.exception())": 0,
   "JSValue.false": 0,
   "JSValue.true": 0,
+  "^\\s*_[a-zA-Z_][^:]*:.*[,=]": 148,
   "alloc.ptr !=": 0,
   "alloc.ptr ==": 0,
   "allocator.ptr !=": 1,

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -38,6 +38,7 @@ const words: Record<string, { reason: string; regex?: boolean }> = {
   "!= alloc.ptr": { reason: "The std.mem.Allocator context pointer can be undefined, which makes this comparison undefined behavior" },
 
   ": [^=]+= undefined,$": { reason: "Do not default a struct field to undefined", regex: true },
+  "^\\s*_[a-zA-Z_][^:]*:.*[,=]": { reason: "Use `#` instead of `_` to denote private struct fields in Zig (e.g., `#foo` instead of `_foo`). The Zig compiler has been extended to support this feature!", regex: true },
   "usingnamespace": { reason: "Zig 0.15 will remove `usingnamespace`" },
 
   "std.fs.Dir": { reason: "Prefer bun.sys + bun.FD instead of std.fs" },


### PR DESCRIPTION
## Summary
- Adds validation to detect Zig struct fields that start with underscore (`_foo`)
- Recommends using the new `#` prefix syntax instead (`#foo`) for private fields
- Shows friendly error message explaining that the Zig compiler has been extended to support this feature

## Changes
- Added regex pattern `^\\s*_[a-zA-Z_][^:]*:.*[,=]` to ban-words.test.ts
- Set limit to 148 existing instances in ban-limits.json for backwards compatibility
- New violations will fail with helpful guidance to use `#` instead of `_`

## Test plan
- [x] Ran `bun bd test test/internal/ban-words.test.ts` - all tests pass
- [x] Verified existing 148 instances are allowed
- [x] Confirmed new underscore-prefixed fields trigger the friendly error message
- [x] Tested that the error message properly recommends using `#` syntax

🤖 Generated with [Claude Code](https://claude.ai/code)