### PR TITLE
Fix import.meta handling in CJS bundles

### DIFF
--- a/src/ast/visitExpr.zig
+++ b/src/ast/visitExpr.zig
@@ -876,6 +876,13 @@ pub fn VisitExpr(
                     .property_access_for_method_call_maybe_should_replace_with_undefined = in.property_access_for_method_call_maybe_should_replace_with_undefined,
                 });
 
+                // When bundling to CJS, replace import.meta.* with undefined
+                if (p.options.bundle and p.options.output_format == .cjs and
+                    e_.target.data == .e_import_meta)
+                {
+                    return p.newExpr(E.Undefined{}, expr.loc);
+                }
+
                 // 'require.resolve' -> .e_require_resolve_call_target
                 if (e_.target.data == .e_require_call_target and
                     strings.eqlComptime(e_.name, "resolve"))

--- a/test/regression/issue/22642.test.ts
+++ b/test/regression/issue/22642.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("import.meta should not appear in CJS bundles (issue #22642)", async () => {
+  using dir = tempDir("issue-22642", {
+    "src/index.ts": `
+      // This code will cause import.meta to appear in the bundle
+      // when bundling @sentry/bun or similar packages
+      const needsEsmLoader = typeof module !== "undefined" && module.register;
+      if (needsEsmLoader) {
+        module.register("some-loader", import.meta.url);
+      }
+      console.log("test");
+    `,
+  });
+
+  // Bundle to CJS format
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./src/index.ts", "--outdir", "dist", "--format", "cjs", "--target", "bun"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+
+  // Now try to run the bundled file
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), "./dist/index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [runStdout, runStderr, runExitCode] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.stderr.text(),
+    runProc.exited,
+  ]);
+
+  // The bundled CJS file should run without errors
+  expect(runExitCode).toBe(0);
+  expect(runStderr).not.toContain("TypeError: Expected CommonJS module to have a function wrapper");
+  expect(runStdout).toContain("test");
+});

--- a/test/regression/issue/22642.test.ts
+++ b/test/regression/issue/22642.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("import.meta should not appear in CJS bundles (issue #22642)", async () => {
@@ -23,11 +23,7 @@ test("import.meta should not appear in CJS bundles (issue #22642)", async () => 
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stderr).toBe("");


### PR DESCRIPTION
## Summary
- Fixes #22642 by properly handling `import.meta` expressions when bundling to CommonJS format
- Replaces `import.meta.*` expressions with `undefined` in CJS bundles to prevent runtime errors

## Problem
When bundling code containing `import.meta` expressions (like `import.meta.url`) to CommonJS format, the bundler was leaving these expressions unchanged. Since `import.meta` is an ESM-only feature, this caused a runtime error:
```
TypeError: Expected CommonJS module to have a function wrapper
```

This issue occurred notably when bundling packages like `@sentry/bun` that conditionally use `import.meta.url`.

## Solution
Modified the AST visitor to detect `import.meta` property access expressions during bundling to CJS format and replace them with `undefined`. This ensures the generated CommonJS bundle doesn't contain ESM-specific syntax.

## Test Plan
- [x] Added regression test in `test/regression/issue/22642.test.ts`
- [x] Test passes with the fix
- [x] Verified the fix works with the original `@sentry/bun` package that triggered the issue
- [x] Bundle runs successfully without errors

## Changes
- Modified `src/ast/visitExpr.zig` to handle `import.meta.*` expressions in CJS bundles
- Added comprehensive regression test

🤖 Generated with [Claude Code](https://claude.ai/code)