### PR TITLE
Disable glibcxx assertions in WebKit release non-asan builds

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 2d2e8dd5b020cc165e2bc1d284461b4504d624e5)
+  set(WEBKIT_VERSION 495c25e24927ba03277ae225cd42811588d03ff8)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)


### PR DESCRIPTION
### What does this PR do?

Evidently, Ubuntu turns them on by default. 

Claude:
```
> What is the typical overhead for glibcxx assertions?

⏺ The overhead of glibc/libstdc++ assertions can be significant, especially in
  performance-critical code:

  Typical Overhead Ranges:

  libstdc++ (C++ standard library) assertions:
  - 5-15% overall performance impact in typical applications
  - Up to 30-50% in container-heavy code (vectors, maps, etc.)
  - Iterator validity checks are particularly expensive

  glibc (C library) assertions:
  - 2-8% overall impact in typical applications
  - Up to 20% in malloc/free intensive code
  - Heap consistency checks, buffer overflow detection
 ```


