### PR TITLE
Enable DCE for process.isBun when target is bun

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -1510,6 +1510,15 @@ pub fn definesFromTransformOptions(
                 .value = .{ .e_undefined = .{} },
             }));
         }
+
+        // Set process.isBun to true for DCE when target is bun
+        if (!user_defines.contains("process.isBun")) {
+            _ = try environment_defines.getOrPutValue("process.isBun", .init(.{
+                .valueless = false,
+                .original_name = "process.isBun",
+                .value = .{ .e_boolean = .{ .value = true } },
+            }));
+        }
     }
 
     const resolved_defines = try defines.DefineData.fromInput(user_defines, drop, log, allocator);

--- a/src/options.zig
+++ b/src/options.zig
@@ -1511,7 +1511,6 @@ pub fn definesFromTransformOptions(
             }));
         }
 
-        // Set process.isBun to true for DCE when target is bun
         if (!user_defines.contains("process.isBun")) {
             _ = try environment_defines.getOrPutValue("process.isBun", .init(.{
                 .valueless = false,

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -3406,15 +3406,15 @@ describe("bundler", () => {
     files: {
       "/entry.js": /* js */ `
         if (process.isBun) {
-          console.log("BUN_CODE");
+          console.log("KEEP_BUN_CODE");
           function bunOnlyFunction() {
-            return "bun-specific";
+            return "KEEP_THIS";
           }
           console.log(bunOnlyFunction());
         } else {
-          console.log("NODE_CODE");
+          console.log("REMOVE_NODE_CODE");
           function nodeOnlyFunction() {
-            return "node-specific";
+            return "DROP_THIS";
           }
           console.log(nodeOnlyFunction());
         }
@@ -3423,7 +3423,7 @@ describe("bundler", () => {
     target: "bun",
     dce: true,
     run: {
-      stdout: "BUN_CODE\nbun-specific",
+      stdout: "KEEP_BUN_CODE\nKEEP_THIS",
     },
   });
 });

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -3401,4 +3401,29 @@ describe("bundler", () => {
   //     "/project/node_modules/pkg/styles.css": `button { color: red }`,
   //   },
   // });
+
+  itBundled("dce/ProcessIsBunTargetBun", {
+    files: {
+      "/entry.js": /* js */ `
+        if (process.isBun) {
+          console.log("BUN_CODE");
+          function bunOnlyFunction() {
+            return "bun-specific";
+          }
+          console.log(bunOnlyFunction());
+        } else {
+          console.log("NODE_CODE");
+          function nodeOnlyFunction() {
+            return "node-specific";
+          }
+          console.log(nodeOnlyFunction());
+        }
+      `,
+    },
+    target: "bun",
+    dce: true,
+    run: {
+      stdout: "BUN_CODE\nbun-specific",
+    },
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `process.isBun` to the define replacements when `--target=bun` 
- Replaces `process.isBun` with literal `true` during bundling, enabling dead code elimination
- **Note:** `process.isBun` already exists in Bun runtime (returns `true`), so this change only affects bundling behavior and shouldn't impact existing code

## Why
This provides an easy, static way to write conditional code for Bun vs Node.js that gets optimized away during bundling. Unlike more complex DCE approaches (like `process.versions.bun` or `typeof Bun`), this is a simple boolean replacement that works with the existing define system.

## Example
```js
// Input code
if (process.isBun) {
  console.log("This code runs on Bun");
  bunSpecificLogic();
} else {
  console.log("This code runs on Node.js");
  nodeSpecificLogic();
}

// Output when --target=bun (DCE applied)
if (true) {
  console.log("This code runs on Bun");
  bunSpecificLogic();
}
// Node branch eliminated

// Output when --target=browser or --target=node (preserved)
if (process.isBun) {
  // ... both branches kept
}
```

## Test plan
✅ Verified `process.isBun` returns `true` at runtime (already existing behavior)
✅ Tested bundling with `--target=bun` - replaces with `true` and eliminates dead code
✅ Tested bundling with `--target=browser` and `--target=node` - preserves original code

🤖 Generated with [Claude Code](https://claude.ai/code)