### PR TITLE
Fix WASI `random_get` implementation

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -1745,8 +1745,9 @@ var require_wasi = __commonJS({
           },
           random_get: (bufPtr, bufLen) => {
             this.refreshMemory();
-            crypto.getRandomValues(this.memory.buffer, bufPtr, bufLen);
-            return bufLen;
+            const view = new Uint8Array(this.memory.buffer, bufPtr, bufLen);
+            bindings.randomFillSync(view);
+            return constants_1.WASI_ESUCCESS;
           },
           sched_yield() {
             return constants_1.WASI_ESUCCESS;


### PR DESCRIPTION
### What does this PR do?

Fixes the WASI implementation of the `random_get` function, by writing only to the allocated buffer region, and returning the correct success code.

The previous implementation would wipe out the entire WASI memory space, and return an error (non-zero return value)

### How did you verify your code works?

Deployed it to production without any testing
