### PR TITLE
docs: Add TypeScript support documentation for YAML imports

### DIFF
--- a/docs/api/yaml.md
+++ b/docs/api/yaml.md
@@ -184,6 +184,45 @@ const { database, redis } = require("./config.yaml");
 console.log(database.port); // 5432
 ```
 
+### TypeScript Support
+
+While Bun can import YAML files directly, TypeScript doesn't know the types of your YAML files by default. To add TypeScript support for your YAML imports, create a declaration file with `.d.ts` appended to the YAML filename (e.g., `config.yaml` → `config.yaml.d.ts`):
+
+```yaml#config.yaml
+features: "advanced"
+server:
+  host: localhost
+  port: 3000
+```
+
+```ts#config.yaml.d.ts
+const contents: {
+  features: string;
+  server: {
+    host: string;
+    port: number;
+  };
+};
+
+export = contents;
+```
+
+Now TypeScript will provide proper type checking and auto-completion:
+
+```ts#app.ts
+import config from "./config.yaml";
+
+// TypeScript knows the types!
+config.server.port; // number
+config.server.host; // string
+config.features; // string
+
+// TypeScript will catch errors
+config.server.unknown; // Error: Property 'unknown' does not exist
+```
+
+This approach works for both ES modules and CommonJS, giving you full type safety while Bun continues to handle the actual YAML parsing at runtime.
+
 ## Hot Reloading with YAML
 
 One of the most powerful features of Bun's YAML support is hot reloading. When you run your application with `bun --hot`, changes to YAML files are automatically detected and reloaded without closing connections

--- a/docs/guides/runtime/import-yaml.md
+++ b/docs/guides/runtime/import-yaml.md
@@ -73,4 +73,32 @@ console.log(data.hobbies); // => ["reading", "coding"]
 
 ---
 
+## TypeScript Support
+
+To add TypeScript support for your YAML imports, create a declaration file by appending `.d.ts` to the YAML filename:
+
+```ts#config.yaml.d.ts
+const contents: {
+  database: {
+    host: string;
+    port: number;
+    name: string;
+  };
+  server: {
+    port: number;
+    timeout: number;
+  };
+  features: {
+    auth: boolean;
+    rateLimit: boolean;
+  };
+};
+
+export = contents;
+```
+
+This gives you full type safety and auto-completion in your editor while Bun handles the actual YAML parsing.
+
+---
+
 See [Docs > API > YAML](https://bun.com/docs/api/yaml) for complete documentation on YAML support in Bun.

--- a/docs/guides/runtime/import-yaml.md
+++ b/docs/guides/runtime/import-yaml.md
@@ -75,7 +75,7 @@ console.log(data.hobbies); // => ["reading", "coding"]
 
 ## TypeScript Support
 
-To add TypeScript support for your YAML imports, create a declaration file by appending `.d.ts` to the YAML filename:
+To add TypeScript support for your YAML imports, create a declaration file with `.d.ts` appended to the YAML filename (e.g., `config.yaml` → `config.yaml.d.ts`);
 
 ```ts#config.yaml.d.ts
 const contents: {
@@ -96,8 +96,6 @@ const contents: {
 
 export = contents;
 ```
-
-This gives you full type safety and auto-completion in your editor while Bun handles the actual YAML parsing.
 
 ---
 


### PR DESCRIPTION
## Summary
- Added documentation for TypeScript support when importing YAML files
- Explains how to create `.d.ts` declaration files to provide type definitions
- Based on solution provided by @alii in issue #22673

## Context
When importing YAML files in TypeScript projects, the TypeScript compiler doesn't know the structure of the imported data. This documentation shows users how to create declaration files that provide proper type definitions, enabling:
- Type checking at compile time
- Auto-completion in editors
- Better developer experience

## Changes
- Updated `/docs/api/yaml.md` with a new "TypeScript Support" section
- Updated `/docs/guides/runtime/import-yaml.md` with TypeScript type definition example

Fixes #22673

🤖 Generated with [Claude Code](https://claude.ai/code)