### PR TITLE
feat(pm): add --json and --depth support to bun pm ls

### DIFF
--- a/test/cli/pm/pm-ls-types.test.ts
+++ b/test/cli/pm/pm-ls-types.test.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun pm ls --json separates dependency types correctly", async () => {
+  using dir = tempDir("pm-ls-types", {
+    "package.json": JSON.stringify({
+      name: "test-dep-types",
+      version: "1.0.0",
+      dependencies: {
+        "is-number": "7.0.0",
+      },
+      devDependencies: {
+        "is-odd": "3.0.1",
+      },
+      optionalDependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  // Install dependencies
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const installExitCode = await installProc.exited;
+  expect(installExitCode).toBe(0);
+
+  // Test JSON output with separated dependency types
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "ls", "--json"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+
+  const json = JSON.parse(stdout);
+
+  // Check that dependencies are in the right sections
+  expect(json).toHaveProperty("dependencies");
+  expect(json.dependencies).toHaveProperty("is-number");
+  expect(json.dependencies["is-number"]).toHaveProperty("from", "7.0.0");
+
+  expect(json).toHaveProperty("devDependencies");
+  expect(json.devDependencies).toHaveProperty("is-odd");
+  expect(json.devDependencies["is-odd"]).toHaveProperty("from", "3.0.1");
+
+  expect(json).toHaveProperty("optionalDependencies");
+  expect(json.optionalDependencies).toHaveProperty("is-even");
+  expect(json.optionalDependencies["is-even"]).toHaveProperty("from", "1.0.0");
+
+  // Ensure no mixing between sections
+  expect(json.dependencies).not.toHaveProperty("is-odd");
+  expect(json.dependencies).not.toHaveProperty("is-even");
+  expect(json.devDependencies).not.toHaveProperty("is-number");
+  expect(json.devDependencies).not.toHaveProperty("is-even");
+  expect(json.optionalDependencies).not.toHaveProperty("is-number");
+  expect(json.optionalDependencies).not.toHaveProperty("is-odd");
+});
+
+test("bun pm ls --json --depth=1 includes nested deps without 'from' field", async () => {
+  using dir = tempDir("pm-ls-nested-from", {
+    "package.json": JSON.stringify({
+      name: "test-nested",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "3.0.1", // This depends on is-number
+      },
+    }),
+  });
+
+  // Install dependencies
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const installExitCode = await installProc.exited;
+  expect(installExitCode).toBe(0);
+
+  // Test JSON output with depth=1
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "ls", "--json", "--depth=1"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+
+  const json = JSON.parse(stdout);
+
+  // Root dependency should have 'from' field
+  expect(json.dependencies["is-odd"]).toHaveProperty("from", "3.0.1");
+
+  // Nested dependencies should NOT have 'from' field
+  if (json.dependencies["is-odd"].dependencies?.["is-number"]) {
+    expect(json.dependencies["is-odd"].dependencies["is-number"]).not.toHaveProperty("from");
+    expect(json.dependencies["is-odd"].dependencies["is-number"]).toHaveProperty("version");
+    expect(json.dependencies["is-odd"].dependencies["is-number"]).toHaveProperty("resolved");
+  }
+});

--- a/test/cli/pm/pm-ls-types.test.ts
+++ b/test/cli/pm/pm-ls-types.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun pm ls --json separates dependency types correctly", async () => {
@@ -38,11 +38,7 @@ test("bun pm ls --json separates dependency types correctly", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stderr).toBe("");
@@ -102,11 +98,7 @@ test("bun pm ls --json --depth=1 includes nested deps without 'from' field", asy
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stderr).toBe("");

--- a/test/cli/pm/pm-ls.test.ts
+++ b/test/cli/pm/pm-ls.test.ts
@@ -1,0 +1,147 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun pm ls --json outputs valid JSON", async () => {
+  using dir = tempDir("pm-ls-json", {
+    "package.json": JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      dependencies: {
+        "is-number": "7.0.0",
+      },
+    }),
+  });
+
+  // Install dependencies
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const installExitCode = await installProc.exited;
+  expect(installExitCode).toBe(0);
+
+  // Test JSON output
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "ls", "--json"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+
+  // Parse JSON output
+  const json = JSON.parse(stdout);
+  expect(json).toHaveProperty("name", "test-project");
+  expect(json).toHaveProperty("version", "1.0.0");
+  expect(json).toHaveProperty("dependencies");
+  expect(json.dependencies).toHaveProperty("is-number");
+  expect(json.dependencies["is-number"]).toHaveProperty("version", "7.0.0");
+  expect(json.dependencies["is-number"]).toHaveProperty("resolved");
+  expect(json.dependencies["is-number"]).toHaveProperty("overridden", false);
+});
+
+test("bun pm ls --json --depth=0 limits depth", async () => {
+  using dir = tempDir("pm-ls-depth", {
+    "package.json": JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      dependencies: {
+        "is-number": "7.0.0", // This has no dependencies itself
+      },
+    }),
+  });
+
+  // Install dependencies
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const installExitCode = await installProc.exited;
+  expect(installExitCode).toBe(0);
+
+  // Test depth=0 (no nested dependencies)
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "ls", "--json", "--depth=0"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+
+  const json = JSON.parse(stdout);
+  expect(json.dependencies["is-number"]).toHaveProperty("version");
+  expect(json.dependencies["is-number"]).not.toHaveProperty("dependencies");
+});
+
+test("bun pm ls --depth limits tree output", async () => {
+  using dir = tempDir("pm-ls-tree-depth", {
+    "package.json": JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      dependencies: {
+        "is-number": "7.0.0",
+      },
+    }),
+  });
+
+  // Install dependencies
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const installExitCode = await installProc.exited;
+  expect(installExitCode).toBe(0);
+
+  // Test regular tree with depth=0
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "ls", "--depth=0"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+
+  // Should only show direct dependencies
+  const lines = stdout.trim().split("\n");
+  expect(lines.length).toBeGreaterThan(0);
+  expect(stdout).toContain("is-number@7.0.0");
+  // Should not show any nested structure (no more ├── or └──)
+  const hasNestedDeps = lines.some(line => line.includes("│"));
+  expect(hasNestedDeps).toBe(false);
+});

--- a/test/cli/pm/pm-ls.test.ts
+++ b/test/cli/pm/pm-ls.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun pm ls --json outputs valid JSON", async () => {
@@ -32,11 +32,7 @@ test("bun pm ls --json outputs valid JSON", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stderr).toBe("");
@@ -83,11 +79,7 @@ test("bun pm ls --json --depth=0 limits depth", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stderr).toBe("");
@@ -128,11 +120,7 @@ test("bun pm ls --depth limits tree output", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stderr).toBe("");


### PR DESCRIPTION
## Summary

Implements `--json` and `--depth` flags for `bun pm ls` to match npm's output schema.

## What's New

- **`--json` flag**: Outputs dependency tree in JSON format matching npm's schema
- **`--depth` flag**: Limits the depth of the dependency tree (works with both JSON and regular tree output)

## Key Features

### Dependency Type Separation
Dependencies are now properly categorized into their respective sections:
- `dependencies` - Production dependencies
- `devDependencies` - Development dependencies  
- `peerDependencies` - Peer dependencies
- `optionalDependencies` - Optional dependencies

### npm-Compatible JSON Output
```json
{
  "version": "1.0.0",
  "name": "my-package",
  "dependencies": {
    "lodash": {
      "version": "4.17.21",
      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
      "overridden": false,
      "from": "^4.17.21"
    }
  },
  "devDependencies": {
    "prettier": {
      "version": "3.0.0",
      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
      "overridden": false,
      "from": "^3.0.0"
    }
  }
}
```

### Proper Data Sources
- Uses lockfile's `resolution.fmtURL()` for accurate resolved URLs
- Leverages `dep.behavior` flags to categorize dependencies correctly
- No hacky JSON parsing - uses proper lockfile data structures

## Examples

```bash
# JSON output with depth limit
bun pm ls --json --depth=1

# Regular tree with depth limit
bun pm ls --depth=0

# Full JSON output
bun pm ls --json
```

## Test Coverage

- ✅ All existing `bun pm` tests pass
- ✅ New tests for JSON output validity
- ✅ New tests for dependency type separation
- ✅ New tests for depth limiting
- ✅ Tests verify `from` field only appears at root level

🤖 Generated with [Claude Code](https://claude.ai/code)