### PR TITLE
Fix zstd decompression truncation for multi-frame responses

### DIFF
--- a/src/deps/zstd.zig
+++ b/src/deps/zstd.zig
@@ -167,8 +167,14 @@ pub const ZstdReaderArrayList = struct {
             this.total_out += bytes_written;
 
             if (rc == 0) {
-                this.end();
-                return;
+                // Frame is complete, but check if there's more input (multiple frames)
+                if (this.total_in >= this.input.len) {
+                    this.end();
+                    return;
+                }
+                // Reset the decompressor for the next frame
+                _ = c.ZSTD_initDStream(this.zstd);
+                continue;
             }
 
             if (bytes_read == next_in.len) {

--- a/src/deps/zstd.zig
+++ b/src/deps/zstd.zig
@@ -182,7 +182,7 @@ pub const ZstdReaderArrayList = struct {
 
             if (rc == 0) {
                 // Frame is complete
-                this.state = .Uninitialized;  // Reset state since frame is complete
+                this.state = .Uninitialized; // Reset state since frame is complete
 
                 // Check if there's more input (multiple frames)
                 if (this.total_in >= this.input.len) {

--- a/src/deps/zstd.zig
+++ b/src/deps/zstd.zig
@@ -173,6 +173,8 @@ pub const ZstdReaderArrayList = struct {
                     return;
                 }
                 // Reset the decompressor for the next frame
+                // ZSTD_initDStream() safely resets the stream state without needing cleanup
+                // It's designed to be called multiple times on the same DStream object
                 _ = c.ZSTD_initDStream(this.zstd);
                 continue;
             }

--- a/test/regression/issue/20053.test.ts
+++ b/test/regression/issue/20053.test.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { zstdCompressSync } from "node:zlib";
+
+test("issue #20053 - multi-frame zstd responses should be fully decompressed", async () => {
+  // Create multiple zstd frames that when concatenated form a single large response
+  // This simulates what happens with chunked encoding where each chunk might be
+  // compressed as a separate frame
+  const part1 = "A".repeat(16384); // Exactly 16KB
+  const part2 = "B".repeat(3627);  // Remaining data to total ~20KB
+
+  const compressed1 = zstdCompressSync(Buffer.from(part1));
+  const compressed2 = zstdCompressSync(Buffer.from(part2));
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      // Concatenate two zstd frames (simulating chunked response with multiple frames)
+      const combined = Buffer.concat([compressed1, compressed2]);
+
+      return new Response(combined, {
+        headers: {
+          "content-type": "text/plain",
+          "content-encoding": "zstd",
+          "transfer-encoding": "chunked",
+        },
+      });
+    },
+  });
+
+  // Make a request to the server
+  const response = await fetch(`http://localhost:${server.port}/`);
+  const text = await response.text();
+
+  // Both frames should be decompressed and concatenated
+  expect(text.length).toBe(part1.length + part2.length);
+  expect(text.substring(0, 16384)).toBe("A".repeat(16384));
+  expect(text.substring(16384)).toBe("B".repeat(3627));
+});
+
+test("issue #20053 - zstd with chunked encoding splits JSON into multiple frames", async () => {
+  // This test simulates the exact scenario from the original issue
+  // where Hono with compression middleware sends multiple zstd frames
+  const largeData = { data: "A".repeat(20000) };
+  const jsonString = JSON.stringify(largeData);
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      // Simulate chunked encoding by compressing in parts
+      // This is what happens when the server uses chunked transfer encoding
+      // with compression - each chunk might be compressed separately
+      const part1 = jsonString.slice(0, 16384);
+      const part2 = jsonString.slice(16384);
+
+      const compressed1 = zstdCompressSync(Buffer.from(part1));
+      const compressed2 = zstdCompressSync(Buffer.from(part2));
+
+      // Server sends multiple zstd frames as would happen with chunked encoding
+      const combined = Buffer.concat([compressed1, compressed2]);
+
+      return new Response(combined, {
+        headers: {
+          "content-type": "application/json",
+          "content-encoding": "zstd",
+          "transfer-encoding": "chunked",
+        },
+      });
+    },
+  });
+
+  const response = await fetch(`http://localhost:${server.port}/`);
+  const text = await response.text();
+
+  // The decompressed response should be the concatenation of all frames
+  expect(text.length).toBe(jsonString.length);
+  expect(text).toBe(jsonString);
+
+  // Verify it can be parsed as JSON
+  const parsed = JSON.parse(text);
+  expect(parsed.data.length).toBe(20000);
+  expect(parsed.data).toBe("A".repeat(20000));
+});

--- a/test/regression/issue/20053.test.ts
+++ b/test/regression/issue/20053.test.ts
@@ -1,5 +1,4 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
 import { zstdCompressSync } from "node:zlib";
 
 test("issue #20053 - multi-frame zstd responses should be fully decompressed", async () => {
@@ -7,7 +6,7 @@ test("issue #20053 - multi-frame zstd responses should be fully decompressed", a
   // This simulates what happens with chunked encoding where each chunk might be
   // compressed as a separate frame
   const part1 = "A".repeat(16384); // Exactly 16KB
-  const part2 = "B".repeat(3627);  // Remaining data to total ~20KB
+  const part2 = "B".repeat(3627); // Remaining data to total ~20KB
 
   const compressed1 = zstdCompressSync(Buffer.from(part1));
   const compressed2 = zstdCompressSync(Buffer.from(part2));


### PR DESCRIPTION
## Summary

Fixes #20053

When a server sends zstd-compressed data with chunked transfer encoding, each chunk may be compressed as a separate zstd frame. Previously, Bun's zstd decompressor would stop after the first frame, causing responses to be truncated at 16KB.

## The Fix

The fix modifies the zstd decompressor (`src/deps/zstd.zig`) to continue decompression when a frame completes but input data remains. When `ZSTD_decompressStream` returns 0 (frame complete), we now check if there's more input data and reinitialize the decompressor to handle the next frame.

## Testing

Added regression tests in `test/regression/issue/20053.test.ts` that:
1. Test multi-frame zstd decompression where two frames need to be concatenated
2. Simulate the exact Hono + compression middleware scenario from the original issue

Both tests fail without the fix (truncating at 16KB) and pass with the fix.

## Verification

```bash
# Without fix (regular bun):
$ bun test test/regression/issue/20053.test.ts
 0 pass
 2 fail

# With fix (debug build):
$ bun bd test test/regression/issue/20053.test.ts  
 2 pass
 0 fail
```

🤖 Generated with [Claude Code](https://claude.ai/code)