### PR TITLE
Replace direct `GCOwnedDataScope` member access with explicit String copy in `ErrorStackTrace`

### DIFF
--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -696,7 +696,7 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const
                                 if (!str->isEmpty()) {
                                     setTypeFlagsIfNecessary();
 
-                                    return str.data;
+                                    return str;
                                 }
                             }
                         }
@@ -711,7 +711,7 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const
                             if (name && name.isString()) {
                                 auto str = asString(name)->tryGetValueWithoutGC();
                                 if (!str->isEmpty()) {
-                                    functionName = str.data;
+                                    functionName = str;
                                     if (!functionName.isEmpty()) {
                                         setTypeFlagsIfNecessary();
                                         return functionName;


### PR DESCRIPTION
### What does this PR do?

 This change fixes direct access to the data member of GCOwnedDataScope<const String&> in the functionName
  function within ErrorStackTrace.cpp. The code now uses implicit conversion through GCOwnedDataScope's operator
  const T() instead of direct member access.

  The segmentation fault occurs in StringImpl::destroy during reference count operations when processing stack
  traces. The suspected issue is that direct access to str.data creates a potential use-after-free condition where
   the String copy constructor may operate on memory from a GCOwnedDataScope that has already been destroyed.

  This change follows the same pattern used elsewhere in JSC codebase, such as [getCalculatedDisplayName](https://github.com/WebKit/WebKit/blob/23fb371328cf3c54930b21696a19a8f9acda0056/Source/JavaScriptCore/runtime/JSFunction.cpp#L531)
### How did you verify your code works?

The is issue flaky, so I wasn't able to create reproduction...

