### PR TITLE
feat(watcher): add support for excluding files from watch patterns

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,22 +27,17 @@
   "git.ignoreLimitWarning": true,
 
   // Zig
-  // "zig.initialSetupDone": true,
-  // "zig.buildOption": "build",
+  "zig.initialSetupDone": true,
+  "zig.buildOption": "build",
   "zig.zls.zigLibPath": "${workspaceFolder}/vendor/zig/lib",
-  "zig.buildOnSaveArgs": [
-    "-Dgenerated-code=./build/debug/codegen",
-    "--watch",
-    "-fincremental"
-  ],
-  // "zig.zls.buildOnSaveStep": "check",
+  "zig.zls.buildOnSaveStep": "check",
   // "zig.zls.enableBuildOnSave": true,
   // "zig.buildOnSave": true,
-  // "zig.buildFilePath": "${workspaceFolder}/build.zig",
+  "zig.buildFilePath": "${workspaceFolder}/build.zig",
   "zig.path": "${workspaceFolder}/vendor/zig/zig.exe",
   "zig.zls.path": "${workspaceFolder}/vendor/zig/zls.exe",
   "zig.formattingProvider": "zls",
-  // "zig.zls.enableInlayHints": false,
+  "zig.zls.enableInlayHints": false,
   "[zig]": {
     "editor.tabSize": 4,
     "editor.useTabStops": false,
@@ -173,4 +168,9 @@
   },
   "git.detectSubmodules": false,
   "bun.test.customScript": "./build/debug/bun-debug test",
+  "zig.buildOnSaveArgs": [
+    "-Dgenerated-code=./build/debug/codegen",
+    "--watch",
+    "-fincremental"
+  ],
 }

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -310,6 +310,7 @@ pub const Run = struct {
     pub fn start(this: *Run) void {
         var vm = this.vm;
         vm.hot_reload = this.ctx.debug.hot_reload;
+        vm.watch_excludes = this.ctx.debug.watch_excludes;
         vm.onUnhandledRejection = &onUnhandledRejectionBeforeClose;
 
         // Start CPU profiler if enabled

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -54,6 +54,7 @@ heap_profiler_config: ?HeapProfilerConfig = null,
 counters: Counters = .{},
 
 hot_reload: bun.cli.Command.HotReload = .none,
+watch_excludes: []const []const u8 = &.{},
 jsc_vm: *VM = undefined,
 
 /// hide bun:wrap from stack traces

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -54,6 +54,10 @@ heap_profiler_config: ?HeapProfilerConfig = null,
 counters: Counters = .{},
 
 hot_reload: bun.cli.Command.HotReload = .none,
+/// Glob patterns for files to exclude from watch mode.
+/// Borrowed slices — owned by the CLI allocator (bunfig strings or argv), which
+/// is process-lifetime and therefore outlives this VirtualMachine and any Watcher
+/// it creates. No duplication or teardown needed.
 watch_excludes: []const []const u8 = &.{},
 jsc_vm: *VM = undefined,
 

--- a/src/jsc/hot_reloader.zig
+++ b/src/jsc/hot_reloader.zig
@@ -134,7 +134,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             };
 
             clear_screen = clear_screen_flag;
-            const watcher = Watcher.init(Reloader, reloader, fs, bun.default_allocator) catch |err| {
+            const watcher = Watcher.init(Reloader, reloader, fs, bun.default_allocator, .{}) catch |err| {
                 bun.handleErrorReturnTrace(err, @errorReturnTrace());
                 Output.panic("Failed to enable File Watcher: {s}", .{@errorName(err)});
             };
@@ -301,12 +301,17 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             };
 
             if (comptime @TypeOf(this.bun_watcher) == ImportWatcher) {
+                const exclude_patterns = if (@hasField(Ctx, "watch_excludes")) this.watch_excludes else &.{};
+
                 this.bun_watcher = if (reload_immediately)
                     .{ .watch = Watcher.init(
                         Reloader,
                         reloader,
                         this.transpiler.fs,
                         bun.default_allocator,
+                        .{
+                            .exclude_patterns = exclude_patterns,
+                        },
                     ) catch |err| {
                         bun.handleErrorReturnTrace(err, @errorReturnTrace());
                         Output.panic("Failed to enable File Watcher: {s}", .{@errorName(err)});
@@ -317,6 +322,9 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                         reloader,
                         this.transpiler.fs,
                         bun.default_allocator,
+                        .{
+                            .exclude_patterns = exclude_patterns,
+                        },
                     ) catch |err| {
                         bun.handleErrorReturnTrace(err, @errorReturnTrace());
                         Output.panic("Failed to enable File Watcher: {s}", .{@errorName(err)});
@@ -328,11 +336,16 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     this.transpiler.resolver.watcher = bun.resolver.ResolveWatcher(*Watcher, Watcher.onMaybeWatchDirectory).init(this.bun_watcher.hot);
                 }
             } else {
+                const exclude_patterns = if (@hasField(Ctx, "watch_excludes")) this.watch_excludes else &.{};
+
                 this.bun_watcher = Watcher.init(
                     Reloader,
                     reloader,
                     this.transpiler.fs,
                     bun.default_allocator,
+                    .{
+                        .exclude_patterns = exclude_patterns,
+                    },
                 ) catch |err| {
                     bun.handleErrorReturnTrace(err, @errorReturnTrace());
                     Output.panic("Failed to enable File Watcher: {s}", .{@errorName(err)});

--- a/src/options_types/Context.zig
+++ b/src/options_types/Context.zig
@@ -92,6 +92,7 @@ pub const DebugOptions = struct {
     fallback_only: bool = false,
     silent: bool = false,
     hot_reload: HotReload = HotReload.none,
+    watch_excludes: []const []const u8 = &.{},
     global_cache: GlobalCache = .auto,
     offline_mode_setting: ?OfflineMode = null,
     run_in_bun: bool = false,

--- a/src/runtime/bake/DevServer.zig
+++ b/src/runtime/bake/DevServer.zig
@@ -383,7 +383,7 @@ pub fn init(options: Options) bun.JSOOM!*DevServer {
     const fs = bun.fs.FileSystem.init(options.root) catch |err|
         return global.throwError(err, generic_action);
 
-    dev.bun_watcher = Watcher.init(DevServer, dev, fs, bun.default_allocator) catch |err|
+    dev.bun_watcher = Watcher.init(DevServer, dev, fs, bun.default_allocator, .{}) catch |err|
         return global.throwError(err, "while initializing file watcher for development server");
 
     errdefer dev.bun_watcher.deinit(false);

--- a/src/runtime/cli/Arguments.zig
+++ b/src/runtime/cli/Arguments.zig
@@ -79,6 +79,7 @@ pub const transpiler_params_ = [_]ParamType{
 pub const runtime_params_ = [_]ParamType{
     clap.parseParam("--watch                           Automatically restart the process on file change") catch unreachable,
     clap.parseParam("--hot                             Enable auto reload in the Bun runtime, test runner, or bundler") catch unreachable,
+    clap.parseParam("--watch-excludes <STR>...         Exclude files matching these glob patterns from watch & hot mode") catch unreachable,
     clap.parseParam("--no-clear-screen                 Disable clearing the terminal screen on reload when --hot or --watch is enabled") catch unreachable,
     clap.parseParam("--smol                            Use less memory, but run garbage collection more often") catch unreachable,
     clap.parseParam("-r, --preload <STR>...            Import a module before other modules are loaded") catch unreachable,
@@ -792,6 +793,20 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
             if (args.flag("--no-clear-screen")) {
                 bun.DotEnv.Loader.has_no_clear_screen_cli_flag = true;
+            }
+        }
+
+        // Combine CLI watch excludes with bunfig.toml excludes
+        const cli_excludes = args.options("--watch-excludes");
+        if (cli_excludes.len > 0) {
+            if (ctx.debug.watch_excludes.len > 0) {
+                // Merge CLI and bunfig excludes
+                var combined = try allocator.alloc([]const u8, ctx.debug.watch_excludes.len + cli_excludes.len);
+                @memcpy(combined[0..ctx.debug.watch_excludes.len], ctx.debug.watch_excludes);
+                @memcpy(combined[ctx.debug.watch_excludes.len..], cli_excludes);
+                ctx.debug.watch_excludes = combined;
+            } else {
+                ctx.debug.watch_excludes = cli_excludes;
             }
         }
 

--- a/src/runtime/cli/bunfig.zig
+++ b/src/runtime/cli/bunfig.zig
@@ -250,7 +250,9 @@ pub const Bunfig = struct {
                     try this.expect(expr, .e_boolean);
                     this.ctx.runtime_options.smol = expr.data.e_boolean.value;
                 }
+            }
 
+            if (comptime cmd == .RunCommand or cmd == .AutoCommand or cmd == .TestCommand) {
                 if (json.get("watch")) |watch| {
                     if (watch.get("excludes")) |expr| {
                         if (expr.asArray()) |array_| {

--- a/src/runtime/cli/bunfig.zig
+++ b/src/runtime/cli/bunfig.zig
@@ -250,6 +250,30 @@ pub const Bunfig = struct {
                     try this.expect(expr, .e_boolean);
                     this.ctx.runtime_options.smol = expr.data.e_boolean.value;
                 }
+
+                if (json.get("watch")) |watch| {
+                    if (watch.get("excludes")) |expr| {
+                        if (expr.asArray()) |array_| {
+                            var array = array_;
+                            var excludes = try std.ArrayList(string).initCapacity(allocator, array.array.items.len);
+                            errdefer excludes.deinit();
+                            while (array.next()) |item| {
+                                try this.expectString(item);
+                                if (item.data.e_string.len() > 0)
+                                    excludes.appendAssumeCapacity(try item.data.e_string.string(allocator));
+                            }
+                            this.ctx.debug.watch_excludes = excludes.items;
+                        } else if (expr.data == .e_string) {
+                            if (expr.data.e_string.len() > 0) {
+                                var excludes = try allocator.alloc(string, 1);
+                                excludes[0] = try expr.data.e_string.string(allocator);
+                                this.ctx.debug.watch_excludes = excludes;
+                            }
+                        } else if (expr.data != .e_null) {
+                            try this.addError(expr.loc, "Expected watch.excludes to be an array or string");
+                        }
+                    }
+                }
             }
 
             if (comptime cmd == .TestCommand) {

--- a/src/runtime/cli/test_command.zig
+++ b/src/runtime/cli/test_command.zig
@@ -1717,6 +1717,7 @@ pub const TestCommand = struct {
         // state and editing a source file should kick off a run.
         if (test_files.len > 0 or (ctx.test_options.changed != null and all_test_files.len > 0)) {
             vm.hot_reload = ctx.debug.hot_reload;
+            vm.watch_excludes = ctx.debug.watch_excludes;
 
             // Install the --changed trigger collector BEFORE the watcher
             // thread starts so a file edit during runAllTests is still

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -25,6 +25,8 @@ thread: std.Thread = undefined,
 running: bool = true,
 close_descriptors: bool = false,
 
+exclude_patterns: []const []const u8 = &.{},
+
 evict_list: [max_eviction_count]WatchItemIndex = undefined,
 evict_list_i: WatchItemIndex = 0,
 
@@ -51,13 +53,23 @@ pub const WatchList = std.MultiArrayList(WatchItem);
 pub const HashType = u32;
 const no_watch_item: WatchItemIndex = std.math.maxInt(WatchItemIndex);
 
+pub const InitConfig = struct {
+    exclude_patterns: []const []const u8 = &.{},
+};
+
 /// Initializes a watcher. Each watcher is tied to some context type, which
 /// receives watch callbacks on the watcher thread. This function does not
 /// actually start the watcher thread.
 ///
-///     const watcher = try Watcher.init(T, instance_of_t, fs, bun.default_allocator)
+/// Basic usage:
+///     const watcher = try Watcher.init(T, instance_of_t, fs, bun.default_allocator, .{})
 ///     errdefer watcher.deinit(false);
 ///     try watcher.start();
+///
+/// With patterns for filtering:
+///     const watcher = try Watcher.init(T, instance_of_t, fs, bun.default_allocator, .{
+///         .exclude_patterns = &[_][]const u8{"*.log", "tmp/**"},
+///     })
 ///
 /// To integrate a started watcher into module resolution:
 ///
@@ -66,7 +78,7 @@ const no_watch_item: WatchItemIndex = std.math.maxInt(WatchItemIndex);
 /// To integrate a started watcher into bundle_v2:
 ///
 ///     bundle_v2.bun_watcher = watcher;
-pub fn init(comptime T: type, ctx: *T, fs: *bun.fs.FileSystem, allocator: std.mem.Allocator) !*Watcher {
+pub fn init(comptime T: type, ctx: *T, fs: *bun.fs.FileSystem, allocator: std.mem.Allocator, config: InitConfig) !*Watcher {
     const wrapped = struct {
         fn onFileUpdateWrapped(ctx_opaque: *anyopaque, events: []WatchEvent, changed_files: []?[:0]u8, watchlist: WatchList) void {
             T.onFileUpdate(@ptrCast(@alignCast(ctx_opaque)), events, changed_files, watchlist);
@@ -95,6 +107,7 @@ pub fn init(comptime T: type, ctx: *T, fs: *bun.fs.FileSystem, allocator: std.me
         .platform = .{},
         .watch_events = try allocator.alloc(WatchEvent, max_count),
         .changed_filepaths = [_]?[:0]u8{null} ** max_count,
+        .exclude_patterns = config.exclude_patterns,
     };
 
     try Platform.init(&watcher.platform, fs.top_level_dir);
@@ -374,6 +387,30 @@ pub fn addFileDescriptorToKQueueWithoutChecks(this: *Watcher, fd: bun.FD, watchl
     );
 }
 
+fn shouldExcludeFile(this: *Watcher, file_path: string) bool {
+    if (this.exclude_patterns.len == 0) {
+        return false;
+    }
+
+    const relative_path = if (strings.startsWith(file_path, this.cwd))
+        file_path[this.cwd.len..]
+    else
+        file_path;
+
+    const clean_path = if (relative_path.len > 0 and relative_path[0] == '/')
+        relative_path[1..]
+    else
+        relative_path;
+
+    for (this.exclude_patterns) |pattern| {
+        if (glob.match(this.allocator, pattern, clean_path).matches()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 fn appendFileAssumeCapacity(
     this: *Watcher,
     fd: bun.FD,
@@ -391,6 +428,13 @@ fn appendFileAssumeCapacity(
             Output.warn("File {s} is not in the project directory and will not be watched\n", .{file_path});
             return .success;
         }
+    }
+
+    if (this.shouldExcludeFile(file_path)) {
+        if (comptime DebugLogScope.isVisible()) {
+            log("Excluded file from watch: {s}", .{file_path});
+        }
+        return .success;
     }
 
     const watchlist_id = this.watchlist.len;
@@ -806,3 +850,4 @@ const FeatureFlags = bun.FeatureFlags;
 const Mutex = bun.Mutex;
 const Output = bun.Output;
 const strings = bun.strings;
+const glob = @import("./glob/match.zig");

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -342,6 +342,40 @@ fn watchLoop(this: *Watcher) bun.sys.Maybe(void) {
     return .success;
 }
 
+fn shouldExcludeFile(this: *Watcher, file_path: string) bool {
+    if (this.exclude_patterns.len == 0) {
+        return false;
+    }
+
+    const relative_path = if (strings.startsWith(file_path, this.cwd))
+        file_path[this.cwd.len..]
+    else
+        file_path;
+
+    const clean_path = if (relative_path.len > 0 and relative_path[0] == '/')
+        relative_path[1..]
+    else
+        relative_path;
+
+    // On Windows, normalize backslashes to forward slashes so that glob
+    // patterns (which always use '/') match correctly.
+    var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+    const match_path: string = if (comptime bun.Environment.isWindows) blk: {
+        const len = @min(clean_path.len, path_buf.len);
+        @memcpy(path_buf[0..len], clean_path[0..len]);
+        std.mem.replaceScalar(u8, path_buf[0..len], '\\', '/');
+        break :blk path_buf[0..len];
+    } else clean_path;
+
+    for (this.exclude_patterns) |pattern| {
+        if (glob.match(this.allocator, pattern, match_path).matches()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /// Register a file descriptor with kqueue on macOS without validation.
 ///
 /// Preconditions (caller must ensure):
@@ -385,30 +419,6 @@ pub fn addFileDescriptorToKQueueWithoutChecks(this: *Watcher, fd: bun.FD, watchl
         0,
         null,
     );
-}
-
-fn shouldExcludeFile(this: *Watcher, file_path: string) bool {
-    if (this.exclude_patterns.len == 0) {
-        return false;
-    }
-
-    const relative_path = if (strings.startsWith(file_path, this.cwd))
-        file_path[this.cwd.len..]
-    else
-        file_path;
-
-    const clean_path = if (relative_path.len > 0 and relative_path[0] == '/')
-        relative_path[1..]
-    else
-        relative_path;
-
-    for (this.exclude_patterns) |pattern| {
-        if (glob.match(this.allocator, pattern, clean_path).matches()) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 fn appendFileAssumeCapacity(

--- a/test/cli/watch/watch-excludes.test.ts
+++ b/test/cli/watch/watch-excludes.test.ts
@@ -1,0 +1,135 @@
+import type { Subprocess } from "bun";
+import { spawn } from "bun";
+import { afterEach, expect, it } from "bun:test";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+
+let watchee: Subprocess;
+
+it("should exclude files matching --watch-excludes patterns", async () => {
+  const cwd = tmpdirSync();
+  const scriptPath = join(cwd, "script.js");
+  const dataPath = join(cwd, "data.json");
+  const logPath = join(cwd, "output.log");
+
+  // Create script that continuously modifies excluded files
+  await Bun.write(scriptPath, `
+    require("fs").writeFileSync("${logPath}", "executed-" + Date.now());
+    
+    setInterval(() => {
+      require("fs").writeFileSync("${dataPath}", JSON.stringify({ timestamp: Date.now() }));
+    }, 500);
+    
+    process.on('SIGTERM', () => process.exit(0));
+  `);
+
+  await Bun.write(dataPath, "{}");
+
+  // Start watching with *.json excluded
+  watchee = spawn({
+    cwd,
+    cmd: [bunExe(), "--watch", "--watch-excludes", "*.json", "script.js"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+
+  await Bun.sleep(1000);
+  const initialLog = await Bun.file(logPath).text();
+
+  // Wait for script to modify excluded files multiple times
+  await Bun.sleep(2000);
+  
+  // Excluded file modifications should not trigger reload
+  expect(await Bun.file(logPath).text()).toBe(initialLog);
+
+  // Modify watched file - should trigger reload
+  await Bun.write(scriptPath, `
+    require("fs").writeFileSync("${logPath}", "reloaded-" + Date.now());
+    process.on('SIGTERM', () => process.exit(0));
+  `);
+
+  await Bun.sleep(1000);
+
+  // Should have reloaded
+  const finalLog = await Bun.file(logPath).text();
+  expect(finalLog).toContain("reloaded-");
+  expect(finalLog).not.toBe(initialLog);
+
+  // Cleanup
+  rmSync(scriptPath, { force: true });
+  rmSync(dataPath, { force: true });
+  rmSync(logPath, { force: true });
+}, 6000);
+
+it("should exclude files using bunfig.toml watch.excludes configuration", async () => {
+  const cwd = tmpdirSync();
+  const scriptPath = join(cwd, "script.js");
+  const dataPath = join(cwd, "data.json");
+  const logPath = join(cwd, "output.log");
+  const bunfigPath = join(cwd, "bunfig.toml");
+
+  // Create bunfig.toml with watch excludes
+  await Bun.write(bunfigPath, `
+[watch]
+excludes = ["*.json"]
+  `);
+
+  // Create script that continuously modifies excluded files
+  await Bun.write(scriptPath, `
+    require("fs").writeFileSync("${logPath}", "executed-" + Date.now());
+    
+    setInterval(() => {
+      require("fs").writeFileSync("${dataPath}", JSON.stringify({ timestamp: Date.now() }));
+    }, 500);
+    
+    process.on('SIGTERM', () => process.exit(0));
+  `);
+
+  // Create excluded data file
+  await Bun.write(dataPath, "{}");
+
+  // Start watching without CLI excludes - should use bunfig.toml
+  watchee = spawn({
+    cwd,
+    cmd: [bunExe(), "--watch", "script.js"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+
+  await Bun.sleep(1000);
+  const initialLog = await Bun.file(logPath).text();
+
+  // Wait for script to modify excluded files multiple times
+  await Bun.sleep(2000);
+  
+  // Excluded file modifications should not trigger reload
+  expect(await Bun.file(logPath).text()).toBe(initialLog);
+
+  // Modify watched file - should trigger reload
+  await Bun.write(scriptPath, `
+    require("fs").writeFileSync("${logPath}", "reloaded-" + Date.now());
+    process.on('SIGTERM', () => process.exit(0));
+  `);
+
+  await Bun.sleep(1000);
+
+  // Should have reloaded
+  const finalLog = await Bun.file(logPath).text();
+  expect(finalLog).toContain("reloaded-");
+  expect(finalLog).not.toBe(initialLog);
+
+  // Cleanup
+  rmSync(scriptPath, { force: true });
+  rmSync(dataPath, { force: true });
+  rmSync(logPath, { force: true });
+  rmSync(bunfigPath, { force: true });
+}, 6000);
+
+afterEach(() => {
+  watchee?.kill();
+});

--- a/test/cli/watch/watch-excludes.test.ts
+++ b/test/cli/watch/watch-excludes.test.ts
@@ -1,32 +1,55 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
-import { rmSync } from "node:fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
-let watchee: Subprocess;
+let watchee: Subprocess | undefined;
+
+async function waitForFile(filePath: string, timeout = 10_000): Promise<string> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try {
+      const content = await Bun.file(filePath).text();
+      if (content.length > 0) return content;
+    } catch {}
+    await Bun.sleep(50);
+  }
+  throw new Error(`Timed out waiting for file: ${filePath}`);
+}
+
+async function waitForFileChange(filePath: string, previous: string, timeout = 10_000): Promise<string> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try {
+      const content = await Bun.file(filePath).text();
+      if (content !== previous) return content;
+    } catch {}
+    await Bun.sleep(50);
+  }
+  throw new Error(`Timed out waiting for ${filePath} to change from: ${previous}`);
+}
 
 it("should exclude files matching --watch-excludes patterns", async () => {
-  const cwd = tmpdirSync();
+  using dir = tempDir("watch-excludes-cli", {});
+  const cwd = String(dir);
   const scriptPath = join(cwd, "script.js");
   const dataPath = join(cwd, "data.json");
   const logPath = join(cwd, "output.log");
 
-  // Create script that continuously modifies excluded files
   await Bun.write(scriptPath, `
-    require("fs").writeFileSync("${logPath}", "executed-" + Date.now());
-    
+    const fs = require("fs");
+    fs.writeFileSync("${logPath}", "executed-" + Date.now());
+    let count = 0;
     setInterval(() => {
-      require("fs").writeFileSync("${dataPath}", JSON.stringify({ timestamp: Date.now() }));
-    }, 500);
-    
+      count++;
+      fs.writeFileSync("${dataPath}", JSON.stringify({ count }));
+    }, 100);
     process.on('SIGTERM', () => process.exit(0));
   `);
 
   await Bun.write(dataPath, "{}");
 
-  // Start watching with *.json excluded
   watchee = spawn({
     cwd,
     cmd: [bunExe(), "--watch", "--watch-excludes", "*.json", "script.js"],
@@ -36,62 +59,54 @@ it("should exclude files matching --watch-excludes patterns", async () => {
     stdin: "ignore",
   });
 
-  await Bun.sleep(1000);
-  const initialLog = await Bun.file(logPath).text();
+  // Wait for initial execution
+  const initialLog = await waitForFile(logPath);
 
-  // Wait for script to modify excluded files multiple times
-  await Bun.sleep(2000);
-  
-  // Excluded file modifications should not trigger reload
+  // Wait until data.json has been modified at least 5 times (excluded file changes)
+  let prev = "{}";
+  for (let i = 0; i < 5; i++) {
+    prev = await waitForFileChange(dataPath, prev);
+  }
+
+  // Excluded file modifications should not have triggered a reload
   expect(await Bun.file(logPath).text()).toBe(initialLog);
 
-  // Modify watched file - should trigger reload
+  // Modify the watched file — should trigger reload
   await Bun.write(scriptPath, `
     require("fs").writeFileSync("${logPath}", "reloaded-" + Date.now());
     process.on('SIGTERM', () => process.exit(0));
   `);
 
-  await Bun.sleep(1000);
-
-  // Should have reloaded
-  const finalLog = await Bun.file(logPath).text();
+  const finalLog = await waitForFileChange(logPath, initialLog);
   expect(finalLog).toContain("reloaded-");
-  expect(finalLog).not.toBe(initialLog);
-
-  // Cleanup
-  rmSync(scriptPath, { force: true });
-  rmSync(dataPath, { force: true });
-  rmSync(logPath, { force: true });
-}, 6000);
+});
 
 it("should exclude files using bunfig.toml watch.excludes configuration", async () => {
-  const cwd = tmpdirSync();
+  using dir = tempDir("watch-excludes-bunfig", {});
+  const cwd = String(dir);
   const scriptPath = join(cwd, "script.js");
   const dataPath = join(cwd, "data.json");
   const logPath = join(cwd, "output.log");
   const bunfigPath = join(cwd, "bunfig.toml");
 
-  // Create bunfig.toml with watch excludes
   await Bun.write(bunfigPath, `
 [watch]
 excludes = ["*.json"]
   `);
 
-  // Create script that continuously modifies excluded files
   await Bun.write(scriptPath, `
-    require("fs").writeFileSync("${logPath}", "executed-" + Date.now());
-    
+    const fs = require("fs");
+    fs.writeFileSync("${logPath}", "executed-" + Date.now());
+    let count = 0;
     setInterval(() => {
-      require("fs").writeFileSync("${dataPath}", JSON.stringify({ timestamp: Date.now() }));
-    }, 500);
-    
+      count++;
+      fs.writeFileSync("${dataPath}", JSON.stringify({ count }));
+    }, 100);
     process.on('SIGTERM', () => process.exit(0));
   `);
 
-  // Create excluded data file
   await Bun.write(dataPath, "{}");
 
-  // Start watching without CLI excludes - should use bunfig.toml
   watchee = spawn({
     cwd,
     cmd: [bunExe(), "--watch", "script.js"],
@@ -101,35 +116,30 @@ excludes = ["*.json"]
     stdin: "ignore",
   });
 
-  await Bun.sleep(1000);
-  const initialLog = await Bun.file(logPath).text();
+  // Wait for initial execution
+  const initialLog = await waitForFile(logPath);
 
-  // Wait for script to modify excluded files multiple times
-  await Bun.sleep(2000);
-  
-  // Excluded file modifications should not trigger reload
+  // Wait until data.json has been modified at least 5 times (excluded file changes)
+  let prev = "{}";
+  for (let i = 0; i < 5; i++) {
+    prev = await waitForFileChange(dataPath, prev);
+  }
+
+  // Excluded file modifications should not have triggered a reload
   expect(await Bun.file(logPath).text()).toBe(initialLog);
 
-  // Modify watched file - should trigger reload
+  // Modify the watched file — should trigger reload
   await Bun.write(scriptPath, `
     require("fs").writeFileSync("${logPath}", "reloaded-" + Date.now());
     process.on('SIGTERM', () => process.exit(0));
   `);
 
-  await Bun.sleep(1000);
-
-  // Should have reloaded
-  const finalLog = await Bun.file(logPath).text();
+  const finalLog = await waitForFileChange(logPath, initialLog);
   expect(finalLog).toContain("reloaded-");
-  expect(finalLog).not.toBe(initialLog);
-
-  // Cleanup
-  rmSync(scriptPath, { force: true });
-  rmSync(dataPath, { force: true });
-  rmSync(logPath, { force: true });
-  rmSync(bunfigPath, { force: true });
-}, 6000);
+});
 
 afterEach(() => {
   watchee?.kill();
+  watchee = undefined;
 });
+


### PR DESCRIPTION
### What does this PR do?

Adds `--watch-excludes` CLI flag to prevent infinite reload loops when scripts modify files they import.

- CLI: `bun --watch --watch-excludes "*.json" "*.log" script.js`
- Config: `[watch] excludes = ["*.json"]` in bunfig.toml
- Works with `--watch`, `--hot`, `test --watch`

related https://github.com/oven-sh/bun/issues/5278

### How did you verify your code works?

- Added tests in `test/cli/watch/watch-excludes.test.ts`
- Manual testing: excluded files don't trigger reloads, watched files do
- All existing tests still pass, no breaking

