### PR TITLE
Fix temp directory crash in package manager

### DIFF
--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -1,8 +1,5 @@
 cache_directory_: ?std.fs.Dir = null,
 cache_directory_path: stringZ = "",
-temp_dir_: ?std.fs.Dir = null,
-temp_dir_path: stringZ = "",
-temp_dir_name: string = "",
 root_dir: *Fs.FileSystem.DirEntry,
 allocator: std.mem.Allocator,
 log: *logger.Log,
@@ -462,7 +459,7 @@ var ensureTempNodeGypScriptOnce = bun.once(struct {
         // used later for adding to path for scripts
         manager.node_gyp_tempdir_name = try manager.allocator.dupe(u8, node_gyp_tempdir_name);
 
-        var node_gyp_tempdir = tempdir.makeOpenPath(manager.node_gyp_tempdir_name, .{}) catch |err| {
+        var node_gyp_tempdir = tempdir.handle.makeOpenPath(manager.node_gyp_tempdir_name, .{}) catch |err| {
             if (err == error.EEXIST) {
                 // it should not exist
                 Output.prettyErrorln("<r><red>error<r>: node-gyp tempdir already exists", .{});
@@ -515,17 +512,17 @@ var ensureTempNodeGypScriptOnce = bun.once(struct {
 
         // Add our node-gyp tempdir to the path
         const existing_path = manager.env.get("PATH") orelse "";
-        var PATH = try std.ArrayList(u8).initCapacity(bun.default_allocator, existing_path.len + 1 + manager.temp_dir_name.len + 1 + manager.node_gyp_tempdir_name.len);
+        var PATH = try std.ArrayList(u8).initCapacity(bun.default_allocator, existing_path.len + 1 + tempdir.name.len + 1 + manager.node_gyp_tempdir_name.len);
         try PATH.appendSlice(existing_path);
         if (existing_path.len > 0 and existing_path[existing_path.len - 1] != std.fs.path.delimiter)
             try PATH.append(std.fs.path.delimiter);
-        try PATH.appendSlice(strings.withoutTrailingSlash(manager.temp_dir_name));
+        try PATH.appendSlice(strings.withoutTrailingSlash(tempdir.name));
         try PATH.append(std.fs.path.sep);
         try PATH.appendSlice(manager.node_gyp_tempdir_name);
         try manager.env.map.put("PATH", PATH.items);
 
         const npm_config_node_gyp = try std.fmt.bufPrint(&path_buf, "{s}{s}{s}{s}{s}", .{
-            strings.withoutTrailingSlash(manager.temp_dir_name),
+            strings.withoutTrailingSlash(tempdir.name),
             std.fs.path.sep_str,
             strings.withoutTrailingSlash(manager.node_gyp_tempdir_name),
             std.fs.path.sep_str,

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -10,15 +10,113 @@ pub inline fn getCacheDirectoryAndAbsPath(this: *PackageManager) struct { FD, bu
     return .{ .fromStdDir(cache_dir), .from(this.cache_directory_path) };
 }
 
-pub inline fn getTemporaryDirectory(this: *PackageManager) std.fs.Dir {
-    return this.temp_dir_ orelse brk: {
-        this.temp_dir_ = ensureTemporaryDirectory(this);
-        var pathbuf: bun.PathBuffer = undefined;
-        const temp_dir_path = bun.getFdPathZ(.fromStdDir(this.temp_dir_.?), &pathbuf) catch Output.panic("Unable to read temporary directory path", .{});
-        this.temp_dir_path = bun.handleOom(bun.default_allocator.dupeZ(u8, temp_dir_path));
-        break :brk this.temp_dir_.?;
-    };
+pub inline fn getTemporaryDirectory(this: *PackageManager) TemporaryDirectory {
+    return getTemporaryDirectoryOnce.call(.{this});
 }
+
+const TemporaryDirectory = struct {
+    handle: std.fs.Dir,
+    path: [:0]const u8,
+    name: []const u8,
+};
+
+var getTemporaryDirectoryOnce = bun.once(struct {
+    // We need a temporary directory that can be rename()
+    // This is important for extracting files.
+    //
+    // However, we want it to be reused! Otherwise a cache is silly.
+    //   Error RenameAcrossMountPoints moving react-is to cache dir:
+    pub fn run(manager: *PackageManager) TemporaryDirectory {
+        var cache_directory = manager.getCacheDirectory();
+        // The chosen tempdir must be on the same filesystem as the cache directory
+        // This makes renameat() work
+        const temp_dir_name = Fs.FileSystem.RealFS.getDefaultTempDir();
+
+        var tried_dot_tmp = false;
+        var tempdir: std.fs.Dir = bun.MakePath.makeOpenPath(std.fs.cwd(), temp_dir_name, .{}) catch brk: {
+            tried_dot_tmp = true;
+            break :brk bun.MakePath.makeOpenPath(cache_directory, bun.pathLiteral(".tmp"), .{}) catch |err| {
+                Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
+                Global.crash();
+            };
+        };
+        var tmpbuf: bun.PathBuffer = undefined;
+        const tmpname = Fs.FileSystem.instance.tmpname("hm", &tmpbuf, bun.fastRandom()) catch unreachable;
+        var timer: std.time.Timer = if (manager.options.log_level != .silent) std.time.Timer.start() catch unreachable else undefined;
+        brk: while (true) {
+            var file = tempdir.createFileZ(tmpname, .{ .truncate = true }) catch |err2| {
+                if (!tried_dot_tmp) {
+                    tried_dot_tmp = true;
+
+                    tempdir = bun.MakePath.makeOpenPath(cache_directory, bun.pathLiteral(".tmp"), .{}) catch |err| {
+                        Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
+                        Global.crash();
+                    };
+
+                    if (PackageManager.verbose_install) {
+                        Output.prettyErrorln("<r><yellow>warn<r>: bun is unable to access tempdir: {s}, using fallback", .{@errorName(err2)});
+                    }
+
+                    continue :brk;
+                }
+                Output.prettyErrorln("<r><red>error<r>: {s} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>", .{
+                    @errorName(err2),
+                });
+                Global.crash();
+            };
+            file.close();
+
+            std.posix.renameatZ(tempdir.fd, tmpname, cache_directory.fd, tmpname) catch |err| {
+                if (!tried_dot_tmp) {
+                    tried_dot_tmp = true;
+                    tempdir = cache_directory.makeOpenPath(".tmp", .{}) catch |err2| {
+                        Output.prettyErrorln("<r><red>error<r>: bun is unable to write files to tempdir: {s}", .{@errorName(err2)});
+                        Global.crash();
+                    };
+
+                    if (PackageManager.verbose_install) {
+                        Output.prettyErrorln("<r><d>info<r>: cannot move files from tempdir: {s}, using fallback", .{@errorName(err)});
+                    }
+
+                    continue :brk;
+                }
+
+                Output.prettyErrorln("<r><red>error<r>: {s} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>", .{
+                    @errorName(err),
+                });
+                Global.crash();
+            };
+            cache_directory.deleteFileZ(tmpname) catch {};
+            break;
+        }
+        if (tried_dot_tmp) {
+            using_fallback_temp_dir = true;
+        }
+        if (manager.options.log_level != .silent) {
+            const elapsed = timer.read();
+            if (elapsed > std.time.ns_per_ms * 100) {
+                var path_buf: bun.PathBuffer = undefined;
+                const cache_dir_path = bun.getFdPath(.fromStdDir(cache_directory), &path_buf) catch "it";
+                Output.prettyErrorln(
+                    "<r><yellow>warn<r>: Slow filesystem detected. If {s} is a network drive, consider setting $BUN_INSTALL_CACHE_DIR to a local folder.",
+                    .{cache_dir_path},
+                );
+            }
+        }
+
+        var buf: bun.PathBuffer = undefined;
+        const temp_dir_path = bun.getFdPathZ(.fromStdDir(tempdir), &buf) catch |err| {
+            Output.err(err, "Failed to read temporary directory path: '{s}'", .{temp_dir_name});
+            Global.exit(1);
+        };
+
+        return .{
+            .handle = tempdir,
+            .name = temp_dir_name,
+            .path = bun.handleOom(bun.default_allocator.dupeZ(u8, temp_dir_path)),
+        };
+    }
+}.run);
 
 noinline fn ensureCacheDirectory(this: *PackageManager) std.fs.Dir {
     loop: while (true) {
@@ -48,92 +146,6 @@ noinline fn ensureCacheDirectory(this: *PackageManager) std.fs.Dir {
         };
     }
     unreachable;
-}
-
-// We need a temporary directory that can be rename()
-// This is important for extracting files.
-//
-// However, we want it to be reused! Otherwise a cache is silly.
-//   Error RenameAcrossMountPoints moving react-is to cache dir:
-noinline fn ensureTemporaryDirectory(this: *PackageManager) std.fs.Dir {
-    var cache_directory = this.getCacheDirectory();
-    // The chosen tempdir must be on the same filesystem as the cache directory
-    // This makes renameat() work
-    this.temp_dir_name = Fs.FileSystem.RealFS.getDefaultTempDir();
-
-    var tried_dot_tmp = false;
-    var tempdir: std.fs.Dir = bun.MakePath.makeOpenPath(std.fs.cwd(), this.temp_dir_name, .{}) catch brk: {
-        tried_dot_tmp = true;
-        break :brk bun.MakePath.makeOpenPath(cache_directory, bun.pathLiteral(".tmp"), .{}) catch |err| {
-            Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
-            Global.crash();
-        };
-    };
-    var tmpbuf: bun.PathBuffer = undefined;
-    const tmpname = Fs.FileSystem.instance.tmpname("hm", &tmpbuf, bun.fastRandom()) catch unreachable;
-    var timer: std.time.Timer = if (this.options.log_level != .silent) std.time.Timer.start() catch unreachable else undefined;
-    brk: while (true) {
-        var file = tempdir.createFileZ(tmpname, .{ .truncate = true }) catch |err2| {
-            if (!tried_dot_tmp) {
-                tried_dot_tmp = true;
-
-                tempdir = bun.MakePath.makeOpenPath(cache_directory, bun.pathLiteral(".tmp"), .{}) catch |err| {
-                    Output.prettyErrorln("<r><red>error<r>: bun is unable to access tempdir: {s}", .{@errorName(err)});
-                    Global.crash();
-                };
-
-                if (PackageManager.verbose_install) {
-                    Output.prettyErrorln("<r><yellow>warn<r>: bun is unable to access tempdir: {s}, using fallback", .{@errorName(err2)});
-                }
-
-                continue :brk;
-            }
-            Output.prettyErrorln("<r><red>error<r>: {s} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>", .{
-                @errorName(err2),
-            });
-            Global.crash();
-        };
-        file.close();
-
-        std.posix.renameatZ(tempdir.fd, tmpname, cache_directory.fd, tmpname) catch |err| {
-            if (!tried_dot_tmp) {
-                tried_dot_tmp = true;
-                tempdir = cache_directory.makeOpenPath(".tmp", .{}) catch |err2| {
-                    Output.prettyErrorln("<r><red>error<r>: bun is unable to write files to tempdir: {s}", .{@errorName(err2)});
-                    Global.crash();
-                };
-
-                if (PackageManager.verbose_install) {
-                    Output.prettyErrorln("<r><d>info<r>: cannot move files from tempdir: {s}, using fallback", .{@errorName(err)});
-                }
-
-                continue :brk;
-            }
-
-            Output.prettyErrorln("<r><red>error<r>: {s} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>", .{
-                @errorName(err),
-            });
-            Global.crash();
-        };
-        cache_directory.deleteFileZ(tmpname) catch {};
-        break;
-    }
-    if (tried_dot_tmp) {
-        using_fallback_temp_dir = true;
-    }
-    if (this.options.log_level != .silent) {
-        const elapsed = timer.read();
-        if (elapsed > std.time.ns_per_ms * 100) {
-            var path_buf: bun.PathBuffer = undefined;
-            const cache_dir_path = bun.getFdPath(.fromStdDir(cache_directory), &path_buf) catch "it";
-            Output.prettyErrorln(
-                "<r><yellow>warn<r>: Slow filesystem detected. If {s} is a network drive, consider setting $BUN_INSTALL_CACHE_DIR to a local folder.",
-                .{cache_dir_path},
-            );
-        }
-    }
-
-    return tempdir;
 }
 
 const CacheDir = struct { path: string, is_node_modules: bool };

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1259,7 +1259,7 @@ fn enqueueLocalTarball(
                     ) catch unreachable,
                     .resolution = resolution,
                     .cache_dir = this.getCacheDirectory(),
-                    .temp_dir = this.getTemporaryDirectory(),
+                    .temp_dir = this.getTemporaryDirectory().handle,
                     .dependency_id = dependency_id,
                     .url = strings.StringOrTinyString.initAppendIfNeeded(
                         path,

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -396,7 +396,7 @@ pub fn doPatchCommit(
     // write the patch contents to temp file then rename
     var tmpname_buf: [1024]u8 = undefined;
     const tempfile_name = bun.span(try bun.fs.FileSystem.instance.tmpname("tmp", &tmpname_buf, bun.fastRandom()));
-    const tmpdir = manager.getTemporaryDirectory();
+    const tmpdir = manager.getTemporaryDirectory().handle;
     const tmpfd = switch (bun.sys.openat(
         .fromStdDir(tmpdir),
         tempfile_name,

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -297,7 +297,7 @@ pub fn runTasks(
                             Npm.PackageManifest.Serializer.saveAsync(
                                 &entry.value_ptr.manifest,
                                 manager.scopeForPackageName(name.slice()),
-                                manager.getTemporaryDirectory(),
+                                manager.getTemporaryDirectory().handle,
                                 manager.getCacheDirectory(),
                             );
                         }
@@ -1066,7 +1066,7 @@ pub fn generateNetworkTaskForTarball(
             ) catch |err| bun.handleOom(err),
             .resolution = package.resolution,
             .cache_dir = this.getCacheDirectory(),
-            .temp_dir = this.getTemporaryDirectory(),
+            .temp_dir = this.getTemporaryDirectory().handle,
             .dependency_id = dependency_id,
             .integrity = package.meta.integrity,
             .url = strings.StringOrTinyString.initAppendIfNeeded(

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -457,7 +457,7 @@ pub const Registry = struct {
                 PackageManifest.Serializer.saveAsync(
                     &package,
                     scope,
-                    package_manager.getTemporaryDirectory(),
+                    package_manager.getTemporaryDirectory().handle,
                     package_manager.getCacheDirectory(),
                 );
             }
@@ -1070,7 +1070,7 @@ pub const PackageManifest = struct {
             // This needs many more call sites, doesn't have much impact on this location.
             var realpath_buf: bun.PathBuffer = undefined;
             const path_to_use_for_opening_file = if (Environment.isWindows)
-                bun.path.joinAbsStringBufZ(PackageManager.get().temp_dir_path, &realpath_buf, &.{ PackageManager.get().temp_dir_path, tmp_path }, .auto)
+                bun.path.joinAbsStringBufZ(PackageManager.get().getTemporaryDirectory().path, &realpath_buf, &.{tmp_path}, .auto)
             else
                 tmp_path;
 

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -522,7 +522,7 @@ pub const PatchTask = struct {
         const patchfile_path = bun.handleOom(manager.allocator.dupeZ(u8, patchdep.path.slice(manager.lockfile.buffers.string_bytes.items)));
 
         const pt = bun.new(PatchTask, .{
-            .tempdir = manager.getTemporaryDirectory(),
+            .tempdir = manager.getTemporaryDirectory().handle,
             .callback = .{
                 .calc_hash = .{
                     .state = state,
@@ -559,7 +559,7 @@ pub const PatchTask = struct {
         const patchfilepath = bun.handleOom(pkg_manager.allocator.dupe(u8, pkg_manager.lockfile.patched_dependencies.get(name_and_version_hash).?.path.slice(pkg_manager.lockfile.buffers.string_bytes.items)));
 
         const pt = bun.new(PatchTask, .{
-            .tempdir = pkg_manager.getTemporaryDirectory(),
+            .tempdir = pkg_manager.getTemporaryDirectory().handle,
             .callback = .{
                 .apply = .{
                     .pkg_id = pkg_id,

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -33,7 +33,7 @@
   "std.debug.dumpStackTrace": 0,
   "std.debug.print": 0,
   "std.enums.tagName(": 2,
-  "std.fs.Dir": 170,
+  "std.fs.Dir": 168,
   "std.fs.File": 62,
   "std.fs.cwd": 104,
   "std.log": 1,


### PR DESCRIPTION
### What does this PR do?
`PackageManager.temp_dir_path` is used for manifest serialization on windows. It is also accessed and potentially set on multiple threads. To avoid the problem entirely this PR wraps `getTemporaryDirectory` in `bun.once`.

fixes #22748
fixes #22629
fixes #19150
fixes #13779
### How did you verify your code works?
Manually