### PR TITLE
Fix dns.resolve callback parameters to match Node.js behavior

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -407,7 +407,7 @@ var InternalResolver = class Resolver {
           switch (rrtype?.toLowerCase()) {
             case "a":
             case "aaaa":
-              callback(null, hostname, results.map(mapResolveX));
+              callback(null, results.map(mapResolveX));
               break;
             default:
               callback(null, results);
@@ -792,7 +792,7 @@ const promises = {
     switch (rrtype?.toLowerCase()) {
       case "a":
       case "aaaa":
-        return translateErrorCode(dns.resolve(hostname, rrtype).then(promisifyLookup(defaultResultOrder())));
+        return translateErrorCode(dns.resolve(hostname, rrtype).then(promisifyResolveX(false)));
       default:
         return translateErrorCode(dns.resolve(hostname, rrtype));
     }
@@ -870,7 +870,7 @@ const promises = {
         case "a":
         case "aaaa":
           return translateErrorCode(
-            Resolver.#getResolver(this).resolve(hostname, rrtype).then(promisifyLookup(defaultResultOrder())),
+            Resolver.#getResolver(this).resolve(hostname, rrtype).then(promisifyResolveX(false)),
           );
         default:
           return translateErrorCode(Resolver.#getResolver(this).resolve(hostname, rrtype));

--- a/test/regression/issue/22712.test.ts
+++ b/test/regression/issue/22712.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import dns from "node:dns";
 
-test("dns.resolve callback parameters match Node.js", (done) => {
+test("dns.resolve callback parameters match Node.js", done => {
   dns.resolve("dns.google", (...args) => {
     // Should receive exactly 2 parameters: error and addresses array
     expect(args.length).toBe(2);
@@ -12,7 +12,7 @@ test("dns.resolve callback parameters match Node.js", (done) => {
   });
 });
 
-test("dns.resolve with A record type callback parameters", (done) => {
+test("dns.resolve with A record type callback parameters", done => {
   dns.resolve("dns.google", "A", (...args) => {
     expect(args.length).toBe(2);
     expect(args[0]).toBe(null);
@@ -22,7 +22,7 @@ test("dns.resolve with A record type callback parameters", (done) => {
   });
 });
 
-test("dns.resolve with AAAA record type callback parameters", (done) => {
+test("dns.resolve with AAAA record type callback parameters", done => {
   // Use a hostname that has AAAA records
   dns.resolve("google.com", "AAAA", (...args) => {
     expect(args.length).toBe(2);

--- a/test/regression/issue/22712.test.ts
+++ b/test/regression/issue/22712.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test";
+import dns from "node:dns";
+
+test("dns.resolve callback parameters match Node.js", (done) => {
+  dns.resolve("dns.google", (...args) => {
+    // Should receive exactly 2 parameters: error and addresses array
+    expect(args.length).toBe(2);
+    expect(args[0]).toBe(null); // no error
+    expect(Array.isArray(args[1])).toBe(true); // addresses should be array
+    expect(args[1].every((addr: any) => typeof addr === "string")).toBe(true); // each address should be string
+    done();
+  });
+});
+
+test("dns.resolve with A record type callback parameters", (done) => {
+  dns.resolve("dns.google", "A", (...args) => {
+    expect(args.length).toBe(2);
+    expect(args[0]).toBe(null);
+    expect(Array.isArray(args[1])).toBe(true);
+    expect(args[1].every((addr: any) => typeof addr === "string")).toBe(true);
+    done();
+  });
+});
+
+test("dns.resolve with AAAA record type callback parameters", (done) => {
+  // Use a hostname that has AAAA records
+  dns.resolve("google.com", "AAAA", (...args) => {
+    expect(args.length).toBe(2);
+    expect(args[0]).toBe(null);
+    expect(Array.isArray(args[1])).toBe(true);
+    expect(args[1].every((addr: any) => typeof addr === "string")).toBe(true);
+    done();
+  });
+});
+
+test("dns.promises.resolve returns array of strings", async () => {
+  const result = await dns.promises.resolve("dns.google");
+  expect(Array.isArray(result)).toBe(true);
+  expect(result.every((addr: any) => typeof addr === "string")).toBe(true);
+});
+
+test("dns.promises.resolve with A record returns array of strings", async () => {
+  const result = await dns.promises.resolve("dns.google", "A");
+  expect(Array.isArray(result)).toBe(true);
+  expect(result.every((addr: any) => typeof addr === "string")).toBe(true);
+});
+
+test("dns.promises.resolve with AAAA record returns array of strings", async () => {
+  const result = await dns.promises.resolve("google.com", "AAAA");
+  expect(Array.isArray(result)).toBe(true);
+  expect(result.every((addr: any) => typeof addr === "string")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Fixed `dns.resolve()` callback to pass 2 parameters instead of 3, matching Node.js
- Fixed `dns.promises.resolve()` to return array of strings for A/AAAA records instead of objects
- Added comprehensive regression tests

## What was wrong?

The `dns.resolve()` callback was incorrectly passing 3 parameters `(error, hostname, results)` instead of Node.js's 2 parameters `(error, results)`. Additionally, `dns.promises.resolve()` was returning objects with `{address, family}` instead of plain string arrays for A/AAAA records.

## How this fixes it

1. Removed the extra `hostname` parameter from the callback in `dns.resolve()` for A/AAAA records
2. Changed promise version to use `promisifyResolveX(false)` instead of `promisifyLookup()` to return string arrays
3. Applied same fixes to the `Resolver` class methods

## Test plan
- Added regression test `test/regression/issue/22712.test.ts` with 6 test cases
- All tests pass with the fix
- Verified existing DNS tests still pass

Fixes #22712

🤖 Generated with [Claude Code](https://claude.ai/code)