### PR TITLE
Fix arrow function names in test files

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -3742,19 +3742,16 @@ pub fn NewParser_(
             }
         }
 
-        pub fn keepExprSymbolName(_: *P, _value: Expr, _: string) Expr {
-            return _value;
-            // var start = p.expr_list.items.len;
-            // p.expr_list.ensureUnusedCapacity(2) catch unreachable;
-            // p.expr_list.appendAssumeCapacity(_value);
-            // p.expr_list.appendAssumeCapacity(p.newExpr(E.String{
-            //     .utf8 = name,
-            // }, _value.loc));
+        pub fn keepExprSymbolName(p: *P, _value: Expr, name: string) Expr {
+            // Create a call to the __name runtime helper
+            var args = p.allocator.alloc(Expr, 2) catch unreachable;
+            args[0] = _value;
+            args[1] = p.newExpr(E.String{ .data = name }, _value.loc);
 
-            // var value = p.callRuntime(_value.loc, "ℹ", p.expr_list.items[start..p.expr_list.items.len]);
-            // // Make sure tree shaking removes this if the function is never used
-            // value.getCall().can_be_unwrapped_if_unused = true;
-            // return value;
+            var value = p.callRuntime(_value.loc, "__name", args);
+            // Make sure tree shaking removes this if the function is never used
+            value.data.e_call.can_be_unwrapped_if_unused = .if_unused;
+            return value;
         }
 
         pub fn isSimpleParameterList(args: []G.Arg, has_rest_arg: bool) bool {

--- a/test/regression/issue/22770.test.ts
+++ b/test/regression/issue/22770.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test";
+
+// Regression test for issue #22770
+// https://github.com/oven-sh/bun/issues/22770
+// Arrow functions defined in tests should preserve their name property
+
+test("arrow function names are preserved inside tests", () => {
+  // Basic arrow function
+  const arrow1 = () => {};
+  expect(arrow1.name).toBe("arrow1");
+
+  // Arrow function with parameters
+  const arrow2 = (x: number) => x * 2;
+  expect(arrow2.name).toBe("arrow2");
+
+  // Arrow function with body
+  const arrow3 = () => {
+    return 42;
+  };
+  expect(arrow3.name).toBe("arrow3");
+
+  // Async arrow function
+  const arrow4 = async () => {};
+  expect(arrow4.name).toBe("arrow4");
+
+  // Arrow function in object literal
+  const obj = {
+    method: () => {},
+  };
+  expect(obj.method.name).toBe("method");
+
+  // Arrow function in nested scope
+  function nested() {
+    const arrow5 = () => {};
+    expect(arrow5.name).toBe("arrow5");
+  }
+  nested();
+
+  // Arrow function assigned later
+  let arrow6: () => void;
+  arrow6 = () => {};
+  expect(arrow6.name).toBe("arrow6");
+});
+
+test("arrow function names work with destructuring", () => {
+  const { foo = () => {} } = {};
+  expect(foo.name).toBe("foo");
+
+  const [bar = () => {}] = [];
+  expect(bar.name).toBe("bar");
+});
+
+test("anonymous arrow functions remain anonymous", () => {
+  const anon = (() => () => {})();
+  expect(anon.name).toBe("");
+
+  const arr = [() => {}];
+  expect(arr[0].name).toBe("");
+});

--- a/test/regression/issue/22770.test.ts
+++ b/test/regression/issue/22770.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // Regression test for issue #22770
 // https://github.com/oven-sh/bun/issues/22770


### PR DESCRIPTION
## Summary

Arrow functions were losing their inferred names when defined inside test blocks. This PR re-enables the `keepExprSymbolName` function to preserve arrow function names using the existing `__name` runtime helper.

Fixes #22770
Fixes #20398 (duplicate issue)

## The Problem

When arrow functions are defined inside test blocks, they lose their inferred names:

```javascript
test("arrow function name is lost", () => {
  const myFunc = () => {};
  console.log(myFunc.name); // "" (empty) - should be "myFunc"
});
```

This only affected test files, not regular JavaScript execution.

## Root Cause Analysis

1. **Test files are transpiled with `bundle = true`**: All test files go through the bundler pipeline with `opts.bundle = true` hardcoded in `ParseTask.zig:1159`

2. **The `keepExprSymbolName` function was disabled**: This function, responsible for preserving arrow function names during transpilation, was commented out and just returned the value unchanged

3. **Missing infrastructure**: The original commented implementation tried to use `p.expr_list.items` which doesn't exist in the parser structure, and referenced a mysterious "ℹ" runtime helper that was never implemented

## The Solution

Re-enabled `keepExprSymbolName` to use the existing `__name` runtime helper from `runtime.js`:

```zig
pub fn keepExprSymbolName(p: *P, _value: Expr, name: string) Expr {
    var args = p.allocator.alloc(Expr, 2) catch unreachable;
    args[0] = _value;
    args[1] = p.newExpr(E.String{ .data = name }, _value.loc);
    
    var value = p.callRuntime(_value.loc, "__name", args);
    value.data.e_call.can_be_unwrapped_if_unused = .if_unused;
    return value;
}
```

This generates a call to the `__name` helper which sets the function's name property at runtime.

## Why was it disabled?

Based on git history analysis, this function has been disabled since at least 2021 when Bun was first being developed. Likely reasons:

1. **Missing infrastructure**: The original implementation referenced non-existent parser fields
2. **Performance concerns**: Runtime helpers add overhead and bundle size
3. **Low priority**: Arrow function names in tests wasn't critical for early development
4. **Complexity**: The original approach with the "ℹ" helper was overly complex

## Testing

Added comprehensive regression tests in `test/regression/issue/22770.test.ts` covering:
- Basic arrow functions
- Arrow functions with parameters and bodies
- Async arrow functions
- Arrow functions in object literals
- Arrow functions in nested scopes
- Destructuring assignments
- Anonymous arrow functions (should remain anonymous)

All tests pass ✅

## Impact

- Fixes arrow function names in test files, making debugging easier
- Uses existing runtime infrastructure (no new helpers needed)
- Minimal performance impact (helper is tree-shakeable if unused)
- Brings test transpilation behavior closer to regular execution

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>