### PR TITLE
vscode extention - don't require start " " in test name pattern

### DIFF
--- a/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
+++ b/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
@@ -30,7 +30,7 @@ describe("BunTestController", () => {
       const pattern = internal.buildTestNamePattern(mockTests);
 
       expect(pattern).toContain(".*?");
-      expect(pattern).toBe("^ ?(test with .*?$)|(test with \\.*?$)");
+      expect(pattern).toBe("(^ ?test with .*?$)|(^ ?test with \\.*?$)");
     });
 
     test("should escape % formatters", () => {
@@ -41,7 +41,7 @@ describe("BunTestController", () => {
 
       const pattern = internal.buildTestNamePattern(mockTests);
 
-      expect(pattern).toBe("^ ?(test with .*?$)|(test with .*?$)");
+      expect(pattern).toBe("(^ ?test with .*?$)|(^ ?test with .*?$)");
     });
 
     test("should join multiple patterns with |", () => {
@@ -53,7 +53,7 @@ describe("BunTestController", () => {
 
       const pattern = internal.buildTestNamePattern(mockTests);
 
-      expect(pattern).toBe("^ ?(test 1$)|(test 2$)|(test 3$)");
+      expect(pattern).toBe("(^ ?test 1$)|(^ ?test 2$)|(^ ?test 3$)");
     });
 
     test("should handle describe blocks differently", () => {
@@ -61,7 +61,7 @@ describe("BunTestController", () => {
 
       const pattern = internal.buildTestNamePattern(mockTests);
 
-      expect(pattern).toBe("^ ?(describe block )");
+      expect(pattern).toBe("(^ ?describe block )");
     });
 
     test("should handle complex nested test names", () => {
@@ -117,7 +117,7 @@ describe("BunTestController", () => {
       ] as any;
 
       const pattern = internal.buildTestNamePattern(mockTests);
-      expect(pattern).toBe("^ ?(test without tags)|(another test)");
+      expect(pattern).toBe("(test without tags)|(another test)");
     });
 
     test("should handle Unicode and emoji in test names", () => {

--- a/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
+++ b/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
@@ -30,7 +30,7 @@ describe("BunTestController", () => {
       const pattern = internal.buildTestNamePattern(mockTests);
 
       expect(pattern).toContain(".*?");
-      expect(pattern).toBe("(^ test with .*?$)|(^ test with \\.*?$)");
+      expect(pattern).toBe("^ ?(test with .*?$)|(test with \\.*?$)");
     });
 
     test("should escape % formatters", () => {
@@ -41,7 +41,7 @@ describe("BunTestController", () => {
 
       const pattern = internal.buildTestNamePattern(mockTests);
 
-      expect(pattern).toBe("(^ test with .*?$)|(^ test with .*?$)");
+      expect(pattern).toBe("^ ?(test with .*?$)|(test with .*?$)");
     });
 
     test("should join multiple patterns with |", () => {
@@ -53,7 +53,7 @@ describe("BunTestController", () => {
 
       const pattern = internal.buildTestNamePattern(mockTests);
 
-      expect(pattern).toBe("(^ test 1$)|(^ test 2$)|(^ test 3$)");
+      expect(pattern).toBe("^ ?(test 1$)|(test 2$)|(test 3$)");
     });
 
     test("should handle describe blocks differently", () => {
@@ -61,7 +61,7 @@ describe("BunTestController", () => {
 
       const pattern = internal.buildTestNamePattern(mockTests);
 
-      expect(pattern).toBe("(^ describe block )");
+      expect(pattern).toBe("^ ?(describe block )");
     });
 
     test("should handle complex nested test names", () => {
@@ -117,7 +117,7 @@ describe("BunTestController", () => {
       ] as any;
 
       const pattern = internal.buildTestNamePattern(mockTests);
-      expect(pattern).toBe("(test without tags)|(another test)");
+      expect(pattern).toBe("^ ?(test without tags)|(another test)");
     });
 
     test("should handle Unicode and emoji in test names", () => {

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -1351,7 +1351,7 @@ export class BunTestController implements vscode.Disposable {
       return null;
     }
 
-    return testNames.map(e => `^ ?(${e})`).join("|");
+    return "^ ?" + testNames.map(e => `(${e})`).join("|");
   }
 
   private disconnectInspector(): void {

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -1339,9 +1339,9 @@ export class BunTestController implements vscode.Disposable {
       t = t.replaceAll(/\$[\w\.\[\]]+/g, ".*?");
 
       if (test?.tags?.some(tag => tag.id === "test" || tag.id === "it")) {
-        testNames.push(`${t}$`);
+        testNames.push(`^ ?${t}$`);
       } else if (test?.tags?.some(tag => tag.id === "describe")) {
-        testNames.push(`${t} `);
+        testNames.push(`^ ?${t} `);
       } else {
         testNames.push(t);
       }
@@ -1351,7 +1351,7 @@ export class BunTestController implements vscode.Disposable {
       return null;
     }
 
-    return "^ ?" + testNames.map(e => `(${e})`).join("|");
+    return testNames.map(e => `(${e})`).join("|");
   }
 
   private disconnectInspector(): void {

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -1339,9 +1339,9 @@ export class BunTestController implements vscode.Disposable {
       t = t.replaceAll(/\$[\w\.\[\]]+/g, ".*?");
 
       if (test?.tags?.some(tag => tag.id === "test" || tag.id === "it")) {
-        testNames.push(`^ ${t}$`);
+        testNames.push(`${t}$`);
       } else if (test?.tags?.some(tag => tag.id === "describe")) {
-        testNames.push(`^ ${t} `);
+        testNames.push(`${t} `);
       } else {
         testNames.push(t);
       }
@@ -1351,7 +1351,7 @@ export class BunTestController implements vscode.Disposable {
       return null;
     }
 
-    return testNames.map(e => `(${e})`).join("|");
+    return testNames.map(e => `^ ?(${e})`).join("|");
   }
 
   private disconnectInspector(): void {


### PR DESCRIPTION
### What does this PR do?

#22534 made `--test-name-pattern` more logical and not start with empty ` ` (space), so fixing the built regex to make it work still for old and new bun

The other main issue that that pr did was make start events for filtered out names which means it appears to rerun them all even when in reality it doesn't as they are skipped (but this pr doesn't fix)

Also in theory with concurrent test, if there's an error after another started it would be assigned to the wrong test because we don't get test id's in the error event, so its just assumed its from the last started one which with parallel means it isn't correct.

### How did you verify your code works?
