### PR TITLE
fix(crypto): add shake-128 and shake-256 algorithms to CryptoHasher and EVP

### DIFF
--- a/src/bun.js/api/crypto/CryptoHasher.zig
+++ b/src/bun.js/api/crypto/CryptoHasher.zig
@@ -487,7 +487,9 @@ const CryptoHasherZig = struct {
         .{ "sha3-384", std.crypto.hash.sha3.Sha3_384 },
         .{ "sha3-512", std.crypto.hash.sha3.Sha3_512 },
         .{ "shake128", std.crypto.hash.sha3.Shake128 },
+        .{ "shake-128", std.crypto.hash.sha3.Shake128 },
         .{ "shake256", std.crypto.hash.sha3.Shake256 },
+        .{ "shake-256", std.crypto.hash.sha3.Shake256 },
     };
 
     inline fn digestLength(Algorithm: type) comptime_int {

--- a/src/bun.js/api/crypto/CryptoHasher.zig
+++ b/src/bun.js/api/crypto/CryptoHasher.zig
@@ -487,8 +487,8 @@ const CryptoHasherZig = struct {
         .{ "sha3-384", std.crypto.hash.sha3.Sha3_384 },
         .{ "sha3-512", std.crypto.hash.sha3.Sha3_512 },
         .{ "shake128", std.crypto.hash.sha3.Shake128 },
-        .{ "shake-128", std.crypto.hash.sha3.Shake128 },
         .{ "shake256", std.crypto.hash.sha3.Shake256 },
+        .{ "shake-128", std.crypto.hash.sha3.Shake128 },
         .{ "shake-256", std.crypto.hash.sha3.Shake256 },
     };
 

--- a/src/bun.js/api/crypto/EVP.zig
+++ b/src/bun.js/api/crypto/EVP.zig
@@ -36,7 +36,9 @@ pub const Algorithm = enum {
     @"sha3-256",
     @"sha3-384",
     @"sha3-512",
+    @"shake-128",
     shake128,
+    @"shake-256",
     shake256,
 
     pub fn md(this: Algorithm) ?*const BoringSSL.EVP_MD {
@@ -98,7 +100,9 @@ pub const Algorithm = enum {
         .{ "sha3-384", .@"sha3-384" },
         .{ "sha3-512", .@"sha3-512" },
         .{ "shake128", .shake128 },
+        .{ "shake-128", .shake128 },
         .{ "shake256", .shake256 },
+        .{ "shake-256", .shake256 },
         // .{ "md5-sha1", .@"MD5-SHA1" },
         // .{ "dsa-sha", .@"DSA-SHA" },
         // .{ "dsa-sha1", .@"DSA-SHA1" },

--- a/src/bun.js/api/crypto/EVP.zig
+++ b/src/bun.js/api/crypto/EVP.zig
@@ -36,10 +36,11 @@ pub const Algorithm = enum {
     @"sha3-256",
     @"sha3-384",
     @"sha3-512",
-    @"shake-128",
     shake128,
-    @"shake-256",
     shake256,
+
+    pub const @"shake-128": Algorithm = .shake128;
+    pub const @"shake-256": Algorithm = .shake256;
 
     pub fn md(this: Algorithm) ?*const BoringSSL.EVP_MD {
         return switch (this) {

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -62,6 +62,7 @@ describe("crypto.hash", () => {
     "sha-512_256",
     "sha-512256",
     "sha512-256",
+    "sha384",
     "sha3-224",
     "sha3-256",
     "sha3-384",
@@ -72,7 +73,7 @@ describe("crypto.hash", () => {
     "shake-256",
   ].forEach(method => {
     test(`output matches crypto.createHash(${method})`, () => {
-      for (const outputEncoding of ["buffer", "hex", "base64", "base64url", undefined]) {
+      for (const outputEncoding of ["buffer", "hex", "base64", undefined]) {
         const oldDigest = crypto
           .createHash(method)
           .update(input)

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -62,7 +62,6 @@ describe("crypto.hash", () => {
     "sha-512_256",
     "sha-512256",
     "sha512-256",
-    "sha384",
     "sha3-224",
     "sha3-256",
     "sha3-384",
@@ -73,7 +72,7 @@ describe("crypto.hash", () => {
     "shake-256",
   ].forEach(method => {
     test(`output matches crypto.createHash(${method})`, () => {
-      for (const outputEncoding of ["buffer", "hex", "base64", undefined]) {
+      for (const outputEncoding of ["buffer", "hex", "base64", "base64url", undefined]) {
         const oldDigest = crypto
           .createHash(method)
           .update(input)

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -68,7 +68,9 @@ describe("crypto.hash", () => {
     "sha3-384",
     "sha3-512",
     "shake128",
+    "shake-128",
     "shake256",
+    "shake-256",
   ].forEach(method => {
     test(`output matches crypto.createHash(${method})`, () => {
       for (const outputEncoding of ["buffer", "hex", "base64", undefined]) {


### PR DESCRIPTION
## What does this PR do?

added support for the shake-128 and shake-256 aliases in crypto.hash so they match node

## How did you verify your code works?

- updated and ran bun bd test test/js/node/crypto/crypto-oneshot.test.ts
- verified that script from original issue outputs correct result
<img width="762" height="88" alt="image" src="https://github.com/user-attachments/assets/d6401a0b-a9c0-44f4-a1a5-448ef3fdc2dc" />

fixes #18019 