### PR TITLE
fix(test): add EXPECTED_COLOR and RECEIVED_COLOR aliases

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -91,6 +91,7 @@ declare module "bun:test" {
   export namespace jest {
     function restoreAllMocks(): void;
     function clearAllMocks(): void;
+    function resetAllMocks(): void;
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     function setSystemTime(now?: number | Date): void;
     function setTimeout(milliseconds: number): void;
@@ -180,6 +181,9 @@ declare module "bun:test" {
      * Clear all mock state (calls, results, etc.) without restoring original implementation
      */
     clearAllMocks: typeof jest.clearAllMocks;
+    resetAllMocks: typeof jest.resetAllMocks;
+    useFakeTimers: typeof jest.useFakeTimers;
+    useRealTimers: typeof jest.useRealTimers;
   };
 
   interface FunctionLike {

--- a/src/bun.js/test/jest.classes.ts
+++ b/src/bun.js/test/jest.classes.ts
@@ -151,6 +151,14 @@ export default [
         fn: "printReceived",
         length: 1,
       },
+      EXPECTED_COLOR: {
+        fn: "printExpected",
+        length: 1,
+      },
+      RECEIVED_COLOR: {
+        fn: "printReceived",
+        length: 1,
+      },
       matcherHint: {
         fn: "matcherHint",
         length: 1,

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -210,12 +210,15 @@ pub const Jest = struct {
             Expect.js.getConstructor(globalObject),
         );
 
-        const vi = JSValue.createEmptyObject(globalObject, 5);
+        const vi = JSValue.createEmptyObject(globalObject, 8);
         vi.put(globalObject, ZigString.static("fn"), mockFn);
         vi.put(globalObject, ZigString.static("mock"), mockModuleFn);
         vi.put(globalObject, ZigString.static("spyOn"), spyOn);
         vi.put(globalObject, ZigString.static("restoreAllMocks"), restoreAllMocks);
+        vi.put(globalObject, ZigString.static("resetAllMocks"), clearAllMocks);
         vi.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
+        vi.put(globalObject, ZigString.static("useFakeTimers"), useFakeTimers);
+        vi.put(globalObject, ZigString.static("useRealTimers"), useRealTimers);
         module.put(globalObject, ZigString.static("vi"), vi);
     }
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -378,3 +378,18 @@ it("works on classes", () => {
   expect.extend(new Foo());
   expect(123)._toBeBar();
 });
+
+describe("MatcherContext", () => {
+  describe("utils", () => {
+    test("RECEIVED_COLOR is a function", () => {
+      expect.extend({
+        toBeCustomColor(_actual, _expected) {
+          expect(this.utils.RECEIVED_COLOR).toBeFunction();
+          return { pass: true };
+        },
+      });
+
+      expect(123).toBeCustomColor(456);
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
This PR does two things.

First, it fixes a bug when using [`jest-dom`](https://github.com/testing-library/jest-dom) where expectation failures would break as `RECEIVED_COLOR` and `EXPECTED_COLOR` are not properties of `ExpectMatcherContext`. 
<img width="1216" height="139" alt="image" src="https://github.com/user-attachments/assets/26ef87c2-f763-4a46-83a3-d96c4c534f3d" />

Second, it adds some existing timer mock functions that were missing from the `vi` object.

### How did you verify your code works?

I've added a test.