### PR TITLE
Fix infinite recursion when error.stack is a circular reference

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2278,6 +2278,13 @@ pub const Formatter = struct {
                 }
             },
             .Error => {
+                // Temporarily remove from the visited map to allow printErrorlikeObject to process it
+                // The circular reference check is already done in printAs, so we know it's safe
+                const was_in_map = if (this.map_node != null) this.map.remove(value) else false;
+                defer if (was_in_map) {
+                    _ = this.map.put(value, {}) catch {};
+                };
+
                 VirtualMachine.get().printErrorlikeObject(
                     value,
                     null,

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -2891,6 +2891,29 @@ fn printErrorInstance(
     comptime allow_ansi_color: bool,
     comptime allow_side_effects: bool,
 ) !void {
+    // Initialize the visited map if not already initialized
+    var remove_from_map = false;
+    if (mode == .js) {
+        if (formatter.map_node == null) {
+            formatter.map_node = ConsoleObject.Formatter.Visited.Pool.get(default_allocator);
+            formatter.map_node.?.data.clearRetainingCapacity();
+            formatter.map = formatter.map_node.?.data;
+        }
+
+        // Check if this error has already been visited
+        const entry = formatter.map.getOrPut(error_instance) catch unreachable;
+        if (entry.found_existing) {
+            try writer.writeAll(comptime Output.prettyFmt("<r><cyan>[Circular]<r>", allow_ansi_color));
+            return;
+        }
+        remove_from_map = true;
+    }
+
+    // Remove from map when we're done processing this error
+    defer if (mode == .js and remove_from_map) {
+        _ = formatter.map.remove(error_instance);
+    };
+
     var exception_holder = if (mode == .js) ZigException.Holder.init();
     var exception = if (mode == .js) exception_holder.zigException() else error_instance;
     defer if (mode == .js) exception_holder.deinit(this);

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4888,6 +4888,10 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
             return;
         if (stackValue) {
+            // Prevent infinite recursion if stack property is the error object itself
+            if (stackValue == val) {
+                return;
+            }
             if (stackValue.isString()) {
                 WTF::String stack = stackValue.toWTFString(global);
                 if (!scope.clearExceptionExceptTermination()) [[unlikely]] {

--- a/test/regression/issue/circular-error-stack-edge-cases.test.ts
+++ b/test/regression/issue/circular-error-stack-edge-cases.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("error.stack getter that throws should not crash", async () => {
@@ -23,11 +23,7 @@ test("error.stack getter that throws should not crash", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("after error print");
@@ -57,11 +53,7 @@ test("error.stack getter returning circular reference", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("after error print");
@@ -97,11 +89,7 @@ test("error with multiple throwing getters", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("after error print");

--- a/test/regression/issue/circular-error-stack-edge-cases.test.ts
+++ b/test/regression/issue/circular-error-stack-edge-cases.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("error.stack getter that throws should not crash", async () => {
+  using dir = tempDir("throwing-stack-getter", {
+    "index.js": `
+      const error = new Error("Test error");
+      Object.defineProperty(error, "stack", {
+        get() {
+          throw new Error("Stack getter throws!");
+        }
+      });
+      console.log(error);
+      console.log("after error print");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("after error print");
+  expect(stdout).not.toContain("Stack getter throws");
+  expect(stderr).not.toContain("Stack getter throws");
+});
+
+test("error.stack getter returning circular reference", async () => {
+  using dir = tempDir("circular-stack-getter", {
+    "index.js": `
+      const error = new Error("Test error");
+      Object.defineProperty(error, "stack", {
+        get() {
+          return error; // Return the error itself
+        }
+      });
+      console.log(error);
+      console.log("after error print");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("after error print");
+  expect(stdout).not.toContain("Maximum call stack");
+  expect(stderr).not.toContain("Maximum call stack");
+});
+
+test("error with multiple throwing getters", async () => {
+  using dir = tempDir("multiple-throwing-getters", {
+    "index.js": `
+      const error = new Error("Test error");
+      Object.defineProperty(error, "stack", {
+        get() {
+          throw new Error("Stack throws!");
+        }
+      });
+      Object.defineProperty(error, "cause", {
+        get() {
+          throw new Error("Cause throws!");
+        }
+      });
+      error.normalProp = "works";
+      console.log(error);
+      console.log("after error print");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("after error print");
+  expect(stdout).toContain("normalProp");
+  expect(stdout).not.toContain("Stack throws");
+  expect(stdout).not.toContain("Cause throws");
+});

--- a/test/regression/issue/circular-error-stack.test.ts
+++ b/test/regression/issue/circular-error-stack.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+test("error with circular stack reference should not cause infinite recursion", async () => {
+  using dir = tempDir("circular-error-stack", {
+    "index.js": `
+      const error = new Error("Test error");
+      error.stack = error;
+      console.log(error);
+      console.log("after error print");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("after error print");
+  expect(stdout).not.toContain("Maximum call stack");
+  expect(stderr).not.toContain("Maximum call stack");
+});
+
+test("error with nested circular references should not cause infinite recursion", async () => {
+  using dir = tempDir("nested-circular-error", {
+    "index.js": `
+      const error1 = new Error("Error 1");
+      const error2 = new Error("Error 2");
+      error1.stack = error2;
+      error2.stack = error1;
+      console.log(error1);
+      console.log("after error print");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("after error print");
+  expect(stdout).not.toContain("Maximum call stack");
+  expect(stderr).not.toContain("Maximum call stack");
+});
+
+test("error with circular reference in cause chain", async () => {
+  using dir = tempDir("circular-error-cause", {
+    "index.js": `
+      const error1 = new Error("Error 1");
+      const error2 = new Error("Error 2");
+      error1.cause = error2;
+      error2.cause = error1;
+      console.log(error1);
+      console.log("after error print");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("after error print");
+  expect(stdout).not.toContain("Maximum call stack");
+  expect(stderr).not.toContain("Maximum call stack");
+});

--- a/test/regression/issue/circular-error-stack.test.ts
+++ b/test/regression/issue/circular-error-stack.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("error with circular stack reference should not cause infinite recursion", async () => {
   using dir = tempDir("circular-error-stack", {
@@ -19,11 +19,7 @@ test("error with circular stack reference should not cause infinite recursion", 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("after error print");
@@ -51,11 +47,7 @@ test("error with nested circular references should not cause infinite recursion"
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("after error print");
@@ -83,11 +75,7 @@ test("error with circular reference in cause chain", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("after error print");


### PR DESCRIPTION
## Summary

This PR fixes infinite recursion and stack overflow crashes when error objects have circular references in their properties, particularly when `error.stack = error`.

### The Problem
When an error object's stack property references itself or creates a circular reference chain, Bun would enter infinite recursion and crash. Common patterns that triggered this:
```javascript
const error = new Error();
error.stack = error;  // Crash!
console.log(error);

// Or circular cause chains:
error1.cause = error2;
error2.cause = error1;  // Crash!
```

### The Solution
Added proper circular reference detection at three levels:

1. **C++ bindings layer** (`bindings.cpp`): Skip processing if `stack` property equals the error object itself
2. **VirtualMachine layer** (`VirtualMachine.zig`): Track visited errors when printing error instances and their causes  
3. **ConsoleObject layer** (`ConsoleObject.zig`): Properly coordinate visited map between formatters

Circular references are now safely detected and printed as `[Circular]` instead of causing crashes.

## Test plan

Added comprehensive tests in `test/regression/issue/circular-error-stack.test.ts`:
- ✅ `error.stack = error` circular reference
- ✅ Nested circular references via error properties  
- ✅ Circular cause chains (`error1.cause = error2; error2.cause = error1`)

All tests pass:
```
bun test circular-error-stack.test.ts
✓ error with circular stack reference should not cause infinite recursion
✓ error with nested circular references should not cause infinite recursion  
✓ error with circular reference in cause chain
```

Manual testing:
```javascript
// Before: Stack overflow crash
// After: Prints error normally
const error = new Error("Test");
error.stack = error;
console.log(error);  // error: Test
```

🤖 Generated with [Claude Code](https://claude.ai/code)