### PR TITLE
Make sure bun can be installed on Alpine Linux (musl) on arm64 hardware

### DIFF
--- a/packages/bun-release/src/platform.ts
+++ b/packages/bun-release/src/platform.ts
@@ -62,7 +62,7 @@ export const platforms: Platform[] = [
   },
   {
     os: "linux",
-    arch: "aarch64",
+    arch: "arm64",
     abi: "musl",
     bin: "bun-linux-aarch64-musl",
     exe: "bin/bun",


### PR DESCRIPTION
### What does this PR do?
This PRs adjusts the "arch" string for Linux-musl variant to make sure it can be installed on ARM64 platforms using `npm`. Without this fix, installing bun on Alpine Linux on arm64 fails because the native binary cannot be found.

#### Why it fails
Bun attempts to find/download the native binaries during the postinstall phase (see [install.ts](https://github.com/oven-sh/bun/blob/bun-v1.1.42/packages/bun-release/src/npm/install.ts)). The platform matching logic lives in [platform.ts](https://github.com/oven-sh/bun/blob/bun-v1.1.42/packages/bun-release/src/platform.ts). Note how the "musl" variant is marked [as "aarch64"](https://github.com/oven-sh/bun/blob/bun-v1.1.42/packages/bun-release/src/platform.ts#L63-L69), while the regular "glibc" variant is marked [as "arm64"](https://github.com/oven-sh/bun/blob/bun-v1.1.42/packages/bun-release/src/platform.ts#L44-L49). On Alpine Linux distributions (or when using "node-alpine" docker image) we're supposed to be using the "musl" binary. However, since bun marks it as "aarch64" while the matching logic relies on `process.arch`, it never gets matched. Node.js uses "arm64", _not_ "aarch64" (see ["process.arch" docs](https://nodejs.org/docs/latest-v22.x/api/process.html#processarch)). In short - a mismatch between the expected arch ("aarch64") and the actual reported arch ("arm64") prevents bun from finding the right binary when installing with npm/pnpm.

### How did you verify your code works?
Verified by running the installer on Alpine Linux on arm64.

cc @magus