### PR TITLE
Improve --reporter flag help and error messages

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -122,7 +122,7 @@
         },
         {
           "name": "reporter",
-          "description": "Specify the test reporter. Currently --reporter=junit is the only supported format.",
+          "description": "Test output reporter format. Available: 'junit' (requires --reporter-outfile). Default: console output.",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -130,7 +130,7 @@
         },
         {
           "name": "reporter-outfile",
-          "description": "The output file used for the format from --reporter.",
+          "description": "Output file path for the reporter format (required with --reporter).",
           "hasValue": true,
           "valueType": "val",
           "required": false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -200,8 +200,8 @@ pub const test_only_params = [_]ParamType{
     clap.parseParam("--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'.") catch unreachable,
     clap.parseParam("--bail <NUMBER>?                 Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1.") catch unreachable,
     clap.parseParam("-t, --test-name-pattern <STR>    Run only tests with a name that matches the given regex.") catch unreachable,
-    clap.parseParam("--reporter <STR>                 Specify the test reporter. Currently --reporter=junit is the only supported format.") catch unreachable,
-    clap.parseParam("--reporter-outfile <STR>         The output file used for the format from --reporter.") catch unreachable,
+    clap.parseParam("--reporter <STR>                 Test output reporter format. Available: 'junit' (requires --reporter-outfile). Default: console output.") catch unreachable,
+    clap.parseParam("--reporter-outfile <STR>         Output file path for the reporter format (required with --reporter).") catch unreachable,
 };
 pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -425,7 +425,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 } else if (bun.strings.eqlComptime(reporter, "lcov")) {
                     ctx.test_options.coverage.reporters.lcov = true;
                 } else {
-                    Output.prettyErrorln("<r><red>error<r>: --coverage-reporter received invalid reporter: \"{s}\"", .{reporter});
+                    Output.prettyErrorln("<r><red>error<r>: invalid coverage reporter '{s}'. Available options: 'text' (console output), 'lcov' (code coverage file)", .{reporter});
                     Global.exit(1);
                 }
             }
@@ -438,12 +438,12 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         if (args.option("--reporter")) |reporter| {
             if (strings.eqlComptime(reporter, "junit")) {
                 if (ctx.test_options.reporter_outfile == null) {
-                    Output.errGeneric("--reporter=junit expects an output file from --reporter-outfile", .{});
+                    Output.errGeneric("--reporter=junit requires --reporter-outfile [file] to specify where to save the XML report", .{});
                     Global.crash();
                 }
                 ctx.test_options.file_reporter = .junit;
             } else {
-                Output.errGeneric("unrecognized reporter format: '{s}'. Currently, only 'junit' is supported", .{reporter});
+                Output.errGeneric("unsupported reporter format '{s}'. Available options: 'junit' (for XML test results)", .{reporter});
                 Global.crash();
             }
         }


### PR DESCRIPTION
## Summary
- Clarifies help text for `--reporter` and `--reporter-outfile` flags
- Improves error messages when invalid reporter formats are specified
- Makes distinction between test reporters and coverage reporters clearer

## Changes
1. Updated help text in `Arguments.zig` to better explain:
   - What formats are currently available (only 'junit' for --reporter)
   - Default behavior (console output for tests)
   - Requirements (--reporter-outfile needed with --reporter=junit)
   
2. Improved error messages to list available options when invalid formats are used

3. Updated CLI completions to match the new help text

## Test plan
- [x] Built and tested with `bun bd`
- [x] Verified help text displays correctly: `./build/debug/bun-debug test --help`
- [x] Tested error message for invalid reporter: `./build/debug/bun-debug test --reporter=json`
- [x] Tested error message for missing outfile: `./build/debug/bun-debug test --reporter=junit`
- [x] Tested error message for invalid coverage reporter: `./build/debug/bun-debug test --coverage-reporter=invalid`
- [x] Verified junit reporter still works: `./build/debug/bun-debug test --reporter=junit --reporter-outfile=/tmp/junit.xml`
- [x] Verified lcov coverage reporter still works: `./build/debug/bun-debug test --coverage --coverage-reporter=lcov`

🤖 Generated with [Claude Code](https://claude.ai/code)