### PR TITLE
 fix version tag infer: return tarball for gitlab tarball urls

### DIFF
--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -662,6 +662,10 @@ pub const Version = struct {
                                 if (isGitHubRepoPath(path)) return .github;
                             }
 
+                            if (isTarball(url)) {
+                                return .tarball;
+                            }
+
                             if (strings.indexOfChar(url, '.')) |dot| {
                                 if (Repository.Hosts.has(url[0..dot])) return .git;
                             }

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -252,7 +252,7 @@ pub inline fn isGitHubTarballPath(dependency: string) bool {
     if (strings.eqlComptime(third_part, "tarball")) {
         // The <ref> is mandatory!! There may actually be any more subpaths
         // (for weird branch names, or not -- github ignores them)
-        return if (url_parts_it.next()) |_| true else false;
+        return if (url_parts_it.next()) |ref| ref.len > 0 else false;
     }
 
     // We're not done... Branches may end with .tar.gz...

--- a/test/cli/install/__snapshots__/bun-install-dep.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install-dep.test.ts.snap
@@ -395,3 +395,36 @@ exports[`dependencies: {"bar": "1.0.0 - 2.0.0"} 1`] = `
   "version": ">=1.0.0 <=2.0.0-bar",
 }
 `;
+
+exports[`npa https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_1_4/inkscape-INKSCAPE_1_4.tar.gz 1`] = `
+{
+  "name": "",
+  "version": {
+    "name": "",
+    "type": "tarball",
+    "url": "https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_1_4/inkscape-INKSCAPE_1_4.tar.gz",
+  },
+}
+`;
+
+exports[`npa file:./path/to/folder 1`] = `
+{
+  "name": "",
+  "version": {
+    "folder": "./path/to/folder",
+    "type": "folder",
+  },
+}
+`;
+
+exports[`npa https://github.com/Jarred-Sumner/test-tarball-url.tgz 1`] = `
+{
+  "name": "",
+  "version": {
+    "owner": "Jarred-Sumner",
+    "ref": "",
+    "repo": "test-tarball-url.tgz",
+    "type": "github",
+  },
+}
+`;

--- a/test/cli/install/bun-install-dep.test.ts
+++ b/test/cli/install/bun-install-dep.test.ts
@@ -1,48 +1,64 @@
 import { npa } from "bun:internal-for-testing";
-import { expect, test } from "bun:test";
+import { expect, test, describe } from "bun:test";
 
-const bitbucket = [
-  "bitbucket:dylan-conway/public-install-test",
-  "bitbucket.org:dylan-conway/public-install-test",
-  "bitbucket.com:dylan-conway/public-install-test",
-  "git@bitbucket.org:dylan-conway/public-install-test",
-];
+const TEST_DEPENDENCIES_BY_TYPE = {
+  "dist_tag": [
+    "package",
+    "@scoped/package",
+  ],
+  "npm": [
+    "@scoped/package@1.0.0",
+    "@scoped/package@1.0.0-beta.1",
+    "@scoped/package@1.0.0-beta.1+build.123",
+    "package@1.0.0",
+    "package@1.0.0-beta.1",
+    "package@1.0.0-beta.1+build.123",
+  ],
+  "tarball": [
+    "./path/to/tarball.tgz",
+    "file:./path/to/tarball.tgz",
+    "http://localhost:5000/no-deps/-/no-deps-2.0.0.tgz",
+    "https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_1_4/inkscape-INKSCAPE_1_4.tar.gz",
+    "https://registry.npmjs.org/no-deps/-/no-deps-2.0.0.tgz",
+  ],
+  "folder": [
+    "file:./path/to/folder",
+  ],
+  "git": [
+    "bitbucket.com:dylan-conway/public-install-test",
+    "bitbucket.org:dylan-conway/public-install-test",
+    "bitbucket:dylan-conway/public-install-test",
+    "git@bitbucket.org:dylan-conway/public-install-test",
+    "git@github.com:dylan-conway/public-install-test",
+    "gitlab.com:dylan-conway/public-install-test",
+    "gitlab:dylan-conway/public-install-test",
+    "https://github.com/dylan-conway/public-install-test.git#semver:^1.0.0",
+  ],
+  "github": [
+    "foo/bar",
+    "github:dylan-conway/public-install-test",
+    "https://github.com/Jarred-Sumner/test-tarball-url.tgz",
+    "https://github.com/dylan-conway/public-install-test",
+    "https://github.com/dylan-conway/public-install-test.git",
+  ],
+};
 
-const tarball_remote = [
-  "http://localhost:5000/no-deps/-/no-deps-2.0.0.tgz",
-  "https://registry.npmjs.org/no-deps/-/no-deps-2.0.0.tgz",
-];
 
-const local_tarball = ["file:./path/to/tarball.tgz", "./path/to/tarball.tgz"];
-const github = ["foo/bar"];
-const folder = ["file:./path/to/folder"];
+const ALL_TEST_DEPENDENCIES = Object.values(TEST_DEPENDENCIES_BY_TYPE).flat();
 
-const gitlab = ["gitlab:dylan-conway/public-install-test", "gitlab.com:dylan-conway/public-install-test"];
-
-const all = [
-  "@scoped/package",
-  "@scoped/package@1.0.0",
-  "@scoped/package@1.0.0-beta.1",
-  "@scoped/package@1.0.0-beta.1+build.123",
-  "package",
-  "package@1.0.0",
-  "package@1.0.0-beta.1",
-  "package@1.0.0-beta.1+build.123",
-  ...bitbucket,
-  ...github,
-  ...gitlab,
-  ...tarball_remote,
-  ...local_tarball,
-  ...github,
-  "github:dylan-conway/public-install-test",
-  "git@github.com:dylan-conway/public-install-test",
-  "https://github.com/dylan-conway/public-install-test",
-  "https://github.com/dylan-conway/public-install-test.git",
-  "https://github.com/dylan-conway/public-install-test.git#semver:^1.0.0",
-];
-
-test.each(all)("npa %s", dep => {
+test.each(ALL_TEST_DEPENDENCIES)("npa %s", dep => {
   expect(npa(dep)).toMatchSnapshot();
+});
+
+describe("Dependency resolution", () => {
+  describe("Resolves to the correct type", () => {
+    const testSeries = Object.entries(TEST_DEPENDENCIES_BY_TYPE)
+      .flatMap(([key, depStrs]) => depStrs.map(dep => [dep, key]));
+
+    test.each(testSeries)("%s resolves as %s", (depStr, expectedType) => {
+      expect(npa(depStr).version.type).toBe(expectedType);
+    });
+  });
 });
 
 const pkgJsonLike = [

--- a/test/cli/install/bun-install-dep.test.ts
+++ b/test/cli/install/bun-install-dep.test.ts
@@ -1,11 +1,8 @@
 import { npa } from "bun:internal-for-testing";
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 const TEST_DEPENDENCIES_BY_TYPE = {
-  "dist_tag": [
-    "package",
-    "@scoped/package",
-  ],
+  "dist_tag": ["package", "@scoped/package"],
   "npm": [
     "@scoped/package@1.0.0",
     "@scoped/package@1.0.0-beta.1",
@@ -21,9 +18,7 @@ const TEST_DEPENDENCIES_BY_TYPE = {
     "https://gitlab.com/inkscape/inkscape/-/archive/INKSCAPE_1_4/inkscape-INKSCAPE_1_4.tar.gz",
     "https://registry.npmjs.org/no-deps/-/no-deps-2.0.0.tgz",
   ],
-  "folder": [
-    "file:./path/to/folder",
-  ],
+  "folder": ["file:./path/to/folder"],
   "git": [
     "bitbucket.com:dylan-conway/public-install-test",
     "bitbucket.org:dylan-conway/public-install-test",
@@ -43,7 +38,6 @@ const TEST_DEPENDENCIES_BY_TYPE = {
   ],
 };
 
-
 const ALL_TEST_DEPENDENCIES = Object.values(TEST_DEPENDENCIES_BY_TYPE).flat();
 
 test.each(ALL_TEST_DEPENDENCIES)("npa %s", dep => {
@@ -52,8 +46,9 @@ test.each(ALL_TEST_DEPENDENCIES)("npa %s", dep => {
 
 describe("Dependency resolution", () => {
   describe("Resolves to the correct type", () => {
-    const testSeries = Object.entries(TEST_DEPENDENCIES_BY_TYPE)
-      .flatMap(([key, depStrs]) => depStrs.map(dep => [dep, key]));
+    const testSeries = Object.entries(TEST_DEPENDENCIES_BY_TYPE).flatMap(([key, depStrs]) =>
+      depStrs.map(dep => [dep, key]),
+    );
 
     test.each(testSeries)("%s resolves as %s", (depStr, expectedType) => {
       expect(npa(depStr).version.type).toBe(expectedType);


### PR DESCRIPTION
GitLab package registry URLs like
`https://gitlab.example.com/api/v4/projects/1/packages/npm/@group/repo/-/@group/repo-x.y.y.tgz` were incorrectly inferred as `git` type due to hostname pattern matching.

These URLs now correctly resolve as `tarball` type.

### What does this PR do?

Fixes #22153

### How did you verify your code works?

Create a project with npm and install a tarball dependency from Gitlab repository

```sh
mkdir bun-gitlab-tarball-bug
cd bun-gitlab-tarball-bug
echo @gitlab-org:registry=https://gitlab.com/api/v4/projects/46519181/packages/npm/ >> .npmrc
npm i @gitlab-org/gitlab-lsp
```

Then check if `package-lock.json` migration works:

```sh
bun install
```
