### PR TITLE
fix(benchmark): postgres benchmark was not performing any queries under deno and node

### DIFF
--- a/bench/postgres/index.mjs
+++ b/bench/postgres/index.mjs
@@ -1,6 +1,6 @@
 const isBun = typeof globalThis?.Bun?.sql !== "undefined";
 import postgres from "postgres";
-const sql = isBun ? Bun.sql : postgres;
+const sql = isBun ? Bun.sql : postgres();
 
 // Create the table if it doesn't exist
 await sql`


### PR DESCRIPTION
### What does this PR do?
Fixes the postgres benchmark so that it actually benchmarks query performance on node and deno.

Before this PR, the `sql` function was just creating a tagged template function, which involved connecting to the database. So basically bun was doing queries, but node and deno were just connecting to the postgres database over and over.

You can see from the first example in the docs that you're supposed to call the default export in order to get back a function to use with template literals: https://www.npmjs.com/package/postgres


### How did you verify your code works?
Ran it