### PR TITLE
Migrate expect errors to use pretty format

### DIFF
--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -1976,6 +1976,40 @@ pub const JSValue = enum(i64) {
         };
     }
 
+    pub const JestPrettyFormatter = struct {
+        value: JSValue,
+        globalObject: *jsc.JSGlobalObject,
+
+        pub fn format(self: JestPrettyFormatter, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+            const vals = [_]JSValue{self.value};
+            try JestPrettyFormat.format(
+                .Debug,
+                self.globalObject,
+                &vals,
+                1,
+                @TypeOf(writer),
+                @TypeOf(writer),
+                writer,
+                .{
+                    .enable_colors = false,
+                    .add_newline = false,
+                    .flush = false,
+                    .quote_strings = true,
+                },
+            );
+        }
+    };
+
+    pub fn toJestPrettyFormat(
+        this: JSValue,
+        globalObject: *jsc.JSGlobalObject,
+    ) JestPrettyFormatter {
+        return JestPrettyFormatter{
+            .value = this,
+            .globalObject = globalObject,
+        };
+    }
+
     /// Check if the JSValue is either a signed 32-bit integer or a double and
     /// return the value as a f64
     ///

--- a/src/bun.js/test/expect/toBe.zig
+++ b/src/bun.js/test/expect/toBe.zig
@@ -25,14 +25,12 @@ pub fn toBe(
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     switch (this.custom_label.isEmpty()) {
         inline else => |has_custom_label| {
             if (not) {
                 const signature = comptime getSignature("toBe", "<green>expected<r>", true);
-                return this.throw(globalThis, signature, "\n\nExpected: not <green>{any}<r>\n", .{right.toFmt(&formatter)});
+                return this.throw(globalThis, signature, "\n\nExpected: not <green>{any}<r>\n", .{right.toJestPrettyFormat(globalThis)});
             }
 
             const signature = comptime getSignature("toBe", "<green>expected<r>", false);
@@ -41,7 +39,7 @@ pub fn toBe(
                     (if (!has_custom_label) "\n\n<d>If this test should pass, replace \"toBe\" with \"toEqual\" or \"toStrictEqual\"<r>" else "") ++
                     "\n\nExpected: <green>{any}<r>\n" ++
                     "Received: serializes to the same string\n";
-                return this.throw(globalThis, signature, fmt, .{right.toFmt(&formatter)});
+                return this.throw(globalThis, signature, fmt, .{right.toJestPrettyFormat(globalThis)});
             }
 
             if (right.isString() and left.isString()) {
@@ -55,8 +53,8 @@ pub fn toBe(
             }
 
             return this.throw(globalThis, signature, "\n\nExpected: <green>{any}<r>\nReceived: <red>{any}<r>\n", .{
-                right.toFmt(&formatter),
-                left.toFmt(&formatter),
+                right.toJestPrettyFormat(globalThis),
+                left.toJestPrettyFormat(globalThis),
             });
         },
     }

--- a/src/bun.js/test/expect/toBeArray.zig
+++ b/src/bun.js/test/expect/toBeArray.zig
@@ -11,9 +11,7 @@ pub fn toBeArray(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeArray", "", true);

--- a/src/bun.js/test/expect/toBeArrayOfSize.zig
+++ b/src/bun.js/test/expect/toBeArrayOfSize.zig
@@ -26,9 +26,7 @@ pub fn toBeArrayOfSize(this: *Expect, globalThis: *JSGlobalObject, callFrame: *C
     if (not) pass = !pass;
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeArrayOfSize", "", true);

--- a/src/bun.js/test/expect/toBeBoolean.zig
+++ b/src/bun.js/test/expect/toBeBoolean.zig
@@ -11,9 +11,7 @@ pub fn toBeBoolean(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeBoolean", "", true);

--- a/src/bun.js/test/expect/toBeCloseTo.zig
+++ b/src/bun.js/test/expect/toBeCloseTo.zig
@@ -55,7 +55,6 @@ pub fn toBeCloseTo(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
 
     if (pass) return .js_undefined;
 
-
     const expected_fmt = expected_.toJestPrettyFormat(globalThis);
     const received_fmt = received_.toJestPrettyFormat(globalThis);
 

--- a/src/bun.js/test/expect/toBeCloseTo.zig
+++ b/src/bun.js/test/expect/toBeCloseTo.zig
@@ -55,11 +55,9 @@ pub fn toBeCloseTo(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
-    const expected_fmt = expected_.toFmt(&formatter);
-    const received_fmt = received_.toFmt(&formatter);
+    const expected_fmt = expected_.toJestPrettyFormat(globalThis);
+    const received_fmt = received_.toJestPrettyFormat(globalThis);
 
     const expected_line = "Expected: <green>{any}<r>\n";
     const received_line = "Received: <red>{any}<r>\n";

--- a/src/bun.js/test/expect/toBeDate.zig
+++ b/src/bun.js/test/expect/toBeDate.zig
@@ -11,9 +11,7 @@ pub fn toBeDate(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFram
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeDate", "", true);

--- a/src/bun.js/test/expect/toBeDefined.zig
+++ b/src/bun.js/test/expect/toBeDefined.zig
@@ -12,9 +12,7 @@ pub fn toBeDefined(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeDefined", "", true);

--- a/src/bun.js/test/expect/toBeEmpty.zig
+++ b/src/bun.js/test/expect/toBeEmpty.zig
@@ -8,8 +8,6 @@ pub fn toBeEmpty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     const not = this.flags.not;
     var pass = false;
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const actual_length = try value.getLengthIfPropertyExistsInternal(globalThis);
 
@@ -45,7 +43,7 @@ pub fn toBeEmpty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
             const signature = comptime getSignature("toBeEmpty", "", false);
             const fmt = signature ++ "\n\nExpected value to be a string, object, or iterable" ++
                 "\n\nReceived: <red>{any}<r>\n";
-            return globalThis.throwPretty(fmt, .{value.toFmt(&formatter)});
+            return globalThis.throwPretty(fmt, .{value.toJestPrettyFormat(globalThis)});
         }
     } else if (std.math.isNan(actual_length)) {
         return globalThis.throw("Received value has non-number length property: {}", .{actual_length});
@@ -57,7 +55,7 @@ pub fn toBeEmpty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
         const signature = comptime getSignature("toBeEmpty", "", true);
         const fmt = signature ++ "\n\nExpected value <b>not<r> to be a string, object, or iterable" ++
             "\n\nReceived: <red>{any}<r>\n";
-        return globalThis.throwPretty(fmt, .{value.toFmt(&formatter)});
+        return globalThis.throwPretty(fmt, .{value.toJestPrettyFormat(globalThis)});
     }
 
     if (not) pass = !pass;
@@ -67,13 +65,13 @@ pub fn toBeEmpty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
         const signature = comptime getSignature("toBeEmpty", "", true);
         const fmt = signature ++ "\n\nExpected value <b>not<r> to be empty" ++
             "\n\nReceived: <red>{any}<r>\n";
-        return globalThis.throwPretty(fmt, .{value.toFmt(&formatter)});
+        return globalThis.throwPretty(fmt, .{value.toJestPrettyFormat(globalThis)});
     }
 
     const signature = comptime getSignature("toBeEmpty", "", false);
     const fmt = signature ++ "\n\nExpected value to be empty" ++
         "\n\nReceived: <red>{any}<r>\n";
-    return globalThis.throwPretty(fmt, .{value.toFmt(&formatter)});
+    return globalThis.throwPretty(fmt, .{value.toJestPrettyFormat(globalThis)});
 }
 
 const bun = @import("bun");

--- a/src/bun.js/test/expect/toBeEmptyObject.zig
+++ b/src/bun.js/test/expect/toBeEmptyObject.zig
@@ -12,9 +12,7 @@ pub fn toBeEmptyObject(this: *Expect, globalThis: *JSGlobalObject, callFrame: *C
     if (not) pass = !pass;
     if (pass) return thisValue;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeEmptyObject", "", true);

--- a/src/bun.js/test/expect/toBeEven.zig
+++ b/src/bun.js/test/expect/toBeEven.zig
@@ -37,9 +37,7 @@ pub fn toBeEven(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFram
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeEven", "", true);

--- a/src/bun.js/test/expect/toBeFalse.zig
+++ b/src/bun.js/test/expect/toBeFalse.zig
@@ -11,9 +11,7 @@ pub fn toBeFalse(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeFalse", "", true);

--- a/src/bun.js/test/expect/toBeFalsy.zig
+++ b/src/bun.js/test/expect/toBeFalsy.zig
@@ -17,9 +17,7 @@ pub fn toBeFalsy(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeFalsy", "", true);

--- a/src/bun.js/test/expect/toBeFinite.zig
+++ b/src/bun.js/test/expect/toBeFinite.zig
@@ -17,9 +17,7 @@ pub fn toBeFinite(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeFinite", "", true);

--- a/src/bun.js/test/expect/toBeFunction.zig
+++ b/src/bun.js/test/expect/toBeFunction.zig
@@ -11,9 +11,7 @@ pub fn toBeFunction(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Call
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeFunction", "", true);

--- a/src/bun.js/test/expect/toBeGreaterThan.zig
+++ b/src/bun.js/test/expect/toBeGreaterThan.zig
@@ -41,10 +41,8 @@ pub fn toBeGreaterThan(this: *Expect, globalThis: *JSGlobalObject, callFrame: *C
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = other_value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = other_value.toJestPrettyFormat(globalThis);
     if (not) {
         const expected_line = "Expected: not \\> <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";

--- a/src/bun.js/test/expect/toBeGreaterThanOrEqual.zig
+++ b/src/bun.js/test/expect/toBeGreaterThanOrEqual.zig
@@ -41,10 +41,8 @@ pub fn toBeGreaterThanOrEqual(this: *Expect, globalThis: *JSGlobalObject, callFr
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = other_value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = other_value.toJestPrettyFormat(globalThis);
     if (not) {
         const expected_line = "Expected: not \\>= <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";

--- a/src/bun.js/test/expect/toBeInstanceOf.zig
+++ b/src/bun.js/test/expect/toBeInstanceOf.zig
@@ -10,12 +10,10 @@ pub fn toBeInstanceOf(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Ca
     }
 
     this.incrementExpectCallCounter();
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const expected_value = arguments[0];
     if (!expected_value.isConstructor()) {
-        return globalThis.throw("Expected value must be a function: {any}", .{expected_value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a function: {any}", .{expected_value.toJestPrettyFormat(globalThis)});
     }
     expected_value.ensureStillAlive();
 
@@ -27,8 +25,8 @@ pub fn toBeInstanceOf(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Ca
     if (pass) return .js_undefined;
 
     // handle failure
-    const expected_fmt = expected_value.toFmt(&formatter);
-    const value_fmt = value.toFmt(&formatter);
+    const expected_fmt = expected_value.toJestPrettyFormat(globalThis);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const expected_line = "Expected constructor: not <green>{any}<r>\n";
         const received_line = "Received value: <red>{any}<r>\n";

--- a/src/bun.js/test/expect/toBeInteger.zig
+++ b/src/bun.js/test/expect/toBeInteger.zig
@@ -11,9 +11,7 @@ pub fn toBeInteger(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeInteger", "", true);

--- a/src/bun.js/test/expect/toBeLessThan.zig
+++ b/src/bun.js/test/expect/toBeLessThan.zig
@@ -41,10 +41,8 @@ pub fn toBeLessThan(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Call
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = other_value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = other_value.toJestPrettyFormat(globalThis);
     if (not) {
         const expected_line = "Expected: not \\< <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";

--- a/src/bun.js/test/expect/toBeLessThanOrEqual.zig
+++ b/src/bun.js/test/expect/toBeLessThanOrEqual.zig
@@ -41,10 +41,8 @@ pub fn toBeLessThanOrEqual(this: *Expect, globalThis: *JSGlobalObject, callFrame
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = other_value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = other_value.toJestPrettyFormat(globalThis);
     if (not) {
         const expected_line = "Expected: not \\<= <green>{any}<r>\n";
         const received_line = "Received: <red>{any}<r>\n";

--- a/src/bun.js/test/expect/toBeNaN.zig
+++ b/src/bun.js/test/expect/toBeNaN.zig
@@ -17,9 +17,7 @@ pub fn toBeNaN(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeNaN", "", true);

--- a/src/bun.js/test/expect/toBeNegative.zig
+++ b/src/bun.js/test/expect/toBeNegative.zig
@@ -17,9 +17,7 @@ pub fn toBeNegative(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Call
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeNegative", "", true);

--- a/src/bun.js/test/expect/toBeNil.zig
+++ b/src/bun.js/test/expect/toBeNil.zig
@@ -11,9 +11,7 @@ pub fn toBeNil(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeNil", "", true);

--- a/src/bun.js/test/expect/toBeNull.zig
+++ b/src/bun.js/test/expect/toBeNull.zig
@@ -12,9 +12,7 @@ pub fn toBeNull(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFram
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeNull", "", true);

--- a/src/bun.js/test/expect/toBeNumber.zig
+++ b/src/bun.js/test/expect/toBeNumber.zig
@@ -11,9 +11,7 @@ pub fn toBeNumber(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeNumber", "", true);

--- a/src/bun.js/test/expect/toBeObject.zig
+++ b/src/bun.js/test/expect/toBeObject.zig
@@ -11,9 +11,7 @@ pub fn toBeObject(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
 
     if (pass) return thisValue;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeObject", "", true);

--- a/src/bun.js/test/expect/toBeOdd.zig
+++ b/src/bun.js/test/expect/toBeOdd.zig
@@ -35,9 +35,7 @@ pub fn toBeOdd(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeOdd", "", true);

--- a/src/bun.js/test/expect/toBeOneOf.zig
+++ b/src/bun.js/test/expect/toBeOneOf.zig
@@ -64,12 +64,10 @@ pub fn toBeOneOf(
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = list_value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = list_value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
     if (not) {
-        const received_fmt = list_value.toFmt(&formatter);
+        const received_fmt = list_value.toJestPrettyFormat(globalThis);
         const expected_line = "Expected to not be one of: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeOneOf", "<green>expected<r>", true);
         return this.throw(globalThis, signature, "\n\n" ++ expected_line, .{ received_fmt, expected_fmt });

--- a/src/bun.js/test/expect/toBePositive.zig
+++ b/src/bun.js/test/expect/toBePositive.zig
@@ -17,9 +17,7 @@ pub fn toBePositive(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Call
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBePositive", "", true);

--- a/src/bun.js/test/expect/toBeString.zig
+++ b/src/bun.js/test/expect/toBeString.zig
@@ -11,9 +11,7 @@ pub fn toBeString(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeString", "", true);

--- a/src/bun.js/test/expect/toBeSymbol.zig
+++ b/src/bun.js/test/expect/toBeSymbol.zig
@@ -11,9 +11,7 @@ pub fn toBeSymbol(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeSymbol", "", true);

--- a/src/bun.js/test/expect/toBeTrue.zig
+++ b/src/bun.js/test/expect/toBeTrue.zig
@@ -11,9 +11,7 @@ pub fn toBeTrue(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFram
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeTrue", "", true);

--- a/src/bun.js/test/expect/toBeTruthy.zig
+++ b/src/bun.js/test/expect/toBeTruthy.zig
@@ -15,9 +15,7 @@ pub fn toBeTruthy(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeTruthy", "", true);

--- a/src/bun.js/test/expect/toBeTypeOf.zig
+++ b/src/bun.js/test/expect/toBeTypeOf.zig
@@ -67,10 +67,8 @@ pub fn toBeTypeOf(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
     if (not) pass = !pass;
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
-    const expected_str = expected.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
+    const expected_str = expected.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeTypeOf", "", true);

--- a/src/bun.js/test/expect/toBeUndefined.zig
+++ b/src/bun.js/test/expect/toBeUndefined.zig
@@ -13,9 +13,7 @@ pub fn toBeUndefined(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Cal
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
     if (not) {
         const received_line = "Received: <red>{any}<r>\n";
         const signature = comptime getSignature("toBeUndefined", "", true);

--- a/src/bun.js/test/expect/toBeValidDate.zig
+++ b/src/bun.js/test/expect/toBeValidDate.zig
@@ -12,9 +12,7 @@ pub fn toBeValidDate(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Cal
 
     if (pass) return thisValue;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const received = value.toFmt(&formatter);
+    const received = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toBeValidDate", "", true);

--- a/src/bun.js/test/expect/toBeWithin.zig
+++ b/src/bun.js/test/expect/toBeWithin.zig
@@ -38,11 +38,9 @@ pub fn toBeWithin(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFr
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const start_fmt = startValue.toFmt(&formatter);
-    const end_fmt = endValue.toFmt(&formatter);
-    const received_fmt = value.toFmt(&formatter);
+    const start_fmt = startValue.toJestPrettyFormat(globalThis);
+    const end_fmt = endValue.toJestPrettyFormat(globalThis);
+    const received_fmt = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const expected_line = "Expected: not between <green>{any}<r> <d>(inclusive)<r> and <green>{any}<r> <d>(exclusive)<r>\n";

--- a/src/bun.js/test/expect/toContain.zig
+++ b/src/bun.js/test/expect/toContain.zig
@@ -76,12 +76,10 @@ pub fn toContain(
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalThis);
         const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const signature = comptime getSignature("toContain", "<green>expected<r>", true);
         return this.throw(globalThis, signature, "\n\n" ++ expected_line, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainAllKeys.zig
+++ b/src/bun.js/test/expect/toContainAllKeys.zig
@@ -46,12 +46,10 @@ pub fn toContainAllKeys(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalObject, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = keys.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = keys.toJestPrettyFormat(globalObject);
+    const expected_fmt = expected.toJestPrettyFormat(globalObject);
     if (not) {
-        const received_fmt = keys.toFmt(&formatter);
+        const received_fmt = keys.toJestPrettyFormat(globalObject);
         const expected_line = "Expected to not contain all keys: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const fmt = "\n\n" ++ expected_line;
         return this.throw(globalObject, comptime getSignature("toContainAllKeys", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainAllValues.zig
+++ b/src/bun.js/test/expect/toContainAllValues.zig
@@ -51,12 +51,10 @@ pub fn toContainAllValues(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalObject, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalObject);
+    const expected_fmt = expected.toJestPrettyFormat(globalObject);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalObject);
         const expected_line = "Expected to not contain all values: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const fmt = "\n\n" ++ expected_line;
         return this.throw(globalObject, comptime getSignature("toContainAllValues", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainAnyKeys.zig
+++ b/src/bun.js/test/expect/toContainAnyKeys.zig
@@ -42,12 +42,10 @@ pub fn toContainAnyKeys(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalThis);
         const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const signature = comptime getSignature("toContainAnyKeys", "<green>expected<r>", true);
         return this.throw(globalThis, signature, "\n\n" ++ expected_line, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainAnyValues.zig
+++ b/src/bun.js/test/expect/toContainAnyValues.zig
@@ -45,12 +45,10 @@ pub fn toContainAnyValues(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalObject, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalObject);
+    const expected_fmt = expected.toJestPrettyFormat(globalObject);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalObject);
         const expected_line = "Expected to not contain any of the following values: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const fmt = "\n\n" ++ expected_line;
         return this.throw(globalObject, comptime getSignature("toContainAnyValues", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainEqual.zig
+++ b/src/bun.js/test/expect/toContainEqual.zig
@@ -85,10 +85,8 @@ pub fn toContainEqual(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
     if (not) {
         const expected_line = "Expected to not contain: <green>{any}<r>\n";
         const signature = comptime getSignature("toContainEqual", "<green>expected<r>", true);

--- a/src/bun.js/test/expect/toContainKey.zig
+++ b/src/bun.js/test/expect/toContainKey.zig
@@ -17,12 +17,10 @@ pub fn toContainKey(
     const expected = arguments[0];
     expected.ensureStillAlive();
     const value: JSValue = try this.getValue(globalThis, thisValue, "toContainKey", "<green>expected<r>");
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const not = this.flags.not;
     if (!value.isObject()) {
-        return globalThis.throwInvalidArguments("Expected value must be an object\nReceived: {}", .{value.toFmt(&formatter)});
+        return globalThis.throwInvalidArguments("Expected value must be an object\nReceived: {}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     var pass = try value.hasOwnPropertyValue(globalThis, expected);
@@ -32,10 +30,10 @@ pub fn toContainKey(
 
     // handle failure
 
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalThis);
         const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const signature = comptime getSignature("toContainKey", "<green>expected<r>", true);
         return this.throw(globalThis, signature, "\n\n" ++ expected_line, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainKeys.zig
+++ b/src/bun.js/test/expect/toContainKeys.zig
@@ -47,12 +47,10 @@ pub fn toContainKeys(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalThis);
         const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const signature = comptime getSignature("toContainKeys", "<green>expected<r>", true);
         return this.throw(globalThis, signature, "\n\n" ++ expected_line, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainValue.zig
+++ b/src/bun.js/test/expect/toContainValue.zig
@@ -36,12 +36,10 @@ pub fn toContainValue(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalObject, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalObject);
+    const expected_fmt = expected.toJestPrettyFormat(globalObject);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalObject);
         const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const fmt = "\n\n" ++ expected_line;
         return this.throw(globalObject, comptime getSignature("toContainValue", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toContainValues.zig
+++ b/src/bun.js/test/expect/toContainValues.zig
@@ -45,12 +45,10 @@ pub fn toContainValues(
     if (pass) return thisValue;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalObject, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalObject);
+    const expected_fmt = expected.toJestPrettyFormat(globalObject);
     if (not) {
-        const received_fmt = value.toFmt(&formatter);
+        const received_fmt = value.toJestPrettyFormat(globalObject);
         const expected_line = "Expected to not contain: <green>{any}<r>\nReceived: <red>{any}<r>\n";
         const fmt = "\n\n" ++ expected_line;
         return this.throw(globalObject, comptime getSignature("toContainValues", "<green>expected<r>", true), fmt, .{ expected_fmt, received_fmt });

--- a/src/bun.js/test/expect/toEndWith.zig
+++ b/src/bun.js/test/expect/toEndWith.zig
@@ -34,10 +34,8 @@ pub fn toEndWith(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
 
     if (not) {
         const expected_line = "Expected to not end with: <green>{any}<r>\n";

--- a/src/bun.js/test/expect/toEqualIgnoringWhitespace.zig
+++ b/src/bun.js/test/expect/toEqualIgnoringWhitespace.zig
@@ -63,10 +63,8 @@ pub fn toEqualIgnoringWhitespace(this: *Expect, globalThis: *JSGlobalObject, cal
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const expected_fmt = expected.toFmt(&formatter);
-    const value_fmt = value.toFmt(&formatter);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const signature = comptime getSignature("toEqualIgnoringWhitespace", "<green>expected<r>", true);

--- a/src/bun.js/test/expect/toHaveBeenCalled.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalled.zig
@@ -13,9 +13,7 @@ pub fn toHaveBeenCalled(this: *Expect, globalThis: *JSGlobalObject, callframe: *
     const calls = try bun.cpp.JSMockFunction__getCalls(globalThis, value);
     this.incrementExpectCallCounter();
     if (!calls.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     const calls_length = try calls.getLength(globalThis);

--- a/src/bun.js/test/expect/toHaveBeenCalledOnce.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalledOnce.zig
@@ -9,9 +9,7 @@ pub fn toHaveBeenCalledOnce(this: *Expect, globalThis: *JSGlobalObject, callfram
 
     const calls = try bun.cpp.JSMockFunction__getCalls(globalThis, value);
     if (!calls.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     const calls_length = try calls.getLength(globalThis);

--- a/src/bun.js/test/expect/toHaveBeenCalledTimes.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalledTimes.zig
@@ -11,9 +11,7 @@ pub fn toHaveBeenCalledTimes(this: *Expect, globalThis: *JSGlobalObject, callfra
 
     const calls = try bun.cpp.JSMockFunction__getCalls(globalThis, value);
     if (!calls.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     if (arguments.len < 1 or !arguments[0].isUInt32AsAnyInt()) {

--- a/src/bun.js/test/expect/toHaveBeenLastCalledWith.zig
+++ b/src/bun.js/test/expect/toHaveBeenLastCalledWith.zig
@@ -10,9 +10,7 @@ pub fn toHaveBeenLastCalledWith(this: *Expect, globalThis: *JSGlobalObject, call
 
     const calls = try bun.cpp.JSMockFunction__getCalls(globalThis, value);
     if (!calls.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return this.throw(globalThis, comptime getSignature("toHaveBeenLastCalledWith", "<green>...expected<r>", false), "\n\nMatcher error: <red>received<r> value must be a mock function\nReceived: {any}", .{value.toFmt(&formatter)});
+        return this.throw(globalThis, comptime getSignature("toHaveBeenLastCalledWith", "<green>...expected<r>", false), "\n\nMatcher error: <red>received<r> value must be a mock function\nReceived: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     const totalCalls: u32 = @truncate(try calls.getLength(globalThis));
@@ -24,9 +22,7 @@ pub fn toHaveBeenLastCalledWith(this: *Expect, globalThis: *JSGlobalObject, call
         lastCallValue = try calls.getIndex(globalThis, totalCalls - 1);
 
         if (!lastCallValue.jsType().isArray()) {
-            var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-            defer formatter.deinit();
-            return globalThis.throw("Expected value must be a mock function with calls: {any}", .{value.toFmt(&formatter)});
+            return globalThis.throw("Expected value must be a mock function with calls: {any}", .{value.toJestPrettyFormat(globalThis)});
         }
 
         if (try lastCallValue.getLength(globalThis) != arguments.len) {
@@ -47,8 +43,6 @@ pub fn toHaveBeenLastCalledWith(this: *Expect, globalThis: *JSGlobalObject, call
     }
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const expected_args_js_array = try JSValue.createEmptyArray(globalThis, arguments.len);
     for (arguments, 0..) |arg, i| {
@@ -59,14 +53,14 @@ pub fn toHaveBeenLastCalledWith(this: *Expect, globalThis: *JSGlobalObject, call
     if (this.flags.not) {
         const signature = comptime getSignature("toHaveBeenLastCalledWith", "<green>...expected<r>", true);
         return this.throw(globalThis, signature, "\n\nExpected last call not to be with: <green>{any}<r>\nBut it was.", .{
-            expected_args_js_array.toFmt(&formatter),
+            expected_args_js_array.toJestPrettyFormat(globalThis),
         });
     }
     const signature = comptime getSignature("toHaveBeenLastCalledWith", "<green>...expected<r>", false);
 
     if (totalCalls == 0) {
         return this.throw(globalThis, signature, "\n\nExpected: <green>{any}<r>\nBut it was not called.", .{
-            expected_args_js_array.toFmt(&formatter),
+            expected_args_js_array.toJestPrettyFormat(globalThis),
         });
     }
 

--- a/src/bun.js/test/expect/toHaveBeenNthCalledWith.zig
+++ b/src/bun.js/test/expect/toHaveBeenNthCalledWith.zig
@@ -10,9 +10,7 @@ pub fn toHaveBeenNthCalledWith(this: *Expect, globalThis: *JSGlobalObject, callf
 
     const calls = try bun.cpp.JSMockFunction__getCalls(globalThis, value);
     if (!calls.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return this.throw(globalThis, comptime getSignature("toHaveBeenNthCalledWith", "<green>n<r>, <green>...expected<r>", false), "\n\nMatcher error: <red>received<r> value must be a mock function\nReceived: {any}", .{value.toFmt(&formatter)});
+        return this.throw(globalThis, comptime getSignature("toHaveBeenNthCalledWith", "<green>n<r>, <green>...expected<r>", false), "\n\nMatcher error: <red>received<r> value must be a mock function\nReceived: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     if (arguments.len == 0 or !arguments[0].isAnyInt()) {
@@ -55,8 +53,6 @@ pub fn toHaveBeenNthCalledWith(this: *Expect, globalThis: *JSGlobalObject, callf
     }
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const expected_args_slice = arguments[1..];
     const expected_args_js_array = try JSValue.createEmptyArray(globalThis, expected_args_slice.len);
@@ -69,7 +65,7 @@ pub fn toHaveBeenNthCalledWith(this: *Expect, globalThis: *JSGlobalObject, callf
         const signature = comptime getSignature("toHaveBeenNthCalledWith", "<green>n<r>, <green>...expected<r>", true);
         return this.throw(globalThis, signature, "\n\nExpected call #{d} not to be with: <green>{any}<r>\nBut it was.", .{
             nthCallNum,
-            expected_args_js_array.toFmt(&formatter),
+            expected_args_js_array.toJestPrettyFormat(globalThis),
         });
     }
     const signature = comptime getSignature("toHaveBeenNthCalledWith", "<green>n<r>, <green>...expected<r>", false);

--- a/src/bun.js/test/expect/toHaveLastReturnedWith.zig
+++ b/src/bun.js/test/expect/toHaveLastReturnedWith.zig
@@ -11,9 +11,7 @@ pub fn toHaveLastReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfr
 
     const returns = try bun.cpp.JSMockFunction__getReturns(globalThis, value);
     if (!returns.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     const calls_count = @as(u32, @intCast(try returns.getLength(globalThis)));
@@ -50,13 +48,11 @@ pub fn toHaveLastReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfr
     }
 
     // Handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const signature = comptime getSignature("toHaveBeenLastReturnedWith", "<green>expected<r>", false);
 
     if (this.flags.not) {
-        return this.throw(globalThis, comptime getSignature("toHaveBeenLastReturnedWith", "<green>expected<r>", true), "\n\n" ++ "Expected mock function not to have last returned: <green>{any}<r>\n" ++ "But it did.\n", .{expected.toFmt(&formatter)});
+        return this.throw(globalThis, comptime getSignature("toHaveBeenLastReturnedWith", "<green>expected<r>", true), "\n\n" ++ "Expected mock function not to have last returned: <green>{any}<r>\n" ++ "But it did.\n", .{expected.toJestPrettyFormat(globalThis)});
     }
 
     if (calls_count == 0) {
@@ -64,7 +60,7 @@ pub fn toHaveLastReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfr
     }
 
     if (last_call_threw) {
-        return this.throw(globalThis, signature, "\n\n" ++ "The last call threw an error: <red>{any}<r>\n", .{last_error_value.toFmt(&formatter)});
+        return this.throw(globalThis, signature, "\n\n" ++ "The last call threw an error: <red>{any}<r>\n", .{last_error_value.toJestPrettyFormat(globalThis)});
     }
 
     // Diff if possible
@@ -73,7 +69,7 @@ pub fn toHaveLastReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfr
         return this.throw(globalThis, signature, "\n\n{any}\n", .{diff_format});
     }
 
-    return this.throw(globalThis, signature, "\n\nExpected: <green>{any}<r>\nReceived: <red>{any}<r>", .{ expected.toFmt(&formatter), last_return_value.toFmt(&formatter) });
+    return this.throw(globalThis, signature, "\n\nExpected: <green>{any}<r>\nReceived: <red>{any}<r>", .{ expected.toJestPrettyFormat(globalThis), last_return_value.toJestPrettyFormat(globalThis) });
 }
 
 const bun = @import("bun");

--- a/src/bun.js/test/expect/toHaveNthReturnedWith.zig
+++ b/src/bun.js/test/expect/toHaveNthReturnedWith.zig
@@ -19,9 +19,7 @@ pub fn toHaveNthReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfra
     this.incrementExpectCallCounter();
     const returns = try bun.cpp.JSMockFunction__getReturns(globalThis, value);
     if (!returns.jsType().isArray()) {
-        var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-        defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a mock function: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     const calls_count = @as(u32, @intCast(try returns.getLength(globalThis)));
@@ -59,13 +57,11 @@ pub fn toHaveNthReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfra
     }
 
     // Handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const signature = comptime getSignature("toHaveNthReturnedWith", "<green>n<r>, <green>expected<r>", false);
 
     if (this.flags.not) {
-        return this.throw(globalThis, comptime getSignature("toHaveNthReturnedWith", "<green>n<r>, <green>expected<r>", true), "\n\n" ++ "Expected mock function not to have returned on call {d}: <green>{any}<r>\n" ++ "But it did.\n", .{ n, expected.toFmt(&formatter) });
+        return this.throw(globalThis, comptime getSignature("toHaveNthReturnedWith", "<green>n<r>, <green>expected<r>", true), "\n\n" ++ "Expected mock function not to have returned on call {d}: <green>{any}<r>\n" ++ "But it did.\n", .{ n, expected.toJestPrettyFormat(globalThis) });
     }
 
     if (!nth_call_exists) {
@@ -73,7 +69,7 @@ pub fn toHaveNthReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfra
     }
 
     if (nth_call_threw) {
-        return this.throw(globalThis, signature, "\n\n" ++ "Call {d} threw an error: <red>{any}<r>\n", .{ n, nth_error_value.toFmt(&formatter) });
+        return this.throw(globalThis, signature, "\n\n" ++ "Call {d} threw an error: <red>{any}<r>\n", .{ n, nth_error_value.toJestPrettyFormat(globalThis) });
     }
 
     // Diff if possible
@@ -82,7 +78,7 @@ pub fn toHaveNthReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfra
         return this.throw(globalThis, signature, "\n\nCall {d}:\n{any}\n", .{ n, diff_format });
     }
 
-    return this.throw(globalThis, signature, "\n\nCall {d}:\nExpected: <green>{any}<r>\nReceived: <red>{any}<r>", .{ n, expected.toFmt(&formatter), nth_return_value.toFmt(&formatter) });
+    return this.throw(globalThis, signature, "\n\nCall {d}:\nExpected: <green>{any}<r>\nReceived: <red>{any}<r>", .{ n, expected.toJestPrettyFormat(globalThis), nth_return_value.toJestPrettyFormat(globalThis) });
 }
 
 const bun = @import("bun");

--- a/src/bun.js/test/expect/toHaveProperty.zig
+++ b/src/bun.js/test/expect/toHaveProperty.zig
@@ -42,23 +42,21 @@ pub fn toHaveProperty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Ca
     if (pass) return .js_undefined;
 
     // handle failure
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
     if (not) {
         if (expected_property != null) {
             const signature = comptime getSignature("toHaveProperty", "<green>path<r><d>, <r><green>value<r>", true);
             if (received_property != .zero) {
                 return this.throw(globalThis, signature, "\n\nExpected path: <green>{any}<r>\n\nExpected value: not <green>{any}<r>\n", .{
-                    expected_property_path.toFmt(&formatter),
-                    expected_property.?.toFmt(&formatter),
+                    expected_property_path.toJestPrettyFormat(globalThis),
+                    expected_property.?.toJestPrettyFormat(globalThis),
                 });
             }
         }
 
         const signature = comptime getSignature("toHaveProperty", "<green>path<r>", true);
         return this.throw(globalThis, signature, "\n\nExpected path: not <green>{any}<r>\n\nReceived value: <red>{any}<r>\n", .{
-            expected_property_path.toFmt(&formatter),
-            received_property.toFmt(&formatter),
+            expected_property_path.toJestPrettyFormat(globalThis),
+            received_property.toJestPrettyFormat(globalThis),
         });
     }
 
@@ -78,13 +76,13 @@ pub fn toHaveProperty(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Ca
         const fmt = "\n\nExpected path: <green>{any}<r>\n\nExpected value: <green>{any}<r>\n\n" ++
             "Unable to find property\n";
         return this.throw(globalThis, signature, fmt, .{
-            expected_property_path.toFmt(&formatter),
-            expected_property.?.toFmt(&formatter),
+            expected_property_path.toJestPrettyFormat(globalThis),
+            expected_property.?.toJestPrettyFormat(globalThis),
         });
     }
 
     const signature = comptime getSignature("toHaveProperty", "<green>path<r>", false);
-    return this.throw(globalThis, signature, "\n\nExpected path: <green>{any}<r>\n\nUnable to find property\n", .{expected_property_path.toFmt(&formatter)});
+    return this.throw(globalThis, signature, "\n\nExpected path: <green>{any}<r>\n\nUnable to find property\n", .{expected_property_path.toJestPrettyFormat(globalThis)});
 }
 
 const DiffFormatter = @import("../diff_format.zig").DiffFormatter;

--- a/src/bun.js/test/expect/toInclude.zig
+++ b/src/bun.js/test/expect/toInclude.zig
@@ -34,10 +34,8 @@ pub fn toInclude(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
 
     if (not) {
         const expected_line = "Expected to not include: <green>{any}<r>\n";

--- a/src/bun.js/test/expect/toIncludeRepeated.zig
+++ b/src/bun.js/test/expect/toIncludeRepeated.zig
@@ -59,11 +59,9 @@ pub fn toIncludeRepeated(this: *Expect, globalThis: *JSGlobalObject, callFrame: 
     if (not) pass = !pass;
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const expect_string_fmt = expect_string.toFmt(&formatter);
-    const substring_fmt = substring.toFmt(&formatter);
-    const times_fmt = count.toFmt(&formatter);
+    const expect_string_fmt = expect_string.toJestPrettyFormat(globalThis);
+    const substring_fmt = substring.toJestPrettyFormat(globalThis);
+    const times_fmt = count.toJestPrettyFormat(globalThis);
 
     const received_line = "Received: <red>{any}<r>\n";
 

--- a/src/bun.js/test/expect/toMatch.zig
+++ b/src/bun.js/test/expect/toMatch.zig
@@ -13,19 +13,17 @@ pub fn toMatch(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
 
     this.incrementExpectCallCounter();
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     const expected_value = arguments[0];
     if (!expected_value.isString() and !expected_value.isRegExp()) {
-        return globalThis.throw("Expected value must be a string or regular expression: {any}", .{expected_value.toFmt(&formatter)});
+        return globalThis.throw("Expected value must be a string or regular expression: {any}", .{expected_value.toJestPrettyFormat(globalThis)});
     }
     expected_value.ensureStillAlive();
 
     const value: JSValue = try this.getValue(globalThis, thisValue, "toMatch", "<green>expected<r>");
 
     if (!value.isString()) {
-        return globalThis.throw("Received value must be a string: {any}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a string: {any}", .{value.toJestPrettyFormat(globalThis)});
     }
 
     const not = this.flags.not;
@@ -42,8 +40,8 @@ pub fn toMatch(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
     if (pass) return .js_undefined;
 
     // handle failure
-    const expected_fmt = expected_value.toFmt(&formatter);
-    const value_fmt = value.toFmt(&formatter);
+    const expected_fmt = expected_value.toJestPrettyFormat(globalThis);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
 
     if (not) {
         const expected_line = "Expected substring or pattern: not <green>{any}<r>\n";

--- a/src/bun.js/test/expect/toMatch.zig
+++ b/src/bun.js/test/expect/toMatch.zig
@@ -13,7 +13,6 @@ pub fn toMatch(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
 
     this.incrementExpectCallCounter();
 
-
     const expected_value = arguments[0];
     if (!expected_value.isString() and !expected_value.isRegExp()) {
         return globalThis.throw("Expected value must be a string or regular expression: {any}", .{expected_value.toJestPrettyFormat(globalThis)});

--- a/src/bun.js/test/expect/toSatisfy.zig
+++ b/src/bun.js/test/expect/toSatisfy.zig
@@ -34,19 +34,17 @@ pub fn toSatisfy(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
 
     if (not) {
         const signature = comptime getSignature("toSatisfy", "<green>expected<r>", true);
-        return this.throw(globalThis, signature, "\n\nExpected: not <green>{any}<r>\n", .{predicate.toFmt(&formatter)});
+        return this.throw(globalThis, signature, "\n\nExpected: not <green>{any}<r>\n", .{predicate.toJestPrettyFormat(globalThis)});
     }
 
     const signature = comptime getSignature("toSatisfy", "<green>expected<r>", false);
 
     return this.throw(globalThis, signature, "\n\nExpected: <green>{any}<r>\nReceived: <red>{any}<r>\n", .{
-        predicate.toFmt(&formatter),
-        value.toFmt(&formatter),
+        predicate.toJestPrettyFormat(globalThis),
+        value.toJestPrettyFormat(globalThis),
     });
 }
 

--- a/src/bun.js/test/expect/toSatisfy.zig
+++ b/src/bun.js/test/expect/toSatisfy.zig
@@ -34,7 +34,6 @@ pub fn toSatisfy(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFra
 
     if (pass) return .js_undefined;
 
-
     if (not) {
         const signature = comptime getSignature("toSatisfy", "<green>expected<r>", true);
         return this.throw(globalThis, signature, "\n\nExpected: not <green>{any}<r>\n", .{predicate.toJestPrettyFormat(globalThis)});

--- a/src/bun.js/test/expect/toStartWith.zig
+++ b/src/bun.js/test/expect/toStartWith.zig
@@ -34,10 +34,8 @@ pub fn toStartWith(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallF
 
     if (pass) return .js_undefined;
 
-    var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
-    defer formatter.deinit();
-    const value_fmt = value.toFmt(&formatter);
-    const expected_fmt = expected.toFmt(&formatter);
+    const value_fmt = value.toJestPrettyFormat(globalThis);
+    const expected_fmt = expected.toJestPrettyFormat(globalThis);
 
     if (not) {
         const expected_line = "Expected to not start with: <green>{any}<r>\n";


### PR DESCRIPTION
Uses the same formatter used for snapshots. This formatter puts strings on multiple lines rather than outputting one very long inline string