### PR TITLE
Fix double slash in error stack traces when root_path has trailing slash

### DIFF
--- a/src/bun.js/bindings/ZigStackFrame.zig
+++ b/src/bun.js/bindings/ZigStackFrame.zig
@@ -69,9 +69,10 @@ pub const ZigStackFrame = extern struct {
                 if (this.enable_color) {
                     const not_root = if (comptime bun.Environment.isWindows) this.root_path.len > "C:\\".len else this.root_path.len > "/".len;
                     if (not_root and strings.startsWith(source_slice, this.root_path)) {
+                        const root_path = strings.withoutTrailingSlash(this.root_path);
                         const relative_path = strings.withoutLeadingPathSeparator(source_slice[this.root_path.len..]);
                         try writer.writeAll(comptime Output.prettyFmt("<d>", true));
-                        try writer.writeAll(this.root_path);
+                        try writer.writeAll(root_path);
                         try writer.writeByte(std.fs.path.sep);
                         try writer.writeAll(comptime Output.prettyFmt("<r><cyan>", true));
                         try writer.writeAll(relative_path);


### PR DESCRIPTION
## Summary
- Fixes double slashes appearing in error stack traces when `root_path` ends with a trailing slash
- Followup to #22469 which added dimmed cwd prefixes to error messages

## Changes
- Use `strings.withoutTrailingSlash()` to strip any trailing separator from `root_path` before adding the path separator
- This prevents paths like `/workspace//file.js` from appearing in error messages

🤖 Generated with [Claude Code](https://claude.ai/code)