### PR TITLE
feat(windows): implement authenticode stripping for --compile

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -724,7 +724,8 @@ pub const StandaloneModuleGraph = struct {
                     return bun.invalid_fd;
                 };
                 defer pe_file.deinit();
-                pe_file.addBunSection(bytes) catch |err| {
+                // Always strip authenticode when adding .bun section for --compile
+                pe_file.addBunSection(bytes, .strip_always) catch |err| {
                     Output.prettyErrorln("Error adding Bun section to PE file: {}", .{err});
                     cleanup(zname, cloned_executable_fd);
                     return bun.invalid_fd;

--- a/src/pe.zig
+++ b/src/pe.zig
@@ -739,10 +739,8 @@ pub const BUN_COMPILED_SECTION_NAME = ".bun";
 extern "C" fn Bun__getStandaloneModuleGraphPELength() u32;
 extern "C" fn Bun__getStandaloneModuleGraphPEData() ?[*]u8;
 
-const std = @import("std");
-
 const bun = @import("bun");
-const strings = bun.strings;
+const std = @import("std");
 
 const mem = std.mem;
 const Allocator = mem.Allocator;

--- a/src/pe.zig
+++ b/src/pe.zig
@@ -401,67 +401,37 @@ pub const PEFile = struct {
             return error.UnexpectedOverlayPresent;
     }
 
-    /// Calculate checksum words using Windows one's-complement algorithm
-    fn calcCheckSumWords(data: []const u8) u16 {
-        // One's-complement sum over (len+1)/2 16-bit little-endian words
-        var sum: u32 = 0;
-        const n_words = (data.len + 1) / 2;
-
-        var i: usize = 0;
-        while (i < n_words) : (i += 1) {
-            const byte_index = i * 2;
-
-            var w: u16 = 0;
-            if (byte_index + 1 < data.len) {
-                // little-endian 16-bit
-                w = @as(u16, data[byte_index]) | (@as(u16, data[byte_index + 1]) << 8);
-            } else {
-                // odd trailing byte, pad high byte with 0
-                w = data[byte_index];
-            }
-
-            sum += w;
-            // fold carry into low 16 each step (one's-complement addition)
-            if ((sum & 0xFFFF0000) != 0) {
-                sum = (sum & 0xFFFF) + (sum >> 16);
-            }
-        }
-
-        // Final fold to 16 bits (lo + hi)
-        sum = (sum & 0xFFFF) + (sum >> 16);
-        return @intCast(sum & 0xFFFF);
-    }
-
-    /// Subtract word with borrow for checksum calculation
-    fn subtractWordWithBorrow(sum16: u32, sub16: u32) u32 {
-        // Emulate 16-bit subtract with borrow into a 32-bit container
-        if ((sum16 & 0xFFFF) >= (sub16 & 0xFFFF)) {
-            return (sum16 - (sub16 & 0xFFFF)) & 0xFFFF;
-        } else {
-            // borrow wraps around 16-bit (one's-complement)
-            return (((sum16 & 0xFFFF) - (sub16 & 0xFFFF)) & 0xFFFF) - 1;
-        }
-    }
-
-    /// Recompute PE checksum exactly as Windows CheckSumMappedFile does
+    /// Recompute PE checksum according to Windows spec
     fn recomputePEChecksum(self: *PEFile) !void {
         const data = self.data.items;
+        const checksum_off = self.optional_header_offset + @offsetOf(OptionalHeader64, "checksum");
 
-        // 1) Sum words over entire file (rounded up), one's-complement style
-        var calc: u32 = calcCheckSumWords(data); // 16-bit result in low word
+        // Zero checksum field before summing
+        @memset(self.data.items[checksum_off .. checksum_off + 4], 0);
 
-        // 2) Subtract existing 32-bit checksum (low word then high word with borrow)
+        var sum: u64 = 0;
+        var i: usize = 0;
+
+        // Sum 16-bit words
+        while (i + 1 < data.len) : (i += 2) {
+            const w: u16 = @as(u16, data[i]) | (@as(u16, data[i + 1]) << 8);
+            sum += w;
+            sum = (sum & 0xffff) + (sum >> 16); // fold periodically
+        }
+        // Odd trailing byte
+        if ((data.len & 1) != 0) {
+            sum += data[data.len - 1];
+        }
+
+        // Final folds + add length
+        sum = (sum & 0xffff) + (sum >> 16);
+        sum = (sum & 0xffff) + (sum >> 16);
+        sum += @as(u64, @intCast(data.len));
+        sum = (sum & 0xffff) + (sum >> 16);
+        const final_sum: u32 = @intCast((sum & 0xffff) + (sum >> 16));
+
         const opt = try self.getOptionalHeaderMut();
-        const hdr_sum: u32 = opt.checksum;
-
-        calc = subtractWordWithBorrow(calc, hdr_sum & 0xFFFF);
-        calc = subtractWordWithBorrow(calc, (hdr_sum >> 16) & 0xFFFF);
-
-        // 3) Add file length (bytes); do NOT fold again
-        calc = (calc & 0xFFFF) + @as(u32, @intCast(data.len));
-
-        // 4) Store the 32-bit checksum exactly like Windows does
-        opt.checksum = calc;
+        opt.checksum = final_sum;
     }
 
     /// Add a new section to the PE file for storing Bun module data


### PR DESCRIPTION
## Summary

Implements authenticode signature stripping for Windows PE files when using `bun build --compile`, ensuring that generated executables can be properly signed with external tools after Bun embeds its data section.

## What Changed

### Core Implementation
- **Authenticode stripping**: Removes digital signatures from PE files before adding the .bun section
- **Safe memory access**: Replaced all `@alignCast` operations with safe unaligned access helpers to prevent crashes
- **Hardened PE parsing**: Added comprehensive bounds checking and validation throughout
- **PE checksum recalculation**: Properly updates checksums after modifications

### Key Features
- Always strips authenticode signatures when using `--compile` for Windows (uses `.strip_always` mode)
- Validates PE file structure according to PE/COFF specification
- Handles overlapping memory regions safely during certificate removal
- Clears `IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY` flag when stripping signatures
- Ensures no unexpected overlay data remains after stripping

### Bug Fixes
- Fixed memory corruption bug using `copyBackwards` for overlapping regions
- Fixed checksum calculation skipping 6 bytes instead of 4
- Added integer overflow protection in payload size calculations
- Fixed double alignment bug in `size_of_image` calculation

## Technical Details

The implementation follows the Windows PE/COFF specification and includes:

- `StripMode` enum to control when signatures are stripped (none/strip_if_signed/strip_always)
- Safe unaligned memory access helpers (`viewAtConst`, `viewAtMut`)
- Proper alignment helpers with overflow protection (`alignUpU32`, `alignUpUsize`)
- Comprehensive error types for all failure cases

## Testing

- Passes all existing PE tests in `test/regression/issue/pe-codesigning-integrity.test.ts`
- Compiles successfully with `bun run zig:check-windows`
- Properly integrated with StandaloneModuleGraph for Windows compilation

## Impact

This ensures Windows users can:
1. Use `bun build --compile` to create standalone executables
2. Sign the resulting executables with their own certificates
3. Distribute properly signed Windows binaries

Fixes issues where previously signed executables would have invalid signatures after Bun added its embedded data.