### PR TITLE
Add modulepreload links to HTML bundles for faster waterfall loading

### DIFF
--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -147,25 +147,17 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
 
         fn getHeadTags(this: *@This(), allocator: std.mem.Allocator) std.ArrayList([]const u8) {
             var array = std.ArrayList([]const u8).init(allocator);
-            // Put CSS before JS to reduce changes of flash of unstyled content
             if (this.chunk.getCSSChunkForHTML(this.chunks)) |css_chunk| {
                 const link_tag = bun.handleOom(std.fmt.allocPrintZ(allocator, "<link rel=\"stylesheet\" crossorigin href=\"{s}\">", .{css_chunk.unique_key}));
                 bun.handleOom(array.append(link_tag));
             }
             if (this.chunk.getJSChunkForHTML(this.chunks)) |js_chunk| {
-                // Brilliant insight: Bun has already flattened ALL chunk dependencies!
-                // The main JS chunk imports every chunk it needs directly (even transitive ones),
-                // so we just copy that list - no recursion needed. Bun already did the hard work.
                 for (js_chunk.cross_chunk_imports.slice()) |import| {
-                    // Skip dynamic imports - they shouldn't be preloaded
                     if (import.import_kind == .dynamic) continue;
-
                     const imported_chunk = &this.chunks[import.chunk_index];
                     const preload = bun.handleOom(std.fmt.allocPrintZ(allocator, "<link rel=\"modulepreload\" crossorigin href=\"{s}\">", .{imported_chunk.unique_key}));
                     bun.handleOom(array.append(preload));
                 }
-
-                // type="module" scripts do not block rendering, so it is okay to put them in head
                 const script = bun.handleOom(std.fmt.allocPrintZ(allocator, "<script type=\"module\" crossorigin src=\"{s}\"></script>", .{js_chunk.unique_key}));
                 bun.handleOom(array.append(script));
             }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -147,6 +147,7 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
 
         fn getHeadTags(this: *@This(), allocator: std.mem.Allocator) std.ArrayList([]const u8) {
             var array = std.ArrayList([]const u8).init(allocator);
+            // Put CSS before JS to reduce changes of flash of unstyled content
             if (this.chunk.getCSSChunkForHTML(this.chunks)) |css_chunk| {
                 const link_tag = bun.handleOom(std.fmt.allocPrintZ(allocator, "<link rel=\"stylesheet\" crossorigin href=\"{s}\">", .{css_chunk.unique_key}));
                 bun.handleOom(array.append(link_tag));
@@ -158,6 +159,7 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
                     const preload = bun.handleOom(std.fmt.allocPrintZ(allocator, "<link rel=\"modulepreload\" crossorigin href=\"{s}\">", .{imported_chunk.unique_key}));
                     bun.handleOom(array.append(preload));
                 }
+                // type="module" scripts do not block rendering, so it is okay to put them in head
                 const script = bun.handleOom(std.fmt.allocPrintZ(allocator, "<script type=\"module\" crossorigin src=\"{s}\"></script>", .{js_chunk.unique_key}));
                 bun.handleOom(array.append(script));
             }

--- a/test/bundler/bundler_html_modulepreload.test.ts
+++ b/test/bundler/bundler_html_modulepreload.test.ts
@@ -255,8 +255,8 @@ export function initAdmin() {
     },
   });
 
-  // Test that pages only preload their own dependencies, not other pages' chunks
-  itBundled("html/chunk-isolation", {
+  // Test that exactly the right chunks are preloaded - not too many, not too few
+  itBundled("html/exact-chunk-preloading", {
     outdir: "out/",
     splitting: true,
     files: {
@@ -359,9 +359,91 @@ export function moduleC() {
       expect(page1Preloads).toEqual(page2Preloads);
       expect(page2Preloads).toEqual(page3Preloads);
 
-      // The important test: verify all pages preload the SAME chunk
-      // (which should be the shared chunk, not page-specific chunks)
-      // This proves that pages don't preload each other's exclusive chunks
+      // Critical tests:
+      // 1. Each page should preload exactly its dependencies
+      // 2. Shared chunks should appear in all pages that need them
+      // 3. Exclusive chunks should NOT appear in other pages
+
+      // All three pages share 'shared.js' (contained in same chunk)
+      // so they should all have the same preload
+      expect(page1Preloads).toEqual(page2Preloads);
+      expect(page2Preloads).toEqual(page3Preloads);
+
+      // Verify the preloaded chunk contains shared code
+      if (page1Preloads.length > 0) {
+        const sharedChunk = api.readFile("out/" + page1Preloads[0]);
+        expect(sharedChunk).toMatch(/shared/);
+
+        // Verify it doesn't contain page-exclusive modules
+        expect(sharedChunk).not.toMatch(/moduleA/);
+        expect(sharedChunk).not.toMatch(/moduleB/);
+        expect(sharedChunk).not.toMatch(/moduleC/);
+      }
+    },
+  });
+
+  // Test with complex dependency graph to ensure all needed chunks are preloaded
+  itBundled("html/deep-dependency-preloading", {
+    outdir: "out/",
+    splitting: true,
+    files: {
+      "/entry1.html": `<!DOCTYPE html><html><head><script type="module" src="./entry1.js"></script></head></html>`,
+      "/entry2.html": `<!DOCTYPE html><html><head><script type="module" src="./entry2.js"></script></head></html>`,
+      "/entry1.js": `
+import { a } from './a.js';
+import { b } from './b.js';
+console.log('E1:', a(), b());`,
+      "/entry2.js": `
+import { b } from './b.js';
+import { c } from './c.js';
+console.log('E2:', b(), c());`,
+      "/a.js": `
+import { shared } from './shared.js';
+export function a() { return 'A:' + shared(); }`,
+      "/b.js": `
+import { shared } from './shared.js';
+export function b() { return 'B:' + shared(); }`,
+      "/c.js": `
+import { shared } from './shared.js';
+export function c() { return 'C:' + shared(); }`,
+      "/shared.js": `export function shared() { return 'shared'; }`,
+    },
+    entryPoints: ["/entry1.html", "/entry2.html"],
+
+    onAfterBundle(api) {
+      const entry1Html = api.readFile("out/entry1.html");
+      const entry2Html = api.readFile("out/entry2.html");
+
+      // Extract preloaded chunks
+      const getPreloads = (html: string) =>
+        [...html.matchAll(/rel="modulepreload"[^>]+href="\.\/([^"]+)"/g)]
+          .map(m => m[1]);
+
+      const entry1Preloads = getPreloads(entry1Html);
+      const entry2Preloads = getPreloads(entry2Html);
+
+      // Both should have preloads
+      expect(entry1Preloads.length).toBeGreaterThan(0);
+      expect(entry2Preloads.length).toBeGreaterThan(0);
+
+      // Verify main scripts are NOT in preloads
+      expect(entry1Html).toMatch(/<script[^>]+src="\.\/entry1-[^"]+\.js"/);
+      expect(entry2Html).toMatch(/<script[^>]+src="\.\/entry2-[^"]+\.js"/);
+
+      const entry1MainScript = entry1Html.match(/src="\.\/([^"]+)"/)?.[1];
+      const entry2MainScript = entry2Html.match(/src="\.\/([^"]+)"/)?.[1];
+
+      // Main scripts should NOT be preloaded
+      expect(entry1Preloads).not.toContain(entry1MainScript);
+      expect(entry2Preloads).not.toContain(entry2MainScript);
+
+      // Count preloads vs script tags
+      const entry1ScriptCount = (entry1Html.match(/<script/g) || []).length;
+      const entry2ScriptCount = (entry2Html.match(/<script/g) || []).length;
+
+      // Should only have one script tag (the main one)
+      expect(entry1ScriptCount).toBe(1);
+      expect(entry2ScriptCount).toBe(1);
     },
   });
 });

--- a/test/bundler/bundler_html_modulepreload.test.ts
+++ b/test/bundler/bundler_html_modulepreload.test.ts
@@ -7,6 +7,28 @@ function getModulePreloads(html: string): string[] {
     .map(m => m[1]);
 }
 
+// Helper to get the main script src
+function getMainScriptSrc(html: string): string | null {
+  const match = html.match(/<script[^>]+type="module"[^>]+src="\.\/([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+// Helper to check tag order in HTML head
+function checkTagOrder(html: string): { cssFirst: boolean; preloadsBeforeScript: boolean } {
+  const headMatch = html.match(/<head[^>]*>([\s\S]*?)<\/head>/);
+  if (!headMatch) return { cssFirst: false, preloadsBeforeScript: false };
+
+  const head = headMatch[1];
+  const cssIndex = head.indexOf('rel="stylesheet"');
+  const firstPreloadIndex = head.indexOf('rel="modulepreload"');
+  const scriptIndex = head.indexOf('<script type="module"');
+
+  return {
+    cssFirst: cssIndex === -1 || firstPreloadIndex === -1 || cssIndex < firstPreloadIndex,
+    preloadsBeforeScript: firstPreloadIndex === -1 || scriptIndex === -1 || firstPreloadIndex < scriptIndex
+  };
+}
+
 // Helper to create simple HTML with script tag
 function createHTML(title: string, scriptSrc: string): string {
   return `<!DOCTYPE html>

--- a/test/bundler/bundler_html_modulepreload.test.ts
+++ b/test/bundler/bundler_html_modulepreload.test.ts
@@ -1,0 +1,130 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  // Test that modulepreload links are added for chunk dependencies
+  itBundled("html/modulepreload-chunks", {
+    outdir: "out/",
+    splitting: true,
+    files: {
+      "/page1.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page 1</title>
+    <script type="module" src="./page1.js"></script>
+  </head>
+  <body>
+    <h1>Page 1</h1>
+  </body>
+</html>`,
+      "/page2.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page 2</title>
+    <script type="module" src="./page2.js"></script>
+  </head>
+  <body>
+    <h1>Page 2</h1>
+  </body>
+</html>`,
+      "/page1.js": `
+import { shared } from './shared.js';
+import { utils } from './utils.js';
+console.log('Page 1:', shared(), utils());
+export function page1Init() {
+  console.log('Page 1 initialized');
+}`,
+      "/page2.js": `
+import { shared } from './shared.js';
+import { utils } from './utils.js';
+console.log('Page 2:', shared(), utils());
+export function page2Init() {
+  console.log('Page 2 initialized');
+}`,
+      "/shared.js": `
+export function shared() {
+  return 'shared code';
+}`,
+      "/utils.js": `
+export function utils() {
+  return 'utils';
+}`,
+    },
+    entryPoints: ["/page1.html", "/page2.html"],
+
+    onAfterBundle(api) {
+      // Check that HTML includes modulepreload links for chunks
+      const page1Html = api.readFile("out/page1.html");
+      const page2Html = api.readFile("out/page2.html");
+
+      // Both pages should have modulepreload links
+      api.expectFile("out/page1.html").toMatch(/rel="modulepreload"/);
+      api.expectFile("out/page2.html").toMatch(/rel="modulepreload"/);
+
+      // Extract the chunk names from modulepreload links
+      const page1Preloads = page1Html.match(/rel="modulepreload"[^>]+href="([^"]+)"/g) || [];
+      const page2Preloads = page2Html.match(/rel="modulepreload"[^>]+href="([^"]+)"/g) || [];
+
+      // Both should preload the shared chunk
+      api.expect(page1Preloads.length).toBeGreaterThan(0);
+      api.expect(page2Preloads.length).toBeGreaterThan(0);
+    },
+  });
+
+  // Test with nested chunk dependencies
+  itBundled("html/modulepreload-nested-chunks", {
+    outdir: "out/",
+    splitting: true,
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Main</title>
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <h1>Main</h1>
+  </body>
+</html>`,
+      "/main.js": `
+import { featureA } from './feature-a.js';
+import { featureB } from './feature-b.js';
+console.log('Main:', featureA(), featureB());`,
+      "/feature-a.js": `
+import { shared } from './shared.js';
+export function featureA() {
+  return 'Feature A: ' + shared();
+}`,
+      "/feature-b.js": `
+import { shared } from './shared.js';
+export function featureB() {
+  return 'Feature B: ' + shared();
+}`,
+      "/shared.js": `
+import { deepDep } from './deep-dep.js';
+export function shared() {
+  return 'shared: ' + deepDep();
+}`,
+      "/deep-dep.js": `
+export function deepDep() {
+  return 'deep dependency';
+}`,
+    },
+    entryPoints: ["/index.html"],
+
+    onAfterBundle(api) {
+      // Check that HTML includes modulepreload links for all dependency chunks
+      api.expectFile("out/index.html").toMatch(/rel="modulepreload"/);
+
+      // Should have preloads for all chunks that the main chunk depends on
+      const htmlContent = api.readFile("out/index.html");
+      const preloadMatches = htmlContent.match(/rel="modulepreload"/g) || [];
+
+      // With nested dependencies, we should have multiple preloads
+      api.expect(preloadMatches.length).toBeGreaterThanOrEqual(1);
+    },
+  });
+});

--- a/test/bundler/bundler_html_modulepreload.test.ts
+++ b/test/bundler/bundler_html_modulepreload.test.ts
@@ -3,8 +3,7 @@ import { itBundled } from "./expectBundled";
 
 // Helper to extract modulepreload links from HTML
 function getModulePreloads(html: string): string[] {
-  return [...html.matchAll(/rel="modulepreload"[^>]+href="\.\/([^"]+)"/g)]
-    .map(m => m[1]);
+  return [...html.matchAll(/rel="modulepreload"[^>]+href="\.\/([^"]+)"/g)].map(m => m[1]);
 }
 
 // Helper to get the main script src
@@ -25,7 +24,7 @@ function checkTagOrder(html: string): { cssFirst: boolean; preloadsBeforeScript:
 
   return {
     cssFirst: cssIndex === -1 || firstPreloadIndex === -1 || cssIndex < firstPreloadIndex,
-    preloadsBeforeScript: firstPreloadIndex === -1 || scriptIndex === -1 || firstPreloadIndex < scriptIndex
+    preloadsBeforeScript: firstPreloadIndex === -1 || scriptIndex === -1 || firstPreloadIndex < scriptIndex,
   };
 }
 
@@ -247,8 +246,8 @@ export function initAdmin() {
       const preloadedFiles = getModulePreloads(indexHtml);
 
       // Dynamic imports should NOT be preloaded
-      expect(preloadedFiles.some(f => f.includes('heavy'))).toBe(false);
-      expect(preloadedFiles.some(f => f.includes('admin'))).toBe(false);
+      expect(preloadedFiles.some(f => f.includes("heavy"))).toBe(false);
+      expect(preloadedFiles.some(f => f.includes("admin"))).toBe(false);
 
       // But there should be some preloads for the static imports
       expect(preloadedFiles.length).toBeGreaterThan(0);
@@ -386,8 +385,7 @@ export function c() { return 'C:' + shared(); }`,
 
       // Extract preloaded chunks
       const getPreloads = (html: string) =>
-        [...html.matchAll(/rel="modulepreload"[^>]+href="\.\/([^"]+)"/g)]
-          .map(m => m[1]);
+        [...html.matchAll(/rel="modulepreload"[^>]+href="\.\/([^"]+)"/g)].map(m => m[1]);
 
       const entry1Preloads = getPreloads(entry1Html);
       const entry2Preloads = getPreloads(entry2Html);


### PR DESCRIPTION
## Summary

This PR adds `<link rel="modulepreload">` tags to HTML bundles to eliminate waterfall loading and significantly improve page load performance.

## Problem

HTML bundles suffered from waterfall loading where JavaScript chunks were discovered and fetched sequentially as scripts executed. This led to poor loading performance as the browser had to wait for each script to load and parse before discovering the next chunk dependency.

## Solution

Modified `generateCompileResultForHtmlChunk.zig` to automatically generate `<link rel="modulepreload">` tags for all statically imported chunks directly in the HTML head. This allows browsers to fetch all required chunks in parallel immediately when parsing the HTML.

## Implementation Details

- **Core Logic**: Added iteration through `cross_chunk_imports` in the HTML chunk generation
- **Selective Preloading**: Only includes statically imported chunks (excludes dynamic imports to avoid fetching unused code)
- **Optimal Tag Order**: Places CSS first, then modulepreload links, then the main script to minimize FOUC (Flash of Unstyled Content)
- **Cross-origin Support**: Includes `crossorigin` attribute for proper CORS handling

## Benefits

- **Parallel Loading**: All chunks fetch simultaneously instead of sequentially
- **Faster Page Loads**: Eliminates network waterfall delays
- **Better UX**: Reduces time to interactive for JavaScript-heavy applications
- **Backward Compatible**: Uses standard web APIs with no breaking changes

## Testing

Added comprehensive test suite covering:
- ✅ Basic modulepreload link generation
- ✅ Multiple script imports with proper preloading
- ✅ Dynamic imports (correctly excluded from preloading)
- ✅ Code splitting scenarios with entry points
- ✅ Tag ordering (CSS → modulepreload → script)
- ✅ Edge cases and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)