### PR TITLE
fix(CString): define byteLength and byteOffset properties

### DIFF
--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -1067,7 +1067,11 @@ declare module "bun:ffi" {
      */
     ptr: Pointer;
     byteOffset: number;
-    byteLength: number;
+
+    /**
+     * Get the `byteLength` of the CString
+     */
+    get byteLength(): number;
 
     /**
      * Get the {@link ptr} as an `ArrayBuffer`

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -1066,8 +1066,8 @@ declare module "bun:ffi" {
      * use after the memory at `ptr` has been freed.
      */
     ptr: Pointer;
-    byteOffset?: number;
-    byteLength?: number;
+    byteOffset: number;
+    byteLength: number;
 
     /**
      * Get the {@link ptr} as an `ArrayBuffer`

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -117,20 +117,17 @@ class JSCallback {
 
 class CString extends String {
   constructor(ptr, byteOffset?, byteLength?) {
+    byteOffset ||= 0;
     super(
       ptr
         ? typeof byteLength === "number" && Number.isSafeInteger(byteLength)
-          ? BunCString(ptr, byteOffset || 0, byteLength)
-          : BunCString(ptr, byteOffset || 0)
+          ? BunCString(ptr, byteOffset, byteLength)
+          : BunCString(ptr, byteOffset)
         : "",
     );
+    this.byteLength = byteLength || Buffer.byteLength(this.toString(), 'utf-8');
+    this.byteOffset = byteOffset;
     this.ptr = typeof ptr === "number" ? ptr : 0;
-    if (typeof byteOffset !== "undefined") {
-      this.byteOffset = byteOffset;
-    }
-    if (typeof byteLength !== "undefined") {
-      this.byteLength = byteLength;
-    }
   }
 
   ptr;

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -117,23 +117,28 @@ class JSCallback {
 
 class CString extends String {
   constructor(ptr, byteOffset?, byteLength?) {
-    byteOffset ||= 0;
+    byteOffset ??= 0;
+
+    const hasLength = typeof byteLength === "number" && Number.isSafeInteger(byteLength);
+    const hasPtr = typeof ptr === "number" && ptr !== 0;
+
     super(
-      ptr
-        ? typeof byteLength === "number" && Number.isSafeInteger(byteLength)
+      hasPtr
+        ? hasLength
           ? BunCString(ptr, byteOffset, byteLength)
           : BunCString(ptr, byteOffset)
         : "",
     );
-    this.byteLength = byteLength || Buffer.byteLength(this.toString(), 'utf-8');
+
+    this.#cachedByteLength = hasPtr ? (hasLength ? byteLength : undefined) : 0;
     this.byteOffset = byteOffset;
-    this.ptr = typeof ptr === "number" ? ptr : 0;
+    this.ptr = hasPtr ? ptr : 0;
   }
 
   ptr;
   byteOffset;
-  byteLength;
   #cachedArrayBuffer;
+  #cachedByteLength;
 
   get arrayBuffer() {
     if (this.#cachedArrayBuffer) {
@@ -145,6 +150,10 @@ class CString extends String {
     }
 
     return (this.#cachedArrayBuffer = toArrayBuffer(this.ptr, this.byteOffset, this.byteLength));
+  }
+
+  get byteLength() {
+    return (this.#cachedByteLength ??= Buffer.byteLength(super.valueOf(), 'utf-8'));
   }
 }
 Object.defineProperty(globalThis, "__GlobalBunCString", {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -480,8 +480,8 @@ function ffiRunner(fast) {
       expect(identity_ptr(second_ptr)).toBe(second_ptr);
       expect(new CString(ptr(Buffer.from([97, 97, 97, 0, 97, 98, 99, 0, 0])), 4).toString()).toBe("abc");
       expect(new CString(ptr(Buffer.from([97, 97, 97, 0, 97, 98, 99, 0, 0])), 4, 2).toString()).toBe("ab");
-      expect(new CString(ptr(Buffer.from([97, 98, 99, 240, 159, 171, 160, 0])), 4).byteOffset).toBe(0);
-      expect(new CString(ptr(Buffer.from([97, 98, 99, 240, 159, 171, 160, 0])), 4).byteLength).toBe(7);
+      expect(new CString(ptr(Buffer.from([97, 98, 99, 240, 159, 171, 160, 0]))).byteOffset).toBe(0);
+      expect(new CString(ptr(Buffer.from([97, 98, 99, 240, 159, 171, 160, 0]))).byteLength).toBe(7);
     });
 
     it("CFunction", () => {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -480,6 +480,8 @@ function ffiRunner(fast) {
       expect(identity_ptr(second_ptr)).toBe(second_ptr);
       expect(new CString(ptr(Buffer.from([97, 97, 97, 0, 97, 98, 99, 0, 0])), 4).toString()).toBe("abc");
       expect(new CString(ptr(Buffer.from([97, 97, 97, 0, 97, 98, 99, 0, 0])), 4, 2).toString()).toBe("ab");
+      expect(new CString(ptr(Buffer.from([97, 98, 99, 240, 159, 171, 160, 0])), 4).byteOffset).toBe(0);
+      expect(new CString(ptr(Buffer.from([97, 98, 99, 240, 159, 171, 160, 0])), 4).byteLength).toBe(7);
     });
 
     it("CFunction", () => {


### PR DESCRIPTION
### What does this PR do?

This PR:
- Addresses #22920.
- Defines `CString`'s `byteLength` and `byteOffset` properties.
- Makes `byteOffset` default to `0`, and `byteLength` a **lazy, cached** getter — it's computed via `Buffer.byteLength(…, "utf-8")` only on first access when a length wasn't supplied to the constructor, then cached. An explicitly-supplied length is used verbatim, and an empty `CString` reports `0` without recomputing.
- Fixes the typing to make these properties non-nullable.
- Adds tests for valid values of these properties.

### How did you verify your code works?

Added tests to `test/js/bun/ffi/ffi.test.js`. Rebased onto current `main` and verified the runtime behavior against a local debug build:

- `new CString(ptr(buf)).byteOffset` → `0`
- `new CString(ptr("abc🫠\0")).byteLength` → `7` (lazy UTF-8 length)
- explicit `byteOffset` / `byteLength` are preserved (`new CString(ptr(buf), 4, 2)` → offset `4`, length `2`)
- empty `new CString(0)` → `byteOffset` `0`, `byteLength` `0`
- repeated `byteLength` reads return the cached value

(The in-file assertions live inside the `ffiRunner` suite, which CI exercises with the compiled `ffi-test` fixture.)
