### PR TITLE
Remove stale path assertion on Windows

### DIFF
--- a/src/string/immutable.zig
+++ b/src/string/immutable.zig
@@ -2313,7 +2313,6 @@ pub const addNTPathPrefix = paths_.addNTPathPrefix;
 pub const addNTPathPrefixIfNeeded = paths_.addNTPathPrefixIfNeeded;
 pub const addLongPathPrefix = paths_.addLongPathPrefix;
 pub const addLongPathPrefixIfNeeded = paths_.addLongPathPrefixIfNeeded;
-pub const assertIsValidWindowsPath = paths_.assertIsValidWindowsPath;
 pub const charIsAnySlash = paths_.charIsAnySlash;
 pub const cloneNormalizingSeparators = paths_.cloneNormalizingSeparators;
 pub const fromWPath = paths_.fromWPath;

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -288,24 +288,6 @@ fn isUNCPath(comptime T: type, path: []const T) bool {
         !bun.path.Platform.windows.isSeparatorT(T, path[2]) and
         path[2] != '.';
 }
-pub fn assertIsValidWindowsPath(comptime T: type, path: []const T) void {
-    if (Environment.allow_assert and Environment.isWindows) {
-        if (bun.path.Platform.windows.isAbsoluteT(T, path) and
-            isWindowsAbsolutePathMissingDriveLetter(T, path) and
-            // is it a null device path? that's not an error. it's just a weird file path.
-            !eqlComptimeT(T, path, "\\\\.\\NUL") and !eqlComptimeT(T, path, "\\\\.\\nul") and !eqlComptimeT(T, path, "\\nul") and !eqlComptimeT(T, path, "\\NUL") and !isUNCPath(T, path))
-        {
-            std.debug.panic("Internal Error: Do not pass posix paths to Windows APIs, was given '{s}'" ++ if (Environment.isDebug) " (missing a root like 'C:\\', see PosixToWinNormalizer for why this is an assertion)" else ". Please open an issue on GitHub with a reproduction.", .{
-                if (T == u8) path else bun.fmt.utf16(path),
-            });
-        }
-        if (hasPrefixComptimeType(T, path, ":/") and Environment.isDebug) {
-            std.debug.panic("Path passed to windows API '{s}' is almost certainly invalid. Where did the drive letter go?", .{
-                if (T == u8) path else bun.fmt.utf16(path),
-            });
-        }
-    }
-}
 
 pub fn toWPathMaybeDir(wbuf: []u16, utf8: []const u8, comptime add_trailing_lash: bool) [:0]u16 {
     bun.unsafeAssert(wbuf.len > 0);

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -500,7 +500,6 @@ const assert = bun.assert;
 
 const strings = bun.strings;
 const copyUTF16IntoUTF8 = strings.copyUTF16IntoUTF8;
-const eqlComptimeT = strings.eqlComptimeT;
 const hasPrefixComptime = strings.hasPrefixComptime;
 const hasPrefixComptimeType = strings.hasPrefixComptimeType;
 const hasPrefixComptimeUTF16 = strings.hasPrefixComptimeUTF16;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -660,7 +660,7 @@ pub fn mkdirA(file_path: []const u8, flags: mode_t) Maybe(void) {
         const wbuf = bun.w_path_buffer_pool.get();
         defer bun.w_path_buffer_pool.put(wbuf);
         const wpath = bun.strings.toKernel32Path(wbuf, file_path);
-        assertIsValidWindowsPath(u16, wpath);
+
         return Maybe(void).errnoSysP(
             kernel32.CreateDirectoryW(wpath.ptr, null),
             .mkdir,
@@ -811,7 +811,7 @@ fn openDirAtWindowsNtPath(
     const no_follow = options.no_follow;
     const can_rename_or_delete = options.can_rename_or_delete;
     const read_only = options.read_only;
-    assertIsValidWindowsPath(u16, path);
+
     const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
         w.SYNCHRONIZE | w.FILE_TRAVERSE;
     const iterable_flag: u32 = if (iterable) w.FILE_LIST_DIRECTORY else 0;
@@ -1010,7 +1010,6 @@ pub fn openFileAtWindowsNtPath(
     // this path is probably already backslash normalized so we're only going to check for '.\'
     // const path = if (bun.strings.hasPrefixComptimeUTF16(path_maybe_leading_dot, ".\\")) path_maybe_leading_dot[2..] else path_maybe_leading_dot;
     // bun.assert(!bun.strings.hasPrefixComptimeUTF16(path_maybe_leading_dot, "./"));
-    assertIsValidWindowsPath(u16, path);
 
     var result: windows.HANDLE = undefined;
 
@@ -2624,7 +2623,6 @@ pub fn mmap(
 }
 
 pub fn mmapFile(path: [:0]const u8, flags: std.c.MAP, wanted_size: ?usize, offset: usize) Maybe([]align(page_size_min) u8) {
-    assertIsValidWindowsPath(u8, path);
     const fd = switch (open(path, bun.O.RDWR, 0)) {
         .result => |fd| fd,
         .err => |err| return .{ .err = err },
@@ -4156,7 +4154,6 @@ const MAX_PATH_BYTES = bun.MAX_PATH_BYTES;
 const c = bun.c; // translated c headers
 const jsc = bun.jsc;
 const libc_stat = bun.Stat;
-const assertIsValidWindowsPath = bun.strings.assertIsValidWindowsPath;
 const darwin_nocancel = bun.darwin.nocancel;
 
 const windows = bun.windows;

--- a/src/sys_uv.zig
+++ b/src/sys_uv.zig
@@ -19,8 +19,6 @@ pub const access = bun.sys.access;
 // Note: `req = undefined; req.deinit()` has a safety-check in a debug build
 
 pub fn open(file_path: [:0]const u8, c_flags: i32, _perm: bun.Mode) Maybe(bun.FileDescriptor) {
-    assertIsValidWindowsPath(u8, file_path);
-
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
 
@@ -41,7 +39,6 @@ pub fn open(file_path: [:0]const u8, c_flags: i32, _perm: bun.Mode) Maybe(bun.Fi
 }
 
 pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_mkdir(uv.Loop.get(), &req, file_path.ptr, flags, null);
@@ -54,7 +51,6 @@ pub fn mkdir(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
 }
 
 pub fn chmod(file_path: [:0]const u8, flags: bun.Mode) Maybe(void) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
 
@@ -81,7 +77,6 @@ pub fn fchmod(fd: FileDescriptor, flags: bun.Mode) Maybe(void) {
 }
 
 pub fn statfs(file_path: [:0]const u8) Maybe(bun.StatFS) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_statfs(uv.Loop.get(), &req, file_path.ptr, null);
@@ -94,7 +89,6 @@ pub fn statfs(file_path: [:0]const u8) Maybe(bun.StatFS) {
 }
 
 pub fn chown(file_path: [:0]const u8, uid: uv.uv_uid_t, gid: uv.uv_uid_t) Maybe(void) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_chown(uv.Loop.get(), &req, file_path.ptr, uid, gid, null);
@@ -121,7 +115,6 @@ pub fn fchown(fd: FileDescriptor, uid: uv.uv_uid_t, gid: uv.uv_uid_t) Maybe(void
 }
 
 pub fn rmdir(file_path: [:0]const u8) Maybe(void) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_rmdir(uv.Loop.get(), &req, file_path.ptr, null);
@@ -134,7 +127,6 @@ pub fn rmdir(file_path: [:0]const u8) Maybe(void) {
 }
 
 pub fn unlink(file_path: [:0]const u8) Maybe(void) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_unlink(uv.Loop.get(), &req, file_path.ptr, null);
@@ -147,7 +139,6 @@ pub fn unlink(file_path: [:0]const u8) Maybe(void) {
 }
 
 pub fn readlink(file_path: [:0]const u8, buf: []u8) Maybe([:0]u8) {
-    assertIsValidWindowsPath(u8, file_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     // Edge cases: http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_realpath
@@ -172,8 +163,6 @@ pub fn readlink(file_path: [:0]const u8, buf: []u8) Maybe([:0]u8) {
 }
 
 pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
-    assertIsValidWindowsPath(u8, from);
-    assertIsValidWindowsPath(u8, to);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_rename(uv.Loop.get(), &req, from.ptr, to.ptr, null);
@@ -187,8 +176,6 @@ pub fn rename(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
 }
 
 pub fn link(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
-    assertIsValidWindowsPath(u8, from);
-    assertIsValidWindowsPath(u8, to);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_link(uv.Loop.get(), &req, from.ptr, to.ptr, null);
@@ -201,8 +188,6 @@ pub fn link(from: [:0]const u8, to: [:0]const u8) Maybe(void) {
 }
 
 pub fn symlinkUV(target: [:0]const u8, new_path: [:0]const u8, flags: c_int) Maybe(void) {
-    assertIsValidWindowsPath(u8, target);
-    assertIsValidWindowsPath(u8, new_path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_symlink(uv.Loop.get(), &req, target.ptr, new_path.ptr, flags, null);
@@ -267,7 +252,6 @@ pub fn fsync(fd: FileDescriptor) Maybe(void) {
 }
 
 pub fn stat(path: [:0]const u8) Maybe(bun.Stat) {
-    assertIsValidWindowsPath(u8, path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_stat(uv.Loop.get(), &req, path.ptr, null);
@@ -280,7 +264,6 @@ pub fn stat(path: [:0]const u8) Maybe(bun.Stat) {
 }
 
 pub fn lstat(path: [:0]const u8) Maybe(bun.Stat) {
-    assertIsValidWindowsPath(u8, path);
     var req: uv.fs_t = uv.fs_t.uninitialized;
     defer req.deinit();
     const rc = uv.uv_fs_lstat(uv.Loop.get(), &req, path.ptr, null);
@@ -402,5 +385,4 @@ const bun = @import("bun");
 const Environment = bun.Environment;
 const FileDescriptor = bun.FileDescriptor;
 const Maybe = bun.sys.Maybe;
-const assertIsValidWindowsPath = bun.strings.assertIsValidWindowsPath;
 const uv = bun.windows.libuv;


### PR DESCRIPTION
### What does this PR do?

This assertion is occasionally incorrect, and was originally added as a workaround for lack of proper error handling in zig's std library. We've seen fixed that so this assertion is no longer needed.

### How did you verify your code works?
