### PR TITLE
node:http2: fix leak in H2FrameParser

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4270,8 +4270,8 @@ pub const H2FrameParser = struct {
     }
 
     pub fn detachNativeSocket(this: *H2FrameParser) void {
-        this.native_socket = .{ .none = {} };
         const native_socket = this.native_socket;
+        this.native_socket = .{ .none = {} };
 
         switch (native_socket) {
             inline .tcp, .tls => |socket| {


### PR DESCRIPTION
verified locally. let's see what CI says
test/js/node/test/parallel/test-http2-*.js