### PR TITLE
vscode: remove old test runner codelens stuff

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -45,3 +45,8 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCODE_EXTENSION }}
         working-directory: packages/bun-vscode/extension
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bun-vscode-${{ github.event.inputs.version }}.vsix
+          path: packages/bun-vscode/extension/bun-vscode-${{ github.event.inputs.version }}.vsix

--- a/packages/bun-vscode/README.md
+++ b/packages/bun-vscode/README.md
@@ -22,7 +22,7 @@ At its core is the _Bun runtime_, a fast JavaScript runtime designed as a drop-i
 ## Features:
 
 - Live in-editor error messages (gif below)
-- Test runner codelens
+- Vscode test runner support
 - Debugger support
 - Run scripts from package.json
 - Visual lockfile viewer for old binary lockfiles (`bun.lockb`)

--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-vscode",
-  "version": "0.0.29",
+  "version": "0.0.31",
   "author": "oven",
   "repository": {
     "type": "git",
@@ -116,20 +116,6 @@
         "category": "Bun",
         "enablement": "!inDebugMode && resourceLangId =~ /^(javascript|typescript|javascriptreact|typescriptreact)$/ && !isInDiffEditor && resourceScheme == 'untitled'",
         "icon": "$(play-circle)"
-      },
-      {
-        "command": "extension.bun.runTest",
-        "title": "Run all tests",
-        "shortTitle": "Run Test",
-        "category": "Bun",
-        "icon": "$(play)"
-      },
-      {
-        "command": "extension.bun.watchTest",
-        "title": "Run all tests in watch mode",
-        "shortTitle": "Run Test Watch",
-        "category": "Bun",
-        "icon": "$(sync)"
       }
     ],
     "menus": {


### PR DESCRIPTION
### What does this PR do?

fix #23001 by removing references to old codelens from before the native integration which should have its own (better and) native way of starting

### How did you verify your code works?
