### PR TITLE
fix(mysql:tests) add more complex password and fix empty password/non empty password tests in mysql2

### DIFF
--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -7,6 +7,7 @@ Docker Compose is a tool for defining and running multi-container Docker applica
 ### Why Use Docker Compose Instead of Plain Docker?
 
 **Without Docker Compose (the old way):**
+
 ```javascript
 // Each test file manages its own container
 const container = await Bun.spawn({
@@ -21,6 +22,7 @@ const container = await Bun.spawn({
 ```
 
 **With Docker Compose (the new way):**
+
 ```javascript
 // All tests share managed containers
 const postgres = await dockerCompose.ensure("postgres_plain");
@@ -34,26 +36,31 @@ const postgres = await dockerCompose.ensure("postgres_plain");
 ## Benefits of This Setup
 
 ### 1. **Speed** 🚀
+
 - Containers start once and stay running
 - Tests run 10-100x faster (no container startup overhead)
 - Example: PostgreSQL tests went from 30s to 3s
 
 ### 2. **No Port Conflicts** 🔌
+
 - Docker Compose assigns random available ports automatically
 - No more "port already in use" errors
 - Multiple developers can run tests simultaneously
 
 ### 3. **Centralized Configuration** 📝
+
 - All services defined in one `docker-compose.yml` file
 - Easy to update versions, add services, or change settings
 - No need to hunt through test files to find container configs
 
 ### 4. **Lazy Loading** 💤
+
 - Services only start when actually needed
 - Running MySQL tests? Only MySQL starts
 - Saves memory and CPU
 
 ### 5. **Better CI/CD** 🔄
+
 - Predictable, reproducible test environments
 - Same setup locally and in CI
 - Easy to debug when things go wrong
@@ -63,6 +70,7 @@ const postgres = await dockerCompose.ensure("postgres_plain");
 ### The Setup
 
 1. **docker-compose.yml** - Defines all test services:
+
 ```yaml
 services:
   postgres_plain:
@@ -70,11 +78,12 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - target: 5432      # Container's port
-        published: 0      # 0 = let Docker pick a random port
+      - target: 5432 # Container's port
+        published: 0 # 0 = let Docker pick a random port
 ```
 
 2. **index.ts** - TypeScript helper for managing services:
+
 ```typescript
 // Start a service (if not already running)
 const info = await dockerCompose.ensure("postgres_plain");
@@ -83,6 +92,7 @@ const info = await dockerCompose.ensure("postgres_plain");
 ```
 
 3. **Test Integration**:
+
 ```typescript
 import * as dockerCompose from "../../docker/index.ts";
 
@@ -90,7 +100,7 @@ test("database test", async () => {
   const pg = await dockerCompose.ensure("postgres_plain");
   const client = new PostgresClient({
     host: pg.host,
-    port: pg.ports[5432],  // Use the mapped port
+    port: pg.ports[5432], // Use the mapped port
   });
   // ... run tests
 });
@@ -98,22 +108,24 @@ test("database test", async () => {
 
 ## Available Services
 
-| Service | Description | Ports | Special Features |
-|---------|-------------|-------|------------------|
-| **PostgreSQL** | | | |
-| `postgres_plain` | Basic PostgreSQL | 5432 | No auth required |
-| `postgres_tls` | PostgreSQL with TLS | 5432 | SSL certificates included |
-| `postgres_auth` | PostgreSQL with auth | 5432 | Username/password required |
-| **MySQL** | | | |
-| `mysql_plain` | Basic MySQL | 3306 | Root user, no password |
-| `mysql_native_password` | MySQL with legacy auth | 3306 | For compatibility testing |
-| `mysql_tls` | MySQL with TLS | 3306 | SSL certificates included |
-| **Redis/Valkey** | | | |
-| `redis_unified` | Redis with all features | 6379 (TCP), 6380 (TLS) | Persistence, Unix sockets, ACLs |
-| **S3/MinIO** | | | |
-| `minio` | S3-compatible storage | 9000 (API), 9001 (Console) | AWS S3 API testing |
-| **WebSocket** | | | |
-| `autobahn` | WebSocket test suite | 9002 | 517 conformance tests |
+| Service                      | Description             | Ports                      | Special Features                |
+| ---------------------------- | ----------------------- | -------------------------- | ------------------------------- |
+| **PostgreSQL**               |                         |                            |                                 |
+| `postgres_plain`             | Basic PostgreSQL        | 5432                       | No auth required                |
+| `postgres_tls`               | PostgreSQL with TLS     | 5432                       | SSL certificates included       |
+| `postgres_auth`              | PostgreSQL with auth    | 5432                       | Username/password required      |
+| **MySQL**                    |                         |                            |                                 |
+| `mysql_plain`                | Basic MySQL 8           | 3306                       | Root user                       |
+| `mysql_plain_empty_password` | Basic MySQL 8           | 3306                       | Root user, no password          |
+| `mysql_native_password`      | MySQL with legacy auth  | 3306                       | For compatibility testing       |
+| `mysql_tls`                  | MySQL with TLS          | 3306                       | SSL certificates included       |
+| `mysql_plain_9`              | Basic MySQL 9           | 3306                       | Root user                       |
+| **Redis/Valkey**             |                         |                            |                                 |
+| `redis_unified`              | Redis with all features | 6379 (TCP), 6380 (TLS)     | Persistence, Unix sockets, ACLs |
+| **S3/MinIO**                 |                         |                            |                                 |
+| `minio`                      | S3-compatible storage   | 9000 (API), 9001 (Console) | AWS S3 API testing              |
+| **WebSocket**                |                         |                            |                                 |
+| `autobahn`                   | WebSocket test suite    | 9002                       | 517 conformance tests           |
 
 ## Usage Examples
 
@@ -193,27 +205,32 @@ This is different from the old approach where every test started and stopped its
 ## Debugging
 
 ### View Running Services
+
 ```bash
 cd test/docker
 docker-compose ps
 ```
 
 ### Check Service Logs
+
 ```bash
 docker-compose logs postgres_plain
 ```
 
 ### Stop All Services
+
 ```bash
 docker-compose down
 ```
 
 ### Remove Everything (Including Data)
+
 ```bash
 docker-compose down -v  # -v removes volumes too
 ```
 
 ### Connection Issues?
+
 ```bash
 # Check if service is healthy
 docker-compose ps
@@ -238,12 +255,14 @@ const pg = await dockerCompose.ensure("postgres_plain");
 ### Persistent Data
 
 Some services use volumes to persist data across container restarts:
+
 - Redis: Uses volume for AOF persistence
 - PostgreSQL/MySQL: Can be configured with volumes if needed
 
 ### Environment Variables
 
 Control behavior with environment variables:
+
 - `COMPOSE_PROJECT_NAME`: Prefix for container names (default: "bun-test-services")
 - `BUN_DOCKER_COMPOSE_PATH`: Override docker-compose.yml location
 
@@ -258,6 +277,7 @@ If you're migrating tests from direct Docker usage:
 5. **Cleanup**: Remove old Docker management code
 
 Example migration:
+
 ```javascript
 // OLD
 const container = spawn(["docker", "run", "-d", "postgres"]);
@@ -298,13 +318,13 @@ A: This tells Docker to pick any available port, preventing conflicts.
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| "Connection refused" | Service might still be starting. Add `waitTcp()` or increase timeout |
-| "Port already in use" | Another service using the port. Use dynamic ports (`published: 0`) |
-| "Container not found" | Run `docker-compose up -d SERVICE_NAME` manually |
-| Tests suddenly slow | Containers might have been stopped. Check with `docker-compose ps` |
-| "Permission denied" | Docker daemon might require sudo. Check Docker installation |
+| Problem               | Solution                                                             |
+| --------------------- | -------------------------------------------------------------------- |
+| "Connection refused"  | Service might still be starting. Add `waitTcp()` or increase timeout |
+| "Port already in use" | Another service using the port. Use dynamic ports (`published: 0`)   |
+| "Container not found" | Run `docker-compose up -d SERVICE_NAME` manually                     |
+| Tests suddenly slow   | Containers might have been stopped. Check with `docker-compose ps`   |
+| "Permission denied"   | Docker daemon might require sudo. Check Docker installation          |
 
 ## Contributing
 

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -95,6 +95,24 @@ services:
       retries: 30
       start_period: 10s
 
+  mysql_plain_9:
+    image: mysql:9
+    environment:
+      MYSQL_ROOT_PASSWORD: "bun123456@#$%^&*()"
+      MYSQL_DATABASE: bun_sql_test
+    ports:
+      - target: 3306
+        published: 0
+        protocol: tcp
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 1h # Effectively disable after startup
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
   mysql_plain_empty_password:
     image: mysql:8.4
     environment:

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   mysql_native_password:
     image: mysql:8.0
     environment:
-      MYSQL_ROOT_PASSWORD: bun
+      MYSQL_ROOT_PASSWORD: "bun123456@#$%^&*()"
       MYSQL_DATABASE: bun_sql_test
       MYSQL_ROOT_HOST: "%"
     command: --default-authentication-plugin=mysql_native_password
@@ -122,7 +122,7 @@ services:
         MYSQL_VERSION: 8.4
     image: bun-mysql-tls:local
     environment:
-      MYSQL_ROOT_PASSWORD: bun
+      MYSQL_ROOT_PASSWORD: "bun123456@#$%^&*()"
       MYSQL_DATABASE: bun_sql_test
     ports:
       - target: 3306

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     image: mysql:8.4
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_ROOT_PASSWORD: "bun123456@#$%^&*()"
       MYSQL_DATABASE: bun_sql_test
     ports:
       - target: 3306

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -95,6 +95,24 @@ services:
       retries: 30
       start_period: 10s
 
+  mysql_plain_empty_password:
+    image: mysql:8.4
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: bun_sql_test
+    ports:
+      - target: 3306
+        published: 0
+        protocol: tcp
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 1h # Effectively disable after startup
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
   mysql_native_password:
     image: mysql:8.0
     environment:

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -936,7 +936,6 @@ export async function describeWithContainer(
       "postgres_tls": 5432,
       "postgres_auth": 5432,
       "mysql_plain": 3306,
-      "mysql_native_password": 3306,
       "mysql_tls": 3306,
       "mysql:8": 3306, // Map mysql:8 to mysql_plain
       "mysql:9": 3306, // Map mysql:9 to mysql_native_password
@@ -951,10 +950,8 @@ export async function describeWithContainer(
       // Map mysql:8 and mysql:9 based on environment variables
       let actualService = image;
       if (image === "mysql:8" || image === "mysql:9") {
-        if (env.MYSQL_ROOT_PASSWORD === "bun") {
-          actualService = "mysql_native_password"; // Has password "bun"
-        } else if (env.MYSQL_ALLOW_EMPTY_PASSWORD === "yes") {
-          actualService = "mysql_plain"; // No password
+        if (env.MYSQL_ALLOW_EMPTY_PASSWORD === "yes") {
+          actualService = "mysql_plain_empty_password"; // No password
         } else {
           actualService = "mysql_plain"; // Default to no password
         }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -938,7 +938,8 @@ export async function describeWithContainer(
       "mysql_plain": 3306,
       "mysql_tls": 3306,
       "mysql:8": 3306, // Map mysql:8 to mysql_plain
-      "mysql:9": 3306, // Map mysql:9 to mysql_native_password
+      "mysql:9": 3306, // Map mysql:9 to mysql_plain_9
+      "mysql_native_password": 3306, // mysql_native_password
       "redis_plain": 6379,
       "redis_unified": 6379,
       "minio": 9000,
@@ -952,8 +953,10 @@ export async function describeWithContainer(
       if (image === "mysql:8" || image === "mysql:9") {
         if (env.MYSQL_ALLOW_EMPTY_PASSWORD === "yes") {
           actualService = "mysql_plain_empty_password"; // No password
+        } else if (image === "mysql:9") {
+          actualService = "mysql_plain_9";
         } else {
-          actualService = "mysql_plain"; // Default to no password
+          actualService = "mysql_plain";
         }
       }
 

--- a/test/integration/mysql2/mysql2.test.ts
+++ b/test/integration/mysql2/mysql2.test.ts
@@ -21,6 +21,19 @@ const tests: {
       password: "bun123456@#$%^&*()",
     },
   },
+  {
+    label: "mysql:8 with root user and empty password",
+    database: {
+      image: "mysql:8",
+      env: {
+        MYSQL_ALLOW_EMPTY_PASSWORD: "yes",
+      },
+    },
+    client: {
+      user: "root",
+      password: "",
+    },
+  },
 ];
 
 for (const { label, client, database } of tests) {

--- a/test/integration/mysql2/mysql2.test.ts
+++ b/test/integration/mysql2/mysql2.test.ts
@@ -15,26 +15,10 @@ const tests: {
     label: "mysql:8 with root user and password",
     database: {
       image: "mysql:8",
-      env: {
-        MYSQL_ROOT_PASSWORD: "bun",
-      },
     },
     client: {
       user: "root",
-      password: "bun",
-    },
-  },
-  {
-    label: "mysql:8 with root user and empty password",
-    database: {
-      image: "mysql:8",
-      env: {
-        MYSQL_ALLOW_EMPTY_PASSWORD: "yes",
-      },
-    },
-    client: {
-      user: "root",
-      password: "",
+      password: "bun123456@#$%^&*()",
     },
   },
 ];

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -12,7 +12,8 @@ describeWithContainer(
   },
   container => {
     // Create getters that will be evaluated when the test runs
-    const getUrl = () => `mysql://root:bun@${container.host}:${container.port}/bun_sql_test`;
+    const getUrl = () =>
+      `mysql://root:${encodeURIComponent("bun123456@#$%^&*()")}@${container.host}:${container.port}/bun_sql_test`;
 
     test("should be able to connect with mysql_native_password auth plugin", async () => {
       console.log("Container info in test:", container);

--- a/test/js/sql/sql-mysql.helpers.test.ts
+++ b/test/js/sql/sql-mysql.helpers.test.ts
@@ -13,7 +13,7 @@ describeWithContainer(
   container => {
     // Use a getter to avoid reading port/host at define time
     const getOptions = () => ({
-      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+      url: `mysql://root:${encodeURIComponent("bun123456@#$%^&*()")}@${container.host}:${container.port}/bun_sql_test`,
       max: 1,
       bigint: true,
     });

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -25,7 +25,7 @@ if (isDockerEnabled()) {
       name: "MySQL 9",
       image: "mysql:9",
       env: {
-        MYSQL_ROOT_PASSWORD: "bun",
+        MYSQL_ROOT_PASSWORD: "bun123456@#$%^&*()",
       },
     },
   ].filter(Boolean);
@@ -40,8 +40,9 @@ if (isDockerEnabled()) {
       },
       container => {
         let sql: SQL;
+        const password = "bun123456@#$%^&*()";
         const getOptions = (): Bun.SQL.Options => ({
-          url: `mysql://root:${encodeURIComponent("bun123456@#$%^&*()")}@${container.host}:${container.port}/bun_sql_test`,
+          url: `mysql://root:${encodeURIComponent(password)}@${container.host}:${container.port}/bun_sql_test`,
           max: 1,
           tls:
             image.name === "MySQL with TLS"

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -40,9 +40,9 @@ if (isDockerEnabled()) {
       },
       container => {
         let sql: SQL;
-        const password = image.image === "mysql_plain" ? "" : "bun";
+        const password = image.image === "mysql_plain" ? "" : "bun123456@#$%^&*()";
         const getOptions = (): Bun.SQL.Options => ({
-          url: `mysql://root:${password}@${container.host}:${container.port}/bun_sql_test`,
+          url: `mysql://root:${encodeURIComponent(password)}@${container.host}:${container.port}/bun_sql_test`,
           max: 1,
           tls:
             image.name === "MySQL with TLS"

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -24,9 +24,6 @@ if (isDockerEnabled()) {
     process.arch === "x64" && {
       name: "MySQL 9",
       image: "mysql:9",
-      env: {
-        MYSQL_ROOT_PASSWORD: "bun123456@#$%^&*()",
-      },
     },
   ].filter(Boolean);
 

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -40,9 +40,8 @@ if (isDockerEnabled()) {
       },
       container => {
         let sql: SQL;
-        const password = image.image === "mysql_plain" ? "" : "bun123456@#$%^&*()";
         const getOptions = (): Bun.SQL.Options => ({
-          url: `mysql://root:${encodeURIComponent(password)}@${container.host}:${container.port}/bun_sql_test`,
+          url: `mysql://root:${encodeURIComponent("bun123456@#$%^&*()")}@${container.host}:${container.port}/bun_sql_test`,
           max: 1,
           tls:
             image.name === "MySQL with TLS"

--- a/test/js/sql/sql-mysql.transactions.test.ts
+++ b/test/js/sql/sql-mysql.transactions.test.ts
@@ -12,7 +12,7 @@ describeWithContainer(
   container => {
     // Use a getter to avoid reading port/host at define time
     const getOptions = () => ({
-      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+      url: `mysql://root:${encodeURIComponent("bun123456@#$%^&*()")}@${container.host}:${container.port}/bun_sql_test`,
       max: 1,
       bigint: true,
     });


### PR DESCRIPTION
### What does this PR do?
Add more complex password to test in plain and tls (auth behaves different under tls so we need both tested)
Map correctly mysql 9 and mysql_native_password and fix mysql2 test to behave like is intended
### How did you verify your code works?
Tests