### PR TITLE
Handle optionals in `bun.memory.deinit`

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -66,12 +66,12 @@ fn deinitIsVoid(comptime T: type) bool {
 }
 
 /// Calls `deinit` on `ptr_or_slice`, or on every element of `ptr_or_slice`, if the pointer points
-/// to a struct or enum.
+/// to a struct or tagged union.
 ///
 /// This function first does the following:
 ///
 /// * If `ptr_or_slice` is a single-item pointer of type `*T`:
-///   - If `T` is a struct or enum, calls `ptr_or_slice.deinit()`
+///   - If `T` is a struct or tagged union, calls `ptr_or_slice.deinit()`
 ///   - If `T` is an optional, checks if `ptr_or_slice` points to a non-null value, and if so,
 ///     calls `bun.memory.deinit` with a pointer to the payload.
 /// * If `ptr_or_slice` is a slice, for each element of the slice, calls `bun.memory.deinit` with

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -86,7 +86,7 @@ pub fn deinit(ptr_or_slice: anytype) void {
     switch (comptime ptr_info.pointer.size) {
         .slice => {
             for (ptr_or_slice) |*elem| {
-                bun.memory.deinit(elem);
+                deinit(elem);
             }
             return;
         },


### PR DESCRIPTION
Currently, if you try to deinit an optional, `bun.memory.deinit` will silently do nothing, even if the optional's payload is a struct with a `deinit` method.

This commit makes sure the payload is deinitialized.

(For internal tracking: fixes STAB-1293)