### PR TITLE
refactor: migrate GarbageCollectionController to use EventLoopTimer

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -299,7 +299,10 @@ pub const All = struct {
         while (this.next(&has_set_now, &now)) |t| {
             switch (t.fire(&now, vm)) {
                 .disarm => {},
-                .rearm => {},
+                .rearm => |next_time| {
+                    t.next = next_time;
+                    this.insert(t);
+                },
             }
         }
     }

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -298,9 +298,13 @@ pub const All = struct {
 
         while (this.next(&has_set_now, &now)) |t| {
             switch (t.fire(&now, vm)) {
-                .disarm => {},
+                .disarm => {
+                    // Timer is done, state should already be set to FIRED
+                },
                 .rearm => |next_time| {
+                    // Reinsert the timer with the new time
                     t.next = next_time;
+                    t.state = .PENDING; // Reset state before inserting
                     this.insert(t);
                 },
             }

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -158,6 +158,7 @@ pub fn onGCRepeatingTimer(this: *GarbageCollectionController, now: *const bun.ti
         this.updateGCRepeatTimer(.fast);
     }
 
+    // Reschedule for the next interval
     const interval: i32 = if (this.gc_repeating_timer_fast) this.gc_timer_interval else 30_000;
     return .{ .rearm = now.addMs(@intCast(interval)) };
 }

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -10,7 +10,7 @@
   ".stdDir()": 41,
   ".stdFile()": 18,
   "// autofix": 167,
-  ": [^=]+= undefined,$": 256,
+  ": [^=]+= undefined,$": 254,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,
   "@import(\"bun\").": 0,


### PR DESCRIPTION
## Summary
- Refactored GarbageCollectionController to use the centralized EventLoopTimer system instead of uws.Timer
- Fixed a bug in Timer.All.drainTimers() where the rearm case wasn't being handled
- Maintains all existing GC timer functionality while improving integration with Bun's event loop

## Changes
- Replace `gc_timer` and `gc_repeating_timer` from `*uws.Timer` to `EventLoopTimer` structs
- Add `GCTimer` and `GCRepeatingTimer` tags to `EventLoopTimer.Tag` enum  
- Update timer callbacks to match EventLoopTimer's `fire()` pattern, returning `Arm` union
- Fix timer scheduling to use `vm.timer.insert()` for initial scheduling and `vm.timer.update()` for rescheduling
- Fix bug in `Timer.All.drainTimers()` where `.rearm` case wasn't re-inserting timers into the heap
- Properly manage timer state transitions (PENDING -> ACTIVE -> FIRED)

## Test plan
- [x] Basic GC timer functionality works
- [x] Recurring GC timers fire periodically as expected
- [x] `BUN_GC_TIMER_INTERVAL` environment variable still controls timer interval
- [x] `BUN_GC_TIMER_DISABLE` environment variable still disables GC timers
- [x] Fast/slow mode switching works based on heap size changes
- [x] No runtime panics or crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)