### PR TITLE
VSCode: Add continuous run support and debugged test results

### DIFF
--- a/packages/bun-vscode/bun.lock
+++ b/packages/bun-vscode/bun.lock
@@ -12,9 +12,7 @@
         "@vscode/test-electron": "^2.4.1",
         "@vscode/vsce": "^2.20.1",
         "esbuild": "^0.19.2",
-        "source-map-js": "^1.2.1",
         "typescript": "^5.0.0",
-        "ws": "^8.18.3",
       },
     },
     "../bun-debug-adapter-protocol": {
@@ -458,7 +456,7 @@
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
-    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+    "source-map-js": ["source-map-js@1.0.2", "", {}, "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="],
 
     "stdin-discarder": ["stdin-discarder@0.1.0", "", { "dependencies": { "bl": "^5.0.0" } }, "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ=="],
 
@@ -518,7 +516,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "ws": ["ws@8.13.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="],
 
     "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 
@@ -551,10 +549,6 @@
     "@vscode/vsce/minimatch": ["minimatch@3.0.8", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "bun-debug-adapter-protocol/source-map-js": ["source-map-js@1.0.2", "", {}, "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="],
-
-    "bun-inspector-protocol/ws": ["ws@8.13.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="],
 
     "chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 

--- a/packages/bun-vscode/bun.lock
+++ b/packages/bun-vscode/bun.lock
@@ -12,7 +12,9 @@
         "@vscode/test-electron": "^2.4.1",
         "@vscode/vsce": "^2.20.1",
         "esbuild": "^0.19.2",
+        "source-map-js": "^1.2.1",
         "typescript": "^5.0.0",
+        "ws": "^8.18.3",
       },
     },
     "../bun-debug-adapter-protocol": {
@@ -25,7 +27,7 @@
     },
     "../bun-inspector-protocol": {
       "name": "bun-inspector-protocol",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "ws": "^8.13.0",
       },
@@ -456,7 +458,7 @@
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
-    "source-map-js": ["source-map-js@1.0.2", "", {}, "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="],
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stdin-discarder": ["stdin-discarder@0.1.0", "", { "dependencies": { "bl": "^5.0.0" } }, "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ=="],
 
@@ -516,7 +518,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.13.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="],
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 
@@ -549,6 +551,10 @@
     "@vscode/vsce/minimatch": ["minimatch@3.0.8", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "bun-debug-adapter-protocol/source-map-js": ["source-map-js@1.0.2", "", {}, "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="],
+
+    "bun-inspector-protocol/ws": ["ws@8.13.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="],
 
     "chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 

--- a/packages/bun-vscode/bun.lock
+++ b/packages/bun-vscode/bun.lock
@@ -5,7 +5,7 @@
       "name": "mock-debug",
       "devDependencies": {
         "@types/bun": "^1.1.10",
-        "@types/vscode": "^1.60.0",
+        "@types/vscode": "^1.91.0",
         "@vscode/debugadapter": "^1.56.0",
         "@vscode/debugadapter-testsupport": "^1.56.0",
         "@vscode/test-cli": "^0.0.10",
@@ -100,7 +100,7 @@
 
     "@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
 
-    "@types/vscode": ["@types/vscode@1.81.0", "", {}, "sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w=="],
+    "@types/vscode": ["@types/vscode@1.104.0", "", {}, "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig=="],
 
     "@types/ws": ["@types/ws@8.5.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ=="],
 

--- a/packages/bun-vscode/example/example.test.ts
+++ b/packages/bun-vscode/example/example.test.ts
@@ -33,4 +33,10 @@ describe("example", () => {
     // if this test runs, it's a success.
     // a failure is if it's either skipped or fails the runner
   });
+
+  test("long running test", async () => {
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    await sleep(2000);
+    expect(true).toBe(true);
+  });
 });

--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -16,9 +16,7 @@
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^2.20.1",
     "esbuild": "^0.19.2",
-    "source-map-js": "^1.2.1",
-    "typescript": "^5.0.0",
-    "ws": "^8.18.3"
+    "typescript": "^5.0.0"
   },
   "activationEvents": [
     "onStartupFinished"

--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -16,7 +16,9 @@
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^2.20.1",
     "esbuild": "^0.19.2",
-    "typescript": "^5.0.0"
+    "source-map-js": "^1.2.1",
+    "typescript": "^5.0.0",
+    "ws": "^8.18.3"
   },
   "activationEvents": [
     "onStartupFinished"

--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -9,7 +9,7 @@
   "main": "dist/extension.js",
   "devDependencies": {
     "@types/bun": "^1.1.10",
-    "@types/vscode": "^1.60.0",
+    "@types/vscode": "^1.91.0",
     "@vscode/debugadapter": "^1.56.0",
     "@vscode/debugadapter-testsupport": "^1.56.0",
     "@vscode/test-cli": "^0.0.10",
@@ -360,7 +360,7 @@
   "description": "The Visual Studio Code extension for Bun.",
   "displayName": "Bun for Visual Studio Code",
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.91.0"
   },
   "extensionKind": [
     "workspace"

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -13,8 +13,6 @@ import {
 } from "../../../bun-debug-adapter-protocol";
 import { getConfig } from "../extension";
 
-export const log = vscode.window.createOutputChannel("Bun - Debugger");
-
 export const DEBUG_CONFIGURATION: vscode.DebugConfiguration = {
   type: "bun",
   internalConsoleOptions: "neverOpen",
@@ -415,20 +413,6 @@ class FileDebugSession extends DebugSession {
     this.adapter.on("Adapter.reverseRequest", ({ command, arguments: args }) =>
       this.sendRequest(command, args, 5000, () => {}),
     );
-
-    const log2 = (eventName: string) => (a: any) => log.appendLine(`\t[MG:${eventName}] ${JSON.stringify(a)}`);
-    this.adapter.on("Adapter.event", log2("Adapter.event"));
-    this.adapter.on("Adapter.initialized", log2("Adapter.initialized"));
-    this.adapter.on("Adapter.request", log2("Adapter.request"));
-    this.adapter.on("Adapter.response", log2("Adapter.response"));
-    this.adapter.on("Inspector.connected", () => log.appendLine("[MG:Connected]"));
-    this.adapter.on("Inspector.request", log2("Inspector.request"));
-    this.adapter.on("Inspector.response", log2("Inspector.response"));
-    this.adapter.on("TestReporter.found", log2("TestReporter.found"));
-    this.adapter.on("TestReporter.start", log2("TestReporter.start"));
-    this.adapter.on("TestReporter.end", log2("TestReporter.end"));
-    this.adapter.on("LifecycleReporter.error", log2("LifecycleReporter.error"));
-    this.adapter.on("Inspector.error", log2("Inspector.error"));
 
     adapters.set(url, this);
   }

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -349,9 +349,10 @@ class FileDebugSession extends DebugSession {
   async initialize(url?: string) {
     const uniqueId = this.sessionId ?? Math.random().toString(36).slice(2);
     url =
-      url || process.platform === "win32"
+      url ??
+      (process.platform === "win32"
         ? `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`
-        : `ws+unix://${tmpdir()}/${uniqueId}.sock`;
+        : `ws+unix://${tmpdir()}/${uniqueId}.sock`);
 
     const { untitledDocPath, bunEvalPath } = this;
     this.adapter = new WebSocketDebugAdapter(url, untitledDocPath, bunEvalPath);

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -350,8 +350,8 @@ class FileDebugSession extends DebugSession {
 
   async initialize(url?: string) {
     const uniqueId = this.sessionId ?? Math.random().toString(36).slice(2);
-    url = url ||
-      process.platform === "win32"
+    url =
+      url || process.platform === "win32"
         ? `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`
         : `ws+unix://${tmpdir()}/${uniqueId}.sock`;
 
@@ -416,19 +416,19 @@ class FileDebugSession extends DebugSession {
       this.sendRequest(command, args, 5000, () => {}),
     );
 
-    const log2 = (eventName: string) => (a: any) => log.appendLine(`\t[MG:${eventName}] ${JSON.stringify(a)}`)
-    this.adapter.on("Adapter.event", log2("Adapter.event"))
-    this.adapter.on("Adapter.initialized", log2("Adapter.initialized"))
-    this.adapter.on("Adapter.request", log2("Adapter.request"))
-    this.adapter.on("Adapter.response", log2("Adapter.response"))
-    this.adapter.on("Inspector.connected", () => log.appendLine("[MG:Connected]"))
-    this.adapter.on("Inspector.request", log2("Inspector.request"))
-    this.adapter.on("Inspector.response", log2("Inspector.response"))
-    this.adapter.on("TestReporter.found", log2("TestReporter.found"))
-    this.adapter.on("TestReporter.start", log2("TestReporter.start"))
-    this.adapter.on("TestReporter.end", log2("TestReporter.end"))
-    this.adapter.on("LifecycleReporter.error", log2("LifecycleReporter.error"))
-    this.adapter.on("Inspector.error", log2("Inspector.error"))
+    const log2 = (eventName: string) => (a: any) => log.appendLine(`\t[MG:${eventName}] ${JSON.stringify(a)}`);
+    this.adapter.on("Adapter.event", log2("Adapter.event"));
+    this.adapter.on("Adapter.initialized", log2("Adapter.initialized"));
+    this.adapter.on("Adapter.request", log2("Adapter.request"));
+    this.adapter.on("Adapter.response", log2("Adapter.response"));
+    this.adapter.on("Inspector.connected", () => log.appendLine("[MG:Connected]"));
+    this.adapter.on("Inspector.request", log2("Inspector.request"));
+    this.adapter.on("Inspector.response", log2("Inspector.response"));
+    this.adapter.on("TestReporter.found", log2("TestReporter.found"));
+    this.adapter.on("TestReporter.start", log2("TestReporter.start"));
+    this.adapter.on("TestReporter.end", log2("TestReporter.end"));
+    this.adapter.on("LifecycleReporter.error", log2("LifecycleReporter.error"));
+    this.adapter.on("Inspector.error", log2("Inspector.error"));
 
     adapters.set(url, this);
   }
@@ -450,7 +450,7 @@ class FileDebugSession extends DebugSession {
         message.arguments.source.path = this.mapLocalToRemote(message.arguments.source.path);
       } else if (command === "initialize") {
         // TODO: Only enable if we are running through the test explorer
-        message.arguments.enableTestReporter = true
+        message.arguments.enableTestReporter = true;
       }
 
       this.adapter.emit("Adapter.request", message);

--- a/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
+++ b/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
@@ -892,101 +892,6 @@ Difference:
       expect(result.message).toContain("Cannot read property 'foo'");
     });
   });
-
-  describe("cleanupTestItem", () => {
-    test("should clean up test item and its children", () => {
-      const mockChild = {
-        id: "child",
-        tags: [],
-        children: new Map(),
-      };
-
-      const mockParent = {
-        id: "parent",
-        tags: [],
-        children: new Map([["child", mockChild]]),
-      };
-
-      expect(() => {
-        internal.cleanupTestItem.call(controller, mockParent as any);
-      }).not.toThrow();
-    });
-
-    test("should handle item without children", () => {
-      const mockItem = {
-        id: "simple-item",
-        tags: [],
-        children: new Map(),
-      };
-
-      expect(() => {
-        internal.cleanupTestItem.call(controller, mockItem as any);
-      }).not.toThrow();
-    });
-
-    test("should handle deeply nested cleanup", () => {
-      const createNestedItem = (depth: number): any => {
-        if (depth === 0) {
-          return {
-            id: `item-0`,
-            tags: [],
-            children: new Map(),
-          };
-        }
-
-        const child = createNestedItem(depth - 1);
-        return {
-          id: `item-${depth}`,
-          tags: [],
-          children: new Map([[`child-${depth}`, child]]),
-        };
-      };
-
-      const deeplyNested = createNestedItem(10);
-
-      expect(() => {
-        internal.cleanupTestItem.call(controller, deeplyNested);
-      }).not.toThrow();
-    });
-
-    test("should handle items with multiple children", () => {
-      const children = Array.from({ length: 20 }, (_, i) => ({
-        id: `child-${i}`,
-        tags: [],
-        children: new Map(),
-      }));
-
-      const parent = {
-        id: "parent-with-many-children",
-        tags: [],
-        children: new Map(children.map(child => [child.id, child])),
-      };
-
-      expect(() => {
-        internal.cleanupTestItem.call(controller, parent as any);
-      }).not.toThrow();
-    });
-
-    test("should handle circular references gracefully", () => {
-      const item1: any = {
-        id: "item1",
-        tags: [],
-        children: new Map(),
-      };
-
-      const item2: any = {
-        id: "item2",
-        tags: [],
-        children: new Map([["item1", item1]]),
-      };
-
-      item1.children.set("item2", item2);
-
-      expect(() => {
-        internal.cleanupTestItem.call(controller, item1);
-      }).not.toThrow();
-    });
-  });
 });
 
 describe("BunTestController - Integration and Coverage", () => {
@@ -1031,7 +936,6 @@ describe("BunTestController - Integration and Coverage", () => {
       expect(typeof internal.findTestByName).toBe("function");
       expect(typeof internal.createTestItem).toBe("function");
       expect(typeof internal.createErrorMessage).toBe("function");
-      expect(typeof internal.cleanupTestItem).toBe("function");
     });
 
     test("should provide consistent API", () => {
@@ -1062,7 +966,6 @@ describe("BunTestController - Integration and Coverage", () => {
       expect(typeof internal.findTestByName).toBe("function");
       expect(typeof internal.createTestItem).toBe("function");
       expect(typeof internal.createErrorMessage).toBe("function");
-      expect(typeof internal.cleanupTestItem).toBe("function");
 
       expect(controller).toBeDefined();
       expect(controller._internal).toBeDefined();

--- a/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
+++ b/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
@@ -393,7 +393,7 @@ describe("BunTestController", () => {
 });
 
 describe("BunTestController - Test Discovery and Management", () => {
-  describe("shouldUseTestNamePattern", () => {
+  describe("shouldFilterByTestName", () => {
     test("should return false for single file test", () => {
       const mockTests = [
         {
@@ -404,7 +404,7 @@ describe("BunTestController - Test Discovery and Management", () => {
         },
       ] as any;
 
-      const result = internal.shouldUseTestNamePattern(mockTests);
+      const result = internal.shouldFilterByTestName(mockTests);
       expect(result).toBe(false);
     });
 
@@ -425,12 +425,12 @@ describe("BunTestController - Test Discovery and Management", () => {
         },
       ] as any;
 
-      const result = internal.shouldUseTestNamePattern(mockTests);
+      const result = internal.shouldFilterByTestName(mockTests);
       expect(result).toBe(true);
     });
 
     test("should return false for empty test array", () => {
-      const result = internal.shouldUseTestNamePattern([]);
+      const result = internal.shouldFilterByTestName([]);
       expect(result).toBe(false);
     });
 
@@ -443,7 +443,7 @@ describe("BunTestController - Test Discovery and Management", () => {
         },
       ] as any;
 
-      const result = internal.shouldUseTestNamePattern(mockTests);
+      const result = internal.shouldFilterByTestName(mockTests);
       expect(result).toBe(false);
     });
 
@@ -471,7 +471,7 @@ describe("BunTestController - Test Discovery and Management", () => {
         },
       ] as any;
 
-      const result = internal.shouldUseTestNamePattern(mockTests);
+      const result = internal.shouldFilterByTestName(mockTests);
       expect(result).toBe(true);
     });
 
@@ -486,7 +486,7 @@ describe("BunTestController - Test Discovery and Management", () => {
         },
       ] as any;
 
-      const result = internal.shouldUseTestNamePattern(mockTests);
+      const result = internal.shouldFilterByTestName(mockTests);
 
       expect(result).toBe(false);
     });
@@ -905,7 +905,7 @@ describe("BunTestController - Integration and Coverage", () => {
       expect(internal).toHaveProperty("stripAnsi");
       expect(internal).toHaveProperty("processErrorData");
       expect(internal).toHaveProperty("escapeTestName");
-      expect(internal).toHaveProperty("shouldUseTestNamePattern");
+      expect(internal).toHaveProperty("shouldFilterByTestName");
 
       expect(internal).toHaveProperty("isTestFile");
       expect(internal).toHaveProperty("customFilePattern");
@@ -928,7 +928,7 @@ describe("BunTestController - Integration and Coverage", () => {
       expect(typeof internal.parseTestBlocks).toBe("function");
       expect(typeof internal.getBraceDepth).toBe("function");
       expect(typeof internal.escapeTestName).toBe("function");
-      expect(typeof internal.shouldUseTestNamePattern).toBe("function");
+      expect(typeof internal.shouldFilterByTestName).toBe("function");
       expect(typeof internal.isTestFile).toBe("function");
       expect(typeof internal.customFilePattern).toBe("function");
       expect(typeof internal.getBunExecutionConfig).toBe("function");
@@ -958,7 +958,7 @@ describe("BunTestController - Integration and Coverage", () => {
       expect(typeof internal.processErrorData).toBe("function");
 
       expect(typeof internal.escapeTestName).toBe("function");
-      expect(typeof internal.shouldUseTestNamePattern).toBe("function");
+      expect(typeof internal.shouldFilterByTestName).toBe("function");
       expect(typeof internal.isTestFile).toBe("function");
       expect(typeof internal.customFilePattern).toBe("function");
       expect(typeof internal.getBunExecutionConfig).toBe("function");

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -425,7 +425,7 @@ export class BunTestController implements vscode.Disposable {
 
       // Run tests if in continuous mode
       if (this.watchingTests.has('ALL')) {
-        this.runHandler(new vscode.TestRunRequest(undefined, undefined, this.watchingTests.get('ALL'), true));
+        this.runHandler(new vscode.TestRunRequest(undefined, undefined, this.watchingTests.get('ALL')));
       } else {
         const include: vscode.TestItem[] = [];
         let profile: vscode.TestRunProfile | undefined;
@@ -438,7 +438,7 @@ export class BunTestController implements vscode.Disposable {
         }
 
         if (include.length) {
-          this.runHandler(new vscode.TestRunRequest(include, undefined, profile, true));
+          this.runHandler(new vscode.TestRunRequest(include, undefined, profile));
         }
       }
     };


### PR DESCRIPTION
### What does this PR do?

- Add the ability to run tests continuously on file changes
- Make debugged tests still report their run time and test results
- Refactor some of the singleton state handling to local variables. This moves towards better supporting parallel test runs

### How did you verify your code works?
I used the built in run configuration and example test to see if the following scenarios work correctly.

- New tests are added to the list of tests, old tests are removed
- Can run all tests or individual tests, test times and results are correctly reported
- Can debug all tests or individual tests, test times and results are correctly reported. Breakpoints are respected.
- Watch mode re-runs the tests on file changes. Both when all tests and when individual tests are watched.

Tested on MacOS.

-----

Discord thread: https://discord.com/channels/876711213126520882/1421149684575240253