### PR TITLE
fix(glob): use original entry name

### DIFF
--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -211,7 +211,7 @@ pub const DirEntryAccessor = struct {
         pub inline fn next(self: *DirIter) Maybe(?IterResult) {
             if (self.value) |*value| {
                 const nextval = value.next() orelse return .{ .result = null };
-                const name = nextval.key_ptr.*;
+                const name = nextval.value_ptr.*.base();
                 const kind = nextval.value_ptr.*.kind(&FS.instance.fs, true);
                 const fskind = switch (kind) {
                     .file => std.fs.File.Kind.file,


### PR DESCRIPTION
### What does this PR do?

Fixes `bun --filter failing with error: ENOENT` on case-sensitive filesystems (e.g. Linux) when a workspace contains directories with uppercase letters. (see: https://github.com/oven-sh/bun/issues/11295#issuecomment-2548827252)
The failure is caused by building filesystem paths from the FS.DirEntry.EntryMap.Iterator key, [which is stored lowercased](https://github.com/oven-sh/bun/blob/d9fdb67d70c5ec5fce0aae2b7e114bd557fc7838/src/fs.zig#L212C13-L212C74), resulting in non-existent paths on case-sensitive systems.

This PR ensures that GlobWalker returns the original entry name (with correct casing) for filesystem access.

### Reproduction

1. Create a workspace directory with uppercase letters, e.g. packages/Pkg-a.
2. Run: `bun --filter './packages/*' run some-command`

On a case-sensitive FS, it fails with error: ENOENT.

Minimal repo: https://github.com/daku10/bun-issue-contains-uppercase-letters

### How did you verify your code works?

Built Bun from source with this patch and tested locally on Ubuntu 24.04.3(WSL2)