### PR TITLE
fix(parser): possible crash with --minify-syntax and string -> dot conversions

### DIFF
--- a/src/ast/visitExpr.zig
+++ b/src/ast/visitExpr.zig
@@ -579,58 +579,7 @@ pub fn VisitExpr(
                         e_.index = .{ .data = .{ .e_private_identifier = private }, .loc = e_.index.loc };
                     },
                     else => {
-                        const index = p.visitExpr(e_.index);
-                        e_.index = index;
-
-                        const unwrapped = e_.index.unwrapInlined();
-                        if (unwrapped.data == .e_string and
-                            unwrapped.data.e_string.isUTF8())
-                        {
-                            // "a['b' + '']" => "a.b"
-                            // "enum A { B = 'b' }; a[A.B]" => "a.b"
-                            if (p.options.features.minify_syntax and
-                                unwrapped.data.e_string.isIdentifier(p.allocator))
-                            {
-                                const dot = p.newExpr(
-                                    E.Dot{
-                                        .name = unwrapped.data.e_string.slice(p.allocator),
-                                        .name_loc = unwrapped.loc,
-                                        .target = e_.target,
-                                        .optional_chain = e_.optional_chain,
-                                    },
-                                    expr.loc,
-                                );
-
-                                if (is_call_target) {
-                                    p.call_target = dot.data;
-                                }
-
-                                if (is_delete_target) {
-                                    p.delete_target = dot.data;
-                                }
-
-                                return p.visitExprInOut(dot, in);
-                            }
-
-                            // Handle property rewrites to ensure things
-                            // like .e_import_identifier tracking works
-                            // Reminder that this can only be done after
-                            // `target` is visited.
-                            if (p.maybeRewritePropertyAccess(
-                                expr.loc,
-                                e_.target,
-                                unwrapped.data.e_string.data,
-                                unwrapped.loc,
-                                .{
-                                    .is_call_target = is_call_target,
-                                    // .is_template_tag = is_template_tag,
-                                    .is_delete_target = is_delete_target,
-                                    .assign_target = in.assign_target,
-                                },
-                            )) |rewrite| {
-                                return rewrite;
-                            }
-                        }
+                        e_.index = p.visitExprInOut(e_.index, .{});
                     },
                 }
 

--- a/src/ast/visitExpr.zig
+++ b/src/ast/visitExpr.zig
@@ -579,7 +579,59 @@ pub fn VisitExpr(
                         e_.index = .{ .data = .{ .e_private_identifier = private }, .loc = e_.index.loc };
                     },
                     else => {
-                        e_.index = p.visitExprInOut(e_.index, .{});
+                        const index = p.visitExpr(e_.index);
+                        e_.index = index;
+
+                        const unwrapped = e_.index.unwrapInlined();
+                        if (unwrapped.data == .e_string and
+                            unwrapped.data.e_string.isUTF8())
+                        {
+                            // "a['b' + '']" => "a.b"
+                            // "enum A { B = 'b' }; a[A.B]" => "a.b"
+                            if (p.options.features.minify_syntax and
+                                unwrapped.data.e_string.isIdentifier(p.allocator))
+                            {
+                                const dot = p.newExpr(
+                                    E.Dot{
+                                        .name = unwrapped.data.e_string.slice(p.allocator),
+                                        .name_loc = unwrapped.loc,
+                                        .target = e_.target,
+                                        .optional_chain = e_.optional_chain,
+                                    },
+                                    expr.loc,
+                                );
+
+                                if (is_call_target) {
+                                    p.call_target = dot.data;
+                                }
+
+                                if (is_delete_target) {
+                                    p.delete_target = dot.data;
+                                }
+
+                                // don't call visitExprInOut on `dot` because we've already visited `target` above!
+                                return dot;
+                            }
+
+                            // Handle property rewrites to ensure things
+                            // like .e_import_identifier tracking works
+                            // Reminder that this can only be done after
+                            // `target` is visited.
+                            if (p.maybeRewritePropertyAccess(
+                                expr.loc,
+                                e_.target,
+                                unwrapped.data.e_string.data,
+                                unwrapped.loc,
+                                .{
+                                    .is_call_target = is_call_target,
+                                    // .is_template_tag = is_template_tag,
+                                    .is_delete_target = is_delete_target,
+                                    .assign_target = in.assign_target,
+                                },
+                            )) |rewrite| {
+                                return rewrite;
+                            }
+                        }
                     },
                 }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3551,6 +3551,19 @@ it("does not crash with 9 comments and typescript type skipping", () => {
   expect(exitCode).toBe(0);
 });
 
+it("does not crash with --minify-syntax and revisiting dot expressions", () => {
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "-p", "[(()=>{})()][''+'c']"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  expect(stderr.toString()).toBe("");
+  expect(stdout.toString()).toBe("undefined\n");
+  expect(exitCode).toBe(0);
+});
+
 it("runtime transpiler stack overflows", async () => {
   expect(async () => await import("./fixtures/lots-of-for-loop.js")).toThrow(`Maximum call stack size exceeded`);
 });


### PR DESCRIPTION
### What does this PR do?
Fixes code like `[(()=>{})()][''+'c']`.

We were calling `visitExpr` on a node that was already visited. This code doesn't exist in esbuild, but we should keep it because it's an optimization.

fixes #18629
fixes #15926

### How did you verify your code works?
Manually and added a test.
