### PR TITLE
fix(parser): TSX arrow function bugfix

### DIFF
--- a/src/ast/TypeScript.zig
+++ b/src/ast/TypeScript.zig
@@ -194,11 +194,11 @@ pub fn isTSArrowFnJSX(p: anytype) !bool {
     }
     if (p.lexer.token == .t_identifier) {
         try p.lexer.next();
-        if (p.lexer.token == .t_comma) {
+        if (p.lexer.token == .t_comma or p.lexer.token == .t_equals) {
             is_ts_arrow_fn = true;
         } else if (p.lexer.token == .t_extends) {
             try p.lexer.next();
-            is_ts_arrow_fn = p.lexer.token != .t_equals and p.lexer.token != .t_greater_than;
+            is_ts_arrow_fn = p.lexer.token != .t_equals and p.lexer.token != .t_greater_than and p.lexer.token != .t_slash;
         }
     }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1357,12 +1357,6 @@ console.log(<div {...obj} key="after" />);`),
     expect(transpiler.transformSync("const element3 = <T extends></T>")).toContain("jsxDEV");
   });
 
-  it("distinguishes TSX arrow functions with extends from JSX elements", () => {
-    var transpiler = new Bun.Transpiler({
-      loader: "tsx",
-    });
-  });
-
   it.todo("JSX", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1344,6 +1344,25 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  it("parses TSX arrow functions correctly", () => {
+    var transpiler = new Bun.Transpiler({
+      loader: "tsx",
+    });
+    expect(transpiler.transformSync("console.log(A = <T = unknown,>() => null)")).toBe(
+      "console.log(A = () => null);\n",
+    );
+    expect(transpiler.transformSync("const B = <T extends string>() => null")).toBe("const B = () => null;\n");
+    expect(transpiler.transformSync("const element = <T extends/>")).toContain("jsxDEV");
+    expect(transpiler.transformSync("const element2 = <T extends={true}/>")).toContain("jsxDEV");
+    expect(transpiler.transformSync("const element3 = <T extends></T>")).toContain("jsxDEV");
+  });
+
+  it("distinguishes TSX arrow functions with extends from JSX elements", () => {
+    var transpiler = new Bun.Transpiler({
+      loader: "tsx",
+    });
+  });
+
   it.todo("JSX", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",


### PR DESCRIPTION
### What does this PR do?
Missing `.t_equals` and `.t_slash` checks. This matches esbuild.

```go
// Returns true if the current less-than token is considered to be an arrow
// function under TypeScript's rules for files containing JSX syntax
func (p *parser) isTSArrowFnJSX() (isTSArrowFn bool) {
	oldLexer := p.lexer
	p.lexer.Next()

	// Look ahead to see if this should be an arrow function instead
	if p.lexer.Token == js_lexer.TConst {
		p.lexer.Next()
	}
	if p.lexer.Token == js_lexer.TIdentifier {
		p.lexer.Next()
		if p.lexer.Token == js_lexer.TComma || p.lexer.Token == js_lexer.TEquals {
			isTSArrowFn = true
		} else if p.lexer.Token == js_lexer.TExtends {
			p.lexer.Next()
			isTSArrowFn = p.lexer.Token != js_lexer.TEquals && p.lexer.Token != js_lexer.TGreaterThan && p.lexer.Token != js_lexer.TSlash
		}
	}

	// Restore the lexer
	p.lexer = oldLexer
	return
}
```

fixes #19697
### How did you verify your code works?
Added some tests.