### PR TITLE
docs: add missing v1.2.21 features to documentation

### DIFF
--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -140,6 +140,19 @@ The `--sourcemap` argument embeds a sourcemap compressed with zstd, so that erro
 
 The `--bytecode` argument enables bytecode compilation. Every time you run JavaScript code in Bun, JavaScriptCore (the engine) will compile your source code into bytecode. We can move this parsing work from runtime to bundle time, saving you startup time.
 
+## Embedding runtime arguments
+
+**`--compile-exec-argv="args"`** - Embed runtime arguments that are available via `process.execArgv`:
+
+```bash
+$ bun build --compile --compile-exec-argv="--smol --user-agent=MyBot" ./app.ts --outfile myapp
+```
+
+```js
+// In the compiled app
+console.log(process.execArgv); // ["--smol", "--user-agent=MyBot"]
+```
+
 ## Act as the Bun CLI
 
 {% note %}

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -145,7 +145,7 @@ The `--bytecode` argument enables bytecode compilation. Every time you run JavaS
 **`--compile-exec-argv="args"`** - Embed runtime arguments that are available via `process.execArgv`:
 
 ```bash
-$ bun build --compile --compile-exec-argv="--smol --user-agent=MyBot" ./app.ts --outfile myapp
+bun build --compile --compile-exec-argv="--smol --user-agent=MyBot" ./app.ts --outfile myapp
 ```
 
 ```js

--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -785,18 +785,6 @@ $ bun build ./index.tsx --outdir ./out --minify --keep-names
 
 boolean; -->
 
-### `sideEffects`
-
-Bun supports `package.json` `sideEffects` field with glob pattern matching:
-
-```json
-{
-  "sideEffects": ["**/*.css", "./src/setup.js"]
-}
-```
-
-Supported glob patterns: `*`, `?`, `**`, `[]`, `{}`.
-
 ### `external`
 
 A list of import paths to consider _external_. Defaults to `[]`.

--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -785,6 +785,18 @@ $ bun build ./index.tsx --outdir ./out --minify --keep-names
 
 boolean; -->
 
+### `sideEffects`
+
+Bun supports `package.json` `sideEffects` field with glob pattern matching:
+
+```json
+{
+  "sideEffects": ["**/*.css", "./src/setup.js"]
+}
+```
+
+Supported glob patterns: `*`, `?`, `**`, `[]`, `{}`.
+
 ### `external`
 
 A list of import paths to consider _external_. Defaults to `[]`.

--- a/docs/cli/bunx.md
+++ b/docs/cli/bunx.md
@@ -68,8 +68,8 @@ $ bunx my-cli --bun # bad
 **`--package <pkg>` or `-p <pkg>`** - Run binary from specific package. Useful when binary name differs from package name:
 
 ```bash
-$ bunx -p renovate renovate-config-validator
-$ bunx --package @angular/cli ng
+bunx -p renovate renovate-config-validator
+bunx --package @angular/cli ng
 ```
 
 To force bun to always be used with a script, use a shebang.

--- a/docs/cli/bunx.md
+++ b/docs/cli/bunx.md
@@ -63,6 +63,15 @@ $ bunx --bun my-cli # good
 $ bunx my-cli --bun # bad
 ```
 
+## Package flag
+
+**`--package <pkg>` or `-p <pkg>`** - Run binary from specific package. Useful when binary name differs from package name:
+
+```bash
+$ bunx -p renovate renovate-config-validator
+$ bunx --package @angular/cli ng
+```
+
 To force bun to always be used with a script, use a shebang.
 
 ```

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -217,7 +217,7 @@ This causes the garbage collector to run more frequently, which can slow down ex
 **`--user-agent <string>`** - Set User-Agent header for all `fetch()` requests:
 
 ```bash
-$ bun --user-agent "MyBot/1.0" run index.tsx
+bun --user-agent "MyBot/1.0" run index.tsx
 ```
 
 ## Resolution order

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -212,6 +212,14 @@ $ bun --smol run index.tsx
 
 This causes the garbage collector to run more frequently, which can slow down execution. However, it can be useful in environments with limited memory. Bun automatically adjusts the garbage collector's heap size based on the available memory (accounting for cgroups and other memory limits) with and without the `--smol` flag, so this is mostly useful for cases where you want to make the heap size grow more slowly.
 
+## `--user-agent`
+
+**`--user-agent <string>`** - Set User-Agent header for all `fetch()` requests:
+
+```bash
+$ bun --user-agent "MyBot/1.0" run index.tsx
+```
+
 ## Resolution order
 
 Absolute paths and paths starting with `./` or `.\\` are always executed as source files. Unless using `bun run`, running a file with an allowed extension will prefer the file over a package.json script.

--- a/docs/install/audit.md
+++ b/docs/install/audit.md
@@ -24,6 +24,26 @@ To update all dependencies to the latest versions (including breaking changes):
   bun update --latest
 ```
 
+### Filtering options
+
+**`--audit-level=<low|moderate|high|critical>`** - Only show vulnerabilities at this severity level or higher:
+
+```bash
+$ bun audit --audit-level=high
+```
+
+**`--prod`** - Audit only production dependencies (excludes devDependencies):
+
+```bash
+$ bun audit --prod
+```
+
+**`--ignore <CVE>`** - Ignore specific CVEs (can be used multiple times):
+
+```bash
+$ bun audit --ignore CVE-2022-25883 --ignore CVE-2023-26136
+```
+
 ### `--json`
 
 Use the `--json` flag to print the raw JSON response from the registry instead of the formatted report:

--- a/docs/install/audit.md
+++ b/docs/install/audit.md
@@ -29,19 +29,19 @@ To update all dependencies to the latest versions (including breaking changes):
 **`--audit-level=<low|moderate|high|critical>`** - Only show vulnerabilities at this severity level or higher:
 
 ```bash
-$ bun audit --audit-level=high
+bun audit --audit-level=high
 ```
 
 **`--prod`** - Audit only production dependencies (excludes devDependencies):
 
 ```bash
-$ bun audit --prod
+bun audit --prod
 ```
 
 **`--ignore <CVE>`** - Ignore specific CVEs (can be used multiple times):
 
 ```bash
-$ bun audit --ignore CVE-2022-25883 --ignore CVE-2023-26136
+bun audit --ignore CVE-2022-25883 --ignore CVE-2023-26136
 ```
 
 ### `--json`


### PR DESCRIPTION
## Summary
- Added documentation for 5 features introduced in Bun v1.2.21 that were missing from the docs
- Kept updates minimal with high information density as requested

## Changes
- **bun audit filtering options** (`docs/install/audit.md`)
  - `--audit-level=<low|moderate|high|critical>` - filter by severity
  - `--prod` - audit only production dependencies  
  - `--ignore <CVE>` - ignore specific vulnerabilities

- **--compile-exec-argv flag** (`docs/bundler/executables.md`)
  - Embed runtime arguments in compiled executables
  - Arguments available via `process.execArgv`

- **bunx --package/-p flag** (`docs/cli/bunx.md`)
  - Run binaries from specific packages when name differs

- **package.json sideEffects glob patterns** (`docs/bundler/index.md`)
  - Support for `*`, `?`, `**`, `[]`, `{}` patterns

- **--user-agent CLI flag** (`docs/cli/run.md`)
  - Customize User-Agent header for all fetch() requests

## Test plan
- [x] Reviewed all changes match Bun v1.2.21 blog post features
- [x] Verified documentation style is concise with code examples
- [x] Checked no existing documentation was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)