### PR TITLE
docs: add missing v1.2.19 features to documentation

### DIFF
--- a/docs/api/glob.md
+++ b/docs/api/glob.md
@@ -175,4 +175,4 @@ const filtered = await promises.glob("**/*", {
 All three functions (`fs.glob()`, `fs.globSync()`, `fs.promises.glob()`) support:
 
 - Array of patterns as the first argument
-- `exclude`/`ignore` options to filter results
+- `exclude` option to filter results

--- a/docs/api/glob.md
+++ b/docs/api/glob.md
@@ -155,3 +155,23 @@ const glob = new Glob("\\!index.ts");
 glob.match("!index.ts"); // => true
 glob.match("index.ts"); // => false
 ```
+
+## Node.js `fs.glob()` compatibility
+
+Bun also implements Node.js's `fs.glob()` functions with additional features:
+
+```ts
+import { glob, globSync, promises } from "node:fs";
+
+// Array of patterns
+const files = await promises.glob(["**/*.ts", "**/*.js"]);
+
+// Exclude patterns
+const filtered = await promises.glob("**/*", {
+  exclude: ["node_modules/**", "*.test.*"]
+});
+```
+
+All three functions (`fs.glob()`, `fs.globSync()`, `fs.promises.glob()`) support:
+- Array of patterns as the first argument
+- `exclude`/`ignore` options to filter results

--- a/docs/api/glob.md
+++ b/docs/api/glob.md
@@ -168,10 +168,11 @@ const files = await promises.glob(["**/*.ts", "**/*.js"]);
 
 // Exclude patterns
 const filtered = await promises.glob("**/*", {
-  exclude: ["node_modules/**", "*.test.*"]
+  exclude: ["node_modules/**", "*.test.*"],
 });
 ```
 
 All three functions (`fs.glob()`, `fs.globSync()`, `fs.promises.glob()`) support:
+
 - Array of patterns as the first argument
 - `exclude`/`ignore` options to filter results

--- a/docs/install/npmrc.md
+++ b/docs/install/npmrc.md
@@ -82,11 +82,11 @@ Controls how workspace packages are installed when available locally:
 link-workspace-packages=true
 ```
 
-The equivalent `bunfig.toml` option is [`install.link-workspace-packages`](https://bun.com/docs/runtime/bunfig#install-link-workspace-packages):
+The equivalent `bunfig.toml` option is [`install.linkWorkspacePackages`](https://bun.com/docs/runtime/bunfig#install-linkworkspacepackages):
 
 ```toml
 [install]
-link-workspace-packages = true
+linkWorkspacePackages = true
 ```
 
 ### `save-exact`: Save exact versions
@@ -97,9 +97,9 @@ Always saves exact versions without the `^` prefix:
 save-exact=true
 ```
 
-The equivalent `bunfig.toml` option is [`install.save-exact`](https://bun.com/docs/runtime/bunfig#install-save-exact):
+The equivalent `bunfig.toml` option is [`install.exact`](https://bun.com/docs/runtime/bunfig#install-exact):
 
 ```toml
 [install]
-save-exact = true
+exact = true
 ```

--- a/docs/install/npmrc.md
+++ b/docs/install/npmrc.md
@@ -73,3 +73,33 @@ The equivalent `bunfig.toml` option is to add a key in [`install.scopes`](https:
 [install.scopes]
 myorg = { url = "http://localhost:4873/", username = "myusername", password = "$NPM_PASSWORD" }
 ```
+
+### `link-workspace-packages`: Control workspace package installation
+
+Controls how workspace packages are installed when available locally:
+
+```ini
+link-workspace-packages=true
+```
+
+The equivalent `bunfig.toml` option is [`install.link-workspace-packages`](https://bun.com/docs/runtime/bunfig#install-link-workspace-packages):
+
+```toml
+[install]
+link-workspace-packages = true
+```
+
+### `save-exact`: Save exact versions
+
+Always saves exact versions without the `^` prefix:
+
+```ini
+save-exact=true
+```
+
+The equivalent `bunfig.toml` option is [`install.save-exact`](https://bun.com/docs/runtime/bunfig#install-save-exact):
+
+```toml
+[install]
+save-exact = true
+```

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -38,7 +38,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 🟢 Fully implemented. 92% of Node.js's test suite passes.
 
-`fs.glob()`, `fs.globSync()`, and `fs.promises.glob()` accept array of patterns and support `exclude`/`ignore` options to filter results.
+`fs.glob()`, `fs.globSync()`, and `fs.promises.glob()` accept array of patterns and support `exclude` option to filter results.
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -38,8 +38,6 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 🟢 Fully implemented. 92% of Node.js's test suite passes.
 
-`fs.glob()`, `fs.globSync()`, and `fs.promises.glob()` accept array of patterns and support `exclude` option to filter results.
-
 ### [`node:http`](https://nodejs.org/api/http.html)
 
 🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed.
@@ -51,8 +49,6 @@ This page is updated regularly to reflect compatibility status of the latest ver
 ### [`node:os`](https://nodejs.org/api/os.html)
 
 🟢 Fully implemented. 100% of Node.js's test suite passes.
-
-`os.networkInterfaces()` returns a `scopeid` property for IPv6 interfaces (not `scope_id`).
 
 ### [`node:path`](https://nodejs.org/api/path.html)
 
@@ -122,8 +118,6 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 🟡 Missing `syncBuiltinESMExports`, `Module#load()`. Overriding `require.cache` is supported for ESM & CJS modules. `module._extensions`, `module._pathCache`, `module._cache` are no-ops. `module.register` is not implemented and we recommend using a [`Bun.plugin`](https://bun.com/docs/runtime/plugins) in the meantime.
 
-`SourceMap` class and `findSourceMap()` function are implemented for parsing and inspecting sourcemaps.
-
 ### [`node:net`](https://nodejs.org/api/net.html)
 
 🟢 Fully implemented.
@@ -155,8 +149,6 @@ This page is updated regularly to reflect compatibility status of the latest ver
 ### [`node:vm`](https://nodejs.org/api/vm.html)
 
 🟡 Core functionality and ES modules are implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`, and `importModuleDynamically` support. Options like `timeout` and `breakOnSigint` are fully supported. Missing `vm.measureMemory` and some `cachedData` functionality.
-
-`vm.constants.DONT_CONTEXTIFY` is supported for passing to vm functions to make `globalThis` behave like typical `globalThis`.
 
 ### [`node:wasi`](https://nodejs.org/api/wasi.html)
 
@@ -357,12 +349,6 @@ The table below lists all globals implemented by Node.js and Bun's current compa
 ### [`process`](https://nodejs.org/api/process.html)
 
 🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented. `process.title` is currently a no-op on macOS & Linux. `getActiveResourcesInfo` `setActiveResourcesInfo`, `getActiveResources` and `setSourceMapsEnabled` are stubs. Newer APIs like `process.loadEnvFile` and `process.getBuiltinModule` are not implemented yet.
-
-`process.features` properties:
-
-- `process.features.typescript` returns `"transform"`
-- `process.features.require_module` returns `true`
-- `process.features.openssl_is_boringssl` returns `true`
 
 ### [`queueMicrotask()`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
 

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -38,6 +38,8 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 🟢 Fully implemented. 92% of Node.js's test suite passes.
 
+`fs.glob()`, `fs.globSync()`, and `fs.promises.glob()` accept array of patterns and support `exclude`/`ignore` options to filter results.
+
 ### [`node:http`](https://nodejs.org/api/http.html)
 
 🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed.
@@ -49,6 +51,8 @@ This page is updated regularly to reflect compatibility status of the latest ver
 ### [`node:os`](https://nodejs.org/api/os.html)
 
 🟢 Fully implemented. 100% of Node.js's test suite passes.
+
+`os.networkInterfaces()` returns a `scopeid` property for IPv6 interfaces (not `scope_id`).
 
 ### [`node:path`](https://nodejs.org/api/path.html)
 
@@ -118,6 +122,8 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 🟡 Missing `syncBuiltinESMExports`, `Module#load()`. Overriding `require.cache` is supported for ESM & CJS modules. `module._extensions`, `module._pathCache`, `module._cache` are no-ops. `module.register` is not implemented and we recommend using a [`Bun.plugin`](https://bun.com/docs/runtime/plugins) in the meantime.
 
+`SourceMap` class and `findSourceMap()` function are implemented for parsing and inspecting sourcemaps.
+
 ### [`node:net`](https://nodejs.org/api/net.html)
 
 🟢 Fully implemented.
@@ -149,6 +155,8 @@ This page is updated regularly to reflect compatibility status of the latest ver
 ### [`node:vm`](https://nodejs.org/api/vm.html)
 
 🟡 Core functionality and ES modules are implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule`, and `importModuleDynamically` support. Options like `timeout` and `breakOnSigint` are fully supported. Missing `vm.measureMemory` and some `cachedData` functionality.
+
+`vm.constants.DONT_CONTEXTIFY` is supported for passing to vm functions to make `globalThis` behave like typical `globalThis`.
 
 ### [`node:wasi`](https://nodejs.org/api/wasi.html)
 
@@ -349,6 +357,11 @@ The table below lists all globals implemented by Node.js and Bun's current compa
 ### [`process`](https://nodejs.org/api/process.html)
 
 🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented. `process.title` is currently a no-op on macOS & Linux. `getActiveResourcesInfo` `setActiveResourcesInfo`, `getActiveResources` and `setSourceMapsEnabled` are stubs. Newer APIs like `process.loadEnvFile` and `process.getBuiltinModule` are not implemented yet.
+
+`process.features` properties:
+- `process.features.typescript` returns `"transform"`
+- `process.features.require_module` returns `true`
+- `process.features.openssl_is_boringssl` returns `true`
 
 ### [`queueMicrotask()`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
 

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -359,6 +359,7 @@ The table below lists all globals implemented by Node.js and Bun's current compa
 🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented. `process.title` is currently a no-op on macOS & Linux. `getActiveResourcesInfo` `setActiveResourcesInfo`, `getActiveResources` and `setSourceMapsEnabled` are stubs. Newer APIs like `process.loadEnvFile` and `process.getBuiltinModule` are not implemented yet.
 
 `process.features` properties:
+
 - `process.features.typescript` returns `"transform"`
 - `process.features.require_module` returns `true`
 - `process.features.openssl_is_boringssl` returns `true`


### PR DESCRIPTION
## Summary
This PR adds documentation for features introduced in Bun v1.2.19 that were missing from the docs.

## Features Documented

### `.npmrc` Options
- `link-workspace-packages`: Controls how workspace packages are installed when available locally
- `save-exact`: Always saves exact versions without the `^` prefix

### Node.js API Enhancements
- `vm.constants.DONT_CONTEXTIFY`: Support for making `globalThis` behave like typical `globalThis`
- `os.networkInterfaces()`: Now returns `scopeid` property for IPv6 interfaces (not `scope_id`)
- `process.features.typescript`: Returns `"transform"`
- `process.features.require_module`: Returns `true`
- `process.features.openssl_is_boringssl`: Returns `true`

### `fs.glob` Enhancements
- Support for array of patterns as first argument
- New `exclude`/`ignore` option to filter results

### `node:module` API
- `SourceMap` class for parsing and inspecting sourcemaps
- `findSourceMap()` function to locate sourcemaps

## Changes Made
- `/docs/install/npmrc.md`: Added `link-workspace-packages` and `save-exact` options
- `/docs/runtime/nodejs-apis.md`: Added Node.js compatibility features
- `/docs/api/glob.md`: Added Node.js fs.glob compatibility section

Documentation was kept concise with high information density as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)