### PR TITLE
docs: add zstd compression documentation for v1.2.14

### DIFF
--- a/docs/api/fetch.md
+++ b/docs/api/fetch.md
@@ -233,6 +233,7 @@ In addition to the standard fetch options, Bun provides several extensions:
 ```ts
 const response = await fetch("http://example.com", {
   // Control automatic response decompression (default: true)
+  // Supports gzip, deflate, brotli (br), and zstd
   decompress: true,
 
   // Disable connection reuse for this request
@@ -339,7 +340,7 @@ This will print the request and response headers to your terminal:
 [fetch] > User-Agent: Bun/$BUN_LATEST_VERSION
 [fetch] > Accept: */*
 [fetch] > Host: example.com
-[fetch] > Accept-Encoding: gzip, deflate, br
+[fetch] > Accept-Encoding: gzip, deflate, br, zstd
 
 [fetch] < 200 OK
 [fetch] < Content-Encoding: gzip

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -633,6 +633,7 @@ const decompressedAsync = await Bun.zstdDecompress(compressed);
 const dec = new TextDecoder();
 dec.decode(decompressedSync);
 // => "hellohellohello..."
+```
 
 ## `Bun.inspect()`
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -602,6 +602,40 @@ dec.decode(decompressed);
 // => "hellohellohello..."
 ```
 
+## `Bun.zstdCompress()` / `Bun.zstdCompressSync()`
+
+Compresses a `Uint8Array` using the Zstandard algorithm.
+
+```ts
+const buf = Buffer.from("hello".repeat(100));
+
+// Synchronous
+const compressed = Bun.zstdCompressSync(buf);
+// Asynchronous
+const compressed = await Bun.zstdCompress(buf);
+
+// With compression level (1-22, default: 3)
+const compressed = Bun.zstdCompressSync(buf, { level: 6 });
+```
+
+## `Bun.zstdDecompress()` / `Bun.zstdDecompressSync()`
+
+Decompresses a `Uint8Array` using the Zstandard algorithm.
+
+```ts
+const buf = Buffer.from("hello".repeat(100));
+const compressed = Bun.zstdCompressSync(buf);
+
+// Synchronous
+const decompressed = Bun.zstdDecompressSync(compressed);
+// Asynchronous
+const decompressed = await Bun.zstdDecompress(compressed);
+
+const dec = new TextDecoder();
+dec.decode(decompressed);
+// => "hellohellohello..."
+```
+
 ## `Bun.inspect()`
 
 Serializes an object to a `string` exactly as it would be printed by `console.log`.

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -616,6 +616,7 @@ const compressedAsync = await Bun.zstdCompress(buf);
 
 // With compression level (1-22, default: 3)
 const compressedLevel = Bun.zstdCompressSync(buf, { level: 6 });
+```
 
 ## `Bun.zstdDecompress()` / `Bun.zstdDecompressSync()`
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -610,13 +610,12 @@ Compresses a `Uint8Array` using the Zstandard algorithm.
 const buf = Buffer.from("hello".repeat(100));
 
 // Synchronous
-const compressed = Bun.zstdCompressSync(buf);
+const compressedSync = Bun.zstdCompressSync(buf);
 // Asynchronous
-const compressed = await Bun.zstdCompress(buf);
+const compressedAsync = await Bun.zstdCompress(buf);
 
 // With compression level (1-22, default: 3)
-const compressed = Bun.zstdCompressSync(buf, { level: 6 });
-```
+const compressedLevel = Bun.zstdCompressSync(buf, { level: 6 });
 
 ## `Bun.zstdDecompress()` / `Bun.zstdDecompressSync()`
 
@@ -627,14 +626,13 @@ const buf = Buffer.from("hello".repeat(100));
 const compressed = Bun.zstdCompressSync(buf);
 
 // Synchronous
-const decompressed = Bun.zstdDecompressSync(compressed);
+const decompressedSync = Bun.zstdDecompressSync(compressed);
 // Asynchronous
-const decompressed = await Bun.zstdDecompress(compressed);
+const decompressedAsync = await Bun.zstdDecompress(compressed);
 
 const dec = new TextDecoder();
-dec.decode(decompressed);
+dec.decode(decompressedSync);
 // => "hellohellohello..."
-```
 
 ## `Bun.inspect()`
 


### PR DESCRIPTION
## Summary
- Documents zstd compression features introduced in Bun v1.2.14
- Adds missing API documentation for zstd utilities

## Changes
- Updated `docs/api/fetch.md` to include zstd in Accept-Encoding examples and note automatic decompression support
- Added `Bun.zstdCompress()/zstdCompressSync()` and `Bun.zstdDecompress()/zstdDecompressSync()` documentation to `docs/api/utils.md`
- Documented compression levels (1-22) with concise usage examples

## Note
HTTP/2 features (`maxSendHeaderBlockLength` and `setNextStreamID`) were not added per request to avoid updating nodejs-apis.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)