### PR TITLE
docs: add missing v1.2.13 features to documentation

### DIFF
--- a/docs/api/redis.md
+++ b/docs/api/redis.md
@@ -88,6 +88,9 @@ await redis.set("user:1:name", "Alice");
 // Get a key
 const name = await redis.get("user:1:name");
 
+// Get a key as Uint8Array
+const buffer = await redis.getBuffer("user:1:name");
+
 // Delete a key
 await redis.del("user:1:name");
 

--- a/docs/api/workers.md
+++ b/docs/api/workers.md
@@ -282,6 +282,31 @@ const worker = new Worker("./i-am-smol.ts", {
 Setting `smol: true` sets `JSC::HeapSize` to be `Small` instead of the default `Large`.
 {% /details %}
 
+## Environment Data
+
+Share data between the main thread and workers using `setEnvironmentData()` and `getEnvironmentData()`.
+
+```js
+import { setEnvironmentData, getEnvironmentData } from "worker_threads";
+
+// In main thread
+setEnvironmentData("config", { apiUrl: "https://api.example.com" });
+
+// In worker
+const config = getEnvironmentData("config");
+console.log(config); // => { apiUrl: "https://api.example.com" }
+```
+
+## Worker Events
+
+Listen for worker creation events using `process.emit()`:
+
+```js
+process.on("worker", (worker) => {
+  console.log("New worker created:", worker.threadId);
+});
+```
+
 ## `Bun.isMainThread`
 
 You can check if you're in the main thread by checking `Bun.isMainThread`.

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -151,6 +151,14 @@ By default, Bun respects this shebang and executes the script with `node`. Howev
 $ bun run --bun vite
 ```
 
+### `--no-addons`
+
+Disable native addons and use the `node-addons` export condition.
+
+```bash
+$ bun --no-addons run server.js
+```
+
 ### Filtering
 
 In monorepos containing multiple packages, you can use the `--filter` argument to execute scripts in many packages at once.


### PR DESCRIPTION
## Summary
- Added documentation for worker_threads environmentData API and process 'worker' event
- Added documentation for --no-addons CLI flag
- Added documentation for RedisClient getBuffer() method

## Context
These features were released in Bun v1.2.13 but were missing from the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)