### PR TITLE
docs: replace exec with run

### DIFF
--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -182,7 +182,7 @@ SQLite supports [write-ahead log mode](https://www.sqlite.org/wal.html) (WAL) wh
 To enable WAL mode, run this pragma query at the beginning of your application:
 
 ```ts
-db.exec("PRAGMA journal_mode = WAL;");
+db.run("PRAGMA journal_mode = WAL;");
 ```
 
 {% details summary="What is WAL mode" %}


### PR DESCRIPTION
### What does this PR do?

To respect the deprecation of the `Database.exec` method, replaces the `db.exec` call for `PRAGMA` with `db.run`.

### How did you verify your code works?
Simple docs update.