### PR TITLE
Fix util.inspect negative fractional number formatting with numericSeparator

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1967,15 +1967,21 @@ function formatNumber(fn, number, numericSeparator) {
     return fn(`${number}`, "number");
   }
   const integer = MathTrunc(number);
-  const string = String(integer);
+  // Handle -0 specially to preserve the negative sign
+  const string = ObjectIs(integer, -0) ? "-0" : String(integer);
   if (integer === number) {
-    if (!NumberIsFinite(number) || StringPrototypeIncludes(string, "e")) {
-      return fn(string, "number");
+    // Check the original number string for scientific notation, not the integer string
+    if (!NumberIsFinite(number) || StringPrototypeIncludes(String(number), "e")) {
+      return fn(`${number}`, "number");
     }
     return fn(`${addNumericSeparator(string)}`, "number");
   }
   if (NumberIsNaN(number)) {
     return fn(string, "number");
+  }
+  // Check the original number string for scientific notation before applying separators
+  if (StringPrototypeIncludes(String(number), "e")) {
+    return fn(`${number}`, "number");
   }
   return fn(
     `${addNumericSeparator(string)}.${addNumericSeparatorEnd(StringPrototypeSlice(String(number), string.length + 1))}`,

--- a/test/regression/issue/23098.test.ts
+++ b/test/regression/issue/23098.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { inspect } from "node:util";
+
+test("util.inspect formats negative fractional numbers correctly with numericSeparator: true (#23098)", () => {
+  // Test the specific cases from the issue
+  const values = [0.1234, -0.12, -0.123, -0.1234, -1.234];
+  const text = inspect(values, { numericSeparator: true });
+  expect(text).toBe("[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]");
+
+  // Test individual values
+  expect(inspect(-0.12, { numericSeparator: true })).toBe("-0.12");
+  expect(inspect(-0.123, { numericSeparator: true })).toBe("-0.123");
+  expect(inspect(-0.1234, { numericSeparator: true })).toBe("-0.123_4");
+  expect(inspect(-0.123456789, { numericSeparator: true })).toBe("-0.123_456_789");
+
+  // Test edge cases
+  expect(inspect(-0, { numericSeparator: true })).toBe("-0");
+  expect(inspect(0, { numericSeparator: true })).toBe("0");
+
+  // Test scientific notation doesn't get separators
+  expect(inspect(1.23e-10, { numericSeparator: true })).toBe("1.23e-10");
+  expect(inspect(-1.23e-10, { numericSeparator: true })).toBe("-1.23e-10");
+  expect(inspect(1.23e10, { numericSeparator: true })).toBe("12_300_000_000");
+  expect(inspect(-1.23e10, { numericSeparator: true })).toBe("-12_300_000_000");
+
+  // Test large negative numbers still work
+  expect(inspect(-123456789.123456789, { numericSeparator: true })).toBe("-123_456_789.123_456_79");
+});


### PR DESCRIPTION
## Summary
- Fixes #23098 
- Negative fractional numbers between -1 and 0 were incorrectly formatted when `numericSeparator: true`
- Example: `-0.12` was displayed as `0..12` instead of `-0.12`

## The Problem
When `numericSeparator: true` is set, `Math.trunc(-0.123)` returns `-0`, but `String(-0)` becomes `"0"`, losing the negative sign. This caused the formatting to lose track of the negative sign for fractional numbers between -1 and 0.

## The Fix
1. Check for `-0` using `Object.is()` and explicitly use `"-0"` as the string representation
2. Fixed scientific notation handling to check the original number string instead of the truncated integer string

## Test Results
```javascript
// Before fix:
[ 0.123_4, 0..12, 0..12_3, 0..12_34, -1.234 ]

// After fix (matches Node.js):
[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]
```

Added comprehensive regression test in `test/regression/issue/23098.test.ts` that covers:
- The reported issue cases
- Edge cases (-0, scientific notation)
- Large negative numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)