### PR TITLE
docs: Add v1.2.22 feature documentation

### DIFF
--- a/docs/api/redis.md
+++ b/docs/api/redis.md
@@ -132,6 +132,10 @@ await redis.hmset("user:123", [
 const userFields = await redis.hmget("user:123", ["name", "email"]);
 console.log(userFields); // ["Alice", "alice@example.com"]
 
+// Get a single field from a hash
+const value = await redis.hget("user:123", "name");
+console.log(value); // "Alice"
+
 // Increment a numeric field in a hash
 await redis.hincrby("user:123", "visits", 1);
 

--- a/docs/api/websockets.md
+++ b/docs/api/websockets.md
@@ -293,6 +293,33 @@ const socket = new WebSocket("ws://localhost:3000", {
 });
 ```
 
+### Subprotocol negotiation
+
+WebSocket clients can request specific subprotocols during the connection handshake. The server can then choose which protocol to use from the client's list.
+
+```js
+// Request multiple protocols
+const ws = new WebSocket("ws://localhost:3000", ["chat", "superchat"]);
+
+ws.onopen = () => {
+  console.log(`Connected with protocol: ${ws.protocol}`); // Server's chosen protocol
+};
+```
+
+### Custom headers
+
+Bun allows you to set custom headers in the WebSocket constructor, including overriding standard WebSocket headers. This is useful for authentication, custom host headers, or other server requirements.
+
+```js
+const ws = new WebSocket("ws://localhost:3000", {
+  headers: {
+    "Host": "custom-host.example.com",
+    "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+    "X-Custom": "value"
+  }
+});
+```
+
 To add event listeners to the socket:
 
 ```ts

--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -781,6 +781,14 @@ $ bun build ./index.tsx --outdir ./out --minify --keep-names
 
 {% /codetabs %}
 
+### Minification optimizations
+
+The minifier applies several optimizations:
+
+- **Constructor simplification**: `new Object()` → `{}`, `new Array(1,2)` → `[1,2]`
+- **typeof checks**: `typeof x === "undefined"` → `typeof x > "u"`
+- **Function names**: Unused function/class expression names are removed unless `--keep-names` is set
+
 <!-- ### `treeshaking`
 
 boolean; -->

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -166,6 +166,16 @@ will execute `<script>` in both `bar` and `baz`, but not in `foo`.
 
 Find more details in the docs page for [filter](https://bun.com/docs/cli/filter#running-scripts-with-filter).
 
+### `--workspaces`
+
+In monorepos with workspaces, you can use the `--workspaces` flag to execute a script in all workspace packages that have the script defined.
+
+```bash
+$ bun run --workspaces build
+```
+
+This will run the `build` script in all workspace packages that have a `build` script defined in their `package.json`. Packages without the specified script will be skipped.
+
 ## `bun run -` to pipe code from stdin
 
 `bun run -` lets you read JavaScript, TypeScript, TSX, or JSX from stdin and execute it without writing to a temporary file first.

--- a/docs/runtime/debugger.md
+++ b/docs/runtime/debugger.md
@@ -323,3 +323,24 @@ Error: here!
     at moduleEvaluation (native)
     at <anonymous> (native)
 ```
+
+### Async stack traces
+
+Bun includes asynchronous call frames in stack traces, making debugging async/await code easier:
+
+```js
+async function foo() {
+  return await bar();
+}
+
+async function bar() {
+  throw new Error("oops");
+}
+
+await foo();
+// error: oops
+//       at bar (async.js:6:9)
+//       at async foo (async.js:2:16)
+```
+
+The stack trace shows the complete async execution path with `async` prefixed to asynchronous frames.

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -40,7 +40,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 
-🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed.
+🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed. `closeIdleConnections()` is implemented.
 
 ### [`node:https`](https://nodejs.org/api/https.html)
 
@@ -80,7 +80,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:tty`](https://nodejs.org/api/tty.html)
 
-🟢 Fully implemented.
+🟢 Fully implemented. Includes interactive TTY support after stdin closes.
 
 ### [`node:url`](https://nodejs.org/api/url.html)
 
@@ -124,7 +124,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:perf_hooks`](https://nodejs.org/api/perf_hooks.html)
 
-🟡 Missing `createHistogram` `monitorEventLoopDelay`. It's recommended to use `performance` global instead of `perf_hooks.performance`.
+🟡 Missing `createHistogram`. `monitorEventLoopDelay` is implemented. It's recommended to use `performance` global instead of `perf_hooks.performance`.
 
 ### [`node:process`](https://nodejs.org/api/process.html)
 
@@ -405,6 +405,10 @@ The table below lists all globals implemented by Node.js and Bun's current compa
 ### [`structuredClone()`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
 
 🟢 Fully implemented.
+
+### Performance
+
+`structuredClone()` uses the same optimized serialization as `postMessage()`. For simple objects containing only primitives, it can be up to 240x faster than standard structured cloning.
 
 ### [`SubtleCrypto`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto)
 


### PR DESCRIPTION
## Summary
- Updated documentation to include features from Bun v1.2.22 release
- Added minimal, accurate documentation for previously undocumented features
- Focused on high information density without filler content

## Changes
- **Async debugging**: Added async stack traces documentation
- **Performance**: Documented structuredClone optimizations  
- **Bundler**: Added minification optimization details (constructor simplification, typeof checks)
- **Node.js APIs**: Updated perf_hooks, http, and tty implementation status
- **WebSocket**: Added subprotocol negotiation and header override documentation
- **Redis**: Documented hget() method
- **CLI**: Added --workspaces flag documentation for bun run

## Test plan
- [x] Documentation builds correctly
- [x] All examples are accurate from v1.2.22 changelog
- [x] Changes are minimal and focused on new features only

🤖 Generated with [Claude Code](https://claude.com/claude-code)