### PR TITLE
docs: add missing documentation for v1.2.22 features

### DIFF
--- a/docs/api/redis.md
+++ b/docs/api/redis.md
@@ -128,6 +128,10 @@ await redis.hmset("user:123", [
   "true",
 ]);
 
+// Get a single field from a hash
+const name = await redis.hget("user:123", "name");
+console.log(name); // "Alice"
+
 // Get multiple fields from a hash
 const userFields = await redis.hmget("user:123", ["name", "email"]);
 console.log(userFields); // ["Alice", "alice@example.com"]
@@ -424,8 +428,9 @@ new RedisClient("redis://localhost:6379");
 // With authentication
 new RedisClient("redis://username:password@localhost:6379");
 
-// With database number
-new RedisClient("redis://localhost:6379/0");
+// With database number - connects to a specific database (0-15)
+new RedisClient("redis://localhost:6379/0");  // Database 0 (default)
+new RedisClient("redis://localhost:6379/2");  // Database 2
 
 // TLS connections
 new RedisClient("rediss://localhost:6379");

--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -1247,6 +1247,10 @@ While the API is unified, there are some behavioral differences:
 
 We haven't implemented `LOAD DATA INFILE` support yet
 
+### PostgreSQL Type Handling
+
+PostgreSQL `TIME` and `TIMETZ` columns are correctly decoded when using the binary protocol. `TIME` columns return the time as microseconds since midnight, while `TIMETZ` columns include timezone information.
+
 ### PostgreSQL-Specific Features
 
 We haven't implemented these yet:

--- a/docs/api/websockets.md
+++ b/docs/api/websockets.md
@@ -293,6 +293,30 @@ const socket = new WebSocket("ws://localhost:3000", {
 });
 ```
 
+You can override special WebSocket headers like `Host`, `Sec-WebSocket-Key`, and `Sec-WebSocket-Protocol`:
+
+```ts
+const socket = new WebSocket("ws://localhost:8080", {
+  headers: {
+    "Host": "custom-host.example.com",
+    "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==", // Must be valid base64-encoded 16-byte key
+    "Sec-WebSocket-Protocol": "chat, superchat",
+  },
+});
+```
+
+### Subprotocol Negotiation
+
+Bun's WebSocket client implements RFC 6455 compliant subprotocol negotiation. When you pass an array of desired subprotocols, Bun sends them in the `Sec-WebSocket-Protocol` header. The server can select one of these protocols, and the selected protocol is available on the `ws.protocol` property:
+
+```ts
+const ws = new WebSocket("ws://localhost:3000", ["chat", "superchat"]);
+
+ws.onopen = () => {
+  console.log(`Connected with protocol: ${ws.protocol}`); // e.g., "chat"
+};
+```
+
 To add event listeners to the socket:
 
 ```ts

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -166,6 +166,16 @@ will execute `<script>` in both `bar` and `baz`, but not in `foo`.
 
 Find more details in the docs page for [filter](https://bun.com/docs/cli/filter#running-scripts-with-filter).
 
+### Running scripts in all workspaces
+
+The `--workspaces` flag runs the specified script in each workspace package:
+
+```bash
+bun run --workspaces <script>
+```
+
+This executes the script in all workspace packages defined in your root `package.json`'s `workspaces` field.
+
 ## `bun run -` to pipe code from stdin
 
 `bun run -` lets you read JavaScript, TypeScript, TSX, or JSX from stdin and execute it without writing to a temporary file first.

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -42,6 +42,8 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed.
 
+`server.closeIdleConnections()` is implemented. This method immediately closes all sockets not currently handling a request.
+
 ### [`node:https`](https://nodejs.org/api/https.html)
 
 🟢 APIs are implemented, but `Agent` is not always used yet.
@@ -124,7 +126,9 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:perf_hooks`](https://nodejs.org/api/perf_hooks.html)
 
-🟡 Missing `createHistogram` `monitorEventLoopDelay`. It's recommended to use `performance` global instead of `perf_hooks.performance`.
+🟡 Missing `createHistogram`. It's recommended to use `performance` global instead of `perf_hooks.performance`.
+
+`monitorEventLoopDelay()` is implemented. This function creates an `IntervalHistogram` object that samples event loop delay in nanoseconds.
 
 ### [`node:process`](https://nodejs.org/api/process.html)
 


### PR DESCRIPTION
## Summary

This PR adds minimal documentation for features introduced in Bun v1.2.22 that were missing from the docs.

## Documentation Status

### Documented
- Bun.YAML.stringify is documented
- MySQL adapter improvements (affectedRows, lastInsertRowid, TLS, mysql_native_password) are documented
- Bundler onEnd hook is documented  
- --keep-names flag is documented
- jsxSideEffects option is documented

### Missing (added in this PR)
- PostgreSQL TIME/TIMETZ decoding is documented
- perf_hooks.monitorEventLoopDelay() is documented
- http.Server.prototype.closeIdleConnections() is documented
- bun run --workspaces flag is documented
- WebSocket subprotocol negotiation is documented
- WebSocket header overrides are documented
- Redis database selection via URL is documented
- redis.hget() method is documented

## Test plan

Documentation only change - no tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)