### PR TITLE
Allow multiple inline snapshots in one call if they are the same

### DIFF
--- a/repro.ts
+++ b/repro.ts
@@ -1,0 +1,7 @@
+function oops(a) {
+  expect(a).toMatchInlineSnapshot();
+}
+test("whoops", () => {
+  oops(1);
+  oops(2);
+});

--- a/repro.ts
+++ b/repro.ts
@@ -1,7 +1,0 @@
-function oops(a) {
-  expect(a).toMatchInlineSnapshot();
-}
-test("whoops", () => {
-  oops(1);
-  oops(2);
-});

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -266,7 +266,7 @@ pub const Snapshots = struct {
             for (ils_info.items) |ils| {
                 if (ils.line == last_line and ils.col == last_col) {
                     if (!bun.strings.eql(ils.value, last_value)) {
-                        const DiffFormatter = @import("diff_format.zig").DiffFormatter;
+                        const DiffFormatter = @import("./diff_format.zig").DiffFormatter;
                         try log.addErrorFmt(source, .{ .start = @intCast(uncommitted_segment_end) }, arena, "Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value:\n{}", .{DiffFormatter{
                             .received_string = ils.value,
                             .expected_string = last_value,

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -262,9 +262,17 @@ pub const Snapshots = struct {
             var last_byte: usize = 0;
             var last_line: c_ulong = 1;
             var last_col: c_ulong = 1;
+            var last_value: []const u8 = "";
             for (ils_info.items) |ils| {
                 if (ils.line == last_line and ils.col == last_col) {
-                    try log.addErrorFmt(source, .{ .start = @intCast(uncommitted_segment_end) }, arena, "Failed to update inline snapshot: Multiple inline snapshots for the same call are not supported", .{});
+                    if (!bun.strings.eql(ils.value, last_value)) {
+                        const DiffFormatter = @import("diff_format.zig").DiffFormatter;
+                        try log.addErrorFmt(source, .{ .start = @intCast(uncommitted_segment_end) }, arena, "Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value:\n{}", .{DiffFormatter{
+                            .received_string = ils.value,
+                            .expected_string = last_value,
+                            .globalThis = vm.global,
+                        }});
+                    }
                     continue;
                 }
 
@@ -279,6 +287,7 @@ pub const Snapshots = struct {
                 last_byte += byte_offset_add;
                 last_line = ils.line;
                 last_col = ils.col;
+                last_value = ils.value;
 
                 var next_start = last_byte;
                 inline_snapshot_dbg("-> Found byte {}", .{next_start});

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -631,7 +631,9 @@ Date)
   });
   it("should error trying to update the same line twice", () => {
     tester.testError(
-      { msg: "error: Failed to update inline snapshot: Multiple inline snapshots for the same call are not supported" },
+      {
+        msg: "error: Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value",
+      },
       /*js*/ `
         function oops(a) {expect(a).toMatchInlineSnapshot()}
         test("whoops", () => {


### PR DESCRIPTION
Multiple inline snapshots from one call should be avoided because they will cause problems if one changes but not the other, but this allows them if they both have the same value.

### What does this PR do?

bad:

```ts
function oops(a) {
  expect(a).toMatchInlineSnapshot();
}
test("whoops", () => {
  oops(1);
  oops(2);
});
```

```
2 |   expect(a).toMatchInlineSnapshot();
                                      ^
error: Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value:
Expected: 1
Received: 2
    at /Users/pfg/Dev/Node/bun/repro.ts:2:35
```

acceptable:

```ts
function ok(a) {
  expect(a).toMatchInlineSnapshot(`1`);
}
test("whokay", () => {
  ok(1);
  ok(1);
});
```

```
✓ whokay

 1 pass
 0 fail
 snapshots: +1 added
 2 expect() calls
```

### How did you verify your code works?

TODO: add tests