### PR TITLE
fix: Ordering Semantics

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -823,6 +823,10 @@ pub fn getRuntimeFeatureFlag(comptime flag: FeatureFlags.RuntimeFeatureFlag) boo
         const state = enum(u8) { idk, disabled, enabled };
         var is_enabled: std.atomic.Value(state) = std.atomic.Value(state).init(.idk);
         pub fn get() bool {
+            // .monotonic is okay because there are no side effects we need to observe from a thread that has
+            // written to this variable. This variable is simply a cache, and if its value is not ready yet, we
+            // compute it below. There are no correctness issues if multiple threads perform this computation
+            // simultaneously, as they will all store the same value.
             return switch (is_enabled.load(.monotonic)) {
                 .enabled => true,
                 .disabled => false,

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -823,7 +823,7 @@ pub fn getRuntimeFeatureFlag(comptime flag: FeatureFlags.RuntimeFeatureFlag) boo
         const state = enum(u8) { idk, disabled, enabled };
         var is_enabled: std.atomic.Value(state) = std.atomic.Value(state).init(.idk);
         pub fn get() bool {
-            return switch (is_enabled.load(.seq_cst)) {
+            return switch (is_enabled.load(.monotonic)) {
                 .enabled => true,
                 .disabled => false,
                 .idk => {
@@ -831,7 +831,7 @@ pub fn getRuntimeFeatureFlag(comptime flag: FeatureFlags.RuntimeFeatureFlag) boo
                         strings.eqlComptime(val, "1") or strings.eqlComptime(val, "true")
                     else
                         false;
-                    is_enabled.store(if (enabled) .enabled else .disabled, .seq_cst);
+                    is_enabled.store(if (enabled) .enabled else .disabled, .monotonic);
                     return enabled;
                 },
             };


### PR DESCRIPTION
### What does this PR do?

Squeezes a tiny bit of performance out of `bun.zig:getRuntimeFeatureFlag`. Stumbled on this guy while doing my other work so decided to send a fix.

### How did you verify your code works?

CI, hopefully, though this will be tough to confirm. I think by plain logic this is correct, however.