### PR TITLE
Enable `--useExplicitResourceManagement` by default

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -302,6 +302,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
         JSC::Options::heapGrowthSteepnessFactor() = 1.0;
         JSC::Options::heapGrowthMaxIncrease() = 2.0;
         JSC::Options::useAsyncStackTrace() = true;
+        JSC::Options::useExplicitResourceManagement() = true;
         JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
 #ifdef BUN_DEBUG


### PR DESCRIPTION
### What does this PR do?

This PR enables `--useExplicitResourceManagement` JSC option by default, to expose following builtins:

- `DisposableStack`
- `AsyncDisposableStack`
- `Iterator@@dispose`
- `AsyncIterator@@asyncDispose`

### How did you verify your code works?

These features are fully tested on JSC side.

