### PR TITLE
docs: add v1.2.2 feature documentation

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -292,6 +292,12 @@ class Foo {
   a = 1;
 }
 Bun.deepEquals(new Foo(), { a: 1 }, true); // false
+
+// objects with same prototype but different types
+Bun.deepEquals(new Date(), {}, true); // false
+
+// TypedArrays vs objects with numeric properties
+Bun.deepEquals(new Uint8Array([1, 2]), { 0: 1, 1: 2 }, true); // false
 ```
 
 ## `Bun.escapeHTML()`

--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -174,6 +174,12 @@ import { stuff } from "foo";
 
 The full specification of this algorithm are officially documented in the [Node.js documentation](https://nodejs.org/api/modules.html); we won't rehash it here. Briefly: if you import `from "foo"`, Bun scans up the file system for a `node_modules` directory containing the package `foo`.
 
+Bun also supports the `NODE_PATH` environment variable for additional module search paths:
+
+```sh
+$ export NODE_PATH="/path/to/modules"
+```
+
 Once it finds the `foo` package, Bun reads the `package.json` to determine how the package should be imported. To determine the package's entrypoint, Bun first reads the `exports` field and checks for the following conditions.
 
 ```jsonc#package.json

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -40,7 +40,11 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 
-🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed.
+🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed. Re-exports `WebSocket`, `CloseEvent`, and `MessageEvent`.
+
+```js
+const { WebSocket } = require("node:http");
+```
 
 ### [`node:https`](https://nodejs.org/api/https.html)
 


### PR DESCRIPTION
## Summary

Minimal documentation updates for user-facing features in Bun v1.2.2:

- **NODE_PATH support**: Added to module resolution docs with example
- **node:http WebSocket exports**: Documented WebSocket/CloseEvent/MessageEvent re-exports
- **Bun.deepEquals**: Added examples of stricter comparison behavior

## Documentation Coverage

Reviewed all features in v1.2.2 blog post. Only documented user-facing API changes:
- ✅ NODE_PATH environment variable support
- ✅ node:http WebSocket/CloseEvent/MessageEvent re-exports  
- ✅ Bun.deepEquals stricter comparison behavior

Did not document (internal improvements/bug fixes):
- GC/memory improvements (internal)
- SIGPWR GC signaling (internal)
- Bun.SQL reliability fixes (bug fixes)
- Various other bug fixes

Already documented:
- fs.glob/globSync/promises.glob (already in docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)