### PR TITLE
docs: document v1.2.1 features

### DIFF
--- a/docs/api/s3.md
+++ b/docs/api/s3.md
@@ -235,6 +235,19 @@ const url = s3file.presign({
 });
 ```
 
+### Storage class
+
+Control the storage class for presigned uploads:
+
+```ts
+const url = s3file.presign({
+  method: "PUT",
+  storageClass: "GLACIER",
+});
+```
+
+Supported storage classes: `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER`, `DEEP_ARCHIVE`, `GLACIER_IR`.
+
 ### `method`
 
 To set the HTTP method for a presigned URL, pass the `method` option.

--- a/docs/api/udp.md
+++ b/docs/api/udp.md
@@ -18,6 +18,20 @@ const socket = await Bun.udpSocket({
 console.log(socket.port); // 41234
 ```
 
+### Socket options
+
+Configure socket behavior with `reuseAddr` and `reusePort`:
+
+```ts
+const socket = await Bun.udpSocket({
+  port: 8080,
+  reuseAddr: true, // Allow binding to addresses in TIME_WAIT state
+  reusePort: true, // Linux-only: share port across multiple processes
+});
+```
+
+`reuseAddr` allows reusing addresses immediately after closing. `reusePort` enables load balancing across processes but is Linux-only.
+
 ### Send a datagram
 
 Specify the data to send, as well as the destination port and address.

--- a/docs/bundler/fullstack.md
+++ b/docs/bundler/fullstack.md
@@ -342,6 +342,22 @@ $ bun add bun-plugin-tailwind
 plugins = ["bun-plugin-tailwind"]
 ```
 
+### Minification
+
+Control HTML import minification in `bunfig.toml`:
+
+```toml#bunfig.toml
+[serve.static]
+# Boolean: enable all minification
+minify = true
+
+# Or object for fine-grained control
+[serve.static.minify]
+whitespace = true
+identifiers = true
+syntax = true
+```
+
 This will allow you to use TailwindCSS utility classes in your HTML and CSS files. All you need to do is import `tailwindcss` somewhere:
 
 ```html#index.html

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -159,6 +159,14 @@ Disable native addons and use the `node-addons` export condition.
 $ bun --no-addons run server.js
 ```
 
+### `--zero-fill-buffers`
+
+Force all `Buffer` allocations to be zero-filled for security (Node.js compatibility):
+
+```bash
+$ bun --zero-fill-buffers run app.js
+```
+
 ### Filtering
 
 In monorepos containing multiple packages, you can use the `--filter` argument to execute scripts in many packages at once.

--- a/docs/runtime/web-apis.md
+++ b/docs/runtime/web-apis.md
@@ -80,6 +80,7 @@ The following Web APIs are partially or completely supported.
 - [`crypto`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)
   [`SubtleCrypto`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto)
   [`CryptoKey`](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey)
+  (X25519 curve support for `crypto.subtle.generateKey()`)
 
 ---
 

--- a/docs/test/snapshots.md
+++ b/docs/test/snapshots.md
@@ -40,6 +40,21 @@ test("inline snapshot", () => {
 
 When you run the test, Bun automatically updates the test file itself with the generated snapshot string. This makes the tests more portable and easier to understand, since the expected output is right next to the test.
 
+Indentation is automatically preserved to match your test file's formatting:
+
+```ts
+test("nested object", () => {
+  expect({ user: { name: "Alice", role: "admin" } }).toMatchInlineSnapshot(`
+    {
+      "user": {
+        "name": "Alice",
+        "role": "admin",
+      },
+    }
+  `);
+});
+```
+
 ### Using inline snapshots
 
 1. Write your test with `.toMatchInlineSnapshot()`


### PR DESCRIPTION
## Summary

Add minimal, high-information-density documentation for new features in Bun v1.2.1:

- **S3**: `storageClass` option for presigned URLs
- **Crypto**: X25519 curve support in `crypto.generateKeyPair()`
- **Testing**: Indented inline snapshots in `bun test`
- **Bundler**: `minify` option for HTML imports in `bunfig.toml`
- **CLI**: `--zero-fill-buffers` flag for Node.js compatibility
- **UDP**: `reuseAddr`/`reusePort` socket options

## Files Changed

- `docs/api/s3.md` - Added storage class documentation
- `docs/api/udp.md` - Added socket options section
- `docs/bundler/fullstack.md` - Added minify configuration
- `docs/cli/run.md` - Added --zero-fill-buffers flag
- `docs/runtime/web-apis.md` - Added X25519 note
- `docs/test/snapshots.md` - Added indentation note

All changes follow existing documentation style with concise explanations and code examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)