### PR TITLE
docs: add v1.2.2 features (NODE_PATH, node:http WebSocket exports)

### DIFF
--- a/docs/runtime/modules.md
+++ b/docs/runtime/modules.md
@@ -174,6 +174,13 @@ import { stuff } from "foo";
 
 The full specification of this algorithm are officially documented in the [Node.js documentation](https://nodejs.org/api/modules.html); we won't rehash it here. Briefly: if you import `from "foo"`, Bun scans up the file system for a `node_modules` directory containing the package `foo`.
 
+Bun also supports the `NODE_PATH` environment variable for resolving modules from additional directories outside of `node_modules`.
+
+```bash
+$ export NODE_PATH="/path/to/global/modules"
+$ bun run my-script.js
+```
+
 Once it finds the `foo` package, Bun reads the `package.json` to determine how the package should be imported. To determine the package's entrypoint, Bun first reads the `exports` field and checks for the following conditions.
 
 ```jsonc#package.json

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -40,7 +40,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 
-🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed.
+🟢 Fully implemented. Outgoing client request body is currently buffered instead of streamed. Re-exports `WebSocket`, `CloseEvent`, and `MessageEvent` globals for Node.js compatibility.
 
 ### [`node:https`](https://nodejs.org/api/https.html)
 


### PR DESCRIPTION
## Summary
- Document NODE_PATH environment variable support for module resolution
- Document WebSocket, CloseEvent, MessageEvent re-exports from node:http

Minimal documentation updates for new features in Bun v1.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)