### PR TITLE
docs: add documentation for v1.2.1 features

### DIFF
--- a/docs/api/binary-data.md
+++ b/docs/api/binary-data.md
@@ -420,6 +420,8 @@ console.log(buf.toString());
 // => Hello world
 ```
 
+`Buffer.prototype.toLocaleString` is an alias for `Buffer.prototype.toString`.
+
 For complete documentation, refer to the [Node.js documentation](https://nodejs.org/api/buffer.html).
 
 ## `Blob`

--- a/docs/api/s3.md
+++ b/docs/api/s3.md
@@ -232,6 +232,9 @@ const url = s3file.presign({
 
   // HTTP method
   method: "PUT",
+
+  // S3 storage class (optional)
+  storageClass: "GLACIER_IR",
 });
 ```
 
@@ -247,6 +250,23 @@ const url = s3file.presign({
   // method: "HEAD",
   // method: "POST",
   // method: "PUT",
+});
+```
+
+### `storageClass`
+
+To set the S3 storage class for a presigned URL, pass the `storageClass` option. This lets you optimize for cost or latency by configuring how S3 stores objects.
+
+```ts
+const url = s3file.presign({
+  storageClass: "GLACIER_IR",
+  // storageClass: "STANDARD",
+  // storageClass: "REDUCED_REDUNDANCY",
+  // storageClass: "STANDARD_IA",
+  // storageClass: "ONEZONE_IA",
+  // storageClass: "INTELLIGENT_TIERING",
+  // storageClass: "GLACIER",
+  // storageClass: "DEEP_ARCHIVE",
 });
 ```
 

--- a/docs/api/udp.md
+++ b/docs/api/udp.md
@@ -18,6 +18,18 @@ const socket = await Bun.udpSocket({
 console.log(socket.port); // 41234
 ```
 
+Enable address and port reuse:
+
+```ts
+const socket = await Bun.udpSocket({
+  port: 8000,
+  reuseAddr: true, // Allow reusing address
+  reusePort: true, // Enable load balancing on Linux
+});
+```
+
+The `reusePort` option enables load balancing between multiple processes on Linux. On other platforms, `reuseAddr` allows reusing an address that is already in use.
+
 ### Send a datagram
 
 Specify the data to send, as well as the destination port and address.

--- a/docs/bundler/fullstack.md
+++ b/docs/bundler/fullstack.md
@@ -340,6 +340,8 @@ $ bun add bun-plugin-tailwind
 ```toml#bunfig.toml
 [serve.static]
 plugins = ["bun-plugin-tailwind"]
+# Optionally disable minification
+# minify = false
 ```
 
 This will allow you to use TailwindCSS utility classes in your HTML and CSS files. All you need to do is import `tailwindcss` somewhere:
@@ -375,6 +377,21 @@ plugins = ["./my-plugin-implementation.ts"]
 Bun will lazily resolve and load each plugin and use them to bundle your routes.
 
 Note: this is currently in `bunfig.toml` to make it possible to know statically which plugins are in use when we eventually integrate this with the `bun build` CLI. These plugins work in `Bun.build()`'s JS API, but are not yet supported in the CLI.
+
+### Minification
+
+Control minification of HTML imports via `bunfig.toml`:
+
+```toml#bunfig.toml
+[serve.static]
+minify = false
+# or granular control:
+# minify.whitespace = false
+# minify.identifiers = false
+# minify.syntax = false
+```
+
+By default, minification is enabled when `development: false` and disabled when `development: true`.
 
 ## How this works
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -228,6 +228,14 @@ $ bun --smol run index.tsx
 
 This causes the garbage collector to run more frequently, which can slow down execution. However, it can be useful in environments with limited memory. Bun automatically adjusts the garbage collector's heap size based on the available memory (accounting for cgroups and other memory limits) with and without the `--smol` flag, so this is mostly useful for cases where you want to make the heap size grow more slowly.
 
+## `--zero-fill-buffers`
+
+Force all newly allocated buffers to be zero-filled for improved security. When enabled, methods like `Buffer.allocUnsafe()` will always return zero-filled buffers.
+
+```bash
+$ bun --zero-fill-buffers run script.js
+```
+
 ## `--user-agent`
 
 **`--user-agent <string>`** - Set User-Agent header for all `fetch()` requests:

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -36,7 +36,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:fs`](https://nodejs.org/api/fs.html)
 
-🟢 Fully implemented. 92% of Node.js's test suite passes.
+🟢 Fully implemented. 92% of Node.js's test suite passes. `fs.fstatSync()` supports the `bigint` option.
 
 ### [`node:http`](https://nodejs.org/api/http.html)
 
@@ -104,7 +104,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:crypto`](https://nodejs.org/api/crypto.html)
 
-🟡 Missing `secureHeapUsed` `setEngine` `setFips`
+🟡 Missing `secureHeapUsed` `setEngine` `setFips`. Supports X25519 curve for key generation with `crypto.generateKeyPair()`.
 
 ### [`node:domain`](https://nodejs.org/api/domain.html)
 

--- a/docs/test/snapshots.md
+++ b/docs/test/snapshots.md
@@ -40,6 +40,8 @@ test("inline snapshot", () => {
 
 When you run the test, Bun automatically updates the test file itself with the generated snapshot string. This makes the tests more portable and easier to understand, since the expected output is right next to the test.
 
+Indentation is automatically detected and preserved when updating snapshots, making test files more readable.
+
 ### Using inline snapshots
 
 1. Write your test with `.toMatchInlineSnapshot()`


### PR DESCRIPTION
## Summary

Added minimal documentation for new features introduced in Bun v1.2.1:

- **S3 storageClass option** - Added to presign section in `docs/api/s3.md`
- **X25519 crypto support** - Noted in `docs/runtime/nodejs-apis.md`
- **Indented inline snapshots** - Brief note in `docs/test/snapshots.md`
- **--zero-fill-buffers flag** - Added to `docs/cli/run.md`
- **HTML minify option** - Added bunfig.toml config in `docs/bundler/fullstack.md`
- **fs.fstatSync bigint option** - Noted in `docs/runtime/nodejs-apis.md`
- **dgram socket options** - Added reuseAddr/reusePort docs in `docs/api/udp.md`
- **Buffer.toLocaleString** - Brief alias note in `docs/api/binary-data.md`

All updates are minimal, high-density, and match existing documentation style. No new files created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)