### PR TITLE
docs: add missing v1.2.3 changelog information

### DIFF
--- a/docs/api/binary-data.md
+++ b/docs/api/binary-data.md
@@ -420,6 +420,16 @@ console.log(buf.toString());
 // => Hello world
 ```
 
+When printing `Buffer` instances with `console.log()`, `Bun.inspect()`, or `node:util.inspect()`, the output format shows byte content in hexadecimal and additional properties:
+
+```ts
+let b = Buffer.allocUnsafe(4);
+b.fill("1234");
+b.specialnumber = 42;
+console.log(b);
+// => <Buffer 31 32 33 34, specialnumber: 42>
+```
+
 For complete documentation, refer to the [Node.js documentation](https://nodejs.org/api/buffer.html).
 
 ## `Blob`

--- a/docs/api/sql.md
+++ b/docs/api/sql.md
@@ -393,6 +393,18 @@ await sql`SELECT * FROM products WHERE ids = ANY(${sql.array([1, 2, 3])})`;
 
 **Note**: `sql.array` is PostgreSQL-only. Multi-dimensional arrays and NULL elements may not be supported yet.
 
+### Retrieving array values
+
+Bun.sql supports retrieving array values from PostgreSQL, including arrays of integers, text, dates, timestamps, and more. Arrays properly handle null values, always returning `null` for null elements:
+
+```ts
+const result = await sql`SELECT ARRAY[0, 1, 2, 3, 4, 5, NULL]::integer[]`;
+console.log(result[0].array); // [0, 1, 2, 3, 4, 5, null]
+
+const strings = await sql`SELECT ARRAY['Hello', 'World', NULL]::text[]`;
+console.log(strings[0].array); // ['Hello', 'World', null]
+```
+
 ## `sql``.simple()`
 
 The PostgreSQL wire protocol supports two types of queries: "simple" and "extended". Simple queries can contain multiple statements but don't support parameters, while extended queries (the default) support parameters but only allow one statement.

--- a/docs/bundler/executables.md
+++ b/docs/bundler/executables.md
@@ -327,7 +327,7 @@ export default {
 };
 ```
 
-Embedded files can be read using `Bun.file`'s functions or the Node.js `fs.readFile` function (in `"node:fs"`).
+Embedded files can be read using `Bun.file`'s functions or the Node.js `fs` module functions (in `"node:fs"`).
 
 For example, to read the contents of the embedded file:
 
@@ -336,8 +336,21 @@ import icon from "./icon.png" with { type: "file" };
 import { file } from "bun";
 
 const bytes = await file(icon).arrayBuffer();
-// await fs.promises.readFile(icon)
-// fs.readFileSync(icon)
+```
+
+Node.js filesystem APIs like `fs.stat`, `fs.readFile`, and `fs.existsSync` are supported for embedded files:
+
+```js
+import { promises as fs } from "node:fs";
+import myEmbeddedFile from "./myEmbeddedFile.txt" with { type: "file" };
+
+await fs.readFile(myEmbeddedFile);
+await fs.stat(myEmbeddedFile);
+
+import fsSync from "node:fs";
+fsSync.readFileSync(myEmbeddedFile);
+fsSync.statSync(myEmbeddedFile);
+fsSync.existsSync(myEmbeddedFile);
 ```
 
 ### Embed SQLite databases

--- a/docs/bundler/html.md
+++ b/docs/bundler/html.md
@@ -171,7 +171,21 @@ Then, add the plugin to your `bunfig.toml`:
 plugins = ["bun-plugin-tailwind"]
 ```
 
-Then, reference TailwindCSS in your HTML via `<link>` tag, `@import` in CSS, or `import` in JavaScript.
+### Environment variables
+
+You can pass environment variables to your HTML files by setting `env` in the `[serve.static]` section of your `bunfig.toml` file:
+
+```toml
+[serve.static]
+# Make all BUN_PUBLIC_* environment variables available to client-side code via process.env
+env = "BUN_PUBLIC_*"
+```
+
+This makes all matching environment variables available to client-side code via `process.env.BUN_PUBLIC_MY_VAR`.
+
+### Using TailwindCSS
+
+Reference TailwindCSS in your HTML via `<link>` tag, `@import` in CSS, or `import` in JavaScript.
 
 {% codetabs %}
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -103,6 +103,16 @@ $ bun install --filter './packages/pkg-a'
 
 For more information on filtering with `bun install`, refer to [Package Manager > Filtering](https://bun.com/docs/cli/filter#bun-install-and-bun-outdated)
 
+## Analyzing and installing missing dependencies
+
+To scan imported packages from source files and add any missing ones to `package.json`:
+
+```bash
+$ bun install --analyze src/**/*.ts
+```
+
+This command analyzes JavaScript/TypeScript source files using Bun's bundler to detect imported packages and ensures they are added to `package.json`.
+
 ## Overrides and resolutions
 
 Bun supports npm's `"overrides"` and Yarn's `"resolutions"` in `package.json`. These are mechanisms for specifying a version range for _metadependencies_—the dependencies of your dependencies. Refer to [Package manager > Overrides and resolutions](https://bun.com/docs/install/overrides) for complete documentation.

--- a/docs/runtime/env.md
+++ b/docs/runtime/env.md
@@ -182,6 +182,11 @@ These environment variables are read by Bun and configure aspects of its behavio
 
 ---
 
+- `NODE_EXTRA_CA_CERTS`
+- Specifies a path to a file containing additional trusted CA certificates for TLS connections. This allows you to specify additional trusted CA certificates beyond the system's default certificate store. Example: `export NODE_EXTRA_CA_CERTS="/path/to/full/bundle.crt"`
+
+---
+
 - `BUN_CONFIG_VERBOSE_FETCH`
 - If `BUN_CONFIG_VERBOSE_FETCH=curl`, then fetch requests will log the url, method, request headers and response headers to the console. This is useful for debugging network requests. This also works with `node:http`. `BUN_CONFIG_VERBOSE_FETCH=1` is equivalent to `BUN_CONFIG_VERBOSE_FETCH=curl` except without the `curl` output.
 

--- a/docs/runtime/nodejs-apis.md
+++ b/docs/runtime/nodejs-apis.md
@@ -348,7 +348,7 @@ The table below lists all globals implemented by Node.js and Bun's current compa
 
 ### [`process`](https://nodejs.org/api/process.html)
 
-🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented. `process.title` is currently a no-op on macOS & Linux. `getActiveResourcesInfo` `setActiveResourcesInfo`, `getActiveResources` and `setSourceMapsEnabled` are stubs. Newer APIs like `process.loadEnvFile` and `process.getBuiltinModule` are not implemented yet.
+🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented, including `process.binding("fs")` and `process.binding("buffer")`. `process.title` is currently a no-op on macOS & Linux. `getActiveResourcesInfo` `setActiveResourcesInfo`, `getActiveResources` and `setSourceMapsEnabled` are stubs. Newer APIs like `process.loadEnvFile` and `process.getBuiltinModule` are not implemented yet.
 
 ### [`queueMicrotask()`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
 

--- a/docs/runtime/web-apis.md
+++ b/docs/runtime/web-apis.md
@@ -125,4 +125,23 @@ The following Web APIs are partially or completely supported.
 
 ---
 
+- WebAssembly
+- [`WebAssembly`](https://developer.mozilla.org/en-US/docs/WebAssembly)
+  [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module)
+  [`WebAssembly.Instance`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Instance)
+
+---
+
 {% /table %}
+
+## WebAssembly
+
+Bun supports WebAssembly through JavaScriptCore's implementation. As of Bun v1.2.3, WebAssembly execution uses the IPInt (in-place interpreter) by default, which provides faster startup times and lower memory usage compared to the previous LLInt interpreter.
+
+The IPInt interpreter executes WebAssembly code directly in its stored format, reducing the time needed before code can start running and minimizing memory overhead. Hot-path functions are still JIT-compiled for maximum performance.
+
+If you encounter issues with WebAssembly modules, you can revert to the previous interpreter:
+
+```bash
+BUN_JSC_useWasmIPInt=0 bun run your-script.js
+```


### PR DESCRIPTION
## Summary

- Added `bun install --analyze` flag documentation to `docs/cli/install.md`
- Added SQL array retrieval documentation to `docs/api/sql.md`
- Added `NODE_EXTRA_CA_CERTS` environment variable to `docs/runtime/env.md`
- Added Buffer.inspect() hexadecimal format documentation to `docs/api/binary-data.md`
- Added Node.js fs APIs support for embedded files to `docs/bundler/executables.md`
- Added environment variables in HTML documentation to `docs/bundler/html.md`
- Added IPInt WebAssembly interpreter documentation to `docs/runtime/web-apis.md`
- Added process.binding("fs") and process.binding("buffer") to `docs/runtime/nodejs-apis.md`

## Test plan

- [x] Verified all information matches the v1.2.3 changelog exactly
- [x] No new files created - only updated existing docs
- [x] Added only information present in the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)