### PR TITLE
Add 'bun why' to help menu

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -640,11 +640,11 @@ extern "C" napi_status napi_is_typedarray(napi_env env, napi_value value, bool* 
 // it doesn't copy the string
 // but it's only safe to use if we are not setting a property
 // because we can't guarantee the lifetime of it
-#define PROPERTY_NAME_FROM_UTF8(identifierName)                                                                            \
-    size_t utf8Len = strlen(utf8Name);                                                                                     \
+#define PROPERTY_NAME_FROM_UTF8(identifierName)                                                                                      \
+    size_t utf8Len = strlen(utf8Name);                                                                                               \
     WTF::String&& nameString = WTF::charactersAreAllASCII(std::span { reinterpret_cast<const Latin1Character*>(utf8Name), utf8Len }) \
-        ? WTF::String(WTF::StringImpl::createWithoutCopying({ utf8Name, utf8Len }))                                        \
-        : WTF::String::fromUTF8(utf8Name);                                                                                 \
+        ? WTF::String(WTF::StringImpl::createWithoutCopying({ utf8Name, utf8Len }))                                                  \
+        : WTF::String::fromUTF8(utf8Name);                                                                                           \
     const JSC::PropertyName identifierName = JSC::Identifier::fromString(vm, nameString);
 
 extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -181,6 +181,7 @@ pub const HelpCommand = struct {
         \\  <b><blue>patch <d>\<pkg\><r>                    Prepare a package for patching
         \\  <b><blue>pm <d>\<subcommand\><r>                Additional package management utilities
         \\  <b><blue>info<r>      <d>{s:<16}<r>     Display package metadata from the registry
+        \\  <b><blue>why<r>       <d>{s:<16}<r>     Explain why a package is installed
         \\
         \\  <b><yellow>build<r>     <d>./a.ts ./b.jsx<r>       Bundle TypeScript & JavaScript into a single file
         \\
@@ -214,6 +215,7 @@ pub const HelpCommand = struct {
             packages_to_remove_filler[package_remove_i],
             packages_to_add_filler[(package_add_i + 1) % packages_to_add_filler.len],
             packages_to_add_filler[(package_add_i + 2) % packages_to_add_filler.len],
+            packages_to_add_filler[(package_add_i + 3) % packages_to_add_filler.len],
             packages_to_create_filler[package_create_i],
         };
 


### PR DESCRIPTION
## Summary

- Added `bun why` command to the help menu (`bun` and `bun --help`)
- Positioned under `info` command in the package management section

## Test plan

- [x] Verified `bun --help` displays the `why` command
- [x] Verified `bun` displays the `why` command
- [x] Verified `bun why --help` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)