### PR TITLE
bun:test performance regression fix

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1837,6 +1837,9 @@ pub const TestCommand = struct {
             reporter.jest.current_file.set(file_title, file_prefix, repeat_count, repeat_index);
 
             bun.jsc.Jest.bun_test.debug.group.log("loadEntryPointForTestRunner(\"{}\")", .{std.zig.fmtEscapes(file_path)});
+
+            // need to wake up so autoTick() doesn't wait for 16-100ms after loading the entrypoint
+            vm.wakeup();
             var promise = try vm.loadEntryPointForTestRunner(file_path);
             reporter.summary().files += 1;
 
@@ -1859,16 +1862,7 @@ pub const TestCommand = struct {
                 else => {},
             }
 
-            {
-                vm.drainMicrotasks();
-                var count = vm.unhandled_error_counter;
-                vm.global.handleRejectedPromises();
-                while (vm.unhandled_error_counter > count) {
-                    count = vm.unhandled_error_counter;
-                    vm.drainMicrotasks();
-                    vm.global.handleRejectedPromises();
-                }
-            }
+            vm.eventLoop().tick();
 
             blk: {
 
@@ -1891,6 +1885,10 @@ pub const TestCommand = struct {
 
                 var prev_unhandled_count = vm.unhandled_error_counter;
                 while (buntest.phase != .done) {
+                    if (buntest.wants_wakeup) {
+                        buntest.wants_wakeup = false;
+                        vm.wakeup();
+                    }
                     vm.eventLoop().autoTick();
                     if (buntest.phase == .done) break;
                     vm.eventLoop().tick();


### PR DESCRIPTION
### What does this PR do?

Fixes #23120

bun:test changes introduced an added 16-100ms sleep between test files. For a test suite with many fast-running test files, this caused significant impact. Elysia's test suite was running 2x slower (1.8s → 3.9s).

<img width="646" height="289" alt="image" src="https://github.com/user-attachments/assets/2ecd8c3e-984c-4a9a-a988-a911576b87c4" />


### How did you verify your code works?

Running elysia test suite & minimized reproduction case

<details>

<summary>Minimzed reproduction case</summary>

```ts
// full2.test.ts
import { it } from 'bun:test'

it("timeout", () => {
	setTimeout(() => {}, 295000);
}, 0);

// bench.ts
import {$} from "bun";

await $`rm -rf tests`;
await $`mkdir -p tests`;
for (let i = 0; i < 128; i += 1) {
    await Bun.write(`tests/${i}.test.ts`, `
        for (let i = 0; i < 1000; i ++) {
            it("test${i}", () => {}, 0);
        }
    `);
}
Bun.spawnSync({
    cmd: ["hyperfine", ...["bun-1.2.22", "bun-1.2.23+wakeup", "bun-1.2.23"].map(v => `${v} test ./full2.test.ts tests`)],
    stdio: ["inherit", "inherit", "inherit"],
});
```

</details>