### PR TITLE
Add `.cloneUpgrade()` to fix clone-upgrade

### DIFF
--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -312,7 +312,7 @@ pub const BunTest = struct {
             buntest_weak.deinit();
         }
         pub fn bunTest(this: *RefData) ?*BunTest {
-            var buntest_strong = this.buntest_weak.clone().upgrade() orelse return null;
+            var buntest_strong = this.buntest_weak.cloneUpgrade() orelse return null;
             defer buntest_strong.deinit();
             return buntest_strong.get();
         }
@@ -380,7 +380,7 @@ pub const BunTest = struct {
         const refdata: *RefData = this_ptr.asPromisePtr(RefData);
         defer refdata.deref();
         const has_one_ref = refdata.ref_count.hasOneRef();
-        var this_strong = refdata.buntest_weak.clone().upgrade() orelse return group.log("bunTestThenOrCatch -> the BunTest is no longer active", .{});
+        var this_strong = refdata.buntest_weak.cloneUpgrade() orelse return group.log("bunTestThenOrCatch -> the BunTest is no longer active", .{});
         defer this_strong.deinit();
         const this = this_strong.get();
 
@@ -434,7 +434,7 @@ pub const BunTest = struct {
 
         if (!should_run) return .js_undefined;
 
-        var strong = ref_in.buntest_weak.clone().upgrade() orelse return .js_undefined;
+        var strong = ref_in.buntest_weak.cloneUpgrade() orelse return .js_undefined;
         defer strong.deinit();
         const buntest = strong.get();
         buntest.addResult(ref_in.phase);
@@ -467,7 +467,7 @@ pub const BunTest = struct {
         errdefer bun.destroy(done_callback_test);
         const task = jsc.ManagedTask.New(RunTestsTask, RunTestsTask.call).init(done_callback_test);
         const vm = globalThis.bunVM();
-        var strong = weak.clone().upgrade() orelse {
+        var strong = weak.cloneUpgrade() orelse {
             if (bun.Environment.ci_assert) bun.assert(false); // shouldn't be calling runNextTick after moving on to the next file
             return; // but just in case
         };
@@ -483,7 +483,7 @@ pub const BunTest = struct {
         pub fn call(this: *RunTestsTask) void {
             defer bun.destroy(this);
             defer this.weak.deinit();
-            var strong = this.weak.clone().upgrade() orelse return;
+            var strong = this.weak.cloneUpgrade() orelse return;
             defer strong.deinit();
             BunTest.run(strong, this.globalThis) catch |e| {
                 strong.get().onUncaughtException(this.globalThis, this.globalThis.takeException(e), false, this.phase);

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -312,7 +312,7 @@ pub const BunTest = struct {
             buntest_weak.deinit();
         }
         pub fn bunTest(this: *RefData) ?BunTestPtr {
-            return this.buntest_weak.cloneUpgrade() orelse return null;
+            return this.buntest_weak.upgrade() orelse return null;
         }
     };
     pub fn getCurrentStateData(this: *BunTest) RefDataValue {
@@ -378,7 +378,7 @@ pub const BunTest = struct {
         const refdata: *RefData = this_ptr.asPromisePtr(RefData);
         defer refdata.deref();
         const has_one_ref = refdata.ref_count.hasOneRef();
-        var this_strong = refdata.buntest_weak.cloneUpgrade() orelse return group.log("bunTestThenOrCatch -> the BunTest is no longer active", .{});
+        var this_strong = refdata.buntest_weak.upgrade() orelse return group.log("bunTestThenOrCatch -> the BunTest is no longer active", .{});
         defer this_strong.deinit();
         const this = this_strong.get();
 
@@ -432,7 +432,7 @@ pub const BunTest = struct {
 
         if (!should_run) return .js_undefined;
 
-        var strong = ref_in.buntest_weak.cloneUpgrade() orelse return .js_undefined;
+        var strong = ref_in.buntest_weak.upgrade() orelse return .js_undefined;
         defer strong.deinit();
         const buntest = strong.get();
         buntest.addResult(ref_in.phase);
@@ -465,7 +465,7 @@ pub const BunTest = struct {
         errdefer bun.destroy(done_callback_test);
         const task = jsc.ManagedTask.New(RunTestsTask, RunTestsTask.call).init(done_callback_test);
         const vm = globalThis.bunVM();
-        var strong = weak.cloneUpgrade() orelse {
+        var strong = weak.upgrade() orelse {
             if (bun.Environment.ci_assert) bun.assert(false); // shouldn't be calling runNextTick after moving on to the next file
             return; // but just in case
         };
@@ -481,7 +481,7 @@ pub const BunTest = struct {
         pub fn call(this: *RunTestsTask) void {
             defer bun.destroy(this);
             defer this.weak.deinit();
-            var strong = this.weak.cloneUpgrade() orelse return;
+            var strong = this.weak.upgrade() orelse return;
             defer strong.deinit();
             BunTest.run(strong, this.globalThis) catch |e| {
                 strong.get().onUncaughtException(this.globalThis, this.globalThis.takeException(e), false, this.phase);

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -311,10 +311,8 @@ pub const BunTest = struct {
             bun.destroy(this);
             buntest_weak.deinit();
         }
-        pub fn bunTest(this: *RefData) ?*BunTest {
-            var buntest_strong = this.buntest_weak.cloneUpgrade() orelse return null;
-            defer buntest_strong.deinit();
-            return buntest_strong.get();
+        pub fn bunTest(this: *RefData) ?BunTestPtr {
+            return this.buntest_weak.cloneUpgrade() orelse return null;
         }
     };
     pub fn getCurrentStateData(this: *BunTest) RefDataValue {

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -32,7 +32,9 @@ pub const Expect = struct {
 
     pub fn incrementExpectCallCounter(this: *Expect) void {
         const parent = this.parent orelse return; // not in bun:test
-        const buntest = parent.bunTest() orelse return; // the test file this expect() call was for is no longer
+        var buntest_strong = parent.bunTest() orelse return; // the test file this expect() call was for is no longer
+        defer buntest_strong.deinit();
+        const buntest = buntest_strong.get();
         if (parent.phase.sequence(buntest)) |sequence| {
             // found active sequence
             sequence.expect_call_count +|= 1;
@@ -44,7 +46,7 @@ pub const Expect = struct {
         }
     }
 
-    pub fn bunTest(this: *Expect) ?*bun.jsc.Jest.bun_test.BunTest {
+    pub fn bunTest(this: *Expect) ?bun.jsc.Jest.bun_test.BunTestPtr {
         const parent = this.parent orelse return null;
         return parent.bunTest();
     }
@@ -275,7 +277,9 @@ pub const Expect = struct {
 
     pub fn getSnapshotName(this: *Expect, allocator: std.mem.Allocator, hint: string) ![]const u8 {
         const parent = this.parent orelse return error.NoTest;
-        const buntest = parent.bunTest() orelse return error.TestNotActive;
+        var buntest_strong = parent.bunTest() orelse return error.TestNotActive;
+        defer buntest_strong.deinit();
+        const buntest = buntest_strong.get();
         const execution_entry = parent.phase.entry(buntest) orelse return error.SnapshotInConcurrentGroup;
 
         const test_name = execution_entry.base.name orelse "(unnamed)";
@@ -748,10 +752,12 @@ pub const Expect = struct {
                     }
                 }
             }
-            const buntest = this.bunTest() orelse {
+            var buntest_strong = this.bunTest() orelse {
                 const signature = comptime getSignature(fn_name, "", false);
                 return this.throw(globalThis, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n", .{});
             };
+            defer buntest_strong.deinit();
+            const buntest = buntest_strong.get();
 
             // 1. find the src loc of the snapshot
             const srcloc = callFrame.getCallerSrcLoc(globalThis);
@@ -825,7 +831,9 @@ pub const Expect = struct {
         const existing_value = Jest.runner.?.snapshots.getOrPut(this, pretty_value.slice(), hint) catch |err| {
             var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis };
             defer formatter.deinit();
-            const buntest = this.bunTest() orelse return globalThis.throw("Snapshot matchers cannot be used outside of a test", .{});
+            var buntest_strong = this.bunTest() orelse return globalThis.throw("Snapshot matchers cannot be used outside of a test", .{});
+            defer buntest_strong.deinit();
+            const buntest = buntest_strong.get();
             const test_file_path = Jest.runner.?.files.get(buntest.file_id).source.path.text;
             return switch (err) {
                 error.FailedToOpenSnapshotFile => globalThis.throw("Failed to open snapshot file for test file: {s}", .{test_file_path}),

--- a/src/bun.js/test/expect/toMatchSnapshot.zig
+++ b/src/bun.js/test/expect/toMatchSnapshot.zig
@@ -12,10 +12,11 @@ pub fn toMatchSnapshot(this: *Expect, globalThis: *JSGlobalObject, callFrame: *C
         return this.throw(globalThis, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n", .{});
     }
 
-    _ = this.bunTest() orelse {
+    var buntest_strong = this.bunTest() orelse {
         const signature = comptime getSignature("toMatchSnapshot", "", true);
         return this.throw(globalThis, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n", .{});
     };
+    defer buntest_strong.deinit();
 
     var hint_string: ZigString = ZigString.Empty;
     var property_matchers: ?JSValue = null;

--- a/src/bun.js/test/expect/toThrowErrorMatchingSnapshot.zig
+++ b/src/bun.js/test/expect/toThrowErrorMatchingSnapshot.zig
@@ -12,11 +12,11 @@ pub fn toThrowErrorMatchingSnapshot(this: *Expect, globalThis: *JSGlobalObject, 
         return this.throw(globalThis, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n", .{});
     }
 
-    const bunTest = this.bunTest() orelse {
+    var bunTest_strong = this.bunTest() orelse {
         const signature = comptime getSignature("toThrowErrorMatchingSnapshot", "", true);
         return this.throw(globalThis, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n", .{});
     };
-    _ = bunTest; // ?
+    defer bunTest_strong.deinit();
 
     var hint_string: ZigString = ZigString.Empty;
     switch (arguments.len) {

--- a/src/bun.js/test/snapshot.zig
+++ b/src/bun.js/test/snapshot.zig
@@ -53,7 +53,9 @@ pub const Snapshots = struct {
         return .{ count_entry.key_ptr.*, count_entry.value_ptr.* };
     }
     pub fn getOrPut(this: *Snapshots, expect: *Expect, target_value: []const u8, hint: string) !?string {
-        const bunTest = expect.bunTest() orelse return error.SnapshotFailed;
+        var buntest_strong = expect.bunTest() orelse return error.SnapshotFailed;
+        defer buntest_strong.deinit();
+        const bunTest = buntest_strong.get();
         switch (try this.getSnapshotFile(bunTest.file_id)) {
             .result => {},
             .err => |err| {

--- a/src/ptr/shared.zig
+++ b/src/ptr/shared.zig
@@ -285,8 +285,8 @@ fn Weak(comptime Pointer: type, comptime options: Options) type {
 
         const SharedNonOptional = WithOptions(NonOptionalPointer, options);
 
-        /// Clones this weak pointer and upgrades it to a shared pointer.
-        pub fn cloneUpgrade(self: Self) ?SharedNonOptional {
+        /// Clones this weak pointer and upgrades it to a shared pointer. You still need to `deinit` the weak pointer.
+        pub fn upgrade(self: Self) ?SharedNonOptional {
             const data = if (comptime info.isOptional())
                 self.getData() orelse return null
             else

--- a/src/ptr/shared.zig
+++ b/src/ptr/shared.zig
@@ -452,7 +452,7 @@ fn FullData(comptime Child: type, comptime options: Options) type {
             // .acq_rel because we need to make sure other threads are done using the object before
             // we free it.
             if ((comptime !options.allow_weak) or self.weak_count.decrement() == 0) {
-                if (bun.Environment.ci_assert) bun.assert(self.strong_count.value == 0);
+                if (bun.Environment.ci_assert) bun.assert(self.strong_count.get(.monotonic) == 0);
                 self.destroy();
             }
         }

--- a/src/ptr/shared.zig
+++ b/src/ptr/shared.zig
@@ -285,10 +285,17 @@ fn Weak(comptime Pointer: type, comptime options: Options) type {
 
         const SharedNonOptional = WithOptions(NonOptionalPointer, options);
 
+        /// Clones this weak pointer and upgrades it to a shared pointer.
+        pub fn cloneUpgrade(self: Self) ?SharedNonOptional {
+            var cloned = self.clone();
+            defer cloned.deinit();
+            return cloned.upgrade();
+        }
+
         /// Upgrades this weak pointer into a normal shared pointer.
         ///
         /// This method invalidates `self`.
-        pub fn upgrade(self: Self) ?SharedNonOptional {
+        pub fn upgrade(self: *Self) ?SharedNonOptional {
             const data = if (comptime info.isOptional())
                 self.getData() orelse return null
             else


### PR DESCRIPTION
### What does this PR do?

Replaces '.upgrade()' with '.cloneUpgrade()'. '.upgrade()' is confusing and `.clone().upgrade()` was causing a leak. Caught by https://github.com/oven-sh/bun/pull/23199#discussion_r2400667320

### How did you verify your code works?
