### PR TITLE
Use cached structure in JSBunRequest::clone

### DIFF
--- a/src/bun.js/bindings/JSBunRequest.cpp
+++ b/src/bun.js/bindings/JSBunRequest.cpp
@@ -102,7 +102,7 @@ JSBunRequest* JSBunRequest::clone(JSC::VM& vm, JSGlobalObject* globalObject)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    auto* structure = createJSBunRequestStructure(vm, defaultGlobalObject(globalObject));
+    auto* structure = defaultGlobalObject(globalObject)->m_JSBunRequestStructure.getInitializedOnMainThread(globalObject);
     auto* raw = Request__clone(this->wrapped(), globalObject);
     EXCEPTION_ASSERT(!!raw == !throwScope.exception());
     RETURN_IF_EXCEPTION(throwScope, nullptr);


### PR DESCRIPTION
## Summary

Replace `createJSBunRequestStructure()` call with direct access to the cached structure in `JSBunRequest::clone()` method for better performance.

## Changes

- Updated `JSBunRequest::clone()` to use `m_JSBunRequestStructure.getInitializedOnMainThread()` instead of calling `createJSBunRequestStructure()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)