### PR TITLE
Increase crash report stack trace buffer from 10 to 20 frames

### DIFF
--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -304,7 +304,7 @@ pub fn crashHandler(
                     writer.print("Crashed while {}\n", .{action}) catch std.posix.abort();
                 }
 
-                var addr_buf: [10]usize = undefined;
+                var addr_buf: [20]usize = undefined;
                 var trace_buf: std.builtin.StackTrace = undefined;
 
                 // If a trace was not provided, compute one now


### PR DESCRIPTION
## Summary

Increase the stack trace buffer size in the crash handler from 10 to 20 frames to ensure more useful frames are included in crash reports sent to bun.report.

## Motivation

Currently, we capture up to 10 stack frames when generating crash reports. However, many of these frames get filtered out when `StackLine.fromAddress()` returns `null` for invalid/empty frames. This results in only a small number of frames (sometimes as few as 5) actually being sent to the server.

## Changes

- Increased `addr_buf` array size from `[10]usize` to `[20]usize` in `src/crash_handler.zig:307`

## Impact

By capturing more frames initially, we ensure that after filtering we still have a meaningful number of frames in the crash report. This will help with debugging crashes by providing more context about the call stack.

The encoding function `encodeTraceString()` has no hardcoded limits and will encode all available frames, so this change directly translates to more frames being sent to bun.report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)