### PR TITLE
fix(pnpm migration): fix `"lockfileVersion"` number parsing

### DIFF
--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -26,14 +26,6 @@ pub fn detectAndLoadOtherLockfile(
                 , .{});
                 Global.exit(1);
             }
-            if (Environment.isDebug) {
-                bun.handleErrorReturnTrace(err, @errorReturnTrace());
-
-                Output.prettyErrorln("Error: {s}", .{@errorName(err)});
-                log.print(Output.errorWriter()) catch {};
-                Output.prettyErrorln("Invalid NPM package-lock.json\nIn a release build, this would ignore and do a fresh install.\nAborting", .{});
-                Global.exit(1);
-            }
             return LoadResult{ .err = .{
                 .step = .migrating,
                 .value = err,
@@ -58,14 +50,6 @@ pub fn detectAndLoadOtherLockfile(
         defer lockfile.close();
         const data = lockfile.readToEnd(allocator).unwrap() catch break :yarn;
         const migrate_result = @import("./yarn.zig").migrateYarnLockfile(this, manager, allocator, log, data, dir) catch |err| {
-            if (Environment.isDebug) {
-                bun.handleErrorReturnTrace(err, @errorReturnTrace());
-
-                Output.prettyErrorln("Error: {s}", .{@errorName(err)});
-                log.print(Output.errorWriter()) catch {};
-                Output.prettyErrorln("Invalid yarn.lock\nIn a release build, this would ignore and do a fresh install.\nAborting", .{});
-                Global.exit(1);
-            }
             return LoadResult{ .err = .{
                 .step = .migrating,
                 .value = err,

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -137,14 +137,7 @@ pub fn detectAndLoadOtherLockfile(
                 },
                 else => {},
             }
-            if (Environment.isDebug) {
-                bun.handleErrorReturnTrace(err, @errorReturnTrace());
-
-                Output.prettyErrorln("Error: {s}", .{@errorName(err)});
-                log.print(Output.errorWriter()) catch {};
-                Output.prettyErrorln("Invalid pnpm-lock.yaml\nIn a release build, this would ignore and do a fresh install.\nAborting", .{});
-                Global.exit(1);
-            }
+            log.reset();
             return LoadResult{ .err = .{
                 .step = .migrating,
                 .value = err,

--- a/src/install/pnpm.zig
+++ b/src/install/pnpm.zig
@@ -130,7 +130,6 @@ pub fn migratePnpmLockfile(
     };
 
     if (lockfile_version_num < 7) {
-        try log.addErrorFmt(null, logger.Loc.Empty, allocator, "pnpm-lock.yaml version is too old (less than v7)", .{});
         return error.PnpmLockfileTooOld;
     }
 

--- a/src/install/pnpm.zig
+++ b/src/install/pnpm.zig
@@ -130,6 +130,7 @@ pub fn migratePnpmLockfile(
     };
 
     if (lockfile_version_num < 7) {
+        try log.addErrorFmt(null, logger.Loc.Empty, allocator, "pnpm-lock.yaml version is too old (less than v7)", .{});
         return error.PnpmLockfileTooOld;
     }
 

--- a/src/install/pnpm.zig
+++ b/src/install/pnpm.zig
@@ -105,21 +105,21 @@ pub fn migratePnpmLockfile(
         return error.PnpmLockfileMissingVersion;
     };
 
-    const lockfile_version_num: u32 = lockfile_version: {
+    const lockfile_version_num: f64 = lockfile_version: {
         err: {
             switch (lockfile_version_expr.data) {
                 .e_number => |num| {
-                    if (num.value < 0 or num.value > std.math.maxInt(u32)) {
+                    if (num.value < 0) {
                         break :err;
                     }
 
-                    break :lockfile_version @intFromFloat(std.math.divExact(f64, num.value, 1) catch break :err);
+                    break :lockfile_version num.value;
                 },
                 .e_string => |version_str| {
                     const str = version_str.slice(allocator);
 
                     const end = strings.indexOfChar(str, '.') orelse str.len;
-                    break :lockfile_version std.fmt.parseUnsigned(u32, str[0..end], 10) catch break :err;
+                    break :lockfile_version std.fmt.parseFloat(f64, str[0..end]) catch break :err;
                 },
                 else => {},
             }

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -67,7 +67,6 @@ test("version is number with dot", async () => {
     stderr: "pipe",
   });
 
-  console.log({ packageDir });
 
   let [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -55,7 +55,7 @@ test("basic", async () => {
 });
 
 test("version is number with dot", async () => {
-  const { packageDir, packageJson } = await verdaccio.createTestDir({
+  const { packageDir } = await verdaccio.createTestDir({
     files: join(import.meta.dir, "pnpm/version-number-dot"),
   });
 
@@ -67,9 +67,9 @@ test("version is number with dot", async () => {
     stderr: "pipe",
   });
 
-  let [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(1);
+  expect(exitCode).toBe(0);
   expect(err).toContain("pnpm-lock.yaml version is too old (< v7)");
 });
 

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -70,7 +70,7 @@ test("version is number with dot", async () => {
   let [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(1);
-  expect(err).toContain("pnpm-lock.yaml version is too old (< v7)");
+  expect(err).toContain("pnpm-lock.yaml version is too old (less than v7)");
 });
 
 describe.todo("bin", () => {

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -54,6 +54,27 @@ test("basic", async () => {
   expect(err).not.toContain("Saved lockfile");
 });
 
+test("version is number with dot", async () => {
+  const { packageDir, packageJson } = await verdaccio.createTestDir({
+    files: join(import.meta.dir, "pnpm/version-number-dot"),
+  });
+
+  let proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  console.log({ packageDir });
+
+  let [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(1);
+  expect(err).toContain("pnpm-lock.yaml version is too old (< v7)");
+});
+
 describe.todo("bin", () => {
   test("manifests are fetched for bins", async () => {
     const { packageDir, packageJson } = await verdaccio.createTestDir({

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -67,7 +67,6 @@ test("version is number with dot", async () => {
     stderr: "pipe",
   });
 
-
   let [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(1);

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -70,7 +70,7 @@ test("version is number with dot", async () => {
   let [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(1);
-  expect(err).toContain("pnpm-lock.yaml version is too old (less than v7)");
+  expect(err).toContain("pnpm-lock.yaml version is too old (< v7)");
 });
 
 describe.todo("bin", () => {

--- a/test/cli/install/migration/pnpm/version-number-dot/pnpm-lock.yaml
+++ b/test/cli/install/migration/pnpm/version-number-dot/pnpm-lock.yaml
@@ -1,0 +1,1 @@
+lockfileVersion: 5.4


### PR DESCRIPTION
### What does this PR do?
Parsing would fail because the lockfile version might be parsing as a non-whole float instead of a string (`5.4` vs `'5.4'`) and the migration would have the wrong error.
### How did you verify your code works?
Added a test