### PR TITLE
Add Claude Code hooks to prevent common development mistakes

### DIFF
--- a/.claude/hooks/post-edit-zig-format.js
+++ b/.claude/hooks/post-edit-zig-format.js
@@ -26,7 +26,7 @@ const result = spawnSync("vendor/zig/zig.exe", ["fmt", filePath], {
 
 if (result.error) {
   console.error(`Failed to format ${filePath}: ${result.error.message}`);
-  process.exit(1);
+  process.exit(0);
 }
 
 if (result.status !== 0) {
@@ -34,7 +34,7 @@ if (result.status !== 0) {
   if (result.stderr) {
     console.error(result.stderr);
   }
-  process.exit(1);
+  process.exit(0);
 }
 
 // Success - file was formatted

--- a/.claude/hooks/post-edit-zig-format.js
+++ b/.claude/hooks/post-edit-zig-format.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+import { extname } from "path";
+import { spawnSync } from "child_process";
+
+const input = await Bun.stdin.json();
+
+const toolName = input.tool_name;
+const toolInput = input.tool_input || {};
+const filePath = toolInput.file_path;
+
+// Only process Write and Edit tools
+if (!["Write", "Edit"].includes(toolName)) {
+  process.exit(0);
+}
+
+// Only format .zig files
+if (!filePath || extname(filePath) !== ".zig") {
+  process.exit(0);
+}
+
+// Format the Zig file
+const result = spawnSync("vendor/zig/zig.exe", ["fmt", filePath], {
+  cwd: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+  encoding: "utf-8"
+});
+
+if (result.error) {
+  console.error(`Failed to format ${filePath}: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  console.error(`zig fmt failed for ${filePath}:`);
+  if (result.stderr) {
+    console.error(result.stderr);
+  }
+  process.exit(1);
+}
+
+// Success - file was formatted
+process.exit(0);

--- a/.claude/hooks/pre-bash-zig-build.js
+++ b/.claude/hooks/pre-bash-zig-build.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+import { basename } from "path";
+
+const input = await Bun.stdin.json();
+
+const toolName = input.tool_name;
+const toolInput = input.tool_input || {};
+const command = toolInput.command || "";
+const timeout = toolInput.timeout;
+const cwd = input.cwd || "";
+
+// Get environment variables from the hook context
+// Note: We check process.env directly as env vars are inherited
+const useSystemBun = process.env.USE_SYSTEM_BUN;
+
+if (toolName !== "Bash" || !command) {
+  process.exit(0);
+}
+
+function denyWithReason(reason) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason
+    }
+  };
+  console.log(JSON.stringify(output));
+  process.exit(0);
+}
+
+// Parse the command to extract argv0 and positional args
+let tokens;
+try {
+  // Simple shell parsing - split on spaces but respect quotes
+  tokens = command.match(/(?:[^\s"]+|"[^"]*")+/g)?.map(t => t.replace(/^"|"$/g, '')) || [];
+} catch {
+  process.exit(0);
+}
+
+if (tokens.length === 0) {
+  process.exit(0);
+}
+
+// Get the executable name (argv0)
+const argv0 = basename(tokens[0]);
+
+// Check if it's zig or zig.exe
+if (argv0 === "zig" || argv0 === "zig.exe") {
+  // Filter out flags (starting with -) to get positional arguments
+  const positionalArgs = tokens.slice(1).filter(arg => !arg.startsWith("-"));
+
+  // Check if the positional args contain "build" followed by "obj"
+  if (positionalArgs.length >= 2 && positionalArgs[0] === "build" && positionalArgs[1] === "obj") {
+    denyWithReason("error: Use `bun bd` to build Bun and wait patiently");
+  }
+}
+
+// Check if argv0 is timeout and the command is "bun bd"
+if (argv0 === "timeout") {
+  // Find the actual command after timeout and its arguments
+  const timeoutArgEndIndex = tokens.slice(1).findIndex(t => !t.startsWith("-") && !/^\d/.test(t));
+  if (timeoutArgEndIndex === -1) {
+    process.exit(0);
+  }
+
+  const actualCommandIndex = timeoutArgEndIndex + 1;
+  if (actualCommandIndex >= tokens.length) {
+    process.exit(0);
+  }
+
+  const actualCommand = basename(tokens[actualCommandIndex]);
+  const restArgs = tokens.slice(actualCommandIndex + 1);
+
+  // Check if it's "bun bd" or "bun-debug bd" without other positional args
+  if (actualCommand === "bun" || actualCommand.includes("bun-debug")) {
+    const positionalArgs = restArgs.filter(arg => !arg.startsWith("-"));
+    if (positionalArgs.length === 1 && positionalArgs[0] === "bd") {
+      denyWithReason("error: Run `bun bd` without a timeout");
+    }
+  }
+}
+
+// Check if command is "bun .* test" or "bun-debug test" with -u/--update-snapshots AND -t/--test-name-pattern
+if (argv0 === "bun" || argv0.includes("bun-debug")) {
+  const allArgs = tokens.slice(1);
+
+  // Check if "test" is in positional args or "bd" followed by "test"
+  const positionalArgs = allArgs.filter(arg => !arg.startsWith("-"));
+  const hasTest = positionalArgs.includes("test") || (positionalArgs[0] === "bd" && positionalArgs[1] === "test");
+
+  if (hasTest) {
+    const hasUpdateSnapshots = allArgs.some(arg => arg === "-u" || arg === "--update-snapshots");
+    const hasTestNamePattern = allArgs.some(arg => arg === "-t" || arg === "--test-name-pattern");
+
+    if (hasUpdateSnapshots && hasTestNamePattern) {
+      denyWithReason("error: Cannot use -u/--update-snapshots with -t/--test-name-pattern");
+    }
+  }
+}
+
+// Check if timeout option is set for "bun bd" command
+if (timeout !== undefined && (argv0 === "bun" || argv0.includes("bun-debug"))) {
+  const positionalArgs = tokens.slice(1).filter(arg => !arg.startsWith("-"));
+  if (positionalArgs.length === 1 && positionalArgs[0] === "bd") {
+    denyWithReason("error: Run `bun bd` without a timeout");
+  }
+}
+
+// Check if running "bun test <file>" without USE_SYSTEM_BUN=1
+if ((argv0 === "bun" || argv0.includes("bun-debug")) && useSystemBun !== "1") {
+  const allArgs = tokens.slice(1);
+  const positionalArgs = allArgs.filter(arg => !arg.startsWith("-"));
+
+  // Check if it's "test" (not "bd test")
+  if (positionalArgs.length >= 1 && positionalArgs[0] === "test" && positionalArgs[0] !== "bd") {
+    denyWithReason("error: In development, use `bun bd test <file>` to test your changes. If you meant to use a release version, set USE_SYSTEM_BUN=1");
+  }
+}
+
+// Check if running "bun bd test" from bun repo root or test folder without a file path
+if (argv0 === "bun" || argv0.includes("bun-debug")) {
+  const allArgs = tokens.slice(1);
+  const positionalArgs = allArgs.filter(arg => !arg.startsWith("-"));
+
+  // Check if it's "bd test"
+  if (positionalArgs.length >= 2 && positionalArgs[0] === "bd" && positionalArgs[1] === "test") {
+    // Check if cwd is the bun repo root or test folder
+    const isBunRepoRoot = cwd === "/workspace/bun" || cwd.endsWith("/bun");
+    const isTestFolder = cwd.includes("/bun/test");
+
+    if (isBunRepoRoot || isTestFolder) {
+      // Check if there's a file path argument (looks like a path: contains / or has test extension)
+      const hasFilePath = positionalArgs.slice(2).some(arg =>
+        arg.includes("/") ||
+        arg.endsWith(".test.ts") ||
+        arg.endsWith(".test.js") ||
+        arg.endsWith(".test.tsx") ||
+        arg.endsWith(".test.jsx")
+      );
+
+      if (!hasFilePath) {
+        denyWithReason("error: `bun bd test` from repo root or test folder will run all tests. Use `bun bd test <path>` with a specific test file.");
+      }
+    }
+  }
+}
+
+// Allow the command to proceed
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-zig-format.js"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-zig-build.js"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Added Claude Code hooks to prevent common development mistakes when working on the Bun codebase.

## Changes

- Created `.claude/hooks/pre-bash-zig-build.js` - A pre-bash hook that validates commands
- Created `.claude/settings.json` - Hook configuration

## Prevented Mistakes

1. **Running `zig build obj` directly** → Redirects to use `bun bd`
2. **Using `bun test` in development** → Must use `bun bd test` (or set `USE_SYSTEM_BUN=1`)
3. **Combining snapshot updates with test filters** → Prevents `-u`/`--update-snapshots` with `-t`/`--test-name-pattern`
4. **Running `bun bd` with timeout** → Build needs time to complete without timeout
5. **Running `bun bd test` from repo root** → Must specify a test file path to avoid running all tests

## Test plan

- [x] Tested all validation rules with various command combinations
- [x] Verified USE_SYSTEM_BUN=1 bypass works
- [x] Verified file path detection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)