### PR TITLE
Fix `bun -` from hanging, show help menu instead.

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -545,6 +545,9 @@ pub const Command = struct {
 
         var next_arg = ((args_iter.next()) orelse return .AutoCommand);
         while (next_arg.len > 0 and next_arg[0] == '-' and !(next_arg.len > 1 and next_arg[1] == 'e')) {
+            if (next_arg.len == 1) {
+                return .HelpCommand;
+            }
             next_arg = ((args_iter.next()) orelse return .AutoCommand);
         }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where `bun -` hangs forever instead of showing the help message. The problem was in the CLI argument parsing logic in src/cli.zig where a single dash `-` was being processed by the flag parsing loop but didn't have a proper exit condition, causing it to fall through to the AutoCommand path which tries to run a file named `-`, resulting in the process hanging while waiting for input.

The fix adds a special case in the loop to check for that case and show the help message.

Fixes #13196 

### How did you verify your code works?

Compiled bun locally and tested `bun -`. Can confirm it works properly with this patch.