### PR TITLE
fix(completions): correct parsing and quoting of complex package.json scripts, filenames and user input

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -48,7 +48,7 @@ _read_scripts_in_package_json() {
         scripts="${scripts//@(\"|\')/}";
         readarray -td, scripts <<<"${scripts}";
         for completion in "${scripts[@]}"; do
-            package_json_compreply+=( "${completion%:*}" );
+            package_json_compreply+=( "${completion%%:*}" );
         done
         COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
     }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -29,10 +29,10 @@ _bun_escape_bash_specials() {
     }
 
     if ((has_patsub)); then
-        echo "${word//${re_exp}/\\&}"
+        printf '%s' "${word//${re_exp}/\\&}"
     else
         # shellcheck disable=SC2001 # substitution can only be used if 'patsub_replacement' option is available
-        sed "s/${re_sed}/\\\\&/g" <<< "${word}"
+        printf '%s' "$(sed "s/${re_sed}/\\\\&/g" <<< "${word}")"
     fi
 }
 
@@ -49,10 +49,10 @@ _bun_escape_glob_specials() {
     }
 
     if ((has_patsub)); then
-        echo "${word//[][!?*]/\\&}"
+        printf '%s' "${word//[][!?*]/\\&}"
     else
         # shellcheck disable=SC2001 # substitution can only be used if 'patsub_replacement' option is available
-        sed 's/[][!?*]/\\&/g' <<< "${word}"
+        printf '%s' "$(sed 's/[][!?*]/\\&/g' <<< "${word}")"
     fi
 }
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -142,7 +142,7 @@ _bun_completions() {
             esac
             return;;
         --cwd|--public-dir)
-            readarray -t COMPREPLY <<<"$(compgen -d -- "${cur_word}"))";
+            readarray -t COMPREPLY <<<"$(compgen -d -- "${cur_word}")";
             return;;
         --jsx-runtime)
             # shellcheck disable=SC2207 # see above.

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -69,7 +69,6 @@ _file_arguments() {
         [[ -z ${candidates[0]} ]] && candidates=()
     fi
 
-    COMPREPLY=() # preserve the behavior of the earlier versoin of the script, update `COMPREPLY` instead of append
     for cnd in "${candidates[@]}"; do
         [[ -f "${cnd}" && "${cnd}" =~ ${extensions} ]] && \
             COMPREPLY+=( "$(_escape_bash_specials "${cnd##*/}" 1)" );
@@ -83,13 +82,13 @@ _long_short_completion() {
 
     if [[ -z "${cur_word}" ]]; then
         # shellcheck disable=SC2207 # the `wordlist` is constant and has no whitespace characters inside each word
-        COMPREPLY=( $(compgen -W "${long_opts} ${short_opts}") );
+        COMPREPLY+=( $(compgen -W "${long_opts} ${short_opts}") );
     elif [[ "${cur_word}" == --* ]]; then
         # shellcheck disable=SC2207 # idem.
-        COMPREPLY=( $(compgen -W "${long_opts}" -- "${cur_word}") );
+        COMPREPLY+=( $(compgen -W "${long_opts}" -- "${cur_word}") );
     elif [[ "${cur_word}" == -* ]]; then
         # shellcheck disable=SC2207 # idem.
-        COMPREPLY=( $(compgen -W "${long_opts} ${short_opts}" -- "${cur_word}") );
+        COMPREPLY+=( $(compgen -W "${long_opts} ${short_opts}" -- "${cur_word}") );
         return;
     fi
 }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -44,7 +44,7 @@ _read_scripts_in_package_json() {
     [[ "${package_json}" =~ "\"scripts\""[[:space:]]*":"[[:space:]]*\{(.*)\} ]] && {
         local package_json_compreply;
         local matched="${BASH_REMATCH[@]:1}";
-        local scripts="${matched%%\}*}";
+        local scripts="${matched%\}*}";
         scripts="${scripts//@(\"|\')/}";
         readarray -td, scripts <<<"${scripts}";
         for completion in "${scripts[@]}"; do

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -1,70 +1,67 @@
 #!/usr/bin/env bash
 
 _escape_bash_specials() {
-    local word="${1}";
-    local escape_all="${2}";
+    local word="${1}"
+    local escape_all="${2}"
 
-    local re_exp;
-    local re_sed;
+    local re_exp
+    local re_sed
 
-    if (( escape_all )); then
+    if ((escape_all)); then
         # escape all bash specials: ]~$"'`><()[{}=|*?;&#\
-        re_exp='[]~$\"'"\'"'\`><\()[{\}=|*?;&#\\]';
-        re_sed='[]~$"'\''`><()[{}=|*?;&#\]';
+        re_exp='[]~$\"'"\'"'\`><\()[{\}=|*?;&#\\]'
+        re_sed='[]~$"'\''`><()[{}=|*?;&#\]'
     else
         # escape all bash specials _except_ " (quote) and \ (backslash)
         # since they are already escaped in package.json: ]~$'`><()[{}=|*?;&#
-        re_exp='[]~$'"\'"'\`><\()[{\}=|*?;&#]';
-        re_sed='[]~$'\''`><()[{}=|*?;&#]';
+        re_exp='[]~$'"\'"'\`><\()[{\}=|*?;&#]'
+        re_sed='[]~$'\''`><()[{}=|*?;&#]'
     fi
 
-    local has_patsub=0;
-    shopt -s patsub_replacement 2>/dev/null && {
+    local has_patsub=0
+    shopt -s patsub_replacement 2> /dev/null && {
         # shellcheck disable=SC2064 # current state of `patsub_replacement` is needed
-        trap "$(shopt -p patsub_replacement)" RETURN;
-        has_patsub=1;
+        trap "$(shopt -p patsub_replacement)" RETURN
+        has_patsub=1
     }
 
-    if (( has_patsub )); then
-        echo "${word//${re_exp}/\\&}";
+    if ((has_patsub)); then
+        echo "${word//${re_exp}/\\&}"
     else
-		    # shellcheck disable=SC2001 # substitution insidde parameter expansion can be used if 'patsub_replacement' option is available
-        sed "s/${re_sed}/\\\\&/g" <<<"${word}";
+        # shellcheck disable=SC2001 # substitution insidde parameter expansion can be used if 'patsub_replacement' option is available
+        sed "s/${re_sed}/\\\\&/g" <<< "${word}"
     fi
 }
 
-
 _is_exist_and_gnu() {
-    local cmd="${1}";
-    local version_string;
+    local cmd="${1}"
+    local version_string
     version_string="$(
-        command -v "$cmd" >/dev/null 2>&1   && \
-        "$cmd" --version 2>/dev/null | head -1;
-    )";
-    [[ "$version_string" == *GNU* ]] && return 0 || return 1;
+        command -v "$cmd" > /dev/null 2>&1 &&
+            "$cmd" --version 2> /dev/null | head -1
+    )"
+    [[ $version_string == *GNU* ]] && return 0 || return 1
 }
 
-
 _file_arguments() {
-    local extensions="${1}";
-    local cur_word="${2}";
+    local extensions="${1}"
+    local cur_word="${2}"
 
-    local -a candidates;
-    if _is_exist_and_gnu find && _is_exist_and_gnu sed
-    then
+    local -a candidates
+    if _is_exist_and_gnu find && _is_exist_and_gnu sed; then
         readarray -t -d '' candidates < <(
             find . -regextype posix-extended -maxdepth 1 \
                 -xtype f -regex "${extensions}" -name "${cur_word}*" -printf '%f\0' |
-            sed -z "s/\n/\$'n'/g"
-    )
+                sed -z "s/\n/\$'n'/g"
+        )
     else
         # the following two `readarray` assumes that filenames has
         # no newline characters in it, otherwise they will be splitted
         # into separate completions.
-        if [[ -z "${cur_word}" ]]; then
-            readarray -t candidates <<<"$(compgen -f)";
+        if [[ -z ${cur_word} ]]; then
+            readarray -t candidates <<< "$(compgen -f)"
         else
-            readarray -t candidates <<<"$(compgen -f -- "${cur_word}")";
+            readarray -t candidates <<< "$(compgen -f -- "${cur_word}")"
         fi
         # if pathname expansion above produces no matching files, then
         # `compgen` output single newline character `\n`, resulting in
@@ -73,216 +70,225 @@ _file_arguments() {
     fi
 
     for cnd in "${candidates[@]}"; do
-        [[ -f "${cnd}" && "${cnd}" =~ ${extensions} ]] && \
-            COMPREPLY+=( "$(_escape_bash_specials "${cnd##*/}" 1)" );
+        [[ -f ${cnd} && ${cnd} =~ ${extensions} ]] &&
+            COMPREPLY+=("$(_escape_bash_specials "${cnd##*/}" 1)")
     done
 }
 
 _long_short_completion() {
-    local long_opts="${1}";
-    local short_opts="${2}";
-    local cur_word="${3}";
+    local long_opts="${1}"
+    local short_opts="${2}"
+    local cur_word="${3}"
 
-    if [[ -z "${cur_word}" ]]; then
+    if [[ -z ${cur_word} ]]; then
         # shellcheck disable=SC2207 # the `wordlist` is constant and has no whitespace characters inside each word
-        COMPREPLY+=( $(compgen -W "${long_opts} ${short_opts}") );
-    elif [[ "${cur_word}" == --* ]]; then
+        COMPREPLY+=($(compgen -W "${long_opts} ${short_opts}"))
+    elif [[ ${cur_word} == --* ]]; then
         # shellcheck disable=SC2207 # idem.
-        COMPREPLY+=( $(compgen -W "${long_opts}" -- "${cur_word}") );
-    elif [[ "${cur_word}" == -* ]]; then
+        COMPREPLY+=($(compgen -W "${long_opts}" -- "${cur_word}"))
+    elif [[ ${cur_word} == -* ]]; then
         # shellcheck disable=SC2207 # idem.
-        COMPREPLY+=( $(compgen -W "${long_opts} ${short_opts}" -- "${cur_word}") );
-        return;
+        COMPREPLY+=($(compgen -W "${long_opts} ${short_opts}" -- "${cur_word}"))
+        return
     fi
 }
 
-
 # loads the scripts block in package.json
 _read_scripts_in_package_json() {
-    local cur_word="${1}";
-    local pre_word="${2}";
+    local cur_word="${1}"
+    local pre_word="${2}"
 
-    local package_json;
-    local working_dir="${PWD}";
-    local line=0;
+    local package_json
+    local working_dir="${PWD}"
+    local line=0
 
-    for ((; line < ${#COMP_WORDS[@]}; line+=1)); do
-        [[ "${COMP_WORDS[${line}]}" == "--cwd" ]] && working_dir="${COMP_WORDS[((line + 1))]}";
+    for (( ; line < ${#COMP_WORDS[@]}; line += 1)); do
+        [[ ${COMP_WORDS[${line}]} == "--cwd" ]] && working_dir="${COMP_WORDS[line + 1]}"
     done
 
-    [[ -f "${working_dir}/package.json" ]] && package_json=$(<"${working_dir}/package.json");
+    [[ -f "${working_dir}/package.json" ]] && package_json=$(< "${working_dir}/package.json")
 
-    [[ "${package_json}" =~ '"scripts"'[[:space:]]*':'[[:space:]]*\{[[:space:]]*(.*)\} ]] && {
-        local matched="${BASH_REMATCH[1]}";
-        local scripts="${matched%\}*}";
-        local -a script_candidates;
+    [[ ${package_json} =~ '"scripts"'[[:space:]]*':'[[:space:]]*\{[[:space:]]*(.*)\} ]] && {
+        local matched="${BASH_REMATCH[1]}"
+        local scripts="${matched%\}*}"
+        local -a script_candidates
 
-        while [[ "${scripts}" =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*":"[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
-            local script;
-            script="$(_escape_bash_specials "${BASH_REMATCH[1]}" 0)";
+        while [[ ${scripts} =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*":"[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
+            local script
+            script="$(_escape_bash_specials "${BASH_REMATCH[1]}" 0)"
 
             # when a script is passed as an option, do not show other scripts as part of the completion anymore
-            [[ "${script}" == "${pre_word}" ]] && return 1;
+            [[ ${script} == "${pre_word}" ]] && return 1
 
-            script_candidates+=( "${script}" );
-            scripts="${scripts:${#BASH_REMATCH[0]}}";
+            script_candidates+=("${script}")
+            scripts="${scripts:${#BASH_REMATCH[0]}}"
         done
     }
 
     for script in "${script_candidates[@]}"; do
-        [[ "${script}" == "${cur_word}"* ]] && COMPREPLY+=( "${script}" );
+        [[ ${script} == "${cur_word}"* ]] && COMPREPLY+=("${script}")
     done
-    return 0;
+    return 0
 }
 
-
 _subcommand_comp_reply() {
-    local sub_commands="${1}";
-    local cur_word="${2}";
-    local pre_word="${3}";
+    local sub_commands="${1}"
+    local cur_word="${2}"
+    local pre_word="${3}"
 
-    local regexp_subcommand="^[dbcriauh]";
+    local regexp_subcommand="^[dbcriauh]"
 
-    [[ "${pre_word}" =~ ${regexp_subcommand} ]] && {
-        if [[ -z "${cur_word}" ]]; then
+    [[ ${pre_word} =~ ${regexp_subcommand} ]] && {
+        if [[ -z ${cur_word} ]]; then
             # shellcheck disable=SC2207 # `sub_commands` is constant and has no whitespace characters in each subcommand
-            COMPREPLY+=( $(compgen -W "${sub_commands}") );
+            COMPREPLY+=($(compgen -W "${sub_commands}"))
         else
             # shellcheck disable=SC2207 # idem.
-            COMPREPLY+=( $(compgen -W "${sub_commands}" -- "${cur_word}") );
+            COMPREPLY+=($(compgen -W "${sub_commands}" -- "${cur_word}"))
         fi
     }
 }
 
-
 _bun_completions() {
-    declare -A GLOBAL_OPTIONS;
-    declare -A PACKAGE_OPTIONS;
-    declare -A PM_OPTIONS;
+    declare -A GLOBAL_OPTIONS
+    declare -A PACKAGE_OPTIONS
+    declare -A PM_OPTIONS
 
-    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x test repl update outdated link unlink build";
+    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x test repl update outdated link unlink build"
 
-    GLOBAL_OPTIONS[LONG_OPTIONS]="--use --cwd --bunfile --server-bunfile --config --disable-react-fast-refresh --disable-hmr --env-file --extension-order --jsx-factory --jsx-fragment --extension-order --jsx-factory --jsx-fragment --jsx-import-source --jsx-production --jsx-runtime --main-fields --no-summary --version --platform --public-dir --tsconfig-override --define --external --help --inject --loader --origin --port --dump-environment-variables --dump-limits --disable-bun-js";
-    GLOBAL_OPTIONS[SHORT_OPTIONS]="-c -v -d -e -h -i -l -u -p";
+    GLOBAL_OPTIONS[LONG_OPTIONS]="--use --cwd --bunfile --server-bunfile --config --disable-react-fast-refresh --disable-hmr --env-file --extension-order --jsx-factory --jsx-fragment --extension-order --jsx-factory --jsx-fragment --jsx-import-source --jsx-production --jsx-runtime --main-fields --no-summary --version --platform --public-dir --tsconfig-override --define --external --help --inject --loader --origin --port --dump-environment-variables --dump-limits --disable-bun-js"
+    GLOBAL_OPTIONS[SHORT_OPTIONS]="-c -v -d -e -h -i -l -u -p"
 
-    PACKAGE_OPTIONS[ADD_OPTIONS_LONG]="--development --optional --peer";
-    PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]="-d";
-    PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]="";
-    PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]="";
+    PACKAGE_OPTIONS[ADD_OPTIONS_LONG]="--development --optional --peer"
+    PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]="-d"
+    PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]=""
+    PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]=""
 
-    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help";
-    PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g";
+    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help"
+    PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g"
 
     PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --help"
     PM_OPTIONS[SHORT_OPTIONS]="-c -y -p -f -g"
 
-    local cur_word="${COMP_WORDS[${COMP_CWORD}]}";
-    local pre_word="${COMP_WORDS[$(( COMP_CWORD - 1 ))]}";
+    local cur_word="${COMP_WORDS[${COMP_CWORD}]}"
+    local pre_word="${COMP_WORDS[$((COMP_CWORD - 1))]}"
+    local cur_word="${COMP_WORDS[${COMP_CWORD}]}"
 
     case "${pre_word}" in
-        help|--help|-h|-v|--version) return;;
-        -c|--config)      _file_arguments '.+\.toml$' "${cur_word}" && return;;
-        --bunfile)        _file_arguments '.+\.bun$' "${cur_word}" && return;;
-        --server-bunfile) _file_arguments '.+\.server\.bun$' "${cur_word}" && return;;
-        --backend)
-            case "${COMP_WORDS[1]}" in
-                a|add|remove|rm|install|i)
-                    # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitespace characters inside
-                    COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") );
-                ;;
-            esac
-            return;;
-        --cwd|--public-dir)
-            readarray -t COMPREPLY <<<"$(compgen -d -- "${cur_word}")";
-            return;;
-        --jsx-runtime)
-            # shellcheck disable=SC2207 # see above
-            COMPREPLY=( $(compgen -W "automatic classic" -- "${cur_word}") );
-            return;;
-        --target)
-            # shellcheck disable=SC2207 # idem.
-            COMPREPLY=( $(compgen -W "browser node bun" -- "${cur_word}") );
-            return;;
-        -l|--loader)
-            [[ "${cur_word}" =~ (:) ]] && {
-                local cut_colon_forward="${cur_word%%:*}";
-                readarray -t COMPREPLY <<<"$(compgen -W "${cut_colon_forward}:jsx ${cut_colon_forward}:js ${cut_colon_forward}:json ${cut_colon_forward}:tsx ${cut_colon_forward}:ts ${cut_colon_forward}:css" -- "${cut_colon_forward}:${cur_word##*:}")";
-            }
-            return;;
+    help | --help | -h | -v | --version) return ;;
+    -c | --config) _file_arguments '.+\.toml$' "${cur_word}" && return ;;
+    --bunfile) _file_arguments '.+\.bun$' "${cur_word}" && return ;;
+    --server-bunfile) _file_arguments '.+\.server\.bun$' "${cur_word}" && return ;;
+    --backend)
+        case "${COMP_WORDS[1]}" in
+        a | add | remove | rm | install | i)
+            # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitespace characters inside
+            COMPREPLY=($(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}"))
+            ;;
+        esac
+        return
+        ;;
+    --cwd | --public-dir)
+        readarray -t COMPREPLY <<< "$(compgen -d -- "${cur_word}")"
+        return
+        ;;
+    --jsx-runtime)
+        # shellcheck disable=SC2207 # see above
+        COMPREPLY=($(compgen -W "automatic classic" -- "${cur_word}"))
+        return
+        ;;
+    --target)
+        # shellcheck disable=SC2207 # idem.
+        COMPREPLY=($(compgen -W "browser node bun" -- "${cur_word}"))
+        return
+        ;;
+    -l | --loader)
+        [[ ${cur_word} =~ (:) ]] && {
+            local cut_colon_forward="${cur_word%%:*}"
+            readarray -t COMPREPLY <<< "$(compgen -W "${cut_colon_forward}:jsx ${cut_colon_forward}:js ${cut_colon_forward}:json ${cut_colon_forward}:tsx ${cut_colon_forward}:ts ${cut_colon_forward}:css" -- "${cut_colon_forward}:${cur_word##*:}")"
+        }
+        return
+        ;;
     esac
 
     case "${COMP_WORDS[1]}" in
-        help|completions|--help|-h|-v|--version) return;;
-        add|a)
-            _long_short_completion \
-                "${PACKAGE_OPTIONS[ADD_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]}" \
-                "${PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${cur_word}";
-            return;;
-        remove|rm|i|install|link|unlink)
-            _long_short_completion \
-                "${PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]}" \
-                "${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${cur_word}";
-            return;;
-        create|c)
-            # shellcheck disable=SC2207 # the literal string of space separated flags is used, there are no flags containing whitespace character
-            COMPREPLY=( $(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}") );
-            return;;
-        upgrade)
-            # shellcheck disable=SC2207 # see above
-            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h" -- "${cur_word}") );
-            return;;
-        run)
-            _file_arguments '.+\.(js|ts|jsx|tsx|mjs|cjs)$' "${cur_word}";
-            # shellcheck disable=SC2207 # idem.
-            COMPREPLY+=( $(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}" ) );
-            _read_scripts_in_package_json "${cur_word}" "${pre_word}";
-            return;;
-        pm)
-            _long_short_completion \
-                "${PM_OPTIONS[LONG_OPTIONS]}" \
-                "${PM_OPTIONS[SHORT_OPTIONS]}" \
-                "${cur_word}";
-            # shellcheck disable=SC2207 # the literal space-separated string of subcommands is used, no subcommand containing the space character exists
-            COMPREPLY+=( $(compgen -W "bin ls cache hash hash-print hash-string" -- "${cur_word}") );
-            return;;
-        *)
-            _long_short_completion \
-                "${GLOBAL_OPTIONS[LONG_OPTIONS]}" \
-                "${GLOBAL_OPTIONS[SHORT_OPTIONS]}" \
-                "${cur_word}";
-            local pre_is_script=0;
-            _read_scripts_in_package_json "${cur_word}" "${pre_word}" || pre_is_script=1;
-            _subcommand_comp_reply "${SUBCOMMANDS}" "${cur_word}" "${pre_word}";
+    help | completions | --help | -h | -v | --version) return ;;
+    add | a)
+        _long_short_completion \
+            "${PACKAGE_OPTIONS[ADD_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]}" \
+            "${PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
+            "${cur_word}"
+        return
+        ;;
+    remove | rm | i | install | link | unlink)
+        _long_short_completion \
+            "${PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]}" \
+            "${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
+            "${cur_word}"
+        return
+        ;;
+    create | c)
+        # shellcheck disable=SC2207 # the literal string of space separated flags is used, there are no flags containing whitespace character
+        COMPREPLY=($(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}"))
+        return
+        ;;
+    upgrade)
+        # shellcheck disable=SC2207 # see above
+        COMPREPLY=($(compgen -W "--version --cwd --help -v -h" -- "${cur_word}"))
+        return
+        ;;
+    run)
+        _file_arguments '.+\.(js|ts|jsx|tsx|mjs|cjs)$' "${cur_word}"
+        # shellcheck disable=SC2207 # idem.
+        COMPREPLY+=($(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}"))
+        _read_scripts_in_package_json "${cur_word}" "${pre_word}"
+        return
+        ;;
+    pm)
+        _long_short_completion \
+            "${PM_OPTIONS[LONG_OPTIONS]}" \
+            "${PM_OPTIONS[SHORT_OPTIONS]}" \
+            "${cur_word}"
+        # shellcheck disable=SC2207 # the literal space-separated string of subcommands is used, no subcommand containing the space character exists
+        COMPREPLY+=($(compgen -W "bin ls cache hash hash-print hash-string" -- "${cur_word}"))
+        return
+        ;;
+    *)
+        _long_short_completion \
+            "${GLOBAL_OPTIONS[LONG_OPTIONS]}" \
+            "${GLOBAL_OPTIONS[SHORT_OPTIONS]}" \
+            "${cur_word}"
+        local pre_is_script=0
+        _read_scripts_in_package_json "${cur_word}" "${pre_word}" || pre_is_script=1
+        _subcommand_comp_reply "${SUBCOMMANDS}" "${cur_word}" "${pre_word}"
 
-            # determine if completion should be continued when
-            # the current word is an empty string and either:
-            # a. the previous word is part of the allowed completion
-            # b. the previous word is an argument to second-to-previous option
-            # c. the previouos word is the script name
-            # FIXME: Is c. a valid case here?
-            [[ -z "${cur_word}" ]] && {
-                for comp in "${COMPREPLY[@]}"; do
-                    # if `pre_word` is script name, then scripts are filtred out from `COMPREPLY`, so
-                    # the `_pre_is_script` is needed to detect that previous word is the script name
-                    [[ "${pre_word}" == "${comp}" ]] && return; # a.
-                done
+        # determine if completion should be continued when
+        # the current word is an empty string and either:
+        # a. the previous word is part of the allowed completion
+        # b. the previous word is an argument to second-to-previous option
+        # c. the previouos word is the script name
+        # FIXME: Is c. a valid case here?
+        [[ -z ${cur_word} ]] && {
+            for comp in "${COMPREPLY[@]}"; do
+                # if `pre_word` is script name, then scripts are filtred out from `COMPREPLY`, so
+                # the `_pre_is_script` is needed to detect that previous word is the script name
+                [[ ${pre_word} == "${comp}" ]] && return # a.
+            done
 
-                local pre_pre_word="${COMP_WORDS[(( COMP_CWORD - 2 ))]}";
-                local global_options_with_arg="--bunfile --server-bunfile --config --port --cwd --public-dir --jsx-runtime --platform --loader";
+            local pre_pre_word="${COMP_WORDS[COMP_CWORD - 2]}"
+            local global_options_with_arg="--bunfile --server-bunfile --config --port --cwd --public-dir --jsx-runtime --platform --loader"
 
-                for opt in "${global_options_with_arg[@]}"; do
-                    [[ "${pre_pre_word}" == "${opt}" ]] && return; # b.
-                done
+            for opt in "${global_options_with_arg[@]}"; do
+                [[ ${pre_pre_word} == "${opt}" ]] && return # b.
+            done
 
-                (( pre_is_script )) && return; # c.
+            ((pre_is_script)) && return # c.
 
-                unset COMPREPLY;
-            }
-            return;;
+            unset COMPREPLY
+        }
+        return
+        ;;
     esac
 }
-
 
 complete -F _bun_completions bun

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -47,20 +47,21 @@ _file_arguments() {
 }
 
 _long_short_completion() {
-    local wordlist="${1}";
-    local short_options="${2}";
+    local long_opts="${1}";
+    local short_opts="${2}";
     local cur_word="${3}";
 
-    [[ -z "${cur_word}" || "${cur_word}" =~ ^- ]] && {
+    if [[ -z "${cur_word}" ]]; then
         # shellcheck disable=SC2207 # the `wordlist` is constant and has no whitespace characters inside each word
-        COMPREPLY=( $(compgen -W "${wordlist}" -- "${cur_word}") );
-        return;
-    }
-    [[ "${cur_word}" =~ ^-[A-Za-z]+ ]] && {
+        COMPREPLY=( $(compgen -W "${long_opts} ${short_opts}") );
+    elif [[ "${cur_word}" == --* ]]; then
         # shellcheck disable=SC2207 # idem.
-        COMPREPLY=( $(compgen -W "${short_options}" -- "${cur_word}") );
+        COMPREPLY=( $(compgen -W "${long_opts}" -- "${cur_word}") );
+    elif [[ "${cur_word}" == -* ]]; then
+        # shellcheck disable=SC2207 # idem.
+        COMPREPLY=( $(compgen -W "${long_opts} ${short_opts}" -- "${cur_word}") );
         return;
-    }
+    fi
 }
 
 # loads the scripts block in package.json
@@ -213,13 +214,13 @@ _bun_completions() {
         help|completions|--help|-h|-v|--version) return;;
         add|a)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[ADD_OPTIONS_LONG]} ${PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
+                "${PACKAGE_OPTIONS[ADD_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]}" \
                 "${PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
                 "${cur_word}";
             return;;
         remove|rm|i|install|link|unlink)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
+                "${PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]}" \
                 "${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
                 "${cur_word}";
             return;;
@@ -239,7 +240,8 @@ _bun_completions() {
             return;;
         pm)
             _long_short_completion \
-                "${PM_OPTIONS[LONG_OPTIONS]} ${PM_OPTIONS[SHORT_OPTIONS]}" \
+                "${PM_OPTIONS[LONG_OPTIONS]}" \
+                "${PM_OPTIONS[SHORT_OPTIONS]}" \
                 "${cur_word}";
             # shellcheck disable=SC2207 # the literal space-separated string of subcommands is used, no subcommand containing the space character exists
             COMPREPLY+=( $(compgen -W "bin ls cache hash hash-print hash-string" -- "${cur_word}") );
@@ -247,7 +249,7 @@ _bun_completions() {
         *)
             declare -g replaced_script;
             _long_short_completion \
-                "${GLOBAL_OPTIONS[*]}" \
+                "${GLOBAL_OPTIONS[LONG_OPTIONS]}" \
                 "${GLOBAL_OPTIONS[SHORT_OPTIONS]}" \
                 "${cur_word}";
             _read_scripts_in_package_json "${cur_word}" "${prev}";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -4,9 +4,8 @@ _is_exist_and_gnu() {
     local cmd="${1}";
     local version_string;
     version_string="$(
-        command -v "$cmd" >/dev/null && \
-        "$cmd" --version 2>&1 \
-        | head -1
+        command -v "$cmd" >/dev/null 2>&1   && \
+        "$cmd" --version 2>/dev/null | head -1
     )";
     [[ "$version_string" == *GNU* ]] && return 0 || return 1;
 }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -441,7 +441,7 @@ _bun_completions() {
         # b. part of the allowed completion, or
         # c. an argument to the second-to-previous option, or
         # d. the script name
-        # FIXME: Is c. a valid case here?
+        # FIXME: Is d. a valid case here?
         [[ -z ${cur_word} ]] && {
             [[ ${pre_word} == 'bun' ]] && return # a.
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -2,7 +2,7 @@
 
 _file_arguments() {
     local extensions="${1}"
-    # shellcheck disable=SC2064 # current state of `extglob` is needed
+    # shellcheck disable=SC2064 # current state of `globstar` is needed
     trap "$(shopt -p globstar)" RETURN
     shopt -s globstar
 
@@ -16,8 +16,8 @@ _file_arguments() {
         readarray -t COMPREPLY <<<"$(compgen -f -X "${extensions}" -- "${cur_word}")";
     fi
     # if pathname expansion above produces no matching files, then
-    # `compgen` output single newline character `\n`, resuling in
-    # singleton `COMPREPLY` with emty string, let us metigate this.
+    # `compgen` output single newline character `\n`, resulting in
+    # singleton `COMPREPLY` with empty string, let us mitigate this.
     [[ -z ${COMPREPLY[0]} ]] && COMPREPLY=()
 }
 
@@ -26,7 +26,7 @@ _long_short_completion() {
     local short_options="${2}"
 
     [[ -z "${cur_word}" || "${cur_word}" =~ ^- ]] && {
-        # shellcheck disable=SC2207 # the `wordlist` is constant and has no whitespace characters inside each word.
+        # shellcheck disable=SC2207 # the `wordlist` is constant and has no whitespace characters inside each word
         COMPREPLY=( $(compgen -W "${wordlist}" -- "${cur_word}") );
         return;
     }
@@ -98,7 +98,7 @@ _subcommand_comp_reply() {
     local sub_commands="${2}"
     local regexp_subcommand="^[dbcriauh]";
     [[ "${prev}" =~ ${regexp_subcommand} ]] && {
-        # shellcheck disable=SC2207 # `sub_commands` is constant and has no whispace characters in each subcommand.
+        # shellcheck disable=SC2207 # `sub_commands` is constant and has no whispace characters in each subcommand
         COMPREPLY+=( $(compgen -W "${sub_commands}" -- "${cur_word}") );
     }
 }
@@ -136,7 +136,7 @@ _bun_completions() {
         --backend)
             case "${COMP_WORDS[1]}" in
                 a|add|remove|rm|install|i)
-                    # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitspace characrters inside.
+                    # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitspace characrters inside
                     COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") );
                 ;;
             esac
@@ -145,7 +145,7 @@ _bun_completions() {
             readarray -t COMPREPLY <<<"$(compgen -d -- "${cur_word}")";
             return;;
         --jsx-runtime)
-            # shellcheck disable=SC2207 # see above.
+            # shellcheck disable=SC2207 # see above
             COMPREPLY=( $(compgen -W "automatic classic" -- "${cur_word}") );
             return;;
         --target)
@@ -173,7 +173,7 @@ _bun_completions() {
                 "${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}";
             return;;
         create|c)
-            # shellcheck disable=SC2207 # the literal string of space separated flags is used, there are no flags containing whitespace character.
+            # shellcheck disable=SC2207 # the literal string of space separated flags is used, there are no flags containing whitespace character
             COMPREPLY=( $(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}") );
             return;;
         upgrade)
@@ -189,7 +189,7 @@ _bun_completions() {
         pm)
             _long_short_completion \
                 "${PM_OPTIONS[LONG_OPTIONS]} ${PM_OPTIONS[SHORT_OPTIONS]}";
-            # shellcheck disable=SC2207 # the literal space-separated string of subcommands is used, no subcommand containing the space character exists.
+            # shellcheck disable=SC2207 # the literal space-separated string of subcommands is used, no subcommand containing the space character exists
             COMPREPLY+=( $(compgen -W "bin ls cache hash hash-print hash-string" -- "${cur_word}") );
             return;;
         *)

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 _escape_bash_specials() {
     local word="${1}";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -28,6 +28,7 @@ _escape_bash_specials() {
     if (( has_patsub )); then
         echo "${word//${re_exp}/\\&}";
     else
+		    # shellcheck disable=SC2001 # substitution insidde parameter expansion can be used if 'patsub_replacement' option is available
         sed "s/${re_sed}/\\\\&/g" <<<"${word}";
     fi
 }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -28,7 +28,7 @@ _escape_bash_specials() {
     if (( has_patsub )); then
         echo "${word//${re_exp}/\\&}";
     else
-        echo "$(sed "s/${re_sed}/\\\\&/g" <<<"${word}")";
+        sed "s/${re_sed}/\\\\&/g" <<<"${word}";
     fi
 }
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -19,11 +19,11 @@ _long_short_completion() {
     local short_options="${2}"
 
     [[ -z "${cur_word}" || "${cur_word}" =~ ^- ]] && {
-        COMPREPLY=( $(compgen -W "${wordlist}" -- "${cur_word}"));
+        COMPREPLY=( $(compgen -W "${wordlist}" -- "${cur_word}") );
         return;
     }
     [[ "${cur_word}" =~ ^-[A-Za_z]+ ]] && {
-        COMPREPLY=( $(compgen -W "${short_options}" -- "${cur_word}"));
+        COMPREPLY=( $(compgen -W "${short_options}" -- "${cur_word}") );
         return;
     }
 }
@@ -115,7 +115,7 @@ _bun_completions() {
             esac
             return ;;
         --cwd|--public-dir)
-            COMPREPLY=( $(compgen -d -- "${cur_word}" ));
+            COMPREPLY=( $(compgen -d -- "${cur_word}") );
             return;;
         --jsx-runtime)
             COMPREPLY=( $(compgen -W "automatic classic" -- "${cur_word}") );
@@ -173,7 +173,7 @@ _bun_completions() {
             # the previous word is not part of the allowed completion
             # the previous word is not an argument to the last two option
             [[ -z "${cur_word}" ]] && {
-                declare -A comp_reply_associative="( $(echo ${COMPREPLY[@]} | sed 's/[^ ]*/[&]=&/g') )";
+                declare -A comp_reply_associative="( $(echo "${COMPREPLY[@]}" | sed 's/[^ ]*/[&]=&/g') )";
                 [[ -z "${comp_reply_associative[${prev}]}" ]] && {
                     local re_prev_prev="(^| )${COMP_WORDS[(( COMP_CWORD - 2 ))]}($| )";
                     local global_option_with_extra_args="--bunfile --server-bunfile --config --port --cwd --public-dir --jsx-runtime --platform --loader";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 # escapes characters having special meaning in bash
 # @param `$1`: string - string/word to escape characters in
 # @param `$2`: enum<int> - 0 escape all specials except " (quote) and \ (backslash), 1 escape all
@@ -37,25 +36,24 @@ _bun_escape_bash_specials() {
     fi
 }
 
-
 # escapes characters having special meaning inside glob-patterns
 # @param `$1`: string - string/word to escape characters in
 _bun_escape_glob_specials() {
-  local word="${1}"
+    local word="${1}"
 
-  local has_patsub=0
-  shopt -s patsub_replacement 2> /dev/null && {
-      # shellcheck disable=SC2064 # current state of `patsub_replacement` is needed
-      trap "$(shopt -p patsub_replacement)" RETURN
-      has_patsub=1
-  }
+    local has_patsub=0
+    shopt -s patsub_replacement 2> /dev/null && {
+        # shellcheck disable=SC2064 # current state of `patsub_replacement` is needed
+        trap "$(shopt -p patsub_replacement)" RETURN
+        has_patsub=1
+    }
 
-  if ((has_patsub)); then
-      echo "${word//[][!?*]/\\&}"
-  else
-      # shellcheck disable=SC2001 # substitution can only be used if 'patsub_replacement' option is available
-      sed 's/[][!?*]/\\&/g' <<< "${word}"
-  fi
+    if ((has_patsub)); then
+        echo "${word//[][!?*]/\\&}"
+    else
+        # shellcheck disable=SC2001 # substitution can only be used if 'patsub_replacement' option is available
+        sed 's/[][!?*]/\\&/g' <<< "${word}"
+    fi
 }
 
 # check if tool is a gnu version
@@ -69,7 +67,6 @@ _bun_is_exist_and_gnu() {
     )"
     [[ $version_string == *GNU* ]] && return 0 || return 1
 }
-
 
 # appends filenames to the the list of completions, considers only files inside current working directory
 # @param `$1`: string - extended-regex aka ERE, white list of file extensions
@@ -107,7 +104,6 @@ _bun_files_completions() {
     done
 }
 
-
 # appends list of long and short options to the list of completions
 # @param `$1`: string - space-separated list of long options
 # @param `$2`: string - space-separated list of short options
@@ -129,7 +125,6 @@ _bun_long_short_completions() {
         return
     fi
 }
-
 
 # appends the script names from package.json inside the current directory, if any, to the list of completions
 # @param `$1`: string - word imidiatelly before the cursor
@@ -171,7 +166,6 @@ _bun_scripts_completions() {
     return 0
 }
 
-
 # appends subcommands to the list of completions
 # @param `$1`: string - word imidiatelly before the cursor
 # @param `$2`: string - word before $1`
@@ -180,27 +174,27 @@ _bun_subcommand_completions() {
     local pre_word="${2}"
 
     local subcommands=(
-			dev
-			create
-			run
-			install
-			add
-			remove
-			upgrade
-			completions
-			discord
-			help
-			init
-			pm
-			x
-			test
-			repl
-			update
-			outdated
-			link
-			unlink
-			build
-		)
+        dev
+        create
+        run
+        install
+        add
+        remove
+        upgrade
+        completions
+        discord
+        help
+        init
+        pm
+        x
+        test
+        repl
+        update
+        outdated
+        link
+        unlink
+        build
+    )
 
     [[ ${pre_word} == 'bun' ]] && {
         if [[ -z ${cur_word} ]]; then
@@ -213,44 +207,43 @@ _bun_subcommand_completions() {
     }
 }
 
-
 # bun completions entry point function
 _bun_completions() {
     GLOBAL_OPTIONS_LONG=(
-			--use
-			--cwd
-			--bunfile
-			--server-bunfile
-			--config
-			--disable-react-fast-refresh
-			--disable-hmr
-			--env-file
-			--extension-order
-			--jsx-factory
-			--jsx-fragment
-			--extension-order
-			--jsx-factory
-			--jsx-fragment
-			--jsx-import-source
-			--jsx-production
-			--jsx-runtime
-			--main-fields
-			--no-summary
-			--version
-			--platform
-			--public-dir
-			--tsconfig-override
-			--define
-			--external
-			--help
-			--inject
-			--loader
-			--origin
-			--port
-			--dump-environment-variables
-			--dump-limits
-			--disable-bun-js
-		)
+        --use
+        --cwd
+        --bunfile
+        --server-bunfile
+        --config
+        --disable-react-fast-refresh
+        --disable-hmr
+        --env-file
+        --extension-order
+        --jsx-factory
+        --jsx-fragment
+        --extension-order
+        --jsx-factory
+        --jsx-fragment
+        --jsx-import-source
+        --jsx-production
+        --jsx-runtime
+        --main-fields
+        --no-summary
+        --version
+        --platform
+        --public-dir
+        --tsconfig-override
+        --define
+        --external
+        --help
+        --inject
+        --loader
+        --origin
+        --port
+        --dump-environment-variables
+        --dump-limits
+        --disable-bun-js
+    )
     GLOBAL_OPTIONS_SHORT=(-c -v -d -e -h -i -l -u -p)
 
     PACKAGE_OPTIONS_ADD_LONG=(--development --optional --peer)
@@ -260,50 +253,50 @@ _bun_completions() {
     PACKAGE_OPTIONS_REMOVE_SHORT=()
 
     PACKAGE_OPTIONS_SHARED_LONG=(
-			--config
-			--yarn
-			--production
-			--frozen-lockfile
-			--no-save
-			--dry-run
-			--force
-			--cache-dir
-			--no-cache
-			--silent
-			--verbose
-			--global
-			--cwd
-			--backend
-			--link-native-bins
-			--help
-		)
+        --config
+        --yarn
+        --production
+        --frozen-lockfile
+        --no-save
+        --dry-run
+        --force
+        --cache-dir
+        --no-cache
+        --silent
+        --verbose
+        --global
+        --cwd
+        --backend
+        --link-native-bins
+        --help
+    )
     PACKAGE_OPTIONS_SHARED_SHORT=(-c -y -p -f -g)
 
     PM_OPTIONS_LONG=(
-			--config
-			--yarn
-			--production
-			--frozen-lockfile
-			--no-save
-			--dry-run
-			--force
-			--cache-dir
-			--no-cache
-			--silent
-			--verbose
-			--no-progress
-			--no-summary
-			--no-verify
-			--ignore-scripts
-			--global
-			--cwd
-			--backend
-			--link-native-bins
-			--help
-		)
+        --config
+        --yarn
+        --production
+        --frozen-lockfile
+        --no-save
+        --dry-run
+        --force
+        --cache-dir
+        --no-cache
+        --silent
+        --verbose
+        --no-progress
+        --no-summary
+        --no-verify
+        --ignore-scripts
+        --global
+        --cwd
+        --backend
+        --link-native-bins
+        --help
+    )
     PM_OPTIONS_SHORT=(-c -y -p -f -g)
 
-		local fst_word="${COMP_WORDS[1]}"
+    local fst_word="${COMP_WORDS[1]}"
     local pre_word="${COMP_WORDS[$((COMP_CWORD - 1))]}"
     local cur_word="${COMP_WORDS[${COMP_CWORD}]}"
 
@@ -315,13 +308,13 @@ _bun_completions() {
     --backend)
         case "${fst_word}" in
         a | add | remove | rm | install | i)
-						local backend_args=(
-							clonefile
-							copyfile
-							hardlink
-							clonefile_each_dir
-							symlink
-						)
+            local backend_args=(
+                clonefile
+                copyfile
+                hardlink
+                clonefile_each_dir
+                symlink
+            )
             # shellcheck disable=SC2207 # `backend_args` is array of words with no space inside each element
             COMPREPLY=($(compgen -W "${backend_args[*]}" -- "${cur_word}"))
             ;;
@@ -333,13 +326,13 @@ _bun_completions() {
         return
         ;;
     --jsx-runtime)
-				local jsx_runtime_args=(automatic classic)
+        local jsx_runtime_args=(automatic classic)
         # shellcheck disable=SC2207 # see above
         COMPREPLY=($(compgen -W "${jsx_runtime_args[*]}" -- "${cur_word}"))
         return
         ;;
     --target)
-				local target_args=(browser node bun)
+        local target_args=(browser node bun)
         # shellcheck disable=SC2207 # see above
         COMPREPLY=($(compgen -W "${target_args[*]}" -- "${cur_word}"))
         return
@@ -348,15 +341,15 @@ _bun_completions() {
         [[ ${cur_word} =~ (:) ]] && {
             local cur_word_wo_suffix="${cur_word%%:*}"
             local loader_args=(
-              jsx
-              js
-              json
-              tsx
-              ts
-              css
+                jsx
+                js
+                json
+                tsx
+                ts
+                css
             )
             readarray -t COMPREPLY <<< "$(
-              compgen -W "${loader_args[@]/#/${cur_word_wo_suffix}:}" -- "${cur_word}"
+                compgen -W "${loader_args[@]/#/${cur_word_wo_suffix}:}" -- "${cur_word}"
             )"
         }
         return
@@ -381,13 +374,13 @@ _bun_completions() {
         ;;
     create | c)
         local create_options=(
-          --force
-          --no-install
-          --help
-          --no-git
-          --verbose
-          --no-package-json
-          --open next react
+            --force
+            --no-install
+            --help
+            --no-git
+            --verbose
+            --no-package-json
+            --open next react
         )
         # shellcheck disable=SC2207 # `create_options` is array of words with no space inside each element
         COMPREPLY=($(compgen -W "${create_options[*]}" -- "${cur_word}"))
@@ -395,11 +388,11 @@ _bun_completions() {
         ;;
     upgrade)
         local upgrade_options=(
-          --version
-          --cwd
-          --help
-          -v
-          -h
+            --version
+            --cwd
+            --help
+            -v
+            -h
         )
         # shellcheck disable=SC2207 # see above
         COMPREPLY=($(compgen -W "${upgrade_options[*]}" -- "${cur_word}"))
@@ -408,12 +401,12 @@ _bun_completions() {
     run)
         _bun_files_completions '.+\.(js|ts|jsx|tsx|mjs|cjs)$' "${cur_word}"
         local run_options=(
-          --version
-          --cwd
-          --help
-          --silent
-          -v
-          -h
+            --version
+            --cwd
+            --help
+            --silent
+            -v
+            -h
         )
         # shellcheck disable=SC2207 # see above
         COMPREPLY+=($(compgen -W "${run_options[*]}" -- "${cur_word}"))
@@ -426,12 +419,12 @@ _bun_completions() {
             "${PM_OPTIONS_SHORT[*]}" \
             "${cur_word}"
         local pm_options=(
-          bin
-          ls
-          cache
-          hash
-          hash-print
-          hash-string
+            bin
+            ls
+            cache
+            hash
+            hash-print
+            hash-string
         )
         # shellcheck disable=SC2207 # see above
         COMPREPLY+=($(compgen -W "${pm_options[*]}" -- "${cur_word}"))
@@ -461,16 +454,16 @@ _bun_completions() {
 
             local pre_pre_word="${COMP_WORDS[COMP_CWORD - 2]}"
             local global_options_with_arg=(
-							--bunfile
-							--server-bunfile
-							--config
-							--port
-							--cwd
-							--public-dir
-							--jsx-runtime
-							--platform
-							--loader
-						)
+                --bunfile
+                --server-bunfile
+                --config
+                --port
+                --cwd
+                --public-dir
+                --jsx-runtime
+                --platform
+                --loader
+            )
 
             for opt in "${global_options_with_arg[@]}"; do
                 [[ ${pre_pre_word} == "${opt}" ]] && return # b.
@@ -484,6 +477,5 @@ _bun_completions() {
         ;;
     esac
 }
-
 
 complete -F _bun_completions bun

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -93,8 +93,11 @@ _long_short_completion() {
     fi
 }
 
-# loads the scripts block in package.json
-_read_scripts_in_package_json() {
+
+# appends the script names from package.json inside the current directory, if any, to the list of completions
+# @param `$1`: string - word imidiatelly before the cursor
+# @param `$2`: string - word before $1`
+_bun_scripts_completions() {
     local cur_word="${1}"
     local pre_word="${2}"
 
@@ -131,20 +134,44 @@ _read_scripts_in_package_json() {
     return 0
 }
 
-_subcommand_comp_reply() {
-    local sub_commands="${1}"
-    local cur_word="${2}"
-    local pre_word="${3}"
 
-    local regexp_subcommand="^[dbcriauh]"
+# appends subcommands to the list of completions
+# @param `$1`: string - word imidiatelly before the cursor
+# @param `$2`: string - word before $1`
+_bun_subcommand_completions() {
+    local cur_word="${1}"
+    local pre_word="${2}"
 
-    [[ ${pre_word} =~ ${regexp_subcommand} ]] && {
+    local subcommands=(
+			dev
+			create
+			run
+			install
+			add
+			remove
+			upgrade
+			completions
+			discord
+			help
+			init
+			pm
+			x
+			test
+			repl
+			update
+			outdated
+			link
+			unlink
+			build
+		)
+
+    [[ ${pre_word} == 'bun' ]] && {
         if [[ -z ${cur_word} ]]; then
-            # shellcheck disable=SC2207 # `sub_commands` is constant and has no whitespace characters in each subcommand
-            COMPREPLY+=($(compgen -W "${sub_commands}"))
+            # shellcheck disable=SC2207 # `sub_commands` is constant space dilimited list
+            COMPREPLY+=($(compgen -W "${subcommands[*]}"))
         else
             # shellcheck disable=SC2207 # idem.
-            COMPREPLY+=($(compgen -W "${sub_commands}" -- "${cur_word}"))
+            COMPREPLY+=($(compgen -W "${subcommands[*]}" -- "${cur_word}"))
         fi
     }
 }
@@ -259,8 +286,8 @@ _bun_completions() {
             "${GLOBAL_OPTIONS[SHORT_OPTIONS]}" \
             "${cur_word}"
         local pre_is_script=0
-        _read_scripts_in_package_json "${cur_word}" "${pre_word}" || pre_is_script=1
-        _subcommand_comp_reply "${SUBCOMMANDS}" "${cur_word}" "${pre_word}"
+        _bun_scripts_completions "${cur_word}" "${pre_word}" || pre_is_script=1
+        _bun_subcommand_completions "${cur_word}" "${pre_word}"
 
         # determine if completion should be continued when
         # the current word is an empty string and either:

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -48,7 +48,7 @@ _read_scripts_in_package_json() {
         readarray -td, scripts <<<"${scripts}";
         for completion in "${scripts[@]}"; do
             [[ "${completion}" =~ "\""(.*)"\""[[:space:]]*":"[[:space:]]*"\""(.*)"\"" ]] && {
-                package_json_compreply+=( "${BASH_REMATCH[1]//\\\\/\\\\\\\\}" ); # '\' in json is '\\'
+                package_json_compreply+=( "${BASH_REMATCH[1]//\\\\/\\\\\\\\}" );
             }
         done
         COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
@@ -60,8 +60,8 @@ _read_scripts_in_package_json() {
         ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
             ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
     ]] && {
-        local re_script=$(echo "${package_json_compreply[@]//\\\\\\\\/\\}" | sed 's/[^ ]*/(&)/g'); # restore each json's '\\' as '\'
-        local sanitize_pat='[][\\\/.^\$*+?()\{\}|]'
+        local re_script=$(echo "${package_json_compreply[@]//\\\\\\\\/\\}" | sed 's/[^ ]*/(&)/g');
+        local sanitize_pat='[][\\\/.^\$*+?\{\}|]'
         local new_reply=$(echo "${COMPREPLY[@]}" | sed -E "s/${re_script//${sanitize_pat}/\\&}//");
         COMPREPLY=( $(compgen -W "${new_reply}" -- "${cur_word}") );
         replaced_script="${prev}";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -276,7 +276,17 @@ _bun_completions() {
             done
 
             local pre_pre_word="${COMP_WORDS[COMP_CWORD - 2]}"
-            local global_options_with_arg="--bunfile --server-bunfile --config --port --cwd --public-dir --jsx-runtime --platform --loader"
+            local global_options_with_arg=(
+							--bunfile
+							--server-bunfile
+							--config
+							--port
+							--cwd
+							--public-dir
+							--jsx-runtime
+							--platform
+							--loader
+						)
 
             for opt in "${global_options_with_arg[@]}"; do
                 [[ ${pre_pre_word} == "${opt}" ]] && return # b.

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -32,7 +32,7 @@ _bun_escape_bash_specials() {
     if ((has_patsub)); then
         echo "${word//${re_exp}/\\&}"
     else
-        # shellcheck disable=SC2001 # substitution insidde parameter expansion can be used if 'patsub_replacement' option is available
+        # shellcheck disable=SC2001 # substitution can only be used if 'patsub_replacement' option is available
         sed "s/${re_sed}/\\\\&/g" <<< "${word}"
     fi
 }
@@ -75,7 +75,7 @@ _bun_is_exist_and_gnu() {
 # @param `$1`: string - extended-regex aka ERE, white list of file extensions
 # @param `$2`: string - word imidiatelly before the cursor
 _bun_files_completions() {
-    if _bun_is_exist_and_gnu find && _bun_is_exist_and_gnu sed; then
+    local extensions="${1}" # FIXME: the list of candidates is filtred twice against `extensions`
     local cur_word="${2}"
 
     local -a candidates
@@ -118,7 +118,7 @@ _bun_long_short_completions() {
     local cur_word="${3}"
 
     if [[ -z ${cur_word} ]]; then
-        # shellcheck disable=SC2207 # the `wordlist` is constant and has no whitespace characters inside each word
+        # shellcheck disable=SC2207 # the `long_opts` and `short_opts` are constant space delimited lists
         COMPREPLY+=($(compgen -W "${long_opts} ${short_opts}"))
     elif [[ ${cur_word} == --* ]]; then
         # shellcheck disable=SC2207 # idem.
@@ -448,9 +448,9 @@ _bun_completions() {
 
         # determine if completion should be continued when
         # the current word is an empty string and either:
-        # a. the previous word is part of the allowed completion
-        # b. the previous word is an argument to second-to-previous option
-        # c. the previouos word is the script name
+        # a. the previous word is part of the allowed completion, or
+        # b. the previous word is an argument to second-to-previous option, or
+        # c. the previouos word is the script name is true
         # FIXME: Is c. a valid case here?
         [[ -z ${cur_word} ]] && {
             for comp in "${COMPREPLY[@]}"; do

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -56,6 +56,10 @@ _long_short_completion() {
 
 # loads the scripts block in package.json
 _read_scripts_in_package_json() {
+    # shellcheck disable=SC2064 # current state of `patsub_replacement` is needed
+    trap "$(shopt -p patsub_replacement)" RETURN
+    shopt -s patsub_replacement
+
     local package_json;
     local line=0;
     local working_dir="${PWD}";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -37,7 +37,7 @@ _file_arguments() {
         # if pathname expansion above produces no matching files, then
         # `compgen` output single newline character `\n`, resulting in
         # singleton `COMPREPLY` with empty string, let us mitigate this.
-        [[ -z ${COMPREPLY[0]} ]] && COMPREPLY=()
+        [[ -z ${candidates[0]} ]] && candidates=()
     fi
 
     for cnd in "${candidates[@]}"; do

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -178,7 +178,7 @@ _bun_completions() {
             return;;
         upgrade)
             # shellcheck disable=SC2207 # see above
-            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h") );
+            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h" -- "${cur_word}") );
             return;;
         run)
             _file_arguments "!(*.@(js|ts|jsx|tsx|mjs|cjs)?($|))";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -147,7 +147,7 @@ _bun_scripts_completions() {
         local scripts="${matched%\}*}"
         local -a script_candidates
 
-        while [[ ${scripts} =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*":"[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
+        while [[ ${scripts} =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*':'[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
             local script
             script="$(_bun_escape_bash_specials "${BASH_REMATCH[1]}" 0)"
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -114,11 +114,9 @@ _read_scripts_in_package_json() {
     [[ "${package_json}" =~ '"scripts"'[[:space:]]*':'[[:space:]]*\{[[:space:]]*(.*)\} ]] && {
         local matched="${BASH_REMATCH[1]}";
         local scripts="${matched%\}*}";
-
-        local scripts_rem="${scripts}";
         local -a script_candidates;
 
-        while [[ "${scripts_rem}" =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*":"[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
+        while [[ "${scripts}" =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*":"[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
             local script;
             script="$(_escape_bash_specials "${BASH_REMATCH[1]}" 0)";
 
@@ -126,7 +124,7 @@ _read_scripts_in_package_json() {
             [[ "${script}" == "${pre_word}" ]] && return 1;
 
             script_candidates+=( "${script}" );
-            scripts_rem="${scripts_rem:${#BASH_REMATCH[0]}}";
+            scripts="${scripts:${#BASH_REMATCH[0]}}";
         done
     }
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -12,13 +12,13 @@ _bun_escape_bash_specials() {
 
     if ((escape_all)); then
         # escape all bash specials: ]~$"'`><()[{}=|*?;&#\
-        re_exp='[]~$\"'"\'"'\`><\()[{\}=|*?;&#\\]'
-        re_sed='[]~$"'\''`><()[{}=|*?;&#\]'
+        re_exp='[]:~$\"'"\'"'\`><\()[{\}=|*?;&#\\]'
+        re_sed='[]:~$"'\''`><()[{}=|*?;&#\]'
     else
         # escape all bash specials _except_ " (quote) and \ (backslash)
         # since they are already escaped in package.json: ]~$'`><()[{}=|*?;&#
-        re_exp='[]~$'"\'"'\`><\()[{\}=|*?;&#]'
-        re_sed='[]~$'\''`><()[{}=|*?;&#]'
+        re_exp='[]:~$'"\'"'\`><\()[{\}=|*?;&#]'
+        re_sed='[]:~$'\''`><()[{}=|*?;&#]'
     fi
 
     local has_patsub=0

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -72,14 +72,13 @@ _bun_is_exist_and_gnu() {
 # @param `$1`: string - extended-regex aka ERE, white list of file extensions
 # @param `$2`: string - word immediately before the cursor
 _bun_files_completions() {
-    local extensions="${1}" # FIXME: the list of candidates is filtred twice against `extensions`
+    local extensions="${1}"
     local cur_word="${2}"
 
     local -a candidates
     if _bun_is_exist_and_gnu find && _bun_is_exist_and_gnu sed; then
         readarray -t -d '' candidates < <(
-            find . -regextype posix-extended \
-                -maxdepth 1 -xtype f -regex "${extensions}" \
+            find . -maxdepth 1 -xtype f \
                 -name "$(_bun_escape_glob_specials "${cur_word}")*" \
                 -printf '%f\0' | sed -z "s/\n/\$'n'/g"
         )

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -137,10 +137,17 @@ _subcommand_comp_reply() {
     local sub_commands="${1}";
     local cur_word="${2}";
     local prev="${3}";
+
     local regexp_subcommand="^[dbcriauh]";
+
     [[ "${prev}" =~ ${regexp_subcommand} ]] && {
-        # shellcheck disable=SC2207 # `sub_commands` is constant and has no whitespace characters in each subcommand
-        COMPREPLY+=( $(compgen -W "${sub_commands}" -- "${cur_word}") );
+        if [[ -z "${cur_word}" ]]; then
+            # shellcheck disable=SC2207 # `sub_commands` is constant and has no whitespace characters in each subcommand
+            COMPREPLY+=( $(compgen -W "${sub_commands}") );
+        else
+            # shellcheck disable=SC2207 # idem.
+            COMPREPLY+=( $(compgen -W "${sub_commands}" -- "${cur_word}") );
+        fi
     }
 }
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -137,7 +137,7 @@ _bun_scripts_completions() {
     local line=0
 
     for (( ; line < ${#COMP_WORDS[@]}; line += 1)); do
-        [[ ${COMP_WORDS[${line}]} == '--cwd' ]] && working_dir="${COMP_WORDS[line + 1]}"
+        [[ ${COMP_WORDS[${line}]} == '--cwd' ]] && working_dir="${COMP_WORDS[$((line + 1))]}"
     done
 
     [[ -f "${working_dir}/package.json" ]] && package_json=$(< "${working_dir}/package.json")

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -169,9 +169,9 @@ _bun_completions() {
 
     case "${prev}" in
         help|--help|-h|-v|--version) return;;
-        -c|--config)      _file_arguments ".+\.toml$" "${cur_word}" && return;;
-        --bunfile)        _file_arguments ".+\.bun$" "${cur_word}" && return;;
-        --server-bunfile) _file_arguments ".+\.server\.bun$" "${cur_word}" && return;;
+        -c|--config)      _file_arguments '.+\.toml$' "${cur_word}" && return;;
+        --bunfile)        _file_arguments '.+\.bun$' "${cur_word}" && return;;
+        --server-bunfile) _file_arguments '.+\.server\.bun$' "${cur_word}" && return;;
         --backend)
             case "${COMP_WORDS[1]}" in
                 a|add|remove|rm|install|i)
@@ -222,7 +222,7 @@ _bun_completions() {
             COMPREPLY=( $(compgen -W "--version --cwd --help -v -h" -- "${cur_word}") );
             return;;
         run)
-            _file_arguments ".+\.(js|ts|jsx|tsx|mjs|cjs)$" "${cur_word}";
+            _file_arguments '.+\.(js|ts|jsx|tsx|mjs|cjs)$' "${cur_word}";
             # shellcheck disable=SC2207 # idem.
             COMPREPLY+=( $(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}" ) );
             _read_scripts_in_package_json "${cur_word}" "${prev}";

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -31,7 +31,6 @@ _long_short_completion() {
 # loads the scripts block in package.json
 _read_scripts_in_package_json() {
     local package_json;
-    local return_package_json
     local line=0;
     local working_dir="${PWD}";
 
@@ -100,8 +99,8 @@ _bun_completions() {
     PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --help"
     PM_OPTIONS[SHORT_OPTIONS]="-c -y -p -f -g"
 
-    local cur_word="${COMP_WORDS[${COMP_CWORD}]}";
-    local prev="${COMP_WORDS[$(( COMP_CWORD - 1 ))]}";
+    cur_word="${COMP_WORDS[${COMP_CWORD}]}";
+    prev="${COMP_WORDS[$(( COMP_CWORD - 1 ))]}";
 
     case "${prev}" in
         help|--help|-h|-v|--version) return;;
@@ -114,7 +113,7 @@ _bun_completions() {
                     COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") );
                     ;;
             esac
-            return ;;
+            return;;
         --cwd|--public-dir)
             COMPREPLY=( $(compgen -d -- "${cur_word}") );
             return;;
@@ -161,7 +160,7 @@ _bun_completions() {
             COMPREPLY+=( $(compgen -W "bin ls cache hash hash-print hash-string" -- "${cur_word}") );
             return;;
         *)
-            local replaced_script;
+            declare -g replaced_script;
             _long_short_completion \
                 "${GLOBAL_OPTIONS[*]}" \
                 "${GLOBAL_OPTIONS[SHORT_OPTIONS]}"

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -70,7 +70,7 @@ _bun_is_exist_and_gnu() {
 
 # appends filenames to the the list of completions, considers only files inside current working directory
 # @param `$1`: string - extended-regex aka ERE, white list of file extensions
-# @param `$2`: string - word imidiatelly before the cursor
+# @param `$2`: string - word immediately before the cursor
 _bun_files_completions() {
     local extensions="${1}" # FIXME: the list of candidates is filtred twice against `extensions`
     local cur_word="${2}"
@@ -85,7 +85,7 @@ _bun_files_completions() {
         )
     else
         # the following two `readarray` assumes that filenames has
-        # no newline characters in it, otherwise they will be splitted
+        # no newline characters in it, otherwise they will be split
         # into separate completions.
         if [[ -z ${cur_word} ]]; then
             readarray -t candidates <<< "$(compgen -f)"
@@ -107,7 +107,7 @@ _bun_files_completions() {
 # appends list of long and short options to the list of completions
 # @param `$1`: string - space-separated list of long options
 # @param `$2`: string - space-separated list of short options
-# @param `$3`: string - word imidiatelly before the cursor
+# @param `$3`: string - word immediately before the cursor
 _bun_long_short_completions() {
     local long_opts="${1}"
     local short_opts="${2}"
@@ -127,7 +127,7 @@ _bun_long_short_completions() {
 }
 
 # appends the script names from package.json inside the current directory, if any, to the list of completions
-# @param `$1`: string - word imidiatelly before the cursor
+# @param `$1`: string - word immediately before the cursor
 # @param `$2`: string - word before $1`
 _bun_scripts_completions() {
     local cur_word="${1}"
@@ -167,7 +167,7 @@ _bun_scripts_completions() {
 }
 
 # appends subcommands to the list of completions
-# @param `$1`: string - word imidiatelly before the cursor
+# @param `$1`: string - word immediately before the cursor
 # @param `$2`: string - word before $1`
 _bun_subcommand_completions() {
     local cur_word="${1}"
@@ -198,7 +198,7 @@ _bun_subcommand_completions() {
 
     [[ ${pre_word} == 'bun' ]] && {
         if [[ -z ${cur_word} ]]; then
-            # shellcheck disable=SC2207 # `sub_commands` is constant space dilimited list
+            # shellcheck disable=SC2207 # `sub_commands` is constant space delimited list
             COMPREPLY+=($(compgen -W "${subcommands[*]}"))
         else
             # shellcheck disable=SC2207 # idem.
@@ -443,11 +443,11 @@ _bun_completions() {
         # the current word is an empty string and either:
         # a. the previous word is part of the allowed completion, or
         # b. the previous word is an argument to second-to-previous option, or
-        # c. the previouos word is the script name is true
+        # c. the previous word is the script name is true
         # FIXME: Is c. a valid case here?
         [[ -z ${cur_word} ]] && {
             for comp in "${COMPREPLY[@]}"; do
-                # if `pre_word` is script name, then scripts are filtred out from `COMPREPLY`, so
+                # if `pre_word` is script name, then scripts are filtered out from `COMPREPLY`, so
                 # the `_pre_is_script` is needed to detect that previous word is the script name
                 [[ ${pre_word} == "${comp}" ]] && return # a.
             done

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -60,7 +60,8 @@ _read_scripts_in_package_json() {
             ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
     ]] && {
         local re_script=$(echo ${package_json_compreply[@]} | sed 's/[^ ]*/(&)/g');
-        local new_reply=$(echo "${COMPREPLY[@]}" | sed -E "s/$re_script//");
+        local sanitize_pat='[][\\\/.^\$*+?()\{\}|]'
+        local new_reply=$(echo "${COMPREPLY[@]}" | sed -E "s/${re_script//${sanitize_pat}/\\&}//");
         COMPREPLY=( $(compgen -W "${new_reply}" -- "${cur_word}") );
         replaced_script="${prev}";
     }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -57,7 +57,7 @@ _bun_escape_glob_specials() {
 }
 
 # check if tool is a gnu version
-# @param `$1` - tool/command to check
+# @param `$1`: string - tool/command to check
 _bun_is_exist_and_gnu() {
     local cmd="${1}"
     local version_string

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -101,7 +101,7 @@ _subcommand_comp_reply() {
     local sub_commands="${2}"
     local regexp_subcommand="^[dbcriauh]";
     [[ "${prev}" =~ ${regexp_subcommand} ]] && {
-        # shellcheck disable=SC2207 # `sub_commands` is constant and has no whispace characters in each subcommand
+        # shellcheck disable=SC2207 # `sub_commands` is constant and has no whitespace characters in each subcommand
         COMPREPLY+=( $(compgen -W "${sub_commands}" -- "${cur_word}") );
     }
 }
@@ -139,7 +139,7 @@ _bun_completions() {
         --backend)
             case "${COMP_WORDS[1]}" in
                 a|add|remove|rm|install|i)
-                    # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitspace characrters inside
+                    # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitespace characters inside
                     COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") );
                 ;;
             esac

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -44,7 +44,7 @@ _read_scripts_in_package_json() {
     local working_dir="${PWD}";
 
     for ((; line < ${#COMP_WORDS[@]}; line+=1)); do
-        [[ "${COMP_WORDS[${line}]}" == "--cwd" ]] && working_dir="${COMP_WORDS[$((line + 1))]}";
+        [[ "${COMP_WORDS[${line}]}" == "--cwd" ]] && working_dir="${COMP_WORDS[((line + 1))]}";
     done
 
     [[ -f "${working_dir}/package.json" ]] && package_json=$(<"${working_dir}/package.json");
@@ -56,10 +56,10 @@ _read_scripts_in_package_json() {
         local scripts_rem="${scripts}";
         while [[ "${scripts_rem}" =~ ^"\""(([^\"\\]|\\.)+)"\""[[:space:]]*":"[[:space:]]*"\""(([^\"\\]|\\.)*)"\""[[:space:]]*(,[[:space:]]*|$) ]]; do
             local script_name="${BASH_REMATCH[1]}";
-            package_json_compreply+=( "$script_name" );
-            case "$script_name" in
-                ( "$cur_word"* )
-                    COMPREPLY+=( "$script_name" );
+            package_json_compreply+=( "${script_name}" );
+            case "${script_name}" in
+                ( "${cur_word}"* )
+                    COMPREPLY+=( "${script_name}" );
                 ;;
             esac
             scripts_rem="${scripts_rem:${#BASH_REMATCH[0]}}";
@@ -211,7 +211,7 @@ _bun_completions() {
             [[ -z "${cur_word}" ]] && {
                 declare -A comp_reply_associative
                     for comp in "${COMPREPLY[@]}"; do
-                        comp_reply_associative["$comp"]="$comp"
+                        comp_reply_associative["$comp"]="${comp}"
                     done
                 [[ -z "${comp_reply_associative["${prev}"]}" ]] && {
                     local global_option_with_extra_args="--bunfile --server-bunfile --config --port --cwd --public-dir --jsx-runtime --platform --loader";
@@ -220,7 +220,7 @@ _bun_completions() {
                             *" ${COMP_WORDS[(( COMP_CWORD - 2 ))]} "*)
                                 return
                             ;;
-                          esac
+                        esac
                     }
                     unset COMPREPLY;
                 }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -127,7 +127,7 @@ _bun_long_short_completions() {
 
 # appends the script names from package.json inside the current directory, if any, to the list of completions
 # @param `$1`: string - word immediately before the cursor
-# @param `$2`: string - word before $1`
+# @param `$2`: string - word before $1
 _bun_scripts_completions() {
     local cur_word="${1}"
     local pre_word="${2}"
@@ -167,7 +167,7 @@ _bun_scripts_completions() {
 
 # appends subcommands to the list of completions
 # @param `$1`: string - word immediately before the cursor
-# @param `$2`: string - word before $1`
+# @param `$2`: string - word before $1
 _bun_subcommand_completions() {
     local cur_word="${1}"
     local pre_word="${2}"
@@ -435,17 +435,20 @@ _bun_completions() {
         _bun_scripts_completions "${cur_word}" "${pre_word}" || pre_is_script=1
         _bun_subcommand_completions "${cur_word}" "${pre_word}"
 
-        # determine if completion should be continued when
-        # the current word is an empty string and either:
-        # a. the previous word is part of the allowed completion, or
-        # b. the previous word is an argument to second-to-previous option, or
-        # c. the previous word is the script name is true
+        # completion should be continued if the current word is
+        # an empty string _and_ the previous word is either...
+        # a. 'bun', that is complete the initial `bun ` stirng, or
+        # b. part of the allowed completion, or
+        # c. an argument to the second-to-previous option, or
+        # d. the script name
         # FIXME: Is c. a valid case here?
         [[ -z ${cur_word} ]] && {
+            [[ ${pre_word} == 'bun' ]] && return # a.
+
             for comp in "${COMPREPLY[@]}"; do
                 # if `pre_word` is script name, then scripts are filtered out from `COMPREPLY`, so
                 # the `_pre_is_script` is needed to detect that previous word is the script name
-                [[ ${pre_word} == "${comp}" ]] && return # a.
+                [[ ${pre_word} == "${comp}" ]] && return # b.
             done
 
             local pre_pre_word="${COMP_WORDS[COMP_CWORD - 2]}"
@@ -462,10 +465,10 @@ _bun_completions() {
             )
 
             for opt in "${global_options_with_arg[@]}"; do
-                [[ ${pre_pre_word} == "${opt}" ]] && return # b.
+                [[ ${pre_pre_word} == "${opt}" ]] && return # c.
             done
 
-            ((pre_is_script)) && return # c.
+            ((pre_is_script)) && return # d.
 
             unset COMPREPLY
         }

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -414,7 +414,7 @@ _bun_completions() {
         return
         ;;
     pm)
-        _bun_scripts_completions \
+        _bun_long_short_completions \
             "${PM_OPTIONS_LONG[*]}" \
             "${PM_OPTIONS_SHORT[*]}" \
             "${cur_word}"
@@ -431,7 +431,7 @@ _bun_completions() {
         return
         ;;
     *)
-        _bun_scripts_completions \
+        _bun_long_short_completions \
             "${GLOBAL_OPTIONS_LONG[*]}" \
             "${GLOBAL_OPTIONS_SHORT[*]}" \
             "${cur_word}"

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -92,7 +92,7 @@ _bun_files_completions() {
             readarray -t candidates <<< "$(compgen -f -- "${cur_word}")"
         fi
         # if pathname expansion above produces no matching files, then
-        # `compgen` output single newline character `\n`, resulting in
+        # `compgen` outputs single newline character `\n`, resulting in
         # singleton `candidates` with empty string, let us mitigate this
         [[ -z ${candidates[0]} ]] && candidates=()
     fi

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -112,7 +112,7 @@ _read_scripts_in_package_json() {
         local scripts="${matched%\}*}";
 
         local scripts_rem="${scripts}";
-        local package_json_compreply;
+        local -a package_json_compreply;
 
         while [[ "${scripts_rem}" =~ ^'"'(([^\"\\]|\\.)+)'"'[[:space:]]*":"[[:space:]]*'"'(([^\"\\]|\\.)*)'"'[[:space:]]*(,[[:space:]]*|$) ]]; do
             local script_name;

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -4,7 +4,7 @@ _file_arguments() {
     local extensions="${1}";
     local cur_word="${2}";
     # escape all bash specials: ]~$"'`><()[{}=|*?;&#\
-    local re_escape_sed='[]~$"'"'"'`><()[{}=|*?;&#\]';
+    local re_escape_sed='[]~$"'\''`><()[{}=|*?;&#\]';
 
     # requires "findutils" package
     readarray -t -d '' COMPREPLY < <(
@@ -51,8 +51,8 @@ _read_scripts_in_package_json() {
         local scripts="${matched%\}*}";
         local scripts_rem="${scripts}";
         # escape all bash specials _except_ " (quote) and \ (backslash)
-        # since they ar already escaped in package.json: ]~$'`><()[{}=|*?;&#
-        local re_escape_bash='[]~$\"'"\'"'\`><\()[{\}=|*?;&#\\]';
+        # since they are already escaped in package.json: ]~$'`><()[{}=|*?;&#
+        local re_escape_bash='[]~$'"\'"'\`><\()[{\}=|*?;&#]';
         while [[ "${scripts_rem}" =~ ^"\""(([^\"\\]|\\.)+)"\""[[:space:]]*":"[[:space:]]*"\""(([^\"\\]|\\.)*)"\""[[:space:]]*(,[[:space:]]*|$) ]]; do
             local script_name="${BASH_REMATCH[1]}";
             package_json_compreply+=( "${script_name}" );

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -221,9 +221,6 @@ _bun_completions() {
         --extension-order
         --jsx-factory
         --jsx-fragment
-        --extension-order
-        --jsx-factory
-        --jsx-fragment
         --jsx-import-source
         --jsx-production
         --jsx-runtime

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -143,7 +143,7 @@ _bun_scripts_completions() {
     local line=0
 
     for (( ; line < ${#COMP_WORDS[@]}; line += 1)); do
-        [[ ${COMP_WORDS[${line}]} == "--cwd" ]] && working_dir="${COMP_WORDS[line + 1]}"
+        [[ ${COMP_WORDS[${line}]} == '--cwd' ]] && working_dir="${COMP_WORDS[line + 1]}"
     done
 
     [[ -f "${working_dir}/package.json" ]] && package_json=$(< "${working_dir}/package.json")

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -138,7 +138,7 @@ _bun_completions() {
                 a|add|remove|rm|install|i)
                     # shellcheck disable=SC2207 # the literal space separated string is used, each element has no whitspace characrters inside.
                     COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") );
-                    ;;
+                ;;
             esac
             return;;
         --cwd|--public-dir)
@@ -204,7 +204,7 @@ _bun_completions() {
             # determine if completion should be continued
             # when the current word is an empty string
             # the previous word is not part of the allowed completion
-            # the previous word is not an argument to the last two option
+            # the previous word is not an argument to the last two options
             [[ -z "${cur_word}" ]] && {
                 declare -A comp_reply_associative
                     for comp in "${COMPREPLY[@]}"; do
@@ -222,7 +222,6 @@ _bun_completions() {
             }
             return;;
     esac
-
 }
 
 complete -F _bun_completions bun

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -5,7 +5,7 @@ _is_exist_and_gnu() {
     local version_string;
     version_string="$(
         command -v "$cmd" >/dev/null && \
-        "$cmd" --version >/dev/null 2>&1 \
+        "$cmd" --version 2>&1 \
         | head -1
     )";
     [[ "$version_string" == *GNU* ]] && return 0 || return 1;

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -30,7 +30,7 @@ _long_short_completion() {
         COMPREPLY=( $(compgen -W "${wordlist}" -- "${cur_word}") );
         return;
     }
-    [[ "${cur_word}" =~ ^-[A-Za_z]+ ]] && {
+    [[ "${cur_word}" =~ ^-[A-Za-z]+ ]] && {
         # shellcheck disable=SC2207 # idem.
         COMPREPLY=( $(compgen -W "${short_options}" -- "${cur_word}") );
         return;

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -437,7 +437,7 @@ _bun_completions() {
 
         # completion should be continued if the current word is
         # an empty string _and_ the previous word is either...
-        # a. 'bun', that is complete the initial `bun ` stirng, or
+        # a. 'bun', that is complete the initial `bun ` string, or
         # b. part of the allowed completion, or
         # c. an argument to the second-to-previous option, or
         # d. the script name

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -345,7 +345,7 @@ _bun_completions() {
                 css
             )
             readarray -t COMPREPLY <<< "$(
-                compgen -W "${loader_args[@]/#/${cur_word_wo_suffix}:}" -- "${cur_word}"
+                compgen -W "${loader_args[*]/#/${cur_word_wo_suffix}:}" -- "${cur_word}"
             )"
         }
         return

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -65,7 +65,7 @@ _file_arguments() {
         fi
         # if pathname expansion above produces no matching files, then
         # `compgen` output single newline character `\n`, resulting in
-        # singleton `COMPREPLY` with empty string, let us mitigate this.
+        # singleton `candidates` with empty string, let us mitigate this.
         [[ -z ${candidates[0]} ]] && candidates=()
     fi
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -1,13 +1,23 @@
 #! /usr/bin/env bash
 
+_is_exist_and_gnu() {
+    local cmd="${1}";
+    local version_string;
+    version_string="$(
+        command -v "$cmd" >/dev/null && \
+        "$cmd" --version >/dev/null 2>&1 \
+        | head -1
+    )";
+    [[ "$version_string" == *GNU* ]] && return 0 || return 1;
+}
+
 _file_arguments() {
     local extensions="${1}";
     local cur_word="${2}";
     # escape all bash specials: ]~$"'`><()[{}=|*?;&#\
     local re_escape_sed='[]~$"'\''`><()[{}=|*?;&#\]';
 
-    if [[ "$(which find && find --version | head -1)" == *GNU* ]] && \
-        [[ "$(sed --version | head -1)" == *GNU* ]]
+    if _is_exist_and_gnu find && _is_exist_and_gnu sed
     then
         # requires "findutils" package
         readarray -t -d '' COMPREPLY < <(

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -85,7 +85,7 @@ _bun_files_completions() {
     else
         # the following two `readarray` assumes that filenames has
         # no newline characters in it, otherwise they will be split
-        # into separate completions.
+        # into separate completions
         if [[ -z ${cur_word} ]]; then
             readarray -t candidates <<< "$(compgen -f)"
         else
@@ -93,7 +93,7 @@ _bun_files_completions() {
         fi
         # if pathname expansion above produces no matching files, then
         # `compgen` output single newline character `\n`, resulting in
-        # singleton `candidates` with empty string, let us mitigate this.
+        # singleton `candidates` with empty string, let us mitigate this
         [[ -z ${candidates[0]} ]] && candidates=()
     fi
 

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -123,7 +123,7 @@ _read_scripts_in_package_json() {
             script="$(_escape_bash_specials "${BASH_REMATCH[1]}" 0)";
 
             # when a script is passed as an option, do not show other scripts as part of the completion anymore
-            [[ "${script}" == "${pre_word}" ]] && _pre_is_script=1 && return;
+            [[ "${script}" == "${pre_word}" ]] && return 1;
 
             script_candidates+=( "${script}" );
             scripts_rem="${scripts_rem:${#BASH_REMATCH[0]}}";
@@ -133,7 +133,7 @@ _read_scripts_in_package_json() {
     for script in "${script_candidates[@]}"; do
         [[ "${script}" == "${cur_word}"* ]] && COMPREPLY+=( "${script}" );
     done
-
+    return 0;
 }
 
 
@@ -212,8 +212,6 @@ _bun_completions() {
             return;;
     esac
 
-    declare -g _pre_is_script=0;
-
     case "${COMP_WORDS[1]}" in
         help|completions|--help|-h|-v|--version) return;;
         add|a)
@@ -255,7 +253,8 @@ _bun_completions() {
                 "${GLOBAL_OPTIONS[LONG_OPTIONS]}" \
                 "${GLOBAL_OPTIONS[SHORT_OPTIONS]}" \
                 "${cur_word}";
-            _read_scripts_in_package_json "${cur_word}" "${pre_word}";
+            local pre_is_script=0;
+            _read_scripts_in_package_json "${cur_word}" "${pre_word}" || pre_is_script=1;
             _subcommand_comp_reply "${SUBCOMMANDS}" "${cur_word}" "${pre_word}";
 
             # determine if completion should be continued when
@@ -278,7 +277,7 @@ _bun_completions() {
                     [[ "${pre_pre_word}" == "${opt}" ]] && return; # b.
                 done
 
-                (( _pre_is_script )) && return; # c.
+                (( pre_is_script )) && return; # c.
 
                 unset COMPREPLY;
             }


### PR DESCRIPTION
### What does this PR do?

- Avoids using `sed` to implement the logic, uses bash's own constructs to handle it.
- Enforces and uses good practices of quoting, escaping and matching.
- Uses elaborated pattern to parse _package.json_, consumes extra spaces and newlines, handles complex script names and values (incorporating `:`, `}` and even any bash special). Completes them passing through the escape function to allow bash special characters inside the script names (even unquoted).
- It does the same for file names: uses gnu `find` and `sed` to complete filenames having any conceivable character in it, fallbacks to `compgen -f`. In both cases escapes all bash-specials, so the completed word is always valid in bash (even without quoting).
- Escapes glob-specials inside user input (current, previous and first word) in places where they are used as glob-patterns (there is actually only one place at this time).
- Simplifies the code by refactoring the excess of loops and conditionals. Makes code more explicit in many places (good for future contributors adding new subcommands and options).
- Introduces the new names using `_bun` prefix, eliminates the usage of global variables (except the main function and helpers).
- Adds explanatory comments and documents the function signatures.
- The code is linted with __shellcheck__. All __shellcheck__ disabling detectives have the comments describing the reason of switching particular inspection off.
- Formatted using __shfmt__

### How did you verify your code works?

Please see the [example] project, which I am used for testing the changes introduced by each commit.

[example]: https://github.com/unennhexium/bun-bash-completion-example

---

> [!IMPORTANT]
> This PR evolved into composite refactor of the script code after [#553d98]. The original version suffered form multiple typos, bugs and errors, e.g. accessing variables out of the scope, unreachable branches, processing chocking on non-alphabetical user input, script and file names; and strange solutions, e.g. to populate completions candidates with script names from _package.json_, then to check some condition: in case of success - filter out all previously added scripts.
>
> Excluding script names from the list of candidates used `sed`s `s/<pat>/<sub>` command: `<pat>` was constructed using script names, wrapping each name into `(`,`)`-pair using another `sed` invocation. Perhaps `(script1)|(script2)|...` was implied, but actually the pattern was `(script1)(script2)...`. This approach is potential hazard and caused repeating error appearing in my terminal emulator.
>
> During extensive conversation with reviewing bot, I gradually changed the script to avoid such errors in the future. All of these caused the careful rewrite of almost every line of the script.

[#553d98]: https://github.com/oven-sh/bun/pull/23274/commits/553d987112dca39d5afdf68835eb229d7c9be1a2

> [!TIP]
> Bellow is the description of the original PR before [#553d98].

<details>
<summary>
<h3>fix(completions): change parsing of package.json with complex "script" values</h3>
</summary>

### What does this PR do?

I recently have a persistent error using the current version of this script

```
sed: -e expression #1, char 403: unknown option to `s'
```

After a little investigation using `local -; set -x` on functions calling `sed`, I discovered the eventual culprit and introduced the sanitization of the interpolated lhs for `sed`'s `s` command. Unfortunately, this change does not help allot (though this minor change is still a good guard against a future errors).

The actual problem was the several of my _package.json_ scripts having `:` inside (they are calling another scripts using `bun run transpile:srv --watch`). This caused the script names to be parsed wrong due to lazy truncation of `:` character, i.e. `"watch:srv": "bun run transpile:` (that is string stops on the last `:`). I fixes this in the one of the commits.

Another problem I have discovered when testing the other `sed -E` special characters, is greedy `}` truncation resulting in the whole value of the `"scripts"` key to be parsed wrong, e.g. `"scripts": { "test": "echo '{hello world}` (that is the rest of the `"scripts"` block is lost. I fixed this in another commit.

Finally the one additional commit inserts the space character in a few places to accommodate the style of these lines to the style of the other ones. 

### How did you verify your code works?

I checked my script locally with the following _package.json_:

<details>
<summary>
<i><b>package.json</b></i>
</summary>

```json
{
  "name": "tmp.v5knjxsjrk",
  "module": "index.ts",
  "type": "module",
  "private": true,
  "devDependencies": {
    "@types/bun": "latest"
  },
  "peerDependencies": {
    "typescript": "^5"
  },
  "scripts": {
      "fourty\": \"one\"": "two",
      "90": "01\", \"01\":",
      "double\\back": "\\slash",
      "docker:pull": "docker pull some/image:latest",
      "^0.1.*+(script|name)?{1:3}": "echo hello world",
      "test": "C:\\(hello?/world.txt:latest^$1.2.*){i|o}"
  }
}
```

</details> 

When I typed `bun run <Tab><Tab>` I got the following:

<details>
<summary>
<i><b>terminal output</b></i>
</summary>

```console
user@LAPTOP-PC:/tmp/tmp.V5kNJxSjRk
$ bun run
^0.1.*+(script|name)?{1:3}  -h                  <- scripts and params are suggested
90                          --help
--cwd                       --silent
docker:pull                 test
double\\back                -v
fourty\": \"one\"           --version
user@LAPTOP-PC:/tmp/tmp.V5kNJxSjRk
$ bun run test -
--cwd      -h         --help     --silent   -v         --version <- only params are
```

</details> 

... which I think the expected output of the completion script in this case.

> Previous version of the script produces the error mentioned above (with different char number indeed).

</details>
