### PR TITLE
fix(parser): unused arrays with no side effects

### DIFF
--- a/src/ast/visitBinaryExpression.zig
+++ b/src/ast/visitBinaryExpression.zig
@@ -136,6 +136,9 @@ pub fn CreateBinaryExpressionVisitor(
                         // "(0, this.fn)()" => "(0, this.fn)()"
                         if (p.options.features.minify_syntax) {
                             if (SideEffects.simplifyUnusedExpr(p, e_.left)) |simplified_left| {
+                                if (simplified_left.isEmpty()) {
+                                    return e_.right;
+                                }
                                 e_.left = simplified_left;
                             } else {
                                 // The left operand has no side effects, but we need to preserve

--- a/test/regression/issue/23287-array-comma-value.test.ts
+++ b/test/regression/issue/23287-array-comma-value.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("issue #23287: (new Array([1, 2]), 'hi') parses correctly", async () => {
+  using dir = tempDir("issue-23287", {
+    "index.js": `
+      // failing since Bun v1.2.22
+      var f = (new Array([1, 2]), "hi");
+      // failing since Bun v1.0.15
+      var h = ([1, 2], "hi");
+      console.log(f, h);
+      `,
+  });
+
+  const { stdout, stderr, exited } = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  expect(err).toBe("");
+  expect(out).toBe("hi hi\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/23287-array-comma-value.test.ts
+++ b/test/regression/issue/23287-array-comma-value.test.ts
@@ -15,6 +15,7 @@ test("issue #23287: (new Array([1, 2]), 'hi') parses correctly", async () => {
   const { stdout, stderr, exited } = Bun.spawn({
     cmd: [bunExe(), "index.js"],
     cwd: dir,
+    env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
     stdin: "ignore",


### PR DESCRIPTION
### What does this PR do?
Fixes a bug since Bun v1.0.15: `var f = ([1, 2], "hi");`
Fixes a regression since Bun v1.2.22: `var f = (new Array([1, 2]), "hi");`

Fixes #23287
### How did you verify your code works?
Added a test