### PR TITLE
fix(node:path): reverse iterate `path.resolve` arguments, and stop on absolute

### DIFF
--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { isWindows } from "harness";
 import assert from "node:assert";
 // import child from "node:child_process";
@@ -92,5 +92,14 @@ describe("path.resolve", () => {
     //     process.cwd = cwd;
     //   }
     // }
+  });
+
+  test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {
+    expect(() => {
+      return path.posix.resolve(undefined, "hi");
+    }).toThrow('The "paths[0]" property must be of type string, got undefined');
+    expect(() => {
+      return path.posix.resolve(undefined, "/hi");
+    }).not.toThrow();
   });
 });

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { isWindows } from "harness";
 import assert from "node:assert";
 // import child from "node:child_process";

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -144,3 +144,5 @@ vendor/elysia/test/core/dynamic.test.ts
 vendor/elysia/test/lifecycle/error.test.ts
 vendor/elysia/test/validator/body.test.ts
 vendor/elysia/test/ws/message.test.ts
+
+test/js/node/test/parallel/test-worker-abort-on-uncaught-exception.js


### PR DESCRIPTION
### What does this PR do?
Matches node behavior.

Fixes #20975
### How did you verify your code works?
Manually and added a test