### PR TITLE
fix: handle import attributes with type: "text" correctly

### DIFF
--- a/test/regression/issue/23299.test.ts
+++ b/test/regression/issue/23299.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+test("TypeScript file imported with type: 'text' should be treated as text, not executed - issue #23299", async () => {
+  using dir = tempDir("issue-23299", {
+    "asset.ts": `console.error("Unreachable!");`,
+    "frontend.ts": `
+//@ts-ignore
+import code from "./asset.ts" with { type: "text" };
+
+console.log(code);
+`,
+    "index.html": `
+<html>
+  <head>
+    <script type="module" src="./frontend.ts"></script>
+  </head>
+  <body></body>
+</html>
+`,
+  });
+
+  // Build the frontend module
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "frontend.ts", "--outdir=dist", "--target=browser"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).not.toContain("error");
+
+  // Read the bundled output
+  const bundled = await Bun.file(`${dir}/dist/frontend.js`).text();
+
+  // The asset.ts content should be a string literal, not executed code
+  expect(bundled).toContain('console.error("Unreachable!")');
+
+  // Make sure the error is NOT executed (it should be in a string)
+  expect(normalizeBunSnapshot(bundled, dir)).toMatchInlineSnapshot(`
+"// asset.ts
+var asset_default = 'console.error("Unreachable!");';
+
+// frontend.ts
+console.log(asset_default);"
+`);
+});
+
+test("TypeScript file should compile when imported normally even if also imported as text - issue #23299", async () => {
+  using dir = tempDir("issue-23299-text-only", {
+    "code.ts": `export const value = 42;`,
+    "text-import.ts": `
+//@ts-ignore
+import text from "./code.ts" with { type: "text" };
+console.log("Source:", text);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "text-import.ts", "--outdir=dist", "--target=browser"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  const bundled = await Bun.file(`${dir}/dist/text-import.js`).text();
+
+  // The TypeScript file should be loaded as text, not compiled
+  expect(bundled).toContain("export const value = 42");
+  expect(bundled).toContain("Source:");
+});


### PR DESCRIPTION
Fixes #23299

### What does this PR do?

Fixes a bug where TypeScript files imported with `type: "text"` import attributes were incorrectly executed as TypeScript instead of being treated as plain text.

**Root cause:** The bundler's `pathToSourceIndexMap` cache didn't account for files being imported with different loaders via import attributes. When the same file was encountered with a different loader, it would skip re-parsing and reuse the cached version with the wrong loader.

**Solution:** Skip the path cache lookup when an import has an explicit loader from import attributes (e.g., `with { type: "text" }`). This ensures files are parsed with the correct loader even if they were previously parsed with a different loader.

### How did you verify your code works?

Added regression tests in `test/regression/issue/23299.test.ts`:
1. Test that `.ts` files imported with `type: "text"` are treated as text, not executed as TypeScript
2. Test that TypeScript files can be correctly imported as text-only

All tests pass:
```
✓ TypeScript file imported with type: 'text' should be treated as text, not executed - issue #23299
✓ TypeScript file should compile when imported normally even if also imported as text - issue #23299
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)