### PR TITLE
fix: zstd decompression with async-compressed data (#23314)

### DIFF
--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -1837,30 +1837,9 @@ pub const JSZstd = struct {
         const input = buffer.slice();
         const allocator = bun.default_allocator;
 
-        // Try to get the decompressed size
-        const decompressed_size = bun.zstd.getDecompressedSize(input);
-
-        if (decompressed_size == std.math.maxInt(c_ulonglong) - 1 or decompressed_size == std.math.maxInt(c_ulonglong) - 2) {
-            // If size is unknown, we'll need to decompress in chunks
-            return globalThis.ERR(.ZSTD, "Decompressed size is unknown. Either the input is not a valid zstd compressed buffer or the decompressed size is too large. If you run into this error with a valid input, please file an issue at https://github.com/oven-sh/bun/issues", .{}).throw();
-        }
-
-        // Allocate output buffer based on decompressed size
-        var output = try allocator.alloc(u8, decompressed_size);
-
-        // Perform decompression
-        const actual_size = switch (bun.zstd.decompress(output, input)) {
-            .success => |actual_size| actual_size,
-            .err => |err| {
-                allocator.free(output);
-                return globalThis.ERR(.ZSTD, "{s}", .{err}).throw();
-            },
+        const output = bun.zstd.decompressAlloc(allocator, input) catch |err| {
+            return globalThis.ERR(.ZSTD, "Decompression failed: {s}", .{@errorName(err)}).throw();
         };
-
-        bun.debugAssert(actual_size <= output.len);
-
-        // mimalloc doesn't care about the self-reported size of the slice.
-        output.len = actual_size;
 
         return jsc.JSValue.createBuffer(globalThis, output);
     }
@@ -1918,34 +1897,10 @@ pub const JSZstd = struct {
                 };
             } else {
                 // Decompression path
-                // Try to get the decompressed size
-                const decompressed_size = bun.zstd.getDecompressedSize(input);
-
-                if (decompressed_size == std.math.maxInt(c_ulonglong) - 1 or decompressed_size == std.math.maxInt(c_ulonglong) - 2) {
-                    job.error_message = "Decompressed size is unknown. Either the input is not a valid zstd compressed buffer or the decompressed size is too large";
-                    return;
-                }
-
-                // Allocate output buffer based on decompressed size
-                job.output = allocator.alloc(u8, decompressed_size) catch {
-                    job.error_message = "Out of memory";
+                job.output = bun.zstd.decompressAlloc(allocator, input) catch {
+                    job.error_message = "Decompression failed";
                     return;
                 };
-
-                // Perform decompression
-                switch (bun.zstd.decompress(job.output, input)) {
-                    .success => |actual_size| {
-                        if (actual_size < job.output.len) {
-                            job.output.len = actual_size;
-                        }
-                    },
-                    .err => |err| {
-                        allocator.free(job.output);
-                        job.output = &[_]u8{};
-                        job.error_message = err;
-                        return;
-                    },
-                }
             }
         }
 

--- a/test/regression/issue/23314/zstd-async-compress.test.ts
+++ b/test/regression/issue/23314/zstd-async-compress.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import zlib from "node:zlib";
+
+// The zlib sync and async implementations create different outputs
+// This may not be a bug in itself, but the async version creates data that causes an out of memory error when decompressed with Bun.zstdDecompressSync
+describe("zstd compression compatibility", () => {
+  it("should decompress data compressed with zlib.zstdCompressSync", () => {
+    const input = "hello world";
+    const compressed = zlib.zstdCompressSync(input);
+    const decompressed = Bun.zstdDecompressSync(compressed);
+    expect(decompressed.toString()).toBe(input);
+  });
+
+  it("should decompress data compressed with zlib.zstdCompress (async)", async () => {
+    const input = "hello world";
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      zlib.zstdCompress(input, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+    const decompressed = Bun.zstdDecompressSync(compressed);
+    expect(decompressed.toString()).toBe(input);
+  });
+
+  it("should decompress data compressed with zlib.zstdCompress using Bun.zstdDecompress", async () => {
+    const input = "hello world";
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      zlib.zstdCompress(input, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+    const decompressed = await Bun.zstdDecompress(compressed);
+    expect(decompressed.toString()).toBe(input);
+  });
+});

--- a/test/regression/issue/23314/zstd-large-decompression.test.ts
+++ b/test/regression/issue/23314/zstd-large-decompression.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import zlib from "node:zlib";
+
+test("should handle large data decompression safely", async () => {
+  // Create data that decompresses to > 16MB
+  const input = "x".repeat(20 * 1024 * 1024); // 20MB of repeated data
+
+  // Compress with pledgedSrcSize so the frame header includes the size
+  const compressed = await new Promise<Buffer>((resolve, reject) => {
+    zlib.zstdCompress(input, { pledgedSrcSize: input.length }, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+
+  // This should use streaming decompression because reported size > 16MB
+  const decompressed = Bun.zstdDecompressSync(compressed);
+  expect(decompressed.length).toBe(input.length);
+  expect(decompressed.toString()).toBe(input);
+});

--- a/test/regression/issue/23314/zstd-large-input.test.ts
+++ b/test/regression/issue/23314/zstd-large-input.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import zlib from "node:zlib";
+
+describe("zstd compression with larger inputs", () => {
+  it("should handle larger strings", async () => {
+    const input = "hello world ".repeat(1000);
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      zlib.zstdCompress(input, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+    const decompressed = Bun.zstdDecompressSync(compressed);
+    expect(decompressed.toString()).toBe(input);
+  });
+
+  it("should handle buffers", async () => {
+    const input = Buffer.from("test data ".repeat(500));
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      zlib.zstdCompress(input, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+    const decompressed = Bun.zstdDecompressSync(compressed);
+    expect(decompressed.toString()).toBe(input.toString());
+  });
+
+  it("should respect custom pledgedSrcSize if provided", async () => {
+    const input = "custom test";
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      zlib.zstdCompress(input, { pledgedSrcSize: input.length }, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+    const decompressed = Bun.zstdDecompressSync(compressed);
+    expect(decompressed.toString()).toBe(input);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #23314 where `zlib.zstdCompress()` created data that caused an out-of-memory error when decompressed with `Bun.zstdDecompressSync()`.

#### 1. `zlib.zstdCompress()` now sets `pledgedSrcSize`

The async convenience method now automatically sets the `pledgedSrcSize` option to the input buffer size. This ensures the compressed frame includes the content size in the header, making sync and async compression produce identical output.

**Node.js compatibility**: `pledgedSrcSize` is a documented Node.js option:
- [`vendor/node/doc/api/zlib.md:754-758`](https://github.com/oven-sh/bun/blob/main/vendor/node/doc/api/zlib.md#L754-L758)
- [`vendor/node/lib/zlib.js:893`](https://github.com/oven-sh/bun/blob/main/vendor/node/lib/zlib.js#L893)
- [`vendor/node/src/node_zlib.cc:890-904`](https://github.com/oven-sh/bun/blob/main/vendor/node/src/node_zlib.cc#L890-L904)

#### 2. Added `bun.zstd.decompressAlloc()` - centralized safe decompression

Created a new function in `src/deps/zstd.zig` that handles decompression in one place with automatic safety features:

- **Handles unknown content sizes**: Automatically switches to streaming decompression when the zstd frame doesn't include content size (e.g., from streams without `pledgedSrcSize`)
- **16MB safety limit**: For security, if the reported decompressed size exceeds 16MB, streaming decompression is used instead of blindly trusting the header
- **Fast path for small files**: Still uses efficient pre-allocation for files < 16MB with known sizes

This centralized fix automatically protects:
- `Bun.zstdDecompressSync()` / `Bun.zstdDecompress()`
- `StandaloneModuleGraph` source map decompression
- Any other code using `bun.zstd` decompression

### How did you verify your code works?

**Before:**
```typescript
const input = "hello world";

// Async compression
const compressed = await new Promise((resolve, reject) => {
  zlib.zstdCompress(input, (err, result) => {
    if (err) reject(err);
    else resolve(result);
  });
});

// This would fail with "Out of memory"
const decompressed = Bun.zstdDecompressSync(compressed);
```
**Error**: `RangeError: Out of memory` (tried to allocate UINT64_MAX bytes)

**After:**
```typescript
const input = "hello world";

// Async compression (now includes content size)
const compressed = await new Promise((resolve, reject) => {
  zlib.zstdCompress(input, (err, result) => {
    if (err) reject(err);
    else resolve(result);
  });
});

// ✅ Works! Falls back to streaming decompression if needed
const decompressed = Bun.zstdDecompressSync(compressed);
console.log(decompressed.toString()); // "hello world"
```

**Tests:**
- ✅ All existing tests pass
- ✅ New regression tests for async/sync compression compatibility (`test/regression/issue/23314/zstd-async-compress.test.ts`)
- ✅ Test for large (>16MB) decompression using streaming (`test/regression/issue/23314/zstd-large-decompression.test.ts`)
- ✅ Test for various input sizes and types (`test/regression/issue/23314/zstd-large-input.test.ts`)

**Security:**
The 16MB safety limit protects against malicious zstd frames that claim huge decompressed sizes in the header, preventing potential OOM attacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>