### PR TITLE
fix(test): lcov reporter now counts only executable lines

### DIFF
--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -252,7 +252,7 @@ pub const Report = struct {
             }
 
             // LF: lines found
-            try writer.print("LF:{d}\n", .{report.total_lines});
+            try writer.print("LF:{d}\n", .{report.executable_lines.count()});
 
             // LH: lines hit
             try writer.print("LH:{d}\n", .{report.lines_which_have_executed.count()});

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -8,7 +8,7 @@ FNH:0
 DA:2,19
 DA:3,16
 DA:4,1
-LF:5
+LF:3
 LH:3
 end_of_record
 TN:
@@ -22,7 +22,7 @@ DA:9,0
 DA:10,0
 DA:11,1
 DA:14,9
-LF:15
+LF:7
 LH:5
 end_of_record"
 `;

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -122,9 +122,7 @@ test("should call both functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"test.test.ts:
-(pass) should call both functions
----------------|---------|---------|-------------------
+"---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |  100.00 |  100.00 |
@@ -187,9 +185,7 @@ test("should call only some functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"test.test.ts:
-(pass) should call only some functions
----------------|---------|---------|-------------------
+"---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |   75.00 |   83.33 |
@@ -252,9 +248,7 @@ test("should call all functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"test.test.ts:
-(pass) should call all functions
---------------|---------|---------|-------------------
+"--------------|---------|---------|-------------------
 File          | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|---------|-------------------
 All files     |  100.00 |  100.00 |
@@ -319,11 +313,7 @@ test("should call all functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"main.test.ts:
-(pass) should call all functions
-
-src/feature.spec.ts:
-----------------|---------|---------|-------------------
+"----------------|---------|---------|-------------------
 File            | % Funcs | % Lines | Uncovered Line #s
 ----------------|---------|---------|-------------------
 All files       |  100.00 |  100.00 |
@@ -387,7 +377,7 @@ FNF:1
 FNH:1
 DA:2,11
 DA:3,17
-LF:5
+LF:2
 LH:2
 end_of_record
 TN:
@@ -401,7 +391,7 @@ DA:6,42
 DA:7,39
 DA:8,36
 DA:9,2
-LF:10
+LF:7
 LH:7
 end_of_record"
 `);
@@ -440,9 +430,7 @@ test("should pass", () => {
 "3 | coveragePathIgnorePatterns = 123
                                  ^
 error: coveragePathIgnorePatterns must be a string or array of strings
-    at <dir>/bunfig.toml:3:30
-
-Invalid Bunfig: failed to load bunfig"
+    at <dir>/bunfig.toml:3:30"
 `);
   expect(result.exitCode).toBe(1);
 });
@@ -479,9 +467,7 @@ test("should pass", () => {
 "3 | coveragePathIgnorePatterns = ["valid-pattern", 123]
                                                    ^
 error: coveragePathIgnorePatterns array must contain only strings
-    at <dir>/bunfig.toml:3:48
-
-Invalid Bunfig: failed to load bunfig"
+    at <dir>/bunfig.toml:3:48"
 `);
   expect(result.exitCode).toBe(1);
 });
@@ -521,9 +507,7 @@ test("should call function", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"test.test.ts:
-(pass) should call function
----------------|---------|---------|-------------------
+"---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |  100.00 |  100.00 |
@@ -574,9 +558,7 @@ test("should call function", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"test.test.ts:
-(pass) should call function
------------|---------|---------|-------------------
+"-----------|---------|---------|-------------------
 File       | % Funcs | % Lines | Uncovered Line #s
 -----------|---------|---------|-------------------
 All files  |    0.00 |    0.00 |

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -122,7 +122,9 @@ test("should call both functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"---------------|---------|---------|-------------------
+"test.test.ts:
+(pass) should call both functions
+---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |  100.00 |  100.00 |
@@ -185,7 +187,9 @@ test("should call only some functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"---------------|---------|---------|-------------------
+"test.test.ts:
+(pass) should call only some functions
+---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |   75.00 |   83.33 |
@@ -248,7 +252,9 @@ test("should call all functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"--------------|---------|---------|-------------------
+"test.test.ts:
+(pass) should call all functions
+--------------|---------|---------|-------------------
 File          | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|---------|-------------------
 All files     |  100.00 |  100.00 |
@@ -313,7 +319,11 @@ test("should call all functions", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"----------------|---------|---------|-------------------
+"main.test.ts:
+(pass) should call all functions
+
+src/feature.spec.ts:
+----------------|---------|---------|-------------------
 File            | % Funcs | % Lines | Uncovered Line #s
 ----------------|---------|---------|-------------------
 All files       |  100.00 |  100.00 |
@@ -430,7 +440,9 @@ test("should pass", () => {
 "3 | coveragePathIgnorePatterns = 123
                                  ^
 error: coveragePathIgnorePatterns must be a string or array of strings
-    at <dir>/bunfig.toml:3:30"
+    at <dir>/bunfig.toml:3:30
+
+Invalid Bunfig: failed to load bunfig"
 `);
   expect(result.exitCode).toBe(1);
 });
@@ -467,7 +479,9 @@ test("should pass", () => {
 "3 | coveragePathIgnorePatterns = ["valid-pattern", 123]
                                                    ^
 error: coveragePathIgnorePatterns array must contain only strings
-    at <dir>/bunfig.toml:3:48"
+    at <dir>/bunfig.toml:3:48
+
+Invalid Bunfig: failed to load bunfig"
 `);
   expect(result.exitCode).toBe(1);
 });
@@ -507,7 +521,9 @@ test("should call function", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"---------------|---------|---------|-------------------
+"test.test.ts:
+(pass) should call function
+---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |  100.00 |  100.00 |
@@ -558,7 +574,9 @@ test("should call function", () => {
   stderr = normalizeBunSnapshot(stderr, dir);
 
   expect(stderr).toMatchInlineSnapshot(`
-"-----------|---------|---------|-------------------
+"test.test.ts:
+(pass) should call function
+-----------|---------|---------|-------------------
 File       | % Funcs | % Lines | Uncovered Line #s
 -----------|---------|---------|-------------------
 All files  |    0.00 |    0.00 |

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -62,6 +62,7 @@ export const bunEnv: NodeJS.Dict<string> = {
   BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE: "1",
   BUN_DEBUG_linkerctx: "0",
   WANTS_LOUD: "0",
+  AGENT: "false",
 };
 
 const ciEnv = { ...bunEnv };


### PR DESCRIPTION
Fixes #12095

Manually confirmed to fix the case, but it would be better to have an automated test to compare default reporter output with lcov reporter output.