### PR TITLE
fix console: print custom properties on empty arrays

### DIFF
--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -240,3 +240,8 @@ Hello NaN %j 1
 Hello \5 6,
 Hello %i 5 6
 %d 1
+[ field_1: "field_1" ]
+[ 1, 2, 3, field_1: "field_1" ]
+[]
+[ field1: "field_1", field2: 2 ]
+[ 1, 2, 3, field1: "field_1", field2: 2 ]

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -270,3 +270,32 @@ console.log("Hello %%i %i", 5, 6);
 
 // doesn't go out of bounds when printing
 console.log("%%d", 1);
+
+// Test array with extra properties
+{
+  // empty array with extra property
+  const emptyArrayWithItem = [];
+  emptyArrayWithItem["field_1"] = "field_1";
+  console.log(emptyArrayWithItem);
+
+  // Non-empty array with extra property
+  const nonEmptyArrayWithItem = [1, 2, 3];
+  nonEmptyArrayWithItem["field_1"] = "field_1";
+  console.log(nonEmptyArrayWithItem);
+
+  // empty array
+  const emptyArray = [];
+  console.log(emptyArray);
+
+  // Multiple properties on empty array
+  const emptyArrayWithItems = [];
+  emptyArrayWithItems.field1 = "field_1";
+  emptyArrayWithItems.field2 = 2;
+  console.log(emptyArrayWithItems);
+
+  // Multiple properties on non empty array
+  const nonEmptyArrayWithItems = [1, 2, 3];
+  nonEmptyArrayWithItems.field1 = "field_1";
+  nonEmptyArrayWithItems.field2 = 2;
+  console.log(nonEmptyArrayWithItems);
+}


### PR DESCRIPTION
### What does this PR do?
- NodeJS prints custom properties on empty arrays. This commit adds the same support to bun.
- Fixes #22790

### How did you verify your code works?
Ran the following scripts on a debug build to ensure they return the expected output

```
// Case 1: empty array with extra property
const a = [];
a.field = 1;
console.log(a); // Returns [ field: 1 ]

// Case 2: non-empty array with extra property
const b = [1, 2, 3];
b.field = 1;
console.log(b); // Returns [ 1, 2, 3, field: 1 ]

// Case 3: Empty array
const c = [];
console.log(c); // Returns []

// Case 4: Multiple properties on empty array
const d = [];
d.field1 = 1;
d.field2 = 2;
console.log(d); // Returns [ field1: 1, field2: 2 ]

// Case 5: Multiple properties on non empty array
const e = [1, 2, 3];
e.field1 = 1;
e.field2 = 2;
console.log(e); // Returns [ 1, 2, 3, field1: 1, field2: 2 ]
```