### PR TITLE
fix(windows): handle libuv 1.51.0 spurious 0-byte pipe reads

### DIFF
--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -928,7 +928,9 @@ pub const WindowsBufferedReader = struct {
         switch (nread_int) {
             0 => {
                 // EAGAIN or EWOULDBLOCK or canceled  (buf is not safe to access here)
-                return this.onRead(.{ .result = 0 }, "", .drained);
+                // Certain readers (such as pipes) may return 0-byte reads even when
+                // not at EOF (libuv 1.51.0+). Just ignore them and wait for the next callback.
+                return;
             },
             uv.UV_EOF => {
                 _ = this.stopReading();


### PR DESCRIPTION
### What does this PR do?

**This is a speculative fix** for #23071 - package.json scripts hanging on Windows in Bun v1.2.23.

### The Issue

Users report that in v1.2.23, running package.json scripts on Windows hangs indefinitely:
- `bun dev` (which runs `"dev": "bun index.ts"`) - hangs
- `bunx rimraf ./dist` - hangs  
- `bun run index.ts` directly - works fine

### Suspected Root Cause

Between v1.2.22 and v1.2.23, commit **e3783c244f** updated libuv from 1.50.1 to 1.51.0. This update changed how the stream read callback works:

- **Before**: `read_cb(context_data, buffer.slice())` - always passed the full buffer
- **After**: `read_cb(context_data, buffer.base[0..@intCast(nreads)])` - passes only actual bytes read

This exposed a behavior where **libuv 1.51.0 on Windows can return 0-byte reads from pipes even when not at EOF**. The same commit included a fix for this in `FileReader.zig`:

```zig
// Certain readers (such as pipes) may return 0-byte reads even when
// not at EOF. Consequently, we need to check whether the reader is
// actually done or not.
if (buf.len == 0 and state == .drained) {
    // If the reader is not done, we still want to keep reading.
    return true;
}
```

However, the same fix was **not applied** to `WindowsBufferedReader` in `PipeReader.zig`, which is used for subprocess stdout/stderr when running package.json scripts.

### The Speculative Fix

When we get a 0-byte read (`nread == 0`) in `onStreamRead()`, just ignore it and return. libuv will call us again when there's actual data.

```zig
0 => {
    // EAGAIN or EWOULDBLOCK or canceled  (buf is not safe to access here)
    // Certain readers (such as pipes) may return 0-byte reads even when
    // not at EOF (libuv 1.51.0+). Just ignore them and wait for the next callback.
    return;
},
```

Previously, the code would call `onRead(.drained)` for 0-byte reads. If libuv 1.51.0 delivers spurious 0-byte reads on Windows pipes (similar to what was observed and fixed in `FileReader.zig`), this could cause the reader to process an empty chunk but never continue reading, hanging indefinitely.

### Why This is Speculative

1. **I don't have a Windows machine** to reproduce the issue or test the fix
2. The root cause analysis is based on code inspection and comparing commits between v1.2.22 and v1.2.23
3. The fix mirrors the approach already used in `FileReader.zig` for the same libuv update, but I cannot confirm this is the actual cause of #23071

### How to Test (for reviewers with Windows)

Reproduction case from #23071:
1. `bun init bun-demo`
2. Add script: `{"scripts": {"dev": "bun index.ts"}}`
3. `bun dev` - currently hangs indefinitely on Windows in v1.2.23

With this fix, it should complete successfully.

### Alternatives to Consider

If this fix doesn't work, other potential causes to investigate:
- The TTY VT mode change (commit 5a709a2dbf) 
- Other libuv 1.51.0 behavioral changes on Windows
- Changes to subprocess or lifecycle script handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>