### PR TITLE
fix single test run from vscode ui, error: regex extra space

### DIFF
--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -1339,9 +1339,9 @@ export class BunTestController implements vscode.Disposable {
       t = t.replaceAll(/\$[\w\.\[\]]+/g, ".*?");
 
       if (test?.tags?.some(tag => tag.id === "test" || tag.id === "it")) {
-        testNames.push(`^ ?${t}$`);
+        testNames.push(`^?${t}$`);
       } else if (test?.tags?.some(tag => tag.id === "describe")) {
-        testNames.push(`^ ?${t} `);
+        testNames.push(`^?${t} `);
       } else {
         testNames.push(t);
       }


### PR DESCRIPTION
### What does this PR do?

Fixes a run single test from vs code ui.

### How did you verify your code works?

Before, running a test on my mac with lastest version of bun and vscode bun extension resulted in test not run.

The error:
```

> bun test ./usageingester/fns.test.ts --test-name-pattern "(^ onDemand integration test$)"

bun test v1.2.23 (cf136713)

usageingester/fns.test.ts:
--------------------- Bun Inspector ---------------------
Listening on unix:///var/folders/nw/c7rwmx7j12169zscr6nqcclm0000gn/T/g70b6t725ci.sock
--------------------- Bun Inspector ---------------------

error: regex "(^ onDemand integration test$)" matched 0 tests. Searched 1 file (skipping 5 tests) [44.00ms]


```

the test

```
test("onDemand integration test", () => {
  const result = fns.createLoadDataPayload("core-gdev-1-europe-west1-v2", onDemandResult, "onDemand", 1742884848);
  //json.parse(json.stringify()) is used to convert bigInt to number
  // expect(result).toEqual(onDemandExpectedResult);
  expect(JSON.parse(JSON.stringify(result, (_, v) => (typeof v === "bigint" ? v.toString() : v)))).toEqual(onDemandExpectedResult);
});
```

the same issue is with any test. 

Tested on Arm Mac 15.6.1, latest vs code, latest bun, latest vscode bun extension.

Changing the regex this way resolved the issue for me (for both zsh and bash expansion)
