### PR TITLE
fix: prevent crash when workspace includes "./" or ".\"

### DIFF
--- a/src/install/lockfile/Package/WorkspaceMap.zig
+++ b/src/install/lockfile/Package/WorkspaceMap.zig
@@ -128,7 +128,7 @@ pub fn processNamesArray(
             return error.InvalidPackageJSON;
         };
 
-        if (input_path.len == 0 or input_path.len == 1 and input_path[0] == '.') continue;
+        if (input_path.len == 0 or input_path.len == 1 and input_path[0] == '.' or strings.eqlComptime(input_path, "./")) continue;
 
         if (glob.detectGlobSyntax(input_path)) {
             bun.handleOom(workspace_globs.append(input_path));

--- a/src/install/lockfile/Package/WorkspaceMap.zig
+++ b/src/install/lockfile/Package/WorkspaceMap.zig
@@ -128,7 +128,7 @@ pub fn processNamesArray(
             return error.InvalidPackageJSON;
         };
 
-        if (input_path.len == 0 or input_path.len == 1 and input_path[0] == '.' or strings.eqlComptime(input_path, "./")) continue;
+        if (input_path.len == 0 or input_path.len == 1 and input_path[0] == '.' or strings.eqlComptime(input_path, "./") or strings.eqlComptime(input_path, ".\\")) continue;
 
         if (glob.detectGlobSyntax(input_path)) {
             bun.handleOom(workspace_globs.append(input_path));

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, beforeEach, expect, setDefaultTimeout, test } from "bun:test";
-import { writeFileSync } from "fs";
+import { mkdirSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 
 let cwd: string;
@@ -37,4 +37,47 @@ test("bad workspace path", () => {
   expect(text).toContain('Workspace not found "i-dont-exist"');
 
   expect(exitCode).toBe(1);
+});
+
+test("workspace with ./ should not crash", () => {
+  writeFileSync(
+    `${cwd}/package.json`,
+    JSON.stringify(
+      {
+        name: "my-app",
+        version: "1.0.0",
+        workspaces: ["./", "some-workspace"],
+        devDependencies: {
+          "@eslint/js": "^9.28.0",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  mkdirSync(`${cwd}/some-workspace`);
+  writeFileSync(
+    `${cwd}/some-workspace/package.json`,
+    JSON.stringify(
+      {
+        name: "some-workspace",
+        version: "1.0.0",
+      },
+      null,
+      2,
+    ),
+  );
+  const { stderr, exitCode } = spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const text = stderr!.toString();
+
+  // Should not crash, should succeed
+  expect(exitCode).toBe(0);
+  expect(text).not.toContain("panic");
+  expect(text).not.toContain("Internal assertion failure");
 });

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -81,3 +81,46 @@ test("workspace with ./ should not crash", () => {
   expect(text).not.toContain("panic");
   expect(text).not.toContain("Internal assertion failure");
 });
+
+test("workspace with .\\ should not crash", () => {
+  writeFileSync(
+    `${cwd}/package.json`,
+    JSON.stringify(
+      {
+        name: "my-app",
+        version: "1.0.0",
+        workspaces: [".\\", "some-workspace"],
+        devDependencies: {
+          "@eslint/js": "^9.28.0",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  mkdirSync(`${cwd}/some-workspace`);
+  writeFileSync(
+    `${cwd}/some-workspace/package.json`,
+    JSON.stringify(
+      {
+        name: "some-workspace",
+        version: "1.0.0",
+      },
+      null,
+      2,
+    ),
+  );
+  const { stderr, exitCode } = spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const text = stderr!.toString();
+
+  // Should not crash, should succeed
+  expect(exitCode).toBe(0);
+  expect(text).not.toContain("panic");
+  expect(text).not.toContain("Internal assertion failure");
+});


### PR DESCRIPTION
## Summary
- Fixes panic that occurred when a package.json's workspaces array included "./" or ".\" as a workspace path
- The workspace parser now properly skips "./" and ".\" in addition to "." and empty strings
- Adds regression tests for both path separators

## Root Cause
In `WorkspaceMap.zig:131`, the code only filtered out empty strings and `"."`, but didn't handle `"./"` or `".\"` which also refer to the current directory. This caused the parser to attempt processing the root package.json as a workspace, leading to memory corruption and eventual panic.

## Test plan
- [x] Added regression test for "./" workspace path
- [x] Added regression test for ".\" workspace path
- [x] All tests pass

Fixes oven-sh/bun#23239

🤖 Generated with [Claude Code](https://claude.com/claude-code)