### PR TITLE
[@types/bun]: Flatten non-wide types in `test.each()`

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -390,11 +390,20 @@ declare module "bun:test" {
      */
     repeats?: number;
   }
-  type IsTuple<T> = T extends readonly unknown[]
-    ? number extends T["length"]
-      ? false // It's an array with unknown length, not a tuple
-      : true // It's an array with a fixed length (a tuple)
-    : false; // Not an array at all
+
+  namespace __internal {
+    type IsTuple<T> = T extends readonly unknown[]
+      ? number extends T["length"]
+        ? false // It's an array with unknown length, not a tuple
+        : true // It's an array with a fixed length (a tuple)
+      : false; // Not an array at all
+
+    /**
+     * Accepts `[1, 2, 3] | ["a", "b", "c"]` and returns `[1 | "a", 2 | "b", 3 | "c"]`
+     */
+    type Flatten<T, Copy extends T = T> = { [Key in keyof T]: Copy[Key] };
+  }
+
   /**
    * Runs a test.
    *
@@ -418,10 +427,16 @@ declare module "bun:test" {
    *
    * @category Testing
    */
-  export interface Test<T extends Readonly<any[]>> {
+  export interface Test<T extends ReadonlyArray<unknown>> {
     (
       label: string,
-      fn: (...args: IsTuple<T> extends true ? [...T, (err?: unknown) => void] : T) => void | Promise<unknown>,
+
+      fn: (
+        ...args: __internal.IsTuple<T> extends true
+          ? [...table: __internal.Flatten<T>, done: (err?: unknown) => void]
+          : T
+      ) => void | Promise<unknown>,
+
       /**
        * - If a `number`, sets the timeout for the test in milliseconds.
        * - If an `object`, sets the options for the test.
@@ -513,8 +528,8 @@ declare module "bun:test" {
      *
      * @param table Array of Arrays with the arguments that are passed into the test fn for each row.
      */
-    each<T extends Readonly<[any, ...any[]]>>(table: readonly T[]): Test<[...T]>;
-    each<T extends any[]>(table: readonly T[]): Test<[...T]>;
+    each<T extends Readonly<[unknown, ...unknown[]]>>(table: readonly T[]): Test<[...T]>;
+    each<T extends unknown[]>(table: readonly T[]): Test<[...T]>;
     each<T>(table: T[]): Test<[T]>;
   }
   /**

--- a/test/integration/bun-types/fixture/23347.test.ts
+++ b/test/integration/bun-types/fixture/23347.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+
+const eachWithDifferingTypes = test.each([
+  ["hello", "world"],
+  ["hello", 2],
+]);
+
+eachWithDifferingTypes("each with differing types", (a, b) => {
+  expect(typeof a).toBe("string");
+  expect(["world", 2]).toContain(b);
+});
+
+const eachWithConst = test.each([
+  ["hello", "world"],
+  ["hello", "alistair"],
+] as const);
+
+eachWithConst("each with `as const`", (a, b) => {
+  expect(a).toBe("hello");
+  expect(["world", "alistair"]).toContain(b);
+});
+
+const eachWithConstAndDifferingTypes = test.each([
+  ["hello", "world"],
+  ["hello", 2],
+] as const);
+
+eachWithConstAndDifferingTypes("each with `as const` and differing types", (a, b) => {
+  expect(a).toBe("hello");
+  expect(["world", 2]).toContain(b);
+});

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -122,6 +122,9 @@ const data = [
   ["a", true, 5],
   ["b", false, "asdf"],
 ];
+
+const a = test.each(data);
+
 test.each(data)("test.each", (a, b, c) => {
   expectType<string | number | boolean | ((err?: unknown) => void)>(a);
   expectType<string | number | boolean | ((err?: unknown) => void)>(b);

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -123,8 +123,6 @@ const data = [
   ["b", false, "asdf"],
 ];
 
-const a = test.each(data);
-
 test.each(data)("test.each", (a, b, c) => {
   expectType<string | number | boolean | ((err?: unknown) => void)>(a);
   expectType<string | number | boolean | ((err?: unknown) => void)>(b);


### PR DESCRIPTION
### What does this PR do?

Fixes #23347

Flattens the values of an `as const` array or tuple of different values so that the test fn callback doesn't have to declare itself as supporting both, which is an impossible state to represent

### How did you verify your code works?

bun-types integration test passes