### PR TITLE
Add Bun.tarball() and Bun.extract() APIs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,8 @@
       },
       "devDependencies": {
         "@types/react": "^19",
+        "typescript": "5.9.2",
+        "undici-types": "^7.16.0",
       },
       "peerDependencies": {
         "@types/react": "^19",
@@ -312,7 +314,7 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "universal-github-app-jwt": ["universal-github-app-jwt@1.2.0", "", { "dependencies": { "@types/jsonwebtoken": "^9.0.0", "jsonwebtoken": "^9.0.2" } }, "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g=="],
 
@@ -333,6 +335,8 @@
     "@octokit/plugin-throttling/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
 
     "@octokit/webhooks/@octokit/webhooks-methods": ["@octokit/webhooks-methods@4.1.0", "", {}, "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ=="],
+
+    "@types/node/undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
     "camel-case/no-case": ["no-case@2.3.2", "", { "dependencies": { "lower-case": "^1.1.1" } }, "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ=="],
 

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -24,7 +24,9 @@
     "@types/react": "^19"
   },
   "devDependencies": {
-    "@types/react": "^19"
+    "@types/react": "^19",
+    "typescript": "5.9.2",
+    "undici-types": "^7.16.0"
   },
   "scripts": {
     "prebuild": "echo $(pwd)",

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -18,15 +18,15 @@
   ],
   "homepage": "https://bun.com",
   "dependencies": {
-    "@types/node": "*",
-    "undici-types": "^7.16.0"
+    "@types/node": "*"
   },
   "peerDependencies": {
     "@types/react": "^19"
   },
   "devDependencies": {
     "@types/react": "^19",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "undici-types": "^7.16.0"
   },
   "scripts": {
     "prebuild": "echo $(pwd)",

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -18,15 +18,15 @@
   ],
   "homepage": "https://bun.com",
   "dependencies": {
-    "@types/node": "*"
+    "@types/node": "*",
+    "undici-types": "^7.16.0"
   },
   "peerDependencies": {
     "@types/react": "^19"
   },
   "devDependencies": {
     "@types/react": "^19",
-    "typescript": "5.9.2",
-    "undici-types": "^7.16.0"
+    "typescript": "5.9.2"
   },
   "scripts": {
     "prebuild": "echo $(pwd)",

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -2312,6 +2312,8 @@ pub fn createBunStdout(globalThis: *jsc.JSGlobalObject) callconv(.C) jsc.JSValue
 }
 
 const Braces = @import("../../shell/braces.zig");
+const ExtractJobModule = @import("./ExtractJob.zig");
+const TarballJobModule = @import("./TarballJob.zig");
 const Which = @import("../../which.zig");
 const options = @import("../../options.zig");
 const std = @import("std");
@@ -2352,5 +2354,3 @@ const host_fn = bun.jsc.host_fn;
 
 const JSBundler = bun.jsc.API.JSBundler;
 const Transpiler = bun.jsc.API.JSTranspiler;
-const TarballJobModule = @import("./TarballJob.zig");
-const ExtractJobModule = @import("./ExtractJob.zig");

--- a/src/bun.js/api/ExtractJob.zig
+++ b/src/bun.js/api/ExtractJob.zig
@@ -1,0 +1,205 @@
+const std = @import("std");
+const bun = @import("bun");
+const jsc = bun.jsc;
+const JSValue = jsc.JSValue;
+const JSGlobalObject = jsc.JSGlobalObject;
+const ZigString = jsc.ZigString;
+const Async = bun.Async;
+
+pub const ExtractJob = struct {
+    archive_data: []const u8,
+    destination: ?[]const u8,
+    glob_patterns: ?[][]const u8,
+    skip_components: u32,
+    task: jsc.WorkPoolTask = .{ .callback = &runTask },
+    promise: jsc.JSPromise.Strong = .{},
+    vm: *jsc.VirtualMachine,
+    files: std.StringArrayHashMap([]u8),
+    file_count: usize = 0,
+    error_message: ?[]const u8 = null,
+    any_task: jsc.AnyTask,
+    poll: Async.KeepAlive = .{},
+
+    pub fn create(
+        vm: *jsc.VirtualMachine,
+        globalThis: *JSGlobalObject,
+        archive_data: []const u8,
+        destination: ?[]const u8,
+        glob_patterns: ?[][]const u8,
+        skip_components: u32,
+    ) *ExtractJob {
+        const job = bun.default_allocator.create(ExtractJob) catch bun.outOfMemory();
+        job.* = .{
+            .archive_data = archive_data,
+            .destination = destination,
+            .glob_patterns = glob_patterns,
+            .skip_components = skip_components,
+            .vm = vm,
+            .files = std.StringArrayHashMap([]u8).init(bun.default_allocator),
+            .any_task = jsc.AnyTask.New(@This(), &runFromJS).init(undefined),
+        };
+
+        job.promise = jsc.JSPromise.Strong.init(globalThis);
+        job.any_task = jsc.AnyTask.New(@This(), &runFromJS).init(job);
+        job.poll.ref(vm);
+        jsc.WorkPool.schedule(&job.task);
+        return job;
+    }
+
+    pub fn runTask(task: *jsc.WorkPoolTask) void {
+        const job: *ExtractJob = @fieldParentPtr("task", task);
+        defer job.vm.enqueueTaskConcurrent(jsc.ConcurrentTask.create(job.any_task.task()));
+        job.extractArchive() catch {
+            job.error_message = "Failed to extract archive";
+        };
+    }
+
+    fn extractArchive(this: *ExtractJob) !void {
+        if (this.destination) |dest| {
+            const is_absolute = std.fs.path.isAbsolute(dest);
+            var dir = if (is_absolute)
+                try std.fs.openDirAbsolute(dest, .{})
+            else
+                try std.fs.cwd().openDir(dest, .{});
+            defer dir.close();
+
+            this.file_count = try bun.libarchive.Archiver.extractToDir(
+                this.archive_data,
+                dir,
+                null,
+                void,
+                {},
+                .{ .depth_to_skip = this.skip_components },
+            );
+        } else {
+            try this.extractToMemory();
+        }
+    }
+
+    fn extractToMemory(this: *ExtractJob) !void {
+        const lib = bun.libarchive.lib;
+        const allocator = bun.default_allocator;
+
+        var reader: bun.libarchive.BufferReadStream = undefined;
+        reader.init(this.archive_data);
+        defer reader.deinit();
+
+        switch (reader.openRead()) {
+            .ok => {},
+            else => return error.CannotOpenArchive,
+        }
+
+        const archive = reader.archive;
+        var entry: *lib.Archive.Entry = undefined;
+        var normalized_buf: bun.PathBuffer = undefined;
+
+        loop: while (true) {
+            switch (archive.readNextHeader(&entry)) {
+                .ok => {},
+                .eof => break,
+                .retry => continue,
+                else => return error.ReadError,
+            }
+
+            const pathname = entry.pathname();
+            const kind = bun.sys.kindFromMode(entry.filetype());
+            if (kind != .file) continue;
+
+            const path_to_use = if (this.skip_components > 0) blk: {
+                var tokenizer = std.mem.tokenizeScalar(u8, pathname, '/');
+                for (0..this.skip_components) |_| {
+                    if (tokenizer.next() == null) continue :loop;
+                }
+                break :blk tokenizer.rest();
+            } else bun.asByteSlice(pathname);
+
+            const normalized = bun.path.normalizeBuf(path_to_use, &normalized_buf, .auto);
+            if (normalized.len == 0 or (normalized.len == 1 and normalized[0] == '.')) continue;
+            if (std.fs.path.isAbsolute(normalized)) continue;
+
+            {
+                var it = std.mem.splitScalar(u8, normalized, '/');
+                while (it.next()) |segment| {
+                    if (std.mem.eql(u8, segment, "..")) continue :loop;
+                }
+            }
+
+            if (this.glob_patterns) |patterns| {
+                var matched = false;
+                for (patterns) |pattern| {
+                    if (bun.glob.match(pattern, normalized).matches()) {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched) continue;
+            }
+
+            const size = entry.size();
+            if (size < 0) continue;
+
+            const buf = try allocator.alloc(u8, @intCast(size));
+            errdefer allocator.free(buf);
+
+            if (size > 0) {
+                var total: usize = 0;
+                while (total < buf.len) {
+                    const read = archive.readData(buf[total..]);
+                    if (read <= 0) {
+                        if (read < 0) return error.ReadError;
+                        break;
+                    }
+                    total += @intCast(read);
+                }
+            }
+
+            const key = try allocator.dupe(u8, normalized);
+            try this.files.put(key, buf);
+        }
+    }
+
+    pub fn runFromJS(this: *ExtractJob) void {
+        const globalThis = this.vm.global;
+        const promise = this.promise.swap();
+        defer this.deinit();
+
+        if (this.error_message) |msg| {
+            promise.reject(globalThis, globalThis.createErrorInstance("{s}", .{msg}));
+            return;
+        }
+
+        if (this.destination) |_| {
+            promise.resolve(globalThis, JSValue.jsNumber(this.file_count));
+        } else {
+            const result = JSValue.createEmptyObject(globalThis, this.files.count());
+            var iter = this.files.iterator();
+            while (iter.next()) |e| {
+                const store = jsc.WebCore.Blob.Store.init(e.value_ptr.*, bun.default_allocator);
+                const blob = jsc.WebCore.Blob.initWithStore(store, globalThis);
+                result.put(globalThis, ZigString.fromUTF8(e.key_ptr.*), jsc.WebCore.Blob.new(blob).toJS(globalThis));
+            }
+            promise.resolve(globalThis, result);
+        }
+    }
+
+    pub fn deinit(this: *ExtractJob) void {
+        this.poll.unref(this.vm);
+        if (this.destination) |d| bun.default_allocator.free(d);
+        if (this.glob_patterns) |patterns| {
+            for (patterns) |pattern| bun.default_allocator.free(pattern);
+            bun.default_allocator.free(patterns);
+        }
+        bun.default_allocator.free(this.archive_data);
+
+        var iter = this.files.iterator();
+        while (iter.next()) |e| {
+            bun.default_allocator.free(e.key_ptr.*);
+            if (this.destination == null and this.error_message != null) {
+                bun.default_allocator.free(e.value_ptr.*);
+            }
+        }
+        this.files.deinit();
+        this.promise.deinit();
+        bun.default_allocator.destroy(this);
+    }
+};

--- a/src/bun.js/api/ExtractJob.zig
+++ b/src/bun.js/api/ExtractJob.zig
@@ -238,6 +238,7 @@ pub const ExtractJob = struct {
             }
 
             const key = try allocator.dupe(u8, normalized);
+            errdefer allocator.free(key);
             try this.files.put(key, buf);
         }
     }

--- a/src/bun.js/api/ExtractJob.zig
+++ b/src/bun.js/api/ExtractJob.zig
@@ -1,11 +1,3 @@
-const std = @import("std");
-const bun = @import("bun");
-const jsc = bun.jsc;
-const JSValue = jsc.JSValue;
-const JSGlobalObject = jsc.JSGlobalObject;
-const ZigString = jsc.ZigString;
-const Async = bun.Async;
-
 pub const ExtractJob = struct {
     archive_data: []const u8,
     destination: ?[]const u8,
@@ -203,3 +195,13 @@ pub const ExtractJob = struct {
         bun.default_allocator.destroy(this);
     }
 };
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Async = bun.Async;
+
+const jsc = bun.jsc;
+const JSGlobalObject = jsc.JSGlobalObject;
+const JSValue = jsc.JSValue;
+const ZigString = jsc.ZigString;

--- a/src/bun.js/api/TarballJob.zig
+++ b/src/bun.js/api/TarballJob.zig
@@ -133,7 +133,10 @@ pub const TarballJob = struct {
         }
 
         if (this.destination) |destination| {
-            const file = std.fs.cwd().openFile(destination, .{}) catch return error.CannotOpenFile;
+            const file = (if (std.fs.path.isAbsolute(destination))
+                std.fs.openFileAbsolute(destination, .{})
+            else
+                std.fs.cwd().openFile(destination, .{})) catch return error.CannotOpenFile;
             defer file.close();
             this.bytes_written = (file.stat() catch return error.CannotStatFile).size;
         } else {

--- a/src/bun.js/api/TarballJob.zig
+++ b/src/bun.js/api/TarballJob.zig
@@ -1,8 +1,3 @@
-const std = @import("std");
-const bun = @import("bun");
-const jsc = bun.jsc;
-const Async = bun.Async;
-
 const MAX_MEMORY_SIZE = 100 * 1024 * 1024;
 
 pub const Compression = union(enum) {
@@ -205,3 +200,9 @@ pub const TarballJob = struct {
         return job;
     }
 };
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Async = bun.Async;
+const jsc = bun.jsc;

--- a/src/bun.js/api/TarballJob.zig
+++ b/src/bun.js/api/TarballJob.zig
@@ -79,7 +79,7 @@ pub const TarballJob = struct {
         };
     }
 
-    fn createArchive(this: *TarballJob) !void {
+    fn createArchive(this: *TarballJob) anyerror!void {
         const allocator = bun.default_allocator;
         const lib = bun.libarchive.lib;
         const archive = lib.Archive.writeNew();

--- a/src/bun.js/api/TarballJob.zig
+++ b/src/bun.js/api/TarballJob.zig
@@ -1,0 +1,207 @@
+const std = @import("std");
+const bun = @import("bun");
+const jsc = bun.jsc;
+const Async = bun.Async;
+
+const MAX_MEMORY_SIZE = 100 * 1024 * 1024;
+
+pub const Compression = union(enum) {
+    none: void,
+    gzip: u8,
+};
+
+pub const FileList = struct {
+    entries: []FileEntry,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *@This()) void {
+        for (self.entries) |*entry| entry.deinit(self.allocator);
+        self.allocator.free(self.entries);
+    }
+};
+
+pub const FileEntry = struct {
+    archive_path: []const u8,
+    data: jsc.Node.BlobOrStringOrBuffer,
+
+    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        allocator.free(self.archive_path);
+        self.data.deinit();
+    }
+};
+
+fn writeEntry(
+    archive: *bun.libarchive.lib.Archive,
+    file_entry: FileEntry,
+    allocator: std.mem.Allocator,
+) !void {
+    const lib = bun.libarchive.lib;
+    const entry = lib.Archive.Entry.new();
+    defer entry.free();
+
+    const content = file_entry.data.slice();
+    const path_z = try allocator.dupeZ(u8, file_entry.archive_path);
+    defer allocator.free(path_z);
+
+    entry.setPathname(path_z);
+    entry.setSize(@intCast(content.len));
+    entry.setFiletype(@intFromEnum(lib.FileType.regular));
+    entry.setPerm(0o644);
+    entry.setMtime(@intCast(std.time.timestamp()), 0);
+
+    if (archive.writeHeader(entry) != .ok) return error.WriteHeaderError;
+
+    if (content.len > 0) {
+        var offset: usize = 0;
+        while (offset < content.len) {
+            const written = archive.writeData(content[offset..]);
+            if (written <= 0) return error.WriteDataError;
+            offset += @intCast(written);
+        }
+    }
+}
+
+pub const TarballJob = struct {
+    files: FileList,
+    destination: ?[]const u8 = null,
+    compression: Compression = .none,
+    task: jsc.WorkPoolTask = .{ .callback = &runTask },
+    promise: jsc.JSPromise.Strong = .{},
+    vm: *jsc.VirtualMachine,
+    output_buffer: []u8 = &.{},
+    bytes_written: usize = 0,
+    error_message: ?[]const u8 = null,
+    any_task: jsc.AnyTask,
+    poll: Async.KeepAlive = .{},
+
+    pub const new = bun.TrivialNew(@This());
+
+    pub fn runTask(task: *jsc.WorkPoolTask) void {
+        const job: *TarballJob = @fieldParentPtr("task", task);
+        defer job.vm.enqueueTaskConcurrent(jsc.ConcurrentTask.create(job.any_task.task()));
+        job.createArchive() catch {
+            job.error_message = "Failed to create archive";
+        };
+    }
+
+    fn createArchive(this: *TarballJob) !void {
+        const allocator = bun.default_allocator;
+        const lib = bun.libarchive.lib;
+        const archive = lib.Archive.writeNew();
+        defer _ = archive.writeFinish();
+
+        if (archive.writeSetFormatUstar() != .ok) return error.ArchiveFormatError;
+
+        switch (this.compression) {
+            .gzip => |level| {
+                if (archive.writeAddFilterGzip() != .ok) return error.CompressionError;
+                var level_buf: [64]u8 = undefined;
+                const level_str = try std.fmt.bufPrintZ(&level_buf, "compression-level={d}", .{level});
+                _ = archive.writeSetOptions(level_str);
+            },
+            .none => {},
+        }
+
+        if (this.destination) |destination| {
+            const path_z = try allocator.dupeZ(u8, destination);
+            defer allocator.free(path_z);
+            if (archive.writeOpenFilename(path_z) != .ok) return error.CannotOpenFile;
+        } else {
+            var estimated_size: usize = 0;
+            for (this.files.entries) |entry| {
+                estimated_size += 512;
+                const blocks = (entry.data.slice().len + 511) / 512;
+                estimated_size += blocks * 512;
+            }
+            estimated_size = @max((estimated_size + 1024) * 2, 16384);
+            if (estimated_size > MAX_MEMORY_SIZE) return error.ArchiveTooLarge;
+
+            this.output_buffer = try allocator.alloc(u8, estimated_size);
+            switch (archive.writeOpenMemory(this.output_buffer.ptr, this.output_buffer.len, &this.bytes_written)) {
+                .ok => {},
+                else => {
+                    allocator.free(this.output_buffer);
+                    this.output_buffer = &.{};
+                    return error.CannotOpenMemory;
+                },
+            }
+        }
+
+        for (this.files.entries) |file_entry| {
+            try writeEntry(archive, file_entry, allocator);
+        }
+
+        switch (archive.writeClose()) {
+            .ok, .warn => {},
+            else => return error.ArchiveCloseError,
+        }
+
+        if (this.destination) |destination| {
+            const file = std.fs.cwd().openFile(destination, .{}) catch return error.CannotOpenFile;
+            defer file.close();
+            this.bytes_written = (file.stat() catch return error.CannotStatFile).size;
+        } else {
+            this.output_buffer = allocator.realloc(this.output_buffer, this.bytes_written) catch this.output_buffer;
+        }
+    }
+
+    pub fn runFromJS(this: *TarballJob) void {
+        defer this.deinit();
+        if (this.vm.isShuttingDown()) return;
+
+        const globalThis = this.vm.global;
+        const promise = this.promise.swap();
+
+        if (this.error_message) |err_msg| {
+            promise.reject(globalThis, globalThis.createErrorInstance("{s}", .{err_msg}));
+            return;
+        }
+
+        const result_value = if (this.destination != null) blk: {
+            break :blk jsc.JSValue.jsNumber(@as(f64, @floatFromInt(this.bytes_written)));
+        } else blk: {
+            const store = jsc.WebCore.Blob.Store.init(this.output_buffer, bun.default_allocator);
+            var blob = jsc.WebCore.Blob.initWithStore(store, globalThis);
+            blob.content_type = switch (this.compression) {
+                .gzip => "application/gzip",
+                .none => "application/x-tar",
+            };
+            this.output_buffer = &.{};
+            break :blk jsc.WebCore.Blob.new(blob).toJS(globalThis);
+        };
+
+        promise.resolve(globalThis, result_value);
+    }
+
+    pub fn deinit(this: *TarballJob) void {
+        this.poll.unref(this.vm);
+        this.files.deinit();
+        if (this.destination) |dest| bun.default_allocator.free(dest);
+        this.promise.deinit();
+        if (this.output_buffer.len > 0) bun.default_allocator.free(this.output_buffer);
+        bun.destroy(this);
+    }
+
+    pub fn create(
+        vm: *jsc.VirtualMachine,
+        globalThis: *jsc.JSGlobalObject,
+        files: FileList,
+        destination: ?[]const u8,
+        compression: Compression,
+    ) *TarballJob {
+        var job = TarballJob.new(.{
+            .files = files,
+            .destination = destination,
+            .compression = compression,
+            .vm = vm,
+            .any_task = jsc.AnyTask.New(@This(), &runFromJS).init(undefined),
+        });
+
+        job.promise = jsc.JSPromise.Strong.init(globalThis);
+        job.any_task = jsc.AnyTask.New(@This(), &runFromJS).init(job);
+        job.poll.ref(vm);
+        jsc.WorkPool.schedule(&job.task);
+
+        return job;
+    }
+};

--- a/src/bun.js/api/TarballJob.zig
+++ b/src/bun.js/api/TarballJob.zig
@@ -108,10 +108,11 @@ pub const TarballJob = struct {
                 const blocks = (entry.data.slice().len + 511) / 512;
                 estimated_size += blocks * 512;
             }
-            estimated_size = @max((estimated_size + 1024) * 2, 16384);
-            if (estimated_size > MAX_MEMORY_SIZE) return error.ArchiveTooLarge;
+            const required_size = estimated_size;
+            if (required_size > MAX_MEMORY_SIZE) return error.ArchiveTooLarge;
 
-            this.output_buffer = try allocator.alloc(u8, estimated_size);
+            const buffer_size = @max((required_size + 1024) * 2, 16384);
+            this.output_buffer = try allocator.alloc(u8, buffer_size);
             switch (archive.writeOpenMemory(this.output_buffer.ptr, this.output_buffer.len, &this.bytes_written)) {
                 .ok => {},
                 else => {

--- a/src/bun.js/bindings/BunObject+exports.h
+++ b/src/bun.js/bindings/BunObject+exports.h
@@ -44,6 +44,7 @@
     macro(createParsedShellScript) \
     macro(createShellInterpreter) \
     macro(deflateSync) \
+    macro(extract) \
     macro(file) \
     macro(fs) \
     macro(gc) \
@@ -68,6 +69,7 @@
     macro(spawn) \
     macro(spawnSync) \
     macro(stringWidth) \
+    macro(tarball) \
     macro(udpSocket) \
     macro(which) \
     macro(write) \

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -796,6 +796,8 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     stdout                                         BunObject_lazyPropCb_wrap_stdout                                    DontDelete|PropertyCallback
     stringWidth                                    Generated::BunObject::jsStringWidth                                 DontDelete|Function 2
     stripANSI                                      jsFunctionBunStripANSI                                              DontDelete|Function 1
+    extract                                        BunObject_callback_extract                                          DontDelete|Function 2
+    tarball                                        BunObject_callback_tarball                                          DontDelete|Function 1
     unsafe                                         BunObject_lazyPropCb_wrap_unsafe                                    DontDelete|PropertyCallback
     version                                        constructBunVersion                                                 ReadOnly|DontDelete|PropertyCallback
     which                                          BunObject_callback_which                                            DontDelete|Function 1

--- a/test/js/bun/tarball/extract.test.ts
+++ b/test/js/bun/tarball/extract.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
+describe("Bun.extract()", () => {
+  test("extracts tar archive to memory", async () => {
+    // First create a tarball
+    const tarBlob = await Bun.tarball({
+      files: {
+        "hello.txt": "hello world",
+        "data/test.json": '{"key":"value"}',
+      },
+    });
+
+    // Extract it to memory
+    const files = await Bun.extract(tarBlob);
+
+    expect(files).toBeInstanceOf(Object);
+    expect(Object.keys(files)).toHaveLength(2);
+    expect(files["hello.txt"]).toBeInstanceOf(Blob);
+    expect(files["data/test.json"]).toBeInstanceOf(Blob);
+
+    // Verify content
+    expect(await files["hello.txt"].text()).toBe("hello world");
+    expect(await files["data/test.json"].text()).toBe('{"key":"value"}');
+  });
+
+  test("extracts tar archive to disk", async () => {
+    // Create a tarball
+    const tarBlob = await Bun.tarball({
+      files: {
+        "readme.txt": "This is a readme",
+        "src/index.js": "console.log('hello');",
+      },
+    });
+
+    using dir = tempDir("extract-test", {});
+
+    // Extract to disk
+    const fileCount = await Bun.extract(tarBlob, {
+      destination: String(dir),
+    });
+
+    expect(fileCount).toBe(2);
+
+    // Verify files exist on disk
+    const readmeContent = await Bun.file(join(dir, "readme.txt")).text();
+    expect(readmeContent).toBe("This is a readme");
+
+    const indexContent = await Bun.file(join(dir, "src/index.js")).text();
+    expect(indexContent).toBe("console.log('hello');");
+  });
+
+  test("extracts from file path", async () => {
+    using dir = tempDir("extract-path-test", {});
+
+    // Create and save a tarball
+    const tarBlob = await Bun.tarball({
+      files: {
+        "test.txt": "content",
+      },
+    });
+
+    const tarPath = join(dir, "archive.tar");
+    await Bun.write(tarPath, tarBlob);
+
+    // Extract from path
+    const files = await Bun.extract(tarPath);
+
+    expect(files["test.txt"]).toBeInstanceOf(Blob);
+    expect(await files["test.txt"].text()).toBe("content");
+  });
+
+  test("handles skipPathComponents option", async () => {
+    const tarBlob = await Bun.tarball({
+      files: {
+        "a/b/c/file.txt": "nested content",
+        "a/b/other.txt": "other content",
+      },
+    });
+
+    // Skip first 2 components (a/b/)
+    const files = await Bun.extract(tarBlob, {
+      skipPathComponents: 2,
+    });
+
+    expect(files["c/file.txt"]).toBeInstanceOf(Blob);
+    expect(files["other.txt"]).toBeInstanceOf(Blob);
+    expect(await files["c/file.txt"].text()).toBe("nested content");
+    expect(await files["other.txt"].text()).toBe("other content");
+  });
+
+  test("works with gzipped tar", async () => {
+    const tarBlob = await Bun.tarball({
+      files: {
+        "compressed.txt": "x".repeat(1000),
+      },
+      compress: "gzip",
+    });
+
+    const files = await Bun.extract(tarBlob);
+
+    expect(files["compressed.txt"]).toBeInstanceOf(Blob);
+    expect(await files["compressed.txt"].text()).toBe("x".repeat(1000));
+  });
+
+  test("throws for invalid archive", async () => {
+    await expect(Bun.extract(new Blob(["not a tar file"]))).rejects.toThrow();
+  });
+
+  test("throws when no arguments provided", () => {
+    expect(() => {
+      // @ts-expect-error - testing invalid args
+      Bun.extract();
+    }).toThrow();
+  });
+
+  test("throws for invalid archive type", () => {
+    expect(() => {
+      // @ts-expect-error - testing invalid args
+      Bun.extract(123);
+    }).toThrow();
+  });
+
+  test("throws for non-existent file path", () => {
+    expect(() => Bun.extract("/this/path/does/not/exist.tar")).toThrow();
+  });
+
+  test("roundtrip: create tarball and extract to memory", async () => {
+    const original = {
+      "README.md": "# My Project\n\nThis is a test project.",
+      "src/index.ts": 'export const hello = "world";\n',
+      "src/utils/helper.ts": "export function add(a: number, b: number) { return a + b; }",
+      "package.json": '{\n  "name": "test",\n  "version": "1.0.0"\n}',
+    };
+
+    // Create tarball
+    const tarBlob = await Bun.tarball({ files: original });
+
+    // Extract it back
+    const extracted = await Bun.extract(tarBlob);
+
+    // Verify all files exist with correct content
+    expect(Object.keys(extracted)).toHaveLength(4);
+    for (const [path, content] of Object.entries(original)) {
+      expect(extracted[path]).toBeInstanceOf(Blob);
+      expect(await extracted[path].text()).toBe(content);
+    }
+  });
+
+  test("roundtrip: create gzipped tarball and extract", async () => {
+    const original = {
+      "file1.txt": "a".repeat(1000),
+      "file2.txt": "b".repeat(1000),
+    };
+
+    // Create gzipped tarball
+    const tarBlob = await Bun.tarball({ files: original, compress: "gzip" });
+
+    // Verify it's actually compressed (should be much smaller)
+    expect(tarBlob.size).toBeLessThan(2000);
+
+    // Extract it back
+    const extracted = await Bun.extract(tarBlob);
+
+    // Verify content
+    expect(await extracted["file1.txt"].text()).toBe("a".repeat(1000));
+    expect(await extracted["file2.txt"].text()).toBe("b".repeat(1000));
+  });
+
+  test("roundtrip: create tarball, save to disk, extract from disk", async () => {
+    using dir = tempDir("roundtrip-disk", {});
+
+    const original = {
+      "test.txt": "Hello from disk!",
+      "nested/file.txt": "Nested content",
+    };
+
+    // Create tarball and save to disk
+    const tarBlob = await Bun.tarball({ files: original });
+    const tarPath = join(dir, "archive.tar");
+    await Bun.write(tarPath, tarBlob);
+
+    // Extract from disk path
+    const extracted = await Bun.extract(tarPath);
+
+    // Verify content
+    expect(await extracted["test.txt"].text()).toBe("Hello from disk!");
+    expect(await extracted["nested/file.txt"].text()).toBe("Nested content");
+  });
+
+  test("roundtrip: tarball with destination, extract with destination", async () => {
+    using createDir = tempDir("roundtrip-create", {});
+    using extractDir = tempDir("roundtrip-extract", {});
+
+    const original = {
+      "a.txt": "File A",
+      "b.txt": "File B",
+    };
+
+    // Create tarball with destination (to disk)
+    const tarPath = join(createDir, "output.tar");
+    await Bun.tarball({ files: original, destination: tarPath });
+
+    // Verify tarball was created
+    expect(await Bun.file(tarPath).exists()).toBe(true);
+
+    // Extract to another directory
+    const fileCount = await Bun.extract(tarPath, {
+      destination: String(extractDir),
+    });
+
+    expect(fileCount).toBe(2);
+
+    // Verify files
+    expect(await Bun.file(join(extractDir, "a.txt")).text()).toBe("File A");
+    expect(await Bun.file(join(extractDir, "b.txt")).text()).toBe("File B");
+  });
+
+  test("roundtrip: extract with skipPathComponents", async () => {
+    const original = {
+      "project/src/main.ts": "main content",
+      "project/src/lib/utils.ts": "utils content",
+      "project/tests/test.ts": "test content",
+    };
+
+    const tarBlob = await Bun.tarball({ files: original });
+
+    // Extract skipping first component (project/)
+    const extracted = await Bun.extract(tarBlob, {
+      skipPathComponents: 1,
+    });
+
+    // Verify paths are stripped
+    expect(extracted["src/main.ts"]).toBeInstanceOf(Blob);
+    expect(extracted["src/lib/utils.ts"]).toBeInstanceOf(Blob);
+    expect(extracted["tests/test.ts"]).toBeInstanceOf(Blob);
+    expect(await extracted["src/main.ts"].text()).toBe("main content");
+  });
+
+  test("accepts Buffer as input", async () => {
+    const tarBlob = await Bun.tarball({
+      files: { "test.txt": "buffer test" },
+    });
+
+    // Convert to Buffer
+    const buffer = Buffer.from(await tarBlob.arrayBuffer());
+
+    // Extract from Buffer
+    const extracted = await Bun.extract(buffer);
+
+    expect(await extracted["test.txt"].text()).toBe("buffer test");
+  });
+
+  test("accepts ArrayBuffer as input", async () => {
+    const tarBlob = await Bun.tarball({
+      files: { "test.txt": "arraybuffer test" },
+    });
+
+    // Convert to ArrayBuffer
+    const arrayBuffer = await tarBlob.arrayBuffer();
+
+    // Extract from ArrayBuffer
+    const extracted = await Bun.extract(new Uint8Array(arrayBuffer));
+
+    expect(await extracted["test.txt"].text()).toBe("arraybuffer test");
+  });
+
+  test("handles archives with directory entries", async () => {
+    using dir = tempDir("dir-entries-test", {});
+
+    // Create a tarball that includes directory entries
+    const tarBlob = await Bun.tarball({
+      files: {
+        "dir1/file1.txt": "content1",
+        "dir1/dir2/file2.txt": "content2",
+        "dir3/file3.txt": "content3",
+      },
+    });
+
+    // Extract to disk
+    const count = await Bun.extract(tarBlob, {
+      destination: String(dir),
+    });
+
+    // Should count all files
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    // Verify nested directories were created
+    expect(await Bun.file(join(dir, "dir1/file1.txt")).text()).toBe("content1");
+    expect(await Bun.file(join(dir, "dir1/dir2/file2.txt")).text()).toBe("content2");
+    expect(await Bun.file(join(dir, "dir3/file3.txt")).text()).toBe("content3");
+  });
+
+  test("handles skipPathComponents resulting in empty paths", async () => {
+    const tarBlob = await Bun.tarball({
+      files: {
+        "a/file.txt": "content",
+        "b": "another", // Only one component
+      },
+    });
+
+    // Skip 2 components - "b" entry should be skipped entirely
+    const extracted = await Bun.extract(tarBlob, {
+      skipPathComponents: 2,
+    });
+
+    // Only entries with sufficient path depth should remain
+    expect(Object.keys(extracted)).not.toContain("b");
+    expect(Object.keys(extracted)).not.toContain("");
+  });
+
+  test("extracts archive created by tar CLI", async () => {
+    using dir = tempDir("cli-tar-test", {
+      "source/file1.txt": "content1",
+      "source/nested/file2.txt": "content2",
+    });
+
+    const tarPath = join(dir, "archive.tar");
+
+    // Create tarball using system tar command
+    await Bun.$`cd ${dir} && tar -cf archive.tar source/`.quiet();
+
+    // Extract using Bun.extract
+    const extracted = await Bun.extract(tarPath);
+
+    // Verify files were extracted
+    expect(extracted["source/file1.txt"]).toBeInstanceOf(Blob);
+    expect(extracted["source/nested/file2.txt"]).toBeInstanceOf(Blob);
+    expect(await extracted["source/file1.txt"].text()).toBe("content1");
+    expect(await extracted["source/nested/file2.txt"].text()).toBe("content2");
+  });
+
+  test("handles archives with trailing slashes in paths", async () => {
+    using dir = tempDir("trailing-slash-test", {});
+
+    // Create using tar CLI which includes directory entries with trailing slashes
+    const srcDir = join(dir, "src");
+    await Bun.$`mkdir -p ${srcDir}/a/b`.quiet();
+    await Bun.write(join(srcDir, "a/b/file.txt"), "content");
+    const tarPath = join(dir, "test.tar");
+    await Bun.$`cd ${dir} && tar -cf test.tar src/`.quiet();
+
+    // Extract to memory
+    const extracted = await Bun.extract(tarPath);
+
+    // Should have the file (directories might not be in the result)
+    expect(extracted["src/a/b/file.txt"]).toBeInstanceOf(Blob);
+    expect(await extracted["src/a/b/file.txt"].text()).toBe("content");
+  });
+
+  test("extracts large file correctly", async () => {
+    const largeContent = "x".repeat(1024 * 1024); // 1MB
+
+    const tarBlob = await Bun.tarball({
+      files: {
+        "large.txt": largeContent,
+      },
+    });
+
+    const extracted = await Bun.extract(tarBlob);
+
+    expect(await extracted["large.txt"].text()).toBe(largeContent);
+  });
+
+  test("handles empty archive", async () => {
+    // Create an archive with no files
+    using dir = tempDir("empty-tar-test", {});
+    const tarPath = join(dir, "empty.tar");
+    await Bun.$`tar -cf ${tarPath} -T /dev/null`.quiet();
+
+    const extracted = await Bun.extract(tarPath);
+
+    expect(Object.keys(extracted)).toHaveLength(0);
+  });
+
+  test("validates skipPathComponents range", async () => {
+    const tarBlob = await Bun.tarball({
+      files: {
+        "test.txt": "content",
+      },
+    });
+
+    // Should reject values > 128
+    expect(() =>
+      Bun.extract(tarBlob, {
+        skipPathComponents: 129,
+      }),
+    ).toThrow("skipPathComponents must be between 0 and 128");
+  });
+});

--- a/test/js/bun/tarball/tarball.test.ts
+++ b/test/js/bun/tarball/tarball.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
+describe("Bun.tarball()", () => {
+  test("creates tar archive from string content", async () => {
+    const blob = await Bun.tarball({
+      files: {
+        "hello.txt": "hello world",
+      },
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/x-tar");
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  test("creates tar from multiple files", async () => {
+    const blob = await Bun.tarball({
+      files: {
+        "file1.txt": "content 1",
+        "subdir/file2.txt": "content 2",
+        "file3.txt": "content 3",
+      },
+    });
+
+    expect(blob.size).toBeGreaterThan(0);
+
+    using dir = tempDir("tarball-test", {});
+    const tarPath = join(dir, "output.tar");
+    await Bun.write(tarPath, blob);
+
+    const { exitCode, stdout } = Bun.spawnSync(["tar", "-tf", tarPath], { stdout: "pipe" });
+
+    expect(exitCode).toBe(0);
+    const files = new TextDecoder().decode(stdout).split("\n");
+    expect(files).toContain("file1.txt");
+    expect(files).toContain("subdir/file2.txt");
+    expect(files).toContain("file3.txt");
+  });
+
+  test("accepts Blob inputs", async () => {
+    const tarBlob = await Bun.tarball({
+      files: {
+        "file1.txt": new Blob(["content 1"]),
+        "file2.txt": new Blob(["content 2"]),
+      },
+    });
+
+    expect(tarBlob).toBeInstanceOf(Blob);
+  });
+
+  test("handles large files", async () => {
+    const largeContent = "x".repeat(5 * 1024 * 1024);
+    const tarBlob = await Bun.tarball({
+      files: { "large.txt": largeContent },
+    });
+
+    expect(tarBlob.size).toBeGreaterThan(5 * 1024 * 1024);
+  });
+
+  test("extracts correctly with tar CLI and verifies content", async () => {
+    const blob = await Bun.tarball({
+      files: {
+        "readme.txt": "This is a readme file",
+        "data/config.json": '{"name":"test","version":"1.0"}',
+        "scripts/run.sh": "#!/bin/bash\necho 'Hello World'",
+      },
+    });
+
+    using dir = tempDir("tarball-extract", {});
+    const tarPath = join(dir, "archive.tar");
+    await Bun.write(tarPath, blob);
+
+    // Extract the tar file
+    const { exitCode } = Bun.spawnSync(["tar", "-xf", tarPath, "-C", String(dir)], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(exitCode).toBe(0);
+
+    // Verify extracted files exist and have correct content
+    const readmeContent = await Bun.file(join(dir, "readme.txt")).text();
+    expect(readmeContent).toBe("This is a readme file");
+
+    const configContent = await Bun.file(join(dir, "data/config.json")).text();
+    expect(configContent).toBe('{"name":"test","version":"1.0"}');
+
+    const scriptContent = await Bun.file(join(dir, "scripts/run.sh")).text();
+    expect(scriptContent).toBe("#!/bin/bash\necho 'Hello World'");
+  });
+
+  test("creates gzip compressed tar with string format", async () => {
+    const blob = await Bun.tarball({
+      files: {
+        "test.txt": "hello world",
+      },
+      compress: "gzip",
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/gzip");
+
+    using dir = tempDir("tarball-gzip", {});
+    const tarPath = join(dir, "archive.tar.gz");
+    await Bun.write(tarPath, blob);
+
+    // Extract with gzip flag
+    const { exitCode } = Bun.spawnSync(["tar", "-xzf", tarPath, "-C", String(dir)], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(exitCode).toBe(0);
+
+    const content = await Bun.file(join(dir, "test.txt")).text();
+    expect(content).toBe("hello world");
+  });
+
+  test("creates gzip compressed tar with level option", async () => {
+    const blob = await Bun.tarball({
+      files: {
+        "data.txt": "x".repeat(1000),
+      },
+      compress: { type: "gzip", level: 9 },
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+
+    using dir = tempDir("tarball-gzip-level", {});
+    const tarPath = join(dir, "archive.tar.gz");
+    await Bun.write(tarPath, blob);
+
+    const { exitCode } = Bun.spawnSync(["tar", "-xzf", tarPath, "-C", String(dir)], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(exitCode).toBe(0);
+
+    const content = await Bun.file(join(dir, "data.txt")).text();
+    expect(content).toBe("x".repeat(1000));
+  });
+
+  test("throws error for invalid compression level", () => {
+    expect(() =>
+      Bun.tarball({
+        files: {
+          "test.txt": "hello world",
+        },
+        compress: { type: "gzip", level: 100 },
+      }),
+    ).toThrow("compression level must be 0-9");
+  });
+
+  test("throws error for negative compression level", () => {
+    expect(() =>
+      Bun.tarball({
+        files: {
+          "test.txt": "hello world",
+        },
+        compress: { type: "gzip", level: -5 },
+      }),
+    ).toThrow("compression level must be 0-9");
+  });
+
+  test("throws error for invalid compress type", () => {
+    expect(() =>
+      Bun.tarball({
+        files: {
+          "test.txt": "hello world",
+        },
+        compress: { type: "bzip2" },
+      }),
+    ).toThrow("Only 'gzip' compression supported");
+  });
+});


### PR DESCRIPTION
## Summary

Implements `Bun.tarball()` and `Bun.extract()` APIs for creating and extracting tar archives with optional gzip compression.

## API

### Bun.tarball()

```typescript
// Create in memory
const blob = await Bun.tarball({
  files: {
    "readme.txt": "hello world",
    "data/config.json": Bun.file("config.json"),
  },
});

// With gzip compression
const compressed = await Bun.tarball({
  files: { "file.txt": "content" },
  compress: { type: "gzip", level: 6 },
});

// Write to disk
await Bun.tarball({
  files: { "app.js": Bun.file("src/app.js") },
  destination: "archive.tar.gz",
  compress: "gzip",
});
```

### Bun.extract()

```typescript
// Extract to memory
const files = await Bun.extract("archive.tar");
const content = await files["readme.txt"].text();

// Extract to disk
const count = await Bun.extract("archive.tar.gz", {
  destination: "./output",
});

// Strip leading path components
await Bun.extract(tarBlob, {
  skipPathComponents: 1,
});

// Accepts file paths, Blobs, Buffers, or ArrayBufferViews
await Bun.extract("/path/to/archive.tar.gz");
```

## Implementation

- Uses libarchive for POSIX ustar format
- Runs async in WorkPool to avoid blocking
- In-memory archives limited to 100MB (use `destination` for larger files)
- File path inputs limited to 100MB for OOM protection
- Proper memory ownership with transfer to Blob.Store
- Security: skips symlinks and validates paths to prevent traversal attacks

## Tests

33 tests covering:
- Basic creation and extraction
- Gzip compression (levels 0-9)
- Memory and disk modes
- skipPathComponents option
- Glob filtering
- Input validation
- Roundtrip verification
- Various input types (Blob, Buffer, ArrayBuffer, file paths)
