### PR TITLE
Fix 23382 (unicode object key printed as 'key" in snapshot instead of "key")

### DIFF
--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -826,7 +826,7 @@ pub const JestPrettyFormat = struct {
                                 writer.writeAll(comptime Output.prettyFmt("<r><green>", true));
                             }
 
-                            writer.writeAll("'");
+                            writer.writeAll("\"");
 
                             while (strings.indexOfAny16(utf16Slice, "\"")) |j| {
                                 writer.write16Bit(utf16Slice[0..j]);

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -818,7 +818,7 @@ pub const JestPrettyFormat = struct {
                                 .{key},
                             );
                         } else if (key.is16Bit()) {
-                            var utf16Slice = key.utf16SliceAligned();
+                            const utf16Slice = key.utf16SliceAligned();
 
                             this.addForNewLine(utf16Slice.len + 2);
 
@@ -827,15 +827,7 @@ pub const JestPrettyFormat = struct {
                             }
 
                             writer.writeAll("\"");
-
-                            while (strings.indexOfAny16(utf16Slice, "\"")) |j| {
-                                writer.write16Bit(utf16Slice[0..j]);
-                                writer.writeAll("\"");
-                                utf16Slice = utf16Slice[j + 1 ..];
-                            }
-
                             writer.write16Bit(utf16Slice);
-
                             writer.print(
                                 comptime Output.prettyFmt("\"<r><d>:<r> ", enable_ansi_colors),
                                 .{},

--- a/test/regression/issue/23382.test.js
+++ b/test/regression/issue/23382.test.js
@@ -1,0 +1,7 @@
+test("correct snapshot formatting for object key with unicode", () => {
+  expect({ "▶": "▹" }).toMatchInlineSnapshot(`
+    {
+      "▶": "▹",
+    }
+  `);
+});


### PR DESCRIPTION
Fixes #23382

Breaking change because any existing snapshots that have unicode keys will need to be regenerated