### PR TITLE
fix (node:zlib): use `runCallback` for calling the error callback

### DIFF
--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -265,7 +265,9 @@ pub fn CompressionStream(comptime T: type) type {
 
             const callback: jsc.JSValue = T.js.errorCallbackGetCached(this_value) orelse
                 Output.panic("Assertion failure: cachedErrorCallback is null in node:zlib binding", .{});
-            _ = try callback.call(globalThis, this_value, &.{ msg_value, err_value, code_value });
+
+            const vm = globalThis.bunVM();
+            vm.eventLoop().runCallback(callback, globalThis, this_value, &.{ msg_value, err_value, code_value });
 
             this.write_in_progress = false;
             if (this.pending_close) _ = closeInternal(this);


### PR DESCRIPTION
### What does this PR do?
Fixes debug panic running `zlib/zlib.test.js`
### How did you verify your code works?
Manually