### PR TITLE
fix: Support options object in fs.writeSync

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2474,11 +2474,11 @@ pub const Arguments = struct {
                         const buf_len = args.buffer.buffer.slice().len;
 
                         // Check if this is an options object
-                        if (current.isObject() and !current.isCallable() and !current.isNumber() and !current.isBigInt()) {
+                        if (current.isObject() and !current.isCallable()) {
                             // Named parameters object: { offset?, length?, position? }
                             // Handle offset
                             if (try current.getTruthy(ctx, "offset")) |offset_val| {
-                                args.offset = @intCast(try jsc.Node.validators.validateInteger(ctx, offset_val, "offset", 0, 9007199254740991));
+                                args.offset = @intCast(try jsc.Node.validators.validateInteger(ctx, offset_val, "offset", 0, jsc.MAX_SAFE_INTEGER));
                             }
 
                             // Handle length
@@ -2505,7 +2505,7 @@ pub const Arguments = struct {
                             arguments.eat();
                         } else {
                             // Positional parameters: offset, length, position
-                            args.offset = @intCast(try jsc.Node.validators.validateInteger(ctx, current, "offset", 0, 9007199254740991));
+                            args.offset = @intCast(try jsc.Node.validators.validateInteger(ctx, current, "offset", 0, jsc.MAX_SAFE_INTEGER));
                             arguments.eat();
                             current = arguments.next() orelse break :parse;
 

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2478,24 +2478,25 @@ pub const Arguments = struct {
 
                             // Handle offset
                             if (try current.getTruthy(ctx, "offset")) |offset_val| {
-                                args.offset = @intCast(try jsc.Node.validators.validateInteger(ctx, offset_val, "offset", 0, 9007199254740991));
+                                const offset = @as(u64, @intCast(try jsc.Node.validators.validateInteger(ctx, offset_val, "offset", 0, 9007199254740991)));
                                 const max_offset = @min(buf_len, std.math.maxInt(i64));
-                                if (args.offset > max_offset) {
+                                if (offset > max_offset) {
                                     return ctx.throwRangeError(
-                                        @as(f64, @floatFromInt(args.offset)),
-                                        .{ .field_name = "offset", .max = @intCast(max_offset) },
+                                        @as(f64, @floatFromInt(offset)),
+                                        .{ .field_name = "offset", .max = @as(i64, @intCast(max_offset)) },
                                     );
                                 }
+                                args.offset = offset;
                             }
 
                             // Handle length
                             if (try current.getTruthy(ctx, "length")) |length_val| {
-                                const length = length_val.to(i64);
+                                const length = try jsc.Node.validators.validateInteger(ctx, length_val, "length", null, null);
                                 const max_len = @min(buf_len - args.offset, std.math.maxInt(i32));
                                 if (length > max_len or length < 0) {
                                     return ctx.throwRangeError(
                                         @as(f64, @floatFromInt(length)),
-                                        .{ .field_name = "length", .min = 0, .max = @intCast(max_len) },
+                                        .{ .field_name = "length", .min = @as(i64, 0), .max = @as(i64, @intCast(max_len)) },
                                     );
                                 }
                                 args.length = @intCast(length);

--- a/test/js/node/test/parallel/test-fs-write-sync-optional-params.js
+++ b/test/js/node/test/parallel/test-fs-write-sync-optional-params.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const common = require('../common');
+
+// This test ensures that fs.writeSync accepts "named parameters" object
+// and doesn't interpret objects as strings
+
+const assert = require('assert');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const dest = tmpdir.resolve('tmp.txt');
+const buffer = Buffer.from('zyx');
+
+function testInvalid(dest, expectedCode, ...bufferAndOptions) {
+  if (bufferAndOptions.length >= 2) {
+    bufferAndOptions[1] = common.mustNotMutateObjectDeep(bufferAndOptions[1]);
+  }
+  let fd;
+  try {
+    fd = fs.openSync(dest, 'w+');
+    assert.throws(
+      () => fs.writeSync(fd, ...bufferAndOptions),
+      { code: expectedCode });
+  } finally {
+    if (fd != null) fs.closeSync(fd);
+  }
+}
+
+function testValid(dest, buffer, options) {
+  const length = options?.length;
+  let fd, bytesWritten, bytesRead;
+
+  try {
+    fd = fs.openSync(dest, 'w');
+    bytesWritten = fs.writeSync(fd, buffer, options);
+  } finally {
+    if (fd != null) fs.closeSync(fd);
+  }
+
+  try {
+    fd = fs.openSync(dest, 'r');
+    bytesRead = fs.readSync(fd, buffer, options);
+  } finally {
+    if (fd != null) fs.closeSync(fd);
+  }
+
+  assert.ok(bytesWritten >= bytesRead);
+  if (length !== undefined && length !== null) {
+    assert.strictEqual(bytesWritten, length);
+    assert.strictEqual(bytesRead, length);
+  }
+}
+
+{
+  // Test if second argument is not wrongly interpreted as string or options
+  for (const badBuffer of [
+    undefined, null, true, 42, 42n, Symbol('42'), NaN, [], () => {},
+    common.mustNotCall(),
+    common.mustNotMutateObjectDeep({}),
+    {},
+    { buffer: 'amNotParam' },
+    { string: 'amNotParam' },
+    { buffer: new Uint8Array(1) },
+    { buffer: new Uint8Array(1).buffer },
+    Promise.resolve(new Uint8Array(1)),
+    new Date(),
+    new String('notPrimitive'),
+    { toString() { return 'amObject'; } },
+    { [Symbol.toPrimitive]: (hint) => 'amObject' },
+  ]) {
+    testInvalid(dest, 'ERR_INVALID_ARG_TYPE', common.mustNotMutateObjectDeep(badBuffer));
+  }
+
+  // First argument (buffer or string) is mandatory
+  testInvalid(dest, 'ERR_INVALID_ARG_TYPE');
+
+  // Various invalid options
+  testInvalid(dest, 'ERR_OUT_OF_RANGE', buffer, { length: 5 });
+  testInvalid(dest, 'ERR_OUT_OF_RANGE', buffer, { offset: 5 });
+  testInvalid(dest, 'ERR_OUT_OF_RANGE', buffer, { length: 1, offset: 3 });
+  testInvalid(dest, 'ERR_OUT_OF_RANGE', buffer, { length: -1 });
+  testInvalid(dest, 'ERR_OUT_OF_RANGE', buffer, { offset: -1 });
+  testInvalid(dest, 'ERR_INVALID_ARG_TYPE', buffer, { offset: false });
+  testInvalid(dest, 'ERR_INVALID_ARG_TYPE', buffer, { offset: true });
+
+  // Test compatibility with fs.readSync counterpart with reused options
+  for (const options of [
+    undefined,
+    null,
+    {},
+    { length: 1 },
+    { position: 5 },
+    { length: 1, position: 5 },
+    { length: 1, position: -1, offset: 2 },
+    { length: null },
+    { position: null },
+    { offset: 1 },
+  ]) {
+    testValid(dest, buffer, common.mustNotMutateObjectDeep(options));
+  }
+}


### PR DESCRIPTION
## Summary

- Added support for passing options as an object to `fs.writeSync()`
- Matches Node.js behavior: `fs.writeSync(fd, buffer, { offset, length, position })`
- Properly validates offset/length and throws `ERR_OUT_OF_RANGE` when values exceed buffer bounds
- Fixes Node.js test `test-fs-write-sync-optional-params.js`

## Test plan

- [x] Run `node /workspace/bun/scripts/runner.node.mjs --quiet --exec-path ./build/debug/bun-debug --node-tests fs-write-sync-optional-params.js` - test passes
- [x] Manual tests confirm proper error codes are thrown
- [x] Existing positional parameter behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)