### PR TITLE
improve(node:http):  uncork after flushing headers to ensure data is sent immediately

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -499,6 +499,8 @@ public:
             Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
         }
+        /* Uncork the socket to allow the client to send the data immediately */
+        this->uncork();
     }
     /* Write parts of the response in chunking fashion. Starts timeout if failed. */
     bool write(std::string_view data, size_t *writtenPtr = nullptr) {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -499,7 +499,7 @@ public:
             Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
         }
-        /* Uncork the socket to allow the client to send the data immediately */
+        /* Uncork the socket to send data to the client immediately */
         this->uncork();
     }
     /* Write parts of the response in chunking fashion. Starts timeout if failed. */

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -478,7 +478,7 @@ public:
         return internalEnd({nullptr, 0}, 0, false, false, closeConnection);
     }
 
-    void flushHeaders() {
+    void flushHeaders(bool flushImmediately = false) {
 
         writeStatus(HTTP_200_OK);
 
@@ -499,8 +499,10 @@ public:
             Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
         }
-        /* Uncork the socket to send data to the client immediately */
-        this->uncork();
+        if (flushImmediately) {
+            /* Uncork the socket to send data to the client immediately */
+            this->uncork();
+        }
     }
     /* Write parts of the response in chunking fashion. Starts timeout if failed. */
     bool write(std::string_view data, size_t *writtenPtr = nullptr) {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -33,7 +33,7 @@ bytes_written: usize = 0,
 
 upgrade_context: UpgradeCTX = .{},
 
-pub const Flags = packed struct(u8) {
+pub const Flags = packed struct(u16) {
     socket_closed: bool = false,
     request_has_completed: bool = false,
     ended: bool = false,
@@ -44,6 +44,7 @@ pub const Flags = packed struct(u8) {
     /// Did we receive the last chunk of data during pause?
     is_data_buffered_during_pause_last: bool = false,
     uncork_scheduled: bool = false,
+    _: u7 = 0,
 
     /// Did the user end the request?
     pub fn isRequestedCompletedOrEnded(this: *const Flags) bool {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -1070,13 +1070,6 @@ pub fn write(this: *NodeHTTPResponse, globalObject: *jsc.JSGlobalObject, callfra
     return writeOrEnd(this, globalObject, arguments, .zero, false);
 }
 
-fn uncorkSocket(this: *NodeHTTPResponse) void {
-    defer this.deref();
-    this.flags.uncork_scheduled = false;
-    if (!this.flags.socket_closed and !this.flags.upgraded and this.raw_response != null) {
-        this.raw_response.?.uncork();
-    }
-}
 pub fn onAutoFlush(this: *NodeHTTPResponse) bool {
     defer this.deref();
     if (!this.flags.socket_closed and !this.flags.upgraded and this.raw_response != null) {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -1075,6 +1075,7 @@ pub fn onAutoFlush(this: *NodeHTTPResponse) bool {
     if (!this.flags.socket_closed and !this.flags.upgraded and this.raw_response != null) {
         this.raw_response.?.uncork();
     }
+    this.auto_flusher.registered = false;
     return false;
 }
 

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -346,7 +346,7 @@ pub fn getFinished(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JS
 }
 
 pub fn getFlags(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {
-    return jsc.JSValue.jsNumber(@as(u16, @bitCast(this.flags)));
+    return jsc.JSValue.jsNumber(@as(u8, @bitCast(this.flags)));
 }
 
 pub fn getAborted(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -255,6 +255,7 @@ fn markRequestAsDone(this: *NodeHTTPResponse) void {
     const server = this.server;
     this.poll_ref.unref(jsc.VirtualMachine.get());
     this.deref();
+    this.unregisterAutoFlush();
     server.onRequestComplete();
 }
 

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -346,7 +346,7 @@ pub fn getFinished(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JS
 }
 
 pub fn getFlags(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {
-    return jsc.JSValue.jsNumber(@as(u8, @bitCast(this.flags)));
+    return jsc.JSValue.jsNumber(@as(u16, @bitCast(this.flags)));
 }
 
 pub fn getAborted(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {
@@ -1079,7 +1079,6 @@ fn uncorkSocket(this: *NodeHTTPResponse) void {
 }
 pub fn onAutoFlush(this: *NodeHTTPResponse) bool {
     defer this.deref();
-    this.flags.uncork_scheduled = false;
     if (!this.flags.socket_closed and !this.flags.upgraded and this.raw_response != null) {
         this.raw_response.?.uncork();
     }
@@ -1089,12 +1088,12 @@ pub fn onAutoFlush(this: *NodeHTTPResponse) bool {
 fn registerAutoFlush(this: *NodeHTTPResponse) void {
     if (this.auto_flusher.registered) return;
     this.ref();
-    AutoFlusher.registerDeferredMicrotaskWithTypeUnchecked(NodeHTTPResponse, this, this.globalThis.bunVM());
+    AutoFlusher.registerDeferredMicrotaskWithTypeUnchecked(NodeHTTPResponse, this, jsc.VirtualMachine.get());
 }
 
 fn unregisterAutoFlush(this: *NodeHTTPResponse) void {
     if (!this.auto_flusher.registered) return;
-    AutoFlusher.unregisterDeferredMicrotaskWithTypeUnchecked(NodeHTTPResponse, this, this.globalThis.bunVM());
+    AutoFlusher.unregisterDeferredMicrotaskWithTypeUnchecked(NodeHTTPResponse, this, jsc.VirtualMachine.get());
     this.deref();
 }
 

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -1235,7 +1235,7 @@ const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSValue = jsc.JSValue;
 const ZigString = jsc.ZigString;
+const AutoFlusher = jsc.WebCore.AutoFlusher;
 
 const AnyServer = jsc.API.AnyServer;
 const ServerWebSocket = jsc.API.ServerWebSocket;
-const AutoFlusher = jsc.WebCore.AutoFlusher;

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -346,7 +346,7 @@ pub fn getFinished(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JS
 }
 
 pub fn getFlags(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {
-    return jsc.JSValue.jsNumber(@as(u8, @bitCast(this.flags)));
+    return jsc.JSValue.jsNumber(@as(u16, @bitCast(this.flags)));
 }
 
 pub fn getAborted(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -35,7 +35,7 @@ upgrade_context: UpgradeCTX = .{},
 
 auto_flusher: AutoFlusher = .{},
 
-pub const Flags = packed struct(u16) {
+pub const Flags = packed struct(u8) {
     socket_closed: bool = false,
     request_has_completed: bool = false,
     ended: bool = false,
@@ -45,7 +45,6 @@ pub const Flags = packed struct(u16) {
     is_data_buffered_during_pause: bool = false,
     /// Did we receive the last chunk of data during pause?
     is_data_buffered_during_pause_last: bool = false,
-    _: u7 = 0,
 
     /// Did the user end the request?
     pub fn isRequestedCompletedOrEnded(this: *const Flags) bool {
@@ -347,7 +346,7 @@ pub fn getFinished(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JS
 }
 
 pub fn getFlags(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {
-    return jsc.JSValue.jsNumber(@as(u16, @bitCast(this.flags)));
+    return jsc.JSValue.jsNumber(@as(u8, @bitCast(this.flags)));
 }
 
 pub fn getAborted(this: *const NodeHTTPResponse, _: *jsc.JSGlobalObject) jsc.JSValue {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -246,6 +246,7 @@ pub fn dumpRequestBody(this: *NodeHTTPResponse, globalObject: *jsc.JSGlobalObjec
 
 fn markRequestAsDone(this: *NodeHTTPResponse) void {
     log("markRequestAsDone()", .{});
+    defer this.deref();
     this.flags.is_request_pending = false;
 
     this.clearOnDataCallback(this.getThisValue(), jsc.VirtualMachine.get().global);
@@ -254,8 +255,8 @@ fn markRequestAsDone(this: *NodeHTTPResponse) void {
     this.buffered_request_body_data_during_pause.clearAndFree(bun.default_allocator);
     const server = this.server;
     this.poll_ref.unref(jsc.VirtualMachine.get());
-    this.deref();
     this.unregisterAutoFlush();
+
     server.onRequestComplete();
 }
 

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1811,6 +1811,16 @@ __attribute__((callback (corker, ctx)))
     }
   }
 
+  bool uws_res_is_corked(int ssl, uws_res_r res) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      return uwsRes->isCorked();
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      return uwsRes->isCorked();
+    }
+  }
+
   void *uws_res_get_socket_data(int ssl, uws_res_r res) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1801,13 +1801,13 @@ __attribute__((callback (corker, ctx)))
     }
   }
 
-  void uws_res_flush_headers(int ssl, uws_res_r res) {
+  void uws_res_flush_headers(int ssl, uws_res_r res, bool flushImmediately) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
-      uwsRes->flushHeaders();
+      uwsRes->flushHeaders(flushImmediately);
     } else {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
-      uwsRes->flushHeaders();
+      uwsRes->flushHeaders(flushImmediately);
     }
   }
 

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -42,8 +42,8 @@ pub fn NewResponse(ssl_flag: i32) type {
             return c.uws_res_is_connect_request(ssl_flag, res.downcast());
         }
 
-        pub fn flushHeaders(res: *Response) void {
-            c.uws_res_flush_headers(ssl_flag, res.downcast());
+        pub fn flushHeaders(res: *Response, flushImmediately: bool) void {
+            c.uws_res_flush_headers(ssl_flag, res.downcast(), flushImmediately);
         }
 
         pub fn state(res: *const Response) State {
@@ -58,11 +58,11 @@ pub fn NewResponse(ssl_flag: i32) type {
             c.uws_res_prepare_for_sendfile(ssl_flag, res.downcast());
         }
 
-        pub fn uncork(_: *Response) void {
-            // c.uws_res_uncork(
-            //     ssl_flag,
-            //     res.downcast(),
-            // );
+        pub fn uncork(res: *Response) void {
+            c.uws_res_uncork(
+                ssl_flag,
+                res.downcast(),
+            );
         }
         pub fn pause(res: *Response) void {
             c.uws_res_pause(ssl_flag, res.downcast());
@@ -377,9 +377,14 @@ pub const AnyResponse = union(enum) {
             inline else => |resp| resp.getRemoteSocketInfo(),
         };
     }
-    pub fn flushHeaders(this: AnyResponse) void {
+    pub fn flushHeaders(this: AnyResponse, flushImmediately: bool) void {
         switch (this) {
-            inline else => |resp| resp.flushHeaders(),
+            inline else => |resp| resp.flushHeaders(flushImmediately),
+        }
+    }
+    pub fn uncork(this: AnyResponse) void {
+        switch (this) {
+            inline else => |resp| resp.uncork(),
         }
     }
     pub fn getWriteOffset(this: AnyResponse) u64 {
@@ -658,7 +663,7 @@ const c = struct {
     pub extern fn uws_res_get_remote_address_info(res: *c.uws_res, dest: *[*]const u8, port: *i32, is_ipv6: *bool) usize;
     pub extern fn uws_res_uncork(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_end(ssl: i32, res: *c.uws_res, data: [*c]const u8, length: usize, close_connection: bool) void;
-    pub extern fn uws_res_flush_headers(ssl: i32, res: *c.uws_res) void;
+    pub extern fn uws_res_flush_headers(ssl: i32, res: *c.uws_res, flushImmediately: bool) void;
     pub extern fn uws_res_get_socket_data(ssl: i32, res: *c.uws_res) ?*uws.SocketData;
     pub extern fn uws_res_pause(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_resume(ssl: i32, res: *c.uws_res) void;

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -45,7 +45,9 @@ pub fn NewResponse(ssl_flag: i32) type {
         pub fn flushHeaders(res: *Response, flushImmediately: bool) void {
             c.uws_res_flush_headers(ssl_flag, res.downcast(), flushImmediately);
         }
-
+        pub fn isCorked(res: *Response) bool {
+            return c.uws_res_is_corked(ssl_flag, res.downcast());
+        }
         pub fn state(res: *const Response) State {
             return c.uws_res_state(ssl_flag, @as(*const c.uws_res, @ptrCast(@alignCast(res))));
         }
@@ -382,6 +384,11 @@ pub const AnyResponse = union(enum) {
             inline else => |resp| resp.flushHeaders(flushImmediately),
         }
     }
+    pub fn isCorked(this: AnyResponse) bool {
+        return switch (this) {
+            inline else => |resp| resp.isCorked(),
+        };
+    }
     pub fn uncork(this: AnyResponse) void {
         switch (this) {
             inline else => |resp| resp.uncork(),
@@ -664,6 +671,7 @@ const c = struct {
     pub extern fn uws_res_uncork(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_end(ssl: i32, res: *c.uws_res, data: [*c]const u8, length: usize, close_connection: bool) void;
     pub extern fn uws_res_flush_headers(ssl: i32, res: *c.uws_res, flushImmediately: bool) void;
+    pub extern fn uws_res_is_corked(ssl: i32, res: *c.uws_res) bool;
     pub extern fn uws_res_get_socket_data(ssl: i32, res: *c.uws_res) ?*uws.SocketData;
     pub extern fn uws_res_pause(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_resume(ssl: i32, res: *c.uws_res) void;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -250,7 +250,7 @@ function ClientRequest(input, options, cb) {
   const onAbort = (_err?: Error) => {
     this[kClearTimeout]?.();
     socketCloseListener();
-    if (!this[abortedSymbol]) {
+    if (!this[abortedSymbol] && !this.finished) {
       process.nextTick(emitAbortNextTick, this);
       this[abortedSymbol] = true;
     }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -250,7 +250,7 @@ function ClientRequest(input, options, cb) {
   const onAbort = (_err?: Error) => {
     this[kClearTimeout]?.();
     socketCloseListener();
-    if (!this[abortedSymbol] && !this.complete) {
+    if (!this[abortedSymbol] && !this?.res?.complete) {
       process.nextTick(emitAbortNextTick, this);
       this[abortedSymbol] = true;
     }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -250,7 +250,7 @@ function ClientRequest(input, options, cb) {
   const onAbort = (_err?: Error) => {
     this[kClearTimeout]?.();
     socketCloseListener();
-    if (!this[abortedSymbol] && !this.finished) {
+    if (!this[abortedSymbol] && !this.complete) {
       process.nextTick(emitAbortNextTick, this);
       this[abortedSymbol] = true;
     }

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -334,7 +334,7 @@ const IncomingMessagePrototype = {
       }
     }
     const req = this.req;
-    if (req) {
+    if (req && !this.complete) {
       req[kAbortController]?.abort?.();
     }
 

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -26,6 +26,7 @@ const {
   headersTuple,
   webRequestOrResponseHasBodyValue,
   getCompleteWebRequestOrResponseBodyValueAsArrayBuffer,
+  kAbortController,
 } = require("internal/http");
 
 const { FakeSocket } = require("internal/http/FakeSocket");
@@ -332,7 +333,10 @@ const IncomingMessagePrototype = {
         socket.destroy(err);
       }
     }
-    this.req?.destroy();
+    const req = this.req;
+    if (req) {
+      req[kAbortController]?.abort?.();
+    }
 
     if ($isCallable(cb)) {
       emitErrorNextTickIfErrorListenerNT(this, err, cb);

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -307,7 +307,6 @@ const IncomingMessagePrototype = {
     if (isAbortError(err)) {
       err = undefined;
     }
-
     var nodeHTTPResponse = this[kHandle];
     if (nodeHTTPResponse) {
       this[kHandle] = undefined;
@@ -333,6 +332,7 @@ const IncomingMessagePrototype = {
         socket.destroy(err);
       }
     }
+    this.req?.destroy();
 
     if ($isCallable(cb)) {
       emitErrorNextTickIfErrorListenerNT(this, err, cb);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1680,22 +1680,23 @@ describe("HTTP Server Security Tests - Advanced", () => {
 
   test("flushHeaders should send the headers immediately", async () => {
     let headers_sent_at: number = 0;
+
+    let server_res: http.ServerResponse | undefined;
     await using server = http.createServer(async (req, res) => {
       res.writeHead(200, { "Content-Type": "text/plain" });
       headers_sent_at = Date.now();
+      server_res = res;
       res.flushHeaders();
-
-      setTimeout(() => {
-        res.write("Hello", () => {
-          res.end(" World");
-        });
-      }, 500);
     });
 
     await once(server.listen(0, "127.0.0.1"), "listening");
     const address = server.address() as AddressInfo;
     const response = await fetch(`http://127.0.0.1:${address.port}`);
     expect(Date.now() - headers_sent_at).toBeLessThan(100);
+    expect(server_res).toBeDefined();
+    server_res!.write("Hello", () => {
+      server_res!.end(" World");
+    });
     const text = await response.text();
     expect(text).toBe("Hello World");
   });


### PR DESCRIPTION
### What does this PR do?
Calls `uncork()` after flushing response headers to ensure data is sent as soon as possible, improving responsiveness.  
This behavior still works correctly even without the explicit `uncork()` call, due to the deferred uncork logic implemented here:  
https://github.com/oven-sh/bun/blob/6e3359dd16aced2f6fca2a8e2de71f09e0bcb3cb/packages/bun-uws/src/Loop.h#L57-L64

A test already covers this scenario in  `test/js/node/test/parallel/test-http-flush-response-headers.js`.


### How did you verify your code works?
CI