### PR TITLE
Fix: preserve bun: prefix in errors for invalid modules

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -2554,12 +2554,18 @@ pub const RuntimeTranspilerStore = struct {
                 }
 
                 if (strings.hasPrefixComptime(import_record.path.text, "bun:")) {
-                    import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
-                    import_record.path.namespace = "bun";
-                    import_record.is_external_without_side_effects = true;
+                    // Validate and strip the bun: prefix for builtin modules.
+                    // Invalid modules (e.g., "bun:invalid") are left unchanged so the
+                    // resolver can report an error with the full "bun:invalid" name instead
+                    // of the confusing "Cannot find package 'invalid'".
+                    if (HardcodedModule.map.has(import_record.path.text)) {
+                        import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
+                        import_record.path.namespace = "bun";
+                        import_record.is_external_without_side_effects = true;
 
-                    if (strings.eqlComptime(import_record.path.text, "test")) {
-                        import_record.tag = .bun_test;
+                        if (strings.eqlComptime(import_record.path.text, "test")) {
+                            import_record.tag = .bun_test;
+                        }
                     }
                 }
             }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3175,17 +3175,21 @@ pub const BundleV2 = struct {
                 }
 
                 if (strings.hasPrefixComptime(import_record.path.text, "bun:")) {
-                    import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
-                    import_record.path.namespace = "bun";
-                    import_record.source_index = Index.invalid;
-                    import_record.is_external_without_side_effects = true;
+                    // Validate and strip the bun: prefix for builtin modules.
+                    // Invalid modules are left unchanged for better error messages.
+                    if (jsc.ModuleLoader.HardcodedModule.map.has(import_record.path.text)) {
+                        import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
+                        import_record.path.namespace = "bun";
+                        import_record.source_index = Index.invalid;
+                        import_record.is_external_without_side_effects = true;
 
-                    if (strings.eqlComptime(import_record.path.text, "test")) {
-                        import_record.tag = .bun_test;
+                        if (strings.eqlComptime(import_record.path.text, "test")) {
+                            import_record.tag = .bun_test;
+                        }
+
+                        // don't link bun
+                        continue;
                     }
-
-                    // don't link bun
-                    continue;
                 }
             }
 

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -176,15 +176,19 @@ pub const Linker = struct {
                         }
 
                         if (strings.hasPrefixComptime(import_record.path.text, "bun:")) {
-                            import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
-                            import_record.path.namespace = "bun";
+                            // Validate and strip the bun: prefix for builtin modules.
+                            // Invalid modules are left unchanged for better error messages.
+                            if (jsc.ModuleLoader.HardcodedModule.map.has(import_record.path.text)) {
+                                import_record.path = Fs.Path.init(import_record.path.text["bun:".len..]);
+                                import_record.path.namespace = "bun";
 
-                            if (strings.eqlComptime(import_record.path.text, "test")) {
-                                import_record.tag = .bun_test;
+                                if (strings.eqlComptime(import_record.path.text, "test")) {
+                                    import_record.tag = .bun_test;
+                                }
+
+                                // don't link bun
+                                continue;
                             }
-
-                            // don't link bun
-                            continue;
                         }
 
                         // Resolve dynamic imports lazily for perf

--- a/test/regression/issue/invalid-bun-module-prefix.test.ts
+++ b/test/regression/issue/invalid-bun-module-prefix.test.ts
@@ -1,16 +1,14 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 test("invalid bun: module should preserve prefix in error", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "bun-invalid-module-"));
-  const file = join(dir, "test.js");
-  writeFileSync(file, 'import foo from "bun:apskdaposkdpok"');
+  const dir = tempDirWithFiles("bun-invalid-module", {
+    "test.js": 'import foo from "bun:apskdaposkdpok"',
+  });
 
   const { stderr } = Bun.spawnSync({
-    cmd: [bunExe(), file],
+    cmd: [bunExe(), "test.js"],
+    cwd: dir,
     env: bunEnv,
     stderr: "pipe",
   });

--- a/test/regression/issue/invalid-bun-module-prefix.test.ts
+++ b/test/regression/issue/invalid-bun-module-prefix.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("invalid bun: module should preserve prefix in error", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "bun-invalid-module-"));
+  const file = join(dir, "test.js");
+  writeFileSync(file, 'import foo from "bun:apskdaposkdpok"');
+
+  const { stderr } = Bun.spawnSync({
+    cmd: [bunExe(), file],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const output = stderr.toString();
+  // Error should mention "bun:apskdaposkdpok" not just "apskdaposkdpok"
+  expect(output).toContain("bun:apskdaposkdpok");
+  // The error could be "Cannot find package" or "Cannot resolve invalid URL"
+  // The key is that it shows the full "bun:..." prefix
+  expect(output).toMatch(/Cannot (find package|resolve invalid URL)/);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes the confusing error message when importing invalid `bun:` modules by preserving the full module name in error messages.

**Before:**
```js
import foo from "bun:apskdaposkdpok"
// error: Cannot find package 'apskdaposkdpok' from '<file>'
```

**After:**
```js
import foo from "bun:apskdaposkdpok"
// error: Cannot resolve invalid URL 'bun:apskdaposkdpok' from '<file>'
```

The code previously stripped the `bun:` prefix unconditionally during transpilation/linking, causing the resolver to report errors with the stripped name instead of what the user actually wrote.

This fix adds validation using `HardcodedModule.map.has()` before stripping the prefix in three locations:
- `src/bun.js/ModuleLoader.zig` - Runtime transpiler
- `src/linker.zig` - Module linker  
- `src/bundler/bundle_v2.zig` - Bundler v2

Invalid modules are now left unchanged so the resolver can report the full `bun:...` name in error messages.

### How did you verify your code works?

1. **Added regression test**: `test/regression/issue/invalid-bun-module-prefix.test.ts`
   - Verifies invalid `bun:` modules preserve the full prefix in errors
   - Uses `tempDirWithFiles` harness utility for proper cleanup

2. **Verified existing tests pass**: `test/js/node/missing-module.test.js`
   - Confirms no regression in existing error handling

3. **Manual testing**:
   - Valid `bun:` modules (`bun:sqlite`, `bun:ffi`, etc.) still work correctly
   - Invalid modules (`bun:doesnotexist`) show the full name in errors

**Performance**: No runtime overhead - uses `ComptimeStringMap` which compiles to O(1) lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)