### PR TITLE
Fix Clang 19 detection in Nix flake by setting CMAKE compiler variables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,14 @@
 
           shellHook = ''
             # Set up build environment
+            export CC="${pkgs.lib.getExe clang}"
+            export CXX="${pkgs.lib.getExe' clang "clang++"}"
+            export AR="${llvm}/bin/llvm-ar"
+            export RANLIB="${llvm}/bin/llvm-ranlib"
+            export CMAKE_C_COMPILER="$CC"
+            export CMAKE_CXX_COMPILER="$CXX"
+            export CMAKE_AR="$AR"
+            export CMAKE_RANLIB="$RANLIB"
             export CMAKE_SYSTEM_PROCESSOR="$(uname -m)"
             export TMPDIR="''${TMPDIR:-/tmp}"
           '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''


### PR DESCRIPTION
## Summary

Fixes Clang 19 detection in the Nix flake environment by explicitly setting CMAKE compiler environment variables in the shellHook.

## Problem

When using `nix develop` or `nix print-dev-env`, CMake was unable to detect the Clang 19 compiler because the `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` environment variables were not being set, even though the compiler was available in the environment.

The `shell.nix` file correctly sets these variables (lines 80-87), but `flake.nix` was missing them.

## Solution

Updated `flake.nix` shellHook to export the same compiler environment variables as `shell.nix`:
- `CC`, `CXX`, `AR`, `RANLIB` 
- `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, `CMAKE_AR`, `CMAKE_RANLIB`

This ensures consistent compiler detection across both Nix entry points (`nix develop` with flakes and `nix-shell` with shell.nix).

## Testing

Verified that all compiler variables are now properly set:
```bash
nix develop --accept-flake-config --impure --command bash -c 'echo "CMAKE_C_COMPILER=$CMAKE_C_COMPILER"'
# Output: CMAKE_C_COMPILER=/nix/store/.../clang-wrapper-19.1.7/bin/clang
```

Also tested with the profile workflow:
```bash
nix develop --accept-flake-config --impure --profile ./dev-profile --command true
eval "$(nix print-dev-env ./dev-profile --accept-flake-config --impure)"
echo "CMAKE_C_COMPILER=$CMAKE_C_COMPILER"
# Output: CMAKE_C_COMPILER=/nix/store/.../clang
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)