### PR TITLE
fix: fix broken scripts in the React templates after the index.ts rename

### DIFF
--- a/src/init/react-app/package.json
+++ b/src/init/react-app/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun --hot src/index.tsx",
+    "dev": "bun --hot src/index.ts",
     "build": "bun build ./src/index.html --outdir=dist --sourcemap --target=browser --minify --define:process.env.NODE_ENV='\"production\"' --env='BUN_PUBLIC_*'",
-    "start": "NODE_ENV=production bun src/index.tsx"
+    "start": "NODE_ENV=production bun src/index.ts"
   },
   "dependencies": {
     "react": "^19",

--- a/src/init/react-shadcn/package.json
+++ b/src/init/react-shadcn/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun --hot src/index.tsx",
-    "start": "NODE_ENV=production bun src/index.tsx",
+    "dev": "bun --hot src/index.ts",
+    "start": "NODE_ENV=production bun src/index.ts",
     "build": "bun run build.ts"
   },
   "dependencies": {

--- a/src/init/react-tailwind/package.json
+++ b/src/init/react-tailwind/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun --hot src/index.tsx",
-    "start": "NODE_ENV=production bun src/index.tsx",
+    "dev": "bun --hot src/index.ts",
+    "start": "NODE_ENV=production bun src/index.ts",
     "build": "bun run build.ts"
   },
   "dependencies": {


### PR DESCRIPTION
### What does this PR do?

Small followup to this PR: https://github.com/oven-sh/bun/pull/23469

This PR fixes the build and dev scripts in the React templates after the above PR, since those still point to `index.tsx`. I missed this when creating the previous PR, sorry about that!

### How did you verify your code works?

Built Bun locally, created all 3 templates and checked if the file name is correct in the `package.json` scripts.