### PR TITLE
Fix Error.prepareStackTrace not respecting custom property descriptors

### DIFF
--- a/test/regression/issue/23493-error-preparestacktrace-getter.test.ts
+++ b/test/regression/issue/23493-error-preparestacktrace-getter.test.ts
@@ -1,0 +1,109 @@
+// https://github.com/oven-sh/bun/issues/23493
+// When Error.prepareStackTrace is defined with Object.defineProperty using a getter/setter,
+// the getter must be called when formatting stack traces
+
+import { expect, test } from "bun:test";
+
+test("Error.prepareStackTrace getter is called when defined with Object.defineProperty", () => {
+  let getterCallCount = 0;
+  let prepareCallCount = 0;
+
+  const myPrepareStackTrace = function (err: Error, callsites: any[]) {
+    prepareCallCount++;
+    return "Custom stack trace";
+  };
+
+  // This is how error-callsites and similar modules define prepareStackTrace
+  Object.defineProperty(Error, "prepareStackTrace", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      getterCallCount++;
+      return myPrepareStackTrace;
+    },
+    set: function (fn: any) {
+      // setter not used in this test
+    },
+  });
+
+  try {
+    const err = new Error("test error");
+    const stack = err.stack;
+
+    // The getter should be called at least once when formatting the stack
+    // The prepare function should also be called
+    expect(getterCallCount).toBeGreaterThan(0);
+    expect(prepareCallCount).toBe(1);
+    expect(stack).toBe("Custom stack trace");
+  } finally {
+    // Cleanup: remove the custom getter
+    delete (Error as any).prepareStackTrace;
+  }
+});
+
+test("error-callsites module compatibility", () => {
+  // Simulate what error-callsites does
+  const callsitesSym = Symbol("callsites");
+
+  const fallback =
+    (Error as any).prepareStackTrace ||
+    function (err: Error, callsites: any[]) {
+      return err.stack;
+    };
+
+  let lastPrepareStackTrace = fallback;
+
+  Object.defineProperty(Error, "prepareStackTrace", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      return csPrepareStackTrace;
+    },
+    set: function (fn: any) {
+      if (fn === csPrepareStackTrace || fn === undefined) {
+        lastPrepareStackTrace = fallback;
+      } else {
+        lastPrepareStackTrace = fn;
+      }
+    },
+  });
+
+  function csPrepareStackTrace(err: any, callsites: any[]) {
+    if (Object.prototype.hasOwnProperty.call(err, callsitesSym)) {
+      return fallback(err, callsites);
+    }
+
+    Object.defineProperty(err, callsitesSym, {
+      enumerable: false,
+      configurable: true,
+      writable: false,
+      value: callsites,
+    });
+
+    return lastPrepareStackTrace(err, callsites);
+  }
+
+  function errorCallsites(err: any) {
+    err.stack; // eslint-disable-line no-unused-expressions
+    return err[callsitesSym];
+  }
+
+  try {
+    const err = new Error("test error");
+    const callsites = errorCallsites(err);
+
+    // Should return an array of callsites, not undefined
+    expect(callsites).toBeDefined();
+    expect(Array.isArray(callsites)).toBe(true);
+    expect(callsites.length).toBeGreaterThan(0);
+
+    // Verify callsites have expected properties
+    const firstCallsite = callsites[0];
+    expect(firstCallsite).toBeDefined();
+    expect(typeof firstCallsite.getFileName).toBe("function");
+    expect(typeof firstCallsite.getLineNumber).toBe("function");
+  } finally {
+    // Cleanup
+    delete (Error as any).prepareStackTrace;
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #23493 - When `Error.prepareStackTrace` is defined using `Object.defineProperty` with a custom getter/setter (as done by libraries like `error-callsites` and `elastic-apm-node`), Bun now properly calls the getter when internally formatting stack traces.

**Root cause**: The code in `ZigGlobalObject.cpp` was directly accessing the cached value (`m_errorConstructorPrepareStackTraceValue`) instead of using the property getter mechanism, bypassing custom property descriptors set by user code.

**Fix**: Modified `formatStackTraceToJSValueWithoutPrepareStackTrace()` and `computeErrorInfoToJSValueWithoutSkipping()` to always use `errorConstructor->getIfPropertyExists()`, which properly invokes custom getters.

### How did you verify your code works?

1. **Created reproduction case** at `/tmp/test-elastic-apm/final-reproduction.js`:
   - Before fix: Getter never called, prepareStackTrace never invoked ❌
   - After fix: Getter called, prepareStackTrace invoked ✅

2. **Tested with error-callsites module**: Now correctly returns callsites array instead of undefined

3. **Added regression test** at `test/regression/issue/23493-error-preparestacktrace-getter.test.ts`:
   - Test for custom getter/setter behavior
   - Test simulating the `error-callsites` module pattern
   - Both tests pass ✅

4. **Verified existing tests still pass**:
   - `test/regression/issue/prepare-stack-trace-crash.test.ts` - 3/3 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)