### PR TITLE
Added Manta Graph button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <a href="https://bun.com/discord" target="_blank"><img height=20 src="https://img.shields.io/discord/876711213126520882" /></a>
 <img src="https://img.shields.io/github/stars/oven-sh/bun" alt="stars">
 <a href="https://twitter.com/jarredsumner/status/1542824445810642946"><img src="https://img.shields.io/static/v1?label=speed&message=fast&color=success" alt="Bun speed" /></a>
+<a href="https://getmanta.ai/bun"><img src="https://getmanta.ai/api/badges?text=Manta%20Graph&link=bun" alt="Bun graph on Manta"></a> 
 </p>
 
 <div align="center">


### PR DESCRIPTION
Manta Graph can be opened through a button in README, to see the solution in a form of interactive graph.

<img width="1499" height="1112" alt="image" src="https://github.com/user-attachments/assets/48ddaa05-1613-43e5-9915-7103bae09013" />
