### PR TITLE
fix: include cookies in WebSocket upgrade response

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -892,6 +892,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 }
             }
 
+            var status_written = false;
+
             if (optional) |opts| {
                 getter: {
                     if (opts.isEmptyOrUndefinedOrNull()) {
@@ -944,6 +946,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                         // we must write the status first so that 200 OK isn't written
                         resp.writeStatus("101 Switching Protocols");
+                        status_written = true;
                         fetch_headers_to_use.toUWSResponse(comptime ssl_enabled, resp);
                     }
 
@@ -958,7 +961,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (upgrader.cookies) |cookies| {
                 // Write the 101 status if it hasn't been written yet
                 // (this happens when no custom headers are provided via upgrade options)
-                resp.writeStatus("101 Switching Protocols");
+                if (!status_written) {
+                    resp.writeStatus("101 Switching Protocols");
+                }
                 cookies.write(globalThis, ssl_enabled, @ptrCast(resp)) catch |err| {
                     return err;
                 };

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -953,6 +953,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 }
             }
 
+            // Write cookies if they were set on the request
+            // This must happen after the status is written but before the upgrade
+            if (upgrader.cookies) |cookies| {
+                // Write the 101 status if it hasn't been written yet
+                // (this happens when no custom headers are provided via upgrade options)
+                resp.writeStatus("101 Switching Protocols");
+                cookies.write(globalThis, ssl_enabled, @ptrCast(resp)) catch |err| {
+                    return err;
+                };
+            }
+
             // --- After this point, do not throw an exception
             // See https://github.com/oven-sh/bun/issues/1339
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -959,6 +959,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             // Write cookies if they were set on the request
             // This must happen after the status is written but before the upgrade
             if (upgrader.cookies) |cookies| {
+                upgrader.cookies = null;
+                defer cookies.deref();
+
                 // Write the 101 status if it hasn't been written yet
                 // (this happens when no custom headers are provided via upgrade options)
                 if (!status_written) {

--- a/test/regression/issue/23474.test.ts
+++ b/test/regression/issue/23474.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "bun:test";
+
+test("request.cookies.set() should set websocket upgrade response cookie - issue #23474", async () => {
+  using server = Bun.serve({
+    port: 0,
+    routes: {
+      "/ws": req => {
+        // Set a cookie before upgrading
+        req.cookies.set("test", "123", {
+          httpOnly: true,
+          path: "/",
+        });
+
+        const upgraded = server.upgrade(req);
+        if (upgraded) {
+          return undefined;
+        }
+        return new Response("Upgrade failed", { status: 500 });
+      },
+    },
+    websocket: {
+      message(ws, message) {
+        ws.close();
+      },
+    },
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers();
+
+  // Use Bun.connect to send a WebSocket upgrade request and check response headers
+  const socket = await Bun.connect({
+    hostname: "localhost",
+    port: server.port,
+    socket: {
+      data(socket, data) {
+        try {
+          const response = new TextDecoder().decode(data);
+
+          // Check that we got a successful upgrade response
+          expect(response).toContain("HTTP/1.1 101");
+          expect(response).toContain("Upgrade: websocket");
+
+          // The critical check: Set-Cookie header should be present
+          expect(response).toContain("Set-Cookie:");
+          expect(response).toContain("test=123");
+
+          socket.end();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      },
+      error(socket, error) {
+        reject(error);
+      },
+    },
+  });
+
+  // Send a valid WebSocket upgrade request
+  socket.write(
+    "GET /ws HTTP/1.1\r\n" +
+      `Host: localhost:${server.port}\r\n` +
+      "Upgrade: websocket\r\n" +
+      "Connection: Upgrade\r\n" +
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+      "Sec-WebSocket-Version: 13\r\n" +
+      "\r\n",
+  );
+
+  await promise;
+});
+
+test("request.cookies.set() should work with custom headers in upgrade - issue #23474", async () => {
+  using server = Bun.serve({
+    port: 0,
+    routes: {
+      "/ws": req => {
+        // Set cookies before upgrading
+        req.cookies.set("session", "abc123", { path: "/" });
+        req.cookies.set("user", "john", { httpOnly: true });
+
+        const upgraded = server.upgrade(req, {
+          headers: {
+            "X-Custom-Header": "test",
+          },
+        });
+        if (upgraded) {
+          return undefined;
+        }
+        return new Response("Upgrade failed", { status: 500 });
+      },
+    },
+    websocket: {
+      message(ws, message) {
+        ws.close();
+      },
+    },
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers();
+
+  const socket = await Bun.connect({
+    hostname: "localhost",
+    port: server.port,
+    socket: {
+      data(socket, data) {
+        try {
+          const response = new TextDecoder().decode(data);
+
+          // Check that we got a successful upgrade response
+          expect(response).toContain("HTTP/1.1 101");
+          expect(response).toContain("Upgrade: websocket");
+
+          // Check custom header
+          expect(response).toContain("X-Custom-Header: test");
+
+          // Check that both cookies are present
+          expect(response).toContain("Set-Cookie:");
+          expect(response).toContain("session=abc123");
+          expect(response).toContain("user=john");
+
+          socket.end();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      },
+      error(socket, error) {
+        reject(error);
+      },
+    },
+  });
+
+  socket.write(
+    "GET /ws HTTP/1.1\r\n" +
+      `Host: localhost:${server.port}\r\n` +
+      "Upgrade: websocket\r\n" +
+      "Connection: Upgrade\r\n" +
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+      "Sec-WebSocket-Version: 13\r\n" +
+      "\r\n",
+  );
+
+  await promise;
+});


### PR DESCRIPTION
Fixes #23474

## Summary

When `request.cookies.set()` is called before `server.upgrade()`, the cookies are now properly included in the WebSocket upgrade response headers.

## Problem

Previously, cookies set on the request via `req.cookies.set()` were only written for regular HTTP responses but were ignored during WebSocket upgrades. Users had to manually pass cookies via the `headers` option:

```js
server.upgrade(req, {
  headers: {
    "Set-Cookie": `SessionId=${sessionId}`,
  },
});
```

## Solution

Modified `src/bun.js/api/server.zig` to check for and write cookies to the WebSocket upgrade response after the "101 Switching Protocols" status is set but before the actual upgrade is performed.

The fix handles both cases:
- When `upgrade()` is called without custom headers
- When `upgrade()` is called with custom headers

## Testing

Added comprehensive regression tests in `test/regression/issue/23474.test.ts` that:
- Verify cookies are set in the upgrade response without custom headers
- Verify cookies are set in the upgrade response with custom headers
- Use `Promise.withResolvers()` for efficient async handling (no arbitrary timeouts)

Tests confirmed:
- ❌ Fail with system bun v1.2.23 (without fix)
- ✅ Pass with debug build v1.3.0 (with fix)

## Manual verification

```bash
curl -i -H "Connection: Upgrade" -H "Upgrade: websocket" \
  -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  -H "Sec-WebSocket-Version: 13" \
  http://localhost:3000/ws
```

Response now includes:
```
HTTP/1.1 101 Switching Protocols
Set-Cookie: test=123; Path=/; SameSite=Lax
Upgrade: websocket
Connection: Upgrade
...
```