### PR TITLE
fix(YAML.stringify): check for more indicators at the beginning of strings

### DIFF
--- a/src/bun.js/api/YAMLObject.zig
+++ b/src/bun.js/api/YAMLObject.zig
@@ -610,7 +610,7 @@ const Stringifier = struct {
         }
 
         switch (str.charAt(0)) {
-            // starting with indicators or whitespace requires quotes
+            // starting with an indicator character requires quotes
             '&',
             '*',
             '?',
@@ -621,11 +621,21 @@ const Stringifier = struct {
             '!',
             '%',
             '@',
+            ':',
+            ',',
+            '[',
+            ']',
+            '{',
+            '}',
+            '#',
+            '\'',
+            '"',
+            '`',
+            // starting with whitespace requires quotes
             ' ',
             '\t',
             '\n',
             '\r',
-            '#',
             => return true,
 
             else => {},

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1038,6 +1038,39 @@ my_config:
       });
     });
 
+    const indicatorQuotingTests = [
+      "-",
+      "?",
+      ":",
+      ",",
+      "[",
+      "]",
+      "{",
+      "}",
+      "#",
+      "&",
+      "*",
+      "!",
+      "|",
+      ">",
+      "'",
+      '"',
+      "%",
+      "@",
+      "`",
+      " ",
+      "\t",
+      "\n",
+      "\r",
+    ];
+
+    for (const indicatorOrWhitespace of indicatorQuotingTests) {
+      test(`round-trip string starting with '${indicatorOrWhitespace}'`, () => {
+        const array = [{ key: indicatorOrWhitespace }];
+        expect(YAML.parse(YAML.stringify(array))).toEqual(array);
+      });
+    }
+
     test("strings are properly referenced", () => {
       const config = {
         version: "1.0",

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1068,6 +1068,7 @@ my_config:
       test(`round-trip string starting with '${indicatorOrWhitespace}'`, () => {
         const array = [{ key: indicatorOrWhitespace }];
         expect(YAML.parse(YAML.stringify(array))).toEqual(array);
+        expect(YAML.parse(YAML.stringify(array, null, 2))).toEqual(array);
       });
     }
 


### PR DESCRIPTION
### What does this PR do?
Makes sure strings are doubled quoted when they start with flow indicators and `:`.

Fixes #23502
### How did you verify your code works?
Added tests for each indicator in flow and block context
