### PR TITLE
Show 'error:' prefix with name property in AI agent mode

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1958,7 +1958,8 @@ pub fn printException(
         .stack_check = bun.StackCheck.init(),
     };
     defer formatter.deinit();
-    if (Output.enable_ansi_colors) {
+    // Disable ANSI colors in AI agent mode to ensure grep '^error:' works reliably
+    if (Output.enable_ansi_colors and !Output.isAIAgent()) {
         this.printErrorlikeObject(exception.value(), exception, exception_list, &formatter, Writer, writer, true, allow_side_effects);
     } else {
         this.printErrorlikeObject(exception.value(), exception, exception_list, &formatter, Writer, writer, false, allow_side_effects);
@@ -1997,7 +1998,8 @@ pub noinline fn runErrorHandler(this: *VirtualMachine, result: JSValue, exceptio
             .error_display_level = .full,
         };
         defer formatter.deinit();
-        switch (Output.enable_ansi_colors) {
+        // Disable ANSI colors in AI agent mode to ensure grep '^error:' works reliably
+        switch (Output.enable_ansi_colors and !Output.isAIAgent()) {
             inline else => |enable_colors| this.printErrorlikeObject(result, null, exception_list, &formatter, @TypeOf(writer), writer, enable_colors, true),
         }
     }
@@ -3306,7 +3308,7 @@ fn printErrorNameAndMessage(
     comptime allow_ansi_color: bool,
     error_display_level: ConsoleObject.FormatOptions.ErrorDisplayLevel,
 ) !void {
-    if (is_browser_error) {
+    if (is_browser_error and !Output.isAIAgent()) {
         try writer.writeAll(Output.prettyFmt("<red>frontend<r> ", true));
     }
     if (!name.isEmpty() and !message.isEmpty()) {

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3115,7 +3115,7 @@ fn printErrorInstance(
         defer iterator.deinit();
         var longest_name_base = iterator.getLongestPropertyName();
         // In AI agent mode, we'll also print the "name" field if it's not "Error".
-        // Since we normalize all errors to "error:" prefix above, we need to preserve
+        // Since we normalize all errors to "error:" prefix in printErrorNameAndMessage, we need to preserve
         // the actual error type (TypeError, ReferenceError, etc.) as a property.
         // This provides structured error information while maintaining grepability.
         if (Output.isAIAgent() and !name.eqlComptime("Error")) {


### PR DESCRIPTION
### What does this PR do?

When running under AI agent mode (detected via `Output.isAIAgent()`), this PR changes error message formatting to consistently use `error:` as the prefix instead of the specific error type (TypeError, ReferenceError, etc.). The actual error type is then shown as a `name` property below the error message.

This allows AI agents to reliably search for all errors using a simple pattern:
```bash
command 2>&1 | grep "^error:"
```
instead of needing to match multiple patterns like:
```bash
grep -E "^(Error|TypeError|ReferenceError|SyntaxError|RangeError|...):"
```

**Before (AI agent mode):**
```
TypeError: This is a test error
      at /tmp/test.js:2:11
```

**After (AI agent mode):**
```
error: This is a test error
 name: "TypeError"

      at /tmp/test.js:2:11
```

### How did you verify your code works?

1. Built Bun with the changes: `bun bd`
2. Tested with various error types (TypeError, ReferenceError, SyntaxError, RangeError) to confirm they all show `error:` prefix in AI agent mode
3. Verified that generic `Error` instances don't show the `name` property (since it's redundant)
4. Tested the grep pattern to confirm it reliably catches all errors:
   ```bash
   $ ./build/debug/bun-debug test-various-errors.js 2>&1 | grep "^error:"
   error: undefined variable
   error: invalid syntax
   error: out of range
   ```
5. Confirmed that normal mode (non-AI agent) behavior remains unchanged

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>