### PR TITLE
Debug adapter: change 'stepNext' to 'stepOver'

### DIFF
--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -565,7 +565,7 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
   }
 
   async next(): Promise<void> {
-    await this.send("Debugger.stepNext");
+    await this.send("Debugger.stepOver");
     this.#stopped = "step";
   }
 


### PR DESCRIPTION
### What does this PR do?

Hi, I found some unexpected behavior when clicking 'Step Over' while debugging in VSCode. Multiple clicks are needed to move past a statement with multiple expressions, e.g. a function call with another function call as an argument, like `logText(getText())`.

The debug adapter uses the 'stepNext' command, which uses expression granularity. Changing to 'stepOver' would use statement granularity, consistent with [vscode-js-debug](https://github.com/microsoft/vscode-js-debug/blob/74702375c67744e2f123d89ef950d7b6859c6f16/src/adapter/debugAdapter.ts#L98) and is [the default in the DAP spec](https://microsoft.github.io/debug-adapter-protocol/specification#:~:text=If%20no%20granularity%20is%20specified,%20a%20granularity%20of).

### How did you verify your code works?

Manual testing:

Before change: 2 clicks per line

https://github.com/user-attachments/assets/5b595d5e-4ddd-4aac-baf5-e174faa0d300

After change: 1 click per line

https://github.com/user-attachments/assets/20d539a4-b25c-4948-904e-7673dbd2f68a

