### PR TITLE
Fix crash handler not dumping stack traces on Linux aarch64

### DIFF
--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -319,7 +319,55 @@ pub fn crashHandler(
                         .index = 0,
                         .instruction_addresses = &addr_buf,
                     };
-                    std.debug.captureStackTrace(begin_addr orelse @returnAddress(), &trace_buf);
+                    const desired_begin_addr = begin_addr orelse @returnAddress();
+
+                    // On Linux with glibc, always use backtrace() instead of Zig's StackIterator
+                    // because Zig's frame pointer-based unwinding doesn't work reliably,
+                    // especially on aarch64. glibc's backtrace() uses DWARF unwinding.
+                    if (bun.Environment.isLinux and !bun.Environment.isMusl) {
+                        const backtrace_fn = struct {
+                            extern "c" fn backtrace(buffer: [*]?*anyopaque, size: c_int) c_int;
+                        }.backtrace;
+                        const count = backtrace_fn(@ptrCast(&addr_buf), addr_buf.len);
+                        if (count > 0) {
+                            trace_buf.index = @intCast(count);
+
+                            // Skip frames until we find begin_addr (or close to it)
+                            // backtrace() captures everything including crash handler frames
+                            var skip: usize = 0;
+                            var found_begin = false;
+                            const tolerance: usize = 128;
+                            for (addr_buf[0..trace_buf.index], 0..) |addr, i| {
+                                // Check if this address is close to begin_addr (within tolerance)
+                                const delta = if (addr >= desired_begin_addr)
+                                    addr - desired_begin_addr
+                                else
+                                    desired_begin_addr - addr;
+                                if (delta <= tolerance) {
+                                    skip = i;
+                                    found_begin = true;
+                                    break;
+                                }
+                                // Give up searching after 8 frames
+                                if (i >= 8) break;
+                            }
+
+                            // Shift the addresses to skip crash handler frames
+                            // If begin_addr was not found, use the complete backtrace
+                            if (found_begin and skip > 0 and skip < trace_buf.index) {
+                                const remaining = trace_buf.index - skip;
+                                var j: usize = 0;
+                                while (j < remaining) : (j += 1) {
+                                    addr_buf[j] = addr_buf[skip + j];
+                                }
+                                trace_buf.index = remaining;
+                            }
+                        }
+                    } else {
+                        // Fall back to Zig's stack capture on other platforms
+                        std.debug.captureStackTrace(desired_begin_addr, &trace_buf);
+                    }
+
                     break :get_backtrace &trace_buf;
                 };
 
@@ -1635,12 +1683,12 @@ pub fn dumpStackTrace(trace: std.builtin.StackTrace, limits: WriteStackTraceLimi
             return;
         },
         .linux => {
+            // In non-debug builds, use WTF's stack trace printer and return early
             if (!bun.Environment.isDebug) {
-                // Linux doesnt seem to be able to decode it's own debug info.
-                // TODO(@paperclover): see if zig 0.14 fixes this
-                WTF__DumpStackTrace(trace.instruction_addresses.ptr, trace.instruction_addresses.len);
+                WTF__DumpStackTrace(trace.instruction_addresses.ptr, trace.index);
                 return;
             }
+            // Otherwise fall through to llvm-symbolizer for debug builds
         },
         else => {
             // Assume debug symbol tooling is reliable.


### PR DESCRIPTION
### What does this PR do?

Fixes the crash handler failing to capture and display stack traces on Linux ARM64 systems.

**Before:**
```
============================================================
panic(main thread): cast causes pointer to be null
```
No stack trace shown.

**After:**
```
============================================================
panic(main thread): cast causes pointer to be null
bun.js.api.FFIObject.Reader.u8
/workspace/bun/src/bun.js/api/FFIObject.zig:67:41

bun.js.jsc.host_fn.toJSHostCall__anon_2545765
/workspace/bun/src/bun.js/jsc/host_fn.zig:93:5
```
Full stack trace with source locations.

#### Root Cause
- Zig's `std.debug.captureStackTrace` uses `StackIterator.init()` which falls back to frame pointer-based unwinding when no context is provided
- Frame pointer-based unwinding doesn't work reliably on ARM64, even with `-fno-omit-frame-pointer` enabled
- This resulted in 0 frames being captured (`trace.index == 0`)

#### Changes
1. **Use glibc's backtrace() on Linux**: On Linux with glibc (not musl), always use glibc's `backtrace()` function instead of Zig's StackIterator. glibc's implementation properly uses DWARF unwinding information from `.eh_frame` sections.

2. **Skip crash handler frames**: After capturing with `backtrace()`, find the desired `begin_addr` in the trace (within 128 byte tolerance) and filter out crash handler internal frames for cleaner output. If `begin_addr` is not found, use the complete backtrace.

3. **Preserve existing behavior**:
   - Non-debug builds: Use WTF printer (fast, no external deps)
   - Debug builds: Fall through to llvm-symbolizer (detailed source info)

### How did you verify your code works?

Reproduced the crash:
```bash
bun-debug --print 'Bun.FFI.read.u8(0)'
```

Verified that:
- ✅ Stack traces now appear on Linux ARM64 with proper source locations
- ✅ Crash handler frames are properly filtered out
- ✅ llvm-symbolizer integration works for debug builds
- ✅ WTF printer is used for release builds
- ✅ When begin_addr is not found, complete backtrace is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)