### PR TITLE
fix(watcher): handle vim atomic save race on macOS

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -7,6 +7,6 @@ Syntax reminders:
 
 Conventions:
 
-- Prefer `@import` at the **bottom** of the file.
-- It's `@import("bun")` not `@import("root").bun`
+- Prefer `@import` at the **bottom** of the file, but the auto formatter will move them so you don't need to worry about it.
+- Prefer `@import("bun")`. Not `@import("root").bun` or `@import("../bun.zig")`.
 - You must be patient with the build.

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1677,7 +1677,7 @@ fn _resolve(
                         );
                     };
 
-                    // Only re-query if we previously had something cached, or if it's main.
+                    // Only re-query if we previously had something cached.
                     if (jsc_vm.transpiler.resolver.bustDirCache(bun.strings.withoutTrailingSlashWindowsPath(buster_name))) {
                         continue;
                     }

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -678,19 +678,13 @@ pub fn uncaughtException(this: *jsc.VirtualMachine, globalObject: *JSGlobalObjec
 }
 
 pub fn reportExceptionInHotReloadedModuleIfNeeded(this: *jsc.VirtualMachine) void {
-    const promise_opt = this.pending_internal_promise;
-    if (promise_opt == null) {
-        this.addMainToWatcherIfNeeded();
-        return;
-    }
-    var promise = promise_opt.?;
+    defer this.addMainToWatcherIfNeeded();
+    var promise = this.pending_internal_promise orelse return;
 
     if (promise.status(this.global.vm()) == .rejected and !promise.isHandled(this.global.vm())) {
         this.unhandledRejection(this.global, promise.result(this.global.vm()), promise.asValue());
         promise.setHandled(this.global.vm());
     }
-
-    this.addMainToWatcherIfNeeded();
 }
 
 pub fn addMainToWatcherIfNeeded(this: *jsc.VirtualMachine) void {

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -420,9 +420,9 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 
                                 if (event.op.write) {
                                     // Check if the entrypoint now exists after an atomic save.
-                                    // If we previously got a NOTE_RENAME on the entrypoint (vim deleted
-                                    // the old inode), this directory write event signals that the new
-                                    // file has been renamed into place. Verify it exists and trigger reload.
+                                    // If we previously got a NOTE_RENAME on the entrypoint (vim renamed
+                                    // the file), this directory write event signals that the new
+                                    // file has been re-created. Verify it exists and trigger reload.
                                     if (this.main.is_waiting_for_dir_change and this.main.dir_hash == current_hash) {
                                         if (bun.sys.faccessat(file_descriptors[event.index], std.fs.path.basename(this.main.file)) == .result) {
                                             this.main.is_waiting_for_dir_change = false;

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -127,10 +127,10 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             hash: Watcher.HashType = 0,
 
             /// On macOS, vim's atomic save triggers a race condition:
-            /// 1. Old file gets NOTE_RENAME (inode deleted)
+            /// 1. Old file gets NOTE_RENAME (file renamed to temp name: a.js -> a.js~)
             /// 2. We receive the event and would normally trigger reload immediately
-            /// 3. But the new file isn't renamed into place yet - reload fails with ENOENT
-            /// 4. New file gets renamed into place (a.js~ -> a.js)
+            /// 3. But the new file hasn't been created yet - reload fails with ENOENT
+            /// 4. New file gets created and written (a.js)
             /// 5. Parent directory gets NOTE_WRITE
             ///
             /// To fix this: when the entrypoint gets NOTE_RENAME, we set this flag

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -381,8 +381,8 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                 if (event.op.rename) {
                                     // Special case for entrypoint: defer reload until we get
                                     // a directory write event confirming the file exists.
-                                    // This handles vim's atomic save which deletes the old inode
-                                    // before the new file is renamed into place.
+                                    // This handles vim's save process which renames the old file
+                                    // before the new file is re-created with a different inode.
                                     if (this.main.hash == current_hash and !reload_immediately) {
                                         this.main.is_waiting_for_dir_change = true;
                                         continue;

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -434,7 +434,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                 var affected_i: usize = 0;
 
                                 // if a file descriptor is stale, we need to close it
-                                if ((event.op.delete) and entries_option != null) {
+                                if (event.op.delete and entries_option != null) {
                                     for (parents, 0..) |parent_hash, entry_id| {
                                         if (parent_hash == current_hash) {
                                             const affected_path = file_paths[entry_id];

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -25,6 +25,17 @@ pub const ImportWatcher = union(enum) {
         };
     }
 
+    pub inline fn addFileByPathSlow(
+        this: ImportWatcher,
+        file_path: string,
+        loader: options.Loader,
+    ) bool {
+        return switch (this) {
+            inline .hot, .watch => |w| w.addFileByPathSlow(file_path, loader),
+            else => true,
+        };
+    }
+
     pub inline fn addFile(
         this: ImportWatcher,
         fd: bun.FD,
@@ -62,6 +73,8 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
         ctx: *Ctx,
         verbose: bool = false,
         pending_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+
+        main: MainFile = .{},
 
         tombstones: bun.StringHashMapUnmanaged(*bun.fs.FileSystem.RealFS.EntriesOption) = .{},
 
@@ -104,6 +117,44 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
         }
 
         pub var clear_screen = false;
+
+        const MainFile = struct {
+            /// Includes a trailing "/"
+            dir: []const u8 = "",
+            dir_hash: Watcher.HashType = 0,
+
+            file: []const u8 = "",
+            hash: Watcher.HashType = 0,
+
+            /// On macOS, vim's atomic save triggers a race condition:
+            /// 1. Old file gets NOTE_RENAME (inode deleted)
+            /// 2. We receive the event and would normally trigger reload immediately
+            /// 3. But the new file isn't renamed into place yet - reload fails with ENOENT
+            /// 4. New file gets renamed into place (a.js~ -> a.js)
+            /// 5. Parent directory gets NOTE_WRITE
+            ///
+            /// To fix this: when the entrypoint gets NOTE_RENAME, we set this flag
+            /// and skip the reload. Then when the parent directory gets NOTE_WRITE,
+            /// we check if the file exists and trigger the reload.
+            is_waiting_for_dir_change: bool = false,
+
+            pub fn init(file: []const u8) MainFile {
+                var main = MainFile{
+                    .file = file,
+                    .hash = if (file.len > 0) Watcher.getHash(file) else 0,
+                    .is_waiting_for_dir_change = false,
+                };
+
+                if (std.fs.path.dirname(file)) |dir| {
+                    bun.assert(bun.isSliceInBuffer(dir, file));
+                    bun.assert(file.len > dir.len + 1);
+                    main.dir = file[0 .. dir.len + 1];
+                    main.dir_hash = Watcher.getHash(dir);
+                }
+
+                return main;
+            }
+        };
 
         pub const Task = struct {
             count: u8 = 0,
@@ -184,7 +235,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             }
         };
 
-        pub fn enableHotModuleReloading(this: *Ctx) void {
+        pub fn enableHotModuleReloading(this: *Ctx, entry_path: ?[]const u8) void {
             if (comptime @TypeOf(this.bun_watcher) == ImportWatcher) {
                 if (this.bun_watcher != .none)
                     return;
@@ -197,6 +248,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             reloader.* = .{
                 .ctx = this,
                 .verbose = Environment.enable_logs or if (@hasField(Ctx, "log")) this.log.level.atLeast(.info) else false,
+                .main = MainFile.init(entry_path orelse ""),
             };
 
             if (comptime @TypeOf(this.bun_watcher) == ImportWatcher) {
@@ -312,7 +364,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 
                 switch (kind) {
                     .file => {
-                        if (event.op.delete or event.op.rename) {
+                        if (event.op.delete or (event.op.rename and Environment.isMac)) {
                             ctx.removeAtIndex(
                                 event.index,
                                 0,
@@ -322,13 +374,29 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                         }
 
                         if (this.verbose)
-                            debug("File changed: {s}", .{fs.relativeTo(file_path)});
+                            debug("File changed: {s} ({})", .{ fs.relativeTo(file_path), event });
 
                         if (event.op.write or event.op.delete or event.op.rename) {
+                            if (comptime Environment.isMac) {
+                                if (event.op.rename) {
+                                    // Special case for entrypoint: defer reload until we get
+                                    // a directory write event confirming the file exists.
+                                    // This handles vim's atomic save which deletes the old inode
+                                    // before the new file is renamed into place.
+                                    if (this.main.hash == current_hash and !reload_immediately) {
+                                        this.main.is_waiting_for_dir_change = true;
+                                        continue;
+                                    }
+                                }
+
+                                // If we got a write event after rename, the file is back - proceed with reload
+                                if (this.main.is_waiting_for_dir_change and this.main.hash == current_hash) {
+                                    this.main.is_waiting_for_dir_change = false;
+                                }
+                            }
+
                             current_task.append(current_hash);
                         }
-
-                        // TODO: delete events?
                     },
                     .directory => {
                         if (comptime Environment.isWindows) {
@@ -350,10 +418,23 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                     entries_option = existing;
                                 }
 
+                                if (event.op.write) {
+                                    // Check if the entrypoint now exists after an atomic save.
+                                    // If we previously got a NOTE_RENAME on the entrypoint (vim deleted
+                                    // the old inode), this directory write event signals that the new
+                                    // file has been renamed into place. Verify it exists and trigger reload.
+                                    if (this.main.is_waiting_for_dir_change and this.main.dir_hash == current_hash) {
+                                        if (bun.sys.faccessat(file_descriptors[event.index], std.fs.path.basename(this.main.file)) == .result) {
+                                            this.main.is_waiting_for_dir_change = false;
+                                            current_task.append(this.main.hash);
+                                        }
+                                    }
+                                }
+
                                 var affected_i: usize = 0;
 
                                 // if a file descriptor is stale, we need to close it
-                                if (event.op.delete and entries_option != null) {
+                                if ((event.op.delete) and entries_option != null) {
                                     for (parents, 0..) |parent_hash, entry_id| {
                                         if (parent_hash == current_hash) {
                                             const affected_path = file_paths[entry_id];
@@ -397,7 +478,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                     bun.asByteSlice(changed_name_.?);
                                 if (changed_name.len == 0 or changed_name[0] == '~' or changed_name[0] == '.') continue;
 
-                                const loader = (this.ctx.getLoaders().get(Fs.PathName.init(changed_name).ext) orelse .file);
+                                const loader = (this.ctx.getLoaders().get(Fs.PathName.findExtname(changed_name)) orelse .file);
                                 var prev_entry_id: usize = std.math.maxInt(usize);
                                 if (loader != .file) {
                                     var path_string: bun.PathString = undefined;
@@ -414,6 +495,8 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                                     if (file_descriptors[entry_id].isValid()) {
                                                         if (prev_entry_id != entry_id) {
                                                             current_task.append(hashes[entry_id]);
+                                                            if (this.verbose)
+                                                                debug("Removing file: {s}", .{path_string.slice()});
                                                             ctx.removeAtIndex(
                                                                 @as(u16, @truncate(entry_id)),
                                                                 0,
@@ -452,7 +535,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                         }
 
                         if (this.verbose) {
-                            debug("Dir change: {s}", .{fs.relativeTo(file_path)});
+                            debug("Dir change: {s} (affecting {d}, {})", .{ fs.relativeTo(file_path), affected.len, event });
                         }
                     },
                 }

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -149,7 +149,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     bun.assert(bun.isSliceInBuffer(dir, file));
                     bun.assert(file.len > dir.len + 1);
                     main.dir = file[0 .. dir.len + 1];
-                    main.dir_hash = Watcher.getHash(dir);
+                    main.dir_hash = Watcher.getHash(main.dir);
                 }
 
                 return main;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -935,7 +935,7 @@ pub const BundleV2 = struct {
 
         const pool = try this.allocator().create(ThreadPool);
         if (cli_watch_flag) {
-            Watcher.enableHotModuleReloading(this);
+            Watcher.enableHotModuleReloading(this, null);
         }
         // errdefer pool.destroy();
         errdefer this.graph.heap.deinit();

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1518,8 +1518,8 @@ pub const TestCommand = struct {
             vm.hot_reload = ctx.debug.hot_reload;
 
             switch (vm.hot_reload) {
-                .hot => jsc.hot_reloader.HotReloader.enableHotModuleReloading(vm),
-                .watch => jsc.hot_reloader.WatchReloader.enableHotModuleReloading(vm),
+                .hot => jsc.hot_reloader.HotReloader.enableHotModuleReloading(vm, null),
+                .watch => jsc.hot_reloader.WatchReloader.enableHotModuleReloading(vm, null),
                 else => {},
             }
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1563,8 +1563,15 @@ pub const PathName = struct {
     filename: string,
 
     pub fn findExtname(_path: string) string {
-        const dot = bun.strings.lastIndexOfChar(_path, '.') orelse return "";
-        return _path[dot..];
+        var start: usize = 0;
+        if (bun.path.lastIndexOfSep(_path)) |i| {
+            start = i + 1;
+        }
+        const base = _path[start..];
+        if (bun.strings.lastIndexOfChar(base, '.')) |dot| {
+            if (dot > 0) return base[dot..];
+        }
+        return "";
     }
 
     pub fn extWithoutLeadingDot(self: *const PathName) string {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1562,6 +1562,11 @@ pub const PathName = struct {
     ext: string,
     filename: string,
 
+    pub fn findExtname(_path: string) string {
+        const dot = bun.strings.lastIndexOfChar(_path, '.') orelse return "";
+        return _path[dot..];
+    }
+
     pub fn extWithoutLeadingDot(self: *const PathName) string {
         return if (self.ext.len > 0 and self.ext[0] == '.') self.ext[1..] else self.ext;
     }

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3183,7 +3183,7 @@ pub fn faccessat(dir_fd: bun.FileDescriptor, subpath: anytype) bun.sys.Maybe(boo
 
     if (comptime !has_sentinel) {
         const path = std.posix.toPosixPath(subpath) catch return bun.sys.Maybe(bool){ .err = Error.fromCode(.NAMETOOLONG, .access) };
-        return faccessat(dir_fd, &path);
+        return faccessat(dir_fd, path);
     }
 
     if (comptime Environment.isLinux) {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3182,8 +3182,8 @@ pub fn faccessat(dir_fd: bun.FileDescriptor, subpath: anytype) bun.sys.Maybe(boo
     const has_sentinel = std.meta.sentinel(@TypeOf(subpath)) != null;
 
     if (comptime !has_sentinel) {
-        const path = std.os.toPosixPath(subpath) catch return bun.sys.Maybe(bool){ .err = Error.fromCode(.NAMETOOLONG, .access) };
-        return faccessat(dir_fd, path);
+        const path = std.posix.toPosixPath(subpath) catch return bun.sys.Maybe(bool){ .err = Error.fromCode(.NAMETOOLONG, .access) };
+        return faccessat(dir_fd, &path);
     }
 
     if (comptime Environment.isLinux) {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3183,7 +3183,7 @@ pub fn faccessat(dir_fd: bun.FileDescriptor, subpath: anytype) bun.sys.Maybe(boo
 
     if (comptime !has_sentinel) {
         const path = std.posix.toPosixPath(subpath) catch return bun.sys.Maybe(bool){ .err = Error.fromCode(.NAMETOOLONG, .access) };
-        return faccessat(dir_fd, path);
+        return faccessat(dir_fd, &path);
     }
 
     if (comptime Environment.isLinux) {


### PR DESCRIPTION
## Summary

Fixes a race condition on macOS where editing the entrypoint with vim's atomic save causes "Module not found" errors during hot reload.

## Root Cause

On macOS, kqueue watches file descriptors/inodes, not paths. Vim's atomic save sequence:
1. Rename `a.js` to `a.js~` → kqueue reports `NOTE_RENAME` on watched fd
2. Hot reloader immediately triggers reload
3. New file hasn't been created yet → `ENOENT` error
4. Vim re-creates `a.js`, and writes file contents into it
5. Directory gets `NOTE_WRITE` but file already removed from watchlist

```
rename("a.js", "a.js~")                 = 0
openat(AT_FDCWD, "a.js", O_WRONLY|O_CREAT, 0664) = 3
ftruncate(3, 0)                         = 0
write(3, "foobar\n", 7)                 = 7
close(3)                                = 0
```

This is macOS-specific because:
- **kqueue**: watches inodes, fd becomes stale when inode deleted
- **inotify (Linux)**: watches paths, gets `IN.MOVED_TO` (not `IN.MOVE_SELF`), so files stay in watchlist

## Solution

When the entrypoint receives `NOTE_RENAME` on macOS:
1. Set `is_waiting_for_dir_change` flag
2. Skip immediate reload
3. Wait for parent directory `NOTE_WRITE` event
4. Use `faccessat()` to verify file exists
5. Trigger reload

This only applies to the entrypoint because dependencies have buffering time during import graph traversal.

## Test Plan

Manual testing with vim on macOS:
1. Run `bun --hot entrypoint.js`
2. Edit entrypoint with vim (`:w`)
3. Verify no "Module not found" errors
4. Verify hot reload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>