### PR TITLE
Fix: Error when using bun build --no-bundle with HTML entrypoint

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -114,6 +114,9 @@ pub fn exit(code: u32) noreturn {
         bun.debug_allocator_data.backing = null;
     }
 
+    // Flush output before exiting to ensure all messages are visible
+    Output.flush();
+
     switch (Environment.os) {
         .mac => std.c.exit(@bitCast(code)),
         .windows => {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -142,7 +142,6 @@ pub const BuildCommand = struct {
             for (this_transpiler.options.entry_points) |entry_point| {
                 if (strings.hasSuffixComptime(entry_point, ".html")) {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> HTML imports are only supported when bundling", .{});
-                    Output.flush();
                     Global.exit(1);
                 }
             }

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -137,6 +137,18 @@ pub const BuildCommand = struct {
             }
         }
 
+        if (ctx.bundler_options.transform_only) {
+            // Check if any entry point is an HTML file
+            for (this_transpiler.options.entry_points) |entry_point| {
+                if (strings.hasSuffixComptime(entry_point, ".html")) {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> HTML imports are only supported when bundling", .{});
+                    Output.flush();
+                    Global.exit(1);
+                    return;
+                }
+            }
+        }
+
         if (ctx.bundler_options.outdir.len == 0 and !ctx.bundler_options.compile and fetcher == null) {
             if (this_transpiler.options.entry_points.len > 1) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> Must use <b>--outdir<r> when specifying more than one entry point.", .{});

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -143,6 +143,7 @@ pub const BuildCommand = struct {
                 if (strings.hasSuffixComptime(entry_point, ".html")) {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> HTML imports are only supported when bundling", .{});
                     Global.exit(1);
+                    return;
                 }
             }
         }

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -144,7 +144,6 @@ pub const BuildCommand = struct {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> HTML imports are only supported when bundling", .{});
                     Output.flush();
                     Global.exit(1);
-                    return;
                 }
             }
         }

--- a/test/regression/issue/23569.test.ts
+++ b/test/regression/issue/23569.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun build --no-bundle with HTML entrypoint should error with helpful message - issue #23569", async () => {
+  using dir = tempDir("23569-html-no-bundle", {
+    "index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <script src="./script.js"></script>
+  </head>
+  <body>
+    <h1>Test</h1>
+  </body>
+</html>`,
+    "script.js": `console.log('Hello');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--no-bundle"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("HTML imports are only supported when bundling");
+});
+
+test("bun build --no-bundle with HTML entrypoint and --outdir should also error - issue #23569", async () => {
+  using dir = tempDir("23569-html-no-bundle-outdir", {
+    "index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <script src="./script.js"></script>
+  </head>
+  <body>
+    <h1>Test</h1>
+  </body>
+</html>`,
+    "script.js": `console.log('Hello');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir", "./build", "--no-bundle"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("HTML imports are only supported when bundling");
+});
+
+test("bun build with HTML entrypoint without --no-bundle should succeed", async () => {
+  using dir = tempDir("23569-html-bundle", {
+    "index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <script src="./script.js"></script>
+  </head>
+  <body>
+    <h1>Test</h1>
+  </body>
+</html>`,
+    "script.js": `console.log('Hello');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir", "./build"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).not.toContain("HTML imports are only supported when bundling");
+});


### PR DESCRIPTION
Fixes #23569

## Summary

HTML imports require bundling to work correctly, as they need to process and transform linked assets (JS/CSS). When `--no-bundle` is used, no bundling or transformation happens, which causes a crash.

This change adds validation to detect HTML entrypoints when `--no-bundle` is used and provides a clear error message explaining that "HTML imports are only supported when bundling".

## Changes

- Added validation in `src/cli/build_command.zig` to check for HTML entrypoints when `--no-bundle` flag is used
- Shows clear error message: "HTML imports are only supported when bundling"
- Added regression tests in `test/regression/issue/23569.test.ts`

## Test Plan

### Before
```bash
$ bun build ./index.html --no-bundle
# Crashes without helpful error
```

### After
```bash
$ bun build ./index.html --no-bundle
error: HTML imports are only supported when bundling
```

### Tests
- ✅ Test with `--no-bundle` flag errors correctly
- ✅ Test with `--no-bundle --outdir` errors correctly  
- ✅ Test without `--no-bundle` works normally
- ✅ All 3 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>