### PR TITLE
fix(parser): advance by enum scopes length during visiting

### DIFF
--- a/src/ast/Parser.zig
+++ b/src/ast/Parser.zig
@@ -618,7 +618,9 @@ pub const Parser = struct {
                     .s_enum => {
                         try parts.appendSlice(preprocessed_enums.items[preprocessed_enum_i]);
                         preprocessed_enum_i += 1;
-                        p.scope_order_to_visit = p.scope_order_to_visit[1..];
+
+                        const enum_scope_count = p.scopes_in_order_for_enum.get(stmt.loc).?.len;
+                        p.scope_order_to_visit = p.scope_order_to_visit[enum_scope_count..];
                     },
                     else => {
                         var sliced = try ListManaged(Stmt).initCapacity(p.allocator, 1);

--- a/src/ast/visit.zig
+++ b/src/ast/visit.zig
@@ -820,7 +820,9 @@ pub fn Visit(
                                 const enum_stmts = preprocessed_enums.items[preprocessed_enum_i];
                                 preprocessed_enum_i += 1;
                                 try visited.appendSlice(enum_stmts);
-                                p.scope_order_to_visit = p.scope_order_to_visit[1..];
+
+                                const enum_scope_count = p.scopes_in_order_for_enum.get(stmt.loc).?.len;
+                                p.scope_order_to_visit = p.scope_order_to_visit[enum_scope_count..];
                                 continue;
                             },
                             else => {},

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -73,6 +73,10 @@ describe("Bun.Transpiler", () => {
       expect(ts.parsed(code, !out.endsWith(";\n"), false)).toBe(out);
     },
 
+    transpiledOutput: code => {
+      return ts.parsed(code, false, false);
+    },
+
     expectPrintedMin_: (code, out) => {
       expect(ts.parsedMin(code, !out.endsWith(";\n"), false)).toBe(out);
     },
@@ -320,6 +324,29 @@ describe("Bun.Transpiler", () => {
 
       err("enum Foo { [2]: 'hi' }", 'Expected identifier but found "["');
       err("enum [] { a }", 'Expected identifier but found "["');
+    });
+
+    it("doesn't crash with functions assigned to enum values", () => {
+      const exp = ts.expectPrinted_;
+
+      expect(
+        ts.transpiledOutput(
+          `
+enum ABC {
+  A = () => {},
+}
+function foo() {}
+`,
+          "hi",
+        ),
+      ).toMatchInlineSnapshot(`
+        "var ABC;
+        ((ABC) => {
+          ABC[ABC["A"] = () => {}] = "A";
+        })(ABC ||= {});
+        function foo() {}
+        "
+      `);
     });
 
     // TODO: fix all the cases that report generic "Parse error"


### PR DESCRIPTION
### What does this PR do?
Matches esbuild behavior.

Fixes #23578
### How did you verify your code works?
Added a test.