### PR TITLE
fix(install): EXDEV handling with `linker: "isolated"`

### DIFF
--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -15,10 +15,6 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
         .result => return .success,
         .err => |err| {
             switch (err.getErrno()) {
-                .XDEV,
-                .OPNOTSUPP,
-                => return .initErr(err),
-
                 .EXIST => {
                     FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
                     return this.clonefileat();

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -1,0 +1,45 @@
+const FileCloner = @This();
+
+// macOS clonefileat only
+
+cache_dir: FD,
+cache_dir_subpath: bun.AutoRelPath,
+dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }),
+
+fn clonefileat(this: *FileCloner) sys.Maybe(void) {
+    return sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), this.dest_subpath.sliceZ());
+}
+
+pub fn clone(this: *FileCloner) sys.Maybe(void) {
+    switch (this.clonefileat()) {
+        .result => return .success,
+        .err => |err| {
+            switch (err.getErrno()) {
+                .XDEV,
+                .OPNOTSUPP,
+                => return .initErr(err),
+
+                .EXIST => {
+                    FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
+                    return this.clonefileat();
+                },
+
+                .NOENT => {
+                    const parent_dest_dir = std.fs.path.dirname(this.dest_subpath.slice()) orelse {
+                        return .initErr(err);
+                    };
+                    FD.cwd().makePath(u8, parent_dest_dir) catch {};
+                    return this.clonefileat();
+                },
+                else => {
+                    return .initErr(err);
+                },
+            }
+        },
+    }
+}
+
+const std = @import("std");
+const bun = @import("bun");
+const FD = bun.FD;
+const sys = bun.sys;

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -40,6 +40,7 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
 }
 
 const std = @import("std");
+
 const bun = @import("bun");
 const FD = bun.FD;
 const sys = bun.sys;

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1416,10 +1416,10 @@ pub const Installer = struct {
 
 const string = []const u8;
 
+const FileCloner = @import("./FileCloner.zig");
 const Hardlinker = @import("./Hardlinker.zig");
 const std = @import("std");
 const Symlinker = @import("./Symlinker.zig").Symlinker;
-const FileCloner = @import("./FileCloner.zig");
 
 const bun = @import("bun");
 const Environment = bun.Environment;


### PR DESCRIPTION
### What does this PR do?
Handles EXDEV correctly after first clonefile fails with ENOENT

Fixes #23579
Fixes #23577
### How did you verify your code works?
Manually