### PR TITLE
chore(libuv): upgrade to latest HEAD (f3ce527e)

### DIFF
--- a/cmake/targets/BuildLibuv.cmake
+++ b/cmake/targets/BuildLibuv.cmake
@@ -4,8 +4,8 @@ register_repository(
   REPOSITORY
     libuv/libuv
   COMMIT
-    # Corresponds to v1.51.0
-    5152db2cbfeb5582e9c27c5ea1dba2cd9e10759b
+    # Latest HEAD (includes recursion bug fix #4784)
+    f3ce527ea940d926c40878ba5de219640c362811
 )
 
 if(WIN32)


### PR DESCRIPTION
### What does this PR do?

Upgrades libuv from v1.51.0 to latest HEAD commit (f3ce527ea940d926c40878ba5de219640c362811) to get critical pipe reading fixes.

### Key fix included since v1.51.0:

**win,pipe: minimal fix to uv_read_cb->uv_read_start recursion bug (#4784)**
- Prevents memory corruption on OVERLAPPED read_req
- Fixes kernel deadlock when reads are issued out of order  
- Resolves issue where uv_read_stop+uv_read_start during callback causes corruption

From the libuv commit:
> Starting a new read after uv_read_cb returns causes memory corruption on the OVERLAPPED read_req if uv_read_stop+uv_read_start was called during the callback after the latest refactoring. This apparently also forces the kernel to deadlock us, since it apparently cannot cancel the second read while the first one is pending (reads apparently are not permitted to finish out of order).

### Other notable changes:
- win: fix path size calculation (#4878)
- win: shrink fd hash table from 2592k to 162k (#4869)
- win: handle empty string in uv_get_process_title (#4807)
- Various compiler warning fixes and minor improvements

### Why this matters

This upgrade should improve Windows pipe stability and potentially resolve remaining console output issues after the v1.51.0 upgrade in September 2025.

The recursion bug fix specifically addresses a deadlock scenario that could occur when:
1. A read callback is active
2. The application calls uv_read_stop followed by uv_read_start
3. A new overlapped read is started while the previous one is still pending
4. Windows kernel deadlocks because reads cannot finish out of order

### Testing

This needs testing on Windows to verify:
- Console output is stable
- No pipe deadlocks
- Child process spawning works correctly
- No regressions in existing tests

### Related Issues

- #23071 - package.json scripts hanging on Windows
- #23315 - ENOTCONN errors  
- #23482 - PowerShell output corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>