### PR TITLE
fix: bun init - add `version` in package.json

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -334,6 +334,7 @@ pub const InitCommand = struct {
     const PackageJSONFields = struct {
         name: string = "project",
         type: string = "module",
+        version: string = "1.0.0",
         object: *js_ast.E.Object = undefined,
         entry_point: stringZ = "",
         private: bool = true,
@@ -649,11 +650,13 @@ pub const InitCommand = struct {
                 if (fields.object.hasProperty("module")) {
                     try fields.object.putString(alloc, "module", fields.entry_point);
                     try fields.object.putString(alloc, "type", "module");
+                    try fields.object.putString(alloc, "version", "1.0.0");
                 } else if (fields.object.hasProperty("main")) {
                     try fields.object.putString(alloc, "main", fields.entry_point);
                 } else {
                     try fields.object.putString(alloc, "module", fields.entry_point);
                     try fields.object.putString(alloc, "type", "module");
+                    try fields.object.putString(alloc, "version", "1.0.0");
                 }
             }
 


### PR DESCRIPTION
### What does this PR do?
I think it's a good idea to add the "version": "number" specifier to the package. It's quite necessary.
https://docs.npmjs.com/creating-and-publishing-scoped-public-packages

### How did you verify your code works?
Here's an example where I encountered a slight error creating and using bun.
_Thank you._

https://github.com/user-attachments/assets/48fe55f2-cf1e-4842-9cdd-df868ede9998