### PR TITLE
Fix Windows crash in bun build with --outdir

### DIFF
--- a/test/regression/issue/23647.test.ts
+++ b/test/regression/issue/23647.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// https://github.com/oven-sh/bun/issues/23647
+// Test that `bun build --outdir=dist --target=browser` works without crashing
+// This was crashing on Windows due to incorrect path handling in build_command.zig
+test("23647 - build with outdir and browser target doesn't crash", async () => {
+  using dir = tempDir("23647", {
+    "index.ts": `
+      import { Hono } from "hono";
+      const app = new Hono();
+      app.get("/hello", (c) => c.text("Hello!"));
+      export default { fetch: app.fetch };
+    `,
+    "package.json": `{
+      "name": "test-23647",
+      "dependencies": {
+        "hono": "^4.9.12"
+      }
+    }`,
+  });
+
+  // First install dependencies
+  const install = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await install.exited;
+
+  // Now run the build that was crashing on Windows
+  const result = Bun.spawn({
+    cmd: [bunExe(), "build", "--outdir=dist", "--target=browser", "--production", "./index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await result.exited;
+  const stdout = await result.stdout.text();
+  const stderr = await result.stderr.text();
+
+  // Should not crash - exit code should be 0
+  expect(exitCode).toBe(0);
+  // Should indicate successful bundling
+  expect(stdout).toContain("module");
+  // Should create the output directory
+  const outputPath = path.join(String(dir), "dist", "index.js");
+  expect(fs.existsSync(outputPath)).toBe(true);
+}, 30000);


### PR DESCRIPTION
Fixes #23647

## Summary

- Fixed a crash on Windows when running `bun build --outdir=dist --target=browser`
- The issue was caused by unconditionally calling `std.posix.toPosixPath()` before opening a directory
- Replaced with `bun.sys.openA()` which handles platform-specific path conversion internally
- Added regression test to prevent this from happening again

## Root Cause

The crash occurred at `build_command.zig:167` where `std.posix.toPosixPath(path)` was called unconditionally before passing to `openDirForPath`. On Windows, this function doesn't properly handle Windows-style paths (with backslashes, drive letters, UNC paths, etc.).

## The Fix

Replaced the manual path conversion approach with `bun.sys.openA()`, which:
- Handles path conversion internally for both Windows (`openatWindowsT`) and POSIX (`std.posix.toPosixPath`) 
- Uses appropriate flags: `O.PATH | O.DIRECTORY` on Linux, `O.RDONLY | O.DIRECTORY` on other POSIX systems
- Is simpler and more maintainable than manual path handling

## Test Plan

- [x] Added regression test in `test/regression/issue/23647.test.ts`
- [x] Test passes on Linux  
- [x] Fix compiles successfully
- [x] Tested with original reproduction case

**Note**: I cannot test on Windows directly as I'm on Linux. The fix is based on code analysis and understanding of how `bun.sys.openA` handles Windows paths internally. Windows CI will validate the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)