### PR TITLE
Updated sqlite.md example to use non-deprecated method

### DIFF
--- a/docs/api/sqlite.md
+++ b/docs/api/sqlite.md
@@ -182,7 +182,7 @@ SQLite supports [write-ahead log mode](https://www.sqlite.org/wal.html) (WAL) wh
 To enable WAL mode, run this pragma query at the beginning of your application:
 
 ```ts
-db.exec("PRAGMA journal_mode = WAL;");
+db.run("PRAGMA journal_mode = WAL;");
 ```
 
 {% details summary="What is WAL mode" %}


### PR DESCRIPTION
Replaced deprecated "exec" method with "run" in the example

### What does this PR do?

Fixes documentation where a deprecated method was used

### How did you verify your code works?

It is documentation and uses the appropriate preferred methods indicated in the other documentation.