### PR TITLE
Add crash pattern rules for duplicate issue detection

### DIFF
--- a/.github/workflows/labeled.yml
+++ b/.github/workflows/labeled.yml
@@ -142,8 +142,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const closeAction = JSON.parse('${{ steps.add-labels.outputs.close-action }}');
-            
+            const closeAction = ${{ steps.add-labels.outputs.close-action }};
+
             // Comment with the reason
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -151,7 +151,7 @@ jobs:
               issue_number: context.issue.number,
               body: closeAction.comment
             });
-            
+
             // Close the issue
             await github.rest.issues.update({
               owner: context.repo.owner,

--- a/.github/workflows/labeled.yml
+++ b/.github/workflows/labeled.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const closeAction = ${{ steps.add-labels.outputs.close-action }};
+            const closeAction = ${{ fromJson(steps.add-labels.outputs.close-action) }};
 
             // Comment with the reason
             await github.rest.issues.createComment({

--- a/scripts/handle-crash-patterns.ts
+++ b/scripts/handle-crash-patterns.ts
@@ -26,8 +26,8 @@ We are tracking worker stability issues in https://github.com/oven-sh/bun/issues
 
 // Check for better-sqlite3 with RunCommand or AutoCommand
 else if (
-  (body.includes("better-sqlite3") || body.toLowerCase().includes("better-sqlite3")) &&
-  (body.includes("RunCommand") || body.includes("AutoCommand"))
+  body.toLowerCase().includes("better-sqlite3") &&
+  (body.toLowerCase().includes("runcommand") || body.toLowerCase().includes("autocommand"))
 ) {
   closeAction = {
     reason: "not_planned",
@@ -38,10 +38,10 @@ better-sqlite3 is not supported yet in Bun due to missing V8 C++ APIs. For now, 
 
 // Check for ENOTCONN with Transport and standalone_executable on v1.2.23
 else if (
-  body.includes("ENOTCONN") &&
-  body.includes("Transport") &&
-  body.includes("standalone_executable") &&
-  (body.includes("1.2.23") || body.includes("v1.2.23"))
+  body.toLowerCase().includes("enotconn") &&
+  body.toLowerCase().includes("transport") &&
+  body.toLowerCase().includes("standalone_executable") &&
+  /\bv?1\.2\.23\b/i.test(body)
 ) {
   closeAction = {
     reason: "completed",

--- a/scripts/handle-crash-patterns.ts
+++ b/scripts/handle-crash-patterns.ts
@@ -15,8 +15,11 @@ interface CloseAction {
 
 let closeAction: CloseAction | null = null;
 
+// Compute lowercase once for performance
+const bodyLower = body.toLowerCase();
+
 // Check for workers_terminated
-if (body.includes("workers_terminated")) {
+if (bodyLower.includes("workers_terminated")) {
   closeAction = {
     reason: "not_planned",
     comment: `Duplicate of #15964
@@ -26,8 +29,8 @@ We are tracking worker stability issues in https://github.com/oven-sh/bun/issues
 
 // Check for better-sqlite3 with RunCommand or AutoCommand
 else if (
-  body.toLowerCase().includes("better-sqlite3") &&
-  (body.toLowerCase().includes("runcommand") || body.toLowerCase().includes("autocommand"))
+  bodyLower.includes("better-sqlite3") &&
+  (bodyLower.includes("runcommand") || bodyLower.includes("autocommand"))
 ) {
   closeAction = {
     reason: "not_planned",
@@ -38,10 +41,10 @@ better-sqlite3 is not supported yet in Bun due to missing V8 C++ APIs. For now, 
 
 // Check for ENOTCONN with Transport and standalone_executable on v1.2.23
 else if (
-  body.toLowerCase().includes("enotconn") &&
-  body.toLowerCase().includes("transport") &&
-  body.toLowerCase().includes("standalone_executable") &&
-  /\bv?1\.2\.23\b/i.test(body)
+  bodyLower.includes("enotconn") &&
+  bodyLower.includes("transport") &&
+  bodyLower.includes("standalone_executable") &&
+  /\bv?1\.2\.23\b/i.test(bodyLower)
 ) {
   closeAction = {
     reason: "completed",
@@ -55,7 +58,7 @@ bun upgrade
 }
 
 // Check for WASM IPInt 32 stack traces - be very specific to avoid false positives
-else if (body.includes("wasm_trampoline_wasm_ipint_call_wide32")) {
+else if (bodyLower.includes("wasm_trampoline_wasm_ipint_call_wide32")) {
   closeAction = {
     reason: "not_planned",
     comment: `Duplicate of #17841.
@@ -71,10 +74,10 @@ We've reported this to WebKit and are tracking the issue in #17841.`,
 
 // Check for CPU architecture issues (Segmentation Fault/Illegal Instruction with no_avx)
 else if (
-  (body.includes("Segmentation Fault") ||
-    body.includes("Illegal Instruction") ||
-    body.includes("IllegalInstruction")) &&
-  body.includes("no_avx")
+  (bodyLower.includes("segmentation fault") ||
+    bodyLower.includes("illegal instruction") ||
+    bodyLower.includes("illegalinstruction")) &&
+  bodyLower.includes("no_avx")
 ) {
   let comment = `Bun requires a CPU with the micro-architecture [\`nehalem\`](https://en.wikipedia.org/wiki/Nehalem_(microarchitecture)) or later (released in 2008). If you're using a CPU emulator like qemu, then try enabling x86-64-v2.`;
 

--- a/scripts/handle-crash-patterns.ts
+++ b/scripts/handle-crash-patterns.ts
@@ -25,11 +25,47 @@ We are tracking worker stability issues in https://github.com/oven-sh/bun/issues
 }
 
 // Check for better-sqlite3 with RunCommand or AutoCommand
-else if (body.includes("better-sqlite3") && (body.includes("[RunCommand]") || body.includes("[AutoCommand]"))) {
+else if (
+  (body.includes("better-sqlite3") || body.toLowerCase().includes("better-sqlite3")) &&
+  (body.includes("RunCommand") || body.includes("AutoCommand"))
+) {
   closeAction = {
     reason: "not_planned",
     comment: `Duplicate of #4290.
 better-sqlite3 is not supported yet in Bun due to missing V8 C++ APIs. For now, you can try [bun:sqlite](https://bun.com/docs/api/sqlite) for an almost drop-in replacement.`,
+  };
+}
+
+// Check for ENOTCONN with Transport and standalone_executable on v1.2.23
+else if (
+  body.includes("ENOTCONN") &&
+  body.includes("Transport") &&
+  body.includes("standalone_executable") &&
+  (body.includes("1.2.23") || body.includes("v1.2.23"))
+) {
+  closeAction = {
+    reason: "completed",
+    comment: `Duplicate of #23342.
+This issue was fixed in Bun v1.3. Please upgrade to the latest version:
+
+\`\`\`sh
+bun upgrade
+\`\`\``,
+  };
+}
+
+// Check for WASM IPInt 32 stack traces - be very specific to avoid false positives
+else if (body.includes("wasm_trampoline_wasm_ipint_call_wide32")) {
+  closeAction = {
+    reason: "not_planned",
+    comment: `Duplicate of #17841.
+This is a known issue with JavaScriptCore's WASM In-place interpreter on Linux x64. You can work around it by:
+
+1. Setting \`BUN_JSC_useWasmIPInt=0\` to disable IPInt (reverts to older Wasm interpreter)
+2. Using an aarch64 CPU instead of x86_64
+3. Using \`BUN_JSC_jitPolicyScale=0\` to force JIT compilation (may impact startup performance)
+
+We've reported this to WebKit and are tracking the issue in #17841.`,
   };
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a critical bug in the crash pattern detection workflow that prevented it from working, and adds three new duplicate detection rules to automatically close duplicate crash issues.

**Bug Fix**: The workflow was failing with "Bad control character in string literal in JSON" when trying to close issues. Fixed by using proper GitHub Actions `fromJson()` wrapper.

**Example failure**: Issue #23638 should have been auto-closed but the workflow failed: https://github.com/oven-sh/bun/actions/runs/18485035867

**New Detection Rules**:

1. **better-sqlite3 + V8 C++ APIs** → Closes as duplicate of #4290
   - Detects when body contains `better-sqlite3` AND (`RunCommand` OR `AutoCommand`)
   - Explains missing V8 C++ API support, suggests `bun:sqlite`

2. **ENOTCONN Transport Issue** → Closes as duplicate of #23342
   - Detects when body contains: `ENOTCONN`, `Transport`, `standalone_executable`, AND version `1.2.23`
   - Issue was fixed in v1.3, suggests `bun upgrade`

3. **WASM IPInt Stack Trace** → Closes as duplicate of #17841
   - Detects specific stack trace: `wasm_trampoline_wasm_ipint_call_wide32`
   - Provides workarounds for JSC WASM IPInt issue on Linux x64

All pattern matching is case-insensitive and uses precise matching to avoid false positives.

### How did you verify your code works?

1. **Unit tested all patterns** with sample issue bodies to ensure:
   - ✅ Correct matches are detected
   - ✅ No false positives (generic mentions don't trigger)
   - ✅ JSON output is properly formatted

2. **Identified real-world failure**: Found issue #23638 that should have been auto-closed but workflow failed with JSON parsing error

3. **Simulation testing**: Ran the fixed script against open issue #23657 (contains WASM pattern) and verified it would correctly close as duplicate of #17841

4. **Addressed code review feedback**: 
   - Made all matching case-insensitive
   - Used regex with word boundaries for version detection
   - Fixed workflow to use `fromJson()` wrapper