### PR TITLE
docs: Fix broken link to Bun.stringWidth() in API reference

### DIFF
--- a/docs/runtime/bun-apis.md
+++ b/docs/runtime/bun-apis.md
@@ -165,7 +165,7 @@ Click the link in the right column to jump to the associated documentation.
 ---
 
 - String & Text Processing
-- [`Bun.escapeHTML()`](https://bun.com/docs/api/utils#bun-escapehtml), [`Bun.stringWidth()`](https://bun.com/docs/api/utils#bun-stringwidth), `Bun.indexOfLine`
+- [`Bun.escapeHTML()`](https://bun.com/docs/api/utils#bun-escapehtml), [`Bun.stringWidth()`](https://bun.com/docs/api/utils#bun-stringwidth-6-756x-faster-string-width-alternative), `Bun.indexOfLine`
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed the broken link to `Bun.stringWidth()` in the Bun APIs documentation page

## Details
The link in `/docs/runtime/bun-apis.md` was pointing to `#bun-stringwidth`, but the actual heading in `/docs/api/utils.md` is `## Bun.stringWidth() ~6,756x faster string-width alternative`, which generates the anchor `#bun-stringwidth-6-756x-faster-string-width-alternative`.

Updated the link to use the correct anchor.

## Test plan
- Verified the heading in `/docs/api/utils.md` at line 313
- Updated the link in `/docs/runtime/bun-apis.md` at line 168

Fixes #23662

🤖 Generated with [Claude Code](https://claude.com/claude-code)