### PR TITLE
Add email field support to .npmrc for registry authentication

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -2825,14 +2825,18 @@ pub const api = struct {
         /// token
         token: []const u8,
 
+        /// email
+        email: []const u8,
+
         pub fn dupe(this: NpmRegistry, allocator: std.mem.Allocator) NpmRegistry {
-            const buf = bun.handleOom(allocator.alloc(u8, this.url.len + this.username.len + this.password.len + this.token.len));
+            const buf = bun.handleOom(allocator.alloc(u8, this.url.len + this.username.len + this.password.len + this.token.len + this.email.len));
 
             var out: NpmRegistry = .{
                 .url = "",
                 .username = "",
                 .password = "",
                 .token = "",
+                .email = "",
             };
 
             var i: usize = 0;
@@ -2853,6 +2857,7 @@ pub const api = struct {
             this.username = try reader.readValue([]const u8);
             this.password = try reader.readValue([]const u8);
             this.token = try reader.readValue([]const u8);
+            this.email = try reader.readValue([]const u8);
             return this;
         }
 
@@ -2861,6 +2866,7 @@ pub const api = struct {
             try writer.writeValue(@TypeOf(this.username), this.username);
             try writer.writeValue(@TypeOf(this.password), this.password);
             try writer.writeValue(@TypeOf(this.token), this.token);
+            try writer.writeValue(@TypeOf(this.email), this.email);
         }
 
         pub const Parser = struct {

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -556,9 +556,10 @@ pub const IniTestingAPIs = struct {
             return log.toJS(globalThis, allocator, "error");
         };
 
-        const default_registry_url, const default_registry_token, const default_registry_username, const default_registry_password = brk: {
+        const default_registry_url, const default_registry_token, const default_registry_username, const default_registry_password, const default_registry_email = brk: {
             const default_registry = install.default_registry orelse break :brk .{
                 bun.String.static(Registry.default_url[0..]),
+                bun.String.empty,
                 bun.String.empty,
                 bun.String.empty,
                 bun.String.empty,
@@ -569,6 +570,7 @@ pub const IniTestingAPIs = struct {
                 bun.String.fromBytes(default_registry.token),
                 bun.String.fromBytes(default_registry.username),
                 bun.String.fromBytes(default_registry.password),
+                bun.String.fromBytes(default_registry.email),
             };
         };
         defer {
@@ -576,6 +578,7 @@ pub const IniTestingAPIs = struct {
             default_registry_token.deref();
             default_registry_username.deref();
             default_registry_password.deref();
+            default_registry_email.deref();
         }
 
         return (try jsc.JSObject.create(.{
@@ -583,6 +586,7 @@ pub const IniTestingAPIs = struct {
             .default_registry_token = default_registry_token,
             .default_registry_username = default_registry_username,
             .default_registry_password = default_registry_password,
+            .default_registry_email = default_registry_email,
         }, globalThis)).toJS();
     }
 
@@ -1181,7 +1185,7 @@ pub fn loadNpmrc(
                 // - @myorg:registry=https://somewhere-else.com/myorg
                 const conf_item: bun.ini.ConfigIterator.Item = conf_item_;
                 switch (conf_item.optname) {
-                    .email, .certfile, .keyfile => {
+                    .certfile, .keyfile => {
                         try log.addWarningFmt(
                             source,
                             iter.config.properties.at(iter.prop_idx - 1).key.?.loc,
@@ -1212,6 +1216,7 @@ pub fn loadNpmrc(
                         .token = "",
                         .username = "",
                         .url = Registry.default_url,
+                        .email = "",
                     };
                     break :brk &install.default_registry.?;
                 };
@@ -1229,7 +1234,10 @@ pub fn loadNpmrc(
                     ._auth => {
                         try @"handle _auth"(allocator, v, &conf_item, log, source);
                     },
-                    .email, .certfile, .keyfile => unreachable,
+                    .email => {
+                        if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| v.email = x;
+                    },
+                    .certfile, .keyfile => unreachable,
                 }
             }
 
@@ -1256,7 +1264,10 @@ pub fn loadNpmrc(
                         ._auth => {
                             try @"handle _auth"(allocator, v, &conf_item, log, source);
                         },
-                        .email, .certfile, .keyfile => unreachable,
+                        .email => {
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| v.email = x;
+                        },
+                        .certfile, .keyfile => unreachable,
                     }
                     // We have to keep going as it could match multiple scopes
                     continue;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -251,6 +251,7 @@ pub fn load(
         .username = "",
         .password = "",
         .token = "",
+        .email = "",
     };
     if (bun_install_) |config| {
         if (config.default_registry) |registry| {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -233,6 +233,7 @@ registry=http://localhost:\${PORT}/
       default_registry_token: string;
       default_registry_username: string;
       default_registry_password: string;
+      default_registry_email: string;
     }) => void,
   ) {
     const optionName = await Promise.all(options.map(async ([name, val]) => `${name} = ${val}`));
@@ -442,6 +443,25 @@ ${Object.keys(opts)
     },
     (stdout: string, stderr: string) => {
       expect(stderr).toContain("received an empty string");
+    },
+  );
+
+  await makeTest([["email", "user@example.com"]], result => {
+    expect(result.default_registry_url).toEqual("https://registry.npmjs.org/");
+    expect(result.default_registry_email).toEqual("user@example.com");
+  });
+
+  await makeTest(
+    [
+      ["username", "testuser"],
+      ["_password", "testpass"],
+      ["email", "test@example.com"],
+    ],
+    result => {
+      expect(result.default_registry_url).toEqual("https://registry.npmjs.org/");
+      expect(result.default_registry_username).toEqual("testuser");
+      expect(result.default_registry_password).toEqual("testpass");
+      expect(result.default_registry_email).toEqual("test@example.com");
     },
   );
 });


### PR DESCRIPTION
### What does this PR do?

This PR implements support for the `email` field in `.npmrc` files for registry scope authentication. Some private registries (particularly Nexus) require the email field to be specified in the registry configuration alongside username/password or token authentication.

The email field can now be specified in `.npmrc` files like:
```ini
//registry.example.com/:email=user@example.com
//registry.example.com/:username=myuser
//registry.example.com/:_password=base64encodedpassword
```

### How did you verify your code works?

1. **Built Bun successfully** - Confirmed the code compiles without errors using `bun bd --debug`

2. **Wrote comprehensive unit tests** - Added two test cases to `test/cli/install/npmrc.test.ts`:
   - Test for standalone email field parsing
   - Test for email combined with username/password authentication

3. **Verified tests pass** - Ran `bun bd test test/cli/install/npmrc.test.ts -t "email"` and confirmed both tests pass:
   ```
   ✓ 2 pass
   ✓ 0 fail
   ✓ 6 expect() calls
   ```

4. **Code changes include**:
   - Added `email` field to `NpmRegistry` struct in `src/api/schema.zig`
   - Updated `encode()` and `decode()` methods to handle the email field
   - Modified `ini.zig` to parse and store the email field from `.npmrc`
   - Removed email from the unsupported options warning (certfile and keyfile remain unsupported)
   - Updated all `NpmRegistry` struct initializations to include the email field
   - Updated `loadNpmrcFromJS` test API to return the email field

🤖 Generated with [Claude Code](https://claude.com/claude-code)