### PR TITLE
feat(EnvVar): Environment Variables Store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,10 @@ test("my feature", async () => {
 - `transpiler.zig` - Wrapper around js_parser with sourcemap support
 - `resolver/` - Module resolution system
 - `allocators/` - Custom memory allocators for performance
+- `os.zig` - Type-safe cross-platform OS abstractions
+- `sys.zig` - Type-safe low-level system calls and utilities
+
+**ALWAYS** prefer using high-quality common abstractions rather than direct syscalls.
 
 #### JavaScript Runtime (`src/bun.js/`)
 

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1260,6 +1260,7 @@ endif()
 
 if(WIN32)
   target_link_libraries(${bun} PRIVATE
+    advapi32
     winmm
     bcrypt
     ntdll
@@ -1308,32 +1309,32 @@ if(NOT BUN_CPP_ONLY)
       OUTPUTS
         ${BUILD_PATH}/${bunStripExe}
     )
-    
+
     # Then sign both executables on Windows
     if(WIN32 AND ENABLE_WINDOWS_CODESIGNING)
       set(SIGN_SCRIPT "${CMAKE_SOURCE_DIR}/.buildkite/scripts/sign-windows.ps1")
-      
+
       # Verify signing script exists
       if(NOT EXISTS "${SIGN_SCRIPT}")
         message(FATAL_ERROR "Windows signing script not found: ${SIGN_SCRIPT}")
       endif()
-      
+
       # Use PowerShell for Windows code signing (native Windows, no path issues)
-      find_program(POWERSHELL_EXECUTABLE 
+      find_program(POWERSHELL_EXECUTABLE
         NAMES pwsh.exe powershell.exe
-        PATHS 
+        PATHS
           "C:/Program Files/PowerShell/7"
           "C:/Program Files (x86)/PowerShell/7"
           "C:/Windows/System32/WindowsPowerShell/v1.0"
         DOC "Path to PowerShell executable"
       )
-      
+
       if(NOT POWERSHELL_EXECUTABLE)
         set(POWERSHELL_EXECUTABLE "powershell.exe")
       endif()
-      
+
       message(STATUS "Using PowerShell executable: ${POWERSHELL_EXECUTABLE}")
-      
+
       # Sign both bun-profile.exe and bun.exe after stripping
       register_command(
         TARGET

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1328,7 +1328,7 @@ pub const StandaloneModuleGraph = struct {
                         var whichbuf: bun.PathBuffer = undefined;
                         if (bun.which(
                             &whichbuf,
-                            bun.getenvZ("PATH") orelse return error.FileNotFound,
+                            bun.env_var.path.get() orelse return error.FileNotFound,
                             "",
                             bun.argv[0],
                         )) |path| {

--- a/src/analytics.zig
+++ b/src/analytics.zig
@@ -12,12 +12,10 @@ pub fn isEnabled() bool {
         .no => false,
         .unknown => {
             enabled = detect: {
-                if (bun.getenvZ("DO_NOT_TRACK")) |x| {
-                    if (x.len == 1 and x[0] == '1') {
-                        break :detect .no;
-                    }
+                if (bun.env_var.do_not_track.get()) {
+                    break :detect .no;
                 }
-                if (bun.getenvZ("HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET") != null) {
+                if (bun.env_var.hyperfine_randomized_environment_offset.get() != null) {
                     break :detect .no;
                 }
                 break :detect .yes;

--- a/src/bake.zig
+++ b/src/bake.zig
@@ -984,7 +984,7 @@ pub const PatternBuffer = struct {
 
 pub fn printWarning() void {
     // Silence this for the test suite
-    if (bun.getenvZ("BUN_DEV_SERVER_TEST_RUNNER") == null) {
+    if (bun.env_var.bun_dev_server_test_runner.get() == null) {
         bun.Output.warn(
             \\Be advised that Bun Bake is highly experimental, and its API
             \\will have breaking changes. Join the <magenta>#bake<r> Discord

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -318,7 +318,7 @@ pub fn init(options: Options) bun.JSOOM!*DevServer {
         .memory_visualizer_timer = .initPaused(.DevServerMemoryVisualizerTick),
         .has_pre_crash_handler = bun.FeatureFlags.bake_debugging_features and
             options.dump_state_on_crash orelse
-                bun.getRuntimeFeatureFlag(.BUN_DUMP_STATE_ON_CRASH),
+                bun.feature_flag.dump_state_on_crash.get(),
         .frontend_only = options.framework.file_system_router_types.len == 0,
         .client_graph = .empty,
         .server_graph = .empty,
@@ -349,7 +349,7 @@ pub fn init(options: Options) bun.JSOOM!*DevServer {
             else
                 true
         else
-            bun.getRuntimeFeatureFlag(.BUN_ASSUME_PERFECT_INCREMENTAL),
+            bun.feature_flag.assume_perfect_incremental.get(),
         .testing_batch_events = .disabled,
         .broadcast_console_log_from_browser_to_server = options.broadcast_console_log_from_browser_to_server,
         .server_transpiler = undefined,

--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -2037,7 +2037,7 @@ fn dumpSourceString(vm: *VirtualMachine, specifier: string, written: []const u8)
 
 fn dumpSourceStringFailiable(vm: *VirtualMachine, specifier: string, written: []const u8) !void {
     if (!Environment.isDebug) return;
-    if (bun.getRuntimeFeatureFlag(.BUN_DEBUG_NO_DUMP)) return;
+    if (bun.feature_flag.debug_no_dump.get()) return;
 
     const BunDebugHolder = struct {
         pub var dir: ?std.fs.Dir = null;

--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -1147,26 +1147,11 @@ pub const internal = struct {
 
     var __max_dns_time_to_live_seconds: ?u32 = null;
     pub fn getMaxDNSTimeToLiveSeconds() u32 {
-        // Amazon Web Services recommends 5 seconds: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/jvm-ttl-dns.html
-        const default_max_dns_time_to_live_seconds = 30;
-
         // This is racy, but it's okay because the number won't be invalid, just stale.
         return __max_dns_time_to_live_seconds orelse {
-            if (bun.getenvZ("BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS")) |string_value| {
-                const value = std.fmt.parseInt(i64, string_value, 10) catch {
-                    __max_dns_time_to_live_seconds = default_max_dns_time_to_live_seconds;
-                    return default_max_dns_time_to_live_seconds;
-                };
-                if (value < 0) {
-                    __max_dns_time_to_live_seconds = std.math.maxInt(u32);
-                } else {
-                    __max_dns_time_to_live_seconds = @truncate(@as(u64, @intCast(value)));
-                }
-                return __max_dns_time_to_live_seconds.?;
-            }
-
-            __max_dns_time_to_live_seconds = default_max_dns_time_to_live_seconds;
-            return default_max_dns_time_to_live_seconds;
+            const value = bun.env_var.bun_config_dns_time_to_live_seconds.get();
+            __max_dns_time_to_live_seconds = @truncate(@as(u64, @intCast(value)));
+            return __max_dns_time_to_live_seconds.?;
         };
     }
 
@@ -1393,12 +1378,12 @@ pub const internal = struct {
     };
     pub fn getHints() std.c.addrinfo {
         var hints_copy = default_hints;
-        if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG)) {
+        if (bun.feature_flag.disable_addrconfig.get()) {
             hints_copy.flags.ADDRCONFIG = false;
         }
-        if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_IPV6)) {
+        if (bun.feature_flag.disable_ipv6.get()) {
             hints_copy.family = std.c.AF.INET;
-        } else if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_IPV4)) {
+        } else if (bun.feature_flag.disable_ipv4.get()) {
             hints_copy.family = std.c.AF.INET6;
         }
 
@@ -1685,7 +1670,7 @@ pub const internal = struct {
         getaddrinfo_calls += 1;
         var timestamp_to_store: u32 = 0;
         // is there a cache hit?
-        if (!bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_DNS_CACHE)) {
+        if (!bun.feature_flag.disable_dns_cache.get()) {
             if (global_cache.get(key, &timestamp_to_store)) |entry| {
                 if (preload) {
                     global_cache.lock.unlock();
@@ -1724,7 +1709,7 @@ pub const internal = struct {
         global_cache.lock.unlock();
 
         if (comptime Environment.isMac) {
-            if (!bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO)) {
+            if (!bun.feature_flag.disable_dns_cache_libinfo.get()) {
                 const res = lookupLibinfo(req, loop.internal_loop_data.getParent());
                 log("getaddrinfo({s}) = cache miss (libinfo)", .{host orelse ""});
                 if (res) return req;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -1351,7 +1351,7 @@ pub fn spawnMaybeSync(
         !jsc_vm.auto_killer.enabled and
         !jsc_vm.jsc_vm.hasExecutionTimeLimit() and
         !jsc_vm.isInspectorEnabled() and
-        !bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH);
+        !bun.feature_flag.disable_spawnsync_fast_path.get();
 
     const spawn_options = bun.spawn.SpawnOptions{
         .cwd = cwd,

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -321,7 +321,7 @@ pub const FFI = struct {
         pub fn compile(this: *CompileC, globalThis: *JSGlobalObject) !struct { *TCC.State, []u8 } {
             const compile_options: [:0]const u8 = if (this.flags.len > 0)
                 this.flags
-            else if (bun.getenvZ("BUN_TCC_OPTIONS")) |tcc_options|
+            else if (bun.env_var.bun_tcc_options.get()) |tcc_options|
                 @ptrCast(tcc_options)
             else
                 default_tcc_options;
@@ -349,7 +349,7 @@ pub const FFI = struct {
             if (Environment.isMac) {
                 add_system_include_dir: {
                     const dirs_to_try = [_][]const u8{
-                        bun.getenvZ("SDKROOT") orelse "",
+                        bun.env_var.sdkroot.get() orelse "",
                         getSystemIncludeDir() orelse "",
                     };
 

--- a/src/bun.js/bindings/libuv/generate_uv_posix_stubs_constants.ts
+++ b/src/bun.js/bindings/libuv/generate_uv_posix_stubs_constants.ts
@@ -1,5 +1,6 @@
 export const test_skipped = [
   "uv_getrusage_thread",
+  "uv_os_homedir",
   "uv_thread_detach",
   "uv_thread_getname",
   "uv_thread_getpriority",

--- a/src/bun.js/bindings/uv-posix-stubs.c
+++ b/src/bun.js/bindings/uv-posix-stubs.c
@@ -1129,10 +1129,10 @@ UV_EXTERN int uv_os_getpriority(uv_pid_t pid, int* priority)
     __builtin_unreachable();
 }
 
+extern int bunuv__os_homedir(char* buffer, size_t* size);
 UV_EXTERN int uv_os_homedir(char* buffer, size_t* size)
 {
-    __bun_throw_not_implemented("uv_os_homedir");
-    __builtin_unreachable();
+    return bunuv__os_homedir(buffer, size);
 }
 
 UV_EXTERN int uv_os_setenv(const char* name, const char* value)

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -37,7 +37,7 @@ pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     actual.internal_loop_data.jsc_vm = vm.jsc_vm;
 
     if (comptime Environment.isDebug) {
-        if (bun.getenvZ("BUN_TRACK_LAST_FN_NAME") != null) {
+        if (bun.env_var.bun_track_last_fn_name.get()) {
             vm.eventLoop().debug.track_last_fn_name = true;
         }
     }

--- a/src/bun.js/node.zig
+++ b/src/bun.js/node.zig
@@ -152,6 +152,25 @@ pub fn Maybe(comptime ReturnTypeT: type, comptime ErrorTypeT: type) type {
             return null;
         }
 
+        pub inline fn asValueConstPtr(this: *const @This()) ?*const ReturnType {
+            if (comptime ReturnType == void)
+                @compileError("Maybe.asValueConstPtr is invalid for ReturnType == void");
+            return switch (this.*) {
+                .result => |*r| r,
+                .err => null,
+            };
+        }
+
+        pub inline fn asValuePtr(this: *@This()) ?*ReturnType {
+            if (comptime ReturnType == void)
+                @compileError("Maybe.asValuePtr is invalid for ReturnType == void");
+
+            return switch (this.*) {
+                .result => |*r| r,
+                .err => null,
+            };
+        }
+
         pub inline fn isOk(this: *const @This()) bool {
             return switch (this.*) {
                 .result => true,

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -302,80 +302,15 @@ pub fn getPriority(global: *jsc.JSGlobalObject, pid: i32) bun.JSError!i32 {
 }
 
 pub fn homedir(global: *jsc.JSGlobalObject) !bun.String {
-    // In Node.js, this is a wrapper around uv_os_homedir.
-    if (Environment.isWindows) {
-        var out: bun.PathBuffer = undefined;
-        var size: usize = out.len;
-        if (libuv.uv_os_homedir(&out, &size).toError(.uv_os_homedir)) |err| {
+    var home_res = bun.os.HomeDir.query(bun.default_allocator);
+    switch (home_res) {
+        .result => |*r| {
+            defer r.deinit();
+            return bun.String.cloneUTF8(r.slice());
+        },
+        .err => |err| {
             return global.throwValue(err.toJS(global));
-        }
-        return bun.String.cloneUTF8(out[0..size]);
-    } else {
-
-        // The posix implementation of uv_os_homedir first checks the HOME
-        // environment variable, then falls back to reading the passwd entry.
-        if (bun.getenvZ("HOME")) |home| {
-            if (home.len > 0)
-                return bun.String.init(home);
-        }
-
-        // From libuv:
-        // > Calling sysconf(_SC_GETPW_R_SIZE_MAX) would get the suggested size, but it
-        // > is frequently 1024 or 4096, so we can just use that directly. The pwent
-        // > will not usually be large.
-        // Instead of always using an allocation, first try a stack allocation
-        // of 4096, then fallback to heap.
-        var stack_string_bytes: [4096]u8 = undefined;
-        var string_bytes: []u8 = &stack_string_bytes;
-        defer if (string_bytes.ptr != &stack_string_bytes)
-            bun.default_allocator.free(string_bytes);
-
-        var pw: bun.c.passwd = undefined;
-        var result: ?*bun.c.passwd = null;
-
-        const ret = while (true) {
-            const ret = bun.c.getpwuid_r(
-                bun.c.geteuid(),
-                &pw,
-                string_bytes.ptr,
-                string_bytes.len,
-                &result,
-            );
-
-            if (ret == @intFromEnum(bun.sys.E.INTR))
-                continue;
-
-            // If the system call wants more memory, double it.
-            if (ret == @intFromEnum(bun.sys.E.RANGE)) {
-                const len = string_bytes.len;
-                bun.default_allocator.free(string_bytes);
-                string_bytes = "";
-                string_bytes = try bun.default_allocator.alloc(u8, len * 2);
-                continue;
-            }
-
-            break ret;
-        };
-
-        if (ret != 0) {
-            return global.throwValue(bun.sys.Error.fromCode(
-                @enumFromInt(ret),
-                .uv_os_homedir,
-            ).toJS(global));
-        }
-
-        if (result == null) {
-            // in uv__getpwuid_r, null result throws UV_ENOENT.
-            return global.throwValue(bun.sys.Error.fromCode(
-                .NOENT,
-                .uv_os_homedir,
-            ).toJS(global));
-        }
-
-        return if (pw.pw_dir) |dir|
-            bun.String.cloneUTF8(bun.span(dir))
-        else
-            bun.String.empty;
+        },
     }
 }
 
@@ -938,15 +873,15 @@ pub fn userInfo(globalThis: *jsc.JSGlobalObject, options: gen.UserInfoOptions) b
     result.put(globalThis, jsc.ZigString.static("homedir"), home.toJS(globalThis));
 
     if (comptime Environment.isWindows) {
-        result.put(globalThis, jsc.ZigString.static("username"), jsc.ZigString.init(bun.getenvZ("USERNAME") orelse "unknown").withEncoding().toJS(globalThis));
+        result.put(globalThis, jsc.ZigString.static("username"), jsc.ZigString.init(bun.env_var.user.get() orelse "unknown").withEncoding().toJS(globalThis));
         result.put(globalThis, jsc.ZigString.static("uid"), jsc.JSValue.jsNumber(-1));
         result.put(globalThis, jsc.ZigString.static("gid"), jsc.JSValue.jsNumber(-1));
         result.put(globalThis, jsc.ZigString.static("shell"), jsc.JSValue.jsNull());
     } else {
-        const username = bun.getenvZ("USER") orelse "unknown";
+        const username = bun.env_var.user.get() orelse "unknown";
 
         result.put(globalThis, jsc.ZigString.static("username"), jsc.ZigString.init(username).withEncoding().toJS(globalThis));
-        result.put(globalThis, jsc.ZigString.static("shell"), jsc.ZigString.init(bun.getenvZ("SHELL") orelse "unknown").withEncoding().toJS(globalThis));
+        result.put(globalThis, jsc.ZigString.static("shell"), jsc.ZigString.init(bun.env_var.shell.get() orelse "unknown").withEncoding().toJS(globalThis));
         result.put(globalThis, jsc.ZigString.static("uid"), jsc.JSValue.jsNumber(c.getuid()));
         result.put(globalThis, jsc.ZigString.static("gid"), jsc.JSValue.jsNumber(c.getgid()));
     }

--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -339,11 +339,11 @@ comptime {
 }
 
 pub export fn Bun__NODE_NO_WARNINGS() bool {
-    return bun.getRuntimeFeatureFlag(.NODE_NO_WARNINGS);
+    return bun.feature_flag.node_no_warnings.get();
 }
 
 pub export fn Bun__suppressCrashOnProcessKillSelfIfDesired() void {
-    if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF)) {
+    if (bun.feature_flag.internal_suppress_crash_on_process_kill_self.get()) {
         bun.crash_handler.suppressReporting();
     }
 }

--- a/src/bun.js/test/debug.zig
+++ b/src/bun.js/test/debug.zig
@@ -55,13 +55,9 @@ pub const group = struct {
     var wants_quiet: ?bool = null;
     fn getLogEnabledRuntime() bool {
         if (wants_quiet) |v| return !v;
-        if (bun.getenvZ("WANTS_LOUD")) |val| {
-            const loud = !std.mem.eql(u8, val, "0");
-            wants_quiet = !loud;
-            return loud;
-        }
-        wants_quiet = true; // default quiet
-        return false;
+        const loud = bun.env_var.wants_loud.get();
+        wants_quiet = !loud;
+        return loud;
     }
     inline fn getLogEnabledStaticFalse() bool {
         return false;

--- a/src/bun.js/webcore/blob/copy_file.zig
+++ b/src/bun.js/webcore/blob/copy_file.zig
@@ -881,7 +881,7 @@ pub const CopyFileWindows = struct {
 
     fn copyfile(this: *CopyFileWindows) void {
         // This is for making it easier for us to test this code path
-        if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE)) {
+        if (bun.feature_flag.disable_uv_fs_copyfile.get()) {
             this.prepareReadWriteLoop();
             return;
         }

--- a/src/bundler/ThreadPool.zig
+++ b/src/bundler/ThreadPool.zig
@@ -118,12 +118,12 @@ pub const ThreadPool = struct {
     }
 
     pub fn usesIOPool() bool {
-        if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_FORCE_IO_POOL)) {
+        if (bun.feature_flag.force_io_pool.get()) {
             // For testing.
             return true;
         }
 
-        if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_IO_POOL)) {
+        if (bun.feature_flag.disable_io_pool.get()) {
             // For testing.
             return false;
         }

--- a/src/bundler/linker_context/StaticRouteVisitor.zig
+++ b/src/bundler/linker_context/StaticRouteVisitor.zig
@@ -18,7 +18,7 @@ pub fn deinit(this: *StaticRouteVisitor) void {
 /// Investigate performance. It can have false negatives (it doesn't properly
 /// handle cycles), but that's okay as it's just used an optimization
 pub fn hasTransitiveUseClient(this: *StaticRouteVisitor, entry_point_source_index: u32) bool {
-    if (bun.Environment.isDebug and bun.getenvZ("BUN_SSG_DISABLE_STATIC_ROUTE_VISITOR") != null) {
+    if (bun.Environment.isDebug and bun.env_var.bun_ssg_disable_static_route_visitor.get()) {
         return false;
     }
 

--- a/src/bundler/linker_context/findImportedFilesInCSSOrder.zig
+++ b/src/bundler/linker_context/findImportedFilesInCSSOrder.zig
@@ -604,7 +604,7 @@ const CssOrderDebugStep = enum {
 fn debugCssOrder(this: *LinkerContext, order: *const BabyList(Chunk.CssImportOrder), comptime step: CssOrderDebugStep) void {
     if (comptime bun.Environment.isDebug) {
         const env_var = "BUN_DEBUG_CSS_ORDER_" ++ @tagName(step);
-        const enable_all = bun.getenvTruthy("BUN_DEBUG_CSS_ORDER");
+        const enable_all = bun.env_var.bun_debug_css_order.get();
         if (enable_all or bun.getenvTruthy(env_var)) {
             debugCssOrderImpl(this, order, step);
         }

--- a/src/c-headers-for-zig.h
+++ b/src/c-headers-for-zig.h
@@ -23,7 +23,9 @@
 #include "../packages/bun-native-bundler-plugin-api/bundler_plugin.h"
 
 #if POSIX
+#include <errno.h>
 #include <ifaddrs.h>
+#include <limits.h>
 #include <netdb.h>
 #include <pwd.h>
 #include <stdlib.h>

--- a/src/ci_info.zig
+++ b/src/ci_info.zig
@@ -73,14 +73,14 @@ const CI = enum {
             var name: []const u8 = "";
             defer ci_name = name;
 
-            if (bun.getenvZ("CI")) |ci| {
+            if (bun.env_var.ci.get()) |ci| {
                 if (strings.eqlComptime(ci, "false")) {
                     return;
                 }
             }
 
             // Special case Heroku
-            if (bun.getenvZ("NODE")) |node| {
+            if (bun.env_var.node.get()) |node| {
                 if (strings.containsComptime(node, "/app/.heroku/node/bin/node")) {
                     name = "heroku";
                     return;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -224,7 +224,7 @@ pub const HelpCommand = struct {
                 if (comptime Environment.isDebug) {
                     if (bun.argv.len == 1) {
                         if (bun.Output.isAIAgent()) {
-                            if (bun.getenvZ("npm_lifecycle_event")) |event| {
+                            if (bun.env_var.npm_lifecycle_event.get()) |event| {
                                 if (bun.strings.hasPrefixComptime(event, "bd")) {
                                     // claude gets very confused by the help menu
                                     // let's give claude some self confidence.
@@ -528,9 +528,9 @@ pub const Command = struct {
             // if we are bunx, but NOT a symlink to bun. when we run `<self> install`, we dont
             // want to recursively run bunx. so this check lets us peek back into bun install.
             if (args_iter.next()) |next| {
-                if (bun.strings.eqlComptime(next, "add") and bun.getRuntimeFeatureFlag(.BUN_INTERNAL_BUNX_INSTALL)) {
+                if (bun.strings.eqlComptime(next, "add") and bun.feature_flag.internal_bunx_install.get()) {
                     return .AddCommand;
-                } else if (bun.strings.eqlComptime(next, "exec") and bun.getRuntimeFeatureFlag(.BUN_INTERNAL_BUNX_INSTALL)) {
+                } else if (bun.strings.eqlComptime(next, "exec") and bun.feature_flag.internal_bunx_install.get()) {
                     return .ExecCommand;
                 }
             }
@@ -659,13 +659,13 @@ pub const Command = struct {
     /// function or that stack space is used up forever.
     pub fn start(allocator: std.mem.Allocator, log: *logger.Log) !void {
         if (comptime Environment.allow_assert) {
-            if (bun.getenvZ("MI_VERBOSE") == null) {
+            if (!bun.env_var.mi_verbose.get()) {
                 bun.mimalloc.mi_option_set_enabled(.verbose, false);
             }
         }
 
         // bun build --compile entry point
-        if (!bun.getRuntimeFeatureFlag(.BUN_BE_BUN)) {
+        if (!bun.feature_flag.be_bun.get()) {
             if (try bun.StandaloneModuleGraph.fromExecutable(bun.default_allocator)) |graph| {
                 var offset_for_passthrough: usize = 0;
 
@@ -1152,8 +1152,8 @@ pub const Command = struct {
                 Command.Tag.CreateCommand => {
                     const intro_text =
                         \\<b>Usage<r><d>:<r>
-                        \\  <b><green>bun create<r> <magenta>\<MyReactComponent.(jsx|tsx)\><r> 
-                        \\  <b><green>bun create<r> <magenta>\<template\><r> <cyan>[...flags]<r> <blue>dest<r> 
+                        \\  <b><green>bun create<r> <magenta>\<MyReactComponent.(jsx|tsx)\><r>
+                        \\  <b><green>bun create<r> <magenta>\<template\><r> <cyan>[...flags]<r> <blue>dest<r>
                         \\  <b><green>bun create<r> <magenta>\<github-org/repo\><r> <cyan>[...flags]<r> <blue>dest<r>
                         \\
                         \\<b>Environment variables<r><d>:<r>

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -242,9 +242,16 @@ pub fn loadConfigPath(allocator: std.mem.Allocator, auto_loaded: bool, config_pa
 }
 
 fn getHomeConfigPath(buf: *bun.PathBuffer) ?[:0]const u8 {
-    if (bun.getenvZ("XDG_CONFIG_HOME") orelse bun.getenvZ(bun.DotEnv.home_env)) |data_dir| {
-        var paths = [_]string{".bunfig.toml"};
+    var paths = [_]string{".bunfig.toml"};
+
+    if (bun.env_var.xdg_config_home.platformGet()) |data_dir| {
         return resolve_path.joinAbsStringBufZ(data_dir, buf, &paths, .auto);
+    }
+
+    var maybe_home_dir = bun.os.HomeDir.query(bun.default_allocator);
+    if (maybe_home_dir.asValuePtr()) |home_dir| {
+        defer home_dir.deinit();
+        return resolve_path.joinAbsStringBufZ(home_dir.slice(), buf, &paths, .auto);
     }
 
     return null;
@@ -595,7 +602,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             const preloads = args.options("--preload");
             const preloads2 = args.options("--require");
             const preloads3 = args.options("--import");
-            const preload4 = bun.getenvZ("BUN_INSPECT_PRELOAD");
+            const preload4 = bun.env_var.bun_inspect_preload.get();
 
             const total_preloads = ctx.preloads.len + preloads.len + preloads2.len + preloads3.len + (if (preload4 != null) @as(usize, 1) else @as(usize, 0));
             if (total_preloads > 0) {
@@ -803,10 +810,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         } else if (use_system_ca) {
             Bun__Node__CAStore = .system;
         } else {
-            if (bun.getenvZ("NODE_USE_SYSTEM_CA")) |val| {
-                if (val.len > 0 and val[0] == '1') {
-                    Bun__Node__CAStore = .system;
-                }
+            if (bun.env_var.node_use_system_ca.get()) {
+                Bun__Node__CAStore = .system;
             }
         }
 

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -772,7 +772,7 @@ pub const BunxCommand = struct {
         switch (spawn_result.status) {
             .exited => |exit| {
                 if (exit.signal.valid()) {
-                    if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN)) {
+                    if (bun.feature_flag.internal_suppress_crash_in_bun_run.get()) {
                         bun.crash_handler.suppressReporting();
                     }
 
@@ -784,7 +784,7 @@ pub const BunxCommand = struct {
                 }
             },
             .signaled => |signal| {
-                if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN)) {
+                if (bun.feature_flag.internal_suppress_crash_in_bun_run.get()) {
                     bun.crash_handler.suppressReporting();
                 }
 

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1885,7 +1885,7 @@ pub const Example = struct {
                 folders[1] = std.fs.cwd().openDir(outdir_path, .{}) catch bun.invalid_fd.stdDir();
             }
 
-            if (env_loader.map.get(bun.DotEnv.home_env)) |home_dir| {
+            if (env_loader.map.get(bun.env_var.home.key())) |home_dir| {
                 var parts = [_]string{ home_dir, BUN_CREATE_DIR };
                 const outdir_path = filesystem.absBuf(&parts, &home_dir_buf);
                 folders[2] = std.fs.cwd().openDir(outdir_path, .{}) catch bun.invalid_fd.stdDir();
@@ -2301,7 +2301,7 @@ pub const CreateListExamplesCommand = struct {
 
         Output.prettyln("<r><d>#<r> You can also paste a GitHub repository:\n\n  <b>bun create <cyan>ahfarmer/calculator calc<r>\n\n", .{});
 
-        if (env_loader.map.get(bun.DotEnv.home_env)) |homedir| {
+        if (env_loader.map.get(bun.env_var.home.key())) |homedir| {
             Output.prettyln(
                 "<d>This command is completely optional. To add a new local template, create a folder in {s}/.bun-create/. To publish a new template, git clone https://github.com/oven-sh/bun, add a new folder to the \"examples\" folder, and submit a PR.<r>",
                 .{homedir},

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -995,14 +995,14 @@ const Template = enum {
         }
 
         // Give some way to opt out.
-        if (bun.getenvTruthy("BUN_AGENT_RULE_DISABLED") or bun.getenvTruthy("CLAUDE_CODE_AGENT_RULE_DISABLED")) {
+        if (bun.env_var.bun_agent_rule_disabled.get() or bun.env_var.claude_code_agent_rule_disabled.get()) {
             return false;
         }
 
         const pathbuffer = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(pathbuffer);
 
-        return bun.which(pathbuffer, bun.getenvZ("PATH") orelse return false, bun.fs.FileSystem.instance.top_level_dir, "claude") != null;
+        return bun.which(pathbuffer, bun.env_var.path.get() orelse return false, bun.fs.FileSystem.instance.top_level_dir, "claude") != null;
     }
 
     pub fn createAgentRule() void {
@@ -1054,7 +1054,7 @@ const Template = enum {
 
     fn isCursorInstalled() bool {
         // Give some way to opt-out.
-        if (bun.getenvTruthy("BUN_AGENT_RULE_DISABLED") or bun.getenvTruthy("CURSOR_AGENT_RULE_DISABLED")) {
+        if (bun.env_var.bun_agent_rule_disabled.get() or bun.env_var.cursor_agent_rule_disabled.get()) {
             return false;
         }
 

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -111,7 +111,7 @@ pub const PackageManagerCommand = struct {
             \\  <b><green>bun pm<r> <blue>version<r> <d>[increment]<r>  bump the version in package.json and create a git tag
             \\  <d>└<r> <cyan>increment<r>                 patch, minor, major, prepatch, preminor, premajor, prerelease, from-git, or a specific version
             \\  <b><green>bun pm<r> <blue>pkg<r>                  manage data in package.json
-            \\  <d>├<r> <cyan>get<r> <d>[key ...]<r> 
+            \\  <d>├<r> <cyan>get<r> <d>[key ...]<r>
             \\  <d>├<r> <cyan>set<r> <d>key=value ...<r>
             \\  <d>├<r> <cyan>delete<r> <d>key ...<r>
             \\  <d>└<r> <cyan>fix<r>                       auto-correct common package.json errors
@@ -200,7 +200,7 @@ pub const PackageManagerCommand = struct {
             if (pm.options.global) {
                 warner: {
                     if (Output.enable_ansi_colors_stderr) {
-                        if (bun.getenvZ("PATH")) |path| {
+                        if (bun.env_var.path.get()) |path| {
                             var path_iter = std.mem.tokenizeScalar(u8, path, std.fs.path.delimiter);
                             while (path_iter.next()) |entry| {
                                 if (strings.eql(entry, output_path)) {

--- a/src/cli/pm_version_command.zig
+++ b/src/cli/pm_version_command.zig
@@ -284,7 +284,7 @@ pub const PmVersionCommand = struct {
             \\  <cyan>patch<r>      <d>{s} → {s}<r>
             \\  <cyan>minor<r>      <d>{s} → {s}<r>
             \\  <cyan>major<r>      <d>{s} → {s}<r>
-            \\  <cyan>prerelease<r> <d>{s} → {s}<r> 
+            \\  <cyan>prerelease<r> <d>{s} → {s}<r>
             \\
         ;
         Output.pretty(increment_help_text, .{
@@ -448,7 +448,7 @@ pub const PmVersionCommand = struct {
 
     fn isGitClean(cwd: []const u8) bun.OOM!bool {
         var path_buf: bun.PathBuffer = undefined;
-        const git_path = bun.which(&path_buf, bun.getenvZ("PATH") orelse "", cwd, "git") orelse {
+        const git_path = bun.which(&path_buf, bun.env_var.path.get() orelse "", cwd, "git") orelse {
             Output.errGeneric("git must be installed to use `bun pm version --git-tag-version`", .{});
             Global.exit(1);
         };
@@ -481,7 +481,7 @@ pub const PmVersionCommand = struct {
 
     fn getVersionFromGit(allocator: std.mem.Allocator, cwd: []const u8) bun.OOM![]const u8 {
         var path_buf: bun.PathBuffer = undefined;
-        const git_path = bun.which(&path_buf, bun.getenvZ("PATH") orelse "", cwd, "git") orelse {
+        const git_path = bun.which(&path_buf, bun.env_var.path.get() orelse "", cwd, "git") orelse {
             Output.errGeneric("git must be installed to use `bun pm version from-git`", .{});
             Global.exit(1);
         };
@@ -528,7 +528,7 @@ pub const PmVersionCommand = struct {
 
     fn gitCommitAndTag(allocator: std.mem.Allocator, version: []const u8, custom_message: ?[]const u8, cwd: []const u8) bun.OOM!void {
         var path_buf: bun.PathBuffer = undefined;
-        const git_path = bun.which(&path_buf, bun.getenvZ("PATH") orelse "", cwd, "git") orelse {
+        const git_path = bun.which(&path_buf, bun.env_var.path.get() orelse "", cwd, "git") orelse {
             Output.errGeneric("git must be installed to use `bun pm version --git-tag-version`", .{});
             Global.exit(1);
         };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -274,7 +274,7 @@ pub const RunCommand = struct {
         };
 
         const ipc_fd: ?bun.FD = if (!Environment.isWindows) blk: {
-            const node_ipc_fd = bun.getenvZ("NODE_CHANNEL_FD") orelse break :blk null;
+            const node_ipc_fd = bun.env_var.node_channel_fd.get() orelse break :blk null;
             const fd = std.fmt.parseInt(u31, node_ipc_fd, 10) catch break :blk null;
             break :blk bun.FD.fromNative(fd);
         } else null; // TODO: implement on Windows
@@ -321,7 +321,7 @@ pub const RunCommand = struct {
                     Output.prettyErrorln("<r><red>error<r><d>:<r> script <b>\"{s}\"<r> was terminated by signal {}<r>", .{ name, exit_code.signal.fmt(Output.enable_ansi_colors_stderr) });
                     Output.flush();
 
-                    if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN)) {
+                    if (bun.feature_flag.internal_suppress_crash_in_bun_run.get()) {
                         bun.crash_handler.suppressReporting();
                     }
 
@@ -344,7 +344,7 @@ pub const RunCommand = struct {
                     Output.flush();
                 }
 
-                if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN)) {
+                if (bun.feature_flag.internal_suppress_crash_in_bun_run.get()) {
                     bun.crash_handler.suppressReporting();
                 }
 
@@ -521,7 +521,7 @@ pub const RunCommand = struct {
                             });
                         }
 
-                        if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN)) {
+                        if (bun.feature_flag.internal_suppress_crash_in_bun_run.get()) {
                             bun.crash_handler.suppressReporting();
                         }
 
@@ -538,7 +538,7 @@ pub const RunCommand = struct {
                                 });
                             }
 
-                            if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN)) {
+                            if (bun.feature_flag.internal_suppress_crash_in_bun_run.get()) {
                                 bun.crash_handler.suppressReporting();
                             }
 
@@ -1502,10 +1502,7 @@ pub const RunCommand = struct {
             const preserve_symlinks = this_transpiler.resolver.opts.preserve_symlinks;
             defer this_transpiler.resolver.opts.preserve_symlinks = preserve_symlinks;
             this_transpiler.resolver.opts.preserve_symlinks = ctx.runtime_options.preserve_symlinks_main or
-                if (bun.getenvZ("NODE_PRESERVE_SYMLINKS_MAIN")) |env|
-                    bun.strings.eqlComptime(env, "1")
-                else
-                    false;
+                bun.env_var.node_preserve_symlinks_main.get();
             break :brk this_transpiler.resolver.resolve(
                 this_transpiler.fs.top_level_dir,
                 target_name,

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -182,9 +182,9 @@ pub const JunitReporter = struct {
 
         const properties: PropertiesList = .{
             .ci = brk: {
-                if (bun.getenvZ("GITHUB_RUN_ID")) |github_run_id| {
-                    if (bun.getenvZ("GITHUB_SERVER_URL")) |github_server_url| {
-                        if (bun.getenvZ("GITHUB_REPOSITORY")) |github_repository| {
+                if (bun.env_var.github_run_id.get()) |github_run_id| {
+                    if (bun.env_var.github_server_url.get()) |github_server_url| {
+                        if (bun.env_var.github_repository.get()) |github_repository| {
                             if (github_run_id.len > 0 and github_server_url.len > 0 and github_repository.len > 0) {
                                 break :brk try std.fmt.allocPrint(allocator, "{s}/{s}/actions/runs/{s}", .{ github_server_url, github_repository, github_run_id });
                             }
@@ -192,7 +192,7 @@ pub const JunitReporter = struct {
                     }
                 }
 
-                if (bun.getenvZ("CI_JOB_URL")) |ci_job_url| {
+                if (bun.env_var.ci_job_url.get()) |ci_job_url| {
                     if (ci_job_url.len > 0) {
                         break :brk ci_job_url;
                     }
@@ -201,19 +201,19 @@ pub const JunitReporter = struct {
                 break :brk "";
             },
             .commit = brk: {
-                if (bun.getenvZ("GITHUB_SHA")) |github_sha| {
+                if (bun.env_var.github_sha.get()) |github_sha| {
                     if (github_sha.len > 0) {
                         break :brk github_sha;
                     }
                 }
 
-                if (bun.getenvZ("CI_COMMIT_SHA")) |sha| {
+                if (bun.env_var.ci_commit_sha.get()) |sha| {
                     if (sha.len > 0) {
                         break :brk sha;
                     }
                 }
 
-                if (bun.getenvZ("GIT_SHA")) |git_sha| {
+                if (bun.env_var.git_sha.get()) |git_sha| {
                     if (git_sha.len > 0) {
                         break :brk git_sha;
                     }

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -557,7 +557,7 @@ pub const UpgradeCommand = struct {
                         save_dir.deleteFileZ(tmpname) catch {};
                         Global.exit(1);
                     }
-                } else if (Environment.isWindows) {
+                } else if (comptime Environment.isWindows) {
                     // Run a powershell script to unzip the file
                     const unzip_script = try std.fmt.allocPrint(
                         ctx.allocator,
@@ -570,9 +570,17 @@ pub const UpgradeCommand = struct {
 
                     var buf: bun.PathBuffer = undefined;
                     const powershell_path =
-                        bun.which(&buf, bun.getenvZ("PATH") orelse "", "", "powershell") orelse
+                        bun.which(&buf, bun.env_var.path.get() orelse "", "", "powershell") orelse
                         hardcoded_system_powershell: {
-                            const system_root = bun.getenvZ("SystemRoot") orelse "C:\\Windows";
+                            var windir = switch (bun.os.win32.WinDir.query(ctx.allocator)) {
+                                .err => {
+                                    Output.prettyErrorln("<r><red>error:<r> Failed to unzip {s} due to PowerShell not being installed.", .{tmpname});
+                                    Global.exit(1);
+                                },
+                                .result => |v| v,
+                            };
+                            defer windir.deinit();
+                            const system_root = windir.slice();
                             const hardcoded_system_powershell = bun.path.joinAbsStringBuf(system_root, &buf, &.{ system_root, "System32\\WindowsPowerShell\\v1.0\\powershell.exe" }, .windows);
                             if (bun.sys.exists(hardcoded_system_powershell)) {
                                 break :hardcoded_system_powershell hardcoded_system_powershell;

--- a/src/compile_target.zig
+++ b/src/compile_target.zig
@@ -66,7 +66,7 @@ pub fn isDefault(this: *const CompileTarget) bool {
 }
 
 pub fn toNPMRegistryURL(this: *const CompileTarget, buf: []u8) ![]const u8 {
-    if (bun.getenvZ("BUN_COMPILE_TARGET_TARBALL_URL")) |url| {
+    if (bun.env_var.bun_compile_target_tarball_url.get()) |url| {
         if (strings.hasPrefixComptime(url, "http://") or strings.hasPrefixComptime(url, "https://"))
             return url;
     }

--- a/src/copy_file.zig
+++ b/src/copy_file.zig
@@ -147,7 +147,7 @@ pub fn canUseCopyFileRangeSyscall() bool {
     const result = can_use_copy_file_range.load(.monotonic);
     if (result == 0) {
         // This flag mostly exists to make other code more easily testable.
-        if (bun.getenvZ("BUN_CONFIG_DISABLE_COPY_FILE_RANGE") != null) {
+        if (bun.env_var.bun_config_disable_copy_file_range.get()) {
             debug("copy_file_range is disabled by BUN_CONFIG_DISABLE_COPY_FILE_RANGE", .{});
             can_use_copy_file_range.store(-1, .monotonic);
             return false;
@@ -179,7 +179,7 @@ pub fn can_use_ioctl_ficlone() bool {
     const result = can_use_ioctl_ficlone_.load(.monotonic);
     if (result == 0) {
         // This flag mostly exists to make other code more easily testable.
-        if (bun.getenvZ("BUN_CONFIG_DISABLE_ioctl_ficlonerange") != null) {
+        if (bun.env_var.bun_config_disable_ioctl_ficlonerange.get()) {
             debug("ioctl_ficlonerange is disabled by BUN_CONFIG_DISABLE_ioctl_ficlonerange", .{});
             can_use_ioctl_ficlone_.store(-1, .monotonic);
             return false;

--- a/src/env.zig
+++ b/src/env.zig
@@ -172,6 +172,55 @@ else if (isAarch64)
 else
     @compileError("Please add your architecture to the Architecture enum");
 
+pub const OsTypeSet = struct {
+    posix: ?type = null,
+    win: ?type = null,
+    macos: ?type = null,
+    linux: ?type = null,
+};
+
+/// Given a type set, which contains possible types for different platforms, selects the correct
+/// type for the current platform.
+pub fn OsTypeSelect(comptime opts: OsTypeSet) type {
+    const err_fmt = "You must specify a type for {} when compiling for {}";
+
+    switch (comptime bun.Environment.os) {
+        .windows => {
+            if (comptime opts.win) |w| {
+                return w;
+            }
+            @compileError(std.fmt.comptimePrint(err_fmt, .{ "win", "Windows" }));
+        },
+        .mac => {
+            if (comptime opts.macos) |m| {
+                return m;
+            }
+
+            if (comptime opts.posix) |p| {
+                return p;
+            }
+
+            @compileError(std.fmt.comptimePrint(err_fmt, .{ "macos", "macOS" }));
+        },
+        .linux => {
+            if (comptime opts.linux) |l| {
+                return l;
+            }
+
+            if (comptime opts.posix) |p| {
+                return p;
+            }
+
+            @compileError(std.fmt.comptimePrint(err_fmt, .{ "linux", "Linux" }));
+        },
+        .wasm => {
+            // WASM doesn't typically have OS-level concepts like home directories or temp directories
+            // For now, we'll just fail at compile time if someone tries to use OsTypeSelect with wasm
+            @compileError("OsTypeSelect is not supported for wasm targets");
+        },
+    }
+}
+
 const builtin = @import("builtin");
 const bun = @import("bun");
 const std = @import("std");

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -1332,8 +1332,6 @@ pub const Map = struct {
 
 pub var instance: ?*Loader = null;
 
-pub const home_env = if (Environment.isWindows) "USERPROFILE" else "HOME";
-
 const string = []const u8;
 
 const Fs = @import("./fs.zig");

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -1,0 +1,662 @@
+//! Unified module for controlling and managing environment variables in Bun.
+//!
+//! This library uses metaprogramming to achieve type-safe accessors for environment variables.
+//! Calling .get() on any of the environment variables will return the correct environment variable
+//! type, whether it's a string, unsigned or boolean. This library also caches the environment
+//! variables for you, for slightly faster access.
+//!
+//! If default values are provided, the .get() method is guaranteed not to return a nullable type,
+//! whereas if no default is provided, the .get() method will return an optional type.
+//!
+//! TODO(markovejnovic): It would be neat if this library supported loading floats as
+//!                      well as strings, integers and booleans, but for now this will do.
+//!
+//! TODO(markovejnovic): As this library migrates away from bun.getenvZ, it should return
+//!                      NUL-terminated slices, rather than plain slices. Perhaps there should be a
+//!                      .getZ() accessor?
+//!
+//! TODO(markovejnovic): This current implementation kind of does redundant work. Instead of
+//!                      scanning envp, and preparing everything on bootup, we lazily load
+//!                      everything. This means that we potentially scan through envp a lot of
+//!                      times, even though we could only do it once.
+
+// Keep this list alphabetically sorted.
+pub const agent = new(.string, "AGENT", .{});
+pub const bamboo_build_key = new(.string, "bamboo.buildKey", .{});
+pub const bun_agent_rule_disabled = new(.boolean, "BUN_AGENT_RULE_DISABLED", .{ .default = false });
+pub const bun_compile_target_tarball_url = new(.string, "BUN_COMPILE_TARGET_TARBALL_URL", .{});
+pub const bun_config_disable_copy_file_range = new(.boolean, "BUN_CONFIG_DISABLE_COPY_FILE_RANGE", .{ .default = false });
+pub const bun_config_disable_ioctl_ficlonerange = new(.boolean, "BUN_CONFIG_DISABLE_ioctl_ficlonerange", .{ .default = false });
+/// TODO(markovejnovic): Legacy usage had the default at 30, even though a the attached comment
+/// quoted: Amazon Web Services recommends 5 seconds:
+/// https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/jvm-ttl-dns.html
+///
+/// It's unclear why this was done.
+pub const bun_config_dns_time_to_live_seconds = new(.unsigned, "BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS", .{ .default = 30 });
+pub const bun_crash_report_url = new(.string, "BUN_CRASH_REPORT_URL", .{});
+pub const bun_debug = new(.string, "BUN_DEBUG", .{});
+pub const bun_debug_css_order = new(.boolean, "BUN_DEBUG_CSS_ORDER", .{ .default = false });
+pub const bun_debug_enable_restore_from_transpiler_cache = new(.boolean, "BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE", .{ .default = false });
+pub const bun_debug_hash_random_seed = new(.string, "BUN_DEBUG_HASH_RANDOM_SEED", .{});
+pub const bun_debug_test_text_lockfile = new(.boolean, "BUN_DEBUG_TEST_TEXT_LOCKFILE", .{ .default = false });
+pub const bun_dev_server_test_runner = new(.string, "BUN_DEV_SERVER_TEST_RUNNER", .{});
+pub const bun_enable_crash_reporting = new(.boolean, "BUN_ENABLE_CRASH_REPORTING", .{});
+/// TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior
+/// so we'll keep it for now.
+pub const bun_inotify_coalesce_interval = new(.unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", .{ .default = 100_000 });
+pub const bun_inspect = new(.string, "BUN_INSPECT", .{ .default = "" });
+pub const bun_inspect_connect_to = new(.string, "BUN_INSPECT_CONNECT_TO", .{ .default = "" });
+pub const bun_inspect_preload = new(.string, "BUN_INSPECT_PRELOAD", .{});
+pub const bun_install = new(.string, "BUN_INSTALL", .{});
+pub const bun_install_bin = new(.string, "BUN_INSTALL_BIN", .{});
+pub const bun_install_global_dir = new(.string, "BUN_INSTALL_GLOBAL_DIR", .{});
+pub const bun_needs_proc_self_workaround = new(.boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", .{ .default = false });
+pub const bun_options = new(.string, "BUN_OPTIONS", .{});
+pub const bun_runtime_transpiler_cache_path = new(.string, "BUN_RUNTIME_TRANSPILER_CACHE_PATH", .{});
+pub const bun_ssg_disable_static_route_visitor = new(.boolean, "BUN_SSG_DISABLE_STATIC_ROUTE_VISITOR", .{ .default = false });
+pub const bun_tcc_options = new(.string, "BUN_TCC_OPTIONS", .{});
+pub const bun_tmpdir = new(.string, "BUN_TMPDIR", .{});
+pub const bun_track_last_fn_name = new(.boolean, "BUN_TRACK_LAST_FN_NAME", .{ .default = false });
+pub const bun_tracy_path = new(.string, "BUN_TRACY_PATH", .{});
+pub const bun_watcher_trace = new(.string, "BUN_WATCHER_TRACE", .{});
+pub const ci = new(.string, "CI", .{});
+pub const ci_commit_sha = new(.string, "CI_COMMIT_SHA", .{});
+pub const ci_job_url = new(.string, "CI_JOB_URL", .{});
+pub const claude_code_agent_rule_disabled = new(.boolean, "CLAUDE_CODE_AGENT_RULE_DISABLED", .{ .default = false });
+pub const claudecode = new(.boolean, "CLAUDECODE", .{ .default = false });
+pub const colorterm = new(.string, "COLORTERM", .{});
+pub const cursor_agent_rule_disabled = new(.boolean, "CURSOR_AGENT_RULE_DISABLED", .{ .default = false });
+pub const do_not_track = new(.boolean, "DO_NOT_TRACK", .{ .default = false });
+pub const dyld_root_path = platformSpecificNew(.string, "DYLD_ROOT_PATH", null, .{});
+/// TODO(markovejnovic): We should support enums in this library, and force_color's usage is,
+/// indeed, an enum. The 80-20 is to make it an unsigned value (which also works well).
+pub const force_color = new(.unsigned, "FORCE_COLOR", .{
+    .deser = .{
+        // It is kind of weird to me to treat FORCE_COLOR="" as truthy, but this was legacy
+        // behavior so we'll keep it for now.
+        .error_handling = .truthy_cast,
+        .empty_string_as = .{ .value = 1 },
+    },
+});
+pub const fpath = platformSpecificNew(.string, "fpath", null, .{});
+pub const git_sha = new(.string, "GIT_SHA", .{});
+pub const github_actions = new(.boolean, "GITHUB_ACTIONS", .{ .default = false });
+pub const github_repository = new(.string, "GITHUB_REPOSITORY", .{});
+pub const github_run_id = new(.string, "GITHUB_RUN_ID", .{});
+pub const github_server_url = new(.string, "GITHUB_SERVER_URL", .{});
+pub const github_sha = new(.string, "GITHUB_SHA", .{});
+pub const github_workspace = new(.string, "GITHUB_WORKSPACE", .{});
+pub const home = platformSpecificNew(.string, "HOME", "USERPROFILE", .{});
+pub const hyperfine_randomized_environment_offset = new(.string, "HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET", .{});
+pub const is_bun_auto_update = new(.boolean, "IS_BUN_AUTO_UPDATE", .{ .default = false });
+pub const jenkins_url = new(.string, "JENKINS_URL", .{});
+/// Dump mimalloc statistics at the end of the process. Note that this is not the same as
+/// `MIMALLOC_VERBOSE`, documented here: https://microsoft.github.io/mimalloc/environment.html
+pub const mi_verbose = new(.boolean, "MI_VERBOSE", .{ .default = false });
+pub const no_color = new(.boolean, "NO_COLOR", .{ .default = false });
+pub const node = new(.string, "node", .{});
+pub const node_channel_fd = new(.string, "NODE_CHANNEL_FD", .{});
+pub const node_preserve_symlinks_main = new(.boolean, "NODE_PRESERVE_SYMLINKS_MAIN", .{ .default = false });
+pub const node_use_system_ca = new(.boolean, "NODE_USE_SYSTEM_CA", .{ .default = false });
+pub const npm_lifecycle_event = new(.string, "npm_lifecycle_event", .{});
+pub const path = new(.string, "PATH", .{});
+pub const repl_id = new(.boolean, "REPL_ID", .{ .default = false });
+pub const runner_debug = new(.boolean, "RUNNER_DEBUG", .{ .default = false });
+pub const sdkroot = platformSpecificNew(.string, "SDKROOT", null, .{});
+pub const shell = platformSpecificNew(.string, "SHELL", null, .{});
+/// C:\Windows, for example.
+/// Note: Do not use this variable directly -- use os.zig's implementation instead.
+pub const system_root = platformSpecificNew(.string, null, "SYSTEMROOT", .{});
+pub const temp = platformSpecificNew(.string, null, "TEMP", .{});
+pub const term = new(.string, "TERM", .{});
+pub const term_program = new(.string, "TERM_PROGRAM", .{});
+pub const tmp = platformSpecificNew(.string, null, "TMP", .{});
+pub const tmpdir = platformSpecificNew(.string, "TMPDIR", null, .{});
+pub const tmux = new(.string, "TMUX", .{});
+pub const todium = new(.string, "TODIUM", .{});
+pub const user = platformSpecificNew(.string, "USER", "USERNAME", .{});
+pub const wants_loud = new(.boolean, "WANTS_LOUD", .{ .default = false });
+/// The same as system_root.
+/// Note: Do not use this variable directly -- use os.zig's implementation instead.
+/// TODO(markovejnovic): Perhaps we could add support for aliases in the library, so you could
+///                      specify both WINDIR and SYSTEMROOT and the loader would check both?
+pub const windir = platformSpecificNew(.string, null, "WINDIR", .{});
+pub const xdg_cache_home = platformSpecificNew(.string, "XDG_CACHE_HOME", null, .{});
+pub const xdg_config_home = platformSpecificNew(.string, "XDG_CONFIG_HOME", null, .{});
+pub const xdg_data_home = platformSpecificNew(.string, "XDG_DATA_HOME", null, .{});
+pub const zdotdir = platformSpecificNew(.string, "ZDOTDIR", null, .{});
+
+// Feature flags, keep sorted alphabetically.
+pub const feature_flag = struct {
+    pub const assume_perfect_incremental = newFeatureFlag("BUN_ASSUME_PERFECT_INCREMENTAL");
+    pub const be_bun = newFeatureFlag("BUN_BE_BUN");
+    pub const debug_no_dump = newFeatureFlag("BUN_DEBUG_NO_DUMP");
+    pub const destruct_vm_on_exit = newFeatureFlag("BUN_DESTRUCT_VM_ON_EXIT");
+    pub const disable_addrconfig = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG");
+    pub const disable_async_transpiler = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER");
+    pub const disable_dns_cache = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_DNS_CACHE");
+    pub const disable_dns_cache_libinfo = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO");
+    pub const disable_install_index = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX");
+    pub const disable_io_pool = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IO_POOL");
+    pub const disable_ipv4 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV4");
+    pub const disable_ipv6 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV6");
+    /// The RedisClient supports auto-pipelining by default. This flag disables that behavior.
+    pub const disable_redis_auto_pipelining = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING");
+    pub const disable_rwf_nonblock = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK");
+    pub const disable_slow_lifecycle_script_logging = newFeatureFlag("BUN_DISABLE_SLOW_LIFECYCLE_SCRIPT_LOGGING");
+    pub const disable_source_code_preview = newFeatureFlag("BUN_DISABLE_SOURCE_CODE_PREVIEW");
+    pub const disable_source_maps = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS");
+    pub const disable_spawnsync_fast_path = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH");
+    pub const disable_sql_auto_pipelining = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING");
+    pub const disable_transpiled_source_code_preview = newFeatureFlag("BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW");
+    pub const disable_uv_fs_copyfile = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE");
+    pub const dump_state_on_crash = newFeatureFlag("BUN_DUMP_STATE_ON_CRASH");
+    pub const enable_experimental_shell_builtins = newFeatureFlag("BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS");
+    pub const experimental_bake = newFeatureFlag("BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE");
+    pub const force_io_pool = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_IO_POOL");
+    pub const force_windows_junctions = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS");
+    pub const instruments = newFeatureFlag("BUN_INSTRUMENTS");
+    pub const internal_bunx_install = newFeatureFlag("BUN_INTERNAL_BUNX_INSTALL");
+    pub const internal_suppress_crash_in_bun_run = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN");
+    pub const internal_suppress_crash_on_napi_abort = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT");
+    pub const internal_suppress_crash_on_process_kill_self = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF");
+    pub const internal_suppress_crash_on_uv_stub = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_ON_UV_STUB");
+    pub const last_modified_pretend_304 = newFeatureFlag("BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304");
+    pub const no_codesign_macho_binary = newFeatureFlag("BUN_NO_CODESIGN_MACHO_BINARY");
+    pub const no_libdeflate = newFeatureFlag("BUN_FEATURE_FLAG_NO_LIBDEFLATE");
+    pub const node_no_warnings = newFeatureFlag("NODE_NO_WARNINGS");
+    pub const trace = newFeatureFlag("BUN_TRACE");
+};
+
+/// Interface between each of the different EnvVar types and the common logic.
+pub fn CacheOutput(comptime NonOptionalReturnType: type) type {
+    return union(enum) {
+        /// The environment variable hasn't been loaded yet.
+        unknown: void,
+        /// The environment variable has been loaded but its not set.
+        not_set: void,
+        /// The environment variable is set to a value.
+        value: NonOptionalReturnType,
+    };
+}
+
+pub fn CacheInput(comptime DefaultArgsType: type) type {
+    return struct {
+        var_name: []const u8,
+        opts: DefaultArgsType,
+    };
+}
+
+/// Structure which encodes the different types of environment variables supported.
+///
+/// This requires the following static members:
+///
+///   - `NonOptionalReturnType`: The underlying environment variable type if one is set. For
+///                              example, a string `$PATH` ought return a `[]const u8` when set.
+///   - `Cache`: A struct implementing the following methods:
+///       - `getCached() CacheOutput(NonOptionalReturnType)`: Retrieve the cached value of the
+///                                                               environment variable, if any.
+///       - `reload(raw_env: ?[]const u8) ?NonOptionalReturnType`: Try to reload the environment
+///                                                                variable from the given raw
+///                                                                environment variable value.
+///   - `ConsOpts`: A struct containing the options passed to the constructor of the environment
+///                 variable definition.
+///
+/// This type will communicate with the common logic via the `CacheOutput` type.
+const EnvVarType = union(enum) {
+    string: struct {
+        const NonOptionalReturnType = []const u8;
+        const Input = CacheInput(ConsOpts);
+        const Output = CacheOutput(NonOptionalReturnType);
+        const ConsOpts = struct {
+            default: ?NonOptionalReturnType = null,
+        };
+
+        fn Cache(comptime ip: Input) type {
+            _ = ip;
+            // This cache tries to be really clever. In order to have atomics, we need to fit them
+            // in a single word. Consequently, we need to fit the pointer and the length in a
+            // single 64-bit type. Some platforms are moving to layer 5 addressing so we're only
+            // left with 8 bits -- that won't do, obviously. Consequently, we need to store offsets
+            // rather than raw pointers. These offsets are relative to std.c.environ.
+            const CachedType = packed struct(u64) {
+                const Self = @This();
+
+                ptr: bun.ptr.TaggedPointer,
+
+                pub inline fn init(ptr: anytype, data: u15) Self {
+                    return .{
+                        .ptr = bun.ptr.TaggedPointer.init(ptr, data),
+                    };
+                }
+
+                pub inline fn get(self: Self, comptime T: type) *T {
+                    return self.ptr.get(T);
+                }
+
+                pub fn eql(self: @This(), other: @This()) bool {
+                    const self_ptr = self.ptr.get(*const u8);
+                    const self_len: usize = @intCast(self.ptr.data);
+                    const other_ptr = other.ptr.get(*const u8);
+                    const other_len: usize = @intCast(other.ptr.data);
+                    return self_ptr == other_ptr and self_len == other_len;
+                }
+            };
+
+            return struct {
+                const unknown_sentinel: CachedType = .init(
+                    @as(*const u8, @ptrFromInt(std.math.maxInt(u64))),
+                    std.math.maxInt(u15),
+                );
+                const not_set_sentinel: CachedType = .init(
+                    @as(*const u8, @ptrFromInt(std.math.maxInt(u64) - 1)),
+                    std.math.maxInt(u15),
+                );
+
+                var value = std.atomic.Value(CachedType).init(unknown_sentinel);
+
+                inline fn getCached() Output {
+                    const val = value.load(.monotonic);
+                    if (val.eql(unknown_sentinel)) {
+                        return .{ .unknown = {} };
+                    }
+
+                    if (val.eql(not_set_sentinel)) {
+                        return .{ .not_set = {} };
+                    }
+
+                    const ptr: [*]const u8 = @ptrCast(val.get(*const u8));
+                    const len: usize = @intCast(val.ptr.data);
+                    return .{ .value = ptr[0..len] };
+                }
+
+                pub inline fn reload(raw_env: ?[]const u8) ?NonOptionalReturnType {
+                    if (raw_env) |ev| {
+                        value.store(.init(ev.ptr, @intCast(ev.len)), .monotonic);
+                    } else {
+                        value.store(not_set_sentinel, .monotonic);
+                    }
+
+                    return raw_env;
+                }
+            };
+        }
+    },
+    boolean: struct {
+        const NonOptionalReturnType = bool;
+        const Input = CacheInput(ConsOpts);
+        const Output = CacheOutput(NonOptionalReturnType);
+        const ConsOpts = struct {
+            default: ?NonOptionalReturnType = null,
+        };
+
+        pub fn stringIsTruthy(s: []const u8) bool {
+            // Most values are considered truthy, except for "", "0", "false", "no", and "off".
+            const false_values = .{ "", "0", "false", "no", "off" };
+
+            inline for (false_values) |tv| {
+                if (std.ascii.eqlIgnoreCase(s, tv)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // This is a template which ignores its parameter, but is necessary so that a separate
+        // Cache type is emitted for every environment variable.
+        fn Cache(comptime ip: Input) type {
+            return struct {
+                const ValueType = enum(u8) { unknown, not_set, no, yes };
+
+                var value = std.atomic.Value(ValueType).init(.unknown);
+
+                pub inline fn getCached() Output {
+                    _ = ip;
+
+                    const cached = value.load(.monotonic);
+                    switch (cached) {
+                        .unknown => {
+                            @branchHint(.unlikely);
+                            return .{ .unknown = {} };
+                        },
+                        .not_set => {
+                            return .{ .not_set = {} };
+                        },
+                        .no => {
+                            return .{ .value = false };
+                        },
+                        .yes => {
+                            return .{ .value = true };
+                        },
+                    }
+                }
+
+                pub inline fn reload(raw_env: ?[]const u8) ?NonOptionalReturnType {
+                    if (raw_env == null) {
+                        value.store(.not_set, .monotonic);
+                        return null;
+                    }
+
+                    const string_is_truthy = stringIsTruthy(raw_env.?);
+                    value.store(if (string_is_truthy) .yes else .no, .monotonic);
+                    return string_is_truthy;
+                }
+            };
+        }
+    },
+    unsigned: struct {
+        const NonOptionalReturnType = u64;
+        const Input = CacheInput(ConsOpts);
+        const Output = CacheOutput(NonOptionalReturnType);
+        const ConsOpts = struct {
+            default: ?NonOptionalReturnType = null,
+            deser: struct {
+                /// Control how deserializing and formatting errors are handled.
+                error_handling: enum {
+                    /// panic on formatting errors.
+                    panic,
+                    /// Ignore formatting errors and treat the variable as not set.
+                    not_set,
+                    /// Fallback to default.
+                    default_fallback,
+                    /// Formatting errors are treated as truthy values.
+                    ///
+                    /// If this library fails to parse the value as an integer and truthy cast is
+                    /// enabled, truthy values will be set to 1 or 0.
+                    ///
+                    /// Note: Most values are considered truthy, except for "", "0", "false", "no",
+                    /// and "off".
+                    truthy_cast,
+                } = .panic,
+
+                /// Control what empty strings are treated as.
+                empty_string_as: union(enum) {
+                    /// Empty strings are handled as the given value.
+                    value: NonOptionalReturnType,
+                    /// Empty strings are treated as formatting errors.
+                    erroneous: void,
+                } = .erroneous,
+            } = .{},
+        };
+
+        fn Cache(comptime ip: Input) type {
+            return struct {
+                const ValueType = NonOptionalReturnType;
+
+                /// The value meaning an environment variable that hasn't been loaded yet.
+                const unknown_sentinel: comptime_int = std.math.maxInt(ValueType);
+                /// The unique value representing an environment variable that is not set.
+                const not_set_sentinel: comptime_int = std.math.maxInt(ValueType) - 1;
+
+                var value = std.atomic.Value(ValueType).init(unknown_sentinel);
+
+                inline fn getCached() Output {
+                    switch (value.load(.monotonic)) {
+                        unknown_sentinel => {
+                            @branchHint(.unlikely);
+                            return .{ .unknown = {} };
+                        },
+                        not_set_sentinel => {
+                            return .{ .not_set = {} };
+                        },
+                        else => |v| {
+                            return .{ .value = v };
+                        },
+                    }
+                }
+
+                inline fn reload(raw_env: ?[]const u8) ?NonOptionalReturnType {
+                    if (raw_env == null) {
+                        value.store(not_set_sentinel, .monotonic);
+                        return null;
+                    }
+
+                    if (std.mem.eql(u8, raw_env.?, "")) {
+                        switch (ip.opts.deser.empty_string_as) {
+                            .value => |v| {
+                                value.store(v, .monotonic);
+                                return v;
+                            },
+                            .erroneous => {
+                                return handleError(raw_env.?, "is an empty string");
+                            },
+                        }
+                    }
+
+                    const formatted = std.fmt.parseInt(ValueType, raw_env.?, 10) catch |err| {
+                        switch (err) {
+                            error.Overflow => {
+                                return handleError(raw_env.?, "overflows u64");
+                            },
+                            error.InvalidCharacter => {
+                                return handleError(raw_env.?, "is not a valid integer");
+                            },
+                        }
+                    };
+
+                    if (formatted == not_set_sentinel or formatted == unknown_sentinel) {
+                        return handleError(raw_env.?, "is a reserved value");
+                    }
+
+                    value.store(formatted, .monotonic);
+                    return formatted;
+                }
+
+                fn handleError(
+                    raw_env: []const u8,
+                    comptime reason: []const u8,
+                ) ?NonOptionalReturnType {
+                    const base_fmt = "Environment variable '{s}' has value '{s}' which ";
+                    const fmt = base_fmt ++ reason ++ ".";
+                    const missing_default_fmt = "Environment variable '{s}' is configured to " ++
+                        "fallback to default on {s}, but no default is set.";
+
+                    switch (ip.opts.deser.error_handling) {
+                        .panic => {
+                            bun.Output.panic(fmt, .{ ip.var_name, raw_env });
+                        },
+                        .not_set => {
+                            value.store(not_set_sentinel, .monotonic);
+                            return null;
+                        },
+                        .truthy_cast => {
+                            if (std.meta.FieldType(EnvVarType, .boolean).stringIsTruthy(raw_env)) {
+                                value.store(1, .monotonic);
+                                return 1;
+                            } else {
+                                value.store(0, .monotonic);
+                                return 0;
+                            }
+                        },
+                        .default_fallback => {
+                            if (comptime ip.opts.default) |d| {
+                                return d;
+                            }
+                            @compileError(std.fmt.comptimePrint(missing_default_fmt, .{
+                                ip.var_name,
+                                "default_fallback",
+                            }));
+                        },
+                    }
+                }
+            };
+        }
+    },
+};
+
+/// Create a new environment variable definition.
+///
+/// The resulting type has methods for interacting with the environment variable.
+///
+/// Technically, none of the operations here are thread-safe, so writing to environment variables
+/// does not guarantee that other threads will see the changes. You should avoid writing to
+/// environment variables.
+fn new(
+    comptime T: std.meta.Tag(EnvVarType),
+    comptime key: [:0]const u8,
+    comptime opts: std.meta.FieldType(EnvVarType, T).ConsOpts,
+) type {
+    return platformSpecificNew(T, key, key, opts);
+}
+
+/// Identical to new, except it allows you to specify different keys for POSIX and Windows.
+///
+/// If the current platform does not have a key specified, all methods that attempt to read the
+/// environment variable will fail at compile time, except for `platformGet` and `platformKey`,
+/// which will return null instead.
+fn platformSpecificNew(
+    comptime T: std.meta.Tag(EnvVarType),
+    comptime posix_key: ?[:0]const u8,
+    comptime windows_key: ?[:0]const u8,
+    comptime opts: std.meta.FieldType(EnvVarType, T).ConsOpts,
+) type {
+    const DefaultType = if (comptime opts.default) |d| @TypeOf(d) else void;
+
+    const comptime_key: []const u8 =
+        if (posix_key) |pk| pk else if (windows_key) |wk| wk else "<unknown>";
+
+    if (posix_key == null and windows_key == null) {
+        @compileError("Environment variable " ++ comptime_key ++ " has no keys for POSIX " ++
+            "nor Windows specified. Provide a key for either POSIX or Windows.");
+    }
+
+    const VariantType = std.meta.FieldType(EnvVarType, T);
+    const KeyType = [:0]const u8;
+
+    // Return type as returned by each of the variants of EnvVarType.
+    const NonOptionalReturnType = VariantType.NonOptionalReturnType;
+
+    // The actual return type of public methods.
+    const ReturnType = if (opts.default != null) NonOptionalReturnType else ?NonOptionalReturnType;
+
+    return struct {
+        const Self = @This();
+
+        const Cache = VariantType.Cache(.{ .var_name = comptime_key, .opts = opts });
+
+        /// Attempt to retrieve the value of the environment variable for the current platform, if
+        /// the current platform has a supported definition. Returns null otherwise, unlike the
+        /// other methods which will fail at compile time if the platform is unsupported.
+        pub fn platformGet() ?NonOptionalReturnType {
+            // Get the platform-specific key
+            const platform_key: ?KeyType = if (comptime bun.Environment.isPosix)
+                posix_key
+            else if (comptime bun.Environment.isWindows)
+                windows_key
+            else
+                null;
+
+            // If platform doesn't have a key, return null
+            const k = platform_key orelse return null;
+
+            // Inline the logic from get() without calling assertPlatformSupported()
+            switch (Cache.getCached()) {
+                .unknown => {
+                    @branchHint(.unlikely);
+
+                    const env_var = bun.getenvZ(k);
+                    const maybe_reloaded = Cache.reload(env_var);
+
+                    if (maybe_reloaded) |v| return v;
+                    if (opts.default) |d| {
+                        return d;
+                    }
+
+                    return null;
+                },
+                .not_set => {
+                    if (opts.default) |d| {
+                        return d;
+                    }
+                    return null;
+                },
+                .value => |v| return v,
+            }
+        }
+
+        /// Retrieve the key of the environment variable for the current platform.
+        pub fn key() KeyType {
+            assertPlatformSupported();
+            return Self.platformKey().?;
+        }
+
+        /// Retrieve the key of the environment variable for the current platform, if any.
+        pub fn platformKey() ?KeyType {
+            if (bun.Environment.isPosix) {
+                return posix_key;
+            }
+
+            if (bun.Environment.isWindows) {
+                return windows_key;
+            }
+
+            return null;
+        }
+
+        /// Retrieve the value of the environment variable, loading it if necessary.
+        /// Fails if the current platform is unsupported.
+        pub fn get() ReturnType {
+            assertPlatformSupported();
+
+            const cached_result = Cache.getCached();
+
+            switch (cached_result) {
+                .unknown => {
+                    @branchHint(.unlikely);
+                    return getForceReload();
+                },
+                .not_set => {
+                    if (opts.default) |d| {
+                        return d;
+                    }
+                    return null;
+                },
+                .value => |v| {
+                    return v;
+                },
+            }
+        }
+
+        /// Retrieve the value of the environment variable, reloading it from the environment.
+        /// Fails if the current platform is unsupported.
+        fn getForceReload() ReturnType {
+            assertPlatformSupported();
+            const env_var = bun.getenvZ(key());
+            const maybe_reloaded = Cache.reload(env_var);
+
+            if (maybe_reloaded) |v| {
+                return v;
+            }
+
+            if (opts.default) |d| {
+                return d;
+            }
+
+            return null;
+        }
+
+        /// Fetch the default value of this environment variable, if any.
+        ///
+        /// It is safe to compare the result of .get() to default to test if the variable is set to
+        /// its default value.
+        pub const default: DefaultType = if (opts.default) |d| d else {};
+
+        fn assertPlatformSupported() void {
+            const missing_key_fmt = "Cannot retrieve the value of " ++ comptime_key ++
+                " for {s} since no {s} key is associated with it.";
+            if (comptime bun.Environment.isWindows and windows_key == null) {
+                @compileError(std.fmt.comptimePrint(missing_key_fmt, .{ "Windows", "Windows" }));
+            } else if (comptime bun.Environment.isPosix and posix_key == null) {
+                @compileError(std.fmt.comptimePrint(missing_key_fmt, .{ "POSIX", "POSIX" }));
+            }
+        }
+    };
+}
+
+pub fn newFeatureFlag(comptime env_var: [:0]const u8) type {
+    return new(.boolean, env_var, .{ .default = false });
+}
+
+const bun = @import("bun");
+const std = @import("std");

--- a/src/feature_flags.zig
+++ b/src/feature_flags.zig
@@ -1,48 +1,5 @@
-/// All runtime feature flags that can be toggled with an environment variable.
-/// The field names correspond exactly to the expected environment variable names.
-pub const RuntimeFeatureFlag = enum {
-    BUN_ASSUME_PERFECT_INCREMENTAL,
-    BUN_BE_BUN,
-    BUN_DEBUG_NO_DUMP,
-    BUN_DESTRUCT_VM_ON_EXIT,
-    BUN_DISABLE_SLOW_LIFECYCLE_SCRIPT_LOGGING,
-    BUN_DISABLE_SOURCE_CODE_PREVIEW,
-    BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW,
-    BUN_DUMP_STATE_ON_CRASH,
-    BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS,
-    BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG,
-    BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER,
-    BUN_FEATURE_FLAG_DISABLE_DNS_CACHE,
-    BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO,
-    BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX,
-    BUN_FEATURE_FLAG_DISABLE_IO_POOL,
-    BUN_FEATURE_FLAG_DISABLE_IPV4,
-    BUN_FEATURE_FLAG_DISABLE_IPV6,
-    BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING,
-    BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK,
-    BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS,
-    BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH,
-    BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING,
-    BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE,
-    BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE,
-    BUN_FEATURE_FLAG_FORCE_IO_POOL,
-    BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS,
-    BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304,
-    BUN_FEATURE_FLAG_NO_LIBDEFLATE,
-    BUN_INSTRUMENTS,
-    BUN_INTERNAL_BUNX_INSTALL,
-    /// Suppress crash reporting and creating a core dump when we abort due to an unsupported libuv function being called
-    BUN_INTERNAL_SUPPRESS_CRASH_ON_UV_STUB,
-    /// Suppress crash reporting and creating a core dump when we abort due to a fatal Node-API error
-    BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT,
-    /// Suppress crash reporting and creating a core dump when `process._kill()` is passed its own PID
-    BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF,
-    /// Suppress crash reporting and creating a core dump when we abort due to a signal in `bun run`
-    BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN,
-    BUN_NO_CODESIGN_MACHO_BINARY,
-    BUN_TRACE,
-    NODE_NO_WARNINGS,
-};
+//! If you are adding feature-flags to this file, you are in the wrong spot. Go to env_var.zig
+//! instead.
 
 /// Enable breaking changes for the next major release of Bun
 // TODO: Make this a CLI flag / runtime var so that we can verify disabled code paths can compile
@@ -51,8 +8,6 @@ pub const breaking_changes_1_4 = false;
 /// Store and reuse file descriptors during module resolution
 /// This was a ~5% performance improvement
 pub const store_file_descriptors = !env.isBrowser;
-
-pub const jsx_runtime_is_cjs = true;
 
 pub const tracing = true;
 
@@ -68,15 +23,7 @@ pub const watch_directories = true;
 // This feature flag exists so when you have defines inside package.json, you can use single quotes in nested strings.
 pub const allow_json_single_quotes = true;
 
-pub const react_specific_warnings = true;
-
 pub const is_macro_enabled = !env.isWasm and !env.isWasi;
-
-// pretend everything is always the macro environment
-// useful for debugging the macro's JSX transform
-pub const force_macro = false;
-
-pub const include_filename_in_jsx = false;
 
 pub const disable_compression_in_http_client = false;
 
@@ -172,13 +119,6 @@ pub const runtime_transpiler_cache = true;
 /// order to isolate your bug.
 pub const windows_bunx_fast_path = true;
 
-// This causes strange bugs where writing via console.log (sync) has a different
-// order than via Bun.file.writer() so we turn it off until there's a unified,
-// buffered writer abstraction shared throughout Bun
-pub const nonblocking_stdout_and_stderr_on_posix = false;
-
-pub const postgresql = env.is_canary or env.isDebug;
-
 // TODO: fix Windows-only test failures in fetch-preconnect.test.ts
 pub const is_fetch_preconnect_supported = env.isPosix;
 
@@ -190,14 +130,14 @@ pub fn isLibdeflateEnabled() bool {
         return false;
     }
 
-    return !bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_NO_LIBDEFLATE);
+    return !bun.feature_flag.no_libdeflate.get();
 }
 
 /// Enable the "app" option in Bun.serve. This option will likely be removed
 /// in favor of HTML loaders and configuring framework options in bunfig.toml
 pub fn bake() bool {
     // In canary or if an environment variable is specified.
-    return env.is_canary or env.isDebug or bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE);
+    return env.is_canary or env.isDebug or bun.feature_flag.experimental_bake.get();
 }
 
 /// Additional debugging features for bake.DevServer, such as the incremental visualizer.

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -530,43 +530,44 @@ pub const FileSystem = struct {
         file_limit: usize = 32,
         file_quota: usize = 32,
 
-        pub var win_tempdir_cache: ?[]const u8 = undefined;
+        pub var sys_tempdir_cache: ?bun.os.SysTmpDir = null;
+        var sys_tempdir_mutex: Mutex = .{};
+
+        fn cleanupSysTempdirCache() callconv(.C) void {
+            if (sys_tempdir_cache) |*c| {
+                c.deinit();
+            }
+        }
 
         pub fn platformTempDir() []const u8 {
-            return switch (Environment.os) {
-                // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw#remarks
-                .windows => win_tempdir_cache orelse {
-                    const value = bun.getenvZ("TEMP") orelse bun.getenvZ("TMP") orelse brk: {
-                        if (bun.getenvZ("SystemRoot") orelse bun.getenvZ("windir")) |windir| {
-                            break :brk std.fmt.allocPrint(
-                                bun.default_allocator,
-                                "{s}\\Temp",
-                                .{strings.withoutTrailingSlash(windir)},
-                            ) catch |err| bun.handleOom(err);
-                        }
+            if (sys_tempdir_cache) |w| {
+                return w.slice();
+            }
 
-                        if (bun.getenvZ("USERPROFILE")) |profile| {
-                            var buf: bun.PathBuffer = undefined;
-                            var parts = [_]string{"AppData\\Local\\Temp"};
-                            const out = bun.path.joinAbsStringBuf(profile, &buf, &parts, .loose);
-                            break :brk bun.handleOom(bun.default_allocator.dupe(u8, out));
-                        }
+            switch (bun.os.SysTmpDir.query(bun.default_allocator)) {
+                .result => |*s| {
+                    sys_tempdir_mutex.lock();
+                    defer sys_tempdir_mutex.unlock();
+                    // After acquiring the mutex, we need to check sys_tempdir_cache again. There
+                    // is a race condition -- another thread may have acquired the lock just prior
+                    // to this thread but this thread will enter the current scope since it there
+                    // is a race condition on sys_temp_dir_cache. Consequently, this thread has to
+                    // check sys_tempdir_cache again.
+                    if (sys_tempdir_cache) |w| {
+                        return w.slice();
+                    }
 
-                        var tmp_buf: bun.PathBuffer = undefined;
-                        const cwd = std.posix.getcwd(&tmp_buf) catch @panic("Failed to get cwd for platformTempDir");
-                        const root = bun.path.windowsFilesystemRoot(cwd);
-                        break :brk std.fmt.allocPrint(
-                            bun.default_allocator,
-                            "{s}\\Windows\\Temp",
-                            .{strings.withoutTrailingSlash(root)},
-                        ) catch |err| bun.handleOom(err);
-                    };
-                    win_tempdir_cache = value;
-                    return value;
+                    sys_tempdir_cache = s.*;
+                    // TODO(markovejnovic): Using atexit for cleanup is pretty bad practice.
+                    // Ideally we would have a bun mechanism for cleanup that could register within
+                    // __fini, but my PR is not responsible to that right now.
+                    _ = bun.c.atexit(cleanupSysTempdirCache);
+                    return sys_tempdir_cache.?.slice();
                 },
-                .mac => "/private/tmp",
-                else => "/tmp",
-            };
+                .err => |e| {
+                    bun.Output.panic("Could not retrieve the system temporary directory: {}", .{e});
+                },
+            }
         }
 
         pub const Tmpfile = switch (Environment.os) {
@@ -578,7 +579,7 @@ pub const FileSystem = struct {
         pub var tmpdir_path_set = false;
         pub fn tmpdirPath(_: *const @This()) []const u8 {
             if (!tmpdir_path_set) {
-                tmpdir_path = bun.getenvZ("BUN_TMPDIR") orelse bun.getenvZ("TMPDIR") orelse platformTempDir();
+                tmpdir_path = bun.env_var.bun_tmpdir.get() orelse platformTempDir();
                 tmpdir_path_set = true;
             }
 
@@ -587,7 +588,7 @@ pub const FileSystem = struct {
 
         pub fn openTmpDir(_: *const RealFS) !std.fs.Dir {
             if (!tmpdir_path_set) {
-                tmpdir_path = bun.getenvZ("BUN_TMPDIR") orelse bun.getenvZ("TMPDIR") orelse platformTempDir();
+                tmpdir_path = bun.env_var.bun_tmpdir.get() orelse platformTempDir();
                 tmpdir_path_set = true;
             }
 
@@ -636,7 +637,7 @@ pub const FileSystem = struct {
         }
 
         pub fn getDefaultTempDir() string {
-            return bun.getenvZ("BUN_TMPDIR") orelse bun.getenvZ("TMPDIR") orelse platformTempDir();
+            return bun.env_var.bun_tmpdir.get() orelse platformTempDir();
         }
 
         pub fn setTempdir(path: ?string) void {

--- a/src/http/websocket_client/WebSocketDeflate.zig
+++ b/src/http/websocket_client/WebSocketDeflate.zig
@@ -129,7 +129,7 @@ pub fn deinit(self: *PerMessageDeflate) void {
 }
 
 fn canUseLibDeflate(len: usize) bool {
-    if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_NO_LIBDEFLATE)) {
+    if (bun.feature_flag.no_libdeflate.get()) {
         return false;
     }
 

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -234,7 +234,7 @@ pub fn forManifest(
     }
 
     // Incase the ETag causes invalidation, we fallback to the last modified date.
-    if (last_modified.len != 0 and bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304)) {
+    if (last_modified.len != 0 and bun.feature_flag.last_modified_pretend_304.get()) {
         this.unsafe_http_client.client.flags.force_last_modified = true;
         this.unsafe_http_client.client.if_modified_since = last_modified;
     }

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -165,12 +165,14 @@ pub fn fetchCacheDirectoryPath(env: *DotEnv.Loader, options: ?*const Options) Ca
         return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
     }
 
-    if (env.get("XDG_CACHE_HOME")) |dir| {
-        var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
-        return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
+    if (bun.env_var.xdg_cache_home.platformKey()) |key| {
+        if (env.get(key)) |dir| {
+            var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
+            return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
+        }
     }
 
-    if (env.get(bun.DotEnv.home_env)) |dir| {
+    if (env.get(bun.env_var.home.key())) |dir| {
         var parts = [_]string{ dir, ".bun/", "install/", "cache/" };
         return CacheDir{ .path = Fs.FileSystem.instance.abs(&parts), .is_node_modules = false };
     }

--- a/src/install/PackageManager/PackageManagerLifecycle.zig
+++ b/src/install/PackageManager/PackageManagerLifecycle.zig
@@ -176,7 +176,7 @@ pub fn sleep(this: *PackageManager) void {
 pub fn reportSlowLifecycleScripts(this: *PackageManager) void {
     const log_level = this.options.log_level;
     if (log_level == .silent) return;
-    if (bun.getRuntimeFeatureFlag(.BUN_DISABLE_SLOW_LIFECYCLE_SCRIPT_LOGGING)) {
+    if (bun.feature_flag.disable_slow_lifecycle_script_logging.get()) {
         return;
     }
 

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -320,7 +320,7 @@ pub fn doPatchCommit(
             },
         };
         var gitbuf: bun.PathBuffer = undefined;
-        const git = bun.which(&gitbuf, bun.getenvZ("PATH") orelse "", cwd, "git") orelse {
+        const git = bun.which(&gitbuf, bun.env_var.path.get() orelse "", cwd, "git") orelse {
             Output.prettyError(
                 "<r><red>error<r>: git must be installed to use `bun patch --commit` <r>\n",
                 .{},

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -569,7 +569,7 @@ fn updatePackageJSONAndInstallAndCLI(
         if (manager.options.global) {
             if (manager.options.bin_path.len > 0 and manager.track_installed_bin == .basename) {
                 var path_buf: bun.PathBuffer = undefined;
-                const needs_to_print = if (bun.getenvZ("PATH")) |PATH|
+                const needs_to_print = if (bun.env_var.path.get()) |PATH|
                     // This is not perfect
                     //
                     // If you already have a different binary of the same
@@ -667,7 +667,7 @@ fn updatePackageJSONAndInstallAndCLI(
                     ,
                         .{
                             bun.fmt.quote(manager.track_installed_bin.basename),
-                            MoreInstructions{ .shell = bun.cli.ShellCompletions.Shell.fromEnv([]const u8, bun.getenvZ("SHELL") orelse ""), .folder = manager.options.bin_path },
+                            MoreInstructions{ .shell = bun.cli.ShellCompletions.Shell.fromEnv([]const u8, bun.env_var.shell.platformGet() orelse ""), .folder = manager.options.bin_path },
                         },
                     );
                     Output.flush();

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -495,7 +495,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
         };
     }
 
-    if (!bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX)) {
+    if (!bun.feature_flag.disable_install_index.get()) {
         // create an index storing each version of a package installed
         if (strings.indexOfChar(basename, '/') == null) create_index: {
             const dest_name = switch (this.resolution.tag) {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -313,7 +313,7 @@ pub fn loadFromDir(
 
     switch (result) {
         .ok => {
-            if (bun.getenvZ("BUN_DEBUG_TEST_TEXT_LOCKFILE") != null and manager != null) {
+            if (bun.env_var.bun_debug_test_text_lockfile.get() and manager != null) {
 
                 // Convert the loaded binary lockfile into a text lockfile in memory, then
                 // parse it back into a binary lockfile.

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -16,21 +16,11 @@ const SloppyGlobalGitConfig = struct {
     }
 
     pub fn loadAndParse() void {
-        const home_dir_path = brk: {
-            if (comptime Environment.isWindows) {
-                if (bun.getenvZ("USERPROFILE")) |env|
-                    break :brk env;
-            } else {
-                if (bun.getenvZ("HOME")) |env|
-                    break :brk env;
-            }
-
-            // won't find anything
-            return;
-        };
+        var home_dir = (bun.os.HomeDir.query(bun.default_allocator)).unwrap() catch return;
+        defer home_dir.deinit();
 
         var config_file_path_buf: bun.PathBuffer = undefined;
-        const config_file_path = bun.path.joinAbsStringBufZ(home_dir_path, &config_file_path_buf, &.{".gitconfig"}, .auto);
+        const config_file_path = bun.path.joinAbsStringBufZ(home_dir.slice(), &config_file_path_buf, &.{".gitconfig"}, .auto);
         var stack_fallback = std.heap.stackFallback(4096, bun.default_allocator);
         const allocator = stack_fallback.get();
         const source = File.toSource(config_file_path, allocator, .{ .convert_bom = true }).unwrap() catch {

--- a/src/interchange/yaml.zig
+++ b/src/interchange/yaml.zig
@@ -4758,7 +4758,7 @@ pub fn Parser(comptime enc: Encoding) type {
                     return this.str.len();
                 }
 
-                pub fn done(self: *const @This()) String {
+                pub fn done(self: *@This()) String {
                     self.parser.whitespace_buf.clearRetainingCapacity();
                     return self.str;
                 }

--- a/src/linker.lds
+++ b/src/linker.lds
@@ -321,7 +321,7 @@ BUN_1.2 {
   uv_write2;
   uv_wtf8_length_as_utf16;
   uv_wtf8_to_utf16;
-	
+
 
 	extern "C++" {
 		v8::*;

--- a/src/linux.zig
+++ b/src/linux.zig
@@ -45,7 +45,7 @@ pub const RWFFlagSupport = enum(u8) {
         if (comptime !bun.Environment.isLinux) return false;
         switch (rwf_bool.load(.monotonic)) {
             .unknown => {
-                if (isLinuxKernelVersionWithBuggyRWF_NONBLOCK() or bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK)) {
+                if (isLinuxKernelVersionWithBuggyRWF_NONBLOCK() or bun.feature_flag.disable_rwf_nonblock.get()) {
                     rwf_bool.store(.unsupported, .monotonic);
                     return false;
                 }

--- a/src/macho.zig
+++ b/src/macho.zig
@@ -190,7 +190,7 @@ pub const MachoFile = struct {
             linkedit_seg.fileoff += @as(usize, @intCast(size_diff));
             linkedit_seg.vmaddr += @as(usize, @intCast(size_diff));
 
-            if (self.header.cputype == macho.CPU_TYPE_ARM64 and !bun.getRuntimeFeatureFlag(.BUN_NO_CODESIGN_MACHO_BINARY)) {
+            if (self.header.cputype == macho.CPU_TYPE_ARM64 and !bun.feature_flag.no_codesign_macho_binary.get()) {
                 // We also update the sizes of the LINKEDIT segment to account for the hashes we're adding
                 linkedit_seg.filesize += @as(usize, @intCast(size_of_new_hashes));
                 linkedit_seg.vmsize += @as(usize, @intCast(size_of_new_hashes));
@@ -341,7 +341,7 @@ pub const MachoFile = struct {
     }
 
     pub fn buildAndSign(self: *MachoFile, writer: anytype) !void {
-        if (self.header.cputype == macho.CPU_TYPE_ARM64 and !bun.getRuntimeFeatureFlag(.BUN_NO_CODESIGN_MACHO_BINARY)) {
+        if (self.header.cputype == macho.CPU_TYPE_ARM64 and !bun.feature_flag.no_codesign_macho_binary.get()) {
             var data = std.ArrayList(u8).init(self.allocator);
             defer data.deinit();
             try self.build(data.writer());

--- a/src/math.zig
+++ b/src/math.zig
@@ -1,0 +1,1 @@
+pub const interval = @import("./math/interval.zig");

--- a/src/math/interval.zig
+++ b/src/math/interval.zig
@@ -1,0 +1,93 @@
+//! Mathematical intervals and operations on them.
+
+/// Represents a mathematical interval with a start and an end of type `T`. The interval may be
+/// `open (x, y)`, `closed [x, y]`, `left-closed [x, y)` or `right-closed (x, y]`.
+fn Interval(
+    comptime T: type,
+    comptime closedness: enum { open, closed, left_closed, right_closed },
+) type {
+    return struct {
+        const Self = @This();
+
+        start: T,
+        end: T,
+
+        /// Initializes a new interval with the given start and end values.
+        pub fn init(start: T, end: T) Self {
+            return .{
+                .start = start,
+                .end = end,
+            };
+        }
+
+        /// Test whether the given value is contained within the interval.
+        pub fn contains(self: *const Self, value: T) bool {
+            switch (closedness) {
+                .open => return (value > self.start) and (value < self.end),
+                .closed => return (value >= self.start) and (value <= self.end),
+                .left_closed => return (value >= self.start) and (value < self.end),
+                .right_closed => return (value > self.start) and (value <= self.end),
+            }
+        }
+
+        /// Clamp a value to be within the interval.
+        ///
+        /// The interval bounds are ALWAYS INCLUSIVE.
+        pub fn clamp(self: *const Self, value: T) T {
+            if (value < self.start) {
+                return self.start;
+            }
+
+            if (value > self.end) {
+                return self.end;
+            }
+
+            return value;
+        }
+
+        /// Format the interval using the given format string and options.
+        ///
+        /// The format specifier is given to the start and end values in that order.
+        pub fn format(
+            self: *const Self,
+            comptime fmt: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = options;
+
+            const lp, const rp = switch (closedness) {
+                .open => .{ "(", ")" },
+                .closed => .{ "[", "]" },
+                .left_closed => .{ "[", ")" },
+                .right_closed => .{ "(", "]" },
+            };
+
+            const f = std.fmt.comptimePrint("{s}{{{s}}},{{{s}}}{s}", .{ lp, fmt, fmt, rp });
+
+            try writer.print(f, .{ self.start, self.end });
+        }
+    };
+}
+
+/// Closed interval [a, b]
+pub fn Closed(comptime T: type) type {
+    return Interval(T, .closed);
+}
+
+/// Open interval (a, b)
+pub fn Open(comptime T: type) type {
+    return Interval(T, .open);
+}
+
+/// Left-closed interval [a, b)
+pub fn LeftClosed(comptime T: type) type {
+    return Interval(T, .left_closed);
+}
+
+/// Right-closed interval (a, b]
+pub fn RightClosed(comptime T: type) type {
+    return Interval(T, .right_closed);
+}
+
+const std = @import("std");

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -1350,7 +1350,7 @@ pub export fn napi_internal_register_cleanup_zig(env_: napi_env) void {
 }
 
 pub export fn napi_internal_suppress_crash_on_abort_if_desired() void {
-    if (bun.getRuntimeFeatureFlag(.BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT)) {
+    if (bun.feature_flag.internal_suppress_crash_on_napi_abort.get()) {
         bun.crash_handler.suppressReporting();
     }
 }

--- a/src/os.zig
+++ b/src/os.zig
@@ -1,0 +1,66 @@
+//! OS-level functionality.
+//! Designed to be slightly higher level than sys.zig
+
+/// Platform-agnostic utility for fetching and interacting with the current system home directory.
+///
+/// Implements the following concept:
+/// ```
+/// fn HomeDirConcept(T type) concept {
+///     fn deinit(self: *T) void;
+///     /// Deduces the current user's home directory.
+///     ///
+///     /// Has multiple strategies depending on the platform and environment. Mostly compliant with
+///     /// the POSIX standard for POSIX systems.
+///     ///
+///     /// Tries to be clever on Windows, but no compliance guarantees are made.
+///     ///
+///     /// There is actually a reasonable desire to be able to query other users' home directories.
+///     /// However, we don't have a need to do that at this moment. See
+///     /// doi:10.1109/IEEESTD.2018.8277153 2.6.1 for further details.
+///     ///
+///     /// Very close to how uv_os_homedir works in libuv.
+///     fn query(allocator: std.mem.Allocator) bun.sys.Maybe(T);
+///     fn slice(self: *const T) []const u8;
+/// }
+/// ```
+pub const HomeDir = bun.Environment.OsTypeSelect(.{
+    .posix = posix.HomeDir,
+    .win = win32.UserProfile,
+});
+
+/// Interact with the current system temporary directory.
+///
+/// The system temporary directory is a directory equivalent to `/tmp` on POSIX systems. Note that
+/// this is not ALWAYS /tmp, as `$TMPDIR` and other mechanisms MAY allow overriding this. Treat
+/// this as a black box for maximum compatibility.
+///
+/// Note: Bun also allows users to explicitly specify the temporary directory bun should use, so
+/// this function alone does not tell you which temporary directory you should commonly use.
+///
+/// Implements the following concept:
+/// ```
+/// fn SysTempDirConcept(T type) concept {
+///     fn deinit(self: *T) void;
+///     fn query(allocator: std.mem.Allocator) bun.sys.Maybe(T);
+///     fn slice(self: *const T) []const u8;
+/// }
+/// ```
+pub const SysTmpDir = bun.Environment.OsTypeSelect(.{
+    .posix = posix.SysTmpDir,
+    .win = win32.TempDir,
+});
+
+pub const win32 = @import("./os/win32.zig");
+pub const posix = @import("./os/posix.zig");
+
+comptime {
+    // TODO(markovejnovic): This probably shouldn't exist in src/os, but rather in another spot.
+    if (bun.Environment.isPosix) {
+        // uvinterop only supports POSIX at the time of writing. No need to pollute the Windows
+        // binary with it.
+        _ = @import("./os/uvinterop.zig"); // Necessary to link into the binary.
+    }
+}
+
+const bun = @import("bun");
+const std = @import("std");

--- a/src/os/posix.zig
+++ b/src/os/posix.zig
@@ -1,0 +1,249 @@
+/// Opaque type representing the user ID.
+pub const Uid = if (bun.Environment.isPosix) struct {
+    const Self = @This();
+
+    _underlying: std.c.uid_t,
+
+    pub fn queryEffective() Self {
+        // TODO(markovejnovic): Unfortunately, geteuid is not available in Zig's stdlib at the
+        //                      moment, so we need to use @cImport above.
+        return .{ ._underlying = bun.c.geteuid() };
+    }
+
+    pub fn queryReal() Self {
+        // TODO(markovejnovic): Unfortunately, getuid is not available in Zig's stdlib at the
+        //                      moment, so we need to use @cImport above.
+        return .{ ._underlying = bun.c.getuid() };
+    }
+
+    /// Falls back to queryEffective.
+    pub fn queryCurrent() Self {
+        return queryEffective();
+    }
+
+    fn init(underlying: std.c.uid_t) Self {
+        return .{ ._underlying = underlying };
+    }
+} else struct {};
+
+/// Fully managed representation of a passwd entry.
+pub const PasswdEntry = if (bun.Environment.isPosix) struct {
+    const Self = @This();
+
+    var _pwbuf_size: std.atomic.Value(usize) = .init(0);
+
+    allocator: std.mem.Allocator,
+    buffer: []u8,
+    entry: bun.c.struct_passwd,
+    entry_ptr: *bun.c.struct_passwd,
+
+    #memo: struct {
+        pw_dir_len: ?usize = null,
+    } = .{},
+
+    pub fn deinit(self: *Self) void {
+        self.allocator.free(self.buffer);
+    }
+
+    pub fn pwNameZ(self: *Self) ?[*:0]u8 {
+        return self.entry_ptr.pw_name;
+    }
+
+    pub fn pwUidC(self: *const Self) std.c.uid_t {
+        return self.entry_ptr.pw_uid;
+    }
+
+    pub fn pwUid(self: *const Self) Uid {
+        return .init(self.pwUidC());
+    }
+
+    pub fn pwGidC(self: *Self) std.c.gid_t {
+        return self.entry_ptr.pw_gid;
+    }
+
+    pub fn pwDir(self: *Self) ?[]u8 {
+        self.#memo.pw_dir_len = std.mem.len(self.entry_ptr.pw_dir);
+        return self.entry_ptr.pw_dir[0..self.#memo.pw_dir_len.?];
+    }
+
+    pub fn pwDirZ(self: *Self) ?[*:0]u8 {
+        return self.entry_ptr.pw_dir;
+    }
+
+    pub fn pwShellZ(self: *Self) ?[*:0]u8 {
+        return self.entry_ptr.pw_shell;
+    }
+
+    /// Attempt to retrieve the result of getpwuid_r.
+    ///
+    /// May spinlock for an extremely brief period of time as it allocates memory.
+    pub fn init(user: Uid, alloc: std.mem.Allocator) bun.sys.Maybe(Self) {
+        // Every iteration we will increase the buffer size by this factor.
+        const buf_size_gain = 2;
+
+        // Claude said that _SC_GETPW_R_SIZE_MAX is by default 1024 on Linux. I don't trust Claude
+        // with anything so we're going 4X that.
+        const default_buf_size: usize = 4096;
+
+        // The maximum total number of attempts we will have at reading getpwuid_r before giving
+        // up. There are a few cases which benefit from re-attempting a read.
+        const max_buf_size: comptime_int = 1 * 1024 * 1024; // If we need to load a 1MB buffer,
+        // something is very wrong.
+
+        var buffer_size: usize = Self._pwbuf_size.load(.monotonic);
+        if (buffer_size == 0) {
+            // We know that we haven't initialized it yet. Let's try to do so now.
+            const initial_buf_size: usize =
+                @intCast(bun.sys.sysconf(bun.c._SC_GETPW_R_SIZE_MAX, .{
+                    .default = default_buf_size,
+                }));
+
+            buffer_size = initial_buf_size;
+        }
+
+        var result: ?*bun.c.struct_passwd = undefined;
+        var self: Self = .{
+            .allocator = alloc,
+            .buffer = alloc.alloc(u8, buffer_size) catch {
+                return .initErr(.fromCode(.NOMEM, .getpwuid_r));
+            },
+            .entry = undefined,
+            .entry_ptr = undefined,
+        };
+        errdefer self.allocator.free(self.buffer);
+
+        while (buffer_size <= max_buf_size) {
+            const rc = bun.c.getpwuid_r(
+                user._underlying,
+                &self.entry,
+                self.buffer.ptr,
+                self.buffer.len,
+                @ptrCast(&result),
+            );
+            if (rc == 0) {
+                // Since we found the correct buffer size, let's store it for future use.
+                Self._pwbuf_size.store(buffer_size, .monotonic);
+
+                if (result) |r| {
+                    self.entry_ptr = r;
+                    return .initResult(self);
+                }
+
+                return .initErr(.fromCode(.NOENT, .getpwuid_r));
+            }
+
+            const err = std.posix.errno(rc);
+            switch (err) {
+                .NOMEM, .RANGE => {
+                    // ENOMEM -- Insufficient memory to allocate passwd structure.
+                    // ERANGE -- Insufficient buffer space supplied.
+                    buffer_size *= buf_size_gain;
+                    self.buffer = alloc.realloc(self.buffer, buffer_size) catch {
+                        return .initErr(.fromCode(.NOMEM, .getpwuid_r));
+                    };
+                    continue;
+                },
+                .INTR => {
+                    // We got hit by a signal, let's just try again.
+                    continue;
+                },
+                .IO, .MFILE, .NFILE => {
+                    return .initErr(.fromCode(err, .getpwuid_r));
+                },
+                else => {
+                    // The man page says we have covered the total set of error codes.
+                    @branchHint(.cold);
+                    return .initErr(.fromCode(err, .getpwuid_r));
+                },
+            }
+        }
+
+        return .initErr(.fromCode(.SRCH, .getpwuid_r));
+    }
+} else struct {};
+
+/// Utilities for fetching and interacting with the current user's home directory.
+pub const HomeDir = if (bun.Environment.isPosix) struct {
+    const Self = @This();
+
+    #path: union(enum) {
+        managed: PasswdEntry,
+        unmanaged: []const u8,
+    },
+
+    pub fn slice(self: *Self) []const u8 {
+        return switch (self.#path) {
+            // Safe to unwrap since all processes which add a .managed field validate that the
+            // field is non-null.
+            .managed => self.#path.managed.pwDir().?,
+            .unmanaged => self.#path.unmanaged,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        switch (self.#path) {
+            .managed => self.#path.managed.deinit(),
+            .unmanaged => {},
+        }
+    }
+
+    /// Deduces the current user's home directory on POSIX systems.
+    ///
+    /// Whichever of the following returns a value is returned.
+    /// - Per doi:10.1109/IEEESTD.2018.8277153, the `$HOME` variable.
+    /// - The `getpwuid_r` function.
+    pub fn query(allocator: std.mem.Allocator) bun.sys.Maybe(Self) {
+        if (bun.env_var.home.get()) |home| {
+            // The user may override $HOME with a non-absolute path. We know that's wrong.
+            if (std.fs.path.isAbsolute(home)) {
+                return .initResult(.{ .#path = .{ .unmanaged = home } });
+            }
+        }
+
+        var passwd_entry = PasswdEntry.init(Uid.queryCurrent(), allocator);
+        switch (passwd_entry) {
+            .err => |e| {
+                return .initErr(e);
+            },
+            .result => |*r| {
+                return if (r.pwDir() != null)
+                    .initResult(.{ .#path = .{ .managed = r.* } })
+                else
+                    .initErr(.fromCode(.NOENT, .getpwuid_r));
+            },
+        }
+    }
+} else struct {};
+
+/// Work with the system temporary directory.
+pub const SysTmpDir = if (bun.Environment.isPosix) struct {
+    const Self = @This();
+
+    pub fn deinit(self: *Self) void {
+        _ = self; // self is unused, it's there for concept compatibility.
+    }
+
+    pub fn slice(self: *const Self) []const u8 {
+        _ = self; // self is unused, it's there for concept compatibility.
+
+        // Implementations are encouraged to provide suitable directory names in the environment
+        // variable TMPDIR and applications are encouraged to use the contents of TMPDIR for
+        // creating temporary files.
+        // - IEEE Std 1003_1-2017 (POSIX 2017)
+        if (bun.env_var.tmpdir.get()) |tmpdir| {
+            return tmpdir;
+        }
+
+        // The /tmp directory is retained in POSIX.1-2017 to accommodate historical applications
+        // that assume its availability.
+        return "/tmp";
+    }
+
+    pub fn query(allocator: std.mem.Allocator) bun.sys.Maybe(Self) {
+        _ = allocator; // Never allocates, used for conformance to
+        return .initResult(.{});
+    }
+} else struct {};
+
+const bun = @import("bun");
+const std = @import("std");

--- a/src/os/uvinterop.zig
+++ b/src/os/uvinterop.zig
@@ -1,0 +1,50 @@
+//! Utilities for interoping with libuv.
+//!
+//! TODO(markovejnovic): This file probably doesn't belong in src/os. Consider moving it to
+//! src/bunuv or similar.
+extern fn uv_translate_sys_error(sys_errno: c_int) callconv(.C) c_int;
+fn translateSysErrorToUv(sys_errno: c_int) c_int {
+    // TODO(markovejnovic): This is a hack because uv_translate_sys_error is stubbed out on POSIX.
+    if (bun.Environment.isPosix) {
+        // Exactly matches libuv's behavior.
+        return if (sys_errno <= 0) sys_errno else -sys_errno;
+    }
+
+    if (bun.Environment.isWindows) {
+        return uv_translate_sys_error(sys_errno);
+    }
+}
+
+pub export fn bunuv__os_homedir(buffer: ?[*]u8, size: ?*usize) callconv(.C) c_int {
+    if (buffer == null or size == null) {
+        return translateSysErrorToUv(@intFromEnum(bun.sys.E.INVAL));
+    }
+
+    // TODO(markovejnovic): This implementation could be slightly better. I don't know how to
+    //                      return the total size needed (from os.HomeDir.query) if the buffer is
+    //                      too small.
+    var homedir = bun.os.HomeDir.query(bun.default_allocator);
+    switch (homedir) {
+        .result => |*r| {
+            defer r.deinit();
+
+            const out = r.slice();
+            // +1 for null terminator
+            if (out.len + 1 > size.?.*) {
+                size.?.* = out.len + 1;
+                return libuv.UV_ENOBUFS;
+            }
+
+            @memcpy(buffer.?[0..out.len], out);
+            buffer.?[out.len] = 0; // null terminator
+            size.?.* = out.len + 1;
+            return 0;
+        },
+        .err => |err| {
+            return translateSysErrorToUv(err.errno);
+        },
+    }
+}
+
+const bun = @import("bun");
+const libuv = @import("../deps/libuv.zig");

--- a/src/os/win32.zig
+++ b/src/os/win32.zig
@@ -1,0 +1,338 @@
+//! Module for higher-level Windows utilities. Unlike sys.zig, this module has a slightly higher
+//! level of abstraction and is not a direct mapping to Win32 APIs, but is still very
+//! Windows-specific.
+
+/// Utilities for retrieving C:\Windows, D:\Windows or whatnot. Does not support POSIX.
+pub const WinDir = if (bun.Environment.isWindows) struct {
+    const Self = @This();
+
+    #path: union(enum) {
+        managed: paths.AutoAbsPath,
+        unmanaged: []const u8,
+    },
+
+    pub fn slice(self: *const Self) []const u8 {
+        return switch (self.#path) {
+            .managed => self.#path.managed.slice(),
+            .unmanaged => self.#path.unmanaged,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        switch (self.#path) {
+            .managed => return self.#path.managed.deinit(),
+            .unmanaged => {},
+        }
+    }
+
+    /// Query the system installation directory, typically C:\Windows.
+    ///
+    /// May or may not allocate. Make no assumptions -- call .deinit(), as that will handle both
+    /// cases for you.
+    pub fn query(allocator: std.mem.Allocator) bun.sys.Maybe(Self) {
+        const env_path = bun.env_var.windir.get() orelse bun.env_var.system_root.get();
+        if (env_path) |p| {
+            return .initResult(.{ .#path = .{ .unmanaged = p } });
+        }
+
+        // This is the slow and expensive path -- we have to actually query the system. Oof.
+        var stack = std.heap.stackFallback(bun.windows.MAX_PATH * @sizeOf(u16), allocator);
+        var alloc = stack.get();
+
+        var wchar_buf = alloc.alloc(u16, bun.windows.MAX_PATH) catch {
+            return .initErr(.fromCode(.NOMEM, .GetSystemWindowsDirectoryW));
+        };
+        defer alloc.free(wchar_buf);
+
+        const rc = queryIntoSlice(wchar_buf);
+        switch (rc) {
+            .err => |e| {
+                return .initErr(e);
+            },
+            .result => |r| {
+                if (r <= wchar_buf.len) {
+                    var path = paths.AutoAbsPath.init();
+                    // GetSystemWindowsDirectoryW returns the length without the null terminator.
+                    path.append(wchar_buf[0..@as(usize, @intCast(r))]);
+                    return .initResult(.{ .#path = .{ .managed = path } });
+                }
+
+                // We need a bigger buffer.
+                wchar_buf = alloc.realloc(wchar_buf, @as(usize, @intCast(r))) catch {
+                    return .initErr(.fromCode(.NOMEM, .GetSystemWindowsDirectoryW));
+                };
+                const rc2 = queryIntoSlice(wchar_buf);
+
+                switch (rc2) {
+                    .err => |e| {
+                        return .initErr(e);
+                    },
+                    .result => |r2| {
+                        if (r2 <= wchar_buf.len) {
+                            var path = paths.AutoAbsPath.init();
+                            // GetSystemWindowsDirectoryW returns the length without the null
+                            // terminator.
+                            path.append(wchar_buf[0..@as(usize, @intCast(r2))]);
+                            return .initResult(.{ .#path = .{ .managed = path } });
+                        }
+                    },
+                }
+
+                // If the buffer is STILL too small, then the system is pulling our leg.
+                bun.Output.panic("GetSystemWindowsDirectoryW keeps returning a size larger than " ++
+                    "the buffer we provide. This is a bug in Bun. Please report it.", .{});
+            },
+        }
+    }
+
+    fn queryIntoSlice(wchar_buf: []u16) bun.sys.Maybe(usize) {
+        const rc = bun.windows.GetSystemWindowsDirectoryW(
+            @ptrCast(wchar_buf.ptr),
+            @intCast(wchar_buf.len),
+        );
+
+        // If the function fails, the return value is zero. To get extended error information, call
+        // GetLastError.
+        if (rc == 0) {
+            const err = bun.windows.GetLastError();
+            // TODO(markovejnovic): This whole conversion between Win32Error -> SystemErrno -> E
+            //                      feels very wrong.
+            return .initErr(.fromCode(@enumFromInt(@intFromEnum(err)), .GetSystemWindowsDirectoryW));
+        }
+
+        // If the function succeeds, the return value is the length of the string copied to the
+        // buffer, in TCHARs, not including the terminating null character.
+        // If the length is greater than the size of the buffer, the return value is the size of
+        // the buffer required to hold the path.
+        //
+        // In both cases, we return the actual length.
+        return .initResult(rc);
+    }
+} else struct {};
+
+/// Utilities for retrieving C:\Users\<User> or whatnot.
+pub const UserProfile = if (bun.Environment.isWindows) struct {
+    const Self = @This();
+
+    #path: union(enum) {
+        managed: paths.AutoAbsPath,
+        unmanaged: []const u8,
+    },
+
+    pub fn slice(self: *const Self) []const u8 {
+        return switch (self.#path) {
+            .managed => self.#path.managed.slice(),
+            .unmanaged => self.#path.unmanaged,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        switch (self.#path) {
+            .managed => return self.#path.managed.deinit(),
+            .unmanaged => {},
+        }
+    }
+
+    pub fn query(allocator: std.mem.Allocator) bun.sys.Maybe(Self) {
+        const env_path = bun.env_var.home.get();
+        if (env_path) |p| {
+            // @markovejnovic:
+            // This feels very counter-intuitive to me but it matches what libuv does -- we run
+            // some heuristics to test the quality of the environment variable. I think this is
+            // kind of misguided, but decided not to deviate from libuv here.
+            if (p.len < "C:\\".len) {
+                return .initErr(.fromCode(.NOENT, .GetUserProfileDirectoryW));
+            }
+
+            return .initResult(.{ .#path = .{ .unmanaged = p } });
+        }
+
+        var stack = std.heap.stackFallback(bun.windows.MAX_PATH * @sizeOf(u16), allocator);
+        var alloc = stack.get();
+
+        var wchar_buf = alloc.alloc(u16, bun.windows.MAX_PATH) catch {
+            return .initErr(.fromCode(.NOMEM, .GetUserProfileDirectoryW));
+        };
+        defer alloc.free(wchar_buf);
+
+        const rc = queryIntoSlice(wchar_buf);
+        switch (rc) {
+            .err => |e| {
+                return .initErr(e);
+            },
+            .result => |r| {
+                if (r <= wchar_buf.len) {
+                    var path = paths.AutoAbsPath.init();
+                    // -1 because we don't want the null terminator.
+                    path.append(wchar_buf[0..@as(usize, if (r == 0) 0 else @intCast(r - 1))]);
+                    return .initResult(.{ .#path = .{ .managed = path } });
+                }
+
+                // We need a bigger buffer.
+                wchar_buf = alloc.realloc(wchar_buf, @as(usize, @intCast(r))) catch {
+                    return .initErr(.fromCode(.NOMEM, .GetUserProfileDirectoryW));
+                };
+                const rc2 = queryIntoSlice(wchar_buf);
+
+                switch (rc2) {
+                    .err => |e| {
+                        return .initErr(e);
+                    },
+                    .result => |r2| {
+                        if (r2 <= wchar_buf.len) {
+                            var path = paths.AutoAbsPath.init();
+                            // -1 because we don't want the null terminator.
+                            path.append(
+                                wchar_buf[0..@as(usize, if (r2 == 0) 0 else @intCast(r2 - 1))],
+                            );
+                            return .initResult(.{ .#path = .{ .managed = path } });
+                        }
+                    },
+                }
+
+                // If the buffer is STILL too small, then the system is pulling our leg.
+                bun.Output.panic("GetUserProfileDirectoryW keeps returning a size larger than " ++
+                    "the buffer we provide. This is a bug in Bun. Please report it.", .{});
+            },
+        }
+    }
+
+    fn queryIntoSlice(wchar_buf: []u16) bun.sys.Maybe(usize) {
+        var proc_token: bun.windows.HANDLE = undefined;
+        const proc_hndl = bun.windows.GetCurrentProcess();
+        var rc = bun.windows.OpenProcessToken(proc_hndl, bun.windows.TOKEN_QUERY, &proc_token);
+        if (rc == bun.windows.FALSE) {
+            const err = bun.windows.GetLastError();
+            // TODO(markovejnovic): This whole conversion between Win32Error -> SystemErrno -> E
+            //                      feels very wrong.
+            return .initErr(.fromCode(@enumFromInt(@intFromEnum(err)), .OpenProcessToken));
+        }
+        defer _ = bun.windows.CloseHandle(proc_token);
+
+        var path_size: bun.windows.DWORD = @as(bun.windows.DWORD, @intCast(wchar_buf.len));
+        rc = bun.windows.GetUserProfileDirectoryW(
+            proc_token,
+            @ptrCast(wchar_buf.ptr),
+            &path_size,
+        );
+
+        if (rc == bun.windows.FALSE and
+            path_size < @as(bun.windows.DWORD, @intCast(wchar_buf.len)))
+        {
+            // Otherwise we found ourselves some really weird error.
+            const err = bun.windows.GetLastError();
+            // TODO(markovejnovic): This whole conversion between Win32Error -> SystemErrno -> E
+            //                      feels very wrong.
+            return .initErr(.fromCode(@enumFromInt(@intFromEnum(err)), .GetUserProfileDirectoryW));
+        }
+
+        // Either the buffer was too small (in which case path_size contains the required size),
+        // or we succeeded (in which case path_size contains the actual size).
+        return .initResult(@intCast(path_size));
+    }
+} else struct {};
+
+// Windows-specific TMP/TEMP directory retrieval.
+pub const TempDir = if (bun.Environment.isWindows) struct {
+    const Self = @This();
+
+    #path: union(enum) {
+        unmanaged: []const u8,
+        managed: struct {
+            allocator: std.mem.Allocator,
+            buf: []u8,
+        },
+    },
+
+    pub fn slice(self: *const Self) []const u8 {
+        return switch (self.#path) {
+            .unmanaged => self.#path.unmanaged,
+            .managed => |*m| m.buf,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        switch (self.#path) {
+            .unmanaged => {},
+            .managed => |*m| {
+                m.allocator.free(m.buf);
+            },
+        }
+    }
+
+    pub fn query(allocator: std.mem.Allocator) bun.sys.Maybe(Self) {
+        // Kind of mimics what GetTempPath2 does.
+        //
+        // Microsoft says:
+        // For non-system processes, the GetTempPath2 function checks for the existence of
+        // environment variables in the following order and uses the first path found:
+        //   1. The path specified by the TMP environment variable.
+        //   2. The path specified by the TEMP environment variable.
+        //   3. The path specified by the USERPROFILE environment variable.
+        //   4. The Windows directory.
+        // The maximum possible return value is MAX_PATH+1 (261).
+        //
+        // They also say:
+        //
+        // When calling this function from a process running as SYSTEM it will
+        // return the path C:\Windows\SystemTemp, which is inaccessible to non-SYSTEM processes.
+        // For non-SYSTEM processes, GetTempPath2 will behave the same as GetTemppaths.
+        //
+        // For system processes, the GetTempPath2 function checks for the existence of the
+        // environment variable SystemTemp. If this environment variable is set, it will use the
+        // value of the environment variable as the path instead of the default system provided
+        // path on the C: drive.
+        //
+        // We do not implement this SYSTEM-specific behavior. There is no reason to call Bun as a
+        // SYSTEM process.
+        //
+        // Furthermore, we deviate from the documented behavior of GetTempPath2 since it's fucking
+        // stupid -- why on earth would we ever want to polute the user directory, or worse even
+        // the Windows directory? That makes zero sense. Therefore, if we do fall that far down the
+        // list, we will append temp to the path.
+        //
+        // This matches Node and is close to what CPython does.
+        if (bun.env_var.tmp.get()) |t| {
+            return .initResult(.{ .#path = .{ .unmanaged = t } });
+        }
+
+        if (bun.env_var.temp.get()) |t| {
+            return .initResult(.{ .#path = .{ .unmanaged = t } });
+        }
+
+        var user_profile = UserProfile.query(allocator);
+        if (user_profile.asValuePtr()) |up| {
+            defer up.deinit();
+            return .initResult(.{ .#path = .{ .managed = .{
+                .allocator = allocator,
+                .buf = std.mem.concat(allocator, u8, &.{ up.slice(), "\\Temp" }) catch |err| {
+                    switch (err) {
+                        error.OutOfMemory => return .initErr(.fromCode(.NOMEM, .GetTempPath2)),
+                    }
+                },
+            } } });
+        }
+
+        var win_dir = WinDir.query(allocator);
+        if (win_dir.asValuePtr()) |wd| {
+            defer wd.deinit();
+            return .initResult(.{ .#path = .{ .managed = .{
+                .allocator = allocator,
+                .buf = std.mem.concat(allocator, u8, &.{ wd.slice(), "\\Temp" }) catch |err| {
+                    switch (err) {
+                        error.OutOfMemory => return .initErr(.fromCode(.NOMEM, .GetTempPath2)),
+                    }
+                },
+            } } });
+        }
+
+        return .initErr(user_profile.asErr() orelse
+            win_dir.asErr() orelse
+            .fromCode(.UNKNOWN, .GetTempPath2));
+    }
+} else struct {};
+
+const std = @import("std");
+
+const bun = @import("bun");
+const paths = bun.paths;

--- a/src/output.zig
+++ b/src/output.zig
@@ -80,35 +80,26 @@ pub const Source = struct {
     }
 
     pub fn isNoColor() bool {
-        const no_color = bun.getenvZ("NO_COLOR") orelse return false;
-        // https://no-color.org/
-        // "when present and not an empty string (regardless of its value)"
-        return no_color.len != 0;
+        return bun.env_var.no_color.get();
     }
 
-    pub fn getForceColorDepth() ?ColorDepth {
-        const force_color = bun.getenvZ("FORCE_COLOR") orelse return null;
+    pub fn getForceColorDepth() ColorDepth {
+        const force_color = bun.env_var.force_color.get() orelse 0;
         // Supported by Node.js, if set will ignore NO_COLOR.
         // - "0" to indicate no color support
         // - "1", "true", or "" to indicate 16-color support
         // - "2" to indicate 256-color support
         // - "3" to indicate 16 million-color support
-        if (strings.eqlComptime(force_color, "1") or strings.eqlComptime(force_color, "true") or strings.eqlComptime(force_color, "")) {
-            return ColorDepth.@"16";
-        }
-
-        if (strings.eqlComptime(force_color, "2")) {
-            return ColorDepth.@"256";
-        }
-        if (strings.eqlComptime(force_color, "3")) {
-            return ColorDepth.@"16m";
-        }
-
-        return ColorDepth.none;
+        return switch (force_color) {
+            1 => .@"16",
+            2 => .@"256",
+            3 => .@"16m",
+            else => .none,
+        };
     }
 
     pub fn isForceColor() bool {
-        return (getForceColorDepth() orelse ColorDepth.none) != .none;
+        return getForceColorDepth() != .none;
     }
 
     pub fn isColorTerminal() bool {
@@ -264,8 +255,8 @@ pub const Source = struct {
     var lazy_color_depth: ColorDepth = .none;
     var color_depth_once = std.once(getColorDepthOnce);
     fn getColorDepthOnce() void {
-        if (getForceColorDepth()) |depth| {
-            lazy_color_depth = depth;
+        lazy_color_depth = getForceColorDepth();
+        if (lazy_color_depth != .none) {
             return;
         }
 
@@ -273,29 +264,28 @@ pub const Source = struct {
             return;
         }
 
-        const term = bun.getenvZ("TERM") orelse "";
+        const term = bun.env_var.term.get() orelse "";
         if (strings.eqlComptime(term, "dumb")) {
             return;
         }
 
-        if (bun.getenvZ("TMUX") != null) {
+        if (bun.env_var.tmux.get() != null) {
             lazy_color_depth = .@"256";
             return;
         }
 
-        if (bun.getenvZ("CI")) |ci| {
+        if (bun.env_var.ci.get()) |ci| {
             inline for (.{ "APPVEYOR", "BUILDKITE", "CIRCLECI", "DRONE", "GITHUB_ACTIONS", "GITLAB_CI", "TRAVIS" }) |ci_env| {
                 if (strings.eqlComptime(ci, ci_env)) {
                     lazy_color_depth = .@"256";
                     return;
                 }
             }
-
             lazy_color_depth = .@"16";
             return;
         }
 
-        if (bun.getenvZ("TERM_PROGRAM")) |term_program| {
+        if (bun.env_var.term_program.get()) |term_program| {
             const use_16m = .{
                 "ghostty",
                 "MacTerm",
@@ -313,7 +303,7 @@ pub const Source = struct {
 
         var has_color_term_set = false;
 
-        if (bun.getenvZ("COLORTERM")) |color_term| {
+        if (bun.env_var.colorterm.get()) |color_term| {
             if (strings.eqlComptime(color_term, "truecolor") or strings.eqlComptime(color_term, "24bit")) {
                 lazy_color_depth = .@"16m";
                 return;
@@ -450,10 +440,9 @@ pub inline fn isEmojiEnabled() bool {
 }
 
 pub fn isGithubAction() bool {
-    if (bun.getenvZ("GITHUB_ACTIONS")) |value| {
-        return strings.eqlComptime(value, "true") and
-            // Do not print github annotations for AI agents because that wastes the context window.
-            !isAIAgent();
+    if (bun.env_var.github_actions.get()) {
+        // Do not print github annotations for AI agents because that wastes the context window.
+        return !isAIAgent();
     }
     return false;
 }
@@ -462,7 +451,7 @@ pub fn isAIAgent() bool {
     const get_is_agent = struct {
         var value = false;
         fn evaluate() bool {
-            if (bun.getenvZ("AGENT")) |env| {
+            if (bun.env_var.agent.get()) |env| {
                 return strings.eqlComptime(env, "1");
             }
 
@@ -471,12 +460,12 @@ pub fn isAIAgent() bool {
             }
 
             // Claude Code.
-            if (bun.getenvTruthy("CLAUDECODE")) {
+            if (bun.env_var.claudecode.get()) {
                 return true;
             }
 
             // Replit.
-            if (bun.getenvTruthy("REPL_ID")) {
+            if (bun.env_var.repl_id.get()) {
                 return true;
             }
 
@@ -509,12 +498,7 @@ pub fn isAIAgent() bool {
 
 pub fn isVerbose() bool {
     // Set by Github Actions when a workflow is run using debug mode.
-    if (bun.getenvZ("RUNNER_DEBUG")) |value| {
-        if (strings.eqlComptime(value, "1")) {
-            return true;
-        }
-    }
-    return false;
+    return bun.env_var.runner_debug.get();
 }
 
 pub fn enableBuffering() void {
@@ -1266,7 +1250,7 @@ extern "c" fn getpid() c_int;
 pub fn initScopedDebugWriterAtStartup() void {
     bun.debugAssert(source_set);
 
-    if (bun.getenvZ("BUN_DEBUG")) |path| {
+    if (bun.env_var.bun_debug.get()) |path| {
         if (path.len > 0 and !strings.eql(path, "0") and !strings.eql(path, "false")) {
             if (std.fs.path.dirname(path)) |dir| {
                 std.fs.cwd().makePath(dir) catch {};

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -1267,7 +1267,7 @@ pub fn spawnOpts(
             "XDG_CONFIG_HOME",
             "USERPROFILE",
         };
-        const PATH = bun.getenvZ("PATH");
+        const PATH = bun.env_var.path.get();
         const envp_buf = bun.handleOom(bun.default_allocator.allocSentinel(?[*:0]const u8, env_arr.len + @as(usize, if (PATH != null) 1 else 0), null));
         for (0..env_arr.len) |i| {
             envp_buf[i] = env_arr[i].ptr;
@@ -1392,7 +1392,7 @@ pub fn gitDiffInternal(
     child_proc.stderr_behavior = .Pipe;
     var map = std.process.EnvMap.init(allocator);
     defer map.deinit();
-    if (bun.getenvZ("PATH")) |v| try map.put("PATH", v);
+    if (bun.env_var.path.get()) |v| try map.put("PATH", v);
     try map.put("GIT_CONFIG_NOSYSTEM", "1");
     try map.put("HOME", "");
     try map.put("XDG_CONFIG_HOME", "");

--- a/src/perf.zig
+++ b/src/perf.zig
@@ -19,13 +19,13 @@ pub const Ctx = union(enum) {
 var is_enabled_once = std.once(isEnabledOnce);
 var is_enabled = std.atomic.Value(bool).init(false);
 fn isEnabledOnMacOSOnce() void {
-    if (bun.getenvZ("DYLD_ROOT_PATH") != null or bun.getRuntimeFeatureFlag(.BUN_INSTRUMENTS)) {
+    if (bun.env_var.dyld_root_path.get() != null or bun.feature_flag.instruments.get()) {
         is_enabled.store(true, .seq_cst);
     }
 }
 
 fn isEnabledOnLinuxOnce() void {
-    if (bun.getRuntimeFeatureFlag(.BUN_TRACE)) {
+    if (bun.feature_flag.trace.get()) {
         is_enabled.store(true, .seq_cst);
     }
 }

--- a/src/shell/Builtin.zig
+++ b/src/shell/Builtin.zig
@@ -112,7 +112,7 @@ pub const Kind = enum {
     }
 
     fn forceEnableOnPosix() bool {
-        return bun.getRuntimeFeatureFlag(.BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS);
+        return bun.feature_flag.enable_experimental_shell_builtins.get();
     }
 
     pub fn fromStr(str: []const u8) ?Builtin.Kind {

--- a/src/sql/mysql/MySQLRequestQueue.zig
+++ b/src/sql/mysql/MySQLRequestQueue.zig
@@ -32,7 +32,7 @@ pub inline fn markAsPrepared(this: *@This()) void {
     }
 }
 pub inline fn canPipeline(this: *@This(), connection: *MySQLConnection) bool {
-    if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING)) {
+    if (bun.feature_flag.disable_sql_auto_pipelining.get()) {
         @branchHint(.unlikely);
         return false;
     }

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -984,7 +984,7 @@ pub fn hasQueryRunning(this: *PostgresSQLConnection) bool {
 }
 
 pub fn canPipeline(this: *PostgresSQLConnection) bool {
-    if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING)) {
+    if (bun.feature_flag.disable_sql_auto_pipelining.get()) {
         @branchHint(.unlikely);
         return false;
     }

--- a/src/string/immutable/visible.zig
+++ b/src/string/immutable/visible.zig
@@ -1,47 +1,31 @@
 pub fn isZeroWidthCodepointType(comptime T: type, cp: T) bool {
-    if (cp <= 0x1f) {
-        return true;
-    }
-
-    if (cp >= 0x7f and cp <= 0x9f) {
-        // C1 control characters
-        return true;
-    }
+    const c1_control_chars = bun.math.interval.Closed(T).init(0x7f, 0x9f);
+    const combining_diacritical_marks = bun.math.interval.Closed(T).init(0x300, 0x36f);
+    const modifying_invisible_chars = bun.math.interval.Closed(T).init(0x200b, 0x200f);
+    const combining_diacritical_marks_for_symbols = bun.math.interval.Closed(T).init(0x20d0, 0x20ff);
+    const variation_selectors_1 = bun.math.interval.Closed(T).init(0xfe00, 0xfe0f);
+    const combining_half_marks = bun.math.interval.Closed(T).init(0xfe20, 0xfe2f);
+    const variation_selectors_2 = bun.math.interval.Closed(T).init(0xe0100, 0xe01ef);
 
     if (comptime @sizeOf(T) == 1) {
         return false;
     }
 
-    if (cp >= 0x300 and cp <= 0x36f) {
-        // Combining Diacritical Marks
-        return true;
-    }
-
-    if (cp >= 0x200b and cp <= 0x200f) {
-        // Modifying Invisible Characters
-        return true;
-    }
-
-    if (cp >= 0x20d0 and cp <= 0x20ff)
-        // Combining Diacritical Marks for Symbols
-        return true;
-
-    if (cp >= 0xfe00 and cp <= 0xfe0f)
-        // Variation Selectors
-        return true;
-    if (cp >= 0xfe20 and cp <= 0xfe2f)
-        // Combining Half Marks
-        return true;
-
     if (cp == 0xfeff)
         // Zero Width No-Break Space (BOM, ZWNBSP)
         return true;
 
-    if (cp >= 0xe0100 and cp <= 0xe01ef)
-        // Variation Selectors
+    if (cp <= 0x1f) {
         return true;
+    }
 
-    return false;
+    return c1_control_chars.contains(cp) or
+        combining_diacritical_marks.contains(cp) or
+        modifying_invisible_chars.contains(cp) or
+        combining_diacritical_marks_for_symbols.contains(cp) or
+        variation_selectors_1.contains(cp) or
+        combining_half_marks.contains(cp) or
+        variation_selectors_2.contains(cp);
 }
 
 /// Official unicode reference: https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -528,7 +528,7 @@ fn dlsym(comptime Type: type, comptime symbol: [:0]const u8) ?Type {
 
             const RLTD: std.c.RTLD = if (bun.Environment.isMac) @bitCast(@as(i32, -2)) else if (bun.Environment.isLinux) .{} else {};
 
-            if (bun.getenvZ("BUN_TRACY_PATH")) |path| {
+            if (bun.env_var.bun_tracy_path.get()) |path| {
                 const handle = bun.sys.dlopen(&(std.posix.toPosixPath(path) catch unreachable), RLTD);
                 if (handle != null) {
                     Handle.handle = handle;

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -902,7 +902,7 @@ pub const Transpiler = struct {
         comptime format: js_printer.Format,
         handler: js_printer.SourceMapHandler,
     ) !usize {
-        if (bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS)) {
+        if (bun.feature_flag.disable_source_maps.get()) {
             return transpiler.printWithSourceMapMaybe(
                 result.ast,
                 &result.source,

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1583,7 +1583,7 @@ fn SocketHandler(comptime ssl: bool) type {
 const Options = struct {
     pub fn fromJS(globalObject: *jsc.JSGlobalObject, options_obj: jsc.JSValue) !valkey.Options {
         var this = valkey.Options{
-            .enable_auto_pipelining = !bun.getRuntimeFeatureFlag(.BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING),
+            .enable_auto_pipelining = !bun.feature_flag.disable_redis_auto_pipelining.get(),
         };
 
         if (try options_obj.getOptionalInt(globalObject, "idleTimeout", u32)) |idle_timeout| {

--- a/src/watcher/INotifyWatcher.zig
+++ b/src/watcher/INotifyWatcher.zig
@@ -94,9 +94,10 @@ pub fn init(this: *INotifyWatcher, _: []const u8) !void {
     bun.assert(!this.loaded);
     this.loaded = true;
 
-    if (bun.getenvZ("BUN_INOTIFY_COALESCE_INTERVAL")) |env| {
-        this.coalesce_interval = std.fmt.parseInt(isize, env, 10) catch 100_000;
-    }
+    const raw_interval = bun.env_var.bun_inotify_coalesce_interval.get();
+    const valid_ns_range = bun.math.interval.Closed(u64).init(0, 999_999_999);
+    const clamped_interval = valid_ns_range.clamp(raw_interval);
+    this.coalesce_interval = @intCast(clamped_interval);
 
     // TODO: convert to bun.sys.Error
     this.fd = .fromNative(try std.posix.inotify_init1(IN.CLOEXEC));

--- a/src/watcher/WatcherTrace.zig
+++ b/src/watcher/WatcherTrace.zig
@@ -6,7 +6,7 @@ var trace_file: ?bun.sys.File = null;
 pub fn init() void {
     if (trace_file != null) return;
 
-    if (bun.getenvZ("BUN_WATCHER_TRACE")) |trace_path| {
+    if (bun.env_var.bun_watcher_trace.get()) |trace_path| {
         if (trace_path.len > 0) {
             const flags = bun.O.WRONLY | bun.O.CREAT | bun.O.APPEND;
             const mode = 0o644;

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -86,6 +86,31 @@ pub const WPathBuffer = if (Environment.isWindows) bun.WPathBuffer else void;
 pub const HANDLE = win32.HANDLE;
 pub const HMODULE = win32.HMODULE;
 
+/// learn.microsoft.com/en-us/windows/win32/secauthz/access-rights-for-access-token-objects
+pub const TOKEN_QUERY: DWORD = 0x0008;
+
+/// learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocesstoken
+pub extern "advapi32" fn OpenProcessToken(
+    ProcessHandle: HANDLE,
+    DesiredAccess: DWORD,
+    TokenHandle: *HANDLE,
+) callconv(windows.WINAPI) BOOL;
+
+/// learn.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-getuserprofiledirectoryw
+pub extern "userenv" fn GetUserProfileDirectoryW(
+    hToken: HANDLE,
+    lpProfileDir: LPWSTR,
+    lpcchSize: *DWORD,
+) callconv(windows.WINAPI) BOOL;
+
+// learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemwindowsdirectoryw
+pub extern "kernel32" fn GetSystemWindowsDirectoryW(
+    lpBuffer: LPWSTR,
+    uSize: UINT,
+) callconv(windows.WINAPI) UINT;
+
+pub const GetCurrentProcess = windows.GetCurrentProcess;
+
 /// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
 pub extern "kernel32" fn GetFileInformationByHandle(
     hFile: HANDLE,

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -36,7 +36,7 @@
   "std.enums.tagName(": 2,
   "std.fs.Dir": 164,
   "std.fs.File": 62,
-  "std.fs.cwd": 103,
+  "std.fs.cwd": 102,
   "std.log": 1,
   "std.mem.indexOfAny(u8": 0,
   "std.unicode": 27,


### PR DESCRIPTION
### What does this PR do?

#### `env_var.zig` - Environment Variable Store

This PR adds a new mechanism to keep track of environment variables. Instead of loading them ad-hoc in various places, it uses a memoization strategy that loads the environment variable once, stores it in `.data` and then loads it as required.

The goal of this PR is to make the tracking and management of environment variables (and feature flags) cleaner and safer

#### Misc

- [x] Made all `.deinit()` operations not take a `const *T` but now they all take `*T` on @taylordotfish's request
- [x] Added POSIX support for `uv_os_homedir`
- [x] Fixed a very minor leak and concurrency bug in `fs.zig`.

### Future Improvements

- [ ] Some of the utilities in `os.zig` could potentially benefit from being memoized. Is `C:\Windows` really going to change during the execution of `Bun`? Probably not -- so it is worthwhile to memoize those too.
- [ ] https://github.com/oven-sh/bun/issues/23793

### How did you verify your code works?

_Hopefully_ regressions pass. This is a refactor and not much more.

### Breaking Changes

- 💔 `BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS` has been changed to no longer accept negative inputs. The legacy behavior would allow you to pass negative numbers which would cause it to mean `std.math.maxInt(32)`.