### PR TITLE
Implement RefCounted for napi_env

### DIFF
--- a/src/bun.js/bindings/NapiRef.cpp
+++ b/src/bun.js/bindings/NapiRef.cpp
@@ -37,7 +37,7 @@ void NapiRef::unref()
 void NapiRef::clear()
 {
     NAPI_LOG("ref clear %p", this);
-    finalizer.call(env, nativeObject);
+    finalizer.call(env.get(), nativeObject);
     globalObject.clear();
     weakValueRef.clear();
     strongRef.clear();

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3519,7 +3519,7 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
 
 napi_env GlobalObject::makeNapiEnv(const napi_module& mod)
 {
-    m_napiEnvs.append(std::make_unique<napi_env__>(this, mod));
+    m_napiEnvs.append(adoptRef(new napi_env__(this, mod)));
     return m_napiEnvs.last().get();
 }
 

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -60,6 +60,9 @@ class GlobalInternals;
 #include "BakeAdditionsToGlobalObject.h"
 #include "WriteBarrierList.h"
 
+struct napi_env__;
+using NapiEnv = WTF::RefPtr<napi_env__>;
+
 namespace Bun {
 class JSCommonJSExtensions;
 class InternalModuleRegistry;
@@ -724,7 +727,7 @@ public:
     // De-optimization once `require("module").runMain` is written to
     bool hasOverriddenModuleRunMain = false;
 
-    WTF::Vector<std::unique_ptr<napi_env__>> m_napiEnvs;
+    WTF::Vector<NapiEnv> m_napiEnvs;
     napi_env makeNapiEnv(const napi_module&);
     napi_env makeNapiEnvForFFI();
     bool hasNapiFinalizers() const;


### PR DESCRIPTION
## Summary

This PR implements reference counting for `napi_env` using WebKit's `RefCounted` pattern, following Node.js's implementation approach.

## Changes

- **Made `napi_env__` extend `RefCounted<napi_env__>`**: Enables automatic reference counting
- **Added `NapiEnv` typedef**: `using NapiEnv = WTF::RefPtr<napi_env__>`
- **Updated `NapiRef` class**: Now stores `NapiEnv` instead of raw `napi_env` pointer
- **Updated `ZigGlobalObject`**: Changed `m_napiEnvs` from `Vector<unique_ptr<napi_env__>>` to `Vector<NapiEnv>`
- **Updated `makeNapiEnv()`**: Uses `adoptRef()` instead of `make_unique()`
- **Updated finalizer lambdas**: Capture `NapiEnv` via `RefPtr` for automatic ref/unref

## Benefits

1. **Automatic memory management**: RefPtr's RAII pattern handles ref/unref through constructors/destructors
2. **Prevents use-after-free**: Ensures `napi_env` stays alive as long as references exist
3. **Matches Node.js pattern**: Aligns with how Node.js manages napi_env lifetime
4. **No manual ref counting**: Eliminates need for explicit `ref()`/`unref()` calls

## Testing

- ✅ Compiles successfully
- ✅ Basic NAPI addon loading works
- ✅ GC test passes without crashes
- ✅ Follows existing Bun patterns for RefCounted objects

## Implementation Details

The implementation uses pure RAII with no manual ref/unref calls:
- When `NapiRef` is constructed, it automatically increments the ref count
- When finalizer lambdas capture `NapiEnv`, the RefPtr copy constructor increments the count
- When these objects are destroyed, destructors automatically decrement the count
- When ref count reaches 0, the `napi_env__` is automatically deleted

This is the clean, safe approach that avoids mixing manual and automatic reference counting.