### PR TITLE
Fix child_process.unref() not keeping parent alive with active IPC channel

### DIFF
--- a/test/regression/issue/23686.test.ts
+++ b/test/regression/issue/23686.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("child_process.unref() should allow parent to exit when IPC is established", async () => {
+  using dir = tempDir("test-23686", {
+    "parent.js": `
+import {fork} from "node:child_process";
+
+const child = fork("./child.js");
+
+child.on('message', (msg) => {
+  console.log(msg);
+});
+
+child.unref();
+child.send('Hello from parent');
+    `,
+    "child.js": `
+process.on('message', (msg) => {
+  console.log(msg);
+  process.send('Hello from child');
+  process.disconnect();
+});
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Set a timeout to kill the process if it hangs
+  const timeout = setTimeout(() => {
+    proc.kill();
+  }, 3000);
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  clearTimeout(timeout);
+
+  // The parent should exit cleanly, not hang
+  expect(exitCode).toBe(0);
+
+  // We should see both messages
+  expect(stdout).toContain("Hello from parent");
+  expect(stdout).toContain("Hello from child");
+
+  // No errors
+  expect(stderr).toBe("");
+}, 5000);


### PR DESCRIPTION
Fixes #23686

## Problem

When `child_process.unref()` was called on a forked process with an active IPC channel, the parent process would exit immediately without waiting to receive messages from the child.

## Root Cause

The `SendQueue.shouldRef()` function in `ipc.zig` was returning `false` when the message queue was empty, causing the IPC keepalive to be removed. This meant that after sending a message that completed immediately, the IPC would no longer keep the event loop alive, causing the parent process to exit before receiving the child's reply.

## Solution

Per Node.js documentation: "Calling `subprocess.unref()` will allow the parent process to exit independently of the child **unless there is an established IPC channel** between the child and the parent."

This means that even after `unref()`, an active IPC connection should keep the parent process alive to allow bidirectional communication.

## Changes

- Modified `SendQueue.shouldRef()` in `ipc.zig` to return `true` when the queue is empty but the socket is still connected, ensuring IPC keeps the event loop alive
- Updated `hasPendingActivityNonThreadsafe()` in `subprocess.zig` to check if IPC keepalive is active rather than just checking if `ipc_data` exists  
- Added clarifying comments to `jsRef()` and `jsUnref()` explaining that IPC keepalive is managed independently and not affected by `unref()`
- Added regression test in `test/regression/issue/23686.test.ts` that verifies both parent and child can exchange messages before exiting

## Testing

The regression test creates a parent process that forks a child, calls `unref()`, and sends a message. The test verifies that:
- The parent receives "Hello from parent" (sent to child)
- The parent receives "Hello from child" (reply from child)
- Both processes exit cleanly (the child calls `disconnect()` after replying)

Without this fix, the parent would exit before receiving the child's reply.