### PR TITLE
fix: align --sourcemap help text in build templates

### DIFF
--- a/src/create/projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.build.ts
+++ b/src/create/projects/react-shadcn-spa/REPLACE_ME_WITH_YOUR_APP_FILE_NAME.build.ts
@@ -15,7 +15,7 @@ Usage: bun run build.ts [options]
 Common Options:
   --outdir <path>          Output directory (default: "dist")
   --minify                 Enable minification (or --minify.whitespace, --minify.syntax, etc)
-  --sourcemap <type>      Sourcemap type: none|linked|inline|external
+  --sourcemap <type>       Sourcemap type: none|linked|inline|external
   --target <target>        Build target: browser|bun|node
   --format <format>        Output format: esm|cjs|iife
   --splitting              Enable code splitting

--- a/src/init/react-shadcn/build.ts
+++ b/src/init/react-shadcn/build.ts
@@ -13,7 +13,7 @@ Usage: bun run build.ts [options]
 Common Options:
   --outdir <path>          Output directory (default: "dist")
   --minify                 Enable minification (or --minify.whitespace, --minify.syntax, etc)
-  --sourcemap <type>      Sourcemap type: none|linked|inline|external
+  --sourcemap <type>       Sourcemap type: none|linked|inline|external
   --target <target>        Build target: browser|bun|node
   --format <format>        Output format: esm|cjs|iife
   --splitting              Enable code splitting

--- a/src/init/react-tailwind/build.ts
+++ b/src/init/react-tailwind/build.ts
@@ -13,7 +13,7 @@ Usage: bun run build.ts [options]
 Common Options:
   --outdir <path>          Output directory (default: "dist")
   --minify                 Enable minification (or --minify.whitespace, --minify.syntax, etc)
-  --sourcemap <type>      Sourcemap type: none|linked|inline|external
+  --sourcemap <type>       Sourcemap type: none|linked|inline|external
   --target <target>        Build target: browser|bun|node
   --format <format>        Output format: esm|cjs|iife
   --splitting              Enable code splitting


### PR DESCRIPTION
## What does this PR do?

Fixes spacing alignment in the help text for the `--sourcemap` option across build template files. This issue was introduced in d181e199 (#21130) when `--source-map` was renamed to `--sourcemap` - the shorter flag name caused misalignment with other option descriptions.

## How did you verify your code works?

Visual inspection of the help text alignment in the affected template files to ensure consistent spacing with surrounding options.