### PR TITLE
Remove duplicate 'linked' option from sourcemap

### DIFF
--- a/docs/bundler/index.md
+++ b/docs/bundler/index.md
@@ -1600,7 +1600,7 @@ interface BuildConfig {
   publicPath?: string;
   define?: Record<string, string>;
   loader?: { [k in string]: Loader };
-  sourcemap?: "none" | "linked" | "inline" | "external" | "linked" | boolean; // default: "none", true -> "inline"
+  sourcemap?: "none" | "linked" | "inline" | "external" | boolean; // default: "none", true -> "inline"
   /**
    * package.json `exports` conditions used when resolving imports
    *


### PR DESCRIPTION
Bun bundler documentation duplicated the "linked" type for sourcemap.

### What does this PR do?

Fix documentation mistake.

### How did you verify your code works?

No code changes have been made.