### PR TITLE
Remove unused EventLoopTimer.Arm return type

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -3625,14 +3625,13 @@ pub fn emitVisualizerMessageIfNeeded(dev: *DevServer) void {
     dev.publish(.incremental_visualizer, payload.items, .binary);
 }
 
-pub fn emitMemoryVisualizerMessageTimer(timer: *EventLoopTimer, _: *const bun.timespec) EventLoopTimer.Arm {
-    if (!bun.FeatureFlags.bake_debugging_features) return .disarm;
+pub fn emitMemoryVisualizerMessageTimer(timer: *EventLoopTimer, _: *const bun.timespec) void {
+    if (!bun.FeatureFlags.bake_debugging_features) return;
     const dev: *DevServer = @alignCast(@fieldParentPtr("memory_visualizer_timer", timer));
     assert(dev.magic == .valid);
     dev.emitMemoryVisualizerMessage();
     timer.state = .FIRED;
     dev.vm.timer.update(timer, &bun.timespec.msFromNow(1000));
-    return .disarm;
 }
 
 pub fn emitMemoryVisualizerMessageIfNeeded(dev: *DevServer) void {

--- a/src/bake/DevServer/SourceMapStore.zig
+++ b/src/bake/DevServer/SourceMapStore.zig
@@ -469,7 +469,7 @@ pub fn locateWeakRef(store: *Self, key: Key) ?struct { index: usize, ref: WeakRe
     return null;
 }
 
-pub fn sweepWeakRefs(timer: *EventLoopTimer, now_ts: *const bun.timespec) EventLoopTimer.Arm {
+pub fn sweepWeakRefs(timer: *EventLoopTimer, now_ts: *const bun.timespec) void {
     mapLog("sweepWeakRefs", .{});
     const store: *Self = @fieldParentPtr("weak_ref_sweep_timer", timer);
     assert(store.owner().magic == .valid);
@@ -489,13 +489,11 @@ pub fn sweepWeakRefs(timer: *EventLoopTimer, now_ts: *const bun.timespec) EventL
                 &store.weak_ref_sweep_timer,
                 &.{ .sec = item.expire + 1, .nsec = 0 },
             );
-            return .disarm;
+            return;
         }
     }
 
     store.weak_ref_sweep_timer.state = .CANCELLED;
-
-    return .disarm;
 }
 
 pub const GetResult = struct {

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -240,7 +240,7 @@ pub const All = struct {
                     // Side-effect: potentially call the StopIfNecessary timer.
                     if (min.tag == .WTFTimer) {
                         _ = this.timers.deleteMin();
-                        _ = min.fire(&now, vm);
+                        min.fire(&now, vm);
                         continue;
                     }
 
@@ -297,10 +297,7 @@ pub const All = struct {
         var has_set_now: bool = false;
 
         while (this.next(&has_set_now, &now)) |t| {
-            switch (t.fire(&now, vm)) {
-                .disarm => {},
-                .rearm => {},
-            }
+            t.fire(&now, vm);
         }
     }
 

--- a/src/bun.js/api/Timer/TimerObjectInternals.zig
+++ b/src/bun.js/api/Timer/TimerObjectInternals.zig
@@ -111,7 +111,7 @@ pub fn asyncID(this: *const TimerObjectInternals) u64 {
     return ID.asyncID(.{ .id = this.id, .kind = this.flags.kind.big() });
 }
 
-pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMachine) EventLoopTimer.Arm {
+pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMachine) void {
     const id = this.id;
     const kind = this.flags.kind.big();
     const async_id: ID = .{ .id = id, .kind = kind };
@@ -146,7 +146,7 @@ pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMac
         this.strong_this.deinit();
         this.deref();
 
-        return .disarm;
+        return;
     }
 
     var time_before_call: timespec = undefined;
@@ -228,8 +228,6 @@ pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMac
         }
     }
     vm.eventLoop().exit();
-
-    return .disarm;
 }
 
 fn convertToInterval(this: *TimerObjectInternals, global: *JSGlobalObject, timer: JSValue, repeat: JSValue) void {

--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -1987,7 +1987,7 @@ pub const Resolver = struct {
     const AddrPendingCache = bun.HiveArray(GetHostByAddrInfoRequest.PendingCacheKey, 32);
     const NameInfoPendingCache = bun.HiveArray(GetNameInfoRequest.PendingCacheKey, 32);
 
-    pub fn checkTimeouts(this: *Resolver, now: *const timespec, vm: *jsc.VirtualMachine) EventLoopTimer.Arm {
+    pub fn checkTimeouts(this: *Resolver, now: *const timespec, vm: *jsc.VirtualMachine) void {
         defer {
             vm.timer.incrementTimerRef(-1);
             this.deref();
@@ -1998,13 +1998,9 @@ pub const Resolver = struct {
         if (this.getChannelOrError(vm.global)) |channel| {
             if (this.anyRequestsPending()) {
                 c_ares.ares_process_fd(channel, c_ares.ARES_SOCKET_BAD, c_ares.ARES_SOCKET_BAD);
-                if (this.addTimer(now)) {
-                    return .{ .rearm = this.event_loop_timer.next };
-                }
+                _ = this.addTimer(now);
             }
         } else |_| {}
-
-        return .disarm;
     }
 
     fn anyRequestsPending(this: *Resolver) bool {

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -350,16 +350,15 @@ fn setEventLoopTimerRefd(this: *Subprocess, refd: bool) void {
     }
 }
 
-pub fn timeoutCallback(this: *Subprocess) bun.api.Timer.EventLoopTimer.Arm {
+pub fn timeoutCallback(this: *Subprocess) void {
     this.setEventLoopTimerRefd(false);
-    if (this.event_loop_timer.state == .CANCELLED) return .disarm;
+    if (this.event_loop_timer.state == .CANCELLED) return;
     if (this.hasExited()) {
         this.event_loop_timer.state = .CANCELLED;
-        return .disarm;
+        return;
     }
     this.event_loop_timer.state = .FIRED;
     _ = this.tryKill(this.killSignal);
-    return .disarm;
 }
 
 pub fn onMaxBuffer(this: *Subprocess, kind: MaxBuf.Kind) void {

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -110,19 +110,17 @@ pub const StatWatcherScheduler = struct {
         this.vm.enqueueTaskConcurrent(jsc.ConcurrentTask.create(jsc.Task.init(&holder.task)));
     }
 
-    pub fn timerCallback(this: *StatWatcherScheduler) EventLoopTimer.Arm {
+    pub fn timerCallback(this: *StatWatcherScheduler) void {
         const has_been_cleared = this.event_loop_timer.state == .CANCELLED or this.vm.scriptExecutionStatus() != .running;
 
         this.event_loop_timer.state = .FIRED;
         this.event_loop_timer.heap = .{};
 
         if (has_been_cleared) {
-            return .disarm;
+            return;
         }
 
         jsc.WorkPool.schedule(&this.task);
-
-        return .disarm;
     }
 
     pub fn workPoolCallback(task: *jsc.WorkPoolTask) void {

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -455,7 +455,7 @@ pub const BunTest = struct {
 
         return .js_undefined;
     }
-    pub fn bunTestTimeoutCallback(this_strong: BunTestPtr, _: *const bun.timespec, vm: *jsc.VirtualMachine) bun.api.Timer.EventLoopTimer.Arm {
+    pub fn bunTestTimeoutCallback(this_strong: BunTestPtr, _: *const bun.timespec, vm: *jsc.VirtualMachine) void {
         group.begin(@src());
         defer group.end();
         const this = this_strong.get();
@@ -472,8 +472,6 @@ pub const BunTest = struct {
         run(this_strong, vm.global) catch |e| {
             this.onUncaughtException(vm.global, vm.global.takeException(e), false, .done);
         };
-
-        return .disarm; // this won't disable the timer if .run() re-arms it
     }
     pub fn runNextTick(weak: BunTestPtr.Weak, globalThis: *jsc.JSGlobalObject, phase: RefDataValue) void {
         const done_callback_test = bun.new(RunTestsTask, .{ .weak = weak.clone(), .globalThis = globalThis, .phase = phase });

--- a/src/deps/uws/UpgradedDuplex.zig
+++ b/src/deps/uws/UpgradedDuplex.zig
@@ -230,7 +230,7 @@ fn onCloseJS(
     return .js_undefined;
 }
 
-pub fn onTimeout(this: *UpgradedDuplex) EventLoopTimer.Arm {
+pub fn onTimeout(this: *UpgradedDuplex) void {
     log("onTimeout", .{});
 
     const has_been_cleared = this.event_loop_timer.state == .CANCELLED or this.vm.scriptExecutionStatus() != .running;
@@ -239,12 +239,10 @@ pub fn onTimeout(this: *UpgradedDuplex) EventLoopTimer.Arm {
     this.event_loop_timer.heap = .{};
 
     if (has_been_cleared) {
-        return .disarm;
+        return;
     }
 
     this.handlers.onTimeout(this.handlers.ctx);
-
-    return .disarm;
 }
 
 pub fn from(

--- a/src/deps/uws/WindowsNamedPipe.zig
+++ b/src/deps/uws/WindowsNamedPipe.zig
@@ -241,7 +241,7 @@ fn onInternalReceiveData(this: *WindowsNamedPipe, data: []const u8) void {
     }
 }
 
-pub fn onTimeout(this: *WindowsNamedPipe) EventLoopTimer.Arm {
+pub fn onTimeout(this: *WindowsNamedPipe) void {
     log("onTimeout", .{});
 
     const has_been_cleared = this.event_loop_timer.state == .CANCELLED or this.vm.scriptExecutionStatus() != .running;
@@ -250,12 +250,10 @@ pub fn onTimeout(this: *WindowsNamedPipe) EventLoopTimer.Arm {
     this.event_loop_timer.heap = .{};
 
     if (has_been_cleared) {
-        return .disarm;
+        return;
     }
 
     this.handlers.onTimeout(this.handlers.ctx);
-
-    return .disarm;
 }
 
 pub fn from(

--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -106,18 +106,18 @@ pub fn resetConnectionTimeout(this: *@This()) void {
     this.#vm.timer.insert(&this.timer);
 }
 
-pub fn onConnectionTimeout(this: *@This()) bun.api.Timer.EventLoopTimer.Arm {
+pub fn onConnectionTimeout(this: *@This()) void {
     this.timer.state = .FIRED;
 
     if (this.#connection.isProcessingData()) {
-        return .disarm;
+        return;
     }
 
-    if (this.#connection.status == .failed) return .disarm;
+    if (this.#connection.status == .failed) return;
 
     if (this.getTimeoutInterval() == 0) {
         this.resetConnectionTimeout();
-        return .disarm;
+        return;
     }
 
     switch (this.#connection.status) {
@@ -135,14 +135,12 @@ pub fn onConnectionTimeout(this: *@This()) bun.api.Timer.EventLoopTimer.Arm {
         },
         .disconnected, .failed => {},
     }
-    return .disarm;
 }
 
-pub fn onMaxLifetimeTimeout(this: *@This()) bun.api.Timer.EventLoopTimer.Arm {
+pub fn onMaxLifetimeTimeout(this: *@This()) void {
     this.max_lifetime_timer.state = .FIRED;
-    if (this.#connection.status == .failed) return .disarm;
+    if (this.#connection.status == .failed) return;
     this.failFmt(error.LifetimeTimeout, "Max lifetime timeout reached after {}", .{bun.fmt.fmtDurationOneDecimal(@as(u64, this.max_lifetime_interval_ms) *| std.time.ns_per_ms)});
-    return .disarm;
 }
 fn setupMaxLifetimeTimerIfNecessary(this: *@This()) void {
     if (this.max_lifetime_interval_ms == 0) return;

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -700,7 +700,7 @@ pub const JSValkeyClient = struct {
         this.timer.state = .CANCELLED;
     }
 
-    pub fn onConnectionTimeout(this: *JSValkeyClient) Timer.EventLoopTimer.Arm {
+    pub fn onConnectionTimeout(this: *JSValkeyClient) void {
         debug("onConnectionTimeout", .{});
 
         // Mark timer as fired
@@ -710,12 +710,12 @@ pub const JSValkeyClient = struct {
         this.ref();
         defer this.deref();
         if (this.client.flags.failed) {
-            return .disarm;
+            return;
         }
 
         if (this.client.getTimeoutInterval() == 0) {
             this.resetConnectionTimeout();
-            return .disarm;
+            return;
         }
 
         var buf: [128]u8 = undefined;
@@ -729,11 +729,9 @@ pub const JSValkeyClient = struct {
                 this.clientFail(msg, protocol.RedisError.ConnectionTimeout) catch {}; // TODO: properly propagate exception upwards
             },
         }
-
-        return .disarm;
     }
 
-    pub fn onReconnectTimer(this: *JSValkeyClient) Timer.EventLoopTimer.Arm {
+    pub fn onReconnectTimer(this: *JSValkeyClient) void {
         debug("Reconnect timer fired, attempting to reconnect", .{});
 
         // Mark timer as fired and store important values before doing any derefs
@@ -745,8 +743,6 @@ pub const JSValkeyClient = struct {
 
         // Execute reconnection logic
         this.reconnect();
-
-        return .disarm;
     }
 
     pub fn reconnect(this: *JSValkeyClient) void {


### PR DESCRIPTION
## Summary

The `EventLoopTimer.Arm` result from `EventLoopTimer.fire()` was being ignored at both call sites. This PR removes the unused return type and simplifies the code.

## Changes

- Changed `EventLoopTimer.fire()` to return `void` instead of `Arm`
- Updated all 15 timer callback functions to return `void`
- Removed the `Arm` type definition
- Simplified the `drainTimers()` loop that was ignoring the return value
- Updated both call sites in `Timer.zig`

## Details

The `.rearm` functionality was unused - timers that need to reschedule themselves (like DNS resolver) handle this by calling `addTimer()`/`update()` directly rather than relying on the return value.

This change removes:
- The `Arm` union enum type (3 lines)
- All `return .disarm` and `return .{ .rearm = ... }` statements
- The switch statement in `drainTimers()` that did nothing with the return value

Net result: **-58 lines** of dead code removed.

## Testing

- [x] Bun builds successfully with `bun bd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)