### PR TITLE
Fix Headers.append() assertion with numeric string property names

### DIFF
--- a/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/bun.js/bindings/webcore/JSFetchHeaders.cpp
@@ -696,7 +696,7 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         for (const auto& it : vec) {
             const auto& name = it.key;
             const auto& value = it.value;
-            obj->putDirect(vm, Identifier::fromString(vm, name.convertToASCIILowercase()), jsString(vm, value), 0);
+            obj->putDirectMayBeIndex(lexicalGlobalObject, Identifier::fromString(vm, name.convertToASCIILowercase()), jsString(vm, value));
         }
     }
 

--- a/test/js/web/fetch/fetch_headers.test.js
+++ b/test/js/web/fetch/fetch_headers.test.js
@@ -57,6 +57,13 @@ describe("Headers", async () => {
       headers2.append("Content-Type", "application/json");
       expect(headers2.toJSON()).toEqual({ "x-test": "yep", "content-type": "application/json" });
     });
+
+    it("should handle numeric string header names", () => {
+      const headers = new Headers();
+      headers.append("52782", "text/xml");
+      expect(headers.toJSON()).toEqual({ "52782": "text/xml" });
+      expect(headers.get("52782")).toBe("text/xml");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes an assertion failure when using `Headers.append()` with numeric string property names like `"52782"`.

## The Bug

```javascript
const headers = new Headers();
headers.append("52782", "text/xml"); // ASSERTION FAILED
```

This triggered:
```
ASSERTION FAILED: !parseIndex(propertyName)
cache/webkit-6d0f3aac0b817cc0/include/JavaScriptCore/JSObjectInlines.h(444)
```

## Root Cause

In `JSFetchHeaders.cpp`, the `getInternalProperties()` function was using `putDirect()` to add header properties to the JavaScript object. However, `putDirect()` asserts that the property name is NOT a numeric index (array index).

When a header name like `"52782"` is used, it creates an Identifier that parses as an array index, triggering the assertion.

## The Fix

Changed from `putDirect()` to `putDirectMayBeIndex()` which:
- Checks if the property name is a numeric index
- Uses `putDirectIndex()` for numeric indices
- Uses `putDirectInternal()` for regular properties

## Testing

- Added regression test in `test/js/web/fetch/fetch_headers.test.js`
- All existing tests pass
- Verified the fix works with the original reproduction case

🤖 Generated with [Claude Code](https://claude.com/claude-code)