### PR TITLE
Add debug logging for test execution with BUN_DEBUG_jest=1

### DIFF
--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -493,10 +493,8 @@ fn onSequenceStarted(_: *Execution, sequence: *ExecutionSequence) void {
 
     sequence.started_at = bun.timespec.now();
 
-    // Log test name when BUN_DEBUG_jest=1 is set
     if (sequence.test_entry) |entry| {
-        const name = entry.base.name orelse "(unnamed)";
-        log("Running test: {s}", .{name});
+        log("Running test: \"{}\"", .{ std.zig.fmtEscapes(entry.base.name orelse "(unnamed)") });
 
         if (entry.base.test_id_for_debugger != 0) {
             if (jsc.VirtualMachine.get().debugger) |*debugger| {
@@ -512,7 +510,6 @@ fn onEntryStarted(_: *Execution, entry: *ExecutionEntry) void {
 
     groupLog.begin(@src());
     defer groupLog.end();
-
     if (entry.timeout != 0) {
         groupLog.log("-> entry.timeout: {}", .{entry.timeout});
         entry.timespec = bun.timespec.msFromNow(entry.timeout);

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -493,7 +493,11 @@ fn onSequenceStarted(_: *Execution, sequence: *ExecutionSequence) void {
 
     sequence.started_at = bun.timespec.now();
 
+    // Log test name when BUN_DEBUG_jest=1 is set
     if (sequence.test_entry) |entry| {
+        const name = entry.base.name orelse "(unnamed)";
+        log("Running test: {s}", .{name});
+
         if (entry.base.test_id_for_debugger != 0) {
             if (jsc.VirtualMachine.get().debugger) |*debugger| {
                 if (debugger.test_reporter_agent.isEnabled()) {
@@ -508,6 +512,7 @@ fn onEntryStarted(_: *Execution, entry: *ExecutionEntry) void {
 
     groupLog.begin(@src());
     defer groupLog.end();
+
     if (entry.timeout != 0) {
         groupLog.log("-> entry.timeout: {}", .{entry.timeout});
         entry.timespec = bun.timespec.msFromNow(entry.timeout);
@@ -631,3 +636,4 @@ const Execution = bun_test.Execution;
 const ExecutionEntry = bun_test.ExecutionEntry;
 const Order = bun_test.Order;
 const groupLog = bun_test.debug.group;
+const log = bun.Output.scoped(.jest, .visible);

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -494,7 +494,7 @@ fn onSequenceStarted(_: *Execution, sequence: *ExecutionSequence) void {
     sequence.started_at = bun.timespec.now();
 
     if (sequence.test_entry) |entry| {
-        log("Running test: \"{}\"", .{ std.zig.fmtEscapes(entry.base.name orelse "(unnamed)") });
+        log("Running test: \"{}\"", .{std.zig.fmtEscapes(entry.base.name orelse "(unnamed)")});
 
         if (entry.base.test_id_for_debugger != 0) {
             if (jsc.VirtualMachine.get().debugger) |*debugger| {

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -624,6 +624,8 @@ pub fn handleUncaughtException(this: *Execution, user_data: bun_test.BunTest.Ref
     };
 }
 
+const log = bun.Output.scoped(.jest, .visible);
+
 const std = @import("std");
 const test_command = @import("../../cli/test_command.zig");
 
@@ -636,4 +638,3 @@ const Execution = bun_test.Execution;
 const ExecutionEntry = bun_test.ExecutionEntry;
 const Order = bun_test.Order;
 const groupLog = bun_test.debug.group;
-const log = bun.Output.scoped(.jest, .visible);


### PR DESCRIPTION
## Summary

Adds debug logging that prints the name of each test when it starts running, controlled by the `BUN_DEBUG_jest=1` environment variable.

## Changes

- Modified `src/bun.js/test/Execution.zig` to add logging in the `onEntryStarted()` function
- Added a scoped logger using `bun.Output.scoped(.jest, .visible)`
- When `BUN_DEBUG_jest=1` is set, prints: `[jest] Running test: <test name>`

## Testing

Manually tested with various test files:

**Without BUN_DEBUG_jest:**
```
$ bun bd test /tmp/test-jest-log.test.ts
bun test v1.3.1 (642d04b9)

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [2.90s]
```

**With BUN_DEBUG_jest=1:**
```
$ BUN_DEBUG_jest=1 bun bd test /tmp/test-jest-log.test.ts
bun test v1.3.1 (642d04b9)
[jest] Running test: first test
[jest] Running test: second test
[jest] Running test: third test

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [2.77s]
```

Also tested with nested describe blocks and all test names are logged correctly.

## Notes

- This feature is only available in debug builds (not release builds)
- No tests were added as this is a debug-only feature
- Helps with debugging test execution flow and understanding when tests start running