### PR TITLE
Fix IP address retrieval in server response

### DIFF
--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -536,7 +536,7 @@ You can also access the `Server` object from the `fetch` handler. It's the secon
 const server = Bun.serve({
   fetch(req, server) {
     const ip = server.requestIP(req);
-    return new Response(`Your IP is ${ip}`);
+    return new Response(`Your IP is ${ip.address}`);
   },
 });
 ```

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,6 +1,6 @@
 import { describe } from "bun:test";
-import { itBundled } from "./expectBundled";
 import { bunEnv } from "harness";
+import { itBundled } from "./expectBundled";
 
 const env = {
   ...bunEnv,


### PR DESCRIPTION
### What does this PR do?
Fix, response example - requestIP return object.

<img width="521" height="116" alt="image" src="https://github.com/user-attachments/assets/14b90a8e-3230-4eb1-8f87-ee06392029cd" />

↓
<img width="333" height="115" alt="image" src="https://github.com/user-attachments/assets/ecf006b3-f02a-4bed-8b8c-b28b8ec2adc8" />
