### PR TITLE
fix(sql): throw proper exception for invalid MySQL parameter types

### DIFF
--- a/src/sql/mysql/MySQLTypes.zig
+++ b/src/sql/mysql/MySQLTypes.zig
@@ -305,16 +305,16 @@ pub const FieldType = enum(u8) {
 
             // Ban these types:
             if (tag == .NumberObject) {
-                return error.JSError;
+                return globalObject.throwInvalidArguments("Cannot bind NumberObject to query parameter. Use a primitive number instead.", .{});
             }
 
             if (tag == .BooleanObject) {
-                return error.JSError;
+                return globalObject.throwInvalidArguments("Cannot bind BooleanObject to query parameter. Use a primitive boolean instead.", .{});
             }
 
             // It's something internal
             if (!tag.isIndexable()) {
-                return error.JSError;
+                return globalObject.throwInvalidArguments("Cannot bind this type to query parameter", .{});
             }
 
             // We will JSON.stringify anything else.

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -591,25 +591,23 @@ if (isDockerEnabled()) {
 
         // Regression test for: panic: A JavaScript exception was thrown, but it was cleared before it could be read.
         // This happened when FieldType.fromJS returned error.JSError without throwing an exception first.
-        test("should handle NumberObject parameter without crashing", async () => {
+        test("should throw error for NumberObject parameter", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });
           // new Number(42) creates a NumberObject (not a primitive number)
           // This used to cause a panic because FieldType.fromJS returned error.JSError without throwing
           const numberObject = new Number(42);
           const err = await sql`SELECT ${numberObject} as value`.catch(x => x);
-          // Should throw a proper error, not crash
-          expect(err).toBeDefined();
-          expect(err.message).toBeDefined();
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toContain("Cannot bind NumberObject to query parameter");
         });
 
-        test("should handle BooleanObject parameter without crashing", async () => {
+        test("should throw error for BooleanObject parameter", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });
           // new Boolean(true) creates a BooleanObject (not a primitive boolean)
           const booleanObject = new Boolean(true);
           const err = await sql`SELECT ${booleanObject} as value`.catch(x => x);
-          // Should throw a proper error, not crash
-          expect(err).toBeDefined();
-          expect(err.message).toBeDefined();
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toContain("Cannot bind BooleanObject to query parameter");
         });
 
         test("should work with fragments", async () => {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -589,6 +589,29 @@ if (isDockerEnabled()) {
           expect(err.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
         });
 
+        // Regression test for: panic: A JavaScript exception was thrown, but it was cleared before it could be read.
+        // This happened when FieldType.fromJS returned error.JSError without throwing an exception first.
+        test("should handle NumberObject parameter without crashing", async () => {
+          await using sql = new SQL({ ...getOptions(), max: 1 });
+          // new Number(42) creates a NumberObject (not a primitive number)
+          // This used to cause a panic because FieldType.fromJS returned error.JSError without throwing
+          const numberObject = new Number(42);
+          const err = await sql`SELECT ${numberObject} as value`.catch(x => x);
+          // Should throw a proper error, not crash
+          expect(err).toBeDefined();
+          expect(err.message).toBeDefined();
+        });
+
+        test("should handle BooleanObject parameter without crashing", async () => {
+          await using sql = new SQL({ ...getOptions(), max: 1 });
+          // new Boolean(true) creates a BooleanObject (not a primitive boolean)
+          const booleanObject = new Boolean(true);
+          const err = await sql`SELECT ${booleanObject} as value`.catch(x => x);
+          // Should throw a proper error, not crash
+          expect(err).toBeDefined();
+          expect(err.message).toBeDefined();
+        });
+
         test("should work with fragments", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });
           const random_name = sql("test_" + randomUUIDv7("hex").replaceAll("-", ""));


### PR DESCRIPTION
## Summary

Fixes a panic that occurred when passing `NumberObject` or `BooleanObject` as MySQL query parameters.

**Panic message:** `A JavaScript exception was thrown, but it was cleared before it could be read.`

## Root Cause

The `FieldType.fromJS` function in `src/sql/mysql/MySQLTypes.zig` was returning `error.JSError` without throwing a JavaScript exception first for:
- `NumberObject` (created via `new Number(42)`)
- `BooleanObject` (created via `new Boolean(true)`)
- Non-indexable types

This violated the contract that `error.JSError` means "an exception has already been thrown and is ready to be taken."

## Call Chain

1. User executes `await sql\`SELECT ${new Number(42)} as value\``
2. `FieldType.fromJS()` detects `.NumberObject` and returns `error.JSError` without throwing
3. Error propagates to `MySQLQuery.runPreparedQuery()`
4. Code checks `hasException()` → returns false (no exception exists!)
5. Calls `mysqlErrorToJS(globalObject, "...", error.JSError)`
6. `mysqlErrorToJS` tries to `takeException(error.JSError)` but there's no exception
7. **PANIC**

## Fix

The fix throws a proper exception with a helpful message before returning `error.JSError`:
- `"Cannot bind NumberObject to query parameter. Use a primitive number instead."`
- `"Cannot bind BooleanObject to query parameter. Use a primitive boolean instead."`
- `"Cannot bind this type to query parameter"`

## Test Plan

Added regression tests in `test/js/sql/sql-mysql.test.ts`:
- Test passing `NumberObject` as parameter
- Test passing `BooleanObject` as parameter

Both tests verify that a proper error is thrown instead of crashing.

Verified manually with local MySQL server that:
- ✅ NumberObject now throws proper error (was crashing)
- ✅ BooleanObject now throws proper error (was crashing)
- ✅ Primitive numbers still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)