### PR TITLE
Add missing minification options to Transpiler types

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1564,7 +1564,29 @@ declare module "bun" {
     };
     treeShaking?: boolean;
     trimUnusedImports?: boolean;
-    jsxOptimizationInline?: boolean;
+
+    /**
+     * Enable or configure minification.
+     * When `true`, enables all minification options.
+     * When an object, allows granular control.
+     * @example
+     * ```js
+     * // Enable all minification
+     * { minify: true }
+     * // Granular control
+     * { minify: { whitespace: true, syntax: true, identifiers: false } }
+     * ```
+     */
+    minify?:
+      | boolean
+      | {
+          /** Minify whitespace and comments */
+          whitespace?: boolean;
+          /** Minify syntax (e.g., `a === undefined` -> `a === void 0`) */
+          syntax?: boolean;
+          /** Minify identifiers (rename variables to shorter names) */
+          identifiers?: boolean;
+        };
 
     /**
      * **Experimental**
@@ -1572,6 +1594,18 @@ declare module "bun" {
      * Minify whitespace and comments from the output.
      */
     minifyWhitespace?: boolean;
+    /**
+     * **Experimental**
+     *
+     * Minify syntax (e.g., `a === undefined` -> `a === void 0`).
+     */
+    minifySyntax?: boolean;
+    /**
+     * **Experimental**
+     *
+     * Minify identifiers (rename variables to shorter names).
+     */
+    minifyIdentifiers?: boolean;
     /**
      * **Experimental**
      *


### PR DESCRIPTION
## Summary
Added missing type definitions for `Bun.Transpiler` minification options and removed unimplemented `jsxOptimizationInline` option.

## Changes
- ✅ Added `minify` option: `boolean | { whitespace?: boolean; syntax?: boolean; identifiers?: boolean }`
- ✅ Added `minifySyntax` option
- ✅ Added `minifyIdentifiers` option  
- ✅ Removed `jsxOptimizationInline` (not implemented in Zig code)

## Implementation Details
These options are implemented in `src/bun.js/api/JSTranspiler.zig`:
- `minify` (boolean): lines 246-264 - enables all minification when true
- `minify` (object): lines 252-260 - granular control over whitespace/syntax/identifiers
- `minifySyntax`: line 238
- `minifyIdentifiers`: line 242

The `jsxOptimizationInline` option was removed because it's defined in the types but not implemented anywhere in the Zig codebase.

## Test Plan
- [x] Verified all options work with debug build (`bun bd`)
- [x] Tested `minify: true` - minifies whitespace and identifiers
- [x] Tested `minify: { whitespace, syntax, identifiers }` - granular control works
- [x] Tested individual `minifyWhitespace`, `minifySyntax`, `minifyIdentifiers` options
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)