### PR TITLE
Add skipLifecycleScripts to skip unnecessary postinstall scripts

### DIFF
--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -1126,7 +1126,9 @@ pub const PackageInstaller = struct {
                         },
                         else => if (!is_trusted and this.metas[package_id].hasInstallScript()) {
                             const alias_str = alias.slice(this.lockfile.buffers.string_bytes.items);
-                            const should_skip = this.lockfile.shouldSkipLifecycleScripts(alias_str);
+                            const canonical_name = this.names[package_id].slice(this.lockfile.buffers.string_bytes.items);
+                            const should_skip = this.lockfile.shouldSkipLifecycleScripts(alias_str) or
+                                this.lockfile.shouldSkipLifecycleScripts(canonical_name);
 
                             if (!should_skip) {
                                 // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
@@ -1274,7 +1276,9 @@ pub const PackageInstaller = struct {
 
             if (resolution.tag != .root and is_trusted) {
                 const alias_str = alias.slice(this.lockfile.buffers.string_bytes.items);
-                const should_skip = this.lockfile.shouldSkipLifecycleScripts(alias_str);
+                const canonical_name = this.names[package_id].slice(this.lockfile.buffers.string_bytes.items);
+                const should_skip = this.lockfile.shouldSkipLifecycleScripts(alias_str) or
+                    this.lockfile.shouldSkipLifecycleScripts(canonical_name);
 
                 if (!should_skip) {
                     var folder_path: bun.AbsPath(.{ .sep = .auto }) = .from(this.node_modules.path.items);

--- a/src/install/default-skipped-lifecycle-scripts.txt
+++ b/src/install/default-skipped-lifecycle-scripts.txt
@@ -1,0 +1,1 @@
+esbuild

--- a/src/install/default-skipped-lifecycle-scripts.txt
+++ b/src/install/default-skipped-lifecycle-scripts.txt
@@ -1,1 +1,2 @@
 esbuild
+protobufjs

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -25,7 +25,7 @@ workspace_versions: VersionHashMap = .{},
 /// empty list or it might not exist
 trusted_dependencies: ?TrustedDependenciesSet = null,
 /// Optional: packages whose lifecycle scripts should be skipped AND excluded from "blocked" count
-skip_lifecycle_scripts: ?TrustedDependenciesSet = null,
+skip_scripts_from: ?TrustedDependenciesSet = null,
 patched_dependencies: PatchedDependenciesMap = .{},
 overrides: OverrideMap = .{},
 catalogs: CatalogMap = .{},
@@ -2173,8 +2173,8 @@ pub const default_skipped_lifecycle_scripts = brk: {
 };
 
 pub fn shouldSkipLifecycleScripts(this: *const Lockfile, name: []const u8) bool {
-    // Check user-specified skipLifecycleScripts first (higher precedence)
-    if (this.skip_lifecycle_scripts) |skip_scripts| {
+    // Check user-specified skipScriptsFrom first (higher precedence)
+    if (this.skip_scripts_from) |skip_scripts| {
         const hash = @as(u32, @truncate(String.Builder.stringHash(name)));
         if (skip_scripts.contains(hash)) return true;
     }

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1572,28 +1572,28 @@ pub fn Package(comptime SemverIntType: type) type {
                     }
                 }
 
-                if (json.asProperty("skipLifecycleScripts")) |q| {
+                if (json.asProperty("skipScriptsFrom")) |q| {
                     switch (q.expr.data) {
                         .e_array => |arr| {
-                            if (lockfile.skip_lifecycle_scripts == null) lockfile.skip_lifecycle_scripts = .{};
-                            try lockfile.skip_lifecycle_scripts.?.ensureUnusedCapacity(allocator, arr.items.len);
+                            if (lockfile.skip_scripts_from == null) lockfile.skip_scripts_from = .{};
+                            try lockfile.skip_scripts_from.?.ensureUnusedCapacity(allocator, arr.items.len);
                             for (arr.slice()) |item| {
                                 const name = item.asString(allocator) orelse {
                                     log.addErrorFmt(source, q.loc, allocator,
-                                        \\skipLifecycleScripts expects an array of strings, e.g.
-                                        \\  <r><green>"skipLifecycleScripts"<r>: [
+                                        \\skipScriptsFrom expects an array of strings, e.g.
+                                        \\  <r><green>"skipScriptsFrom"<r>: [
                                         \\    <green>"package_name"<r>
                                         \\  ]
                                     , .{}) catch {};
                                     return error.InvalidPackageJSON;
                                 };
-                                lockfile.skip_lifecycle_scripts.?.putAssumeCapacity(@as(TruncatedPackageNameHash, @truncate(String.Builder.stringHash(name))), {});
+                                lockfile.skip_scripts_from.?.putAssumeCapacity(@as(TruncatedPackageNameHash, @truncate(String.Builder.stringHash(name))), {});
                             }
                         },
                         else => {
                             log.addErrorFmt(source, q.loc, allocator,
-                                \\skipLifecycleScripts expects an array of strings, e.g.
-                                \\  <r><green>"skipLifecycleScripts"<r>: [
+                                \\skipScriptsFrom expects an array of strings, e.g.
+                                \\  <r><green>"skipScriptsFrom"<r>: [
                                 \\    <green>"package_name"<r>
                                 \\  ]
                             , .{}) catch {};

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2922,7 +2922,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
-    test("skipLifecycleScripts prevents scripts and excludes from blocked count", async () => {
+    test("skipScriptsFrom prevents scripts and excludes from blocked count", async () => {
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
       await writeFile(
         packageJson,
@@ -2933,7 +2933,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             "all-lifecycle-scripts": "1.0.0",
             "uses-what-bin": "1.0.0",
           },
-          skipLifecycleScripts: ["all-lifecycle-scripts"],
+          skipScriptsFrom: ["all-lifecycle-scripts"],
         }),
       );
 
@@ -2980,7 +2980,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       const whatBinDir = join(packageDir, "node_modules", "uses-what-bin");
       expect(await exists(join(whatBinDir, "what-bin.txt"))).toBeFalse();
 
-      // Verify skipLifecycleScripts has higher precedence than trustedDependencies
+      // Verify skipScriptsFrom has higher precedence than trustedDependencies
       await writeFile(
         packageJson,
         JSON.stringify({
@@ -2990,7 +2990,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
             "all-lifecycle-scripts": "1.0.0",
           },
           trustedDependencies: ["all-lifecycle-scripts"],
-          skipLifecycleScripts: ["all-lifecycle-scripts"],
+          skipScriptsFrom: ["all-lifecycle-scripts"],
         }),
       );
 
@@ -3007,7 +3007,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       out = await stdout.text();
       expect(err).not.toContain("error:");
 
-      // Should not show any blocked scripts message because the only package is in skipLifecycleScripts
+      // Should not show any blocked scripts message because the only package is in skipScriptsFrom
       const outLines = out.replace(/\s*\[[0-9\.]+m?s\]$/m, "").split(/\r?\n/);
       expect(outLines).not.toContain(expect.stringContaining("Blocked"));
       expect(await exited).toBe(0);

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -3016,6 +3016,21 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await exists(join(depDir, "preinstall.txt"))).toBeFalse();
       expect(await exists(join(depDir, "install.txt"))).toBeFalse();
       expect(await exists(join(depDir, "postinstall.txt"))).toBeFalse();
+
+      // Verify skipped packages don't appear in untrusted list
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "pm", "untrusted"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: testEnv,
+      }));
+
+      out = await stdout.text();
+      err = await stderr.text();
+      expect(err).not.toContain("error:");
+      expect(out).not.toContain("all-lifecycle-scripts");
+      expect(await exited).toBe(0);
     });
 
     test("skipScriptsFrom works with aliased dependencies (default list)", async () => {
@@ -3122,6 +3137,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await exists(join(scriptsDir, "prepare.txt"))).toBeTrue(); // prepare always runs
     });
 
+    // skipScriptsFrom accepts either the dependency alias or canonical package name for flexibility
     test("skipScriptsFrom by alias name", async () => {
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
       await writeFile(


### PR DESCRIPTION
## Summary

Adds a new `skipScriptsFrom` field to package.json that allows skipping lifecycle scripts for packages where they're unnecessary and just waste CI time.

## What it does

When a package is in `skipScriptsFrom`:
1. Its lifecycle scripts are **never executed** (even if it's also in `trustedDependencies`)
2. It's **excluded from the "X postinstall scripts blocked" message**

This has **higher precedence** than `trustedDependencies`.

## Implementation

- Added `skip_scripts_from` field to Lockfile struct  
- Created `default-skipped-lifecycle-scripts.txt` with `esbuild` and `protobufjs` as defaults
- Added parsing for `skipScriptsFrom` array in package.json (similar to trustedDependencies)
- Updated PackageInstaller to check skip list before blocking or enqueueing scripts
- Added comprehensive test verifying skip behavior and precedence

## Example usage

```json
{
  "name": "my-app",
  "dependencies": {
    "esbuild": "^0.19.0",
    "protobufjs": "^7.0.0",
    "some-other-package": "^1.0.0"
  },
  "skipScriptsFrom": ["some-other-package"]
}
```

With this:
- `esbuild` and `protobufjs` are automatically skipped (in default list)
- `some-other-package` is also skipped (user-specified)
- None of these will show up in the "blocked scripts" message

## Why these packages?

**esbuild**: Its postinstall script just runs `npm install` to work around old yarn bugs - completely unnecessary for Bun users.

**protobufjs**: Its postinstall script is not needed for normal usage and just adds noise to the blocked scripts message.

By having them in the default skip list, Bun users won't be nagged about adding them to trustedDependencies.

## Manual testing

Verified the feature works correctly:
- `esbuild` alone: No "Blocked" message ✅
- `protobufjs` alone: No "Blocked" message ✅
- `esbuild + protobufjs`: No "Blocked" message ✅
- With `skipScriptsFrom: ["some-package"]`: That package is also skipped ✅
- Precedence test: `skipScriptsFrom` overrides `trustedDependencies` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)