### PR TITLE
fix(bundler): copy file/wasm/napi/sqlite entrypoints directly without JS wrapper

### DIFF
--- a/test/bundler/bun-build-static-entrypoints.test.ts
+++ b/test/bundler/bun-build-static-entrypoints.test.ts
@@ -107,7 +107,7 @@ describe("Bun.build with static file entrypoints", () => {
     expect(build.success).toBe(true);
     expect(build.outputs).toHaveLength(1);
     expect(build.outputs[0].kind).toBe("asset");
-    expect(build.outputs[0].path).toMatch(/logo.*\.png$/); // Should be a PNG file, not JS
+    expect(build.outputs[0].path).toEndWith("logo.png"); // Should preserve original filename (no hash)
 
     const content = await build.outputs[0].arrayBuffer();
     const buffer = Buffer.from(content);
@@ -129,7 +129,7 @@ describe("Bun.build with static file entrypoints", () => {
     expect(build.success).toBe(true);
     expect(build.outputs).toHaveLength(1);
     expect(build.outputs[0].kind).toBe("asset");
-    expect(build.outputs[0].path).toMatch(/readme.*\.txt$/);
+    expect(build.outputs[0].path).toEndWith("readme.txt"); // Should preserve original filename (no hash)
 
     const content = await build.outputs[0].text();
     expect(content).toBe("Hello World");
@@ -160,7 +160,7 @@ describe("Bun.build with static file entrypoints", () => {
     expect(build.success).toBe(true);
     expect(build.outputs).toHaveLength(1);
     expect(build.outputs[0].kind).toBe("asset");
-    expect(build.outputs[0].path).toMatch(/module.*\.wasm$/);
+    expect(build.outputs[0].path).toEndWith("module.wasm"); // Should preserve original filename (no hash)
 
     const content = await build.outputs[0].arrayBuffer();
     const buffer = Buffer.from(content);
@@ -185,6 +185,10 @@ describe("Bun.build with static file entrypoints", () => {
     expect(build.outputs).toHaveLength(3);
     expect(build.outputs.every(o => o.kind === "asset")).toBe(true);
     expect(build.outputs.every(o => o.path.endsWith(".txt"))).toBe(true);
+    // Should preserve original filenames (no hash)
+    expect(build.outputs.some(o => o.path.endsWith("a.txt"))).toBe(true);
+    expect(build.outputs.some(o => o.path.endsWith("b.txt"))).toBe(true);
+    expect(build.outputs.some(o => o.path.endsWith("c.txt"))).toBe(true);
   });
 
   test("importing static files from JS should still create proxy + asset", async () => {
@@ -258,6 +262,10 @@ describe("Bun.build with static file entrypoints", () => {
     // Should produce ONLY asset files, no JS wrappers
     expect(build.outputs.every(o => o.kind === "asset")).toBe(true);
     expect(build.outputs.every(o => o.path.endsWith(".png"))).toBe(true);
+
+    // Should preserve original filenames (no hash) for entrypoints
+    expect(build.outputs.some(o => o.path.endsWith("logo.png"))).toBe(true);
+    expect(build.outputs.some(o => o.path.endsWith("favicon.png"))).toBe(true);
 
     // Verify actual PNG content
     for (const output of build.outputs) {

--- a/test/bundler/bun-build-static-entrypoints.test.ts
+++ b/test/bundler/bun-build-static-entrypoints.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
+import { join } from "path";
+
+describe("Bun.build with static file entrypoints", () => {
+  test("JSON entrypoint should create JS module with inlined content", async () => {
+    const dir = tempDirWithFiles("bun-build-json-entry", {
+      "data.json": JSON.stringify({ hello: "world", foo: 123 }),
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "data.json")],
+      outdir: join(dir, "out"),
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+    expect(build.outputs[0].kind).toBe("entry-point");
+    expect(build.outputs[0].path).toEndWith("data.js");
+
+    const content = await build.outputs[0].text();
+    // Should contain the actual JSON data inlined, not a path to a separate file
+    expect(content).toContain("hello");
+    expect(content).toContain("world");
+    expect(content).toContain('var hello = "world"'); // Data should be inlined as JS vars
+  });
+
+  test("file loader entrypoint should copy file directly without JS wrapper", async () => {
+    const dir = tempDirWithFiles("bun-build-file-entry", {
+      "logo.png": Buffer.from([
+        0x89,
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a, // PNG signature
+        0x00,
+        0x00,
+        0x00,
+        0x0d,
+        0x49,
+        0x48,
+        0x44,
+        0x52, // IHDR chunk
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x01, // 1x1 pixel
+        0x08,
+        0x06,
+        0x00,
+        0x00,
+        0x00,
+        0x1f,
+        0x15,
+        0xc4,
+        0x89,
+        0x00,
+        0x00,
+        0x00,
+        0x0a,
+        0x49,
+        0x44,
+        0x41,
+        0x54,
+        0x78,
+        0x9c,
+        0x63,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x05,
+        0x00,
+        0x01,
+        0x0d,
+        0x0a,
+        0x2d,
+        0xb4,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x49,
+        0x45,
+        0x4e,
+        0x44,
+        0xae,
+        0x42,
+        0x60,
+        0x82,
+      ]),
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "logo.png")],
+      outdir: join(dir, "out"),
+      loader: { ".png": "file" }, // Explicitly use file loader
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+    expect(build.outputs[0].kind).toBe("asset");
+    expect(build.outputs[0].path).toMatch(/logo.*\.png$/); // Should be a PNG file, not JS
+
+    const content = await build.outputs[0].arrayBuffer();
+    const buffer = Buffer.from(content);
+    // Check PNG signature
+    expect(buffer.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  });
+
+  test("text file with file loader should copy directly", async () => {
+    const dir = tempDirWithFiles("bun-build-text-file", {
+      "readme.txt": "Hello World",
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "readme.txt")],
+      outdir: join(dir, "out"),
+      loader: { ".txt": "file" },
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+    expect(build.outputs[0].kind).toBe("asset");
+    expect(build.outputs[0].path).toMatch(/readme.*\.txt$/);
+
+    const content = await build.outputs[0].text();
+    expect(content).toBe("Hello World");
+  });
+
+  test("wasm entrypoint should copy directly without JS wrapper", async () => {
+    // Minimal valid WASM module
+    const wasmBytes = new Uint8Array([
+      0x00,
+      0x61,
+      0x73,
+      0x6d, // magic number
+      0x01,
+      0x00,
+      0x00,
+      0x00, // version
+    ]);
+
+    const dir = tempDirWithFiles("bun-build-wasm-entry", {
+      "module.wasm": Buffer.from(wasmBytes),
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "module.wasm")],
+      outdir: join(dir, "out"),
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+    expect(build.outputs[0].kind).toBe("asset");
+    expect(build.outputs[0].path).toMatch(/module.*\.wasm$/);
+
+    const content = await build.outputs[0].arrayBuffer();
+    const buffer = Buffer.from(content);
+    // Check WASM magic number
+    expect(buffer.subarray(0, 4)).toEqual(Buffer.from([0x00, 0x61, 0x73, 0x6d]));
+  });
+
+  test("multiple file loader entrypoints", async () => {
+    const dir = tempDirWithFiles("bun-build-multi-file", {
+      "a.txt": "File A",
+      "b.txt": "File B",
+      "c.txt": "File C",
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "a.txt"), join(dir, "b.txt"), join(dir, "c.txt")],
+      outdir: join(dir, "out"),
+      loader: { ".txt": "file" },
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(3);
+    expect(build.outputs.every(o => o.kind === "asset")).toBe(true);
+    expect(build.outputs.every(o => o.path.endsWith(".txt"))).toBe(true);
+  });
+
+  test("importing static files from JS should still create proxy + asset", async () => {
+    // When a JS file imports a static asset, it should create:
+    // 1. JS bundle with the asset path inlined
+    // 2. The hashed asset file
+    const pngData = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00,
+      0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49,
+      0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00,
+      0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+
+    const dir = tempDirWithFiles("bun-build-import-static", {
+      "index.js": 'export { default as logo } from "./logo.png";',
+      "logo.png": pngData,
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "index.js")],
+      outdir: join(dir, "out"),
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(2);
+
+    // Should have 1 entry-point (index.js) and 1 asset (logo.png)
+    const entryPoint = build.outputs.find(o => o.kind === "entry-point");
+    const asset = build.outputs.find(o => o.kind === "asset");
+
+    expect(entryPoint).toBeDefined();
+    expect(asset).toBeDefined();
+
+    expect(entryPoint!.path).toMatch(/index\.js$/);
+    expect(asset!.path).toMatch(/logo.*\.png$/);
+
+    // The JS should contain a reference to the hashed PNG
+    const jsContent = await entryPoint!.text();
+    expect(jsContent).toContain("logo");
+    expect(jsContent).toContain(".png");
+
+    // The asset should be the actual PNG
+    const assetContent = await asset!.arrayBuffer();
+    const buffer = Buffer.from(assetContent);
+    expect(buffer.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  });
+
+  test("copying files use case - PNG without explicit loader", async () => {
+    // PNG files default to .file loader, so they should be copied directly
+    const pngData = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00,
+      0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49,
+      0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00,
+      0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+
+    const dir = tempDirWithFiles("bun-build-copy-png", {
+      "logo.png": pngData,
+      "favicon.png": pngData,
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "logo.png"), join(dir, "favicon.png")],
+      outdir: join(dir, "out"),
+      // No explicit loader - PNG defaults to .file
+    });
+
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(2);
+
+    // Should produce ONLY asset files, no JS wrappers
+    expect(build.outputs.every(o => o.kind === "asset")).toBe(true);
+    expect(build.outputs.every(o => o.path.endsWith(".png"))).toBe(true);
+
+    // Verify actual PNG content
+    for (const output of build.outputs) {
+      const content = await output.arrayBuffer();
+      const buffer = Buffer.from(content);
+      expect(buffer.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    }
+  });
+});

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -672,15 +672,16 @@ describe("bundler", () => {
     },
     outdir: "/out",
     entryPointsRaw: ["./entry.zig"],
-    runtimeFiles: {
-      "/exec.js": `
-        import assert from 'node:assert';
-        import the_path from './out/entry.js';
-        assert.strictEqual(the_path, './entry-z5artd5z.zig');
-      `,
-    },
-    run: {
-      file: "./exec.js",
+    // With the new behavior, asset entrypoints (file loader) are copied directly
+    // without creating JS wrappers. Need to specify expected output path explicitly.
+    outputPaths: ["/out/entry.zig"],
+    onAfterBundle(api) {
+      const fs = require("fs");
+      const path = require("path");
+      const outPath = path.join(api.outdir, "entry.zig");
+      api.assertFileExists("out/entry.zig");
+      const content = fs.readFileSync(outPath, "utf8");
+      expect(content).toContain("Hello, world!");
     },
   });
   itBundled("edgecase/ExportDefaultUndefined", {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -127,8 +127,11 @@ describe("bundler", async () => {
     },
   });
 
-  const loaders: Loader[] = ["wasm", "json", "file" /* "napi" */, "text"];
-  const exts = ["wasm", "json", "lmao" /*  ".node" */, "txt"];
+  // Test loaders that inline content into JS (json, text)
+  // Note: wasm and file loaders are excluded because when used as entrypoints,
+  // they now copy files directly without creating JS wrappers
+  const loaders: Loader[] = ["json", "text"];
+  const exts = ["json", "txt"];
   for (let i = 0; i < loaders.length; i++) {
     const loader = loaders[i];
     const ext = exts[i];
@@ -153,8 +156,6 @@ describe("bundler", async () => {
           expect(module.default).toStrictEqual({ hello: "friends" });
         } else if (loader === "text") {
           expect(module.default).toStrictEqual('{ "hello": "friends" }');
-        } else {
-          api.assertFileExists(join("out", module.default));
         }
       },
     });
@@ -179,8 +180,6 @@ describe("bundler", async () => {
           expect(module.default).toStrictEqual({ hello: "friends" });
         } else if (loader === "text") {
           expect(module.default).toStrictEqual('{ "hello": "friends" }');
-        } else {
-          api.assertFileExists(join("out", module.default));
         }
       },
     });


### PR DESCRIPTION
## Problem

When using static files as entrypoints with loaders that create "proxy" JS modules (`.file`, `.wasm`, `.napi`, `.sqlite`), Bun creates **both** a JavaScript wrapper file **and** the asset file:

```bash
bun build logo.png --outdir dist
```

**Before (current behavior):**
```
dist/logo.js           # JS file: export default "./logo-[hash].png"
dist/logo-[hash].png   # The actual PNG file
```

This is confusing because:
1. Users expect `bun build logo.png` to just copy the PNG file
2. The JS wrapper serves no purpose when the file itself is the entrypoint
3. It's the wrong default for the common use case of copying static assets

## Why This Happens

Certain loaders (`.file`, `.wasm`, `.napi`, `.sqlite`) are designed to create "proxy" JS modules that export a path or handle to an external resource:

```javascript
// What .file loader generates when logo.png is imported:
export default "./logo-abc123.png"
```

This makes sense **when importing from another module** (the JS code needs a way to reference the asset), but doesn't make sense when the file itself is the entrypoint.

## Solution

When files with proxy-creating loaders are used as **user-specified entrypoints**, copy them directly without creating JS wrappers:

```bash
bun build logo.png favicon.ico --outdir dist
```

**After (with this fix):**
```
dist/logo.png     # Just the PNG file (no hash - preserves original name)
dist/favicon.ico  # Just the ICO file (no hash - preserves original name)
```

### Key Design Decisions

#### 1. Only Affects Entrypoints
Importing from JS still works normally (creates proxy + asset **with hash for cache busting**):
```javascript
// app.js
import logo from './logo.png'
```
```bash
bun build app.js --outdir dist
# Output: app.js + logo-[hash].png (hash present for cache busting)
```

#### 2. Entrypoints Preserve Filenames, Imports Get Hashed

This is a critical distinction:

- **Entrypoints** (user-specified files): Use entry naming template (no hash by default)
  - `bun build logo.png` → `logo.png` (filename preserved)
  - Respects `--entry-naming` flag if provided
  
- **Imports** (referenced from other modules): Use asset naming template (hash included)
  - `import logo from './logo.png'` → `logo-[hash].png` (hash for cache busting)
  - Respects `--asset-naming` flag if provided

**Why?** Entrypoints are explicitly named by the user and should preserve their filenames. Imported assets need content hashing for cache busting. This can technically result in duplicate files (same asset as entrypoint and import), but this edge case is acceptable.

#### 3. Only Affects Proxy Loaders

Loaders that **inline content** are not affected:
- `.json` → Still creates JS module with inlined JSON data (good for tree-shaking)
- `.text` → Still creates JS module with inlined string content
- `.yaml`, `.toml` → Still parse and inline

Only loaders that create **proxy files** are affected:
- `.file` → Copy directly as entrypoint
- `.wasm` → Copy directly as entrypoint  
- `.napi` → Copy directly as entrypoint
- `.sqlite` / `.sqlite_embedded` → Copy directly as entrypoint

#### 4. Users Can Still Control Behavior

Want JSON copied instead of bundled? Use the file loader:
```bash
bun build data.json --loader .json:file --outdir dist
# Output: data.json (just the JSON file, no hash)
```

Want hashed entrypoint names? Use `--entry-naming`:
```bash
bun build logo.png --entry-naming '[name]-[hash][ext]' --outdir dist
# Output: logo-[hash].png (hash included)
```

## Use Cases Enabled

### 1. Copying Static Assets
```bash
bun build public/*.png public/*.svg --outdir dist/assets
```
Output: Files copied with original names, no unwanted JS wrappers!

### 2. Deploying WebAssembly Modules
```bash
bun build module.wasm --outdir dist
```
Output: Just `module.wasm`, ready to be loaded

### 3. Distributing Native Addons
```bash
bun build addon.node --outdir dist
```
Output: Just `addon.node`, no JS proxy

## Implementation

### Changes Made

1. **Added `shouldCopyAsEntrypoint()` function** (`src/options.zig`)
   - Returns `true` for loaders that create proxy JS modules
   - Includes: `.file`, `.wasm`, `.napi`, `.sqlite`, `.sqlite_embedded`

2. **Filter entrypoints before chunk creation** (`src/bundler/bundle_v2.zig`)
   - Added `filterEntryPointsForChunking()` to separate JS/CSS/HTML entrypoints from copy-only assets
   - Called before `linker.link()` in 3 locations

3. **Mark copy-only entrypoints during enqueue** (`src/bundler/bundle_v2.zig`)
   - Extended condition to mark files for copying when they're copy-only entrypoints
   - Ensures these files are added to `additional_files` list

4. **Generate unique keys for copy-only entrypoints** (`src/bundler/ParseTask.zig`)
   - Ensures static file entrypoints get proper content hashing
   - Sets `unique_key_for_additional_file` so they're copied correctly

5. **Handle zero-chunk case** (`src/bundler/bundle_v2.zig`)
   - When all entrypoints are copy-only, return asset files directly without attempting chunk creation

6. **Smart path template selection** (`src/bundler/bundle_v2.zig` in `processFilesToCopy()`)
   - Detects if a file is a copy-only entrypoint vs. an import
   - Uses **entry naming template** (no hash) for entrypoints
   - Uses **asset naming template** (with hash) for imports
   - This ensures cache busting for imports while preserving entrypoint names

### Testing

Added comprehensive test suite (`test/bundler/bun-build-static-entrypoints.test.ts`) covering:

- ✅ JSON entrypoints still create JS modules (content inlined - not affected by fix)
- ✅ File loader PNG entrypoints copy directly without JS wrapper **and without hash**
- ✅ Text files with file loader copy directly
- ✅ WASM entrypoints copy directly
- ✅ Multiple file loader entrypoints
- ✅ **Importing static files from JS still creates proxy + asset WITH hash** (critical - ensures imports work with cache busting)
- ✅ **Copy use case with PNG files** (realistic scenario without explicit loader)

All tests pass with the fix, and the tests that should fail on system bun do fail (confirming the bug exists).

## Before/After Comparison

### Scenario 1: Copying Images (Most Common Use Case)
```bash
bun build logo.png favicon.png --outdir dist
```

**Before:**
- ❌ `dist/logo.js` (unnecessary proxy)
- ✅ `dist/logo-[hash].png`
- ❌ `dist/favicon.js` (unnecessary proxy)
- ✅ `dist/favicon-[hash].png`

**After:**
- ✅ `dist/logo.png` (just the file, **no hash**)
- ✅ `dist/favicon.png` (just the file, **no hash**)

### Scenario 2: Bundling JSON (Should Be Unchanged)
```bash
bun build data.json --outdir dist
```

**Before:**
- ✅ `dist/data.js` (with JSON data inlined)

**After:**
- ✅ `dist/data.js` (with JSON data inlined) — **No change!**

### Scenario 3: Importing Assets from JS (Gets Hash for Cache Busting)
```javascript
// app.js
import logo from './logo.png'
import data from './data.json'
```
```bash
bun build app.js --outdir dist
```

**Before:**
- ✅ `dist/app.js` (contains "./logo-[hash].png" and data object)
- ✅ `dist/logo-[hash].png`

**After:**
- ✅ `dist/app.js` (contains "./logo-[hash].png" and data object) — **No change!**
- ✅ `dist/logo-[hash].png` — **Still has hash for cache busting!**

### Scenario 4: Edge Case - Same File as Both Entrypoint and Import
```javascript
// app.js
import logo from './logo.png'
```
```bash
bun build app.js logo.png --outdir dist
```

**After:**
- ✅ `dist/app.js` (contains "./logo-[hash].png")
- ✅ `dist/logo.png` (entrypoint - no hash)
- ✅ `dist/logo-[hash].png` (import - has hash)

This creates two copies, but it's acceptable because:
1. This scenario is rare (why specify a file as entrypoint AND import it?)
2. Each serves a different purpose (one for direct access, one for cache busting)

## Why This Is The Right Behavior

1. **Matches User Expectations**: `bun build file.png` should copy the PNG, not create a JS file
2. **Enables Common Use Cases**: Copying static assets, deploying WASM modules, distributing native addons
3. **Maintains Optimization**: JSON/YAML/etc. still bundle with tree-shaking support
4. **Preserves Import Behavior**: Importing assets from JS still works with hashed assets for cache busting
5. **User Controllable**: Can still use `--entry-naming` and `--loader` flags to control behavior
6. **Best of Both Worlds**: Entrypoints preserve names, imports get cache busting hashes

## Breaking Changes

**Minimal.** This only changes behavior for entrypoints using proxy-creating loaders:

- **Before**: `bun build logo.png` → `logo.js` + `logo-[hash].png`
- **After**: `bun build logo.png` → `logo.png` (no hash)

The previous behavior was arguably broken (creating unnecessary JS wrappers), so this fix aligns with expected behavior rather than breaking existing functionality.

If users need the old behavior (hashed entrypoint names), they can use `--entry-naming '[name]-[hash][ext]'`.

## Related Issues

Fixes the issue where `bun build` creates unnecessary JS wrapper files for static asset entrypoints.