### PR TITLE
fix(MySQL) ref and status usage

### DIFF
--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -37,6 +37,7 @@ pub const ref = RefCount.ref;
 pub const deref = RefCount.deref;
 
 pub fn onAutoFlush(this: *@This()) bool {
+    debug("onAutoFlush", .{});
     if (this.#connection.hasBackpressure()) {
         this.auto_flusher.registered = false;
         // if we have backpressure, wait for onWritable
@@ -93,8 +94,8 @@ fn getTimeoutInterval(this: *@This()) u32 {
     };
 }
 pub fn resetConnectionTimeout(this: *@This()) void {
-    debug("resetConnectionTimeout", .{});
     const interval = this.getTimeoutInterval();
+    debug("resetConnectionTimeout {d}", .{interval});
     if (this.timer.state == .ACTIVE) {
         this.#vm.timer.remove(&this.timer);
     }
@@ -178,6 +179,7 @@ pub fn close(this: *@This()) void {
 }
 
 fn drainInternal(this: *@This()) void {
+    debug("drainInternal", .{});
     if (this.#vm.isShuttingDown()) return this.close();
     this.ref();
     defer this.deref();
@@ -225,13 +227,15 @@ fn SocketHandler(comptime ssl: bool) type {
             const socket = _socket(s);
             this.#connection.setSocket(socket);
 
-            this.setupMaxLifetimeTimerIfNecessary();
-            this.resetConnectionTimeout();
             if (socket == .SocketTCP) {
-                // when upgrading to TLS the onOpen callback will be called again and at this moment we dont wanna to change the status to handshaking
+                // This handshake is not TLS handleshake is actually the MySQL handshake
+                // When a connection is upgraded to TLS, the onOpen callback is called again and at this moment we dont wanna to change the status to handshaking
                 this.#connection.status = .handshaking;
                 this.ref(); // keep a ref for the socket
             }
+            // Only set up the timers after all status changes are complete — the timers rely on the status to determine timeouts.
+            this.setupMaxLifetimeTimerIfNecessary();
+            this.resetConnectionTimeout();
             this.updateReferenceType();
         }
 
@@ -305,15 +309,17 @@ fn updateReferenceType(this: *@This()) void {
     if (this.#connection.isActive()) {
         debug("connection is active", .{});
         if (this.#js_value.isNotEmpty() and this.#js_value == .weak) {
-            debug("strong ref", .{});
+            debug("strong ref until connection is closed", .{});
             this.#js_value.upgrade(this.#globalObject);
         }
-        this.#poll_ref.ref(this.#vm);
+        if (this.#connection.status == .connected and this.#connection.isIdle()) {
+            this.#poll_ref.unref(this.#vm);
+        } else {
+            this.#poll_ref.ref(this.#vm);
+        }
         return;
     }
-    debug("connection is not active", .{});
     if (this.#js_value.isNotEmpty() and this.#js_value == .strong) {
-        debug("week ref", .{});
         this.#js_value.downgrade();
     }
     this.#poll_ref.unref(this.#vm);

--- a/test/js/sql/sql-idle-exit-fixture.ts
+++ b/test/js/sql/sql-idle-exit-fixture.ts
@@ -1,0 +1,14 @@
+const tls = process.env.CA_PATH ? { ca: Bun.file(process.env.CA_PATH) } : undefined;
+const sql = new Bun.SQL({
+  url: process.env.MYSQL_URL,
+  tls,
+  max: 1,
+  // ensure that the process doesn't exit because of timeouts
+  idleTimeout: 100,
+  maxLifetime: 100,
+  connectionTimeout: 100,
+});
+
+const result = await sql`select 1`;
+console.log(result);
+// process should exit with code 0

--- a/test/js/sql/sql-idle-exit-fixture.ts
+++ b/test/js/sql/sql-idle-exit-fixture.ts
@@ -3,7 +3,7 @@ const sql = new Bun.SQL({
   url: process.env.MYSQL_URL,
   tls,
   max: 1,
-  // ensure that the process doesn't exit because of timeouts
+  // Set timeouts high enough to not fire during this test
   idleTimeout: 100,
   maxLifetime: 100,
   connectionTimeout: 100,

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1,6 +1,6 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
 import net from "net";
 import path from "path";
 const dir = tempDirWithFiles("sql-test", {
@@ -55,6 +55,14 @@ if (isDockerEnabled()) {
           sql = new SQL(getOptions());
         });
 
+        test("process should exit when idle", async () => {
+          const { stderr } = bunRun(path.join(import.meta.dir, "sql-idle-exit-fixture.ts"), {
+            ...bunEnv,
+            MYSQL_URL: getOptions().url,
+            CA_PATH: image.name === "MySQL with TLS" ? path.join(import.meta.dir, "mysql-tls", "ssl", "ca.pem") : "",
+          });
+          expect(stderr).toBe("");
+        });
         test("should return lastInsertRowid and affectedRows", async () => {
           await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
           using sql = await db.reserve();
@@ -587,27 +595,6 @@ if (isDockerEnabled()) {
           await using sql = new SQL({ ...getOptions(), max: 1 });
           const err = await sql`wat 1`.catch(x => x);
           expect(err.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
-        });
-
-        // Regression test for: panic: A JavaScript exception was thrown, but it was cleared before it could be read.
-        // This happened when FieldType.fromJS returned error.JSError without throwing an exception first.
-        test("should throw error for NumberObject parameter", async () => {
-          await using sql = new SQL({ ...getOptions(), max: 1 });
-          // new Number(42) creates a NumberObject (not a primitive number)
-          // This used to cause a panic because FieldType.fromJS returned error.JSError without throwing
-          const numberObject = new Number(42);
-          const err = await sql`SELECT ${numberObject} as value`.catch(x => x);
-          expect(err).toBeInstanceOf(Error);
-          expect(err.message).toContain("Cannot bind NumberObject to query parameter");
-        });
-
-        test("should throw error for BooleanObject parameter", async () => {
-          await using sql = new SQL({ ...getOptions(), max: 1 });
-          // new Boolean(true) creates a BooleanObject (not a primitive boolean)
-          const booleanObject = new Boolean(true);
-          const err = await sql`SELECT ${booleanObject} as value`.catch(x => x);
-          expect(err).toBeInstanceOf(Error);
-          expect(err.message).toContain("Cannot bind BooleanObject to query parameter");
         });
 
         test("should work with fragments", async () => {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -597,6 +597,27 @@ if (isDockerEnabled()) {
           expect(err.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
         });
 
+        // Regression test for: panic: A JavaScript exception was thrown, but it was cleared before it could be read.
+        // This happened when FieldType.fromJS returned error.JSError without throwing an exception first.
+        test("should throw error for NumberObject parameter", async () => {
+          await using sql = new SQL({ ...getOptions(), max: 1 });
+          // new Number(42) creates a NumberObject (not a primitive number)
+          // This used to cause a panic because FieldType.fromJS returned error.JSError without throwing
+          const numberObject = new Number(42);
+          const err = await sql`SELECT ${numberObject} as value`.catch(x => x);
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toContain("Cannot bind NumberObject to query parameter");
+        });
+
+        test("should throw error for BooleanObject parameter", async () => {
+          await using sql = new SQL({ ...getOptions(), max: 1 });
+          // new Boolean(true) creates a BooleanObject (not a primitive boolean)
+          const booleanObject = new Boolean(true);
+          const err = await sql`SELECT ${booleanObject} as value`.catch(x => x);
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toContain("Cannot bind BooleanObject to query parameter");
+        });
+
         test("should work with fragments", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });
           const random_name = sql("test_" + randomUUIDv7("hex").replaceAll("-", ""));


### PR DESCRIPTION
### What does this PR do?
Let MySQL unref when idle and make sure that is behaving like this.
Only set up the timers after all status changes are complete since the timers rely on the status to determine timeouts, this was causing the CPU usage spike to 100% (thats why only happened in TLS) 
CPU usage it self will be improved in https://github.com/oven-sh/bun/pull/23700 not in this PR

Fixes: https://github.com/oven-sh/bun/issues/23273
Fixes: https://github.com/oven-sh/bun/issues/23256
### How did you verify your code works?
Test
