### PR TITLE
zig: fix s3 list-objects memory leak

### DIFF
--- a/src/s3/list_objects.zig
+++ b/src/s3/list_objects.zig
@@ -34,8 +34,7 @@ const ObjectRestoreStatus = struct {
 
 const S3ListObjectsContents = struct {
     key: []const u8,
-    etag: ?[]const u8,
-    etag_allocated_len: usize,
+    etag: ?bun.ptr.OwnedIn([]const u8, bun.allocators.MaybeOwned(bun.DefaultAllocator)),
     checksum_type: ?[]const u8,
     checksum_algorithme: ?[]const u8,
     last_modified: ?[]const u8,
@@ -45,7 +44,7 @@ const S3ListObjectsContents = struct {
     restore_status: ?ObjectRestoreStatus,
 
     pub fn deinit(self: *S3ListObjectsContents) void {
-        if (self.etag_allocated_len > 0) bun.default_allocator.free(self.etag.?.ptr[0..self.etag_allocated_len]);
+        if (self.etag) |*etag| etag.deinit();
     }
 };
 
@@ -63,7 +62,7 @@ pub const S3ListObjectsV2Result = struct {
     common_prefixes: ?std.ArrayList([]const u8),
     contents: ?std.ArrayList(S3ListObjectsContents),
 
-    pub fn deinit(this: @This()) void {
+    pub fn deinit(this: *const @This()) void {
         if (this.contents) |contents| {
             for (contents.items) |*item| item.deinit();
             contents.deinit();
@@ -73,7 +72,7 @@ pub const S3ListObjectsV2Result = struct {
         }
     }
 
-    pub fn toJS(this: @This(), globalObject: *JSGlobalObject) bun.JSError!JSValue {
+    pub fn toJS(this: *const @This(), globalObject: *JSGlobalObject) bun.JSError!JSValue {
         const jsResult = JSValue.createEmptyObject(globalObject, 12);
 
         if (this.name) |name| {
@@ -123,7 +122,7 @@ pub const S3ListObjectsV2Result = struct {
                 objectInfo.put(globalObject, jsc.ZigString.static("key"), try bun.String.createUTF8ForJS(globalObject, item.key));
 
                 if (item.etag) |etag| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("eTag"), try bun.String.createUTF8ForJS(globalObject, etag));
+                    objectInfo.put(globalObject, jsc.ZigString.static("eTag"), try bun.String.createUTF8ForJS(globalObject, etag.get()));
                 }
 
                 if (item.checksum_algorithme) |checksum_algorithme| {
@@ -224,7 +223,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                     var object_size: ?i64 = null;
                     var storage_class: ?[]const u8 = null;
                     var etag: ?[]const u8 = null;
-                    var etag_allocated_len: usize = 0;
+                    var etag_owned: bool = false;
                     var checksum_type: ?[]const u8 = null;
                     var checksum_algorithme: ?[]const u8 = null;
                     var owner_id: ?[]const u8 = null;
@@ -288,7 +287,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
 
                                         if (len != 0) {
                                             etag = output[0 .. input.len - len * 5]; // 5 = "&quot;".len - 1 for replacement "
-                                            etag_allocated_len = size;
+                                            etag_owned = true;
                                         } else {
                                             bun.default_allocator.free(output);
                                             etag = input;
@@ -382,8 +381,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
 
                         try contents.append(.{
                             .key = object_key_val,
-                            .etag = etag,
-                            .etag_allocated_len = etag_allocated_len,
+                            .etag = if (etag) |etag_| if (etag_owned) .fromRawIn(etag_, .init()) else .fromRawIn(etag_, .initBorrowed()) else null,
                             .checksum_type = checksum_type,
                             .checksum_algorithme = checksum_algorithme,
                             .last_modified = last_modified,


### PR DESCRIPTION
discovered by https://github.com/oven-sh/bun/pull/21663
when running `test/js/bun/s3/s3-list-objects.test.ts`, eliminates the following:

```
Direct leak of 1360358 byte(s) in 40011 object(s) allocated from:
    #0 0x000123fca6f4 in posix_memalign+0x80 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x526f4)
    #1 0x000104a76f80 in heap.CAllocator.alignedAlloc heap.zig:164
    #2 0x0001041e85a8 in heap.CAllocator.alloc heap.zig:209
    #3 0x000102c4bb80 in mem.Allocator.allocBytesWithAlignment__anon_266944 Allocator.zig:287
    #4 0x000102b80ce8 in mem.Allocator.allocWithSizeAndAlignment__anon_239257 Allocator.zig:278
    #5 0x000102499f54 in mem.Allocator.alloc__anon_6361 Allocator.zig:196
    #6 0x000104d2dd68 in s3.list_objects.parseS3ListObjectsResult list_objects.zig:278
    #7 0x0001045de118 in s3.simple_request.S3HttpSimpleTask.onResponse simple_request.zig:262
    #8 0x000103ce8110 in bun.js.event_loop.Task.tickQueueWithCount Task.zig:203
    #9 0x0001036f048c in bun.js.event_loop.tickWithCount event_loop.zig:217
    #10 0x0001031a6794 in bun.js.event_loop.tick event_loop.zig:497
    #11 0x000104d580ac in cli.test_command.TestCommand.run test_command.zig:1945
    #12 0x000104605a2c in cli.test_command.TestCommand.runAllTests.Context.begin test_command.zig:1816
    #13 0x000103cf8ec8 in bun.js.jsc.OpaqueWrap__anon_495178__struct_707659.callback jsc.zig:234
    #14 0x000100167240 in JSC__VM__holdAPILock bindings.cpp:4629
    #15 0x000102569dec in bun.js.bindings.VM.VM.holdAPILock VM.zig:35
    #16 0x0001031ae5d8 in bun.js.VirtualMachine.runWithAPILock__anon_342769 VirtualMachine.zig:2335
    #17 0x000102b1e6d4 in cli.test_command.TestCommand.runAllTests test_command.zig:1826
    #18 0x000102b17170 in cli.test_command.TestCommand.exec test_command.zig:1526
    #19 0x000102b72cfc in cli.Command.start cli.zig:833
    #20 0x0001024778e8 in cli.Cli.start cli.zig:20
    #21 0x000102473dac in main.main main.zig:60
    #22 0x000102473b78 in main start.zig:635
    #23 0x000199886b94 in start+0x17b8 (dyld:arm64+0xfffffffffff3ab94)
```
