### PR TITLE
Add GitHub issue deduplication automation

### DIFF
--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -1,0 +1,38 @@
+---
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh api:*), Bash(gh issue comment:*)
+description: Find duplicate GitHub issues
+---
+
+Find up to 3 likely duplicate issues for a given GitHub issue.
+
+To do this, follow these steps precisely:
+
+1. Use an agent to check if the Github issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
+2. Use an agent to view a Github issue, and ask the agent to return a summary of the issue
+3. Then, launch 5 parallel agents to search Github for duplicates of this issue, using diverse keywords and search approaches, using the summary from #1
+4. Next, feed the results from #1 and #2 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.
+5. Finally, comment back on the issue with a list of up to three duplicate issues (or zero, if there are no likely duplicates)
+
+Notes (be sure to tell this to your agents, too):
+
+- Use `gh` to interact with Github, rather than web fetch
+- Do not use other tools, beyond `gh` (eg. don't use other MCP servers, file edit, etc.)
+- Make a todo list first
+- For your comment, follow the following format precisely (assuming for this example that you found 3 suspected duplicates):
+
+---
+
+Found 3 possible duplicate issues:
+
+1. <link to issue>
+2. <link to issue>
+3. <link to issue>
+
+This issue will be automatically closed as a duplicate in 3 days.
+
+- If your issue is a duplicate, please close it and 👍 the existing issue instead
+- To prevent auto-closure, add a comment or 👎 this comment
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+---

--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -3,21 +3,24 @@ allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), 
 description: Find duplicate GitHub issues
 ---
 
+# Issue deduplication command
+
 Find up to 3 likely duplicate issues for a given GitHub issue.
 
 To do this, follow these steps precisely:
 
-1. Use an agent to check if the Github issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
-2. Use an agent to view a Github issue, and ask the agent to return a summary of the issue
-3. Then, launch 5 parallel agents to search Github for duplicates of this issue, using diverse keywords and search approaches, using the summary from #1
-4. Next, feed the results from #1 and #2 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.
+1. Use an agent to check if the GitHub issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
+2. Use an agent to view a GitHub issue, and ask the agent to return a summary of the issue
+3. Then, launch 5 parallel agents to search GitHub for duplicates of this issue, using diverse keywords and search approaches, using the summary from Step 2. **IMPORTANT**: Always scope searches with `repo:owner/repo` to constrain results to the current repository only.
+4. Next, feed the results from Steps 2 and 3 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.
 5. Finally, comment back on the issue with a list of up to three duplicate issues (or zero, if there are no likely duplicates)
 
 Notes (be sure to tell this to your agents, too):
 
-- Use `gh` to interact with Github, rather than web fetch
+- Use `gh` to interact with GitHub, rather than web fetch
 - Do not use other tools, beyond `gh` (eg. don't use other MCP servers, file edit, etc.)
 - Make a todo list first
+- Always scope searches with `repo:owner/repo` to prevent cross-repo false positives
 - For your comment, follow the following format precisely (assuming for this example that you found 3 suspected duplicates):
 
 ---
@@ -34,5 +37,7 @@ This issue will be automatically closed as a duplicate in 3 days.
 - To prevent auto-closure, add a comment or 👎 this comment
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
+
+<!-- dedupe-bot:marker -->
 
 ---

--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -9,7 +9,7 @@ Find up to 3 likely duplicate issues for a given GitHub issue.
 
 To do this, follow these steps precisely:
 
-1. Use an agent to check if the GitHub issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
+1. Use an agent to check if the GitHub issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicate detection comment (check for the exact HTML marker `<!-- dedupe-bot:marker -->` in the issue comments - ignore other bot comments). If so, do not proceed.
 2. Use an agent to view a GitHub issue, and ask the agent to return a summary of the issue
 3. Then, launch 5 parallel agents to search GitHub for duplicates of this issue, using diverse keywords and search approaches, using the summary from Step 2. **IMPORTANT**: Always scope searches with `repo:owner/repo` to constrain results to the current repository only.
 4. Next, feed the results from Steps 2 and 3 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.

--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -18,9 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Auto-close duplicate issues
         run: bun run scripts/auto-close-duplicates.ts

--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -1,0 +1,30 @@
+name: Auto-close duplicate issues
+description: Auto-closes issues that are duplicates of existing issues
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  auto-close-duplicates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Auto-close duplicate issues
+        run: bun run scripts/auto-close-duplicates.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -1,5 +1,4 @@
 name: Auto-close duplicate issues
-description: Auto-closes issues that are duplicates of existing issues
 on:
   schedule:
     - cron: "0 9 * * *"
@@ -9,6 +8,9 @@ jobs:
   auto-close-duplicates:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: auto-close-duplicates-${{ github.repository }}
+      cancel-in-progress: true
     permissions:
       contents: read
       issues: write
@@ -24,5 +26,4 @@ jobs:
         run: bun run scripts/auto-close-duplicates.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -1,0 +1,32 @@
+name: Claude Issue Dedupe
+description: Automatically dedupe GitHub issues using Claude Code
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to process for duplicate detection'
+        required: true
+        type: string
+
+jobs:
+  claude-dedupe-issues:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Claude Code slash command
+        uses: anthropics/claude-code-base-action@beta
+        with:
+          prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-sonnet-4-5-20250929"
+          claude_env: |
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -1,5 +1,4 @@
 name: Claude Issue Dedupe
-description: Automatically dedupe GitHub issues using Claude Code
 on:
   issues:
     types: [opened]
@@ -14,6 +13,9 @@ jobs:
   claude-dedupe-issues:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: claude-dedupe-issues-${{ github.event.issue.number || inputs.issue_number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       issues: write

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -105,10 +105,10 @@ async function closeIssueAsDuplicate(
   duplicateOfNumber: number,
   token: string,
 ): Promise<void> {
-  // Close the issue with state_reason "not_planned" (GitHub doesn't have a "duplicate" state_reason in the API)
+  // Close the issue as duplicate
   await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, token, "PATCH", {
     state: "closed",
-    state_reason: "not_planned",
+    state_reason: "duplicate",
   });
 
   await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, token, "POST", {

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -105,10 +105,11 @@ async function closeIssueAsDuplicate(
   duplicateOfNumber: number,
   token: string,
 ): Promise<void> {
-  // Close the issue as duplicate
+  // Close the issue as duplicate and add the duplicate label
   await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, token, "PATCH", {
     state: "closed",
     state_reason: "duplicate",
+    labels: ["duplicate"],
   });
 
   await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, token, "POST", {

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+
+declare global {
+  var process: {
+    env: Record<string, string | undefined>;
+  };
+}
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  user: { id: number };
+  created_at: string;
+}
+
+interface GitHubComment {
+  id: number;
+  body: string;
+  created_at: string;
+  user: { type: string; id: number };
+}
+
+interface GitHubReaction {
+  user: { id: number };
+  content: string;
+}
+
+async function githubRequest<T>(endpoint: string, token: string, method: string = "GET", body?: any): Promise<T> {
+  const response = await fetch(`https://api.github.com${endpoint}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "auto-close-duplicates-script",
+      ...(body && { "Content-Type": "application/json" }),
+    },
+    ...(body && { body: JSON.stringify(body) }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+function extractDuplicateIssueNumber(commentBody: string): number | null {
+  // Try to match #123 format first
+  let match = commentBody.match(/#(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+
+  // Try to match GitHub issue URL format: https://github.com/owner/repo/issues/123
+  match = commentBody.match(/github\.com\/[^\/]+\/[^\/]+\/issues\/(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+
+  return null;
+}
+
+async function closeIssueAsDuplicate(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  duplicateOfNumber: number,
+  token: string,
+): Promise<void> {
+  await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, token, "PATCH", {
+    state: "closed",
+    state_reason: "duplicate",
+    labels: ["duplicate"],
+  });
+
+  await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, token, "POST", {
+    body: `This issue has been automatically closed as a duplicate of #${duplicateOfNumber}.
+
+If this is incorrect, please re-open this issue or create a new one.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)`,
+  });
+}
+
+async function autoCloseDuplicates(): Promise<void> {
+  console.log("[DEBUG] Starting auto-close duplicates script");
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("GITHUB_TOKEN environment variable is required");
+  }
+  console.log("[DEBUG] GitHub token found");
+
+  const owner = process.env.GITHUB_REPOSITORY_OWNER || "oven-sh";
+  const repo = process.env.GITHUB_REPOSITORY_NAME || "bun";
+  console.log(`[DEBUG] Repository: ${owner}/${repo}`);
+
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+  console.log(`[DEBUG] Checking for duplicate comments older than: ${threeDaysAgo.toISOString()}`);
+
+  console.log("[DEBUG] Fetching open issues created more than 3 days ago...");
+  const allIssues: GitHubIssue[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const pageIssues: GitHubIssue[] = await githubRequest(
+      `/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}&page=${page}`,
+      token,
+    );
+
+    if (pageIssues.length === 0) break;
+
+    // Filter for issues created more than 3 days ago
+    const oldEnoughIssues = pageIssues.filter(issue => new Date(issue.created_at) <= threeDaysAgo);
+
+    allIssues.push(...oldEnoughIssues);
+    page++;
+
+    // Safety limit to avoid infinite loops
+    if (page > 20) break;
+  }
+
+  const issues = allIssues;
+  console.log(`[DEBUG] Found ${issues.length} open issues`);
+
+  let processedCount = 0;
+  let candidateCount = 0;
+
+  for (const issue of issues) {
+    processedCount++;
+    console.log(`[DEBUG] Processing issue #${issue.number} (${processedCount}/${issues.length}): ${issue.title}`);
+
+    console.log(`[DEBUG] Fetching comments for issue #${issue.number}...`);
+    const comments: GitHubComment[] = await githubRequest(
+      `/repos/${owner}/${repo}/issues/${issue.number}/comments`,
+      token,
+    );
+    console.log(`[DEBUG] Issue #${issue.number} has ${comments.length} comments`);
+
+    const dupeComments = comments.filter(
+      comment =>
+        comment.body.includes("Found") && comment.body.includes("possible duplicate") && comment.user.type === "Bot",
+    );
+    console.log(`[DEBUG] Issue #${issue.number} has ${dupeComments.length} duplicate detection comments`);
+
+    if (dupeComments.length === 0) {
+      console.log(`[DEBUG] Issue #${issue.number} - no duplicate comments found, skipping`);
+      continue;
+    }
+
+    const lastDupeComment = dupeComments[dupeComments.length - 1];
+    const dupeCommentDate = new Date(lastDupeComment.created_at);
+    console.log(
+      `[DEBUG] Issue #${issue.number} - most recent duplicate comment from: ${dupeCommentDate.toISOString()}`,
+    );
+
+    if (dupeCommentDate > threeDaysAgo) {
+      console.log(`[DEBUG] Issue #${issue.number} - duplicate comment is too recent, skipping`);
+      continue;
+    }
+    console.log(
+      `[DEBUG] Issue #${issue.number} - duplicate comment is old enough (${Math.floor(
+        (Date.now() - dupeCommentDate.getTime()) / (1000 * 60 * 60 * 24),
+      )} days)`,
+    );
+
+    const commentsAfterDupe = comments.filter(comment => new Date(comment.created_at) > dupeCommentDate);
+    console.log(`[DEBUG] Issue #${issue.number} - ${commentsAfterDupe.length} comments after duplicate detection`);
+
+    if (commentsAfterDupe.length > 0) {
+      console.log(`[DEBUG] Issue #${issue.number} - has activity after duplicate comment, skipping`);
+      continue;
+    }
+
+    console.log(`[DEBUG] Issue #${issue.number} - checking reactions on duplicate comment...`);
+    const reactions: GitHubReaction[] = await githubRequest(
+      `/repos/${owner}/${repo}/issues/comments/${lastDupeComment.id}/reactions`,
+      token,
+    );
+    console.log(`[DEBUG] Issue #${issue.number} - duplicate comment has ${reactions.length} reactions`);
+
+    const authorThumbsDown = reactions.some(
+      reaction => reaction.user.id === issue.user.id && reaction.content === "-1",
+    );
+    console.log(`[DEBUG] Issue #${issue.number} - author thumbs down reaction: ${authorThumbsDown}`);
+
+    if (authorThumbsDown) {
+      console.log(`[DEBUG] Issue #${issue.number} - author disagreed with duplicate detection, skipping`);
+      continue;
+    }
+
+    const duplicateIssueNumber = extractDuplicateIssueNumber(lastDupeComment.body);
+    if (!duplicateIssueNumber) {
+      console.log(`[DEBUG] Issue #${issue.number} - could not extract duplicate issue number from comment, skipping`);
+      continue;
+    }
+
+    candidateCount++;
+    const issueUrl = `https://github.com/${owner}/${repo}/issues/${issue.number}`;
+
+    try {
+      console.log(`[INFO] Auto-closing issue #${issue.number} as duplicate of #${duplicateIssueNumber}: ${issueUrl}`);
+      await closeIssueAsDuplicate(owner, repo, issue.number, duplicateIssueNumber, token);
+      console.log(`[SUCCESS] Successfully closed issue #${issue.number} as duplicate of #${duplicateIssueNumber}`);
+    } catch (error) {
+      console.error(`[ERROR] Failed to close issue #${issue.number} as duplicate: ${error}`);
+    }
+  }
+
+  console.log(
+    `[DEBUG] Script completed. Processed ${processedCount} issues, found ${candidateCount} candidates for auto-close`,
+  );
+}
+
+autoCloseDuplicates().catch(console.error);
+
+// Make it a module
+export {};


### PR DESCRIPTION
## Summary

This PR adds a Claude Code-powered issue deduplication system to help reduce duplicate issues in the Bun repository.

### What's included:

1. **`/dedupe` slash command** (`.claude/commands/dedupe.md`)
   - Claude Code command to find up to 3 duplicate issues for a given GitHub issue
   - Uses parallel agent searches with diverse keywords
   - Filters out false positives

2. **Automatic dedupe on new issues** (`.github/workflows/claude-dedupe-issues.yml`)
   - Runs automatically when a new issue is opened
   - Can also be triggered manually via workflow_dispatch
   - Uses the Claude Code base action to run the `/dedupe` command

3. **Auto-close workflow** (`.github/workflows/auto-close-duplicates.yml`)
   - Runs daily to close issues marked as duplicates after 3 days
   - Only closes if:
     - Issue has a duplicate detection comment from bot
     - Comment is 3+ days old
     - No comments or activity after duplicate comment
     - Author hasn't reacted with 👎 to the duplicate comment

4. **Auto-close script** (`scripts/auto-close-duplicates.ts`)
   - TypeScript script that handles the auto-closing logic
   - Fetches open issues and checks for duplicate markers
   - Closes issues with proper labels and notifications

### How it works:

1. When a new issue is opened, the workflow runs Claude Code to analyze it
2. Claude searches for duplicates and comments on the issue if any are found
3. Users have 3 days to respond if they disagree
4. After 3 days with no activity, the issue is automatically closed

### Requirements:

- `ANTHROPIC_API_KEY` secret needs to be set in the repository settings for the dedupe workflow to run

## Test plan

- [x] Verified workflow files have correct syntax
- [x] Verified script references correct repository (oven-sh/bun)
- [x] Verified slash command matches claude-code implementation
- [ ] Test workflow manually with workflow_dispatch (requires ANTHROPIC_API_KEY)
- [ ] Monitor initial runs to ensure proper behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)