### PR TITLE
chore: Add path separator utilities

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -914,7 +914,7 @@ fn getArgv0(globalThis: *jsc.JSGlobalObject, PATH: []const u8, cwd: []const u8, 
 
     // This mimicks libuv's behavior, which mimicks execvpe
     // Only resolve from $PATH when the command is not an absolute path
-    const PATH_to_use: []const u8 = if (strings.containsChar(argv0_to_use, '/'))
+    const PATH_to_use: []const u8 = if (bun.path.hasPosixPathSeparators(argv0_to_use))
         ""
         // If no $PATH is provided, we fallback to the one from environ
         // This is already the behavior of the PATH passed in here.

--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -372,7 +372,7 @@ pub const FSEventsLoop = struct {
                     }
 
                     // Do not emit events from subdirectories (without option set)
-                    if (path.len == 0 or (bun.strings.containsChar(path, '/') and !handle.recursive)) {
+                    if (path.len == 0 or (bun.path.hasPosixPathSeparators(path) and !handle.recursive)) {
                         continue;
                     }
 

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -220,7 +220,7 @@ pub const PathWatcherManager = struct {
                                 }
 
                                 // Do not emit events from subdirectories (without option set)
-                                if (path.len == 0 or (bun.strings.containsChar(path, '/') and !watcher.recursive)) {
+                                if (path.len == 0 or (bun.path.hasPosixPathSeparators(path) and !watcher.recursive)) {
                                     continue;
                                 }
                                 watcher.emit(event_type.toEvent(path), hash, timestamp, true);
@@ -271,7 +271,7 @@ pub const PathWatcherManager = struct {
                                 }
 
                                 // Do not emit events from subdirectories (without option set)
-                                if (path.len == 0 or (bun.strings.containsChar(path, '/') and !watcher.recursive)) {
+                                if (path.len == 0 or (bun.path.hasPosixPathSeparators(path) and !watcher.recursive)) {
                                     continue;
                                 }
 

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1045,7 +1045,7 @@ pub const PackCommand = struct {
                     const bin_without_trailing = strings.withoutTrailingSlash(bin.path);
                     if (strings.hasPrefix(maybe_bin_path, bin_without_trailing)) {
                         const remain = maybe_bin_path[bin_without_trailing.len..];
-                        if (remain.len > 1 and remain[0] == '/' and !strings.containsChar(remain[1..], '/')) {
+                        if (remain.len > 1 and remain[0] == '/' and !bun.path.hasPosixPathSeparators(remain[1..])) {
                             return true;
                         }
                     }

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2056,6 +2056,24 @@ pub fn posixToPlatformInPlace(comptime T: type, path_buffer: []T) void {
     }
 }
 
+/// Test whether the path contains path slashes appropriate to this platform.
+pub fn hasPathSlashes(str: []const u8) bool {
+    return if (bun.Environment.isWindows)
+        hasPosixPathSeparators(str) or hasWindowsPathSeparators(str)
+    else
+        hasPosixPathSeparators(str);
+}
+
+/// Test whether the path contains Windows backslashes.
+pub fn hasWindowsPathSeparators(str: []const u8) bool {
+    return strings.containsChar(str, '\\');
+}
+
+/// Test whether the path contains POSIX forward slashes.
+pub fn hasPosixPathSeparators(str: []const u8) bool {
+    return strings.containsChar(str, '/');
+}
+
 const Fs = @import("../fs.zig");
 const std = @import("std");
 

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -239,7 +239,7 @@ pub fn toWDirNormalized(wbuf: []u16, utf8: []const u8) [:0]const u16 {
 
     var path_to_use = utf8;
 
-    if (bun.strings.containsChar(utf8, '/')) {
+    if (bun.path.hasPosixPathSeparators(utf8)) {
         renormalized = bun.path_buffer_pool.get();
         @memcpy(renormalized.?[0..utf8.len], utf8);
         for (renormalized.?[0..utf8.len]) |*c| {

--- a/src/which.zig
+++ b/src/which.zig
@@ -41,7 +41,7 @@ pub fn which(buf: *bun.PathBuffer, path: []const u8, cwd: []const u8, bin: []con
         return null;
     }
 
-    if (bun.strings.containsChar(bin, '/')) {
+    if (bun.path.hasPathSlashes(bin)) {
         if (cwd.len > 0) {
             if (isValid(
                 buf,
@@ -141,7 +141,7 @@ pub fn whichWin(buf: *bun.WPathBuffer, path: []const u8, cwd: []const u8, bin: [
     }
 
     // check if bin is in cwd
-    if (bun.strings.containsChar(bin, '/') or bun.strings.containsChar(bin, '\\')) {
+    if (bun.path.hasPathSlashes(bin)) {
         if (searchBinInPath(
             buf,
             path_buf,


### PR DESCRIPTION
### What does this PR do?

These changes are cherry-picked out of https://github.com/oven-sh/bun/pull/23107 for easier review.

Adds functions for testing whether a string has path separators or not. These are equivalent to:

- `strings.containsChar(<>, '/')`
- `strings.containsChar(<>, '\\')`

It is my opinion that the intent of code is clearer with the utilities I add. 

### How did you verify your code works?

CI, not necessary to verify.