### PR TITLE
bug(SlicedString.zig): Fix incorrect assertion in SlicedString.sub

### DIFF
--- a/src/semver/SlicedString.zig
+++ b/src/semver/SlicedString.zig
@@ -30,8 +30,14 @@ pub inline fn value(this: SlicedString) String {
 
 pub inline fn sub(this: SlicedString, input: string) SlicedString {
     if (Environment.allow_assert) {
-        if (!(@intFromPtr(this.buf.ptr) <= @intFromPtr(this.buf.ptr) and ((@intFromPtr(input.ptr) + input.len) <= (@intFromPtr(this.buf.ptr) + this.buf.len)))) {
-            @panic("SlicedString.sub input is not a substring of the slice");
+        if (!bun.isSliceInBuffer(input, this.buf)) {
+            const start_buf = @intFromPtr(this.buf.ptr);
+            const end_buf = @intFromPtr(this.buf.ptr) + this.buf.len;
+            const start_i = @intFromPtr(input.ptr);
+            const end_i = @intFromPtr(input.ptr) + input.len;
+
+            bun.Output.panic("SlicedString.sub input [{}, {}) is not a substring of the " ++
+                "slice [{}, {})", .{ start_i, end_i, start_buf, end_buf });
         }
     }
     return SlicedString{ .buf = this.buf, .slice = input };


### PR DESCRIPTION
### What does this PR do?

Fixes a small bug I found in https://github.com/oven-sh/bun/pull/23107 which caused `SlicedString` not to correctly provide us with subslices.

This would have been a **killer** use-case for the interval utility we decided to reject in https://github.com/oven-sh/bun/pull/23882. Consider how nice the code could've been:

```zig
pub inline fn sub(this: SlicedString, input: string) SlicedString {
    const buf_r = bun.math.interval.fromSlice(this.buf);
    const inp_r = bun.math.interval.fromSlice(this.input);

    if (Environment.allow_assert) {
        if (!buf_r.superset(inp_r)) {
            bun.Output.panic("SlicedString.sub input [{}, {}) is not a substring of the " ++
                "slice [{}, {})", .{ start_i, end_i, start_buf, end_buf });
        }
    }
    return SlicedString{ .buf = this.buf, .slice = input };
}
```

That's a lot more readable than the middle-school algebra we have here, but here we are.

### How did you verify your code works?

CI