### PR TITLE
Fix Windows bunx fast path index out of bounds panic

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1562,7 +1562,7 @@ pub const RunCommand = struct {
             @memcpy(ptr[0..ext.len], ext);
             ptr[ext.len] = 0;
 
-            const l = root.len + cwd_len + prefix.len + target_name.len + ext.len;
+            const l = root.len + cwd_len + prefix.len + encoded.len + ext.len;
             const path_to_use = BunXFastPath.direct_launch_buffer[0..l :0];
             BunXFastPath.tryLaunch(ctx, path_to_use, this_transpiler.env, ctx.passthrough);
         }


### PR DESCRIPTION
## Summary

Fixed a bug in the Windows bunx fast path code where UTF-8 byte length was incorrectly used instead of UTF-16 code unit length when calculating buffer offsets.

## Details

In `run_command.zig:1565`, the code was using `target_name.len` (UTF-8 byte length) instead of `encoded.len` (UTF-16 code unit length) when calculating the total path length. This caused an index out of bounds panic when package names contained multi-byte UTF-8 characters.

**Example scenario:**
- Package name contains character "中" (U+4E2D)
- UTF-8: 3 bytes (0xE4 0xB8 0xAD) → `target_name.len` counts as 3
- UTF-16: 1 code unit (0x4E2D) → `encoded.len` counts as 1
- Using the wrong length led to: `panic: index out of bounds: index 62, len 60`

## Changes

- Changed line 1565 from `target_name.len` to `encoded.len`

## Test plan

- [x] Build compiles successfully
- [x] Code review confirms the fix addresses the root cause
- [ ] Windows-specific testing (if available)

Fixes the panic reported in Sentry/crash reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)