### PR TITLE
Fix Response constructor crash when passed a function as init

### DIFF
--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -715,11 +715,17 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame, j
                 .headers = null,
             };
         }
+        if (arguments[1].isCallable()) {
+            if (!globalThis.hasException()) {
+                return globalThis.throwInvalidArguments("Failed to construct 'Response': The provided value is not of type 'ResponseInit'", .{});
+            }
+            return error.JSError;
+        }
         if (arguments[1].isObject()) {
             break :brk try Init.init(globalThis, arguments[1]) orelse unreachable;
         }
         if (!globalThis.hasException()) {
-            return globalThis.throwInvalidArguments("Failed to construct 'Response': The provided body value is not of type 'ResponseInit'", .{});
+            return globalThis.throwInvalidArguments("Failed to construct 'Response': The provided value is not of type 'ResponseInit'", .{});
         }
         return error.JSError;
     });

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (3.82 KB) {
+    "Response (4.28 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -108,4 +108,17 @@ test("new Response(123, { statusText: 123 }) does not throw", () => {
 test("new Response(123, { method: 456 }) does not throw", () => {
   // @ts-expect-error
   expect(() => new Response("123", { method: 456 })).not.toThrow();
+});
+
+test("Response constructor should reject function as init (regression test for stack overflow)", () => {
+  function f0() {
+    const v1 = [1046375616, -1024, -1024, -268435456, 536870887, -77930801, -53473, 24365];
+    // @ts-expect-error - Testing invalid usage
+    Response(v1, f0, f0).arrayBuffer(v1, Response);
+    v1.forEach(f0);
+    return Response;
+  }
+
+  // This should throw an error instead of causing a stack overflow
+  expect(() => f0()).toThrow();
 });


### PR DESCRIPTION
## Summary

Fixes a stack overflow crash that occurred when passing a function as the second argument (ResponseInit) to the Response constructor.

## The Bug

The Response constructor was checking `isObject()` to validate the second argument, which returns `true` for functions. It would then call `Init.init()` which attempts to read properties like `.headers`, `.status`, etc. from the object. When a function is passed, this could cause infinite recursion in edge cases.

Example crash case:
```js
function f0() {
    const v1 = [1046375616,-1024,-1024,-268435456,536870887,-77930801,-53473,24365];
    Response(v1, f0, f0).arrayBuffer(v1, Response);
    v1.forEach(f0);
    return Response;
}
f0(); // Would crash with stack overflow
```

## The Fix

Added an explicit check using `isCallable()` to reject callable objects before processing them as ResponseInit. Now it throws a proper TypeError:

```
TypeError: Failed to construct 'Response': The provided value is not of type 'ResponseInit'
```

## Testing

- Added regression test in `test/js/web/fetch/response.test.ts`
- All existing Response tests pass
- Verified the fix prevents the stack overflow

## Impact

Low risk - this only affects invalid API usage (passing a function where an object is expected). The fix makes the error handling more robust and prevents crashes.