### PR TITLE
Fix null pointer dereference in CookieMap.delete() with invalid constructor args

### DIFF
--- a/src/bun.js/bindings/webcore/JSCookieMap.cpp
+++ b/src/bun.js/bindings/webcore/JSCookieMap.cpp
@@ -455,8 +455,12 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_deleteBody(JSC::J
         auto* options = optionsArg.getObject();
 
         // Extract name
-        if (nameValue.isUndefined()) nameValue = options->getIfPropertyExists(lexicalGlobalObject, PropertyName(vm.propertyNames->name));
-        RETURN_IF_EXCEPTION(throwScope, {});
+        if (nameValue.isUndefined()) {
+            auto nameValueFromOptions = options->getIfPropertyExists(lexicalGlobalObject, PropertyName(vm.propertyNames->name));
+            RETURN_IF_EXCEPTION(throwScope, {});
+            if (nameValueFromOptions)
+                nameValue = nameValueFromOptions;
+        }
 
         // Extract optional domain
         auto domainValue = options->getIfPropertyExists(lexicalGlobalObject, names.domainPublicName());

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -330,4 +330,13 @@ describe("iterator", () => {
     a=b"
   `);
   });
+
+  test("delete with invalid constructor args should not crash", () => {
+    // Regression test for null pointer deref when calling delete with invalid args
+    const CookieMapConstructor = Bun.CookieMap;
+    const cookieMap = new CookieMapConstructor(CookieMapConstructor, CookieMapConstructor, Bun, CookieMapConstructor);
+    // Should throw TypeError instead of crashing with null pointer dereference
+    expect(() => cookieMap.delete(cookieMap)).toThrow(TypeError);
+    expect(() => cookieMap.delete(cookieMap)).toThrow("Cookie name is required");
+  });
 });

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -336,7 +336,6 @@ describe("iterator", () => {
     const CookieMapConstructor = Bun.CookieMap;
     const cookieMap = new CookieMapConstructor(CookieMapConstructor, CookieMapConstructor, Bun, CookieMapConstructor);
     // Should throw TypeError instead of crashing with null pointer dereference
-    expect(() => cookieMap.delete(cookieMap)).toThrow(TypeError);
-    expect(() => cookieMap.delete(cookieMap)).toThrow("Cookie name is required");
+    expect(() => cookieMap.delete(cookieMap)).toThrow(new TypeError("Cookie name is required"));
   });
 });

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -333,8 +333,7 @@ describe("iterator", () => {
 
   test("delete with invalid constructor args should not crash", () => {
     // Regression test for null pointer deref when calling delete with invalid args
-    const CookieMapConstructor = Bun.CookieMap;
-    const cookieMap = new CookieMapConstructor(CookieMapConstructor, CookieMapConstructor, Bun, CookieMapConstructor);
+    const cookieMap = new Bun.CookieMap(Bun.CookieMap, Bun.CookieMap, Bun, Bun.CookieMap);
     // Should throw TypeError instead of crashing with null pointer dereference
     expect(() => cookieMap.delete(cookieMap)).toThrow(new TypeError("Cookie name is required"));
   });


### PR DESCRIPTION
## Summary

Fixes a null pointer dereference crash when `CookieMap.delete()` is called with invalid arguments after the CookieMap was constructed with invalid constructor arguments.

## Root Cause

In `jsCookieMapPrototypeFunction_deleteBody`, the code was directly assigning the return value of `getIfPropertyExists()` without checking if it was valid:

```cpp
if (nameValue.isUndefined()) nameValue = options->getIfPropertyExists(...);
```

When `getIfPropertyExists()` doesn't find a property, it returns an empty JSValue, which was being assigned directly to `nameValue`, leading to a null pointer dereference.

## The Fix

Added proper validation to check if the returned JSValue is valid before assigning it, matching the pattern already used for `domain` and `path` extraction in the same function.

## Test Plan

- [x] Added regression test in `test/js/bun/cookie/cookie-map.test.ts`
- [x] Test verifies the fix throws `TypeError: Cookie name is required` instead of crashing
- [x] All 22 tests in cookie-map test suite pass
- [x] Verified with `bun bd test test/js/bun/cookie/cookie-map.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)