### PR TITLE
Fix malformed error message in ReadableStream.getReader

### DIFF
--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -395,7 +395,7 @@ export function getReader(this, options) {
     return new ReadableStreamBYOBReader(this);
   }
 
-  throw $ERR_INVALID_ARG_VALUE("mode", mode, "byob");
+  throw $ERR_INVALID_ARG_VALUE("mode", mode, "must be 'byob'");
 }
 
 export function pipeThrough(this, streams, options) {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1142,3 +1142,17 @@ it("pipeThrough doesn't cause unhandled rejections on readable errors", async ()
 
   expect(unhandledRejectionCaught).toBe(false);
 });
+
+it("ReadableStream.getReader with invalid mode should show correct error message", () => {
+  const stream = new ReadableStream();
+
+  // Test with invalid mode value
+  try {
+    stream.getReader({ mode: "invalid" });
+    expect.unreachable("Should have thrown an error");
+  } catch (error) {
+    expect(error.code).toBe("ERR_INVALID_ARG_VALUE");
+    expect(error.message).toContain("must be 'byob'");
+    expect(error.message).toContain("mode");
+  }
+});


### PR DESCRIPTION
## Summary
Fixes a malformed error message in `ReadableStream.getReader()` when an invalid `mode` argument is provided.

## Before
```
The argument 'mode' byob. Received 'invalid'
```

## After
```
The argument 'mode' must be 'byob'. Received 'invalid'
```

## Changes
- Updated `src/js/builtins/ReadableStream.ts:398` to include "must be 'byob'" instead of just "byob"
- Added regression test in `test/js/web/streams/streams.test.js`

## Testing
```bash
# Test the specific fix
bun bd test test/js/web/streams/streams.test.js -t "invalid mode"
```

The test passes with the fix and fails with the old code, confirming proper error message formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)