### PR TITLE
Fix Buffer.isEncoding('') to return false

### DIFF
--- a/src/bun.js/bindings/JSBufferEncodingType.cpp
+++ b/src/bun.js/bindings/JSBufferEncodingType.cpp
@@ -104,9 +104,7 @@ template<> std::optional<BufferEncodingType> parseEnumerationFromView<BufferEnco
 {
     // caller must check if value is a string
     switch (encoding.length()) {
-    case 0: {
-        return BufferEncodingType::utf8;
-    }
+    case 0:
     case 1:
     case 2: {
         return std::nullopt;

--- a/test/regression/issue23966.test.ts
+++ b/test/regression/issue23966.test.ts
@@ -22,7 +22,6 @@ test("Buffer.isEncoding() should match Node.js behavior", () => {
   expect(Buffer.isEncoding("utf-16le")).toBe(true);
 
   // Invalid encodings should return false
-  expect(Buffer.isEncoding("")).toBe(false);
   expect(Buffer.isEncoding("invalid")).toBe(false);
   expect(Buffer.isEncoding("utf32")).toBe(false);
   expect(Buffer.isEncoding("something")).toBe(false);

--- a/test/regression/issue23966.test.ts
+++ b/test/regression/issue23966.test.ts
@@ -1,0 +1,36 @@
+// https://github.com/oven-sh/bun/issues/23966
+// Buffer.isEncoding() behaves differently in Bun compared to Node.js
+import { expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+
+test("Buffer.isEncoding('') should return false", () => {
+  expect(Buffer.isEncoding("")).toBe(false);
+});
+
+test("Buffer.isEncoding() should match Node.js behavior", () => {
+  // Valid encodings should return true
+  expect(Buffer.isEncoding("utf8")).toBe(true);
+  expect(Buffer.isEncoding("utf-8")).toBe(true);
+  expect(Buffer.isEncoding("hex")).toBe(true);
+  expect(Buffer.isEncoding("base64")).toBe(true);
+  expect(Buffer.isEncoding("ascii")).toBe(true);
+  expect(Buffer.isEncoding("latin1")).toBe(true);
+  expect(Buffer.isEncoding("binary")).toBe(true);
+  expect(Buffer.isEncoding("ucs2")).toBe(true);
+  expect(Buffer.isEncoding("ucs-2")).toBe(true);
+  expect(Buffer.isEncoding("utf16le")).toBe(true);
+  expect(Buffer.isEncoding("utf-16le")).toBe(true);
+
+  // Invalid encodings should return false
+  expect(Buffer.isEncoding("")).toBe(false);
+  expect(Buffer.isEncoding("invalid")).toBe(false);
+  expect(Buffer.isEncoding("utf32")).toBe(false);
+  expect(Buffer.isEncoding("something")).toBe(false);
+
+  // Non-string values should return false
+  expect(Buffer.isEncoding(123 as any)).toBe(false);
+  expect(Buffer.isEncoding(null as any)).toBe(false);
+  expect(Buffer.isEncoding(undefined as any)).toBe(false);
+  expect(Buffer.isEncoding({} as any)).toBe(false);
+  expect(Buffer.isEncoding([] as any)).toBe(false);
+});

--- a/test/regression/issue23966.test.ts
+++ b/test/regression/issue23966.test.ts
@@ -3,33 +3,40 @@
 import { expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 
-test("Buffer.isEncoding('') should return false", () => {
+test.concurrent("Buffer.isEncoding('') should return false", () => {
   expect(Buffer.isEncoding("")).toBe(false);
 });
 
-test("Buffer.isEncoding() should match Node.js behavior", () => {
-  // Valid encodings should return true
-  expect(Buffer.isEncoding("utf8")).toBe(true);
-  expect(Buffer.isEncoding("utf-8")).toBe(true);
-  expect(Buffer.isEncoding("hex")).toBe(true);
-  expect(Buffer.isEncoding("base64")).toBe(true);
-  expect(Buffer.isEncoding("ascii")).toBe(true);
-  expect(Buffer.isEncoding("latin1")).toBe(true);
-  expect(Buffer.isEncoding("binary")).toBe(true);
-  expect(Buffer.isEncoding("ucs2")).toBe(true);
-  expect(Buffer.isEncoding("ucs-2")).toBe(true);
-  expect(Buffer.isEncoding("utf16le")).toBe(true);
-  expect(Buffer.isEncoding("utf-16le")).toBe(true);
+const validEncodings = [
+  "utf8",
+  "utf-8",
+  "hex",
+  "base64",
+  "ascii",
+  "latin1",
+  "binary",
+  "ucs2",
+  "ucs-2",
+  "utf16le",
+  "utf-16le",
+];
+const invalidEncodings = ["invalid", "utf32", "something"];
+const nonStringValues = [
+  { value: 123, name: "number" },
+  { value: null, name: "null" },
+  { value: undefined, name: "undefined" },
+  { value: {}, name: "object" },
+  { value: [], name: "array" },
+];
 
-  // Invalid encodings should return false
-  expect(Buffer.isEncoding("invalid")).toBe(false);
-  expect(Buffer.isEncoding("utf32")).toBe(false);
-  expect(Buffer.isEncoding("something")).toBe(false);
+test.concurrent.each(validEncodings)("Buffer.isEncoding('%s') should return true", encoding => {
+  expect(Buffer.isEncoding(encoding)).toBe(true);
+});
 
-  // Non-string values should return false
-  expect(Buffer.isEncoding(123 as any)).toBe(false);
-  expect(Buffer.isEncoding(null as any)).toBe(false);
-  expect(Buffer.isEncoding(undefined as any)).toBe(false);
-  expect(Buffer.isEncoding({} as any)).toBe(false);
-  expect(Buffer.isEncoding([] as any)).toBe(false);
+test.concurrent.each(invalidEncodings)("Buffer.isEncoding('%s') should return false", encoding => {
+  expect(Buffer.isEncoding(encoding)).toBe(false);
+});
+
+test.concurrent.each(nonStringValues)("Buffer.isEncoding($name) should return false for non-string", ({ value }) => {
+  expect(Buffer.isEncoding(value as any)).toBe(false);
 });


### PR DESCRIPTION
## Summary
Fixes `Buffer.isEncoding('')` to return `false` instead of `true`, matching Node.js behavior.

## Description
Previously, `Buffer.isEncoding('')` incorrectly returned `true` in Bun, while Node.js correctly returns `false`. This was caused by `parseEnumerationFromView` in `JSBufferEncodingType.cpp` treating empty strings (length 0) as valid utf8 encoding.

The fix modifies the switch statement to return `std::nullopt` for empty strings, along with other invalid short strings.

## Changes
- Modified `src/bun.js/bindings/JSBufferEncodingType.cpp` to return `std::nullopt` for empty strings
- Added regression test `test/regression/issue23966.test.ts`

## Test Plan
- [x] Test fails with `USE_SYSTEM_BUN=1 bun test test/regression/issue23966.test.ts` (confirms bug exists)
- [x] Test passes with `bun bd test test/regression/issue23966.test.ts` (confirms fix works)
- [x] Verified behavior matches Node.js v24.3.0
- [x] All test cases for valid/invalid encodings pass

Fixes #23966

🤖 Generated with [Claude Code](https://claude.com/claude-code)