### PR TITLE
Fix segv when `process.nextTick` is overwritten

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3437,7 +3437,10 @@ void Process::queueNextTick(JSC::JSGlobalObject* globalObject, const ArgList& ar
 
     ASSERT(!args.isEmpty());
     JSObject* nextTickFn = this->m_nextTickFunction.get();
-    ASSERT(nextTickFn);
+    if (!nextTickFn) [[unlikely]] {
+        throwVMError(globalObject, scope, "Faild to call nextTick"_s);
+        return;
+    }
     ASSERT_WITH_MESSAGE(!args.at(0).inherits<AsyncContextFrame>(), "queueNextTick must not pass an AsyncContextFrame. This will cause a crash.");
     JSC::call(globalObject, nextTickFn, args, "Failed to call nextTick"_s);
     RELEASE_AND_RETURN(scope, void());

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import crypto from "crypto";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, gc, tls, tempDir } from "harness";
+import { bunEnv, bunExe, gc, tempDir, tls } from "harness";
 import { createServer } from "net";
 import { join } from "path";
 import process from "process";


### PR DESCRIPTION
### What does this PR do?

When `process.nextTick` is overwritten, segv will be occured via internal `processTick` call.
This patch fixes it.

### How did you verify your code works?

Tests.
