### PR TITLE
feat(install): add insecure flag to skip tls/ssl certificate validation

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -3051,6 +3051,8 @@ pub const api = struct {
             list: []const []const u8,
         } = null,
 
+        insecure: ?bool = null,
+
         ignore_scripts: ?bool = null,
 
         link_workspace_packages: ?bool = null,

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -3051,6 +3051,7 @@ pub const api = struct {
             list: []const []const u8,
         } = null,
 
+        /// insecure
         insecure: ?bool = null,
 
         ignore_scripts: ?bool = null,

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -494,6 +494,15 @@ pub const Bunfig = struct {
                     if (install_obj.get("insecure")) |insecure| {
                         if (insecure.asBool()) |value| {
                             install.insecure = value;
+                            
+                            // Warn if CA/cafile settings are present but will be ignored due to insecure mode
+                            if (value) {
+                                if (install_obj.get("ca")) |_| {
+                                    this.log.addWarning(this.source, insecure.loc, "CA settings will be ignored when insecure mode is enabled") catch {};
+                                } else if (install_obj.get("cafile")) |_| {
+                                    this.log.addWarning(this.source, insecure.loc, "cafile settings will be ignored when insecure mode is enabled") catch {};
+                                }
+                            }
                         }
                     }
 

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -491,6 +491,12 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (install_obj.get("insecure")) |insecure| {
+                        if (insecure.asBool()) |value| {
+                            install.insecure = value;
+                        }
+                    }
+
                     if (install_obj.get("exact")) |exact| {
                         if (exact.asBool()) |value| {
                             install.exact = value;

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -135,12 +135,13 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             const reject_unauthorized: i32 = if (init_opts.insecure) 0 else 1;
             
             // Guard against overflow when casting ca.len to ca_count field type
-            const ca_count_max = std.math.maxInt(@TypeOf(@as(uws.SocketContext.BunSocketContextOptions, undefined).ca_count));
-            const ca_count_value: u32 = if (!init_opts.insecure) value: {
+            const CaCountT = @TypeOf(@as(uws.SocketContext.BunSocketContextOptions, undefined).ca_count);
+            const ca_count_max = std.math.maxInt(CaCountT);
+            const ca_count_value: CaCountT = if (!init_opts.insecure) value: {
                 if (bun.Environment.isDebug) {
                     bun.assert(init_opts.ca.len <= ca_count_max);
                 }
-                break :value @intCast(@min(init_opts.ca.len, ca_count_max));
+                break :value @as(CaCountT, @intCast(@min(init_opts.ca.len, ca_count_max)));
             } else 0;
             
             var opts: uws.SocketContext.BunSocketContextOptions = .{

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -123,12 +123,16 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             if (!comptime ssl) {
                 @compileError("ssl only");
             }
+            
+            // When insecure mode is enabled, disable all certificate verification
+            const reject_unauthorized: i32 = if (init_opts.insecure) 0 else 1;
+            
             var opts: uws.SocketContext.BunSocketContextOptions = .{
                 .ca = if (init_opts.ca.len > 0 and !init_opts.insecure) @ptrCast(init_opts.ca) else null,
                 .ca_count = if (!init_opts.insecure) @intCast(init_opts.ca.len) else 0,
                 .ca_file_name = if (init_opts.abs_ca_file_name.len > 0 and !init_opts.insecure) init_opts.abs_ca_file_name else null,
                 .request_cert = 1,
-                .reject_unauthorized = if (init_opts.insecure) 0 else 1,
+                .reject_unauthorized = reject_unauthorized,
             };
 
             try this.initWithOpts(&opts);

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -124,10 +124,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 @compileError("ssl only");
             }
             var opts: uws.SocketContext.BunSocketContextOptions = .{
-                .ca = if (init_opts.ca.len > 0) @ptrCast(init_opts.ca) else null,
-                .ca_count = @intCast(init_opts.ca.len),
-                .ca_file_name = if (init_opts.abs_ca_file_name.len > 0) init_opts.abs_ca_file_name else null,
+                .ca = if (init_opts.ca.len > 0 and !init_opts.insecure) @ptrCast(init_opts.ca) else null,
+                .ca_count = if (!init_opts.insecure) @intCast(init_opts.ca.len) else 0,
+                .ca_file_name = if (init_opts.abs_ca_file_name.len > 0 and !init_opts.insecure) init_opts.abs_ca_file_name else null,
                 .request_cert = 1,
+                .reject_unauthorized = if (init_opts.insecure) 0 else 1,
             };
 
             try this.initWithOpts(&opts);

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -159,6 +159,7 @@ pub const InitOpts = struct {
     ca: []stringZ = &.{},
     abs_ca_file_name: stringZ = &.{},
     for_install: bool = false,
+    insecure: bool = false,
 
     onInitError: *const fn (err: InitError, opts: InitOpts) noreturn = &onInitErrorNoop,
 };

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -170,10 +170,12 @@ fn initOnce(opts: *const InitOpts) void {
         .http_context = .{
             .us_socket_context = undefined,
             .pending_sockets = NewHTTPContext(false).PooledSocketHiveAllocator.empty,
+            .insecure = false,
         },
         .https_context = .{
             .us_socket_context = undefined,
             .pending_sockets = NewHTTPContext(true).PooledSocketHiveAllocator.empty,
+            .insecure = false,
         },
         .timer = std.time.Timer.start() catch unreachable,
     };

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -374,6 +374,9 @@ pub fn httpProxy(this: *PackageManager, url: URL) ?URL {
 }
 
 pub fn tlsRejectUnauthorized(this: *PackageManager) bool {
+    if (this.options.insecure) {
+        return false;
+    }
     return this.env.getTLSRejectUnauthorized();
 }
 

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -920,9 +920,9 @@ pub fn init(
     var ca: []stringZ = &.{};
     var abs_ca_file_name: stringZ = &.{};
     
-    // Skip CA file loading if --insecure is set
+    // Skip CA file loading if insecure mode is enabled (via --insecure flag or bunfig)
     if (manager.options.insecure) {
-        Output.warn("Using --insecure flag: TLS/SSL certificate verification is disabled. This is dangerous and should only be used for debugging.", .{});
+        Output.warn("Insecure mode enabled (--insecure or bunfig): TLS/SSL certificate verification is disabled. This is dangerous and should only be used for debugging.", .{});
         Output.flush();
     } else {
         if (manager.options.ca.len > 0) {

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -915,26 +915,33 @@ pub fn init(
     );
 
     var ca: []stringZ = &.{};
-    if (manager.options.ca.len > 0) {
-        ca = try manager.allocator.alloc(stringZ, manager.options.ca.len);
-        for (ca, manager.options.ca) |*z, s| {
-            z.* = try manager.allocator.dupeZ(u8, s);
-        }
-    }
-
     var abs_ca_file_name: stringZ = &.{};
-    if (manager.options.ca_file_name.len > 0) {
-        // resolve with original cwd
-        if (std.fs.path.isAbsolute(manager.options.ca_file_name)) {
-            abs_ca_file_name = try manager.allocator.dupeZ(u8, manager.options.ca_file_name);
-        } else {
-            var path_buf: bun.PathBuffer = undefined;
-            abs_ca_file_name = try manager.allocator.dupeZ(u8, bun.path.joinAbsStringBuf(
-                original_cwd_clone,
-                &path_buf,
-                &.{manager.options.ca_file_name},
-                .auto,
-            ));
+    
+    // Skip CA file loading if --insecure is set
+    if (manager.options.insecure) {
+        Output.warn("Using --insecure flag: TLS/SSL certificate verification is disabled. This is dangerous and should only be used for debugging.", .{});
+        Output.flush();
+    } else {
+        if (manager.options.ca.len > 0) {
+            ca = try manager.allocator.alloc(stringZ, manager.options.ca.len);
+            for (ca, manager.options.ca) |*z, s| {
+                z.* = try manager.allocator.dupeZ(u8, s);
+            }
+        }
+
+        if (manager.options.ca_file_name.len > 0) {
+            // resolve with original cwd
+            if (std.fs.path.isAbsolute(manager.options.ca_file_name)) {
+                abs_ca_file_name = try manager.allocator.dupeZ(u8, manager.options.ca_file_name);
+            } else {
+                var path_buf: bun.PathBuffer = undefined;
+                abs_ca_file_name = try manager.allocator.dupeZ(u8, bun.path.joinAbsStringBuf(
+                    original_cwd_clone,
+                    &path_buf,
+                    &.{manager.options.ca_file_name},
+                    .auto,
+                ));
+            }
         }
     }
 
@@ -954,6 +961,7 @@ pub fn init(
     HTTP.HTTPThread.init(&.{
         .ca = ca,
         .abs_ca_file_name = abs_ca_file_name,
+        .insecure = manager.options.insecure,
         .onInitError = &httpThreadOnInitError,
     });
 

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -27,6 +27,7 @@ const shared_params = [_]ParamType{
     clap.parseParam("--save                                Save to package.json (true by default)") catch unreachable,
     clap.parseParam("--ca <STR>...                         Provide a Certificate Authority signing certificate") catch unreachable,
     clap.parseParam("--cafile <STR>                        The same as `--ca`, but is a file path to the certificate") catch unreachable,
+    clap.parseParam("--insecure                            Skip TLS/SSL certificate verification (dangerous, use only for debugging)") catch unreachable,
     clap.parseParam("--dry-run                             Don't install anything") catch unreachable,
     clap.parseParam("--frozen-lockfile                     Disallow changes to lockfile") catch unreachable,
     clap.parseParam("-f, --force                           Always request the latest versions from the registry & reinstall all dependencies") catch unreachable,
@@ -226,6 +227,7 @@ tolerate_republish: bool = false,
 
 ca: []const string = &.{},
 ca_file_name: string = "",
+insecure: bool = false,
 
 save_text_lockfile: ?bool = null,
 
@@ -824,6 +826,8 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     if (args.option("--cafile")) |ca_file_name| {
         cli.ca_file_name = ca_file_name;
     }
+
+    cli.insecure = args.flag("--insecure");
 
     if (args.option("--network-concurrency")) |network_concurrency| {
         cli.network_concurrency = std.fmt.parseInt(u16, network_concurrency, 10) catch {

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -689,7 +689,9 @@ pub fn load(
         if (cli.ca_file_name.len > 0) {
             this.ca_file_name = cli.ca_file_name;
         }
-        this.insecure = cli.insecure;
+        if (cli.insecure) {
+            this.insecure = true;
+        }
 
         // `bun pm version` command options
         this.git_tag_version = cli.git_tag_version;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -51,6 +51,7 @@ publish_config: PublishConfig = .{},
 
 ca: []const string = &.{},
 ca_file_name: string = &.{},
+insecure: bool = false,
 
 // if set to `false` in bunfig, save a binary lockfile
 save_text_lockfile: ?bool = null,
@@ -305,6 +306,10 @@ pub fn load(
 
         if (config.cafile) |cafile| {
             this.ca_file_name = cafile;
+        }
+
+        if (config.insecure) |insecure| {
+            this.insecure = insecure;
         }
 
         if (config.disable_cache orelse false) {
@@ -684,6 +689,7 @@ pub fn load(
         if (cli.ca_file_name.len > 0) {
             this.ca_file_name = cli.ca_file_name;
         }
+        this.insecure = cli.insecure;
 
         // `bun pm version` command options
         this.git_tag_version = cli.git_tag_version;

--- a/test/cli/install/bun-install-insecure-tls.test.ts
+++ b/test/cli/install/bun-install-insecure-tls.test.ts
@@ -64,8 +64,8 @@ registry = "https://localhost:${server.port}/"
     const stderrText1 = await stderr1.text();
     const exitCode1 = await exited1;
 
-    expect(exitCode1).toBe(1);
     expect(stderrText1).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(exitCode1).toBe(1);
 
     // Now try with --insecure - should succeed and show warning
     // Run in a fresh process to ensure HTTP thread is initialized with --insecure
@@ -81,10 +81,10 @@ registry = "https://localhost:${server.port}/"
     const stderrText2 = await proc2.stderr.text();
     const exitCode2 = await proc2.exited;
 
-    expect(exitCode2).toBe(0);
     expect(stderrText2).toContain("--insecure");
     expect(stderrText2).toContain("TLS/SSL certificate verification is disabled");
     expect(stderrText2).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(exitCode2).toBe(0);
 
     // Verify package was installed
     const installed = await readdirSorted(join(testDir, "node_modules"));

--- a/test/cli/install/bun-install-insecure-tls.test.ts
+++ b/test/cli/install/bun-install-insecure-tls.test.ts
@@ -52,7 +52,7 @@ registry = "https://localhost:${server.port}/"
     });
 
     // First, try without --insecure - should fail with certificate error
-    const { stderr: stderr1, exited: exited1 } = spawn({
+    const { stdout: stdout1, stderr: stderr1, exited: exited1 } = spawn({
       cmd: [bunExe(), "install"],
       cwd: testDir,
       env: bunEnv,
@@ -60,15 +60,16 @@ registry = "https://localhost:${server.port}/"
       stderr: "pipe",
     });
 
-    const exitCode1 = await exited1;
+    const stdoutText1 = await stdout1.text();
     const stderrText1 = await stderr1.text();
+    const exitCode1 = await exited1;
 
     expect(exitCode1).toBe(1);
     expect(stderrText1).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
 
     // Now try with --insecure - should succeed and show warning
     // Run in a fresh process to ensure HTTP thread is initialized with --insecure
-    const { stdout: stdout2, stderr: stderr2, exited: exited2 } = spawn({
+    await using proc2 = spawn({
       cmd: [bunExe(), "install", "--insecure"],
       cwd: testDir,
       env: bunEnv,
@@ -76,8 +77,9 @@ registry = "https://localhost:${server.port}/"
       stderr: "pipe",
     });
 
-    const exitCode2 = await exited2;
-    const stderrText2 = await stderr2.text();
+    const stdoutText2 = await proc2.stdout.text();
+    const stderrText2 = await proc2.stderr.text();
+    const exitCode2 = await proc2.exited;
 
     expect(exitCode2).toBe(0);
     expect(stderrText2).toContain("--insecure");

--- a/test/cli/install/bun-install-insecure-tls.test.ts
+++ b/test/cli/install/bun-install-insecure-tls.test.ts
@@ -1,7 +1,6 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { writeFile } from "fs/promises";
-import { bunEnv, bunExe, readdirSorted, tmpdirSync, tls } from "harness";
+import { bunEnv, bunExe, readdirSorted, tempDir, tls } from "harness";
 import { join } from "path";
 
 describe("bun install --insecure with HTTPS", () => {
@@ -37,26 +36,20 @@ describe("bun install --insecure with HTTPS", () => {
       ...tls, // Use self-signed cert
     });
 
-    const testDir = tmpdirSync();
-    await writeFile(
-      join(testDir, "package.json"),
-      JSON.stringify({
+    using testDir = tempDir("test-insecure-https", {
+      "package.json": JSON.stringify({
         name: "test-insecure-https",
         version: "1.0.0",
         dependencies: {
           bar: "0.0.2",
         },
       }),
-    );
-
-    await writeFile(
-      join(testDir, "bunfig.toml"),
-      `
+      "bunfig.toml": `
 [install]
 cache = false
 registry = "https://localhost:${server.port}/"
 `,
-    );
+    });
 
     // First, try without --insecure - should fail with certificate error
     const { stderr: stderr1, exited: exited1 } = spawn({

--- a/test/cli/install/bun-install-insecure-tls.test.ts
+++ b/test/cli/install/bun-install-insecure-tls.test.ts
@@ -81,7 +81,7 @@ registry = "https://localhost:${server.port}/"
     const stderrText2 = await proc2.stderr.text();
     const exitCode2 = await proc2.exited;
 
-    expect(stderrText2).toContain("--insecure");
+    expect(stderrText2).toContain("Insecure mode enabled");
     expect(stderrText2).toContain("TLS/SSL certificate verification is disabled");
     expect(stderrText2).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
     expect(exitCode2).toBe(0);

--- a/test/cli/install/bun-install-insecure-tls.test.ts
+++ b/test/cli/install/bun-install-insecure-tls.test.ts
@@ -1,0 +1,99 @@
+import { file, spawn } from "bun";
+import { describe, expect, it } from "bun:test";
+import { writeFile } from "fs/promises";
+import { bunEnv, bunExe, readdirSorted, tmpdirSync, tls } from "harness";
+import { join } from "path";
+
+describe("bun install --insecure with HTTPS", () => {
+  it("should bypass self-signed certificate errors with --insecure", async () => {
+    // Set up an HTTPS server with a self-signed certificate
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith(".tgz")) {
+          // Serve the tarball
+          return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+        }
+        // Serve package metadata
+        return new Response(
+          JSON.stringify({
+            name: "bar",
+            versions: {
+              "0.0.2": {
+                name: "bar",
+                version: "0.0.2",
+                dist: {
+                  tarball: `https://localhost:${server.port}/bar-0.0.2.tgz`,
+                },
+              },
+            },
+            "dist-tags": {
+              latest: "0.0.2",
+            },
+          }),
+        );
+      },
+      ...tls, // Use self-signed cert
+    });
+
+    const testDir = tmpdirSync();
+    await writeFile(
+      join(testDir, "package.json"),
+      JSON.stringify({
+        name: "test-insecure-https",
+        version: "1.0.0",
+        dependencies: {
+          bar: "0.0.2",
+        },
+      }),
+    );
+
+    await writeFile(
+      join(testDir, "bunfig.toml"),
+      `
+[install]
+cache = false
+registry = "https://localhost:${server.port}/"
+`,
+    );
+
+    // First, try without --insecure - should fail with certificate error
+    const { stderr: stderr1, exited: exited1 } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: testDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode1 = await exited1;
+    const stderrText1 = await stderr1.text();
+
+    expect(exitCode1).toBe(1);
+    expect(stderrText1).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+
+    // Now try with --insecure - should succeed and show warning
+    // Run in a fresh process to ensure HTTP thread is initialized with --insecure
+    const { stdout: stdout2, stderr: stderr2, exited: exited2 } = spawn({
+      cmd: [bunExe(), "install", "--insecure"],
+      cwd: testDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode2 = await exited2;
+    const stderrText2 = await stderr2.text();
+
+    expect(exitCode2).toBe(0);
+    expect(stderrText2).toContain("--insecure");
+    expect(stderrText2).toContain("TLS/SSL certificate verification is disabled");
+    expect(stderrText2).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+
+    // Verify package was installed
+    const installed = await readdirSorted(join(testDir, "node_modules"));
+    expect(installed).toContain("bar");
+  });
+});
+

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -1,7 +1,7 @@
-import { spawn } from "bun";
+import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { writeFile } from "fs/promises";
-import { bunEnv, bunExe, readdirSorted } from "harness";
+import { bunEnv, bunExe, readdirSorted, tempDir, tls } from "harness";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -9,6 +9,7 @@ import {
   dummyBeforeAll,
   dummyBeforeEach,
   dummyRegistry,
+  getPort,
   package_dir,
   setHandler,
 } from "./dummy.registry";
@@ -52,8 +53,8 @@ describe("bun install --insecure flag", () => {
     const stdoutText = await stdout.text();
     const exitCode = await exited;
 
-    // Should display warning about insecure flag
-    expect(stderrText).toContain("--insecure");
+    // Should display warning about insecure mode
+    expect(stderrText).toContain("Insecure mode enabled");
     expect(stderrText).toContain("TLS/SSL certificate verification is disabled");
     expect(stderrText).toContain("dangerous");
 
@@ -101,7 +102,7 @@ describe("bun install --insecure flag", () => {
     const stdoutText = await stdout.text();
     const exitCode = await exited;
 
-    expect(stderrText).toContain("--insecure");
+    expect(stderrText).toContain("Insecure mode enabled");
     expect(exitCode).toBe(0);
 
     // Should install production dependencies only
@@ -139,7 +140,7 @@ describe("bun install --insecure flag", () => {
     const stdoutText = await stdout.text();
     const exitCode = await exited;
 
-    expect(stderrText).toContain("--insecure");
+    expect(stderrText).toContain("Insecure mode enabled");
     expect(exitCode).toBe(0);
 
     // Package should be added
@@ -179,11 +180,203 @@ describe("bun install --insecure flag", () => {
     const exitCode = await exited;
 
     // Should NOT display insecure warning in normal mode
-    expect(stderrText).not.toContain("--insecure");
+    expect(stderrText).not.toContain("Insecure mode enabled");
     expect(stderrText).not.toContain("TLS/SSL certificate verification is disabled");
     expect(exitCode).toBe(0);
 
     // Package should still be installed
+    const installed = await readdirSorted(join(package_dir, "node_modules"));
+    expect(installed).toContain("bar");
+  });
+
+  it("bunfig install.insecure=true should bypass self-signed certificate errors (verifying HTTP thread propagation)", async () => {
+    // Set up an HTTPS server with a self-signed certificate
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith(".tgz")) {
+          // Serve the tarball
+          return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+        }
+        // Serve package metadata
+        return new Response(
+          JSON.stringify({
+            name: "bar",
+            versions: {
+              "0.0.2": {
+                name: "bar",
+                version: "0.0.2",
+                dist: {
+                  tarball: `https://localhost:${server.port}/bar-0.0.2.tgz`,
+                },
+              },
+            },
+            "dist-tags": {
+              latest: "0.0.2",
+            },
+          }),
+        );
+      },
+      ...tls, // Use self-signed cert
+    });
+
+    using testDir = tempDir("test-bunfig-insecure-https", {
+      "package.json": JSON.stringify({
+        name: "test-bunfig-insecure-https",
+        version: "1.0.0",
+        dependencies: {
+          bar: "0.0.2",
+        },
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "https://localhost:${server.port}/"
+insecure = true
+`,
+    });
+
+    // With bunfig insecure=true (no CLI flag), should bypass certificate errors
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"], // No --insecure flag, using bunfig config
+      cwd: testDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdoutText = await stdout.text();
+    const stderrText = await stderr.text();
+    const exitCode = await exited;
+
+    // Should NOT fail with certificate error (proves insecure propagated to HTTP thread)
+    expect(stderrText).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(exitCode).toBe(0);
+
+    // Verify package was installed (proves the insecure config worked)
+    const installed = await readdirSorted(join(testDir, "node_modules"));
+    expect(installed).toContain("bar");
+  });
+
+  it("bunfig install.insecure=true should work with bun add and bypass TLS errors", async () => {
+    // Set up an HTTPS server with a self-signed certificate
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith(".tgz")) {
+          // Serve the tarball
+          return new Response(file(join(import.meta.dir, "boba-0.0.2.tgz")));
+        }
+        // Serve package metadata
+        return new Response(
+          JSON.stringify({
+            name: "boba",
+            versions: {
+              "0.0.2": {
+                name: "boba",
+                version: "0.0.2",
+                dist: {
+                  tarball: `https://localhost:${server.port}/boba-0.0.2.tgz`,
+                },
+              },
+            },
+            "dist-tags": {
+              latest: "0.0.2",
+            },
+          }),
+        );
+      },
+      ...tls, // Use self-signed cert
+    });
+
+    using testDir = tempDir("test-bunfig-insecure-add", {
+      "package.json": JSON.stringify({
+        name: "test-bunfig-insecure-add",
+        version: "1.0.0",
+        dependencies: {},
+      }),
+      "bunfig.toml": `
+[install]
+cache = false
+registry = "https://localhost:${server.port}/"
+insecure = true
+`,
+    });
+
+    // With bunfig insecure=true, bun add should bypass certificate errors
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", "boba@0.0.2"], // No --insecure flag
+      cwd: testDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdoutText = await stdout.text();
+    const stderrText = await stderr.text();
+    const exitCode = await exited;
+
+    // Should NOT fail with certificate error (proves insecure propagated to HTTP thread)
+    expect(stderrText).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(exitCode).toBe(0);
+
+    // Verify package was added
+    const installed = await readdirSorted(join(testDir, "node_modules"));
+    expect(installed).toContain("boba");
+  });
+
+  it("CLI --insecure flag should override bunfig install.insecure=false", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.2": {},
+      }),
+    );
+
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "test-cli-override-bunfig",
+        version: "1.0.0",
+        dependencies: {
+          bar: "0.0.2",
+        },
+      }),
+    );
+
+    // Create bunfig.toml with install.insecure = false and registry pointing to dummy
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      `[install]
+cache = false
+registry = "http://localhost:${getPort()}/"
+insecure = false
+`,
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--insecure"], // CLI flag should override
+      cwd: package_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stderrText = await stderr.text();
+    const stdoutText = await stdout.text();
+    const exitCode = await exited;
+
+    // Should display warning since CLI flag is present
+    expect(stderrText).toContain("Insecure mode enabled");
+    expect(stderrText).toContain("TLS/SSL certificate verification is disabled");
+    expect(stderrText).toContain("dangerous");
+
+    // Should succeed
+    expect(exitCode).toBe(0);
+
+    // Package should be installed
     const installed = await readdirSorted(join(package_dir, "node_modules"));
     expect(installed).toContain("bar");
   });

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -148,47 +148,6 @@ describe("bun install --insecure flag", () => {
     expect(installed).toContain("boba");
   });
 
-  it("should work without the --insecure flag (normal mode)", async () => {
-    const urls: string[] = [];
-    setHandler(
-      dummyRegistry(urls, {
-        "0.0.2": {},
-      }),
-    );
-
-    await writeFile(
-      join(package_dir, "package.json"),
-      JSON.stringify({
-        name: "test-normal-mode",
-        version: "1.0.0",
-        dependencies: {
-          bar: "0.0.2",
-        },
-      }),
-    );
-
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: package_dir,
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const stderrText = await stderr.text();
-    const stdoutText = await stdout.text();
-    const exitCode = await exited;
-
-    // Should NOT display insecure warning in normal mode
-    expect(stderrText).not.toContain("Insecure mode enabled");
-    expect(stderrText).not.toContain("TLS/SSL certificate verification is disabled");
-    expect(exitCode).toBe(0);
-
-    // Package should still be installed
-    const installed = await readdirSorted(join(package_dir, "node_modules"));
-    expect(installed).toContain("bar");
-  });
-
   it("bunfig install.insecure=true should bypass self-signed certificate errors (verifying HTTP thread propagation)", async () => {
     // Set up an HTTPS server with a self-signed certificate
     using server = Bun.serve({

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 function createRegistryHandler(urls: string[], info: any, rootUrl: string) {
   return async (request: Request) => {
     urls.push(request.url);
-    const url = request.url.replaceAll("%2f", "/");
+    const url = request.url.replaceAll(/%2f/gi, "/");
     
     if (url.endsWith(".tgz")) {
       return new Response(file(join(import.meta.dir, new URL(url).pathname.split("/").pop()!.toLowerCase())));

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -48,8 +48,9 @@ describe("bun install --insecure flag", () => {
       stderr: "pipe",
     });
 
-    const exitCode = await exited;
     const stderrText = await stderr.text();
+    const stdoutText = await stdout.text();
+    const exitCode = await exited;
 
     // Should display warning about insecure flag
     expect(stderrText).toContain("--insecure");
@@ -88,7 +89,7 @@ describe("bun install --insecure flag", () => {
     );
 
     // Test --insecure with --production
-    const { exited, stderr } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "install", "--insecure", "--production"],
       cwd: package_dir,
       env: bunEnv,
@@ -96,8 +97,9 @@ describe("bun install --insecure flag", () => {
       stderr: "pipe",
     });
 
-    const exitCode = await exited;
     const stderrText = await stderr.text();
+    const stdoutText = await stdout.text();
+    const exitCode = await exited;
 
     expect(stderrText).toContain("--insecure");
     expect(exitCode).toBe(0);
@@ -125,7 +127,7 @@ describe("bun install --insecure flag", () => {
       }),
     );
 
-    const { exited, stderr } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", "boba@0.0.2", "--insecure"],
       cwd: package_dir,
       env: bunEnv,
@@ -133,8 +135,9 @@ describe("bun install --insecure flag", () => {
       stderr: "pipe",
     });
 
-    const exitCode = await exited;
     const stderrText = await stderr.text();
+    const stdoutText = await stdout.text();
+    const exitCode = await exited;
 
     expect(stderrText).toContain("--insecure");
     expect(exitCode).toBe(0);
@@ -163,7 +166,7 @@ describe("bun install --insecure flag", () => {
       }),
     );
 
-    const { exited, stderr } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "install"],
       cwd: package_dir,
       env: bunEnv,
@@ -171,8 +174,9 @@ describe("bun install --insecure flag", () => {
       stderr: "pipe",
     });
 
-    const exitCode = await exited;
     const stderrText = await stderr.text();
+    const stdoutText = await stdout.text();
+    const exitCode = await exited;
 
     // Should NOT display insecure warning in normal mode
     expect(stderrText).not.toContain("--insecure");

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -42,12 +42,11 @@ function createRegistryHandler(urls: string[], info: any, rootUrl: string) {
 
 describe.concurrent("bun install --insecure flag", () => {
   it("should accept the --insecure flag and display warning", async () => {
-    const urls: string[] = [];
     using server = Bun.serve({
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler(urls, { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
       },
     });
 
@@ -92,12 +91,11 @@ registry = "http://localhost:${server.port}/"
   });
 
   it("should work with other install flags", async () => {
-    const urls: string[] = [];
     using server = Bun.serve({
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler(urls, { "0.0.2": {}, "0.0.3": {} }, rootUrl)(request);
+        return await createRegistryHandler([], { "0.0.2": {}, "0.0.3": {} }, rootUrl)(request);
       },
     });
 
@@ -142,12 +140,11 @@ registry = "http://localhost:${server.port}/"
   });
 
   it("should work with bun add --insecure", async () => {
-    const urls: string[] = [];
     using server = Bun.serve({
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler(urls, { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
       },
     });
 
@@ -323,12 +320,11 @@ insecure = true
   });
 
   it("CLI --insecure flag should override bunfig install.insecure=false", async () => {
-    const urls: string[] = [];
     using server = Bun.serve({
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler(urls, { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
       },
     });
 

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -51,13 +51,13 @@ describe("bun install --insecure flag", () => {
     const exitCode = await exited;
     const stderrText = await stderr.text();
 
-    // Should succeed
-    expect(exitCode).toBe(0);
-
     // Should display warning about insecure flag
     expect(stderrText).toContain("--insecure");
     expect(stderrText).toContain("TLS/SSL certificate verification is disabled");
     expect(stderrText).toContain("dangerous");
+
+    // Should succeed
+    expect(exitCode).toBe(0);
 
     // Package should still be installed
     const installed = await readdirSorted(join(package_dir, "node_modules"));
@@ -99,8 +99,8 @@ describe("bun install --insecure flag", () => {
     const exitCode = await exited;
     const stderrText = await stderr.text();
 
-    expect(exitCode).toBe(0);
     expect(stderrText).toContain("--insecure");
+    expect(exitCode).toBe(0);
 
     // Should install production dependencies only
     const installed = await readdirSorted(join(package_dir, "node_modules"));
@@ -136,8 +136,8 @@ describe("bun install --insecure flag", () => {
     const exitCode = await exited;
     const stderrText = await stderr.text();
 
-    expect(exitCode).toBe(0);
     expect(stderrText).toContain("--insecure");
+    expect(exitCode).toBe(0);
 
     // Package should be added
     const installed = await readdirSorted(join(package_dir, "node_modules"));
@@ -174,11 +174,10 @@ describe("bun install --insecure flag", () => {
     const exitCode = await exited;
     const stderrText = await stderr.text();
 
-    expect(exitCode).toBe(0);
-
     // Should NOT display insecure warning in normal mode
     expect(stderrText).not.toContain("--insecure");
     expect(stderrText).not.toContain("TLS/SSL certificate verification is disabled");
+    expect(exitCode).toBe(0);
 
     // Package should still be installed
     const installed = await readdirSorted(join(package_dir, "node_modules"));

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -1,0 +1,188 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { writeFile } from "fs/promises";
+import { bunEnv, bunExe, readdirSorted } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  setHandler,
+} from "./dummy.registry";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+beforeEach(async () => {
+  await dummyBeforeEach();
+});
+afterEach(dummyAfterEach);
+
+describe("bun install --insecure flag", () => {
+  it("should accept the --insecure flag and display warning", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.2": {},
+      }),
+    );
+
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "test-insecure-flag",
+        version: "1.0.0",
+        dependencies: {
+          bar: "0.0.2",
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--insecure"],
+      cwd: package_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await exited;
+    const stderrText = await stderr.text();
+
+    // Should succeed
+    expect(exitCode).toBe(0);
+
+    // Should display warning about insecure flag
+    expect(stderrText).toContain("--insecure");
+    expect(stderrText).toContain("TLS/SSL certificate verification is disabled");
+    expect(stderrText).toContain("dangerous");
+
+    // Package should still be installed
+    const installed = await readdirSorted(join(package_dir, "node_modules"));
+    expect(installed).toContain("bar");
+  });
+
+  it("should work with other install flags", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.2": {},
+        "0.0.3": {},
+      }),
+    );
+
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "test-insecure-with-flags",
+        version: "1.0.0",
+        dependencies: {
+          bar: "0.0.2",
+        },
+        devDependencies: {
+          baz: "0.0.3",
+        },
+      }),
+    );
+
+    // Test --insecure with --production
+    const { exited, stderr } = spawn({
+      cmd: [bunExe(), "install", "--insecure", "--production"],
+      cwd: package_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await exited;
+    const stderrText = await stderr.text();
+
+    expect(exitCode).toBe(0);
+    expect(stderrText).toContain("--insecure");
+
+    // Should install production dependencies only
+    const installed = await readdirSorted(join(package_dir, "node_modules"));
+    expect(installed).toContain("bar");
+    expect(installed).not.toContain("baz");
+  });
+
+  it("should work with bun add --insecure", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.2": {},
+      }),
+    );
+
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "test-add-insecure",
+        version: "1.0.0",
+        dependencies: {},
+      }),
+    );
+
+    const { exited, stderr } = spawn({
+      cmd: [bunExe(), "add", "boba@0.0.2", "--insecure"],
+      cwd: package_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await exited;
+    const stderrText = await stderr.text();
+
+    expect(exitCode).toBe(0);
+    expect(stderrText).toContain("--insecure");
+
+    // Package should be added
+    const installed = await readdirSorted(join(package_dir, "node_modules"));
+    expect(installed).toContain("boba");
+  });
+
+  it("should work without the --insecure flag (normal mode)", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.2": {},
+      }),
+    );
+
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "test-normal-mode",
+        version: "1.0.0",
+        dependencies: {
+          bar: "0.0.2",
+        },
+      }),
+    );
+
+    const { exited, stderr } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await exited;
+    const stderrText = await stderr.text();
+
+    expect(exitCode).toBe(0);
+
+    // Should NOT display insecure warning in normal mode
+    expect(stderrText).not.toContain("--insecure");
+    expect(stderrText).not.toContain("TLS/SSL certificate verification is disabled");
+
+    // Package should still be installed
+    const installed = await readdirSorted(join(package_dir, "node_modules"));
+    expect(installed).toContain("bar");
+  });
+});
+

--- a/test/cli/install/bun-install-insecure.test.ts
+++ b/test/cli/install/bun-install-insecure.test.ts
@@ -4,9 +4,8 @@ import { bunEnv, bunExe, readdirSorted, tempDir, tls } from "harness";
 import { join } from "path";
 
 // Helper to create a registry handler with proper URL context
-function createRegistryHandler(urls: string[], info: any, rootUrl: string) {
+function createRegistryHandler(info: any, rootUrl: string) {
   return async (request: Request) => {
-    urls.push(request.url);
     const url = request.url.replaceAll(/%2f/gi, "/");
     
     if (url.endsWith(".tgz")) {
@@ -46,7 +45,7 @@ describe.concurrent("bun install --insecure flag", () => {
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler({ "0.0.2": {} }, rootUrl)(request);
       },
     });
 
@@ -95,7 +94,7 @@ registry = "http://localhost:${server.port}/"
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler([], { "0.0.2": {}, "0.0.3": {} }, rootUrl)(request);
+        return await createRegistryHandler({ "0.0.2": {}, "0.0.3": {} }, rootUrl)(request);
       },
     });
 
@@ -144,7 +143,7 @@ registry = "http://localhost:${server.port}/"
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler({ "0.0.2": {} }, rootUrl)(request);
       },
     });
 
@@ -324,7 +323,7 @@ insecure = true
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler({ "0.0.2": {} }, rootUrl)(request);
       },
     });
 
@@ -374,7 +373,7 @@ insecure = false
       port: 0,
       async fetch(request) {
         const rootUrl = `http://localhost:${server.port}`;
-        return await createRegistryHandler([], { "0.0.2": {} }, rootUrl)(request);
+        return await createRegistryHandler({ "0.0.2": {} }, rootUrl)(request);
       },
     });
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a `--insecure` flag for `bun install`, allowing to skip tls/ssl certificate validation for debugging. Fixes https://github.com/oven-sh/bun/issues/22661
### How did you verify your code works?
I created 2 tests: 
`test/cli/install/bun-install-insecure.test.ts` to verify `bun install` functionality works with and without the `--insecure` flag correctly
`test/cli/install/bun-install-insecure-tls.test.ts` to verify `bun install --insecure` disables tls validation by requesting from an insecure registry
