### PR TITLE
docs(watch): rename filename to relativePath in recursive example

### DIFF
--- a/docs/guides/read-file/watch.md
+++ b/docs/guides/read-file/watch.md
@@ -24,8 +24,8 @@ import { watch } from "fs";
 const watcher = watch(
   import.meta.dir,
   { recursive: true },
-  (event, filename) => {
-    console.log(`Detected ${event} in ${filename}`);
+  (event, relativePath) => {
+    console.log(`Detected ${event} in ${relativePath}`);
   },
 );
 ```


### PR DESCRIPTION
When using `fs.watch()` with `recursive: true`, the callback receives a relative path from the watched directory (e.g., `'subdir/file.txt'`), not just a filename.

Renaming the parameter from `filename` to `relativePath` makes this behavior immediately clear to developers.

**Before:**
```ts
(event, filename) => {
  console.log(`Detected ${event} in ${filename}`);
}
```

**After:**
```ts
(event, relativePath) => {
  console.log(`Detected ${event} in ${relativePath}`);
}
```

This is a documentation-only change that improves clarity without altering any functionality.