### PR TITLE
Fix integer overflow when reading MySQL OK packets

### DIFF
--- a/src/sql/mysql/protocol/OKPacket.zig
+++ b/src/sql/mysql/protocol/OKPacket.zig
@@ -34,8 +34,11 @@ pub fn decodeInternal(this: *OKPacket, comptime Context: type, reader: NewReader
 
     // Info (EOF-terminated string)
     if (reader.peek().len > 0) {
-        // everything else is info
-        this.info = try reader.read(@truncate(this.packet_size - read_size));
+        var remaining: usize = 0;
+        if (read_size < this.packet_size) {
+            remaining = this.packet_size - read_size;
+        }
+        this.info = try reader.read(@truncate(remaining));
     }
 }
 

--- a/src/sql/mysql/protocol/OKPacket.zig
+++ b/src/sql/mysql/protocol/OKPacket.zig
@@ -34,10 +34,7 @@ pub fn decodeInternal(this: *OKPacket, comptime Context: type, reader: NewReader
 
     // Info (EOF-terminated string)
     if (reader.peek().len > 0 and this.packet_size > read_size) {
-        var remaining: usize = 0;
-        if (read_size < this.packet_size) {
-            remaining = this.packet_size - read_size;
-        }
+        const remaining = this.packet_size - read_size;
         this.info = try reader.read(@truncate(remaining));
     }
 }

--- a/src/sql/mysql/protocol/OKPacket.zig
+++ b/src/sql/mysql/protocol/OKPacket.zig
@@ -33,7 +33,7 @@ pub fn decodeInternal(this: *OKPacket, comptime Context: type, reader: NewReader
     this.warnings = try reader.int(u16);
 
     // Info (EOF-terminated string)
-    if (reader.peek().len > 0) {
+    if (reader.peek().len > 0 and this.packet_size > read_size) {
         var remaining: usize = 0;
         if (read_size < this.packet_size) {
             remaining = this.packet_size - read_size;


### PR DESCRIPTION
### Description
This PR fixes a crash caused by integer underflow in `OKPacket.decodeInternal`.  
Previously, when `read_size` exceeded `packet_size`, the subtraction  
`packet_size - read_size` wrapped around, producing a huge `count` value  
passed into `reader.read()`. This led to an integer overflow panic at runtime.

### What does this PR do
- Added a safe subtraction guard in `decodeInternal` to clamp `remaining` to `0`  
  when `read_size >= packet_size`.  
- Ensures empty or truncated OK packets no longer cause crashes.  
- Behavior for valid packets remains unchanged.

### Impact
Prevents integer overflow panics in MySQL OK packet parsing, improving  
stability when handling short or empty responses (e.g., queries that  
return no rows or minimal metadata).

### How did you verify your code works?
Tested with proof of concept: https://github.com/Lillious/Bun-MySql-Integer-Overflow-PoC