### PR TITLE
fix prompt input truncating

### DIFF
--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -276,7 +276,7 @@ pub const prompt = struct {
 
             if (c_termios.isatty(bun.FD.stdin().native()) == 1) {
                 var original_termios: c_termios.termios = undefined;
-                var pendingSigint: bool = false;
+                var pending_sigint: bool = false;
                 if (c_termios.tcgetattr(bun.FD.stdin().native(), &original_termios) != 0) {
                     return .null;
                 }
@@ -286,8 +286,8 @@ pub const prompt = struct {
                     // Move cursor to next line after input is done
                     _ = bun.Output.writer().writeAll("\n") catch {};
                     bun.Output.flush();
-                    if (pendingSigint) {
-                        _ = c_signal.raise(c_signal.SIGINT);
+                    if (pending_sigint) {
+                        _ = c_termios.raise(c_termios.SIGINT);
                     }
                 }
 
@@ -353,7 +353,7 @@ pub const prompt = struct {
                         // Ctrl+C
                         3 => {
                             // This will trigger the defer and restore terminal settings
-                            pendingSigint = true;
+                            pending_sigint = true;
                             return .null;
                         },
 

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -429,11 +429,13 @@ pub const prompt = struct {
         const has_default = arguments.len >= 2;
         const default_value = if (has_default) arguments[1] else .null;
 
+        var message_slice: []const u8 = undefined;
         if (has_message) {
             const message = try arguments[0].toSlice(globalObject, allocator);
             defer message.deinit();
+            message_slice = message.slice();
 
-            output.writeAll(message.slice()) catch {
+            output.writeAll(message_slice) catch {
                 return .null; // Failed to show message
             };
         }
@@ -442,11 +444,13 @@ pub const prompt = struct {
             return .null; // Failed to show prompt
         };
 
+        var default_string_slice: []const u8 = undefined;
         if (has_default) {
             const default_string = try arguments[1].toSlice(globalObject, allocator);
             defer default_string.deinit();
+            default_string_slice = default_string.slice();
 
-            output.print("[{s}] ", .{default_string.slice()}) catch {
+            output.print("[{s}] ", .{default_string_slice}) catch {
                 return .null; // Failed to show default value
             };
         }
@@ -485,17 +489,12 @@ pub const prompt = struct {
 
             // Calculate initial prompt width.
             if (has_message) {
-                const message = try arguments[0].toSlice(globalObject, allocator);
-                defer message.deinit();
-                prompt_width += columnWidth(message.slice());
+                prompt_width += columnWidth(message_slice);
             }
             prompt_width += columnWidth(if (has_message) " " else "Prompt ");
 
             if (has_default) {
-                const default_string = try arguments[1].toSlice(globalObject, allocator);
-                defer default_string.deinit();
-
-                prompt_width += columnWidth("[") + columnWidth(default_string.slice()) + columnWidth("] ");
+                prompt_width += columnWidth("[") + columnWidth(default_string_slice) + columnWidth("] ");
             }
 
             // Deferred cleanup: restore terminal settings and print a newline.

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -463,7 +463,7 @@ pub const prompt = struct {
         };
 
         // Handle interactive TTY input for non-Windows systems.
-        if ((comptime !Environment.isWindows) and bun.c.isatty(bun.FD.stdin().native()) == 1) {
+        if ((comptime !Environment.isWindows) and bun.c.isatty(bun.FD.stdin().native()) == 1 and bun.c.isatty(bun.FD.stdout().native()) == 1) {
             const original_ttymode = Bun__ttySetMode(bun.FD.stdin().native(), 1);
             const stdin_fd = bun.FD.stdin().native();
 

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -172,17 +172,12 @@ pub const prompt = struct {
             const old_cursor_index = cursor_index.*;
             const prev_codepoint_start = utf8Prev(input.items, old_cursor_index);
 
-            if (prev_codepoint_start) |start| {
-                var i: usize = 0;
-                while (i < old_cursor_index - start) : (i += 1) {
-                    _ = input.orderedRemove(start);
-                }
-                cursor_index.* = start;
-            } else {
-                // Fallback: delete one byte if invalid UTF-8
-                _ = input.orderedRemove(old_cursor_index - 1);
-                cursor_index.* -= 1;
+            const start = prev_codepoint_start.?;
+            var i: usize = 0;
+            while (i < old_cursor_index - start) : (i += 1) {
+                _ = input.orderedRemove(start);
             }
+            cursor_index.* = start;
         }
     }
 

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -198,7 +198,7 @@ pub const prompt = struct {
     /// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-prompt
     /// This implementation has two modes:
     /// 1. If stdin is an interactive TTY, it switches the terminal to raw mode to
-    ///    provide a rich editing experience with cursor movement and history.
+    ///    provide a rich editing experience with cursor movement.
     /// 2. If stdin is not a TTY (e.g., piped input), it falls back to a simple
     ///    buffered line reader.
     pub fn call(

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -214,12 +214,14 @@ pub const prompt = struct {
         while (i < input.items.len) {
             const char = input.items[i];
             if (char == '\t') {
-                const spaces_to_add = 8;
+                const tab_width = 8;
+                const next_tab_stop = ((current_column / tab_width) + 1) * tab_width;
+                const spaces_to_add = next_tab_stop - current_column;
                 var j: usize = 0;
                 while (j < spaces_to_add) : (j += 1) {
                     _ = stdout_writer.writeByte(' ') catch {};
                 }
-                current_column += spaces_to_add;
+                current_column = next_tab_stop;
                 i += 1;
             } else {
                 const codepoint_slice = input.items[i..];
@@ -250,8 +252,9 @@ pub const prompt = struct {
         while (i < byte_index) {
             const char = slice[i];
             if (char == '\t') {
-                // Tab stop of 8 columns
-                column += 8;
+                // Align to next tab stop (multiple of 8)
+                const tab_width = 8;
+                column = ((column / tab_width) + 1) * tab_width;
                 i += 1;
             } else {
                 // Use the project's visible width function for other characters

--- a/src/bun.js/webcore/prompt.zig
+++ b/src/bun.js/webcore/prompt.zig
@@ -676,11 +676,15 @@ pub const prompt = struct {
         };
 
         if (first_byte == '\n') {
+            if (!has_default) return bun.String.empty.toJS(globalObject);
             return default_value;
         } else if (first_byte == '\r') {
             const second = reader.readByte() catch return .null;
             second_byte = second;
-            if (second == '\n') return default_value;
+            if (second == '\n') {
+                if (!has_default) return bun.String.empty.toJS(globalObject);
+                return default_value;
+            }
         }
 
         var input = std.array_list.Managed(u8).initCapacity(allocator, 2048) catch {


### PR DESCRIPTION
### What does this PR do?
Previously, prompt's input would be truncated by canonical mode in the terminal.
This temporarily turns off canonical mode if it is enabled on unix based systems and manually parses the inputs.

### How did you verify your code works?
```ts
console.log("Testing prompt() with long input...");

const result = prompt();

if (result) {
    console.log(`\nresult:\n#####\n${result}\n#####`);
    console.log(`\nInput length: ${result.length} bytes`);
} else {
    console.log("prompt() returned null");
}
```