### PR TITLE
Fix End-of-Result Detection and Empty String Handling for Multi-Connection Query Execution

### DIFF
--- a/src/sql/mysql/MySQLConnection.zig
+++ b/src/sql/mysql/MySQLConnection.zig
@@ -1032,7 +1032,9 @@ fn handleResultSet(this: *MySQLConnection, comptime Context: type, reader: NewRe
                 try statement.columns[statement.columns_received].decode(reader);
                 statement.columns_received += 1;
             } else {
-                if (packet_type == .OK or packet_type == .EOF) {
+                const is_end_packet = (packet_type == .OK and header_length >= 7) or packet_type == .EOF;
+
+                if (is_end_packet) {
                     if (request.isSimple() or packet_type == .EOF) {
                         // if we are using the text protocol for sure this is a OK packet otherwise will be OK packet with 0xFE code
                         // If is not simple and is EOF this is actually a OK packet but with the flag EOF


### PR DESCRIPTION
### What does this PR do?
This update refines the logic for detecting the end of result sets and improves how rows with **empty string values** are handled. The previous implementation caused issues **only when multiple connections were active (i.e., `max > 1`)**, where back-to-back queries could fail or hang due to premature end-of-result detection and inconsistent result formatting.

### How did you verify your code works?
Updated PoC and tested: https://github.com/Lillious/Bun-MySql-Integer-Overflow-PoC

---

##  Changes Introduced

### 1. Improved End-of-Result Detection
Introduced a new variable `is_end_packet` to clarify and standardize how end packets are detected:

```zig
const is_end_packet = (packet_type == .OK and header_length >= 7) or packet_type == .EOF;
```

**Enhancements:**
- `.OK` packets with a header length ≥ 7 (binary protocol) are now correctly recognized as valid end packets.  
- `.EOF` packets continue to signal end-of-result in text protocol.  
- Prevents **premature connection state resets** that occurred when multiple connections were active, ensuring each connection properly completes its query lifecycle.

This change resolves an issue where multiple concurrent or sequential queries (in pools with `max > 1`) could not run reliably due to incorrect packet handling.

---

### 2. Updated Return Format for Empty String Row Values
Previously, when a query returned a row with an empty string value (e.g., `SELECT "" AS poc_col;`), the result was represented as:

**Before:**
```js
[]
```

Now, the result correctly returns a structured response including the empty string and metadata:

**After:**
```js
[
  {
    poc_col: "",
  },
  count: 1,
  command: null,
  lastInsertRowid: 0,
  affectedRows: 0
]
```