### PR TITLE
zig: env_var: fix output port

### DIFF
--- a/src/output.zig
+++ b/src/output.zig
@@ -807,7 +807,7 @@ fn ScopedLogger(comptime tagname: []const u8, comptime visibility: Visibility) t
             } else if (bun.env_var.BUN_DEBUG_ALL.get()) |val| {
                 really_disable.store(val, .monotonic);
             } else if (bun.env_var.BUN_DEBUG_QUIET_LOGS.get()) |val| {
-                really_disable.store(really_disable.load(.monotonic) or !val, .monotonic);
+                really_disable.store(really_disable.load(.monotonic) or val, .monotonic);
             } else {
                 for (bun.argv) |arg| {
                     if (strings.eqlCaseInsensitiveASCII(arg, comptime "--debug-" ++ tagname, true)) {

--- a/src/output.zig
+++ b/src/output.zig
@@ -805,7 +805,7 @@ fn ScopedLogger(comptime tagname: []const u8, comptime visibility: Visibility) t
             if (bun.getenvZAnyCase("BUN_DEBUG_" ++ tagname)) |val| {
                 really_disable.store(strings.eqlComptime(val, "0"), .monotonic);
             } else if (bun.env_var.BUN_DEBUG_ALL.get()) |val| {
-                really_disable.store(val, .monotonic);
+                really_disable.store(!val, .monotonic);
             } else if (bun.env_var.BUN_DEBUG_QUIET_LOGS.get()) |val| {
                 really_disable.store(really_disable.load(.monotonic) or val, .monotonic);
             } else {


### PR DESCRIPTION
the not'ing happens inside bun.env_var now
BUN_DEBUG_QUIET_LOGS is a "false-y" check so !val is a double-negative
this typo was making logs show up in debug mode when BUN_DEBUG_QUIET_LOGS was in fact set