### PR TITLE
fix(css): process color-scheme rules inside @layer blocks

### DIFF
--- a/src/css/rules/rules.zig
+++ b/src/css/rules/rules.zig
@@ -216,8 +216,8 @@ pub fn CssRuleList(comptime AtRule: type) type {
                         debug("TODO: ContainerRule", .{});
                     },
                     .layer_block => |*lay| {
-                        _ = lay; // autofix
-                        debug("TODO: LayerBlockRule", .{});
+                        try lay.rules.minify(context, parent_is_unused);
+                        if (lay.rules.v.items.len == 0) continue;
                     },
                     .layer_statement => |*lay| {
                         _ = lay; // autofix

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -9,7 +9,7 @@
   ".jsBoolean(true)": 0,
   ".stdDir()": 41,
   ".stdFile()": 16,
-  "// autofix": 165,
+  "// autofix": 164,
   ": [^=]+= undefined,$": 255,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7308,6 +7308,68 @@ describe("css tests", () => {
         `,
       { chrome: Some(90 << 16) },
     );
+
+    // Test color-scheme inside @layer blocks (issue #20689)
+    prefix_test(
+      `@layer colors {
+        .foo { color-scheme: dark; }
+      }`,
+      `@layer colors {
+          .foo {
+            --buncss-light: ;
+            --buncss-dark: initial;
+            color-scheme: dark;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `@layer shm.colors {
+        body.theme-dark {
+          color-scheme: dark;
+        }
+        body.theme-light {
+          color-scheme: light;
+        }
+      }`,
+      `@layer shm.colors {
+          body.theme-dark {
+            --buncss-light: ;
+            --buncss-dark: initial;
+            color-scheme: dark;
+          }
+
+          body.theme-light {
+            --buncss-light: initial;
+            --buncss-dark: ;
+            color-scheme: light;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `@layer {
+        .foo { color-scheme: light dark; }
+      }`,
+      `@layer {
+          .foo {
+            --buncss-light: initial;
+            --buncss-dark: ;
+            color-scheme: light dark;
+          }
+
+          @media (prefers-color-scheme: dark) {
+            .foo {
+              --buncss-light: ;
+              --buncss-dark: initial;
+            }
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
   });
 
   describe("edge cases", () => {


### PR DESCRIPTION
## Summary

Fixes #20689

Previously, `@layer` blocks were not being processed through the CSS minifier, which meant that `color-scheme` properties inside `@layer` blocks would not get the required `--buncss-light`/`--buncss-dark` variable injections needed for browsers that don't support the `light-dark()` function.

## Changes

- Implemented proper minification for `LayerBlockRule` in `src/css/rules/rules.zig:218-221`
- Added recursive call to `minify()` on nested rules, matching the behavior of other at-rules like `@media` and `@supports`
- Added comprehensive tests for `color-scheme` inside `@layer` blocks

## Test Plan

Added three new test cases in `test/js/bun/css/css.test.ts`:
1. Simple `@layer` with `color-scheme: dark`
2. Named layers (`@layer shm.colors`) with multiple rules
3. Anonymous `@layer` with `color-scheme: light dark` (generates media query)

All tests pass:
```bash
bun bd test test/js/bun/css/css.test.ts -t "color-scheme"
```

## Before

```css
/* Input */
@layer shm.colors {
  body.theme-dark {
    color-scheme: dark;
  }
}

/* Output (broken - no variables) */
@layer shm.colors {
  body.theme-dark {
    color-scheme: dark;
  }
}
```

## After

```css
/* Input */
@layer shm.colors {
  body.theme-dark {
    color-scheme: dark;
  }
}

/* Output (fixed - variables injected) */
@layer shm.colors {
  body.theme-dark {
    --buncss-light: ;
    --buncss-dark: initial;
    color-scheme: dark;
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)