### PR TITLE
feat(test): implement onTestFinished hook for bun:test

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -257,13 +257,13 @@ $ bun test --watch
 
 Bun supports the following lifecycle hooks:
 
-| Hook              | Description                                                |
-| ----------------- | ---------------------------------------------------------- |
-| `beforeAll`       | Runs once before all tests.                                |
-| `beforeEach`      | Runs before each test.                                     |
-| `afterEach`       | Runs after each test.                                      |
-| `afterAll`        | Runs once after all tests.                                 |
-| `onTestFinished`  | Runs after a test finishes, including after `afterEach`.   |
+| Hook             | Description                                              |
+| ---------------- | -------------------------------------------------------- |
+| `beforeAll`      | Runs once before all tests.                              |
+| `beforeEach`     | Runs before each test.                                   |
+| `afterEach`      | Runs after each test.                                    |
+| `afterAll`       | Runs once after all tests.                               |
+| `onTestFinished` | Runs after a test finishes, including after `afterEach`. |
 
 These hooks can be defined inside test files, or in a separate file that is preloaded with the `--preload` flag.
 

--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -257,12 +257,13 @@ $ bun test --watch
 
 Bun supports the following lifecycle hooks:
 
-| Hook         | Description                 |
-| ------------ | --------------------------- |
-| `beforeAll`  | Runs once before all tests. |
-| `beforeEach` | Runs before each test.      |
-| `afterEach`  | Runs after each test.       |
-| `afterAll`   | Runs once after all tests.  |
+| Hook              | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `beforeAll`       | Runs once before all tests.                                |
+| `beforeEach`      | Runs before each test.                                     |
+| `afterEach`       | Runs after each test.                                      |
+| `afterAll`        | Runs once after all tests.                                 |
+| `onTestFinished`  | Runs after a test finishes, including after `afterEach`.   |
 
 These hooks can be defined inside test files, or in a separate file that is preloaded with the `--preload` flag.
 

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -359,6 +359,28 @@ declare module "bun:test" {
     options?: HookOptions,
   ): void;
   /**
+   * Runs a function after a test finishes, including after all afterEach hooks.
+   *
+   * This is useful for cleanup tasks that need to run at the very end of a test,
+   * after all other hooks have completed.
+   *
+   * Can only be called inside a test, not in describe blocks.
+   *
+   * @example
+   * test("my test", () => {
+   *   onTestFinished(() => {
+   *     // This runs after all afterEach hooks
+   *     console.log("Test finished!");
+   *   });
+   * });
+   *
+   * @param fn the function to run
+   */
+  export function onTestFinished(
+    fn: (() => void | Promise<unknown>) | ((done: (err?: unknown) => void) => void),
+    options?: HookOptions,
+  ): void;
+  /**
    * Sets the default timeout for all tests in the current file. If a test specifies a timeout, it will
    * override this value. The default timeout is 5000ms (5 seconds).
    *

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -77,7 +77,11 @@ pub const js_fns = struct {
                     .execution => {
                         const active = bunTest.getCurrentStateData();
                         const sequence, _ = bunTest.execution.getCurrentAndValidExecutionSequence(active) orelse {
-                            return globalThis.throw("Cannot call {s}() here. It cannot be called inside a concurrent test. Call it inside describe() instead.", .{@tagName(tag)});
+                            const message = if (tag == .onTestFinished)
+                                "Cannot call {s}() here. It cannot be called inside a concurrent test. Use test.serial or remove test.concurrent."
+                            else
+                                "Cannot call {s}() here. It cannot be called inside a concurrent test. Call it inside describe() instead.";
+                            return globalThis.throw(message, .{@tagName(tag)});
                         };
 
                         const append_point = switch (tag) {

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -84,16 +84,12 @@ pub const js_fns = struct {
 
                             const append_point = switch (tag) {
                                 .afterAll, .afterEach => blk: {
-                                    var point = sequence.active_entry;
+                                    var iter = sequence.active_entry;
+                                    while (iter) |entry| : (iter = entry.next) {
+                                        if (entry == sequence.test_entry) break :blk sequence.test_entry.?;
+                                    }
 
-                                    var iter = point;
-                                    const before_test_entry = while (iter) |entry| : (iter = entry.next) {
-                                        if (entry == sequence.test_entry) break true;
-                                    } else false;
-
-                                    if (before_test_entry) point = sequence.test_entry;
-
-                                    break :blk point orelse return globalThis.throw("Cannot call {s}() here. Call it inside describe() instead.", .{@tagName(tag)});
+                                    break :blk sequence.active_entry orelse return globalThis.throw("Cannot call {s}() here. Call it inside describe() instead.", .{@tagName(tag)});
                                 },
                                 .onTestFinished => blk: {
                                     // Find the last entry in the sequence

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -163,7 +163,7 @@ pub const Jest = struct {
     }
 
     pub fn createTestModule(globalObject: *JSGlobalObject) bun.JSError!JSValue {
-        const module = JSValue.createEmptyObject(globalObject, 19);
+        const module = JSValue.createEmptyObject(globalObject, 20);
 
         const test_scope_functions = try bun_test.ScopeFunctions.createBound(globalObject, .@"test", .zero, .{}, bun_test.ScopeFunctions.strings.@"test");
         module.put(globalObject, ZigString.static("test"), test_scope_functions);

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -183,6 +183,7 @@ pub const Jest = struct {
         module.put(globalObject, ZigString.static("beforeAll"), jsc.host_fn.NewFunction(globalObject, ZigString.static("beforeAll"), 1, bun_test.js_fns.genericHook(.beforeAll).hookFn, false));
         module.put(globalObject, ZigString.static("afterAll"), jsc.host_fn.NewFunction(globalObject, ZigString.static("afterAll"), 1, bun_test.js_fns.genericHook(.afterAll).hookFn, false));
         module.put(globalObject, ZigString.static("afterEach"), jsc.host_fn.NewFunction(globalObject, ZigString.static("afterEach"), 1, bun_test.js_fns.genericHook(.afterEach).hookFn, false));
+        module.put(globalObject, ZigString.static("onTestFinished"), jsc.host_fn.NewFunction(globalObject, ZigString.static("onTestFinished"), 1, bun_test.js_fns.genericHook(.onTestFinished).hookFn, false));
         module.put(globalObject, ZigString.static("setDefaultTimeout"), jsc.host_fn.NewFunction(globalObject, ZigString.static("setDefaultTimeout"), 1, jsSetDefaultTimeout, false));
         module.put(globalObject, ZigString.static("expect"), Expect.js.getConstructor(globalObject));
         module.put(globalObject, ZigString.static("expectTypeOf"), ExpectTypeOf.js.getConstructor(globalObject));

--- a/test/js/bun/test/test-on-test-finished.test.ts
+++ b/test/js/bun/test/test-on-test-finished.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, describe, onTestFinished, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, onTestFinished, test } from "bun:test";
 
 // Test the basic ordering of onTestFinished
 describe("onTestFinished ordering", () => {
@@ -21,16 +21,7 @@ describe("onTestFinished ordering", () => {
   test("test 2", () => {
     output.push("test 2");
     // After test 2, verify the order from test 1
-    if (output.length >= 4) {
-      const expected = ["test 1", "inner afterAll", "afterEach", "onTestFinished"];
-      for (let i = 0; i < expected.length; i++) {
-        if (output[i] !== expected[i]) {
-          throw new Error(
-            `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
-          );
-        }
-      }
-    }
+    expect(output.slice(0, 4)).toEqual(["test 1", "inner afterAll", "afterEach", "onTestFinished"]);
   });
 });
 
@@ -53,14 +44,7 @@ describe("multiple onTestFinished", () => {
   });
 
   test("verify order", () => {
-    const expected = ["test", "afterEach", "onTestFinished 1", "onTestFinished 2"];
-    for (let i = 0; i < expected.length; i++) {
-      if (output[i] !== expected[i]) {
-        throw new Error(
-          `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
-        );
-      }
-    }
+    expect(output).toEqual(["test", "afterEach", "onTestFinished 1", "onTestFinished 2"]);
   });
 });
 
@@ -81,14 +65,7 @@ describe("async onTestFinished", () => {
   });
 
   test("verify async order", () => {
-    const expected = ["test", "afterEach", "onTestFinished async"];
-    for (let i = 0; i < expected.length; i++) {
-      if (output[i] !== expected[i]) {
-        throw new Error(
-          `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
-        );
-      }
-    }
+    expect(output).toEqual(["test", "afterEach", "onTestFinished async"]);
   });
 });
 
@@ -112,13 +89,6 @@ describe("onTestFinished with all hooks", () => {
 
   test("verify complete order", () => {
     // Expected order: test body, inner afterAll, afterEach, onTestFinished
-    const expected = ["test", "inner afterAll", "afterEach", "onTestFinished"];
-    for (let i = 0; i < expected.length; i++) {
-      if (output[i] !== expected[i]) {
-        throw new Error(
-          `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
-        );
-      }
-    }
+    expect(output).toEqual(["test", "inner afterAll", "afterEach", "onTestFinished"]);
   });
 });

--- a/test/js/bun/test/test-on-test-finished.test.ts
+++ b/test/js/bun/test/test-on-test-finished.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, afterEach, describe, onTestFinished, test } from "bun:test";
+
+// Test the basic ordering of onTestFinished
+describe("onTestFinished ordering", () => {
+  const output: string[] = [];
+
+  afterEach(() => {
+    output.push("afterEach");
+  });
+
+  test("test 1", () => {
+    afterAll(() => {
+      output.push("inner afterAll");
+    });
+    onTestFinished(() => {
+      output.push("onTestFinished");
+    });
+    output.push("test 1");
+  });
+
+  test("test 2", () => {
+    output.push("test 2");
+    // After test 2, verify the order from test 1
+    if (output.length >= 4) {
+      const expected = ["test 1", "inner afterAll", "afterEach", "onTestFinished"];
+      for (let i = 0; i < expected.length; i++) {
+        if (output[i] !== expected[i]) {
+          throw new Error(
+            `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
+          );
+        }
+      }
+    }
+  });
+});
+
+// Test multiple onTestFinished calls
+describe("multiple onTestFinished", () => {
+  const output: string[] = [];
+
+  afterEach(() => {
+    output.push("afterEach");
+  });
+
+  test("test with multiple onTestFinished", () => {
+    onTestFinished(() => {
+      output.push("onTestFinished 1");
+    });
+    onTestFinished(() => {
+      output.push("onTestFinished 2");
+    });
+    output.push("test");
+  });
+
+  test("verify order", () => {
+    const expected = ["test", "afterEach", "onTestFinished 1", "onTestFinished 2"];
+    for (let i = 0; i < expected.length; i++) {
+      if (output[i] !== expected[i]) {
+        throw new Error(
+          `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
+        );
+      }
+    }
+  });
+});
+
+// Test onTestFinished with async callbacks
+describe("async onTestFinished", () => {
+  const output: string[] = [];
+
+  afterEach(() => {
+    output.push("afterEach");
+  });
+
+  test("async onTestFinished", async () => {
+    onTestFinished(async () => {
+      await new Promise(resolve => setTimeout(resolve, 1));
+      output.push("onTestFinished async");
+    });
+    output.push("test");
+  });
+
+  test("verify async order", () => {
+    const expected = ["test", "afterEach", "onTestFinished async"];
+    for (let i = 0; i < expected.length; i++) {
+      if (output[i] !== expected[i]) {
+        throw new Error(
+          `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
+        );
+      }
+    }
+  });
+});
+
+// Test onTestFinished with afterEach and afterAll together
+describe("onTestFinished with all hooks", () => {
+  const output: string[] = [];
+
+  afterEach(() => {
+    output.push("afterEach");
+  });
+
+  test("test with all hooks", () => {
+    afterAll(() => {
+      output.push("inner afterAll");
+    });
+    onTestFinished(() => {
+      output.push("onTestFinished");
+    });
+    output.push("test");
+  });
+
+  test("verify complete order", () => {
+    // Expected order: test body, inner afterAll, afterEach, onTestFinished
+    const expected = ["test", "inner afterAll", "afterEach", "onTestFinished"];
+    for (let i = 0; i < expected.length; i++) {
+      if (output[i] !== expected[i]) {
+        throw new Error(
+          `Expected output[${i}] to be "${expected[i]}", but got "${output[i]}". Full output: ${JSON.stringify(output)}`,
+        );
+      }
+    }
+  });
+});

--- a/test/js/bun/test/test-on-test-finished.test.ts
+++ b/test/js/bun/test/test-on-test-finished.test.ts
@@ -68,6 +68,29 @@ describe("async onTestFinished", () => {
   });
 });
 
+// Test that onTestFinished throws proper error in concurrent tests
+describe("onTestFinished errors", () => {
+  test.concurrent("cannot be called in concurrent test 1", () => {
+    expect(() => {
+      onTestFinished(() => {
+        console.log("should not run");
+      });
+    }).toThrow(
+      "Cannot call onTestFinished() here. It cannot be called inside a concurrent test. Use test.serial or remove test.concurrent.",
+    );
+  });
+
+  test.concurrent("cannot be called in concurrent test 2", () => {
+    expect(() => {
+      onTestFinished(() => {
+        console.log("should not run");
+      });
+    }).toThrow(
+      "Cannot call onTestFinished() here. It cannot be called inside a concurrent test. Use test.serial or remove test.concurrent.",
+    );
+  });
+});
+
 // Test onTestFinished with afterEach and afterAll together
 describe("onTestFinished with all hooks", () => {
   const output: string[] = [];

--- a/test/js/bun/test/test-on-test-finished.test.ts
+++ b/test/js/bun/test/test-on-test-finished.test.ts
@@ -19,9 +19,8 @@ describe("onTestFinished ordering", () => {
   });
 
   test("test 2", () => {
-    output.push("test 2");
-    // After test 2, verify the order from test 1
-    expect(output.slice(0, 4)).toEqual(["test 1", "inner afterAll", "afterEach", "onTestFinished"]);
+    // After test 2 starts, verify the order from test 1
+    expect(output).toEqual(["test 1", "inner afterAll", "afterEach", "onTestFinished"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements `onTestFinished()` for `bun:test`, which runs after all `afterEach` hooks have completed.

## Implementation

- Added `onTestFinished` export to the test module in `jest.zig`
- Modified `genericHook` in `bun_test.zig` to handle `onTestFinished` as a special case that:
  - Can only be called inside a test (not in describe blocks or preload)
  - Appends hooks at the very end of the execution sequence
- Added comprehensive tests covering basic ordering, multiple callbacks, async callbacks, and interaction with other hooks

## Execution Order

When called inside a test:
1. Test body executes
2. `afterAll` hooks (if added inside the test)
3. `afterEach` hooks
4. `onTestFinished` hooks ✨

## Test Plan

- ✅ All new tests pass with `bun bd test`
- ✅ Tests correctly fail with `USE_SYSTEM_BUN=1` (feature not in released version)
- ✅ Verifies correct ordering with `afterEach`, `afterAll`, and multiple `onTestFinished` calls
- ✅ Tests async `onTestFinished` callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>