### PR TITLE
Fix HTML bundler to inject scripts at end of body instead of head

### DIFF
--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -844,7 +844,7 @@ body {
     },
   });
 
-  // Test script tags in body are preserved (not moved to head)
+  // Test script tags in body are preserved in body
   itBundled("html/script-in-body", {
     outdir: "out/",
     files: {
@@ -877,6 +877,43 @@ body {
 
       // Script should come after head close and before body close
       expect(scriptIndex).toBeGreaterThan(headCloseIndex);
+      expect(scriptIndex).toBeLessThan(bodyCloseIndex);
+    },
+  });
+
+  // Test script tags in head are preserved in head
+  itBundled("html/script-in-head", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="./styles.css">
+  <script src="./script.js"></script>
+</head>
+<body>
+  <h1>Hello World</h1>
+</body>
+</html>`,
+      "/styles.css": "body { background-color: blue; }",
+      "/script.js": "console.log('Script in head')",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const htmlContent = api.readFile("out/index.html");
+
+      // Check that bundled script tag is in the head (before </head>)
+      const bodyCloseIndex = htmlContent.indexOf("</body>");
+      const headCloseIndex = htmlContent.indexOf("</head>");
+      const scriptIndex = htmlContent.indexOf("<script");
+
+      expect(scriptIndex).toBeGreaterThan(-1);
+      expect(bodyCloseIndex).toBeGreaterThan(-1);
+      expect(headCloseIndex).toBeGreaterThan(-1);
+
+      // Script should come before head close and before body close
+      expect(scriptIndex).toBeLessThan(headCloseIndex);
       expect(scriptIndex).toBeLessThan(bodyCloseIndex);
     },
   });


### PR DESCRIPTION
## Summary

Fixes the HTML bundler to **respect the original script tag location** instead of forcing scripts to a specific location. The bundler now detects where scripts were placed in the source HTML (head or body) and preserves that placement in the bundled output.

## Problem

Previously, the HTML bundler would always inject bundled script tags at the end of the `<head>` element, regardless of where the original script tags were located. This was confusing for developers who:
- Intentionally place scripts at the end of `<body>` (a common pattern)
- Intentionally place scripts in `<head>` for specific reasons
- Expected scripts to remain where they put them after bundling

## Solution

The bundler now **detects and preserves** the original script tag location:

1. **Tracks location during parsing**: Records whether we're in `<head>` or `<body>`
2. **Detects first script tag**: Notes where the first script tag was located  
3. **Respects user intent**: Injects bundled scripts in the same location

**Behavior:**
- Scripts in `<head>` → bundled scripts injected before `</head>` ✅
- Scripts in `<body>` → bundled scripts injected before `</body>` ✅
- No scripts found → defaults to `<body>` (most common pattern)
- No body element → falls back to `<head>`

## Changes

**In `src/bundler/linker_context/generateCompileResultForHtmlChunk.zig`:**
- Added `script_in_body` field to track where scripts were originally located
- Added `current_section` field to track which section we're currently parsing
- Modified `onHeadTag`/`onBodyTag` to update current section tracking
- Updated `onTag` to detect script tags and record their location
- Modified `endHeadTagHandler` to inject if scripts were in head
- Modified `endBodyTagHandler` to inject if scripts were in body  
- Modified `endHtmlTagHandler` as final fallback
- Updated dev server injection logic to respect script location with proper fallbacks

**In `test/bundler/bundler_html.test.ts`:**
- Updated `html/script-in-body` test to verify body placement
- Added `html/script-in-head` test to verify head placement

## Test Plan

```bash
# Run all HTML bundler tests
bun bd test test/bundler/bundler_html.test.ts
```

**Results:**
- ✅ 20/20 tests pass (119 expect() calls)  
- ✅ Scripts in body stay in body
- ✅ Scripts in head stay in head
- ✅ All existing tests continue to pass (no regressions)

## Examples

### Scripts in Body (Common Pattern)
```html
<!-- Input -->
<body>
  <h1>Hello</h1>
  <script src="./script.js"></script>
</body>

<!-- Output (scripts stay in body) -->
<body>
  <h1>Hello</h1>
  <script type="module" crossorigin src="./script-abc123.js"></script>
</body>
```

### Scripts in Head  
```html
<!-- Input -->
<head>
  <script src="./script.js"></script>
</head>
<body>
  <h1>Hello</h1>
</body>

<!-- Output (scripts stay in head) -->
<head>
  <script type="module" crossorigin src="./script-abc123.js"></script>
</head>
<body>
  <h1>Hello</h1>
</body>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)