### PR TITLE
Add Cobertura code coverage reporter

### DIFF
--- a/src/bun.js/bindings/generated_perf_trace_events.h
+++ b/src/bun.js/bindings/generated_perf_trace_events.h
@@ -56,7 +56,11 @@
   macro(RuntimeTranspilerCache.toFile, 52) \
   macro(StandaloneModuleGraph.serialize, 53) \
   macro(Symbols.followAll, 54) \
-  macro(TestCommand.printCodeCoverageLCov, 55) \
-  macro(TestCommand.printCodeCoverageLCovAndText, 56) \
-  macro(TestCommand.printCodeCoverageText, 57) \
+  macro(TestCommand.printCodeCoverageCobertura, 55) \
+  macro(TestCommand.printCodeCoverageCoberturaAndText, 56) \
+  macro(TestCommand.printCodeCoverageLCov, 57) \
+  macro(TestCommand.printCodeCoverageLCovAndCobertura, 58) \
+  macro(TestCommand.printCodeCoverageLCovAndText, 59) \
+  macro(TestCommand.printCodeCoverageLCovCoberturaAndText, 60) \
+  macro(TestCommand.printCodeCoverageText, 61) \
   // end

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -260,13 +260,15 @@ pub const Bunfig = struct {
                     }
 
                     if (test_.get("coverageReporter")) |expr| brk: {
-                        this.ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false };
+                        this.ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false, .cobertura = false };
                         if (expr.data == .e_string) {
                             const item_str = expr.asString(bun.default_allocator) orelse "";
                             if (bun.strings.eqlComptime(item_str, "text")) {
                                 this.ctx.test_options.coverage.reporters.text = true;
                             } else if (bun.strings.eqlComptime(item_str, "lcov")) {
                                 this.ctx.test_options.coverage.reporters.lcov = true;
+                            } else if (bun.strings.eqlComptime(item_str, "cobertura")) {
+                                this.ctx.test_options.coverage.reporters.cobertura = true;
                             } else {
                                 try this.addErrorFormat(expr.loc, allocator, "Invalid coverage reporter \"{s}\"", .{item_str});
                             }
@@ -283,6 +285,8 @@ pub const Bunfig = struct {
                                 this.ctx.test_options.coverage.reporters.text = true;
                             } else if (bun.strings.eqlComptime(item_str, "lcov")) {
                                 this.ctx.test_options.coverage.reporters.lcov = true;
+                            } else if (bun.strings.eqlComptime(item_str, "cobertura")) {
+                                this.ctx.test_options.coverage.reporters.cobertura = true;
                             } else {
                                 try this.addErrorFormat(item.loc, allocator, "Invalid coverage reporter \"{s}\"", .{item_str});
                             }

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -432,14 +432,16 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         }
 
         if (args.options("--coverage-reporter").len > 0) {
-            ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false };
+            ctx.test_options.coverage.reporters = .{ .text = false, .lcov = false, .cobertura = false };
             for (args.options("--coverage-reporter")) |reporter| {
                 if (bun.strings.eqlComptime(reporter, "text")) {
                     ctx.test_options.coverage.reporters.text = true;
                 } else if (bun.strings.eqlComptime(reporter, "lcov")) {
                     ctx.test_options.coverage.reporters.lcov = true;
+                } else if (bun.strings.eqlComptime(reporter, "cobertura")) {
+                    ctx.test_options.coverage.reporters.cobertura = true;
                 } else {
-                    Output.prettyErrorln("<r><red>error<r>: invalid coverage reporter '{s}'. Available options: 'text' (console output), 'lcov' (code coverage file)", .{reporter});
+                    Output.prettyErrorln("<r><red>error<r>: invalid coverage reporter '{s}'. Available options: 'text' (console output), 'lcov' (code coverage file), 'cobertura' (XML coverage file)", .{reporter});
                     Global.exit(1);
                 }
             }

--- a/src/generated_perf_trace_events.zig
+++ b/src/generated_perf_trace_events.zig
@@ -55,7 +55,11 @@ pub const PerfEvent = enum(i32) {
     @"RuntimeTranspilerCache.toFile",
     @"StandaloneModuleGraph.serialize",
     @"Symbols.followAll",
+    @"TestCommand.printCodeCoverageCobertura",
+    @"TestCommand.printCodeCoverageCoberturaAndText",
     @"TestCommand.printCodeCoverageLCov",
+    @"TestCommand.printCodeCoverageLCovAndCobertura",
     @"TestCommand.printCodeCoverageLCovAndText",
+    @"TestCommand.printCodeCoverageLCovCoberturaAndText",
     @"TestCommand.printCodeCoverageText",
 };

--- a/src/sourcemap/CodeCoverage.zig
+++ b/src/sourcemap/CodeCoverage.zig
@@ -357,7 +357,7 @@ pub const Report = struct {
                 try writer.writeAll("    <packages>\n");
 
                 // Group reports by directory
-                var package_map = std.StringHashMap(std.ArrayListUnmanaged(*const Report)).init(this.allocator);
+                var package_map = bun.StringHashMap(std.ArrayListUnmanaged(*const Report)).init(this.allocator);
                 defer {
                     var iter = package_map.iterator();
                     while (iter.next()) |entry| {

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -30,7 +30,7 @@ end_of_record"
 exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
 "<?xml version="1.0" ?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage lines-valid="21" lines-covered="20" line-rate="0.9524" timestamp="0" complexity="0" version="0.1">
+<coverage lines-valid="21" lines-covered="20" line-rate="0.9524" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="0" complexity="0" version="0.1">
     <sources>
         <source><dir></source>
     </sources>

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -26,3 +26,70 @@ LF:7
 LH:5
 end_of_record"
 `;
+
+exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
+"<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="21" lines-covered="20" line-rate="0.9524" timestamp="0" complexity="0" version="0.1">
+    <sources>
+        <source><dir></source>
+    </sources>
+    <packages>
+        <package name="src" line-rate="0.9524">
+            <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000">
+                <methods>
+                    <method name="(anonymous_0)" hits="1" signature="()V">
+                        <lines>
+                            <line number="6" hits="1"/>
+                        </lines>
+                    </method>
+                    <method name="(anonymous_1)" hits="1" signature="()V">
+                        <lines>
+                            <line number="5" hits="1"/>
+                        </lines>
+                    </method>
+                    <method name="(anonymous_2)" hits="1" signature="()V">
+                        <lines>
+                            <line number="12" hits="1"/>
+                        </lines>
+                    </method>
+                </methods>
+                <lines>
+                    <line number="2" hits="48"/>
+                    <line number="3" hits="31"/>
+                    <line number="5" hits="27"/>
+                    <line number="6" hits="31"/>
+                    <line number="7" hits="30"/>
+                    <line number="9" hits="26"/>
+                    <line number="10" hits="4"/>
+                    <line number="12" hits="43"/>
+                    <line number="13" hits="29"/>
+                    <line number="15" hits="25"/>
+                    <line number="16" hits="3"/>
+                    <line number="17" hits="2"/>
+                </lines>
+            </class>
+            <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889">
+                <methods>
+                    <method name="(anonymous_0)" hits="1" signature="()V">
+                        <lines>
+                            <line number="2" hits="1"/>
+                        </lines>
+                    </method>
+                </methods>
+                <lines>
+                    <line number="2" hits="12"/>
+                    <line number="3" hits="12"/>
+                    <line number="4" hits="0"/>
+                    <line number="5" hits="2"/>
+                    <line number="7" hits="17"/>
+                    <line number="8" hits="12"/>
+                    <line number="9" hits="2"/>
+                    <line number="11" hits="23"/>
+                    <line number="13" hits="17"/>
+                </lines>
+            </class>
+        </package>
+    </packages>
+</coverage>"
+`;

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -35,20 +35,20 @@ exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
         <source><dir></source>
     </sources>
     <packages>
-        <package name="src" line-rate="0.9524">
-            <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000">
+        <package name="src" line-rate="0.9524" branch-rate="0" complexity="0">
+            <class name="foo.test.ts" filename="src/foo.test.ts" line-rate="1.0000" branch-rate="0.0" complexity="0.0">
                 <methods>
-                    <method name="(anonymous_0)" hits="1" signature="()V">
+                    <method name="(anonymous_0)" signature="()V" line-rate="1.0" branch-rate="0" complexity="0">
                         <lines>
                             <line number="6" hits="1"/>
                         </lines>
                     </method>
-                    <method name="(anonymous_1)" hits="1" signature="()V">
+                    <method name="(anonymous_1)" signature="()V" line-rate="1.0" branch-rate="0" complexity="0">
                         <lines>
                             <line number="5" hits="1"/>
                         </lines>
                     </method>
-                    <method name="(anonymous_2)" hits="1" signature="()V">
+                    <method name="(anonymous_2)" signature="()V" line-rate="1.0" branch-rate="0" complexity="0">
                         <lines>
                             <line number="12" hits="1"/>
                         </lines>
@@ -69,9 +69,9 @@ exports[`cobertura coverage reporter: cobertura-coverage-reporter-output 1`] = `
                     <line number="17" hits="2"/>
                 </lines>
             </class>
-            <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889">
+            <class name="foo.ts" filename="src/foo.ts" line-rate="0.8889" branch-rate="0.0" complexity="0.0">
                 <methods>
-                    <method name="(anonymous_0)" hits="1" signature="()V">
+                    <method name="(anonymous_0)" signature="()V" line-rate="1.0" branch-rate="0" complexity="0">
                         <lines>
                             <line number="2" hits="1"/>
                         </lines>


### PR DESCRIPTION
## Summary
Implements Cobertura XML code coverage reporter for `bun test`, following the existing LCOV pattern.

Fixes https://github.com/oven-sh/bun/issues/24076

## Changes
- **New Feature**: `--coverage-reporter cobertura` option
- **Configuration**: Added `cobertura` to bunfig.toml `coverageReporter` options
- **Implementation**: Full Cobertura XML generation in `src/sourcemap/CodeCoverage.zig`
  - Proper XML escaping for special characters
  - Package/class/method/line hierarchy
  - Files grouped by directory into packages
  - Line coverage rates calculated per file and overall
- **Tests**: Added comprehensive test coverage

## Example Usage
```bash
bun test --coverage --coverage-reporter cobertura
```

Output file: `coverage/cobertura.xml`

## Technical Notes
- Cobertura requires collecting all reports before writing (unlike LCOV which streams)
- Implementation uses separate comptime-gated scope to avoid memory corruption
- No interference with existing text/lcov reporters
- All existing tests continue to pass

## Test Plan
- ✅ All 13 coverage tests pass
- ✅ Cobertura XML validates against DTD
- ✅ Existing LCOV/text reporters unaffected
- ✅ Proper line/function coverage metrics