### PR TITLE
Fix panic when exception thrown in uncaughtException handler

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -656,9 +656,12 @@ pub fn uncaughtException(this: *jsc.VirtualMachine, globalObject: *JSGlobalObjec
     }
 
     if (this.is_handling_uncaught_exception) {
+        // Nested exception while handling an uncaught exception
+        // Log it and exit without panicking
         this.runErrorHandler(err, null);
-        bun.api.node.process.exit(globalObject, 7);
-        @panic("Uncaught exception while handling uncaught exception");
+        this.exit_handler.exit_code = 7;
+        this.onExit();
+        this.globalExit();
     }
     if (this.exit_on_uncaught_exception) {
         this.runErrorHandler(err, null);
@@ -675,6 +678,10 @@ pub fn uncaughtException(this: *jsc.VirtualMachine, globalObject: *JSGlobalObjec
         this.onUnhandledRejection(this, globalObject, err);
     }
     return handled;
+}
+
+pub export fn Bun__VM__isHandlingUncaughtException(vm: *jsc.VirtualMachine) callconv(.C) bool {
+    return vm.is_handling_uncaught_exception;
 }
 
 pub fn reportExceptionInHotReloadedModuleIfNeeded(this: *jsc.VirtualMachine) void {

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -83,40 +83,4 @@ describe("process.on", () => {
     });
     expect(result2.exitCode).toBe(0);
   });
-
-  it("should handle exceptions in uncaughtException handlers without panic", () => {
-    const dir = tempDirWithFiles("uncaught-exception-test", {
-      "test.ts": `
-// Throw an error in an uncaughtException handler
-// This should exit with code 7 without panicking
-process.on('uncaughtException', (err) => {
-  // This will throw a TypeError
-  err instanceof undefined;
-});
-
-// Trigger the uncaughtException handler
-throw new Error("Test error");
-`,
-    });
-
-    const result = Bun.spawnSync({
-      cmd: [bunExe(), path.join(dir, "test.ts")],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-
-    const stderr = result.stderr.toString();
-
-    // Should not panic
-    expect(stderr).not.toContain("panic:");
-    expect(stderr).not.toContain("SHOULD NEVER BE REACHED");
-
-    // Should show the TypeError
-    expect(stderr).toContain("TypeError");
-    expect(stderr).toContain("Right hand side of instanceof is not an object");
-
-    // Should exit with code 7 (nested exception in uncaught handler)
-    expect(result.exitCode).toBe(7);
-  });
 });

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -83,4 +83,40 @@ describe("process.on", () => {
     });
     expect(result2.exitCode).toBe(0);
   });
+
+  it("should handle exceptions in uncaughtException handlers without panic", () => {
+    const dir = tempDirWithFiles("uncaught-exception-test", {
+      "test.ts": `
+// Throw an error in an uncaughtException handler
+// This should exit with code 7 without panicking
+process.on('uncaughtException', (err) => {
+  // This will throw a TypeError
+  err instanceof undefined;
+});
+
+// Trigger the uncaughtException handler
+throw new Error("Test error");
+`,
+    });
+
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), path.join(dir, "test.ts")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const stderr = result.stderr.toString();
+
+    // Should not panic
+    expect(stderr).not.toContain("panic:");
+    expect(stderr).not.toContain("SHOULD NEVER BE REACHED");
+
+    // Should show the TypeError
+    expect(stderr).toContain("TypeError");
+    expect(stderr).toContain("Right hand side of instanceof is not an object");
+
+    // Should exit with code 7 (nested exception in uncaught handler)
+    expect(result.exitCode).toBe(7);
+  });
 });

--- a/test/regression/issue/24069.test.ts
+++ b/test/regression/issue/24069.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("should not panic when exception is thrown in uncaughtException handler in worker", async () => {
+  const dir = tempDirWithFiles("uncaught-exception-worker-test", {
+    "worker.js": `
+const observedWindows = [{ Error: undefined }];
+
+process.on('uncaughtException', (error) => {
+  // This mimics what happy-dom does - checking instanceof with undefined
+  // This will throw TypeError: Right hand side of instanceof is not an object
+  for (const window of observedWindows) {
+    if (error instanceof window.Error) {
+      break;
+    }
+  }
+});
+
+throw new Error("Test error");
+`,
+    "main.js": `
+import { Worker } from 'worker_threads';
+
+const worker = new Worker('./worker.js');
+worker.on('exit', (code) => {
+  // Worker should exit with code 7 (nested exception)
+  process.exit(code === 7 ? 0 : 1);
+});
+
+setTimeout(() => process.exit(1), 5000);
+`,
+  });
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should not panic
+  expect(stderr).not.toContain("panic:");
+  expect(stderr).not.toContain("oh no: Bun has crashed");
+
+  // Should show the TypeError
+  expect(stderr).toContain("TypeError");
+  expect(stderr).toContain("Right hand side of instanceof is not an object");
+
+  // Should exit 0 (worker exited with 7, main treats that as success)
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #24069

When an exception is thrown inside an `uncaughtException` event handler (especially in worker threads), Bun would panic with "Uncaught exception while handling uncaught exception".

This commonly occurs with packages like `@happy-dom/server-renderer` which check `error instanceof window.Error` where `window.Error` can be `undefined`, causing a `TypeError: Right hand side of instanceof is not an object`.

## Root Cause

In `VirtualMachine.zig`, when `is_handling_uncaught_exception` is true and another exception occurs, the code would call `@panic()`. This happens because `EventEmitter` catches exceptions internally and calls `Bun__reportUnhandledError`, which triggers `uncaughtException()` again while the flag is still set.

## Changes

Replace the `@panic()` with a clean exit using `globalExit()`, matching Node.js behavior which exits with code 7 for nested uncaught exceptions.

## Test

Added `test/regression/issue/24069.test.ts` which:
- ✅ Passes with this fix (no panic, clean exit with code 7)
- ❌ Fails on current main (panics)

Tested with the original reproduction case from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>