### PR TITLE
Refactor Socket to use jsc.JSRef instead of hasPendingActivity

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -365,7 +365,7 @@ pub fn onCreate(comptime ssl: bool, socket: uws.NewSocketHandler(ssl)) void {
     const this_socket = bun.new(Socket, .{
         .ref_count = .init(),
         .handlers = &listener.handlers,
-        .this_value = .zero,
+        .this_value = jsc.JSRef.empty(),
         .socket = socket,
         .protos = listener.protos,
         .flags = .{ .owned_protos = false },
@@ -758,7 +758,7 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
                 prev_maybe_tcp;
 
             const socket = if (maybe_previous) |prev| blk: {
-                bun.assert(prev.this_value != .zero);
+                bun.assert(prev.this_value.tryGet() != null);
                 if (prev.handlers) |prev_handlers| {
                     prev_handlers.deinit();
                     handlers.vm.allocator.destroy(prev_handlers);
@@ -773,7 +773,7 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
             } else bun.new(SocketType, .{
                 .ref_count = .init(),
                 .handlers = handlers_ptr,
-                .this_value = .zero,
+                .this_value = jsc.JSRef.empty(),
                 .socket = SocketType.Socket.detached,
                 .connection = connection,
                 .protos = if (ssl) |s| s.takeProtos() else null,

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -4,7 +4,6 @@ function generate(ssl) {
   return define({
     name: !ssl ? "TCPSocket" : "TLSSocket",
     JSType: "0b11101110",
-    hasPendingActivity: true,
     noConstructor: true,
     configurable: false,
     memoryCost: true,


### PR DESCRIPTION
## Summary

This PR refactors the Socket implementation to use `jsc.JSRef` for managing JavaScript object lifecycle instead of the `hasPendingActivity` callback pattern. This follows the same pattern as the subprocess JSRef refactor and provides better GC lifecycle management.

## Changes

### Core Refactoring
- Replace `this_value: jsc.JSValue` with `this_value: jsc.JSRef`
- Remove `has_pending_activity: std.atomic.Value(bool)` field
- Remove `hasPendingActivity()` callback function
- Remove `hasPendingActivity: true` from `sockets.classes.ts`

### New Functions
- `computeHasPendingActivity()`: Determines pending activity state based on `flags.is_active`
- `updateHasPendingActivity()`: Upgrades to strong reference when active, downgrades to weak when inactive

### Updated Functions
- `getThisValue()`: Uses `JSRef.tryGet()` and `setWeak()` for initialization
- `finalize()`: Calls `this_value.finalize()` for proper cleanup
- `markActive()` and `markInactive()`: Call `updateHasPendingActivity()` instead of directly manipulating atomics
- `setData()`: Gets JSValue from JSRef before passing to `dataSetCached()`

### Initialization Sites
- Updated all socket creation sites in `socket.zig` and `Listener.zig` to use `jsc.JSRef.empty()` instead of `.zero`
- Fixed comparisons from `.zero` to `tryGet() != null`

## Benefits

1. **Better GC lifecycle management**: Uses weak/strong references instead of callbacks
2. **Consistent with codebase patterns**: Follows the same approach as subprocess refactor
3. **Cleaner code**: Removes the need for atomic boolean and separate callback function
4. **Automatic reference management**: JSRef handles upgrade/downgrade based on pending activity

## Test Plan

- Build completed successfully
- All existing socket tests should continue to pass
- Socket lifecycle (creation, active state, finalization) is properly managed through JSRef

🤖 Generated with [Claude Code](https://claude.com/claude-code)