### PR TITLE
Refactor FSWatcher to use JSRef instead of hasPendingActivity

### DIFF
--- a/src/bun.js/node/node.classes.ts
+++ b/src/bun.js/node/node.classes.ts
@@ -81,7 +81,6 @@ export default [
     noConstructor: true,
     finalize: true,
     configurable: false,
-    hasPendingActivity: true,
     klass: {},
     JSType: "0b11101110",
     proto: {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5967,7 +5967,7 @@ pub const NodeFS = struct {
 
     pub fn watch(_: *NodeFS, args: Arguments.Watch, _: Flavor) Maybe(Return.Watch) {
         return switch (args.createFSWatcher()) {
-            .result => |result| .{ .result = result.js_this },
+            .result => |result| .{ .result = result.this_value.tryGet() orelse .zero },
             .err => |err| .{ .err = err },
         };
     }


### PR DESCRIPTION
## Summary

Refactors `FSWatcher` to use `jsc.JSRef` instead of manual `hasPendingActivity` tracking, following the pattern established in the Subprocess refactor (see `claude/refactor-subprocess-jsref`).

This simplifies lifecycle management by using weak/strong references instead of atomic counters.

## Changes

### Core Refactor
- **Replaced `js_this: jsc.JSValue`** with `this_value: jsc.JSRef` in FSWatcher struct
- **Replaced `pending_activity_count: std.atomic.Value(u32)`** with `task_count: u32` (mutex-protected)
- **Added lifecycle methods:**
  - `updateHasPendingActivity()` - manages weak/strong ref transitions
  - `updateHasPendingActivityLocked()` - internal helper
  - `computeHasPendingActivity()` - checks if tasks are pending

### Updated Files
- `src/bun.js/node/node_fs_watcher.zig` - Main refactor
- `src/bun.js/node/node_fs.zig` - Update `watch()` to use `this_value.tryGet()`
- `src/bun.js/node/node.classes.ts` - Remove `hasPendingActivity: true` (line 84)

### How It Works

The `task_count` field tracks active operations:
- Starts at 1 when watcher is initialized
- Increments when tasks are enqueued via `refTask()`
- Decrements when tasks complete via `unrefTask()`
- When count > 0: JSRef is upgraded to strong (prevents GC)
- When count = 0: JSRef is downgraded to weak (allows GC)

This automatic weak/strong management eliminates the need for the `hasPendingActivity` callback.

## Test Plan

Ran existing fs.watch test suite:
```bash
bun bd test test/js/node/watch/fs.watch.test.ts
```

**Results:** 29/31 tests pass (same as main branch)
- The 2 failing tests are pre-existing permission-related issues that also fail on main

## Related

- Similar pattern used in Subprocess refactor: `claude/refactor-subprocess-jsref`
- Example diff: `git diff origin/main..origin/claude/refactor-subprocess-jsref -- src/bun.js/api/bun/subprocess.zig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)