### PR TITLE
feat: Implements the `Module.findPackageJSON` function Node.js

### DIFF
--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -289,7 +289,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
         scope, JSValue::encode(Bun::JSCommonJSModule::createBoundRequireFunction(vm, globalObject, val)));
 }
 
-extern "C" void Bun__findPackageJSON(BunString* path, BunString* result);
+extern "C" void Bun__findPackageJSON(JSC::JSGlobalObject* globalObject, BunString* path, BunString* result);
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPackageJSON,
     (JSC::JSGlobalObject * globalObject,
@@ -328,7 +328,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPackageJSON,
 
     BunString input = Bun::toString(val);
     BunString result;
-    Bun__findPackageJSON(&input, &result);
+    Bun__findPackageJSON(globalObject, &input, &result);
 
     if (result.tag == BunStringTag::Empty) {
         return JSValue::encode(jsNull());

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2612,7 +2612,7 @@ pub const Resolver = struct {
         return PackageJSON.new(pkg);
     }
 
-    fn dirInfoCached(r: *ThisResolver, path: string) !?*DirInfo {
+    pub fn dirInfoCached(r: *ThisResolver, path: string) !?*DirInfo {
         return try r.dirInfoCachedMaybeLog(path, true, true);
     }
 

--- a/test/js/node/module/node-module-findPackageJSON.test.ts
+++ b/test/js/node/module/node-module-findPackageJSON.test.ts
@@ -3,50 +3,60 @@ import { findPackageJSON } from "node:module";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 
-describe("Module.findPackageJSON", () => {
-  test("finds package.json from file URL", () => {
+describe.concurrent("Module.findPackageJSON", () => {
+  test.concurrent("finds package.json from file URL", () => {
     const fileUrl = pathToFileURL(__filename).href;
     const result = findPackageJSON(fileUrl);
 
-    expect(result).toBeDefined();
-    expect(result).toContain("package.json");
-    expect(result).toContain(path.resolve(import.meta.dir, "../../../.."));
+    expect(typeof result).toBe("string");
+    expect(path.basename(result!)).toBe("package.json");
+    expect(path.isAbsolute(result!)).toBe(true);
   });
 
-  test("finds package.json from directory path", () => {
+  test.concurrent("finds package.json from directory path", () => {
     const dirUrl = pathToFileURL(import.meta.dir).href;
     const result = findPackageJSON(dirUrl);
 
-    expect(result).toBeDefined();
-    expect(result).toContain("package.json");
+    expect(typeof result).toBe("string");
+    expect(path.basename(result!)).toBe("package.json");
+    expect(path.isAbsolute(result!)).toBe(true);
   });
 
-  test("finds package.json from nested file", () => {
+  test.concurrent("finds package.json from nested file", () => {
     const nestedPath = path.join(import.meta.dir, "../../..");
     const fileUrl = pathToFileURL(path.join(nestedPath, "some-file.js")).href;
     const result = findPackageJSON(fileUrl);
 
-    expect(result).toBeDefined();
-    expect(result).toContain("package.json");
+    expect(typeof result).toBe("string");
+    expect(path.basename(result!)).toBe("package.json");
+    expect(path.isAbsolute(result!)).toBe(true);
   });
 
-  test("returns null when no package.json found", () => {
+  test.concurrent("returns null when no package.json found", () => {
     // Use a path that's unlikely to have a package.json
     const rootPath = path.parse(import.meta.dir).root;
     const deepPath = path.join(rootPath, "nonexistent", "deep", "path", "file.js");
     const fileUrl = pathToFileURL(deepPath).href;
     const result = findPackageJSON(fileUrl);
 
-    // Should return null or empty when not found
-    expect(result === null || result === "").toBe(true);
+    // Should return null when not found
+    expect(result).toBeNull();
   });
 
-  test("works with absolute paths as file URLs", () => {
+  test.concurrent("works with absolute paths as file URLs", () => {
     const absolutePath = path.resolve(import.meta.dir, "node-module-findPackageJSON.test.ts");
     const fileUrl = pathToFileURL(absolutePath).href;
     const result = findPackageJSON(fileUrl);
 
-    expect(result).toBeDefined();
-    expect(result).toContain("package.json");
+    expect(typeof result).toBe("string");
+    expect(path.basename(result!)).toBe("package.json");
+    expect(path.isAbsolute(result!)).toBe(true);
+  });
+
+  test.concurrent("accepts absolute path string", () => {
+    const result = findPackageJSON(import.meta.dir);
+    expect(typeof result).toBe("string");
+    expect(path.basename(result!)).toBe("package.json");
+    expect(path.isAbsolute(result!)).toBe(true);
   });
 });

--- a/test/js/node/module/node-module-findPackageJSON.test.ts
+++ b/test/js/node/module/node-module-findPackageJSON.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "bun:test";
+import { findPackageJSON } from "node:module";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+describe("Module.findPackageJSON", () => {
+  test("finds package.json from file URL", () => {
+    const fileUrl = pathToFileURL(__filename).href;
+    const result = findPackageJSON(fileUrl);
+
+    expect(result).toBeDefined();
+    expect(result).toContain("package.json");
+    expect(result).toContain(path.resolve(import.meta.dir, "../../../.."));
+  });
+
+  test("finds package.json from directory path", () => {
+    const dirUrl = pathToFileURL(import.meta.dir).href;
+    const result = findPackageJSON(dirUrl);
+
+    expect(result).toBeDefined();
+    expect(result).toContain("package.json");
+  });
+
+  test("finds package.json from nested file", () => {
+    const nestedPath = path.join(import.meta.dir, "../../..");
+    const fileUrl = pathToFileURL(path.join(nestedPath, "some-file.js")).href;
+    const result = findPackageJSON(fileUrl);
+
+    expect(result).toBeDefined();
+    expect(result).toContain("package.json");
+  });
+
+  test("returns null when no package.json found", () => {
+    // Use a path that's unlikely to have a package.json
+    const rootPath = path.parse(import.meta.dir).root;
+    const deepPath = path.join(rootPath, "nonexistent", "deep", "path", "file.js");
+    const fileUrl = pathToFileURL(deepPath).href;
+    const result = findPackageJSON(fileUrl);
+
+    // Should return null or empty when not found
+    expect(result === null || result === "").toBe(true);
+  });
+
+  test("works with absolute paths as file URLs", () => {
+    const absolutePath = path.resolve(import.meta.dir, "node-module-findPackageJSON.test.ts");
+    const fileUrl = pathToFileURL(absolutePath).href;
+    const result = findPackageJSON(fileUrl);
+
+    expect(result).toBeDefined();
+    expect(result).toContain("package.json");
+  });
+});


### PR DESCRIPTION
Closes: https://github.com/oven-sh/bun/issues/23898

### What does this PR do?

- **C++ (`NodeModuleModule.cpp`)**: Added `jsFunctionFindPackageJSON` that accepts file URLs or absolute paths and returns the path to the nearest package.json file or null if not found
- **Zig (`path.zig`)**: Implemented `Bun__findPackageJSON` that searches upward through the directory tree with platform-aware path operations (Windows/POSIX)
- **Tests**: Added comprehensive test suite with 5 test cases covering file URLs, directories, nested paths, and edge cases


The function traverses up the directory tree from the given path until it finds a package.json file, returning its absolute path. Returns null when no package.json is found.


### How did you verify your code works?
```typescript
import { findPackageJSON } from "node:module";
import { pathToFileURL } from "node:url";

const pkgPath = findPackageJSON(pathToFileURL("/path/to/file.js").href);
```

**Screenshot**
<img width="821" height="124" alt="Screenshot 2025-10-26 at 4 06 57 PM" src="https://github.com/user-attachments/assets/aeaefde9-d3a0-45a1-a64a-645df146e5ca" />

