### PR TITLE
fix: inconsistent tabs used during `library` initialization

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -19,11 +19,12 @@ pub const InitCommand = struct {
                 const key_start = j + 1;
                 const key_end = key_start + key.len;
                 if (key_end <= line.len and std.mem.eql(u8, line[key_start..key_end], key)) {
-                    const after_key = if (key_end < line.len) line[key_end] else 0;
-                    const after_key2 = if (key_end + 1 < line.len) line[key_end + 1] else 0;
-                    // Match ": after key
-                    if (after_key == '"' and after_key2 == ':') {
-                        skip = true;
+                    if (key_end < line.len and line[key_end] == '"') {
+                        var p: usize = key_end + 1;
+                        while (p < line.len and (line[p] == ' ' or line[p] == '\t')) : (p += 1) {}
+                        if (p < line.len and line[p] == ':') {
+                            skip = true;
+                        }
                     }
                 }
             }

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1,27 +1,3 @@
-const std = @import("std");
-const bun = @import("bun");
-const CLI = @import("../cli.zig");
-const Fs = @import("../fs.zig");
-const options = @import("../options.zig");
-const initializeStore = @import("./create_command.zig").initializeStore;
-
-const Environment = bun.Environment;
-const Global = bun.Global;
-const JSON = bun.json;
-const JSPrinter = bun.js_printer;
-const MutableString = bun.MutableString;
-const Output = bun.Output;
-const default_allocator = bun.default_allocator;
-const js_ast = bun.ast;
-const logger = bun.logger;
-const strings = bun.strings;
-
-const exists = bun.sys.exists;
-const existsZ = bun.sys.existsZ;
-
-const string = []const u8;
-const stringZ = [:0]const u8;
-
 pub const InitCommand = struct {
     fn removeJsonPropertyLine(alloc: std.mem.Allocator, content: []const u8, key: []const u8) ![]u8 {
         var out = std.ArrayList(u8).init(alloc);
@@ -1311,6 +1287,30 @@ const Template = enum {
         Output.flush();
     }
 };
+
+const std = @import("std");
+const bun = @import("bun");
+const CLI = @import("../cli.zig");
+const Fs = @import("../fs.zig");
+const options = @import("../options.zig");
+const initializeStore = @import("./create_command.zig").initializeStore;
+
+const Environment = bun.Environment;
+const Global = bun.Global;
+const JSON = bun.json;
+const JSPrinter = bun.js_printer;
+const MutableString = bun.MutableString;
+const Output = bun.Output;
+const default_allocator = bun.default_allocator;
+const js_ast = bun.ast;
+const logger = bun.logger;
+const strings = bun.strings;
+
+const exists = bun.sys.exists;
+const existsZ = bun.sys.existsZ;
+
+const string = []const u8;
+const stringZ = [:0]const u8;
 
 test "removeJsonPropertyLine removes jsx property line and preserves others" {
     const alloc = std.testing.allocator;


### PR DESCRIPTION
Closes #19319 

### What does this PR do?

Fixes an inconsistency when running bun init with the Library template: `package.json` was configured for a library while `tsconfig.json` still included a React JSX setting. This change removes the JSX property for the Library template without introducing a new asset file and aligns imports with project conventions.

### How did you verify your code works?
Integration coverage for “bun init —library” behaviour and tsconfig checks



**Screenshots**
<img width="793" height="797" alt="Screenshot 2025-10-26 at 6 02 25 PM" src="https://github.com/user-attachments/assets/8f5850bd-c703-43a6-ae9e-588601c64f58" />
