### PR TITLE
scripts: teach machine.mjs how to spawn a freebsd image on aws

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "machine:linux:alpine": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=linux --distro=alpine --release=3.22",
     "machine:linux:amazonlinux": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=linux --distro=amazonlinux --release=2023",
     "machine:windows:2019": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=windows --release=2019",
+    "machine:freebsd": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.large --os=freebsd --release=14.3",
     "sync-webkit-source": "bun ./scripts/sync-webkit-source.ts"
   }
 }

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -391,7 +391,7 @@ const aws = {
       }
     } else if (os === "freebsd") {
       owner = "782442783595"; // upstream member of FreeBSD team, likely Colin Percival
-      name = `FreeBSD ${release}-STABLE-amd64-* UEFI-PREFERRED cloud-init UFS`;
+      name = `FreeBSD ${release}-STABLE-${{ "arm64": "arm64", "x64": "amd64" }[arch] ?? "amd64"}-* UEFI-PREFERRED cloud-init UFS`;
     }
 
     if (!name) {

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -391,7 +391,7 @@ const aws = {
       }
     } else if (os === "freebsd") {
       owner = "782442783595"; // upstream member of FreeBSD team, likely Colin Percival
-      name = `FreeBSD ${release}-STABLE-${{ "arm64": "arm64", "x64": "amd64" }[arch] ?? "amd64"}-* UEFI-PREFERRED cloud-init UFS`;
+      name = `FreeBSD ${release}-STABLE-${{ "aarch64": "arm64", "x64": "amd64" }[arch] ?? "amd64"}-* UEFI-PREFERRED cloud-init UFS`;
     }
 
     if (!name) {
@@ -429,6 +429,8 @@ const aws = {
     }
 
     const { ImageId, Name, RootDeviceName, BlockDeviceMappings } = image;
+    // console.table({ os, arch, instanceType, Name, ImageId });
+
     const blockDeviceMappings = BlockDeviceMappings.map(device => {
       const { DeviceName } = device;
       if (DeviceName === RootDeviceName) {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1538,7 +1538,7 @@ export function parseNumber(value) {
 
 /**
  * @param {string} string
- * @returns {"darwin" | "linux" | "windows"}
+ * @returns {"darwin" | "linux" | "windows" | "freebsd"}
  */
 export function parseOs(string) {
   if (/darwin|apple|mac/i.test(string)) {
@@ -1549,6 +1549,9 @@ export function parseOs(string) {
   }
   if (/win/i.test(string)) {
     return "windows";
+  }
+  if (/freebsd/i.test(string)) {
+    return "freebsd";
   }
   throw new Error(`Unsupported operating system: ${string}`);
 }
@@ -1900,21 +1903,20 @@ export function getUsernameForDistro(distro) {
   if (/windows/i.test(distro)) {
     return "administrator";
   }
-
   if (/alpine|centos/i.test(distro)) {
     return "root";
   }
-
   if (/debian/i.test(distro)) {
     return "admin";
   }
-
   if (/ubuntu/i.test(distro)) {
     return "ubuntu";
   }
-
   if (/amazon|amzn|al\d+|rhel/i.test(distro)) {
     return "ec2-user";
+  }
+  if (/freebsd/i.test(distro)) {
+    return "root";
   }
 
   throw new Error(`Unsupported distro: ${distro}`);


### PR DESCRIPTION
exploratory look into https://github.com/oven-sh/bun/issues/1524
this still leaves that far off from being closed but an important first step
this is important because this script is used to spawn our base images for CI and will provide boxes for local testing

not sure how far i'll get but a rough "road to freebsd" map for anyone reading:

- [x] this
- [ ] ensure `bootstrap.sh` can run successfully
- [ ] ensure WebKit can build from source
- [ ] ensure other dependencies can build from source
- [ ] add freebsd to our WebKit fork releases
- [ ] add freebsd to our Zig fork releases
- [ ] ensure bun can build from source
- [ ] run `[build images]` and add freebsd to CI
- [ ] fix runtime test failures

<img width="2072" height="956" alt="image" src="https://github.com/user-attachments/assets/ea1acf45-b746-4ffa-8043-be674b87bb60" />
