### PR TITLE
Don't send Content-Length on 204 No Content responses

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2229,6 +2229,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             else
                 status;
 
+            if (status == 204) {
+                this.flags.needs_content_length = false;
+            }
+
             const content_type, const needs_content_type, const content_type_needs_free = getContentType(
                 response.getInitHeaders(),
                 &this.blob,
@@ -2325,6 +2329,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             const blob = this.blob;
             const bytes = blob.slice();
             if (this.resp) |resp| {
+                if (!this.flags.needs_content_length) {
+                    return resp.endWithoutBody(this.shouldCloseConnection());
+                }
+
                 if (!resp.tryEnd(
                     bytes,
                     bytes.len,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2189,3 +2189,14 @@ it.concurrent("#20283", async () => {
   // there should be no cookies and the clone should have succeeded
   expect(json).toEqual({ cookies: {}, clonedCookies: {} });
 });
+
+it("#20676 204 responses should not have Content-Length", async () => {
+  using server = Bun.serve({
+    routes: {
+      "/": async req => { return Response(undefined, { status: 204 }) }
+    }
+  });
+
+  const response = await fetch(server.url);
+  expect(response.headers.get('Content-Length')).toBeNull();
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2193,10 +2193,12 @@ it.concurrent("#20283", async () => {
 it("#20676 204 responses should not have Content-Length", async () => {
   using server = Bun.serve({
     routes: {
-      "/": async req => { return Response(undefined, { status: 204 }) }
-    }
+      "/": async req => {
+        return Response(undefined, { status: 204 });
+      },
+    },
   });
 
   const response = await fetch(server.url);
-  expect(response.headers.get('Content-Length')).toBeNull();
+  expect(response.headers.get("Content-Length")).toBeNull();
 });


### PR DESCRIPTION
### What does this PR do?

Stop sending Content-Length headers on 204 responses. Fixes https://github.com/oven-sh/bun/issues/20676

### How did you verify your code works?

Local testing with a `serve` route which just returned a 204, wrote a test as well. Not ready for production yet, just trying to figure out how things work