### PR TITLE
fix: body already used error to throw TypeError

### DIFF
--- a/src/bun.js/bindings/ErrorCode.ts
+++ b/src/bun.js/bindings/ErrorCode.ts
@@ -20,7 +20,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_ASSERTION", Error],
   ["ERR_ASYNC_CALLBACK", TypeError],
   ["ERR_ASYNC_TYPE", TypeError],
-  ["ERR_BODY_ALREADY_USED", Error],
+  ["ERR_BODY_ALREADY_USED", TypeError],
   ["ERR_BORINGSSL", Error],
   ["ERR_ZSTD", Error],
   ["ERR_BROTLI_INVALID_PARAM", RangeError],

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from "bun:test";
 describe("body-mixin-errors", () => {
   it.concurrent.each([
     ["Response", () => new Response("a"), (b: Response | Request) => b.text()],
-    ["Request", () => new Request("https://example.com", { body: "{}", method: "POST" }), (b: Response | Request) => b.json()],
+    [
+      "Request",
+      () => new Request("https://example.com", { body: "{}", method: "POST" }),
+      (b: Response | Request) => b.json(),
+    ],
   ])("should throw TypeError when body already used on %s", async (type, createBody, secondCall) => {
     const body = createBody();
     await body.text();

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -6,7 +6,7 @@ describe("body-mixin-errors", () => {
     ["Request", () => new Request("https://example.com", { body: "{}", method: "POST" }), (b: Response | Request) => b.json()],
   ])("should throw TypeError when body already used on %s", async (type, createBody, secondCall) => {
     const body = createBody();
-    await (body as any).text();
+    await body.text();
 
     try {
       await secondCall(body);

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from "bun:test";
 
 describe("body-mixin-errors", () => {
-  it("should fail when bodyUsed", async () => {
-    var res = new Response("a");
-    expect(res.bodyUsed).toBe(false);
-    await res.text();
-    expect(res.bodyUsed).toBe(true);
+  it.concurrent.each([
+    ["Response", () => new Response("a"), (b: Response | Request) => b.text()],
+    ["Request", () => new Request("https://example.com", { body: "{}", method: "POST" }), (b: Response | Request) => b.json()],
+  ])("should throw TypeError when body already used on %s", async (type, createBody, secondCall) => {
+    const body = createBody();
+    await (body as any).text();
 
     try {
-      await res.text();
-      throw new Error("should not get here");
-    } catch (e: any) {
-      expect(e.message).toBe("Body already used");
+      await secondCall(body);
+      expect.unreachable("body is already used");
+    } catch (err: any) {
+      expect(err.name).toBe("TypeError");
+      expect(err.message).toBe("Body already used");
+      expect(err instanceof TypeError).toBe(true);
     }
   });
 });


### PR DESCRIPTION
Should fix https://github.com/oven-sh/bun/issues/24104

### What does this PR do?

This PR is changing `ERR_BODY_ALREADY_USED` to be TypeError instead of Error.


### How did you verify your code works?
A test case added to verify that request call correctly throws a TypeError after another request call on the same Request, confirming the fix addresses the issue.