### PR TITLE
fix(node:http): Fix ServerResponse.writableNeedDrain causing stream pause

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1526,7 +1526,7 @@ ServerResponse.prototype._implicitHeader = function () {
 
 Object.defineProperty(ServerResponse.prototype, "writableNeedDrain", {
   get() {
-    return !this.destroyed && !this.finished && (this[kHandle]?.bufferedAmount ?? 1) !== 0;
+    return !this.destroyed && !this.finished && (this[kHandle]?.bufferedAmount ?? 0) !== 0;
   },
 });
 

--- a/test/regression/issue/19111.test.ts
+++ b/test/regression/issue/19111.test.ts
@@ -1,8 +1,9 @@
 // https://github.com/oven-sh/bun/issues/19111
 // stream.Readable's `readable` event not firing in Bun 1.2.6+
-import { expect, test } from "bun:test";
-import { IncomingMessage, ServerResponse } from "http";
-import { PassThrough, Readable } from "stream";
+import assert from "node:assert";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { PassThrough, Readable } from "node:stream";
+import { test } from "node:test";
 
 // Focused regression test: Standalone ServerResponse.writableNeedDrain should be false
 test("Standalone ServerResponse.writableNeedDrain is false", () => {
@@ -14,7 +15,7 @@ test("Standalone ServerResponse.writableNeedDrain is false", () => {
   const res = new ServerResponse(mockReq);
 
   // Regression for #19111: previously true due to defaulting bufferedAmount to 1
-  expect(res.writableNeedDrain).toBe(false);
+  assert.strictEqual(res.writableNeedDrain, false);
 });
 
 // Helper function for connect-to-web pattern
@@ -93,6 +94,6 @@ test("Readable.pipe(ServerResponse) flows without stalling (regression for #1911
   src.pipe(res);
 
   const out = await onReadable;
-  expect(out.statusCode).toBe(200);
-  expect(out.headers["content-type"]).toBe("text/plain");
+  assert.strictEqual(out.statusCode, 200);
+  assert.strictEqual(out.headers["content-type"], "text/plain");
 });

--- a/test/regression/issue/19111.test.ts
+++ b/test/regression/issue/19111.test.ts
@@ -1,0 +1,130 @@
+// https://github.com/oven-sh/bun/issues/19111
+// stream.Readable's `readable` event not firing in Bun 1.2.6+
+import { expect, test } from "bun:test";
+import { IncomingMessage, ServerResponse } from "http";
+import { PassThrough, Readable } from "stream";
+
+test("PassThrough stream 'readable' event should fire when data is written", async () => {
+  const passThrough = new PassThrough();
+
+  let readableEventFired = false;
+  const promise = new Promise<void>(resolve => {
+    passThrough.once("readable", () => {
+      readableEventFired = true;
+      resolve();
+    });
+  });
+
+  // Write data to the stream
+  passThrough.write("Hello, world!");
+  passThrough.end();
+
+  await promise;
+  expect(readableEventFired).toBe(true);
+});
+
+test("ServerResponse with PassThrough pattern (connect-to-web pattern)", async () => {
+  // This reproduces the pattern from connect-to-web.ts
+  function createServerResponse(incomingMessage: IncomingMessage) {
+    const res = new ServerResponse(incomingMessage);
+    const passThrough = new PassThrough();
+    let resolved = false;
+
+    const onReadable = new Promise<{
+      readable: Readable;
+      headers: Record<string, any>;
+      statusCode: number;
+    }>((resolve, reject) => {
+      const handleReadable = () => {
+        if (resolved) return;
+        resolved = true;
+        resolve({
+          readable: Readable.from(passThrough),
+          headers: res.getHeaders(),
+          statusCode: res.statusCode,
+        });
+      };
+
+      const handleError = (err: Error) => {
+        reject(err);
+      };
+
+      passThrough.once("readable", handleReadable);
+      passThrough.once("end", handleReadable);
+      passThrough.once("error", handleError);
+      res.once("error", handleError);
+    });
+
+    res.once("finish", () => {
+      passThrough.end();
+    });
+
+    passThrough.on("drain", () => {
+      res.emit("drain");
+    });
+
+    res.write = passThrough.write.bind(passThrough);
+    res.end = (passThrough as any).end.bind(passThrough);
+
+    res.writeHead = function writeHead(
+      statusCode: number,
+      statusMessage?: string | any,
+      headers?: any,
+    ): ServerResponse {
+      res.statusCode = statusCode;
+      if (typeof statusMessage === "object") {
+        headers = statusMessage;
+        statusMessage = undefined;
+      }
+      if (headers) {
+        Object.entries(headers).forEach(([key, value]) => {
+          if (value !== undefined) {
+            res.setHeader(key, value);
+          }
+        });
+      }
+      return res;
+    };
+
+    return { res, onReadable };
+  }
+
+  // Create a mock IncomingMessage
+  const mockReq = Object.assign(Readable.from([]), {
+    url: "/test",
+    method: "GET",
+    headers: {},
+  }) as IncomingMessage;
+
+  const { res, onReadable } = createServerResponse(mockReq);
+
+  // Simulate a middleware writing to the response
+  setTimeout(() => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.write("Hello, world!");
+    res.end();
+  }, 10);
+
+  // The promise should resolve when the readable event fires
+  const result = await onReadable;
+  expect(result.statusCode).toBe(200);
+  expect(result.headers["content-type"]).toBe("text/plain");
+}, 1000);
+
+test("PassThrough readable event fires immediately if data written before listener", async () => {
+  const passThrough = new PassThrough();
+
+  // Write data BEFORE adding the listener
+  passThrough.write("Hello, world!");
+
+  let readableEventFired = false;
+  const promise = new Promise<void>(resolve => {
+    passThrough.once("readable", () => {
+      readableEventFired = true;
+      resolve();
+    });
+  });
+
+  await promise;
+  expect(readableEventFired).toBe(true);
+});


### PR DESCRIPTION
## Summary

Fixes #19111

This PR fixes a bug where `fs.createReadStream().pipe(ServerResponse)` would fail to transfer data when ServerResponse had no handle (standalone usage). This affected Vite's static file serving and other middleware adapters using the connect-to-web pattern.

## Root Cause

The bug was in the `ServerResponse.writableNeedDrain` getter at line 1529 of `_http_server.ts`:

```typescript
return !this.destroyed && !this.finished && (this[kHandle]?.bufferedAmount ?? 1) !== 0;
```

When `ServerResponse` had no handle (which is common in middleware scenarios), the nullish coalescing operator defaulted `bufferedAmount` to **1** instead of **0**. This caused `writableNeedDrain` to always return `true`.

## Impact

When `pipe()` checks `dest.writableNeedDrain === true`, it immediately pauses the source stream to handle backpressure. With the bug, standalone ServerResponse instances always appeared to need draining, causing piped streams to pause and never resume.

## Fix

Changed the default value from `1` to `0`:

```typescript
return !this.destroyed && !this.finished && (this[kHandle]?.bufferedAmount ?? 0) !== 0;
```

## Test Plan

- ✅ Added regression test in `test/regression/issue/19111.test.ts`
- ✅ Verified fix with actual Vite middleware reproduction
- ✅ Confirmed behavior matches Node.js

Generated with [Claude Code](https://claude.com/claude-code)