### PR TITLE
Fix source index bounds check in sourcemap decoder

### DIFF
--- a/src/sourcemap/Mapping.zig
+++ b/src/sourcemap/Mapping.zig
@@ -449,7 +449,7 @@ pub fn parse(
         }
         source_index += source_index_delta.value;
 
-        if (source_index < 0 or source_index > sources_count) {
+        if (source_index < 0 or source_index >= sources_count) {
             return .{
                 .fail = .{
                     .msg = "Invalid source index value",


### PR DESCRIPTION
## Summary

Fix the source index bounds check in `src/sourcemap/Mapping.zig` to correctly validate indices against the range `[0, sources_count)`.

## Changes

- Changed the bounds check condition from `source_index > sources_count` to `source_index >= sources_count` on line 452
- This prevents accepting `source_index == sources_count`, which would be out of bounds when indexing into the sources array

## Test plan

- [x] Built successfully with `bun bd`
- The existing test suite should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)