### PR TITLE
Fix sourcemap comparator to use strict weak ordering

### DIFF
--- a/src/sourcemap/Mapping.zig
+++ b/src/sourcemap/Mapping.zig
@@ -108,7 +108,13 @@ pub const List = struct {
             const a = ctx.generated[a_index];
             const b = ctx.generated[b_index];
 
-            return a.lines.zeroBased() < b.lines.zeroBased() or (a.lines.zeroBased() == b.lines.zeroBased() and a.columns.zeroBased() <= b.columns.zeroBased());
+            if (a.lines.zeroBased() != b.lines.zeroBased()) {
+                return a.lines.zeroBased() < b.lines.zeroBased();
+            }
+            if (a.columns.zeroBased() != b.columns.zeroBased()) {
+                return a.columns.zeroBased() < b.columns.zeroBased();
+            }
+            return a_index < b_index;
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes the comparator function in `src/sourcemap/Mapping.zig` to use strict weak ordering as required by sort algorithms.

## Changes

- Changed `<=` to `<` in the column comparison to ensure strict ordering
- Refactored the comparator to use clearer if-statement structure
- Added index comparison as a tiebreaker for stable sorting when both line and column positions are equal

## Problem

The original comparator used `<=` which would return true for equal elements, violating the strict weak ordering requirement. This could lead to undefined behavior in sorting.

**Before:**
```zig
return a.lines.zeroBased() < b.lines.zeroBased() or (a.lines.zeroBased() == b.lines.zeroBased() and a.columns.zeroBased() <= b.columns.zeroBased());
```

**After:**
```zig
if (a.lines.zeroBased() != b.lines.zeroBased()) {
    return a.lines.zeroBased() < b.lines.zeroBased();
}
if (a.columns.zeroBased() != b.columns.zeroBased()) {
    return a.columns.zeroBased() < b.columns.zeroBased();
}
return a_index < b_index;
```

## Test plan

- [x] Verified compilation with `bun bd`
- The sort now properly follows strict weak ordering semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)