### PR TITLE
Make 'bun list' an alias for 'bun pm ls'

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -617,7 +617,7 @@ pub const Command = struct {
             RootCommandMatcher.case("logout") => .ReservedCommand,
             RootCommandMatcher.case("whoami") => .PackageManagerCommand,
             RootCommandMatcher.case("prune") => .ReservedCommand,
-            RootCommandMatcher.case("list") => .ReservedCommand,
+            RootCommandMatcher.case("list") => .PackageManagerCommand,
             RootCommandMatcher.case("why") => .WhyCommand,
 
             RootCommandMatcher.case("-e") => .AutoCommand,

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -103,7 +103,7 @@ pub const PackageManagerCommand = struct {
             \\  <d>└<r> <cyan>--quiet<r>                   only output the tarball filename
             \\  <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
             \\  <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
-            \\  <b><green>bun<r> <blue>list<r>, <b><green>bun pm<r> <blue>list|ls<r>   list the dependency tree according to the current lockfile
+            \\  <b><green>bun<r> <blue>list<r>                  list the dependency tree according to the current lockfile
             \\  <d>└<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
             \\  <b><green>bun pm<r> <blue>why<r> <d>\<pkg\><r>            show dependency tree explaining why a package is installed
             \\  <b><green>bun pm<r> <blue>whoami<r>               print the current npm username

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -103,7 +103,7 @@ pub const PackageManagerCommand = struct {
             \\  <d>└<r> <cyan>--quiet<r>                   only output the tarball filename
             \\  <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
             \\  <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
-            \\  <b><green>bun pm<r> <blue>ls<r>                   list the dependency tree according to the current lockfile
+            \\  <b><green>bun<r> <blue>list<r>, <b><green>bun pm<r> <blue>ls<r>        list the dependency tree according to the current lockfile
             \\  <d>└<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
             \\  <b><green>bun pm<r> <blue>why<r> <d>\<pkg\><r>            show dependency tree explaining why a package is installed
             \\  <b><green>bun pm<r> <blue>whoami<r>               print the current npm username
@@ -158,7 +158,14 @@ pub const PackageManagerCommand = struct {
         };
         defer ctx.allocator.free(cwd);
 
-        const subcommand = if (is_direct_whoami) "whoami" else getSubcommand(&pm.options.positionals);
+        var subcommand = if (is_direct_whoami) "whoami" else getSubcommand(&pm.options.positionals);
+
+        // Check if we're being invoked directly as "bun list" instead of "bun pm list"
+        const is_direct_list = if (bun.argv.len > 1) strings.eqlComptime(bun.argv[1], "list") else false;
+        if (is_direct_list) {
+            subcommand = "ls";
+        }
+
         if (pm.options.global) {
             try pm.setupGlobalDir(ctx);
         }

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -103,7 +103,7 @@ pub const PackageManagerCommand = struct {
             \\  <d>└<r> <cyan>--quiet<r>                   only output the tarball filename
             \\  <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
             \\  <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
-            \\  <b><green>bun<r> <blue>list<r>, <b><green>bun pm<r> <blue>ls<r>        list the dependency tree according to the current lockfile
+            \\  <b><green>bun<r> <blue>list<r>, <b><green>bun pm<r> <blue>list|ls<r>   list the dependency tree according to the current lockfile
             \\  <d>└<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
             \\  <b><green>bun pm<r> <blue>why<r> <d>\<pkg\><r>            show dependency tree explaining why a package is installed
             \\  <b><green>bun pm<r> <blue>whoami<r>               print the current npm username
@@ -160,9 +160,8 @@ pub const PackageManagerCommand = struct {
 
         var subcommand = if (is_direct_whoami) "whoami" else getSubcommand(&pm.options.positionals);
 
-        // Check if we're being invoked directly as "bun list" instead of "bun pm list"
-        const is_direct_list = if (bun.argv.len > 1) strings.eqlComptime(bun.argv[1], "list") else false;
-        if (is_direct_list) {
+        // Normalize "list" to "ls" (handles both "bun list" and "bun pm list")
+        if (strings.eqlComptime(subcommand, "list")) {
             subcommand = "ls";
         }
 

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -444,3 +444,178 @@ test("bun pm whoami still works", async () => {
   // Exit code will be non-zero due to missing auth
   expect(exitCode).toBe(1);
 });
+
+test("bun list executes pm ls", async () => {
+  // Test that "bun list" works as an alias for "bun pm ls"
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-list",
+      version: "1.0.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  // Install dependencies first
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  // Test "bun list"
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "list"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  // Should not show reservation message
+  expect(stderrText).not.toContain("reserved for future use");
+  expect(stdoutText).not.toContain("reserved for future use");
+
+  // Should show package list
+  expect(stdoutText).toContain("node_modules");
+  expect(stdoutText).toContain("bar@");
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm list works as alias for bun pm ls", async () => {
+  // Test that "bun pm list" works as an alias for "bun pm ls"
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-pm-list",
+      version: "1.0.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  // Install dependencies first
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  // Test "bun pm list"
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "list"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  expect(stdoutText).toContain("node_modules");
+  expect(stdoutText).toContain("bar@");
+  expect(exitCode).toBe(0);
+});
+
+test("bun list --all shows full dependency tree", async () => {
+  // Test that "bun list --all" works correctly
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-list-all",
+      version: "1.0.0",
+      dependencies: {
+        moo: "./moo",
+      },
+    }),
+  );
+  await mkdir(join(package_dir, "moo"));
+  await writeFile(
+    join(package_dir, "moo", "package.json"),
+    JSON.stringify({
+      name: "moo",
+      version: "0.1.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  // Install dependencies first
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  // Test "bun list --all"
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "list", "--all"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  expect(stdoutText).toContain("node_modules");
+  expect(stdoutText).toContain("bar@");
+  expect(stdoutText).toContain("moo@");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

This PR makes `bun list` an alias for `bun pm ls`, allowing users to list their dependency tree with a shorter command.

## Changes

- Updated `src/cli.zig` to route `list` command to `PackageManagerCommand` instead of `ReservedCommand`
- Modified `src/cli/package_manager_command.zig` to detect when `bun list` is invoked directly and treat it as `ls`
- Updated help text in `bun pm --help` to show both `bun list` and `bun pm ls` as valid options

## Implementation Details

The implementation follows the same pattern used for `bun whoami`, which is also a direct alias to a pm subcommand. When `bun list` is detected, it's internally converted to the `ls` subcommand.

## Testing

Tested locally:
- ✅ `bun list` shows the dependency tree
- ✅ `bun list --all` works correctly with the `--all` flag
- ✅ `bun pm ls` continues to work (backward compatible)

## Test Output

```bash
$ bun list
/tmp/test-bun-list node_modules (3)
└── react@18.3.1

$ bun list --all
/tmp/test-bun-list node_modules
├── js-tokens@4.0.0
├── loose-envify@1.4.0
└── react@18.3.1

$ bun pm ls
/tmp/test-bun-list node_modules (3)
└── react@18.3.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)