### PR TITLE
FIX: kqueue returns EINVAL on macOS when polling tty

### DIFF
--- a/src/io/openForWriting.zig
+++ b/src/io/openForWriting.zig
@@ -87,7 +87,8 @@ pub fn openForWritingImpl(
                 }
 
                 if (isatty) {
-                    pollable.* = true;
+                    // macOS doesn't allow polling ttys and end up with EINVAL on kqueue.
+                    pollable.* = !comptime bun.Environment.isMac;
                 }
 
                 is_socket.* = std.posix.S.ISSOCK(stat.mode);


### PR DESCRIPTION
### What does this PR do?

Addressed the issue described in #24158, which macOS kqeueu return EINVAL when polling TTY fd,
therefore following a small reproducible code didn't work.
To workaround this behavior, if it's on macOS, set `pollable` always `false` for tty.

```
import tty from 'node:tty';
import fs from 'node:fs';

const ttyOut = new tty.WriteStream(fs.openSync("/dev/tty", "w"));
```

### How did you verify your code works?

Build and ensure the previous reproducible code can run on Bun on macOS.
Tested on 15.7.1 (24G231) manually.