### PR TITLE
fix(node:http): emit close event on ServerResponse when client disconnects

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -901,6 +901,9 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
         req.destroy();
       }
     }
+
+    // Emit close event on the socket to trigger onServerResponseClose
+    callCloseCallback(this);
   }
   #onCloseForDestroy(closeCallback) {
     this.#onClose();

--- a/test/regression/issue/14697.test.ts
+++ b/test/regression/issue/14697.test.ts
@@ -1,0 +1,58 @@
+// https://github.com/oven-sh/bun/issues/14697
+// node:http ServerResponse should emit close event when client disconnects
+import { expect, test } from "bun:test";
+import { createServer } from "node:http";
+
+test("ServerResponse emits close event when client disconnects", async () => {
+  const events: string[] = [];
+  let resolveTest: () => void;
+  const testPromise = new Promise<void>(resolve => {
+    resolveTest = resolve;
+  });
+
+  const server = createServer((req, res) => {
+    req.once("close", () => {
+      events.push("request-close");
+    });
+
+    res.once("close", () => {
+      events.push("response-close");
+      // Both events should have fired by now
+      resolveTest();
+    });
+
+    // Don't send any response, let the client disconnect
+  });
+
+  await new Promise<void>(resolve => {
+    server.listen(0, () => resolve());
+  });
+
+  const port = (server.address() as any).port;
+
+  // Connect and immediately disconnect
+  const socket = await Bun.connect({
+    hostname: "localhost",
+    port,
+    socket: {
+      open(socket) {
+        // Send a minimal HTTP request
+        socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        // Immediately close the connection
+        socket.end();
+      },
+      data() {},
+      error() {},
+      close() {},
+    },
+  });
+
+  // Wait for both close events to fire
+  await testPromise;
+
+  server.close();
+
+  // Both request and response should have emitted close events
+  expect(events).toContain("request-close");
+  expect(events).toContain("response-close");
+});


### PR DESCRIPTION
Fixes #14697

## Summary

ServerResponse was not emitting the "close" event when the client disconnected, causing resource leaks in long-running connections like server-sent events and live streaming.

## Root Cause

The issue was in the `NodeHTTPServerSocket`'s `#onClose()` method in `/workspace/bun/src/js/node/_http_server.ts`. When the underlying handle closed:

1. The method cleaned up incomplete requests
2. BUT it did not call `callCloseCallback(this)` 
3. This prevented `onServerResponseClose` from being invoked
4. Therefore the close event never propagated to the ServerResponse

## The Fix

Added a call to `callCloseCallback(this)` at the end of `#onClose()`, ensuring the close callback chain executes properly:
- Socket close → callCloseCallback → onServerResponseClose → emitCloseNT → ServerResponse emits "close"

## Testing

### Before Fix
```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/14697.test.ts
(fail) ServerResponse emits close event when client disconnects [5000.06ms]
  ^ this test timed out after 5000ms.
```

Running the reproduction script only showed:
```
Request closed
```

### After Fix
```
$ bun bd test test/regression/issue/14697.test.ts
 1 pass
 0 fail
```

Running the reproduction script now correctly shows:
```
Response closed
Request closed
```

## Changes
- Added `callCloseCallback(this)` in `NodeHTTPServerSocket.#onClose()` 
- Added regression test in `test/regression/issue/14697.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>