### PR TITLE
Implement --trace-warnings and Node.js-compatible warning formatting

### DIFF
--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -342,6 +342,11 @@ pub export fn Bun__NODE_NO_WARNINGS() bool {
     return bun.feature_flag.NODE_NO_WARNINGS.get();
 }
 
+extern var Bun__Node__ProcessTraceWarnings: bool;
+pub export fn Bun__NODE_TRACE_WARNINGS() bool {
+    return Bun__Node__ProcessTraceWarnings;
+}
+
 pub export fn Bun__suppressCrashOnProcessKillSelfIfDesired() void {
     if (bun.feature_flag.BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF.get()) {
         bun.crash_handler.suppressReporting();

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -102,6 +102,7 @@ pub const runtime_params_ = [_]ParamType{
     clap.parseParam("--expose-gc                       Expose gc() on the global object. Has no effect on Bun.gc().") catch unreachable,
     clap.parseParam("--no-deprecation                  Suppress all reporting of the custom deprecation.") catch unreachable,
     clap.parseParam("--throw-deprecation               Determine whether or not deprecation warnings result in errors.") catch unreachable,
+    clap.parseParam("--trace-warnings                  Show stack traces on process warnings") catch unreachable,
     clap.parseParam("--title <STR>                     Set the process title") catch unreachable,
     clap.parseParam("--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled.") catch unreachable,
     clap.parseParam("--use-system-ca                   Use the system's trusted certificate authorities") catch unreachable,
@@ -784,6 +785,9 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         if (args.flag("--throw-deprecation")) {
             Bun__Node__ProcessThrowDeprecation = true;
         }
+        if (args.flag("--trace-warnings")) {
+            Bun__Node__ProcessTraceWarnings = true;
+        }
         if (args.option("--title")) |title| {
             CLI.Bun__Node__ProcessTitle = title;
         }
@@ -1319,6 +1323,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 export var Bun__Node__ZeroFillBuffers = false;
 export var Bun__Node__ProcessNoDeprecation = false;
 export var Bun__Node__ProcessThrowDeprecation = false;
+export var Bun__Node__ProcessTraceWarnings = false;
 
 pub const BunCAStore = enum(u8) { bundled, openssl, system };
 pub export var Bun__Node__CAStore: BunCAStore = .bundled;

--- a/test/js/node/process/process-trace-warnings.test.ts
+++ b/test/js/node/process/process-trace-warnings.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("process.emitWarning without --trace-warnings shows minimal format", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `process.emitWarning('test warning');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should show minimal format with PID
+  expect(stderr).toMatch(/\(bun:\d+\) Warning: test warning/);
+  // Should show the hint about --trace-warnings
+  expect(stderr).toContain("(Use `bun --trace-warnings ...` to show where the warning was created)");
+  // Should NOT show stack trace
+  expect(stderr).not.toContain("at ");
+
+  expect(exitCode).toBe(0);
+});
+
+test("process.emitWarning with --trace-warnings shows stack trace", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `process.emitWarning('test warning');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--trace-warnings", "test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should show minimal format with PID
+  expect(stderr).toMatch(/\(bun:\d+\) Warning: test warning/);
+  // Should show stack trace
+  expect(stderr).toContain("at ");
+  // Should NOT show the hint when --trace-warnings is used
+  expect(stderr).not.toContain("(Use `bun --trace-warnings ...` to show where the warning was created)");
+
+  expect(exitCode).toBe(0);
+});
+
+test("process.emitWarning with custom type", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `process.emitWarning('custom message', 'CustomWarning');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should show custom warning type
+  expect(stderr).toMatch(/\(bun:\d+\) CustomWarning: custom message/);
+
+  expect(exitCode).toBe(0);
+});
+
+test("multiple warnings show hint only once", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `
+      process.emitWarning('warning 1');
+      process.emitWarning('warning 2');
+      process.emitWarning('warning 3');
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should show all three warnings
+  expect(stderr).toContain("Warning: warning 1");
+  expect(stderr).toContain("Warning: warning 2");
+  expect(stderr).toContain("Warning: warning 3");
+
+  // Should show the hint only once
+  const hintCount = (stderr.match(/Use `bun --trace-warnings/g) || []).length;
+  expect(hintCount).toBe(1);
+
+  expect(exitCode).toBe(0);
+});
+
+test("DeprecationWarning is shown by default", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `process.emitWarning('deprecated API', 'DeprecationWarning');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toMatch(/\(bun:\d+\) DeprecationWarning: deprecated API/);
+
+  expect(exitCode).toBe(0);
+});
+
+test("NODE_NO_WARNINGS=1 suppresses warnings", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `process.emitWarning('test warning');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    env: { ...bunEnv, NODE_NO_WARNINGS: "1" },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should NOT show any warning
+  expect(stderr).not.toContain("Warning:");
+  expect(stderr).not.toContain("test warning");
+
+  expect(exitCode).toBe(0);
+});
+
+test("process.emitWarning with code and detail", async () => {
+  using dir = tempDir("trace-warnings-test", {
+    "test.js": `
+      process.emitWarning('test warning', {
+        type: 'CustomWarning',
+        code: 'CODE001',
+        detail: 'Additional details here'
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toMatch(/\(bun:\d+\) CustomWarning: test warning/);
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes `process.emitWarning()` to match Node.js formatting. Currently, Bun displays warnings with full stack traces by default, which can confuse users into thinking there's a bug in Bun when it's just an informational warning. Node.js shows a minimal format by default and only displays stack traces with `--trace-warnings`.

### Before
```
Warning: test warning
      at /workspace/bun/[eval]:1:9
      at loadAndEvaluateModule (7:44)
      at asyncFunctionResume (9:85)
      at promiseReactionJobWithoutPromiseUnwrapAsyncContext (14:20)
```

### After (default)
```
(bun:3742) Warning: test1
(Use `bun --trace-warnings ...` to show where the warning was created)
(bun:3742) Warning: test2
```

### After (with `--trace-warnings`)
```
(bun:3831) Warning: test
    at emitWarning (unknown)
    at /workspace/bun/[eval]:1:9
    at evaluate (unknown)
    at moduleEvaluation (native:21:22)
```

## Changes
- Add `--trace-warnings` CLI flag
- Format warnings as `(bun:PID) WarningName: message`
- Stack traces only appear when `--trace-warnings` is passed
- Show hint about `--trace-warnings` flag once per process
- Warnings output to stderr instead of using console.warn (which was showing full error objects)
- Add comprehensive test coverage

## Test plan
- [x] Run `bun bd test test/js/node/process/process-trace-warnings.test.ts` - all 7 tests pass
- [x] Verify behavior matches Node.js
- [x] Test with/without `--trace-warnings` flag
- [x] Test custom warning types, codes, and multiple warnings
- [x] Test `NODE_NO_WARNINGS=1` suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)