### PR TITLE
Add type assertion for request body in POST handler

### DIFF
--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -26,7 +26,7 @@ Bun.serve({
     "/api/posts": {
       GET: () => new Response("List posts"),
       POST: async req => {
-        const body = await req.json();
+        const body = await req.json() as any;
         return Response.json({ created: true, ...body });
       },
     },

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -26,7 +26,7 @@ Bun.serve({
     "/api/posts": {
       GET: () => new Response("List posts"),
       POST: async req => {
-        const body = await req.json() as any;
+        const body = await req.json() as Record<string, unknown>;
         return Response.json({ created: true, ...body });
       },
     },


### PR DESCRIPTION
### What does this PR do?

This pull request adds a type assertion (`as Record<string, unknown>`) to resolve a TypeScript compilation error occurring when spreading a variable with an `unknown` type in the request body.
The error message was:

```
Spread types may only be created from object types.ts(2698)
const body: unknown
```

By asserting the type as `Record<string, unknown>`, the code now correctly handles the spread operation without causing a TypeScript type error.

---

### How did you verify your code works?

* Ran the TypeScript compiler to ensure the error was resolved.
