### PR TITLE
Fix url.domainToASCII to return empty string for invalid domains

### DIFF
--- a/src/bun.js/bindings/NodeURL.cpp
+++ b/src/bun.js/bindings/NodeURL.cpp
@@ -68,8 +68,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToASCIIErrors) && numCharactersConverted) {
         return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
     }
-    throwTypeError(globalObject, scope, "domainToASCII failed"_s);
-    return {};
+    return JSC::JSValue::encode(jsEmptyString(vm));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -139,8 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject,
     if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToUnicodeErrors) && numCharactersConverted) {
         return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
     }
-    throwTypeError(globalObject, scope, "domainToUnicode failed"_s);
-    return {};
+    return JSC::JSValue::encode(jsEmptyString(vm));
 }
 
 JSC::JSValue createNodeURLBinding(Zig::GlobalObject* globalObject)

--- a/test/regression/issue/24191.test.ts
+++ b/test/regression/issue/24191.test.ts
@@ -1,0 +1,16 @@
+// https://github.com/oven-sh/bun/issues/24191
+// `url.domainToASCII` should return an empty string for invalid domains, not throw an error
+
+import { expect, test } from "bun:test";
+import url from "node:url";
+
+test("domainToASCII should not throw for invalid punycode with unicode", () => {
+  // The primary issue from the bug report: invalid punycode with unicode characters
+  // This was throwing "TypeError: domainToASCII failed" but should return empty string
+  expect(url.domainToASCII("xn--iñvalid.com")).toBe("");
+});
+
+test("domainToUnicode should not throw for invalid domains", () => {
+  // Should also return empty string for invalid domains, not throw
+  expect(url.domainToUnicode("xn--iñvalid.com")).toBe("");
+});


### PR DESCRIPTION
Fixes #24191

## Summary

Previously, `url.domainToASCII` and `url.domainToUnicode` would throw a `TypeError` when encountering invalid domains, such as punycode domains with unicode characters (e.g., `xn--iñvalid.com`). According to Node.js behavior and the WHATWG URL spec, these functions should return an empty string instead of throwing an error.

## Changes

- Modified `jsDomainToASCII` in `src/bun.js/bindings/NodeURL.cpp` to return empty string instead of throwing
- Modified `jsDomainToUnicode` in `src/bun.js/bindings/NodeURL.cpp` to return empty string instead of throwing  
- Added regression test in `test/regression/issue/24191.test.ts`

## Test Plan

```bash
# Test the specific case from the issue
$ echo "import url from 'node:url'; console.log(url.domainToASCII('xn--iñvalid.com'));" > test.mjs
$ bun test.mjs
# (prints empty line, matching Node.js behavior)

# Run the regression test
$ bun bd test test/regression/issue/24191.test.ts
# ✓ 2 pass

# Run existing url domain tests  
$ bun bd test test/js/node/url/url-domain-ascii-unicode.test.js
# ✓ 130 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)