### PR TITLE
Add --target=cloudflare support to bundler

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -741,6 +741,9 @@ pub const api = struct {
         /// bun_macro
         bun_macro,
 
+        /// cloudflare
+        cloudflare,
+
         _,
 
         pub fn jsonStringify(self: @This(), writer: anytype) !void {

--- a/src/bundler/linker_context/computeChunks.zig
+++ b/src/bundler/linker_context/computeChunks.zig
@@ -375,6 +375,7 @@ pub noinline fn computeChunks(
                 .bun => "bun",
                 .node => "node",
                 .bun_macro => "macro",
+                .cloudflare => "cloudflare",
                 .bake_server_components_ssr => "ssr",
             };
         }

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -911,7 +911,12 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             }
         }
 
-        const TargetMatcher = strings.ExactSizeMatcher(8);
+        const TargetMatcher = bun.ComptimeStringMap(Api.Target, .{
+            .{ "browser", .browser },
+            .{ "node", .node },
+            .{ "bun", .bun },
+            .{ "cloudflare", .cloudflare },
+        });
         if (args.option("--target")) |_target| brk: {
             if (comptime cmd == .BuildCommand) {
                 if (args.flag("--compile")) {
@@ -925,15 +930,13 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                         break :brk;
                     }
                 }
+                if (strings.eqlComptime(_target, "macro")) {
+                    opts.target = .bun_macro;
+                    break :brk;
+                }
             }
 
-            opts.target = opts.target orelse switch (TargetMatcher.match(_target)) {
-                TargetMatcher.case("browser") => Api.Target.browser,
-                TargetMatcher.case("node") => Api.Target.node,
-                TargetMatcher.case("macro") => if (cmd == .BuildCommand) Api.Target.bun_macro else Api.Target.bun,
-                TargetMatcher.case("bun") => Api.Target.bun,
-                else => CLI.invalidTarget(&diag, _target),
-            };
+            opts.target = opts.target orelse TargetMatcher.get(_target) orelse CLI.invalidTarget(&diag, _target);
 
             if (opts.target.? == .bun) {
                 ctx.debug.run_in_bun = opts.target.? == .bun;

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -916,6 +916,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             .{ "node", .node },
             .{ "bun", .bun },
             .{ "cloudflare", .cloudflare },
+            .{ "macro", .bun_macro },
         });
         if (args.option("--target")) |_target| brk: {
             if (comptime cmd == .BuildCommand) {
@@ -929,10 +930,6 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                         opts.target = .bun;
                         break :brk;
                     }
-                }
-                if (strings.eqlComptime(_target, "macro")) {
-                    opts.target = .bun_macro;
-                    break :brk;
                 }
             }
 

--- a/src/css/targets.zig
+++ b/src/css/targets.zig
@@ -78,7 +78,7 @@ pub const Targets = struct {
             }
         }
         return switch (target) {
-            .node, .bun => runtimeDefault(),
+            .node, .bun, .cloudflare => runtimeDefault(),
             .browser, .bun_macro, .bake_server_components_ssr => browserDefault(),
         };
     }

--- a/src/options.zig
+++ b/src/options.zig
@@ -356,6 +356,7 @@ pub const Target = enum {
     bun,
     bun_macro,
     node,
+    cloudflare,
 
     /// This is used by bake.Framework.ServerComponents.separate_ssr_graph
     bake_server_components_ssr,
@@ -366,6 +367,7 @@ pub const Target = enum {
         .{ "bun_macro", .bun_macro },
         .{ "macro", .bun_macro },
         .{ "node", .node },
+        .{ "cloudflare", .cloudflare },
     });
 
     pub fn fromJS(global: *jsc.JSGlobalObject, value: jsc.JSValue) bun.JSError!?Target {
@@ -381,12 +383,13 @@ pub const Target = enum {
             .browser => .browser,
             .bun, .bake_server_components_ssr => .bun,
             .bun_macro => .bun_macro,
+            .cloudflare => .cloudflare,
         };
     }
 
     pub inline fn isServerSide(this: Target) bool {
         return switch (this) {
-            .bun_macro, .node, .bun, .bake_server_components_ssr => true,
+            .bun_macro, .node, .bun, .bake_server_components_ssr, .cloudflare => true,
             else => false,
         };
     }
@@ -416,7 +419,7 @@ pub const Target = enum {
         return switch (target) {
             .browser => .client,
             .bake_server_components_ssr => .ssr,
-            .bun_macro, .bun, .node => .server,
+            .bun_macro, .bun, .node, .cloudflare => .server,
         };
     }
 
@@ -448,6 +451,7 @@ pub const Target = enum {
             .browser => .browser,
             .bun => .bun,
             .bun_macro => .bun_macro,
+            .cloudflare => .cloudflare,
             else => .browser,
         };
     }
@@ -495,6 +499,7 @@ pub const Target = enum {
         array.set(Target.bun, &listd);
         array.set(Target.bun_macro, &listd);
         array.set(Target.bake_server_components_ssr, &listd);
+        array.set(Target.cloudflare, &listd);
 
         // Original comment:
         // The neutral target is for people that don't want esbuild to try to
@@ -527,6 +532,11 @@ pub const Target = enum {
             "macro",
             "bun",
             "node",
+        });
+        array.set(Target.cloudflare, &.{
+            "workerd",
+            "worker",
+            "browser",
         });
 
         break :brk array;

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -660,7 +660,7 @@ pub const Transpiler = struct {
                 var writer = js_printer.BufferPrinter.init(buffer_writer);
 
                 output_file.size = switch (transpiler.options.target) {
-                    .browser, .node => try transpiler.print(
+                    .browser, .node, .cloudflare => try transpiler.print(
                         result,
                         *js_printer.BufferPrinter,
                         &writer,

--- a/test/bundler/bundler_cloudflare.test.ts
+++ b/test/bundler/bundler_cloudflare.test.ts
@@ -1,0 +1,238 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  itBundled("cloudflare/ExportsWorkerdCondition", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg'; console.log('done');`,
+      "/Users/user/project/node_modules/pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "workerd": "./workerd.js",
+            "worker": "./worker.js",
+            "browser": "./browser.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg/workerd.js": `console.log('workerd')`,
+      "/Users/user/project/node_modules/pkg/worker.js": `console.log('worker')`,
+      "/Users/user/project/node_modules/pkg/browser.js": `console.log('browser')`,
+      "/Users/user/project/node_modules/pkg/default.js": `console.log('default')`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "workerd\ndone",
+    },
+  });
+
+  itBundled("cloudflare/ExportsWorkerFallback", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg'; console.log('done');`,
+      "/Users/user/project/node_modules/pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "worker": "./worker.js",
+            "browser": "./browser.js",
+            "node": "./node.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg/worker.js": `console.log('worker')`,
+      "/Users/user/project/node_modules/pkg/browser.js": `console.log('browser')`,
+      "/Users/user/project/node_modules/pkg/node.js": `console.log('node')`,
+      "/Users/user/project/node_modules/pkg/default.js": `console.log('default')`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "worker\ndone",
+    },
+  });
+
+  itBundled("cloudflare/ExportsBrowserFallback", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg'; console.log('done');`,
+      "/Users/user/project/node_modules/pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "browser": "./browser.js",
+            "node": "./node.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg/browser.js": `console.log('browser')`,
+      "/Users/user/project/node_modules/pkg/node.js": `console.log('node')`,
+      "/Users/user/project/node_modules/pkg/default.js": `console.log('default')`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "browser\ndone",
+    },
+  });
+
+  itBundled("cloudflare/ExportsFallbackToDefault", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg'; console.log('done');`,
+      "/Users/user/project/node_modules/pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "node": "./node.js",
+            "deno": "./deno.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg/node.js": `console.log('node')`,
+      "/Users/user/project/node_modules/pkg/deno.js": `console.log('deno')`,
+      "/Users/user/project/node_modules/pkg/default.js": `console.log('default')`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "default\ndone",
+    },
+  });
+
+  itBundled("cloudflare/ExportsPriorityOrder", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg'; console.log('done');`,
+      "/Users/user/project/node_modules/pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "workerd": "./workerd.js",
+            "worker": "./worker.js",
+            "browser": "./browser.js",
+            "node": "./node.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg/workerd.js": `console.log('workerd')`,
+      "/Users/user/project/node_modules/pkg/worker.js": `console.log('worker')`,
+      "/Users/user/project/node_modules/pkg/browser.js": `console.log('browser')`,
+      "/Users/user/project/node_modules/pkg/node.js": `console.log('node')`,
+      "/Users/user/project/node_modules/pkg/default.js": `console.log('default')`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "workerd\ndone",
+    },
+  });
+
+  itBundled("cloudflare/MainFieldsPreferModule", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import fn from 'demo-pkg'
+        console.log(fn())
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "module": "./main.esm.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": /* js */ `
+        module.exports = function() {
+          return 'cjs'
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.esm.js": /* js */ `
+        export default function() {
+          return 'esm'
+        }
+      `,
+    },
+    target: "cloudflare",
+    run: {
+      stdout: "esm",
+    },
+  });
+
+  itBundled("cloudflare/IsServerSide", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        // Cloudflare should behave like a server-side target
+        console.log(typeof process !== 'undefined' ? 'server' : 'client')
+      `,
+    },
+    target: "cloudflare",
+    run: {
+      stdout: "server",
+    },
+  });
+
+  itBundled("cloudflare/MultiplePackagesWithDifferentConditions", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import 'pkg1'
+        import 'pkg2'
+        import 'pkg3'
+        console.log('done')
+      `,
+      "/Users/user/project/node_modules/pkg1/package.json": /* json */ `
+        {
+          "exports": {
+            "workerd": "./workerd.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg1/workerd.js": `console.log('pkg1:workerd')`,
+      "/Users/user/project/node_modules/pkg1/default.js": `console.log('pkg1:default')`,
+      "/Users/user/project/node_modules/pkg2/package.json": /* json */ `
+        {
+          "exports": {
+            "worker": "./worker.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg2/worker.js": `console.log('pkg2:worker')`,
+      "/Users/user/project/node_modules/pkg2/default.js": `console.log('pkg2:default')`,
+      "/Users/user/project/node_modules/pkg3/package.json": /* json */ `
+        {
+          "exports": {
+            "browser": "./browser.js",
+            "default": "./default.js"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg3/browser.js": `console.log('pkg3:browser')`,
+      "/Users/user/project/node_modules/pkg3/default.js": `console.log('pkg3:default')`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "pkg1:workerd\npkg2:worker\npkg3:browser\ndone",
+    },
+  });
+
+  itBundled("cloudflare/NestedExportsWithConditions", {
+    files: {
+      "/Users/user/project/src/entry.js": `import { foo } from 'pkg/sub'; console.log(foo);`,
+      "/Users/user/project/node_modules/pkg/package.json": /* json */ `
+        {
+          "exports": {
+            "./sub": {
+              "workerd": "./sub-workerd.js",
+              "default": "./sub-default.js"
+            }
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg/sub-workerd.js": `export const foo = 'workerd'`,
+      "/Users/user/project/node_modules/pkg/sub-default.js": `export const foo = 'default'`,
+    },
+    target: "cloudflare",
+    outfile: "/Users/user/project/out.js",
+    run: {
+      stdout: "workerd",
+    },
+  });
+});


### PR DESCRIPTION
## Summary

Implements `--target=cloudflare` for the Bun bundler with export conditions matching Wrangler's official behavior.

## Implementation Details

### Export Conditions (matches Wrangler)
- **`workerd`** (first priority) - Cloudflare's runtime
- **`worker`** (second priority) - Generic web worker  
- **`browser`** (third priority) - Browser-compatible code

This exactly matches the official Wrangler bundler behavior as documented in:
https://github.com/cloudflare/workers-sdk/blob/1e43d3f9f5d494c5c2c09cee0800676290c8895e/packages/wrangler/src/deployment-bundle/bundle.ts#L51-L88

### Target Characteristics
Like `node` and `bun` targets, `cloudflare` is a server-side target:
- Uses `isServerSide() = true`
- Prefers `module` field over `main` in package.json
- Uses `.esm` output format (not `.esm_ascii` like bun target)

## Changes

**Core Implementation:**
- Added `cloudflare` to `options.Target` enum with conditions `["workerd", "worker", "browser"]`
- Added `cloudflare` to `Api.Target` enum
- Updated all switch statements to handle cloudflare case:
  - `src/bundler/linker_context/computeChunks.zig`
  - `src/css/targets.zig`
  - `src/transpiler.zig`

**CLI Improvements:**
- Refactored CLI argument parser to use `ComptimeStringMap` instead of `ExactSizeMatcher`
- This makes the code more maintainable and removes size limitations

**Testing:**
- Added comprehensive test suite: `test/bundler/bundler_cloudflare.test.ts`
- 9 tests covering:
  - `workerd` condition priority
  - `worker` condition fallback
  - `browser` condition fallback  
  - Default fallback when no cloudflare-related conditions match
  - Multiple packages with different conditions
  - Nested exports
  - Package.json main fields

## Examples

### Package with workerd condition
```bash
bun build entry.js --target=cloudflare --outfile=out.js
```

For a package with:
```json
{
  "exports": {
    "workerd": "./cloudflare.js",
    "worker": "./worker.js",
    "browser": "./browser.js",
    "default": "./index.js"
  }
}
```

The bundler will select `./cloudflare.js` (workerd condition).

### Package with worker fallback
For a package without `workerd` but with `worker`:
```json
{
  "exports": {
    "worker": "./worker.js",
    "browser": "./browser.js"
  }
}
```

The bundler will select `./worker.js` (worker condition fallback).

### Package with browser fallback
For a package with only `browser`:
```json
{
  "exports": {
    "browser": "./browser.js",
    "node": "./node.js"
  }
}
```

The bundler will select `./browser.js` (browser condition fallback).

## Testing

All tests pass:
- ✅ 9 new cloudflare target tests
- ✅ All existing bundler tests (bun, node, browser)
- ✅ CLI argument parsing
- ✅ Package.json exports resolution

```bash
bun bd test test/bundler/bundler_cloudflare.test.ts
# 9 pass, 0 fail
```

## Related

This aligns with how Cloudflare's official tooling works:
- Wrangler uses the `["workerd", "worker", "browser"]` export conditions
- These are the default conditions when bundling for Cloudflare Workers
- Packages like `postgres` publish `workerd` entry points for Cloudflare-specific optimizations