### PR TITLE
Fix bun link failing in workspace with sibling dependencies

### DIFF
--- a/test/regression/issue/24190.test.ts
+++ b/test/regression/issue/24190.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun link <package> within workspace that depends on sibling workspace", async () => {
+  using dir = tempDir("bun-link-workspace", {
+    "work/package.json": JSON.stringify({ workspaces: ["foo", "bar"] }),
+    "work/foo/package.json": JSON.stringify({ name: "foo", dependencies: { bar: "workspace:*" } }),
+    "work/bar/package.json": JSON.stringify({ name: "bar" }),
+    "dep/package.json": JSON.stringify({ name: "dep" }),
+  });
+
+  // First, run `bun install` in the workspace root to set up the workspace
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: `${dir}/work`,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [installStdout, installStderr, installExitCode] = await Promise.all([
+    installProc.stdout.text(),
+    installProc.stderr.text(),
+    installProc.exited,
+  ]);
+
+  expect(installExitCode).toBe(0);
+
+  // Register the dep package as a linked package
+  await using linkProc = Bun.spawn({
+    cmd: [bunExe(), "link"],
+    cwd: `${dir}/dep`,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [linkStdout, linkStderr, linkExitCode] = await Promise.all([
+    linkProc.stdout.text(),
+    linkProc.stderr.text(),
+    linkProc.exited,
+  ]);
+
+  expect(linkStderr).not.toContain("Workspace dependency");
+  expect(linkStderr).not.toContain("not found");
+  expect(linkExitCode).toBe(0);
+
+  // Now try to link the dep package from within the foo workspace
+  // This should not fail with "Workspace dependency 'bar' not found"
+  await using linkDepProc = Bun.spawn({
+    cmd: [bunExe(), "link", "dep"],
+    cwd: `${dir}/work/foo`,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [linkDepStdout, linkDepStderr, linkDepExitCode] = await Promise.all([
+    linkDepProc.stdout.text(),
+    linkDepProc.stderr.text(),
+    linkDepProc.exited,
+  ]);
+
+  expect(linkDepStderr).not.toContain("Workspace dependency");
+  expect(linkDepStderr).not.toContain("not found");
+  expect(linkDepExitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #24190

When running `bun link <package>` from within a workspace subdirectory that depends on sibling workspaces, Bun would fail with an error like:
```
error: Workspace dependency "bar" not found

Searched in "./*"

Workspace documentation: https://bun.com/docs/install/workspaces

error: bar@workspace:* failed to resolve
```

## Root Cause

The issue was that the `link` subcommand was not finding the workspace root, so it would try to resolve workspace dependencies relative to the current working directory instead of the workspace root.

Specifically, `shouldChdirToRoot()` was returning `false` for the `link` subcommand, which prevented the code from searching up the directory tree to find the workspace root package.json.

## Changes

1. **Updated `shouldChdirToRoot()`** to return `true` for all subcommands (including `link`), so that the workspace root is properly found
2. **Updated `original_package_json_path`** to point to the workspace root package.json when a workspace is found, ensuring workspace dependencies are resolved relative to the correct directory

## Test Plan

Created regression test in `test/regression/issue/24190.test.ts` that:
1. Sets up a workspace with two packages (`foo` and `bar`) where `foo` depends on `bar` via `workspace:*`
2. Creates an external package `dep` and registers it with `bun link`
3. Runs `bun link dep` from within the `foo` workspace subdirectory
4. Verifies no "Workspace dependency not found" error occurs

The test fails on the system Bun (before fix) and passes with the debug build (with fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>