### PR TITLE
Fix CPU profiler timestamps - use setDouble() instead of setInteger()

### DIFF
--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -79,6 +79,15 @@ describe.concurrent("--cpu-prof", () => {
     expect(profile.timeDeltas.length).toBe(profile.samples.length);
     // For very fast programs, start and end times might be equal or very close
     expect(profile.startTime).toBeLessThanOrEqual(profile.endTime);
+
+    // CRITICAL: Validate timestamps are positive and in microseconds
+    // Chrome DevTools requires timestamps in microseconds since Unix epoch
+    // A valid timestamp should be > 1000000000000000 (around year 2001)
+    // and < 3000000000000000 (around year 2065)
+    expect(profile.startTime).toBeGreaterThan(1000000000000000);
+    expect(profile.startTime).toBeLessThan(3000000000000000);
+    expect(profile.endTime).toBeGreaterThan(1000000000000000);
+    expect(profile.endTime).toBeLessThan(3000000000000000);
   });
 
   test("--cpu-prof-name sets custom filename", async () => {


### PR DESCRIPTION
## Summary

Fixes CPU profiler generating invalid timestamps that Chrome DevTools couldn't parse (though VSCode's profiler viewer accepted them).

## The Problem

CPU profiles generated by `--cpu-prof` had timestamps that were either:
1. Negative (in the original broken profile from the gist)
2. Truncated/corrupted (after initial timestamp calculation fix)

Example from the broken profile:
```json
{
  "startTime": -822663297,
  "endTime": -804820609
}
```

After initial fix, timestamps were positive but still wrong:
```json
{
  "startTime": 1573519100,  // Should be ~1761784720948727
  "endTime": 1573849434
}
```

## Root Cause

**Primary Issue**: `WTF::JSON::Object::setInteger()` has precision issues with large values (> 2^31). When setting timestamps like `1761784720948727` (microseconds since Unix epoch - 16 digits), the method was truncating/corrupting them.

**Secondary Issue**: The timestamp calculation logic needed clarification - now explicitly uses the earliest sample's wall clock time as startTime and calculates a consistent wallClockOffset.

## The Fix

### src/bun.js/bindings/BunCPUProfiler.cpp

Changed from `setInteger()` to `setDouble()` for timestamp serialization:

```cpp
// Before (broken):
json->setInteger("startTime"_s, static_cast<long long>(startTime));
json->setInteger("endTime"_s, static_cast<long long>(endTime));

// After (fixed):
json->setDouble("startTime"_s, startTime);
json->setDouble("endTime"_s, endTime);
```

JSON `Number` type can precisely represent integers up to 2^53 (~9 quadrillion), which is far more than needed for microsecond timestamps (~10^15 for current dates).

Also clarified the timestamp calculation to use `wallClockStart` directly as the profile's `startTime` and calculate a `wallClockOffset` for converting stopwatch times to wall clock times.

### test/cli/run/cpu-prof.test.ts

Added validation that timestamps are:
- Positive
- In microseconds (> 1000000000000000, < 3000000000000000)
- Within valid Unix epoch range

## Testing

```bash
bun bd test test/cli/run/cpu-prof.test.ts
```

All tests pass ✅

Generated profile now has correct timestamps:
```json
{
  "startTime": 1761784720948727.2,
  "endTime": 1761784721305814
}
```

## Why VSCode Worked But Chrome DevTools Didn't

- **VSCode**: Only cares about relative timing (duration = endTime - startTime), doesn't validate absolute timestamp ranges
- **Chrome DevTools**: Expects timestamps in microseconds since Unix epoch (positive, ~16 digits), fails validation when timestamps are negative, too small, or out of valid range

## References

- Gist with CPU profile format documentation: https://gist.github.com/Jarred-Sumner/2c12da481845e20ce6a6175ee8b05a3e
- Chrome DevTools Protocol - Profiler: https://chromedevtools.github.io/devtools-protocol/tot/Profiler/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>