### PR TITLE
Fix Output.enable_ansi_colors usage to check stdout vs stderr

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -721,7 +721,7 @@ pub inline fn autoGarbageCollect(this: *const VirtualMachine) void {
 
 pub fn reload(this: *VirtualMachine, _: *HotReloader.Task) void {
     Output.debug("Reloading...", .{});
-    const should_clear_terminal = !this.transpiler.env.hasSetNoClearTerminalOnReload(!Output.enable_ansi_colors);
+    const should_clear_terminal = !this.transpiler.env.hasSetNoClearTerminalOnReload(!Output.enable_ansi_colors_stdout);
     if (this.hot_reload == .watch) {
         Output.flush();
         bun.reloadProcess(
@@ -1967,7 +1967,7 @@ pub fn printException(
         .stack_check = bun.StackCheck.init(),
     };
     defer formatter.deinit();
-    if (Output.enable_ansi_colors) {
+    if (Output.enable_ansi_colors_stderr) {
         this.printErrorlikeObject(exception.value(), exception, exception_list, &formatter, Writer, writer, true, allow_side_effects);
     } else {
         this.printErrorlikeObject(exception.value(), exception, exception_list, &formatter, Writer, writer, false, allow_side_effects);
@@ -2006,7 +2006,7 @@ pub noinline fn runErrorHandler(this: *VirtualMachine, result: JSValue, exceptio
             .error_display_level = .full,
         };
         defer formatter.deinit();
-        switch (Output.enable_ansi_colors) {
+        switch (Output.enable_ansi_colors_stderr) {
             inline else => |enable_colors| this.printErrorlikeObject(result, null, exception_list, &formatter, @TypeOf(writer), writer, enable_colors, true),
         }
     }

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -561,7 +561,7 @@ pub fn getOrigin(globalThis: *jsc.JSGlobalObject, _: *jsc.JSObject) jsc.JSValue 
 
 pub fn enableANSIColors(globalThis: *jsc.JSGlobalObject, _: *jsc.JSObject) jsc.JSValue {
     _ = globalThis;
-    return JSValue.jsBoolean(Output.enable_ansi_colors);
+    return JSValue.jsBoolean(Output.enable_ansi_colors_stdout or Output.enable_ansi_colors_stderr);
 }
 
 fn getMain(globalThis: *jsc.JSGlobalObject) callconv(jsc.conv) jsc.JSValue {

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -376,7 +376,7 @@ pub const JSGlobalObject = opaque {
     }
 
     pub fn throwPretty(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) bun.JSError {
-        const instance = switch (Output.enable_ansi_colors) {
+        const instance = switch (Output.enable_ansi_colors_stderr) {
             inline else => |enabled| this.createErrorInstance(Output.prettyFmt(fmt, enabled), args),
         };
         bun.assert(instance != .zero);

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -727,7 +727,7 @@ pub const JSValue = enum(i64) {
         defer buf.deinit();
 
         var writer = buf.writer();
-        switch (Output.enable_ansi_colors) {
+        switch (Output.enable_ansi_colors_stderr) {
             inline else => |enabled| try writer.print(Output.prettyFmt(fmt, enabled), args),
         }
         return String.init(buf.slice()).toJS(globalThis);

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -291,7 +291,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                 this.transpiler.resolver.watcher = bun.resolver.ResolveWatcher(*Watcher, Watcher.onMaybeWatchDirectory).init(this.bun_watcher.?);
             }
 
-            clear_screen = !this.transpiler.env.hasSetNoClearTerminalOnReload(!Output.enable_ansi_colors);
+            clear_screen = !this.transpiler.env.hasSetNoClearTerminalOnReload(!Output.enable_ansi_colors_stdout);
 
             reloader.getContext().start() catch @panic("Failed to start File Watcher");
         }

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -11,7 +11,7 @@ pub const DiffFormatter = struct {
         // defer scope.deinit(); // TODO: fix leaks
         const allocator = scope.allocator();
 
-        const diff_config: DiffConfig = .default(Output.isAIAgent(), Output.enable_ansi_colors);
+        const diff_config: DiffConfig = .default(Output.isAIAgent(), Output.enable_ansi_colors_stderr);
 
         if (this.expected_string != null and this.received_string != null) {
             const received = this.received_string.?;

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -109,7 +109,7 @@ pub const Expect = struct {
     }
 
     pub fn throwPrettyMatcherError(globalThis: *JSGlobalObject, custom_label: bun.String, matcher_name: anytype, matcher_params: anytype, flags: Flags, comptime message_fmt: string, message_args: anytype) bun.JSError {
-        switch (Output.enable_ansi_colors) {
+        switch (Output.enable_ansi_colors_stderr) {
             inline else => |colors| {
                 const chain = switch (flags.promise) {
                     .resolves => if (flags.not) Output.prettyFmt("resolves<d>.<r>not<d>.<r>", colors) else Output.prettyFmt("resolves<d>.<r>", colors),
@@ -164,7 +164,7 @@ pub const Expect = struct {
         };
         value.ensureStillAlive();
 
-        const matcher_params = switch (Output.enable_ansi_colors) {
+        const matcher_params = switch (Output.enable_ansi_colors_stderr) {
             inline else => |colors| comptime Output.prettyFmt(matcher_params_fmt, colors),
         };
         return processPromise(this.custom_label, this.flags, globalThis, value, matcher_name, matcher_params, false);
@@ -1011,7 +1011,7 @@ pub const Expect = struct {
             "Matcher functions should return an object in the following format:\n" ++
             "  {{message?: string | function, pass: boolean}}\n" ++
             "'{any}' was returned";
-        const err = switch (Output.enable_ansi_colors) {
+        const err = switch (Output.enable_ansi_colors_stderr) {
             inline else => |colors| globalThis.createErrorInstance(Output.prettyFmt(fmt, colors), .{ matcher_name, result.toFmt(&formatter) }),
         };
         err.put(globalThis, ZigString.static("name"), bun.String.static("InvalidMatcherError").toJS(globalThis));
@@ -1097,7 +1097,7 @@ pub const Expect = struct {
         }
 
         const matcher_params = CustomMatcherParamsFormatter{
-            .colors = Output.enable_ansi_colors,
+            .colors = Output.enable_ansi_colors_stderr,
             .globalThis = globalThis,
             .matcher_fn = matcher_fn,
         };
@@ -1131,7 +1131,7 @@ pub const Expect = struct {
         const matcher_name = try matcher_fn.getName(globalThis);
 
         const matcher_params = CustomMatcherParamsFormatter{
-            .colors = Output.enable_ansi_colors,
+            .colors = Output.enable_ansi_colors_stderr,
             .globalThis = globalThis,
             .matcher_fn = matcher_fn,
         };
@@ -1840,7 +1840,7 @@ pub const ExpectMatcherUtils = struct {
         var writer = buffered_writer.writer();
 
         if (comptime color_or_null) |color| {
-            if (Output.enable_ansi_colors) {
+            if (Output.enable_ansi_colors_stderr) {
                 try writer.writeAll(Output.prettyFmt(color, true));
             }
         }
@@ -1850,7 +1850,7 @@ pub const ExpectMatcherUtils = struct {
         try writer.print("{}", .{value.toFmt(&formatter)});
 
         if (comptime color_or_null) |_| {
-            if (Output.enable_ansi_colors) {
+            if (Output.enable_ansi_colors_stderr) {
                 try writer.writeAll(Output.prettyFmt("<r>", true));
             }
         }

--- a/src/bun.js/test/expect/toHaveBeenCalledWith.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalledWith.zig
@@ -101,7 +101,7 @@ pub fn toHaveBeenCalledWith(this: *Expect, globalThis: *JSGlobalObject, callfram
         \\    Number of calls: {d}
     ;
 
-    switch (Output.enable_ansi_colors) {
+    switch (Output.enable_ansi_colors_stderr) {
         inline else => |colors| {
             return this.throw(globalThis, signature, Output.prettyFmt("\n\n" ++ fmt ++ "\n", colors), .{
                 expected_args_js_array.toFmt(&formatter),

--- a/src/bun.js/test/expect/toHaveReturnedWith.zig
+++ b/src/bun.js/test/expect/toHaveReturnedWith.zig
@@ -106,7 +106,7 @@ pub fn toHaveReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callframe:
             \\    Number of calls:   {d}
         ;
 
-        switch (Output.enable_ansi_colors) {
+        switch (Output.enable_ansi_colors_stderr) {
             inline else => |colors| {
                 return this.throw(globalThis, signature, Output.prettyFmt("\n\n" ++ fmt ++ "\n", colors), .{
                     expected.toFmt(&formatter),
@@ -131,7 +131,7 @@ pub fn toHaveReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callframe:
             \\    Number of returns: {d}
         ;
 
-        switch (Output.enable_ansi_colors) {
+        switch (Output.enable_ansi_colors_stderr) {
             inline else => |colors| {
                 return this.throw(globalThis, signature, Output.prettyFmt("\n\n" ++ fmt ++ "\n", colors), .{
                     expected.toFmt(&formatter),

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -131,7 +131,7 @@ pub const ProgressBuf = struct {
     }
 
     pub fn pretty(comptime fmt: string, args: anytype) !string {
-        if (Output.enable_ansi_colors) {
+        if (Output.enable_ansi_colors_stdout) {
             return ProgressBuf.print(comptime Output.prettyFmt(fmt, true), args);
         } else {
             return ProgressBuf.print(comptime Output.prettyFmt(fmt, false), args);
@@ -2212,7 +2212,7 @@ pub const Example = struct {
         );
         async_http.client.flags.reject_unauthorized = env_loader.getTLSRejectUnauthorized();
 
-        if (Output.enable_ansi_colors) {
+        if (Output.enable_ansi_colors_stdout) {
             async_http.client.progress_node = progress_node;
         }
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -42,7 +42,7 @@ pub const InitCommand = struct {
     extern fn Bun__ttySetMode(fd: i32, mode: i32) i32;
 
     fn processRadioButton(label: string, comptime Choices: type) !Choices {
-        const colors = Output.enable_ansi_colors;
+        const colors = Output.enable_ansi_colors_stdout;
         const choices = switch (colors) {
             inline else => |colors_comptime| comptime choices: {
                 const choices_fields = bun.meta.EnumFields(Choices);

--- a/src/cli/outdated_command.zig
+++ b/src/cli/outdated_command.zig
@@ -69,7 +69,7 @@ pub const OutdatedCommand = struct {
             .ok => |ok| ok.lockfile,
         };
 
-        switch (Output.enable_ansi_colors) {
+        switch (Output.enable_ansi_colors_stdout) {
             inline else => |enable_ansi_colors| {
                 if (manager.options.filter_patterns.len > 0) {
                     const filters = manager.options.filter_patterns;

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -1635,7 +1635,7 @@ pub const PackCommand = struct {
             var node: *Progress.Node = undefined;
             if (log_level.showProgress()) {
                 progress = .{};
-                progress.supports_ansi_escape_codes = Output.enable_ansi_colors;
+                progress.supports_ansi_escape_codes = Output.enable_ansi_colors_stderr;
                 node = progress.start("", pack_queue.count() + bundled_pack_queue.count() + 1);
                 node.unit = " files";
             }

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -779,12 +779,12 @@ pub const PublishCommand = struct {
             const offset = 0;
             const padding = 1;
 
-            const horizontal = if (Output.enable_ansi_colors) "─" else "-";
-            const vertical = if (Output.enable_ansi_colors) "│" else "|";
-            const top_left = if (Output.enable_ansi_colors) "┌" else "|";
-            const top_right = if (Output.enable_ansi_colors) "┐" else "|";
-            const bottom_left = if (Output.enable_ansi_colors) "└" else "|";
-            const bottom_right = if (Output.enable_ansi_colors) "┘" else "|";
+            const horizontal = if (Output.enable_ansi_colors_stdout) "─" else "-";
+            const vertical = if (Output.enable_ansi_colors_stdout) "│" else "|";
+            const top_left = if (Output.enable_ansi_colors_stdout) "┌" else "|";
+            const top_right = if (Output.enable_ansi_colors_stdout) "┐" else "|";
+            const bottom_left = if (Output.enable_ansi_colors_stdout) "└" else "|";
+            const bottom_right = if (Output.enable_ansi_colors_stdout) "┘" else "|";
 
             const width = (padding * 2) + auth_url_str.len;
 

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -1162,7 +1162,7 @@ pub const UpdateInteractiveCommand = struct {
     }
 
     fn processMultiSelect(state: *MultiSelectState, initial_terminal_size: TerminalSize) ![]bool {
-        const colors = Output.enable_ansi_colors;
+        const colors = Output.enable_ansi_colors_stdout;
 
         // Clear any previous progress output
         Output.print("\r\x1B[2K", .{}); // Clear entire line
@@ -1427,7 +1427,7 @@ pub const UpdateInteractiveCommand = struct {
 
                     const uses_default_registry = pkg.manager.options.scope.url_hash == Install.Npm.Registry.default_url_hash and
                         pkg.manager.scopeForPackageName(pkg.name).url_hash == Install.Npm.Registry.default_url_hash;
-                    const package_url = if (Output.enable_ansi_colors and uses_default_registry)
+                    const package_url = if (Output.enable_ansi_colors_stdout and uses_default_registry)
                         try std.fmt.allocPrint(bun.default_allocator, "https://npmjs.org/package/{s}/v/{s}", .{ pkg.name, brk: {
                             if (selected) {
                                 if (pkg.use_latest) {

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -255,11 +255,11 @@ pub fn crashHandler(
                         has_printed_message = true;
                     }
                 } else {
-                    if (Output.enable_ansi_colors) {
+                    if (Output.enable_ansi_colors_stderr) {
                         writer.writeAll(Output.prettyFmt("<red>", true)) catch std.posix.abort();
                     }
                     writer.writeAll("oh no") catch std.posix.abort();
-                    if (Output.enable_ansi_colors) {
+                    if (Output.enable_ansi_colors_stderr) {
                         writer.writeAll(Output.prettyFmt("<r><d>: multiple threads are crashing<r>\n", true)) catch std.posix.abort();
                     } else {
                         writer.writeAll(Output.prettyFmt(": multiple threads are crashing\n", true)) catch std.posix.abort();
@@ -267,13 +267,13 @@ pub fn crashHandler(
                 }
 
                 if (reason != .out_of_memory or debug_trace) {
-                    if (Output.enable_ansi_colors) {
+                    if (Output.enable_ansi_colors_stderr) {
                         writer.writeAll(Output.prettyFmt("<red>", true)) catch std.posix.abort();
                     }
 
                     writer.writeAll("panic") catch std.posix.abort();
 
-                    if (Output.enable_ansi_colors) {
+                    if (Output.enable_ansi_colors_stderr) {
                         writer.writeAll(Output.prettyFmt("<r><d>", true)) catch std.posix.abort();
                     }
 
@@ -294,7 +294,7 @@ pub fn crashHandler(
                     }
 
                     writer.writeAll(": ") catch std.posix.abort();
-                    if (Output.enable_ansi_colors) {
+                    if (Output.enable_ansi_colors_stderr) {
                         writer.writeAll(Output.prettyFmt("<r>", true)) catch std.posix.abort();
                     }
                     writer.print("{}\n", .{reason}) catch std.posix.abort();
@@ -385,7 +385,7 @@ pub fn crashHandler(
                     if (!has_printed_message) {
                         has_printed_message = true;
                         writer.writeAll("oh no") catch std.posix.abort();
-                        if (Output.enable_ansi_colors) {
+                        if (Output.enable_ansi_colors_stderr) {
                             writer.writeAll(Output.prettyFmt("<r><d>:<r> ", true)) catch std.posix.abort();
                         } else {
                             writer.writeAll(Output.prettyFmt(": ", true)) catch std.posix.abort();
@@ -435,7 +435,7 @@ pub fn crashHandler(
                         }
                     }
 
-                    if (Output.enable_ansi_colors) {
+                    if (Output.enable_ansi_colors_stderr) {
                         writer.print(Output.prettyFmt("<cyan>", true), .{}) catch std.posix.abort();
                     }
 
@@ -452,7 +452,7 @@ pub fn crashHandler(
                     writer.writeAll("\n") catch std.posix.abort();
                 }
 
-                if (Output.enable_ansi_colors) {
+                if (Output.enable_ansi_colors_stderr) {
                     writer.writeAll(Output.prettyFmt("<r>\n", true)) catch std.posix.abort();
                 } else {
                     writer.writeAll("\n") catch std.posix.abort();
@@ -957,7 +957,7 @@ pub fn printMetadata(writer: anytype) !void {
         }
     }
 
-    if (Output.enable_ansi_colors) {
+    if (Output.enable_ansi_colors_stderr) {
         try writer.writeAll(Output.prettyFmt("<r><d>", true));
     }
 
@@ -1045,7 +1045,7 @@ pub fn printMetadata(writer: anytype) !void {
         try writer.writeAll("\n");
     }
 
-    if (Output.enable_ansi_colors) {
+    if (Output.enable_ansi_colors_stderr) {
         try writer.writeAll(Output.prettyFmt("<r>", true));
     }
     try writer.writeAll("\n");

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -707,12 +707,6 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
         check_for_unhighlighted_write: bool = true,
 
         redact_sensitive_information: bool = false,
-
-        pub const default: Options = .{
-            .enable_colors = Output.enable_ansi_colors,
-            .check_for_no_highlighting = true,
-            .redact_sensitive_information = false,
-        };
     };
 
     const ColorCode = enum {

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -369,7 +369,7 @@ pub const PackageInstaller = struct {
                         const args = .{ name, @errorName(err) };
 
                         if (log_level.showProgress()) {
-                            switch (Output.enable_ansi_colors) {
+                            switch (Output.enable_ansi_colors_stderr) {
                                 inline else => |enable_ansi_colors| {
                                     this.progress.log(comptime Output.prettyFmt(fmt, enable_ansi_colors), args);
                                 },
@@ -452,7 +452,7 @@ pub const PackageInstaller = struct {
                     const args = .{ package_name, @errorName(err) };
 
                     if (log_level.showProgress()) {
-                        switch (Output.enable_ansi_colors) {
+                        switch (Output.enable_ansi_colors_stderr) {
                             inline else => |enable_ansi_colors| {
                                 this.progress.log(comptime Output.prettyFmt(fmt, enable_ansi_colors), args);
                             },
@@ -1328,7 +1328,7 @@ pub const PackageInstaller = struct {
                 const args = .{ folder_name, @errorName(err) };
 
                 if (log_level.showProgress()) {
-                    switch (Output.enable_ansi_colors) {
+                    switch (Output.enable_ansi_colors_stderr) {
                         inline else => |enable_ansi_colors| {
                             this.progress.log(comptime Output.prettyFmt(fmt, enable_ansi_colors), args);
                         },

--- a/src/install/PackageManager/ProgressStrings.zig
+++ b/src/install/PackageManager/ProgressStrings.zig
@@ -25,23 +25,23 @@ pub const ProgressStrings = struct {
     pub const script_emoji: string = "  ⚙️  ";
 
     pub inline fn download() string {
-        return if (Output.isEmojiEnabled()) download_with_emoji else download_no_emoji;
+        return if (Output.enable_ansi_colors_stderr) download_with_emoji else download_no_emoji;
     }
 
     pub inline fn save() string {
-        return if (Output.isEmojiEnabled()) save_with_emoji else save_no_emoji;
+        return if (Output.enable_ansi_colors_stderr) save_with_emoji else save_no_emoji;
     }
 
     pub inline fn extract() string {
-        return if (Output.isEmojiEnabled()) extract_with_emoji else extract_no_emoji;
+        return if (Output.enable_ansi_colors_stderr) extract_with_emoji else extract_no_emoji;
     }
 
     pub inline fn install() string {
-        return if (Output.isEmojiEnabled()) install_with_emoji else install_no_emoji;
+        return if (Output.enable_ansi_colors_stderr) install_with_emoji else install_no_emoji;
     }
 
     pub inline fn script() string {
-        return if (Output.isEmojiEnabled()) script_with_emoji else script_no_emoji;
+        return if (Output.enable_ansi_colors_stderr) script_with_emoji else script_no_emoji;
     }
 };
 
@@ -52,7 +52,7 @@ pub fn setNodeName(
     emoji: string,
     comptime is_first: bool,
 ) void {
-    if (Output.isEmojiEnabled()) {
+    if (Output.enable_ansi_colors_stderr) {
         if (is_first) {
             @memcpy(this.progress_name_buf[0..emoji.len], emoji);
             @memcpy(this.progress_name_buf[emoji.len..][0..name.len], name);

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -947,7 +947,7 @@ fn printInstallSummary(
             // We deliberately do not disable it after this.
             Output.enableBuffering();
             const writer = Output.writerBuffered();
-            switch (Output.enable_ansi_colors) {
+            switch (Output.enable_ansi_colors_stdout) {
                 inline else => |enable_ansi_colors| {
                     try Lockfile.Printer.Tree.print(&printer, this, @TypeOf(writer), writer, enable_ansi_colors, log_level);
                 },

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -982,7 +982,7 @@ pub const SecurityScanSubprocess = struct {
                 },
             }
         } else if (this.manager.options.log_level != .silent and duration >= 1000) {
-            const maybeHourglass = if (Output.isEmojiEnabled()) "⏳" else "";
+            const maybeHourglass = if (Output.enable_ansi_colors_stderr) "⏳" else "";
             if (packages_scanned == 1) {
                 Output.prettyErrorln("<d>{s}[{s}] Scanning 1 package took {d}ms<r>", .{ maybeHourglass, security_scanner, duration });
             } else {

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -851,7 +851,7 @@ pub const Log = struct {
     }
 
     pub inline fn allocPrint(allocator: std.mem.Allocator, comptime fmt: string, args: anytype) OOM!string {
-        return switch (Output.enable_ansi_colors) {
+        return switch (Output.enable_ansi_colors_stderr) {
             inline else => |enable_ansi_colors| std.fmt.allocPrint(allocator, Output.prettyFmt(fmt, enable_ansi_colors), args),
         };
     }
@@ -1283,7 +1283,7 @@ pub const Log = struct {
     }
 
     pub fn print(self: *const Log, to: anytype) !void {
-        return switch (Output.enable_ansi_colors) {
+        return switch (Output.enable_ansi_colors_stderr) {
             inline else => |enable_ansi_colors| self.printWithEnableAnsiColors(to, enable_ansi_colors),
         };
     }

--- a/src/semver/Version.zig
+++ b/src/semver/Version.zig
@@ -91,7 +91,7 @@ pub fn VersionType(comptime IntType: type) type {
             other_buf: string,
 
             pub fn format(this: DiffFormatter, comptime fmt_: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-                if (!Output.enable_ansi_colors) {
+                if (!Output.enable_ansi_colors_stdout) {
                     // print normally if no colors
                     const formatter: Formatter = .{ .version = this.version, .input = this.buf };
                     return Formatter.format(formatter, fmt_, options, writer);


### PR DESCRIPTION
## Summary

Updated all 49 usages of `Output.enable_ansi_colors` to properly check either `Output.enable_ansi_colors_stdout` or `Output.enable_ansi_colors_stderr` based on their output destination.

This prevents bugs where ANSI colors are checked against the wrong stream (e.g., checking stdout colors when writing to stderr).

## Changes

### Added
- `Output.enable_ansi_colors` now a `@compileError` to prevent future misuse with helpful error message directing to correct variants

### Deleted
- `Output.isEmojiEnabled()` - replaced all usages with `enable_ansi_colors_stderr` (all were error/progress output)
- `Output.prettyWithPrinterFn()` - removed unused dead code

### Updated by Output Destination

**Stderr (error/diagnostic output):**
- logger.zig: Log messages and errors
- crash_handler.zig: Crash reports and stack traces (10 instances)
- PackageInstaller.zig: Error messages from lifecycle scripts (3 instances)
- JSValue.zig: Test expectation error messages
- JSGlobalObject.zig: Exception throwing
- pack_command.zig: Progress indicators
- VirtualMachine.zig: Exception printing (2 instances)
- Test expect files: Test failure messages and diffs (10 instances)
- diff_format.zig: Test diff output
- ProgressStrings.zig: Package manager progress emojis (6 functions)
- security_scanner.zig: Security scan progress emoji
- output.zig: panic(), resetTerminal()

**Stdout (primary output/interactive UI):**
- hot_reloader.zig: Terminal clearing on reload
- Version.zig: Version diff formatting
- install_with_manager.zig: Package installation tree
- update_interactive_command.zig: Interactive update UI (2 instances)
- init_command.zig: Interactive radio buttons
- create_command.zig: Template creation output (2 instances)
- outdated_command.zig: Outdated packages table
- publish_command.zig: Box drawing characters (6 instances)

**Backward Compatible:**
- BunObject.zig: `Bun.enableANSIColors` property returns `(stdout || stderr)` to maintain compatibility
- fmt.zig: Removed unused `.default` field from Options struct

## Test Plan

- ✅ All changes compile successfully with `bun run zig:check`
- ✅ Verified all 49 usages have been updated to appropriate variant
- ✅ Verified no remaining references to deprecated functions/variables
- ✅ Compile error triggers if someone tries to use `Output.enable_ansi_colors`

## Stats

- 24 files changed
- 58 insertions, 77 deletions (net -19 lines)
- 49 usages correctly updated
- 3 items deleted/deprecated

🤖 Generated with [Claude Code](https://claude.com/claude-code)