### PR TITLE
Add %j (JSON stringify) support to console formatter

### DIFF
--- a/test/regression/issue/19992.test.ts
+++ b/test/regression/issue/19992.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("console.log %j formatter", () => {
+  it("should format strings with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", "abc")`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe('"abc"\n');
+  });
+
+  it("should format numbers with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", 123)`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe("123\n");
+  });
+
+  it("should format objects with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", { a: 1, b: 2 })`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe('{"a":1,"b":2}\n');
+  });
+
+  it("should format arrays with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", [1, 2, 3])`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe("[1,2,3]\n");
+  });
+
+  it("should format null with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", null)`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe("null\n");
+  });
+
+  it("should format undefined with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", undefined)`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    // JSON.stringify(undefined) returns undefined
+    // Node.js prints "undefined" for undefined values
+    expect(proc.stdout.toString("utf8")).toBe("undefined\n");
+  });
+
+  it("should handle circular references with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `const a = {}; a.self = a; console.log("%j", a)`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe("[Circular]\n");
+  });
+
+  it("should format multiple values with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j %j", "abc", 123)`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe('"abc" 123\n');
+  });
+
+  it("should append remaining args after format string", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", "abc", "extra")`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe('"abc" extra\n');
+  });
+
+  it("should handle %% escape sequence", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%%j", "abc")`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe("%j abc\n");
+  });
+
+  it("should format booleans with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j %j", true, false)`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe("true false\n");
+  });
+
+  it("should format nested objects with %j", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.log("%j", { a: { b: { c: 1 } } })`],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString("utf8")).toBeEmpty();
+    expect(proc.stdout.toString("utf8")).toBe('{"a":{"b":{"c":1}}}\n');
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the `%j` format specifier in `console.log()` and related console methods to match Node.js behavior. The `%j` formatter calls `JSON.stringify()` on the argument.

## Behavior

- **Strings, numbers, objects, arrays**: JSON stringified normally
- **undefined**: prints `"undefined"` (matching Node.js)
- **Circular references**: prints `"[Circular]"` (matching Node.js)
- **Other JSON stringify errors**: prints `"[Circular]"`

## Changes

- Modified `src/bun.js/ConsoleObject.zig`:
  - Added `j` to the `PercentTag` enum
  - Added parsing for `'j'` character in format string
  - Implemented handler that calls `jsonStringify()` with error handling
- Added comprehensive tests in `test/regression/issue/19992.test.ts`

## Test Plan

All tests pass:
```bash
bun bd test test/regression/issue/19992.test.ts
```

Tests verified to fail with system Bun (without the changes).

## Examples

```javascript
console.log("%j", "abc");     // "abc"
console.log("%j", {a: 1});    // {"a":1}
console.log("%j", undefined); // undefined
const a = {}; a.self = a;
console.log("%j", a);         // [Circular]
```

Fixes #19992

🤖 Generated with [Claude Code](https://claude.com/claude-code)