### PR TITLE
fix(shell): use NOFOLLOW in `rm -rf`

### DIFF
--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -830,7 +830,7 @@ pub const ShellRmTask = struct {
             return Maybe(void).initErr(Syscall.Error.fromCode(bun.sys.E.ISDIR, .TODO).withPath(bun.handleOom(bun.default_allocator.dupeZ(u8, dir_task.path))));
         }
 
-        const flags = bun.O.DIRECTORY | bun.O.RDONLY;
+        const flags = bun.O.DIRECTORY | bun.O.RDONLY | bun.O.NOFOLLOW;
         const fd = switch (ShellSyscall.openat(dirfd, path, flags, 0)) {
             .result => |fd| fd,
             .err => |e| {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -25,10 +25,15 @@ const BUN = process.argv0;
 const DEV_NULL = process.platform === "win32" ? "NUL" : "/dev/null";
 
 describe.concurrent("bunshell rm", () => {
-  TestBuilder.command`echo ${packagejson()} > package.json; ${BUN} install &> ${DEV_NULL}; rm -rf node_modules/`
+  TestBuilder.command`echo ${hoistedPackageJson()} > package.json; ${BUN} install --linker hoisted &> ${DEV_NULL}; rm -rf node_modules/`
     .ensureTempDir()
     .doesNotExist("node_modules")
-    .runAsTest("node_modules");
+    .runAsTest("hoisted node_modules");
+
+  TestBuilder.command`echo ${isolatedPackageJson()} > package.json; ${BUN} install --linker isolated &> ${DEV_NULL}; rm -rf node_modules/`
+    .ensureTempDir()
+    .doesNotExist("node_modules")
+    .runAsTest("isolated node_modules");
 
   test("force", async () => {
     const files = {
@@ -146,7 +151,7 @@ foo/
   });
 });
 
-function packagejson() {
+function hoistedPackageJson() {
   return `{
   "name": "dummy",
   "dependencies": {
@@ -169,5 +174,14 @@ function packagejson() {
     "@typescript-eslint/parser": "^5.31.0"
   },
   "version": "0.0.0"
+}`;
+}
+
+function isolatedPackageJson() {
+  return `{
+  "name": "pkg",
+  "dependencies": {
+    "react": "next"
+  }
 }`;
 }


### PR DESCRIPTION
### What does this PR do?
Test was hanging in CI because `bun install --isolated` created the node_modules

fixes #17895

### How did you verify your code works?
Added a test for deleting node_modules created from isolated install