### PR TITLE
fix: prefer default allocator until real http connection to prevent MemoryReportingAllocator itself leaking memory

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1516,7 +1516,7 @@ pub fn Bun__fetch_(
     bun.analytics.Features.fetch += 1;
     const vm = jsc.VirtualMachine.get();
 
-    var memory_reporter: *bun.MemoryReportingAllocator = undefined;
+    var memory_reporter: ?*bun.MemoryReportingAllocator = null;
     var has_memory_reporter = false;
     // used to clean up dynamically allocated memory on error (a poor man's errdefer)
     var is_error = false;

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1517,7 +1517,6 @@ pub fn Bun__fetch_(
     const vm = jsc.VirtualMachine.get();
 
     var memory_reporter: ?*bun.MemoryReportingAllocator = null;
-    var has_memory_reporter = false;
     // used to clean up dynamically allocated memory on error (a poor man's errdefer)
     var is_error = false;
     var upgraded_connection = false;


### PR DESCRIPTION
### What does this PR do?
we suffer intense memory leak issue and pods die sporadically during a websocket connection - and it's affecting thousands of our users in production as we handle audio mixing on our own with Bun (a lot of Buffer and streaming). the issue particularly stood out during local development where some of our services would die immediately on start. 

memory leak fix part 1: 

`Bun__fetch_` creates a `MemoryReportingAllocator` up front and wraps the default allocator. However - on the `data:`, `file:`, and `blob:` short-circuit paths, no `FetchTasklet` is created to own and later destroy this memory_reporter. The function’s defer only destroys it on error, very likely each such fast path call leaks a `MemoryReportingAllocator` instance. Prefer to use the default_allocator to prevent memory went out of bounds. 

another thing is also allocations done via `allocator = memory_reporter.wrap(default)` will hold a pointer to the memory_reporter object; that can’t be destroyed without invalidating the allocator used by the Response/Blob.

incoming: 
part 2: Request body ReadableStream ownership and potential retention
part 3: Response finalizer logic/comments mismatch and body ignoring heuristics
part 4: S3 streaming + AbortSignal not wired for cancellation 
part 5: `has_schedule_callback` atomic usage and scheduling robustness
part 6: Body buffering allocator handoff 
part 7: edge cases for Request-body “ReadableStream not started yet”

### How did you verify your code works?
linking local build as my local bun version to work on our repo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized memory allocation efficiency for fetch operations by deferring resource initialization until actual network requests are needed, improving performance for data URLs and fast-path operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->