### PR TITLE
fix: vi typing in bun:test

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -172,7 +172,7 @@ declare module "bun:test" {
     /**
      * Mock a module
      */
-    module: typeof mock.module;
+    mock: typeof mock.module;
     /**
      * Restore all mocks to their original implementation
      */

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -7,6 +7,7 @@ import {
   expect,
   expectTypeOf,
   jest,
+  vi,
   mock,
   type Mock,
   spyOn,
@@ -334,6 +335,16 @@ expectType(spy.mock.calls).is<[message?: any, ...optionalParams: any[]][]>();
 
 jest.spyOn(console, "log");
 jest.fn(() => 123 as const);
+
+// vi (Vitest-compatible) API: simple type checks
+expectType<typeof jest.fn>(vi.fn);
+expectType<typeof spyOn>(vi.spyOn);
+expectType<typeof mock.module>(vi.mock);
+expectType<typeof jest.restoreAllMocks>(vi.restoreAllMocks);
+expectType<typeof jest.clearAllMocks>(vi.clearAllMocks);
+expectType<typeof jest.resetAllMocks>(vi.resetAllMocks);
+expectType<typeof jest.useFakeTimers>(vi.useFakeTimers);
+expectType<typeof jest.useRealTimers>(vi.useRealTimers);
 
 xtest("", () => {});
 xdescribe("", () => {});

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -7,7 +7,6 @@ import {
   expect,
   expectTypeOf,
   jest,
-  vi,
   mock,
   type Mock,
   spyOn,
@@ -335,16 +334,6 @@ expectType(spy.mock.calls).is<[message?: any, ...optionalParams: any[]][]>();
 
 jest.spyOn(console, "log");
 jest.fn(() => 123 as const);
-
-// vi (Vitest-compatible) API: simple type checks
-expectType<typeof jest.fn>(vi.fn);
-expectType<typeof spyOn>(vi.spyOn);
-expectType<typeof mock.module>(vi.mock);
-expectType<typeof jest.restoreAllMocks>(vi.restoreAllMocks);
-expectType<typeof jest.clearAllMocks>(vi.clearAllMocks);
-expectType<typeof jest.resetAllMocks>(vi.resetAllMocks);
-expectType<typeof jest.useFakeTimers>(vi.useFakeTimers);
-expectType<typeof jest.useRealTimers>(vi.useRealTimers);
 
 xtest("", () => {});
 xdescribe("", () => {});


### PR DESCRIPTION
### What does this PR do?
`vi.mock` was incorrectly typed as `vi.module`

Example:
```
import { vi } from 'bun:test';

// Property 'mock' does not exist on type '{ fn: ... }'
vi.mock('fs/promises', () => {
  return { readFile: () => Promise.resolve('hello world') };
});

// this throws TypeError: vi.module is not a function
vi.module('fs/promises', () => {
  return { readFile: () => Promise.resolve('hello world') };
});
```


### How did you verify your code works?
Updated `test/integration/bun-types/fixture/test.ts` to include type-level checks for the `vi` object, and verified that the bun-types integration test passes
