### PR TITLE
Fix bun update --interactive not installing packages

### DIFF
--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -54,8 +54,6 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
     });
 
     try {
-      // Wait for UI to render
-
       // Select first package and confirm
       updateProc.stdin.write(" "); // space to select
       updateProc.stdin.write("\r"); // enter to confirm
@@ -148,8 +146,6 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
     });
 
     try {
-      // Wait for UI to render
-
       updateProc.stdin.write("l"); // toggle latest
       updateProc.stdin.write(" "); // select
       updateProc.stdin.write("\r"); // confirm

--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
-describe("bun update --interactive actually installs packages", () => {
+describe.concurrent("bun update --interactive actually installs packages", () => {
   test("should update package.json AND install packages", async () => {
     using dir = tempDir("update-interactive-install", {
       "package.json": JSON.stringify({
@@ -55,11 +55,9 @@ describe("bun update --interactive actually installs packages", () => {
 
     try {
       // Wait for UI to render
-      await Bun.sleep(500);
 
       // Select first package and confirm
       updateProc.stdin.write(" "); // space to select
-      await Bun.sleep(50);
       updateProc.stdin.write("\r"); // enter to confirm
       updateProc.stdin.end();
 
@@ -97,6 +95,7 @@ describe("bun update --interactive actually installs packages", () => {
 
       // The installed version should NOT be the old version
       expect(installedVersion).not.toBe("0.1.0");
+      expect(Bun.semver.satisfies(installedVersion, ">0.1.0")).toBe(true);
 
       // And ideally should match the expected version (or at least be compatible)
       // We check that it starts with the expected major.minor
@@ -150,12 +149,9 @@ describe("bun update --interactive actually installs packages", () => {
 
     try {
       // Wait for UI to render
-      await Bun.sleep(500);
 
       updateProc.stdin.write("l"); // toggle latest
-      await Bun.sleep(50);
       updateProc.stdin.write(" "); // select
-      await Bun.sleep(50);
       updateProc.stdin.write("\r"); // confirm
       updateProc.stdin.end();
 
@@ -179,6 +175,7 @@ describe("bun update --interactive actually installs packages", () => {
 
       // Should be newer than 0.1.0
       expect(updatedPkgJson.version).not.toBe("0.1.0");
+      expect(Bun.semver.satisfies(updatedPkgJson.version, ">0.1.0")).toBe(true);
     } catch (err) {
       // Ensure cleanup on failure
       updateProc.stdin.end();

--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+describe("bun update --interactive actually installs packages", () => {
+  test("should update package.json AND install packages", async () => {
+    using dir = tempDir("update-interactive-install", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: {
+          // Use a very old version that definitely has updates available
+          "is-even": "0.1.0",
+        },
+      }),
+    });
+
+    // First, run bun install to create initial node_modules
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const installExitCode = await installProc.exited;
+    expect(installExitCode).toBe(0);
+
+    // Verify initial installation
+    const initialPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
+    expect(initialPackageJson.dependencies["is-even"]).toBe("0.1.0");
+
+    // Check that node_modules was created
+    expect(existsSync(join(String(dir), "node_modules"))).toBe(true);
+    expect(existsSync(join(String(dir), "node_modules", "is-even"))).toBe(true);
+
+    // Read the initial installed version from package.json in node_modules
+    const initialInstalledPkgJson = JSON.parse(
+      readFileSync(join(String(dir), "node_modules", "is-even", "package.json"), "utf8"),
+    );
+    const initialVersion = initialInstalledPkgJson.version;
+    expect(initialVersion).toBe("0.1.0");
+
+    // Now run update --interactive with automatic selection
+    await using updateProc = Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    try {
+      // Wait for UI to render
+      await Bun.sleep(500);
+
+      // Select first package and confirm
+      updateProc.stdin.write(" "); // space to select
+      await Bun.sleep(50);
+      updateProc.stdin.write("\r"); // enter to confirm
+      updateProc.stdin.end();
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        updateProc.stdout.text(),
+        updateProc.stderr.text(),
+        updateProc.exited,
+      ]);
+
+      // Debug output if test fails
+      if (exitCode !== 0) {
+        console.log("STDOUT:", stdout);
+        console.log("STDERR:", stderr);
+      }
+
+      expect(exitCode).toBe(0);
+
+      // Check that package.json was updated
+      const updatedPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
+      const updatedVersion = updatedPackageJson.dependencies["is-even"];
+
+      // The version should have changed from "0.1.0"
+      expect(updatedVersion).not.toBe("0.1.0");
+
+      // Most importantly: verify that node_modules was actually updated!
+      // This is the bug - previously only package.json changed but not node_modules
+      const installedPkgJson = JSON.parse(
+        readFileSync(join(String(dir), "node_modules", "is-even", "package.json"), "utf8"),
+      );
+      const installedVersion = installedPkgJson.version;
+
+      // The installed version should match what's in package.json
+      // Extract version number from potentially semver-prefixed string (e.g., "^1.1.0" -> "1.1.0")
+      const expectedVersion = updatedVersion.replace(/^[\^~]/, "");
+
+      // The installed version should NOT be the old version
+      expect(installedVersion).not.toBe("0.1.0");
+
+      // And ideally should match the expected version (or at least be compatible)
+      // We check that it starts with the expected major.minor
+      const [expectedMajor, expectedMinor] = expectedVersion.split(".");
+      expect(installedVersion).toContain(`${expectedMajor}.${expectedMinor}`);
+    } catch (err) {
+      // Ensure cleanup on failure
+      updateProc.stdin.end();
+      updateProc.kill();
+      throw err;
+    }
+  });
+
+  test("should work with --latest flag", async () => {
+    using dir = tempDir("update-interactive-latest", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: {
+          "is-odd": "0.1.0", // Use old version of is-odd
+        },
+      }),
+    });
+
+    // Initial install
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await installProc.exited;
+
+    // Verify initial version
+    const initialPkgJson = JSON.parse(
+      readFileSync(join(String(dir), "node_modules", "is-odd", "package.json"), "utf8"),
+    );
+    expect(initialPkgJson.version).toBe("0.1.0");
+
+    // Run update --interactive with 'l' to toggle latest, then select and confirm
+    await using updateProc = Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    try {
+      // Wait for UI to render
+      await Bun.sleep(500);
+
+      updateProc.stdin.write("l"); // toggle latest
+      await Bun.sleep(50);
+      updateProc.stdin.write(" "); // select
+      await Bun.sleep(50);
+      updateProc.stdin.write("\r"); // confirm
+      updateProc.stdin.end();
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        updateProc.stdout.text(),
+        updateProc.stderr.text(),
+        updateProc.exited,
+      ]);
+
+      if (exitCode !== 0) {
+        console.log("STDOUT:", stdout);
+        console.log("STDERR:", stderr);
+      }
+
+      expect(exitCode).toBe(0);
+
+      // Verify node_modules was updated
+      const updatedPkgJson = JSON.parse(
+        readFileSync(join(String(dir), "node_modules", "is-odd", "package.json"), "utf8"),
+      );
+
+      // Should be newer than 0.1.0
+      expect(updatedPkgJson.version).not.toBe("0.1.0");
+    } catch (err) {
+      // Ensure cleanup on failure
+      updateProc.stdin.end();
+      updateProc.kill();
+      throw err;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where `bun update --interactive` only updated `package.json` but didn't actually install the updated packages. Users had to manually run `bun install` afterwards.

## Root Cause

The bug was in `savePackageJson()` in `src/cli/update_interactive_command.zig`:

1. The function wrote the updated `package.json` to disk
2. But it **didn't update the in-memory cache** (`WorkspacePackageJSONCache`)
3. When `installWithManager()` ran, it called `getWithPath()` which returned the **stale cached version**
4. So the installation proceeded with the old dependencies

## The Fix

Update the cache entry after writing to disk (line 116):
```zig
package_json.*.source.contents = new_package_json_source;
```

This matches the behavior in `updatePackageJSONAndInstall.zig` line 269.

## Test Plan

Added comprehensive regression tests in `test/cli/update_interactive_install.test.ts`:
- ✅ Verifies that `package.json` is updated
- ✅ Verifies that `node_modules` is updated (this was failing before the fix)
- ✅ Tests both normal update and `--latest` flag
- ✅ Compares installed version to confirm packages were actually installed

Run tests with:
```bash
bun bd test test/cli/update_interactive_install.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)