### PR TITLE
fix(resolver): use export fallbacks when files are missing

### DIFF
--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1721,7 +1721,7 @@ pub const ESModule = struct {
         if (resolution.status != .Exact and resolution.status != .ExactEndsWithStar) {
             return true; // Not a file path, so assume valid
         }
-        
+
         if (resolution.path.len == 0 or resolution.path[0] != std.fs.path.sep) {
             return true; // Invalid path format
         }
@@ -1738,7 +1738,7 @@ pub const ESModule = struct {
         const base = bun.path.basename(abs_esm_path);
         const dir_path = bun.path.dirname(abs_esm_path, .auto);
         if (dir_path.len == 0) return false;
-        
+
         const dir_info = (r.resolver.readDirInfo(dir_path) catch null) orelse return false;
         const entries = dir_info.getEntries(r.resolver.generation) orelse return false;
         const entry_query = entries.get(base) orelse return false;
@@ -1846,7 +1846,7 @@ pub const ESModule = struct {
                     const status: Status = if (strings.endsWithCharOrIsZeroLength(result, '*') and strings.indexOfChar(result, '*').? == result.len - 1)
                         .ExactEndsWithStar
                     else
-                        .Exact; 
+                        .Exact;
                     return Resolution{ .path = result, .status = status, .debug = .{ .token = target.first_token } };
                 } else {
                     const parts2 = [_]string{ package_url, str, subpath };
@@ -1995,7 +1995,7 @@ pub const ESModule = struct {
                             continue;
                         }
                     }
-                    
+
                     return result;
                 }
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1802,6 +1802,7 @@ pub const Resolver = struct {
                                 // The condition set is determined by the kind of import
                                 var module_type = package_json.module_type;
                                 const esmodule = ESModule{
+                                    .resolver = r,
                                     .conditions = switch (kind) {
                                         ast.ImportKind.require, ast.ImportKind.require_resolve => r.opts.conditions.require,
                                         ast.ImportKind.at, ast.ImportKind.at_conditional => r.opts.conditions.style,
@@ -1810,6 +1811,7 @@ pub const Resolver = struct {
                                     .allocator = r.allocator,
                                     .debug_logs = if (r.debug_logs) |*debug| debug else null,
                                     .module_type = &module_type,
+                                    .abs_package_path = abs_package_path,
                                 };
 
                                 // Resolve against the path "/", then join it with the absolute
@@ -2080,6 +2082,7 @@ pub const Resolver = struct {
                             if (package_json.exports) |exports_map| {
                                 // The condition set is determined by the kind of import
                                 const esmodule = ESModule{
+                                    .resolver = r,
                                     .conditions = switch (kind) {
                                         ast.ImportKind.require,
                                         ast.ImportKind.require_resolve,
@@ -2092,6 +2095,7 @@ pub const Resolver = struct {
                                         debug
                                     else
                                         null,
+                                    .abs_package_path = abs_package_path,
                                 };
 
                                 // Resolve against the path "/", then join it with the absolute
@@ -3119,6 +3123,7 @@ pub const Resolver = struct {
         var module_type = options.ModuleType.unknown;
 
         const esmodule = ESModule{
+            .resolver = r,
             .conditions = switch (kind) {
                 ast.ImportKind.require,
                 ast.ImportKind.require_resolve,
@@ -3128,6 +3133,7 @@ pub const Resolver = struct {
             .allocator = r.allocator,
             .debug_logs = if (r.debug_logs) |*debug| debug else null,
             .module_type = &module_type,
+            .abs_package_path = dir_info.abs_path,
         };
 
         const esm_resolution = esmodule.resolveImports(import_path, imports_map.root);


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in ESM module resolution where fallback patterns were not used when earlier patterns resolved to non-existent files.

for example, resolving `pkg/foo/bar` would fail with the below `package.json` if `dist/bar.js` did not exist:
```json
{
  "name": "pkg",
  "exports": {
    "./foo": ["./dist/*.js", "./src/*.ts"]
  }
}
```

### How did you verify your code works?
There is a test