### PR TITLE
fix(NAPI): empty input `napi_create_external_buffer`

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1990,15 +1990,35 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
     NAPI_CHECK_ARG(env, result);
 
     Zig::GlobalObject* globalObject = toJS(env);
-
-    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(data), length }, createSharedTask<void(void*)>([env = WTF::Ref<NapiEnv>(*env), finalize_hint, finalize_cb](void* p) {
-        NAPI_LOG("external buffer finalizer");
-        env->doFinalizer(finalize_cb, p, finalize_hint);
-    }));
+    JSC::VM& vm = JSC::getVM(globalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
+
+    if (data == nullptr || length == 0) {
+        auto* buffer = JSC::JSUint8Array::createUninitialized(globalObject, subclassStructure, 0);
+        NAPI_RETURN_IF_EXCEPTION(env);
+
+        vm.heap.addFinalizer(buffer, [env = WTF::Ref<NapiEnv>(*env), finalize_cb, data, finalize_hint](JSCell* cell) -> void {
+            NAPI_LOG("external buffer finalizer (empty buffer)");
+            env->doFinalizer(finalize_cb, data, finalize_hint);
+        });
+
+        *result = toNapi(buffer, globalObject);
+        NAPI_RETURN_SUCCESS(env);
+    }
+
+    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(data), length }, createSharedTask<void(void*)>([](void*) {
+        // do nothing
+    }));
 
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTFMove(arrayBuffer), 0, length);
     NAPI_RETURN_IF_EXCEPTION(env);
+
+    // setup finalizer after creating the array. if it throws callers of napi_create_external_buffer are expected
+    // to free input
+    vm.heap.addFinalizer(buffer, [env = WTF::Ref<NapiEnv>(*env), finalize_cb, data, finalize_hint](JSCell* cell) -> void {
+        NAPI_LOG("external buffer finalizer");
+        env->doFinalizer(finalize_cb, data, finalize_hint);
+    });
 
     *result = toNapi(buffer, globalObject);
     NAPI_RETURN_SUCCESS(env);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -266,6 +266,16 @@ describe.concurrent("napi", () => {
     });
   });
 
+  describe("napi_create_external_buffer", () => {
+    it("handles empty/null data without throwing", async () => {
+      const result = await checkSameOutput("test_napi_create_external_buffer_empty", []);
+      expect(result).toContain("PASS: napi_create_external_buffer with nullptr and zero length");
+      expect(result).toContain("PASS: napi_create_external_buffer with non-null data and zero length");
+      expect(result).toContain("PASS: napi_create_external_buffer with nullptr finalizer");
+      expect(result).not.toContain("FAIL");
+    });
+  });
+
   describe("napi_async_work", () => {
     it("null checks execute callbacks", async () => {
       const output = await checkSameOutput("test_napi_async_work_execute_null_check", []);


### PR DESCRIPTION
### What does this PR do?
If the input was empty `ArrayBuffer::createFromBytes` would create a buffer that `JSUint8Array::create` would see as detached, so it would throw an exception. This would likely cause crashes in `node-addon-api` because finalize data is freed if `napi_create_external_buffer` fails, and we already setup the finalizer.

Example of creating empty buffer:
https://github.com/node-ffi-napi/ref-napi/blob/a7f62a4caa3e0c32aeb66c015641b0bc01ba03ab/src/binding.cc#L687

fixes #6737
fixes #10965
fixes #12331
fixes #12937
fixes #13622
most likely fixes #14822
### How did you verify your code works?
Manually and added tests.