### PR TITLE
Reduce ConcurrentTask size from 24 to 16 bytes by packing auto_delete

### DIFF
--- a/src/bake/DevServer/WatcherAtomics.zig
+++ b/src/bake/DevServer/WatcherAtomics.zig
@@ -132,7 +132,7 @@ pub fn watcherReleaseAndSubmitEvent(self: *Self, ev: *HotReloadEvent) void {
                 self.dbg_server_event = ev;
             }
             ev.concurrent_task = .{
-                .next = .{},
+                .next = .zero,
                 .task = jsc.Task.init(ev),
             };
             ev.concurrent_task.next.setAutoDelete(false);

--- a/src/bake/DevServer/WatcherAtomics.zig
+++ b/src/bake/DevServer/WatcherAtomics.zig
@@ -132,10 +132,10 @@ pub fn watcherReleaseAndSubmitEvent(self: *Self, ev: *HotReloadEvent) void {
                 self.dbg_server_event = ev;
             }
             ev.concurrent_task = .{
-                .auto_delete = false,
-                .next = null,
+                .next = .{},
                 .task = jsc.Task.init(ev),
             };
+            ev.concurrent_task.next.setAutoDelete(false);
             ev.owner.vm.event_loop.enqueueTaskConcurrent(&ev.concurrent_task);
         },
 

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -321,7 +321,7 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
             dest.deinit();
         }
 
-        if (task.next.autoDelete()) {
+        if (task.auto_delete()) {
             to_destroy = task;
         }
 

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -321,7 +321,7 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
             dest.deinit();
         }
 
-        if (task.auto_delete) {
+        if (task.next.autoDelete()) {
             to_destroy = task;
         }
 

--- a/src/bun.js/event_loop/ConcurrentTask.zig
+++ b/src/bun.js/event_loop/ConcurrentTask.zig
@@ -28,6 +28,20 @@ pub const PackedNext = packed struct(u64) {
         return .{};
     }
 
+    pub fn initPreserveAutoDelete(self: PackedNext, ptr: ?*ConcurrentTask) PackedNext {
+        if (ptr) |p| {
+            const addr = @intFromPtr(p);
+            return .{
+                .ptr_bits = @as(u63, @truncate(addr)),
+                .auto_delete = self.auto_delete,
+            };
+        }
+        return .{
+            .ptr_bits = 0,
+            .auto_delete = self.auto_delete,
+        };
+    }
+
     pub fn get(self: PackedNext) ?*ConcurrentTask {
         if (self.ptr_bits == 0) return null;
         const ptr: u64 = @as(u64, self.ptr_bits);
@@ -39,6 +53,8 @@ pub const PackedNext = packed struct(u64) {
     }
 
     pub fn setAutoDelete(self: *PackedNext, value: bool) void {
+        // Non-atomic write is safe because this is only called during initialization
+        // before the task is shared with other threads
         self.auto_delete = value;
     }
 

--- a/src/bun.js/event_loop/ConcurrentTask.zig
+++ b/src/bun.js/event_loop/ConcurrentTask.zig
@@ -104,15 +104,6 @@ pub fn from(this: *ConcurrentTask, of: anytype, auto_deinit: AutoDeinit) *Concur
     return this;
 }
 
-const std = @import("std");
-
-const bun = @import("bun");
-const UnboundedQueue = bun.threading.UnboundedQueue;
-
-const jsc = bun.jsc;
-const ManagedTask = jsc.ManagedTask;
-const Task = jsc.Task;
-
 comptime {
     // Verify that ConcurrentTask is 16 bytes (not 24)
     // Task is 8 bytes (u64), PackedNext is 8 bytes (u64) = 16 bytes total
@@ -120,3 +111,10 @@ comptime {
         @compileError(bun.fmt.comptimePrint("ConcurrentTask should be 16 bytes, but it's {d} bytes", .{@sizeOf(ConcurrentTask)}));
     }
 }
+
+const bun = @import("bun");
+const std = @import("std");
+
+const jsc = bun.jsc;
+const ManagedTask = jsc.ManagedTask;
+const Task = jsc.Task;

--- a/src/bun.js/event_loop/JSCScheduler.zig
+++ b/src/bun.js/event_loop/JSCScheduler.zig
@@ -27,7 +27,7 @@ export fn Bun__queueJSCDeferredWorkTaskConcurrently(jsc_vm: *VirtualMachine, tas
     var loop = jsc_vm.eventLoop();
     const concurrent_task = ConcurrentTask.new(.{
         .task = Task.init(task),
-        .next = .{},
+        .next = .zero,
     });
     concurrent_task.next.setAutoDelete(true);
     loop.enqueueTaskConcurrent(concurrent_task);

--- a/src/bun.js/event_loop/JSCScheduler.zig
+++ b/src/bun.js/event_loop/JSCScheduler.zig
@@ -25,11 +25,12 @@ export fn Bun__eventLoop__incrementRefConcurrently(jsc_vm: *VirtualMachine, delt
 export fn Bun__queueJSCDeferredWorkTaskConcurrently(jsc_vm: *VirtualMachine, task: *JSCScheduler.JSCDeferredWorkTask) void {
     jsc.markBinding(@src());
     var loop = jsc_vm.eventLoop();
-    loop.enqueueTaskConcurrent(ConcurrentTask.new(.{
+    const concurrent_task = ConcurrentTask.new(.{
         .task = Task.init(task),
-        .next = null,
-        .auto_delete = true,
-    }));
+        .next = .{},
+    });
+    concurrent_task.next.setAutoDelete(true);
+    loop.enqueueTaskConcurrent(concurrent_task);
 }
 
 export fn Bun__tickWhilePaused(paused: *bool) void {

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -225,7 +225,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     .hashes = this.hashes,
                     .concurrent_task = undefined,
                 });
-                that.concurrent_task = .{ .task = jsc.Task.init(that), .next = .{} };
+                that.concurrent_task = .{ .task = jsc.Task.init(that), .next = .zero };
                 that.concurrent_task.next.setAutoDelete(false);
                 that.reloader.enqueueTaskConcurrent(&that.concurrent_task);
                 this.count = 0;

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -225,7 +225,8 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     .hashes = this.hashes,
                     .concurrent_task = undefined,
                 });
-                that.concurrent_task = .{ .task = jsc.Task.init(that), .auto_delete = false };
+                that.concurrent_task = .{ .task = jsc.Task.init(that), .next = .{} };
+                that.concurrent_task.next.setAutoDelete(false);
                 that.reloader.enqueueTaskConcurrent(&that.concurrent_task);
                 this.count = 0;
             }

--- a/src/threading.zig
+++ b/src/threading.zig
@@ -9,3 +9,4 @@ pub const WaitGroup = @import("./threading/WaitGroup.zig");
 pub const ThreadPool = @import("./threading/ThreadPool.zig");
 pub const Channel = @import("./threading/channel.zig").Channel;
 pub const UnboundedQueue = @import("./threading/unbounded_queue.zig").UnboundedQueue;
+pub const UnboundedQueuePacked = @import("./threading/unbounded_queue.zig").UnboundedQueuePacked;


### PR DESCRIPTION
## Summary

Pack the `auto_delete` boolean into the lowest bit of the `next` pointer in `ConcurrentTask`, reducing memory usage by 33% (from 24 to 16 bytes).

## Implementation Details

- **Created `PackedNext` struct** that packs u63 pointer + bool into u64
- **Extended `UnboundedQueue`** to support packed pointer types via `UnboundedQueuePacked` function
- **Added getter/setter helpers** to abstract packed vs unpacked access
- **All atomic operations properly handle packed pointers**:
  - Packed mode uses `@atomicLoad(u64, ...)` and `@atomicStore(u64, ...)`
  - Unpacked mode continues using `@atomicLoad(?*T, ...)` and `@atomicStore(?*T, ...)`
  - No new atomic primitives needed
- **Preserves `auto_delete` flag** during atomic pointer updates via read-modify-write
- **Added compile-time assertion** to ensure `ConcurrentTask` is exactly 16 bytes

## Technical Notes

The next pointer uses only 63 bits since pointers on 64-bit systems don't use the full address space, leaving the LSB for the `auto_delete` flag.

When atomically updating a task's `next` pointer in `pushBatch`, we preserve the task's existing `auto_delete` flag by:
1. Loading current packed value (pointer + auto_delete bit)
2. Creating new packed value with updated pointer but same auto_delete bit
3. Storing atomically as u64

Queue `front`/`back` pointers remain as plain `?*T` pointers (not packed), only the per-task `next` field is packed.

## Memory Savings

Before: `Task (8 bytes) + next pointer (8 bytes) + auto_delete bool (8 bytes due to alignment) = 24 bytes`
After: `Task (8 bytes) + PackedNext (8 bytes with pointer + bool) = 16 bytes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)