### PR TITLE
Add inkeep chat to new docs

### DIFF
--- a/docs/inkeep.js
+++ b/docs/inkeep.js
@@ -1,0 +1,55 @@
+function loadScript(url, callback) {
+  const script = document.createElement("script");
+  script.src = url;
+  script.type = "text/javascript";
+  script.onload = callback;
+  document.head.appendChild(script);
+}
+
+loadScript(
+  "https://cdn.jsdelivr.net/npm/@inkeep/cxkit-mintlify@0.5/dist/index.js",
+  () => {
+    const settings = {
+      baseSettings: {
+        apiKey: "f38a3d4e0a621e192a5d161c6f4babd951fdfc20854bc4b0", // required
+        primaryBrandColor: "#F267AD", // required -- your brand color, the color scheme is derived from this
+        organizationDisplayName: "Bun",
+      },
+      aiChatSettings: {
+        aiAssistantAvatar: "https://storage.googleapis.com/organization-image-assets/bun-botAvatarSrcUrl-1705417749067.svg",
+        chatSubjectName: "Bun",
+        exampleQuestions: [
+          "Can I use Bun with my existing Node.js project?",
+          "How is Bun faster than Node.js? How can I benchmark it?",
+          "Do I still need a bundler or TypeScript compiler?",
+        ],
+        getHelpOptions: [
+          {
+            icon: {
+              builtIn: "FaDiscord"
+            },
+            name: "Discord",
+            action: {
+              type: "open_link",
+              url: "https://bun.com/discord"
+            }
+          },
+          {
+            icon: {
+              builtIn: "FaBriefcase"
+            },
+            name: "Migration help for organizations",
+            action: {
+              type: "open_link",
+              url: "https://t.co/0CA0Neqgts"
+            }
+          }
+        ]
+      },
+      canToggleView: false, // set to true to enable search
+    };
+
+    // Initialize the UI components
+    Inkeep.ChatButton(settings); // 'Ask AI' button
+  }
+);


### PR DESCRIPTION
### What does this PR do?
Adds the inkeep chat button to bottom right.
<img width="1214" height="796" alt="Screenshot 2025-11-03 at 10 56 53 AM" src="https://github.com/user-attachments/assets/0a317f47-9756-4845-9788-734f20009523" />

<img width="1214" height="796" alt="Screenshot 2025-11-03 at 10 56 49 AM" src="https://github.com/user-attachments/assets/a76de8a2-152d-407a-8331-79aa064da3b4" />


### How did you verify your code works?
I created a new API key in the Inkeep portal that is only enabled for [https://bun.com/docs](https://bun.com/docs).  For local development / testing you can use this [API key](https://portal.inkeep.com/bun/projects/clmg4g43l0004s601dwaz9k9a/assistants/cmhjhurn800wes601sw641fgi).
