### PR TITLE
fix(tls) undo some changes added in root_certs

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -203,8 +203,6 @@ STACK_OF(X509) *us_get_root_extra_cert_instances() {
 }
 
 STACK_OF(X509) *us_get_root_system_cert_instances() {
-  if (!us_should_use_system_ca())
-    return NULL;
   // Ensure single-path initialization via us_internal_init_root_certs
   auto certs = us_get_default_ca_certificates();
   return certs->root_system_cert_instances;
@@ -216,13 +214,9 @@ extern "C" X509_STORE *us_get_default_ca_store() {
     return NULL;
   }
 
-  // Only load system default paths when NODE_USE_SYSTEM_CA=1
-  // Otherwise, rely on bundled certificates only (like Node.js behavior)
-  if (us_should_use_system_ca()) {
-    if (!X509_STORE_set_default_paths(store)) {
-      X509_STORE_free(store);
-      return NULL;
-    }
+  if (!X509_STORE_set_default_paths(store)) {
+    X509_STORE_free(store);
+    return NULL;
   }
 
   us_default_ca_certificates *default_ca_certificates = us_get_default_ca_certificates();


### PR DESCRIPTION
### What does this PR do?
Restore call to us_get_default_ca_certificates, and X509_STORE_set_default_paths

Fixes https://github.com/oven-sh/bun/issues/23735
### How did you verify your code works?
Manually test running:
```bash
bun -e "await fetch('https://secure-api.eloview.com').then(res => res.t
ext()).then(console.log);"
```
should not result in:
```js
error: unable to get local issuer certificate
  path: "https://secure-api.eloview.com/",
 errno: 0,
  code: "UNABLE_TO_GET_ISSUER_CERT_LOCALLY"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system root certificate handling to ensure consistent validation across all secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->