### PR TITLE
Update old `format` methods

### DIFF
--- a/src/StaticHashMap.zig
+++ b/src/StaticHashMap.zig
@@ -77,9 +77,7 @@ pub fn HashMap(comptime K: type, comptime V: type, comptime Context: type, compt
                 return self.hash == empty_hash;
             }
 
-            pub fn format(self: Entry, comptime layout: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-                _ = layout;
-                _ = options;
+            pub fn format(self: Entry, writer: *std.Io.Writer) !void {
                 try writer.print("(hash: {}, key: {}, value: {})", .{ self.hash, self.key, self.value });
             }
         };
@@ -353,9 +351,7 @@ pub fn SortedHashMap(comptime V: type, comptime max_load_percentage: comptime_in
                 return cmp(self.hash, empty_hash) == .eq;
             }
 
-            pub fn format(self: Entry, comptime layout: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-                _ = layout;
-                _ = options;
+            pub fn format(self: Entry, writer: *std.Io.Writer) !void {
                 try writer.print("(hash: {x}, value: {})", .{ mem.asBytes(&self.hash), self.value });
             }
         };

--- a/src/bake/FrameworkRouter.zig
+++ b/src/bake/FrameworkRouter.zig
@@ -423,8 +423,7 @@ pub const Part = union(enum(u3)) {
         };
     }
 
-    pub fn format(part: Part, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-        comptime bun.assert(fmt.len == 0);
+    pub fn format(part: Part, writer: *std.Io.Writer) !void {
         try writer.writeAll("Part \"");
         try part.toStringForInternalUse(writer);
         try writer.writeAll("\"");

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -25,7 +25,7 @@ pub const JSValue = enum(i64) {
     pub const is_pointer = false;
     pub const JSType = @import("./JSType.zig").JSType;
 
-    pub fn format(_: JSValue, writer: *std.Io.Writer) !void {
+    pub fn format(_: JSValue, _: *std.Io.Writer) !void {
         @compileError("Formatting a JSValue directly is not allowed. Use jsc.ConsoleObject.Formatter");
     }
 

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -25,7 +25,7 @@ pub const JSValue = enum(i64) {
     pub const is_pointer = false;
     pub const JSType = @import("./JSType.zig").JSType;
 
-    pub fn format(_: JSValue, comptime _: []const u8, _: std.fmt.FormatOptions, _: anytype) !void {
+    pub fn format(_: JSValue, writer: *std.Io.Writer) !void {
         @compileError("Formatting a JSValue directly is not allowed. Use jsc.ConsoleObject.Formatter");
     }
 

--- a/src/bun.js/node/assert/myers_diff.zig
+++ b/src/bun.js/node/assert/myers_diff.zig
@@ -394,7 +394,6 @@ pub fn Diff(comptime T: type) type {
             return self.kind == other.kind and mem.eql(T, self.value, other.value);
         }
 
-        /// pub fn format(value: ?, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void
         pub fn format(value: anytype, writer: *std.Io.Writer) !void {
             const specifier = switch (T) {
                 u8 => "c",

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -898,10 +898,7 @@ pub const PathOrFileDescriptor = union(Tag) {
         };
     }
 
-    pub fn format(this: jsc.Node.PathOrFileDescriptor, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-        if (fmt.len != 0 and fmt[0] != 's') {
-            @compileError("Unsupported format argument: '" ++ fmt ++ "'.");
-        }
+    pub fn format(this: jsc.Node.PathOrFileDescriptor, writer: *std.Io.Writer) !void {
         switch (this) {
             .path => |p| try writer.writeAll(p.slice()),
             .fd => |fd| try writer.print("{}", .{fd}),

--- a/src/bun.js/uuid.zig
+++ b/src/bun.js/uuid.zig
@@ -267,6 +267,4 @@ pub const UUID5 = struct {
 };
 
 const bun = @import("bun");
-
 const std = @import("std");
-const fmt = std.fmt;

--- a/src/bun.js/uuid.zig
+++ b/src/bun.js/uuid.zig
@@ -188,13 +188,8 @@ pub const UUID7 = struct {
         return .{ .bytes = bytes };
     }
 
-    pub fn format(
-        self: UUID7,
-        comptime layout: []const u8,
-        options: fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        return self.toUUID().format(layout, options, writer);
+    pub fn format(self: UUID7, writer: *std.Io.Writer) !void {
+        return self.toUUID().format(writer);
     }
 };
 
@@ -266,13 +261,8 @@ pub const UUID5 = struct {
         return .{ .bytes = bytes };
     }
 
-    pub fn format(
-        self: UUID5,
-        comptime layout: []const u8,
-        options: fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        return self.toUUID().format(layout, options, writer);
+    pub fn format(self: UUID5, writer: *std.Io.Writer) !void {
+        return self.toUUID().format(writer);
     }
 };
 

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -2770,10 +2770,7 @@ pub const ReturnCode = enum(c_int) {
     zero = 0,
     _,
 
-    pub fn format(this: ReturnCode, comptime fmt_: []const u8, options_: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt_;
-        _ = options_;
-
+    pub fn format(this: ReturnCode, writer: *std.Io.Writer) !void {
         if (this.errEnum()) |err| {
             try writer.writeAll(@tagName(err));
         } else {

--- a/src/install/windows-shim/bun_shim_impl.zig
+++ b/src/install/windows-shim/bun_shim_impl.zig
@@ -164,9 +164,7 @@ const FailReason = enum {
         };
     }
 
-    pub fn format(reason: FailReason, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-        if (fmt.len != 0) @compileError("FailReason.format() only takes empty format string");
-
+    pub fn format(reason: FailReason, writer: *std.Io.Writer) !void {
         if (!is_standalone and bun.Environment.allow_assert and reason == .InvalidShimValidation) {
             @panic("Internal Assertion: When encountering FailReason.InvalidShimValidation, you must not print the error, but rather fallback to running the .exe file");
         }

--- a/src/safety/CriticalSection.zig
+++ b/src/safety/CriticalSection.zig
@@ -37,13 +37,7 @@ const OptionalThreadId = struct {
         return .{ .inner = id };
     }
 
-    pub fn format(
-        self: OptionalThreadId,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = .{ fmt, options };
+    pub fn format(self: OptionalThreadId, writer: *std.Io.Writer) !void {
         if (self.inner == invalid_thread_id) {
             try writer.writeAll("another thread");
         } else {

--- a/src/string.zig
+++ b/src/string.zig
@@ -1200,9 +1200,9 @@ pub const SliceWithUnderlyingString = struct {
         return this.utf8.slice();
     }
 
-    pub fn format(self: SliceWithUnderlyingString, comptime fmt: []const u8, opts: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: SliceWithUnderlyingString, writer: *std.Io.Writer) !void {
         if (self.utf8.len == 0) {
-            try self.underlying.format(fmt, opts, writer);
+            try self.underlying.format(writer);
             return;
         }
 


### PR DESCRIPTION
Update `format` methods using the old signature (`[]const u8, std.fmt.FormatOptions, anytype`).