### PR TITLE
Support multi folder workspace for "Debug File" and "Run File"

### DIFF
--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -19,7 +19,7 @@ export const DEBUG_CONFIGURATION: vscode.DebugConfiguration = {
   request: "launch",
   name: "Debug File",
   program: "${file}",
-  cwd: "${workspaceFolder}",
+  cwd: "${fileWorkspaceFolder}",
   stopOnEntry: false,
   watchMode: false,
 };
@@ -30,7 +30,7 @@ export const RUN_CONFIGURATION: vscode.DebugConfiguration = {
   request: "launch",
   name: "Run File",
   program: "${file}",
-  cwd: "${workspaceFolder}",
+  cwd: "${fileWorkspaceFolder}",
   noDebug: true,
   watchMode: false,
 };


### PR DESCRIPTION
### What does this PR do?

This PR makes "Bun: Debug File" and "Bun: Run File" commands be able to run in multi folder workspace.

Currently this two commands can not run in multi folder workspace and will throw error:

```
DialogService: refused to show dialog in tests. Contents: Variable workspaceFolder can not be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.: Error: DialogService: refused to show dialog in tests. Contents: Variable workspaceFolder can not be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.
```

### How did you verify your code works?

Create a test `test.code-workspace` in `bun-vscode` folder:

```json
{
	"folders": [
		{
			"path": "../bun-vscode"
		},
		{
			"path": "../bun-types"
		}
	]
}
```

Change the `workspaceFolder` of `scripts/dev.mjs` to:

```js
workspaceFolder: join(workspacePath, "test.code-workspace")
```

And run `bun dev`.

In the `vscode-test` window, write a test TypeScript file and run "Bun: Debug File".