### PR TITLE
Fix bundler plugin namespace collision

### DIFF
--- a/src/bundler/PathToSourceIndexMap.zig
+++ b/src/bundler/PathToSourceIndexMap.zig
@@ -5,38 +5,62 @@ const PathToSourceIndexMap = @This();
 /// We assume it's arena allocated.
 map: Map = .{},
 
-const Map = bun.StringHashMapUnmanaged(Index.Int);
+/// HashMap context that makes path lookups namespace-aware.
+/// For file namespace, uses only path.text for backwards compatibility.
+/// For other namespaces, combines namespace and path in the hash.
+const PathHashContext = struct {
+    pub fn hash(_: @This(), path: Fs.Path) u64 {
+        return path.hashKey();
+    }
+
+    pub fn eql(_: @This(), a: Fs.Path, b: Fs.Path) bool {
+        // For file namespace, only compare path text
+        if (a.isFile() and b.isFile()) {
+            return bun.strings.eqlLong(a.text, b.text, true);
+        }
+
+        // For non-file namespaces, compare both namespace and path
+        return bun.strings.eqlLong(a.namespace, b.namespace, true) and
+            bun.strings.eqlLong(a.text, b.text, true);
+    }
+};
+
+const Map = std.HashMapUnmanaged(Fs.Path, Index.Int, PathHashContext, std.hash_map.default_max_load_percentage);
 
 pub fn getPath(this: *const PathToSourceIndexMap, path: *const Fs.Path) ?Index.Int {
-    return this.get(path.text);
+    return this.map.get(path.*);
 }
 
 pub fn get(this: *const PathToSourceIndexMap, text: []const u8) ?Index.Int {
-    return this.map.get(text);
+    const file_path = Fs.Path.init(text);
+    return this.map.get(file_path);
 }
 
 pub fn putPath(this: *PathToSourceIndexMap, allocator: std.mem.Allocator, path: *const Fs.Path, value: Index.Int) bun.OOM!void {
-    try this.map.put(allocator, path.text, value);
+    try this.map.put(allocator, path.*, value);
 }
 
 pub fn put(this: *PathToSourceIndexMap, allocator: std.mem.Allocator, text: []const u8, value: Index.Int) bun.OOM!void {
-    try this.map.put(allocator, text, value);
+    const file_path = Fs.Path.init(text);
+    try this.map.put(allocator, file_path, value);
 }
 
 pub fn getOrPutPath(this: *PathToSourceIndexMap, allocator: std.mem.Allocator, path: *const Fs.Path) bun.OOM!Map.GetOrPutResult {
-    return this.getOrPut(allocator, path.text);
+    return try this.map.getOrPut(allocator, path.*);
 }
 
 pub fn getOrPut(this: *PathToSourceIndexMap, allocator: std.mem.Allocator, text: []const u8) bun.OOM!Map.GetOrPutResult {
-    return try this.map.getOrPut(allocator, text);
+    const file_path = Fs.Path.init(text);
+    return try this.map.getOrPut(allocator, file_path);
 }
 
 pub fn remove(this: *PathToSourceIndexMap, text: []const u8) bool {
-    return this.map.remove(text);
+    const file_path = Fs.Path.init(text);
+    return this.map.remove(file_path);
 }
 
 pub fn removePath(this: *PathToSourceIndexMap, path: *const Fs.Path) bool {
-    return this.remove(path.text);
+    return this.map.remove(path.*);
 }
 
 const std = @import("std");


### PR DESCRIPTION
## Summary

Fixes bundler plugins where different imports are resolved to the same path but different namespaces. Previously, these would incorrectly be treated as the same module due to namespace-blind caching.

## Changes

- Updated `PathToSourceIndexMap` to include namespace in cache keys for non-file namespaces
- Modified cache key format to use `"namespace:::::path"` for non-file namespaces
- Updated all `PathToSourceIndexMap` operations (`getPath`, `putPath`, `getOrPutPath`, `removePath`) to handle namespaces
- Made the resolve queue in `bundle_v2.zig` namespace-aware to prevent duplicate ParseTasks
- Added test case that verifies plugins can use the same path in different namespaces

## Test plan

- ✅ Added test case in `test/bundler/bundler_plugin_chain.test.ts` that reproduces the bug
- ✅ Test fails with `USE_SYSTEM_BUN=1` (confirms it reproduces the bug)
- ✅ Test passes with `bun bd test` (confirms the fix works)
- ✅ All existing plugin chain tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)