### PR TITLE
add some debug logs for import resolution

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1270,6 +1270,7 @@ pub const JSBundler = struct {
             jsc.markBinding(@src());
             const tracer = bun.perf.trace("JSBundler.matchOnResolve");
             defer tracer.end();
+            debug("JSBundler.matchOnResolve(0x{x}, {s}, {s})", .{ @intFromPtr(this), namespace, path });
             const namespace_string = if (strings.eqlComptime(namespace, "file"))
                 bun.String.empty
             else


### PR DESCRIPTION
### What does this PR do?
Adds some debug logs for choices made during import resolution handling

### How did you verify your code works?
Built `bun-debug` and ran it on a gnarly import scenario I'm trying to figure out, setting `BUN_DEBUG_QUIET_LOGS=1 BUN_DEBUG_Bundle=1 BUN_DEBUG_Transpiler=1`