### PR TITLE
build(ENG-21464): Remove sccache --show-stats on local builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -101,9 +101,11 @@ async function build(args) {
 
   await startGroup("CMake Build", () => spawn("cmake", buildArgs, { env }));
 
-  await startGroup("sccache stats", () => {
-    spawn("sccache", ["--show-stats"], { env });
-  });
+  if (isBuildkite()) {
+    await startGroup("sccache stats", () => {
+      spawn("sccache", ["--show-stats"], { env });
+    });
+  }
 
   printDuration("total", Date.now() - startTime);
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -101,7 +101,7 @@ async function build(args) {
 
   await startGroup("CMake Build", () => spawn("cmake", buildArgs, { env }));
 
-  if (isBuildkite()) {
+  if (isCI) {
     await startGroup("sccache stats", () => {
       spawn("sccache", ["--show-stats"], { env });
     });


### PR DESCRIPTION
### What does this PR do?

Removes `sccache --show-stats` from local builds, but keeps them in CI.

### How did you verify your code works?

Ran `bun run build` locally and confirmed no `sccache --show-stats` output was present.