### PR TITLE
build(ENG-21466): Fix `sccache` not caching across builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -103,7 +103,8 @@ async function build(args) {
 
   await startGroup("CMake Build", () => spawn("cmake", buildArgs, { env }));
 
-  if (isCI) {
+  const target = buildOptions["--target"] || buildOptions["-t"];
+  if (isCI && target === "build-cpp") {
     await startGroup("sccache stats", () => {
       spawn("sccache", ["--show-stats"], { env });
     });

--- a/test/js/node/path/browserify.test.js
+++ b/test/js/node/path/browserify.test.js
@@ -469,7 +469,12 @@ describe("browserify path tests", () => {
     const failures = [];
     const cwd = process.cwd();
     const cwdParent = path.dirname(cwd);
-    const parentIsRoot = isWindows ? cwdParent.match(/^[A-Z]:\\$/) : cwdParent === "/";
+    const parentIsRoot = (levels = 1) => {
+      const dir = Array(levels)
+        .fill()
+        .reduce(wd => path.dirname(wd), cwd);
+      return isWindows ? dir.match(/^[a-zA-Z]:\\$/) : dir === "/";
+    };
 
     const relativeTests = [
       [
@@ -529,19 +534,19 @@ describe("browserify path tests", () => {
           ["/webp4ck-hot-middleware", "/webpack/buildin/module.js", "../webpack/buildin/module.js"],
           ["/webpack-hot-middleware", "/webp4ck/buildin/module.js", "../webp4ck/buildin/module.js"],
           ["/var/webpack-hot-middleware", "/var/webpack/buildin/module.js", "../webpack/buildin/module.js"],
-          ["/app/node_modules/pkg", "../static", `../../..${parentIsRoot ? "" : path.posix.resolve("../")}/static`],
+          ["/app/node_modules/pkg", "../static", `../../..${parentIsRoot() ? "" : path.posix.resolve("../")}/static`],
           [
             "/app/node_modules/pkg",
             "../../static",
-            `../../..${parentIsRoot ? "" : path.posix.resolve("../../")}/static`,
+            `../../..${parentIsRoot(2) ? "" : path.posix.resolve("../../")}/static`,
           ],
-          ["/app", "../static", `..${parentIsRoot ? "" : path.posix.resolve("../")}/static`],
+          ["/app", "../static", `..${parentIsRoot() ? "" : path.posix.resolve("../")}/static`],
           ["/app", "../".repeat(64) + "static", "../static"],
           [".", "../static", cwd == "/" ? "static" : "../static"],
-          ["/", "../static", parentIsRoot ? "static" : `${path.posix.resolve("../")}/static`.slice(1)],
+          ["/", "../static", parentIsRoot() ? "static" : `${path.posix.resolve("../")}/static`.slice(1)],
           ["../", "../", ""],
-          ["../", "../../", parentIsRoot ? "" : ".."],
-          ["../../", "../", parentIsRoot ? "" : path.basename(cwdParent)],
+          ["../", "../../", parentIsRoot() ? "" : ".."],
+          ["../../", "../", parentIsRoot() ? "" : path.basename(cwdParent)],
           ["../../", "../../", ""],
         ],
       ],


### PR DESCRIPTION
### What does this PR do?

Fixes `sccache` not actually caching across CI builds for Linux and Windows executors. The reason this was failing to cache is because buildkite created builds in `/var/log/buildkite-agent/<hostname>/...` and `sccache` requires that absolute paths match to get a build hit.

https://github.com/mozilla/sccache/issues/964

### How did you verify your code works?

Ran in CI.