### PR TITLE
ENG-21468: RELEASE=1 disables sccache

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,10 +3,12 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
 import {
   formatAnnotationToHtml,
+  getEnv,
   getSecret,
   isCI,
   isWindows,
   parseAnnotations,
+  parseBoolean,
   printEnvironment,
   reportAnnotationToBuildKite,
   startGroup,
@@ -71,7 +73,8 @@ async function build(args) {
   }
 
   if (!generateOptions["-DCACHE_STRATEGY"]) {
-    generateOptions["-DCACHE_STRATEGY"] = "read-write";
+    generateOptions["-DCACHE_STRATEGY"] =
+      parseBoolean(getEnv("RELEASE", false) || "false") ? "none" : "read-write";
   }
 
   const toolchain = generateOptions["--toolchain"];

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -73,8 +73,7 @@ async function build(args) {
   }
 
   if (!generateOptions["-DCACHE_STRATEGY"]) {
-    generateOptions["-DCACHE_STRATEGY"] =
-      parseBoolean(getEnv("RELEASE", false) || "false") ? "none" : "read-write";
+    generateOptions["-DCACHE_STRATEGY"] = parseBoolean(getEnv("RELEASE", false) || "false") ? "none" : "read-write";
   }
 
   const toolchain = generateOptions["--toolchain"];


### PR DESCRIPTION
### What does this PR do?

What the title says

### How did you verify your code works?

Tested locally:

```bash
killall sccache
RELEASE=1 bun run build
sccache --show-stats
```

```
marko@fedora:~/Desktop/bun-2$ sccache --show-stats
Compile requests                      0
Compile requests executed             0
Cache hits                            0
Cache misses                          0
Cache hits rate                       -
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Cache errors                          0
Compilations                          0
Compilation failures                  0
Non-cacheable compilations            0
Non-cacheable calls                   0
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.000 s
Average compiler                  0.000 s
Average cache read hit            0.000 s
Failed distributed compilations       0
Cache location                  Local disk: "/home/marko/.cache/sccache"
Use direct/preprocessor mode?   yes
Version (client)                0.12.0
Max cache size                       10 GiB
```