### PR TITLE
ENG-21473: Fix installations without sccache

### DIFF
--- a/cmake/Globals.cmake
+++ b/cmake/Globals.cmake
@@ -310,7 +310,7 @@ function(find_command)
     ${FIND_VALIDATOR}
   )
 
-  if(NOT FIND_REQUIRED STREQUAL "OFF" AND ${FIND_VARIABLE} MATCHES "NOTFOUND")
+  if(FIND_REQUIRED AND ${FIND_VARIABLE} MATCHES "NOTFOUND")
     set(error "Command not found: \"${FIND_NAME}\"")
 
     if(FIND_VERSION)


### PR DESCRIPTION
### What does this PR do?

https://github.com/oven-sh/bun/commit/782f684b2e67ed08ef6fa61b65c30f4ed5e7979c introduced a regression which caused users who do not have `sccache` installed to lose out on performance.

I think this was introduced because originally I used `find_program` (cmake builtin which has the semantics that I used), tested it, and then migrated to `find_command`, which was broken.

### How did you verify your code works?

Tested locally and made sure it worked.
