### PR TITLE
Fix panic when using --config with extensionless files like NUL on Windows

### DIFF
--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -1163,7 +1163,7 @@ pub const Bunfig = struct {
     pub fn parse(allocator: std.mem.Allocator, source: *const logger.Source, ctx: Command.Context, comptime cmd: Command.Tag) !void {
         const log_count = ctx.log.errors + ctx.log.warnings;
 
-        const expr = if (strings.eqlComptime(source.path.name.ext[1..], "toml")) TOML.parse(source, ctx.log, allocator, true) catch |err| {
+        const expr = if (strings.eqlComptime(source.path.name.ext, ".toml")) TOML.parse(source, ctx.log, allocator, true) catch |err| {
             if (ctx.log.errors + ctx.log.warnings == log_count) {
                 try ctx.log.addErrorOpts("Failed to parse", .{
                     .source = source,

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -76,5 +76,22 @@ describe("bun", () => {
         fs.unlinkSync(path);
       }
     });
+
+    test("test --config=NUL on Windows should not panic", () => {
+      // On Windows, NUL is a special device file (like /dev/null on Unix)
+      // Using it as --config should not cause a panic due to empty extension slicing
+      const configPath = process.platform === "win32" ? "NUL" : "/dev/null";
+      const p = Bun.spawnSync({
+        cmd: [bunExe(), `--config=${configPath}`],
+        env: {},
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      // Should not panic - may fail to parse, but should not crash
+      // Exit code doesn't matter as long as it doesn't panic
+      const stderr = p.stderr?.toString() || "";
+      expect(stderr).not.toContain("panic:");
+      expect(stderr).not.toContain("start index 1 is larger than end index 0");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a panic that occurs when using `bun --config=NUL` on Windows (or any extensionless file).

## The Problem

When running `bun --config=NUL` on Windows, Bun would panic with:
```
panic: start index 1 is larger than end index 0
```

This occurred in `src/bunfig.zig:1166` where the code tried to slice `ext[1..]` to remove the leading dot before comparing the extension. When `NUL` (a special Windows device file) or any extensionless file was used, the `ext` field was empty (`""`), making the slice operation invalid.

## The Fix

Simply compare the full extension (which includes the dot) directly:

```zig
// Before (buggy):
if (strings.eqlComptime(source.path.name.ext[1..], "toml"))

// After (clean):
if (strings.eqlComptime(source.path.name.ext, ".toml"))
```

No need to slice the dot off at all - just compare `.ext` with `".toml"` directly. This is simpler, cleaner, and handles empty extensions gracefully.

## Testing

Added a regression test that verifies extensionless config files don't cause panics.

## Related

- Crash report: https://bun.report/1.3.1/wa189fa0f3AA6st8Fgqq5Fumc+nLo8iy4DCYKERNEL32.DLLut0LCSntdll.dll4zijBA0eNorLkksKlHIzEtJrVAwVMgsVshJLEpPLVIoyUjMU0jNS4FKGQAAJmAN+w