### PR TITLE
Fix panic when parsing declare global with type annotations

### DIFF
--- a/src/ast/parseStmt.zig
+++ b/src/ast/parseStmt.zig
@@ -1185,6 +1185,17 @@ pub fn ParseStmt(
                 switch (expr.data) {
                     .e_identifier => |ident| {
                         if (p.lexer.token == .t_colon and !opts.hasDecorators()) {
+                            // In TypeScript declare contexts, "identifier: Type" is a type annotation, not a label
+                            if (comptime is_typescript_enabled) {
+                                if (opts.is_typescript_declare) {
+                                    // Skip the colon and type annotation
+                                    try p.lexer.next();
+                                    try p.skipTypeScriptType(.lowest);
+                                    try p.lexer.expectOrInsertSemicolon();
+                                    return p.s(S.TypeScript{}, loc);
+                                }
+                            }
+
                             _ = try p.pushScopeForParsePass(.label, loc);
                             defer p.popScope();
 

--- a/test/js/bun/transpiler/declare-global.test.ts
+++ b/test/js/bun/transpiler/declare-global.test.ts
@@ -30,16 +30,31 @@ console.log("SUCCESS");
   expect(exitCode).toBe(0);
 });
 
-test("declare global with multiple type annotations", async () => {
+test("declare global with multiple type annotations and nested arrow functions", async () => {
   using dir = tempDir("declare-global-multi", {
     "test.ts": `
 declare global {
+  TIMER: NodeJS.Timeout;
   FOO: string;
   BAR: number;
   BAZ: () => void;
 }
 
-console.log("SUCCESS");
+// Test nested arrow functions to ensure scope handling is correct
+if (globalThis.TIMER) clearInterval(globalThis.TIMER);
+globalThis.TIMER = setInterval(() => {
+  const nested = () => {
+    const deeplyNested = () => console.log("nested");
+    deeplyNested();
+  };
+  nested();
+}, 1000);
+
+setTimeout(() => {
+  clearInterval(globalThis.TIMER);
+  console.log("SUCCESS");
+  process.exit(0);
+}, 100);
 `,
   });
 

--- a/test/js/bun/transpiler/declare-global.test.ts
+++ b/test/js/bun/transpiler/declare-global.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("declare global with type annotation should not crash", async () => {
+  using dir = tempDir("declare-global-test", {
+    "test.ts": `
+declare global {
+  TIMER: NodeJS.Timeout;
+}
+
+if (globalThis.TIMER) clearInterval(globalThis.TIMER);
+globalThis.TIMER = setInterval(() => console.log("Started"), 1000);
+
+setTimeout(() => {
+  clearInterval(globalThis.TIMER);
+  console.log("SUCCESS");
+  process.exit(0);
+}, 100);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("Scope mismatch");
+  expect(stdout).toContain("SUCCESS");
+  expect(exitCode).toBe(0);
+});
+
+test("declare global with multiple type annotations", async () => {
+  using dir = tempDir("declare-global-multi", {
+    "test.ts": `
+declare global {
+  FOO: string;
+  BAR: number;
+  BAZ: () => void;
+}
+
+console.log("SUCCESS");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("Scope mismatch");
+  expect(stdout).toContain("SUCCESS");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/transpiler/declare-global.test.ts
+++ b/test/js/bun/transpiler/declare-global.test.ts
@@ -41,20 +41,16 @@ declare global {
 }
 
 // Test nested arrow functions to ensure scope handling is correct
-if (globalThis.TIMER) clearInterval(globalThis.TIMER);
-globalThis.TIMER = setInterval(() => {
+const fn = () => {
   const nested = () => {
-    const deeplyNested = () => console.log("nested");
-    deeplyNested();
+    const deeplyNested = () => "nested";
+    return deeplyNested();
   };
-  nested();
-}, 1000);
+  return nested();
+};
 
-setTimeout(() => {
-  clearInterval(globalThis.TIMER);
-  console.log("SUCCESS");
-  process.exit(0);
-}, 100);
+console.log(fn());
+console.log("SUCCESS");
 `,
   });
 

--- a/test/js/bun/transpiler/declare-global.test.ts
+++ b/test/js/bun/transpiler/declare-global.test.ts
@@ -5,17 +5,12 @@ test("declare global with type annotation should not crash", async () => {
   using dir = tempDir("declare-global-test", {
     "test.ts": `
 declare global {
-  TIMER: NodeJS.Timeout;
+  A: 'a';
 }
 
-if (globalThis.TIMER) clearInterval(globalThis.TIMER);
-globalThis.TIMER = setInterval(() => console.log("Started"), 1000);
+() => {};
 
-setTimeout(() => {
-  clearInterval(globalThis.TIMER);
-  console.log("SUCCESS");
-  process.exit(0);
-}, 100);
+console.log("SUCCESS");
 `,
   });
 


### PR DESCRIPTION
## Summary

Fixes a panic that occurs when parsing TypeScript code with `declare global { ... }` blocks containing type annotations.

## The Problem

When parsing code like this:

```ts
declare global {
  TIMER: NodeJS.Timeout;
}

globalThis.TIMER = setInterval(() => console.log("Started"), 1000);
```

The parser incorrectly treated `TIMER: NodeJS.Timeout;` as a labeled statement instead of a type annotation. This caused the parser to push a `.label` scope during the parse pass, but when visiting the arrow function later, it expected a `.function_args` scope, resulting in:

```
panic(main thread): Scope mismatch while visiting
Expected this scope (.function_args)
Found this scope (.label)
```

## The Fix

Added a check in `src/ast/parseStmt.zig` to detect when we're in a TypeScript declare context (`opts.is_typescript_declare`). When an identifier followed by a colon is encountered in this context, we now skip the type annotation and return a TypeScript node instead of creating a label scope.

## Testing

- Added comprehensive tests in `test/js/bun/transpiler/declare-global.test.ts`
- Tests fail on stable Bun (reproduces the crash) ✅
- Tests pass with this fix ✅
- All existing transpiler tests still pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>