### PR TITLE
Replace std.ArrayList with bun.collections.ArrayListDefault

### DIFF
--- a/src/bake/production.zig
+++ b/src/bake/production.zig
@@ -322,7 +322,7 @@ pub fn buildWithVm(ctx: bun.cli.Command.Context, cwd: []const u8, vm: *VirtualMa
         allocator,
         .{ .js = vm.event_loop },
     );
-    const bundled_outputs = bundled_outputs_list.items;
+    const bundled_outputs = bundled_outputs_list.items();
     if (bundled_outputs.len == 0) {
         Output.prettyln("done", .{});
         Output.flush();

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1548,7 +1548,7 @@ pub const BundleV2 = struct {
         bake_options: BakeOptions,
         alloc: std.mem.Allocator,
         event_loop: EventLoop,
-    ) !std.ArrayList(options.OutputFile) {
+    ) !bun.collections.ArrayListDefault(options.OutputFile) {
         var this = try BundleV2.init(
             server_transpiler,
             bake_options,
@@ -1596,7 +1596,7 @@ pub const BundleV2 = struct {
         );
 
         if (chunks.len == 0) {
-            return std.ArrayList(options.OutputFile).init(bun.default_allocator);
+            return bun.collections.ArrayListDefault(options.OutputFile).init();
         }
 
         return try this.linker.generateChunksInParallel(chunks, false);

--- a/src/bundler/linker_context/generateChunksInParallel.zig
+++ b/src/bundler/linker_context/generateChunksInParallel.zig
@@ -2,7 +2,7 @@ pub fn generateChunksInParallel(
     c: *LinkerContext,
     chunks: []Chunk,
     comptime is_dev_server: bool,
-) !if (is_dev_server) void else std.ArrayList(options.OutputFile) {
+) !if (is_dev_server) void else bun.collections.ArrayListDefault(options.OutputFile) {
     const trace = bun.perf.trace("Bundler.generateChunksInParallel");
     defer trace.end();
 

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1257,7 +1257,7 @@ pub fn saveToDisk(this: *Lockfile, load_result: *const LoadResult, options: *con
             break :bytes writer_buf.list.items;
         }
 
-        var bytes = std.ArrayList(u8).init(bun.default_allocator);
+        var bytes = bun.collections.ArrayListDefault(u8).init();
 
         var total_size: usize = 0;
         var end_pos: usize = 0;
@@ -1265,9 +1265,9 @@ pub fn saveToDisk(this: *Lockfile, load_result: *const LoadResult, options: *con
             Output.err(err, "failed to serialize lockfile", .{});
             Global.crash();
         };
-        if (bytes.items.len >= end_pos)
-            bytes.items[end_pos..][0..@sizeOf(usize)].* = @bitCast(total_size);
-        break :bytes bytes.items;
+        if (bytes.items().len >= end_pos)
+            bytes.items()[end_pos..][0..@sizeOf(usize)].* = @bitCast(total_size);
+        break :bytes bytes.toOwnedSlice() catch bun.outOfMemory();
     };
     defer bun.default_allocator.free(bytes);
 

--- a/src/string.zig
+++ b/src/string.zig
@@ -857,10 +857,10 @@ pub const String = extern struct {
 
     pub fn createFormatForJS(globalObject: *jsc.JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) bun.JSError!jsc.JSValue {
         jsc.markBinding(@src());
-        var builder = std.ArrayList(u8).init(bun.default_allocator);
+        var builder = bun.collections.ArrayListDefault(u8).init();
         defer builder.deinit();
         bun.handleOom(builder.writer().print(fmt, args));
-        return bun.cpp.BunString__createUTF8ForJS(globalObject, builder.items.ptr, builder.items.len);
+        return bun.cpp.BunString__createUTF8ForJS(globalObject, builder.items().ptr, builder.items().len);
     }
 
     pub fn parseDate(this: *String, globalObject: *jsc.JSGlobalObject) bun.JSError!f64 {


### PR DESCRIPTION
## Summary

Replace 5 instances of `std.ArrayList(...).init(bun.default_allocator)` with `bun.collections.ArrayListDefault(...)` for better memory management and consistency.

## Changes

### 1. src/string.zig:860
- **Type**: `ArrayList(u8)`
- String formatting buffer
- Updated `.items` → `.items()`

### 2. src/install/lockfile.zig:1260
- **Type**: `ArrayList(u8)`
- Lockfile serialization buffer
- Updated `.items` → `.items()`
- Uses `.toOwnedSlice()` to transfer ownership

### 3. src/io/PipeWriter.zig:1100
- **Type**: `ArrayList(u8)` (struct field in `StreamBuffer`)
- Updated all property accesses to use function call syntax
- Fixed `.expandToCapacity()` to include required `init_value` parameter

### 4. src/s3/list_objects.zig:199-200
- **Types**: `ArrayList(S3ListObjectsContents)` and `ArrayList([]const u8)`
- Updated struct definition to use new type
- **Used `.deinitShallow()` for `common_prefixes`** because `[]const u8` has no deinit method
- Regular `.deinit()` for `contents` since `S3ListObjectsContents` has a deinit method

### 5. src/bundler/bundle_v2.zig:1599
- **Type**: `ArrayList(options.OutputFile)` (return type)
- Updated `generateFromBakeProductionCLI` return type
- Updated `generateChunksInParallel` in `src/bundler/linker_context/generateChunksInParallel.zig`
- Updated caller in `src/bake/production.zig`

## Benefits

- **Zero overhead**: `ArrayListDefault` has no runtime overhead compared to `std.ArrayList` with default allocator
- **Consistent semantics**: Automatic deinit of elements (when applicable)
- **Type safety**: Explicit allocator type in the type signature
- **Better memory management**: Proper cleanup of complex types like `OutputFile` and `S3ListObjectsContents`

## Testing

- [ ] Build passes: `bun bd`
- [ ] Tests pass for affected modules

cc @Jarred-Sumner