### PR TITLE
Fix Bun.serve to respect development flag for sourcemap generation

### DIFF
--- a/src/bun.js/api/server/HTMLBundle.zig
+++ b/src/bun.js/api/server/HTMLBundle.zig
@@ -282,11 +282,12 @@ pub const Route = struct {
         if (!is_development) {
             bun.handleOom(config.define.put("process.env.NODE_ENV", "\"production\""));
             config.jsx.development = false;
+            config.source_map = .none;
         } else {
             config.force_node_env = .development;
             config.jsx.development = true;
+            config.source_map = .linked;
         }
-        config.source_map = .linked;
 
         const completion_task = try bun.BundleV2.createAndScheduleCompletionTask(
             config,

--- a/test/js/bun/http/bun-serve-html-sourcemaps.test.ts
+++ b/test/js/bun/http/bun-serve-html-sourcemaps.test.ts
@@ -1,0 +1,249 @@
+import type { Subprocess } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+describe("Bun.serve sourcemap generation", () => {
+  test("development: false should not include sourcemap comments in JS", async () => {
+    const dir = tempDirWithFiles("html-no-sourcemaps", {
+      "index.html": /*html*/ `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Production Build</title>
+            <script type="module" src="script.js"></script>
+          </head>
+          <body>
+            <h1>Production</h1>
+          </body>
+        </html>
+      `,
+      "script.js": /*js*/ `
+        console.log("Hello from production");
+        const foo = () => {
+          return "bar";
+        };
+        foo();
+      `,
+    });
+
+    const { subprocess, port, hostname } = await waitForProductionServer(dir, {
+      "/": join(dir, "index.html"),
+    });
+    await using server = subprocess;
+
+    const html = await (await fetch(`http://${hostname}:${port}/`)).text();
+    const jsSrc = html.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1];
+
+    if (!jsSrc) {
+      throw new Error("No script src found in HTML");
+    }
+
+    const response = await fetch(new URL(jsSrc, `http://${hostname}:${port}`));
+    const js = await response.text();
+    const headers = response.headers;
+
+    // Should NOT contain sourceMappingURL comment
+    expect(js).not.toContain("sourceMappingURL");
+
+    // Should NOT have SourceMap header
+    expect(headers.get("SourceMap")).toBeNull();
+  });
+
+  test("development: true should include sourcemap comments in JS", async () => {
+    const dir = tempDirWithFiles("html-with-sourcemaps", {
+      "index.html": /*html*/ `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Development Build</title>
+            <script type="module" src="script.js"></script>
+          </head>
+          <body>
+            <h1>Development</h1>
+          </body>
+        </html>
+      `,
+      "script.js": /*js*/ `
+        console.log("Hello from development");
+        const foo = () => {
+          return "bar";
+        };
+        foo();
+      `,
+    });
+
+    const { subprocess, port, hostname } = await waitForDevelopmentServer(dir, {
+      "/": join(dir, "index.html"),
+    });
+    await using server = subprocess;
+
+    const html = await (await fetch(`http://${hostname}:${port}/`)).text();
+    const jsSrc = html.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1];
+
+    if (!jsSrc) {
+      throw new Error("No script src found in HTML");
+    }
+
+    const response = await fetch(new URL(jsSrc, `http://${hostname}:${port}`));
+    const js = await response.text();
+    const headers = response.headers;
+
+    // SHOULD contain sourceMappingURL comment
+    expect(js).toContain("sourceMappingURL");
+
+    // SHOULD have SourceMap header
+    expect(headers.get("SourceMap")).toBeTruthy();
+  });
+
+  test("development: { hmr: false } should not include sourcemap comments", async () => {
+    const dir = tempDirWithFiles("html-dev-no-hmr", {
+      "index.html": /*html*/ `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Development without HMR</title>
+            <script type="module" src="script.js"></script>
+          </head>
+          <body>
+            <h1>Development without HMR</h1>
+          </body>
+        </html>
+      `,
+      "script.js": /*js*/ `
+        console.log("Hello from dev no hmr");
+      `,
+    });
+
+    const { subprocess, port, hostname } = await waitForDevNoHMRServer(dir, {
+      "/": join(dir, "index.html"),
+    });
+    await using server = subprocess;
+
+    const html = await (await fetch(`http://${hostname}:${port}/`)).text();
+    const jsSrc = html.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1];
+
+    if (!jsSrc) {
+      throw new Error("No script src found in HTML");
+    }
+
+    const response = await fetch(new URL(jsSrc, `http://${hostname}:${port}`));
+    const js = await response.text();
+    const headers = response.headers;
+
+    // In development mode (even without HMR), sourcemaps SHOULD be included
+    expect(js).toContain("sourceMappingURL");
+    expect(headers.get("SourceMap")).toBeTruthy();
+  });
+});
+
+async function waitForProductionServer(
+  dir: string,
+  entryPoints: Record<string, string>,
+): Promise<{
+  subprocess: Subprocess;
+  port: number;
+  hostname: string;
+}> {
+  let defer = Promise.withResolvers<{
+    subprocess: Subprocess;
+    port: number;
+    hostname: string;
+  }>();
+
+  const process = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fixtures", "serve-production.js")],
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+    },
+    cwd: dir,
+    stdio: ["inherit", "inherit", "inherit"],
+    ipc(message, subprocess) {
+      subprocess.send({
+        files: entryPoints,
+      });
+      defer.resolve({
+        subprocess,
+        port: message.port,
+        hostname: message.hostname,
+      });
+    },
+  });
+
+  return defer.promise;
+}
+
+async function waitForDevelopmentServer(
+  dir: string,
+  entryPoints: Record<string, string>,
+): Promise<{
+  subprocess: Subprocess;
+  port: number;
+  hostname: string;
+}> {
+  let defer = Promise.withResolvers<{
+    subprocess: Subprocess;
+    port: number;
+    hostname: string;
+  }>();
+
+  const process = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fixtures", "serve-development.js")],
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+    },
+    cwd: dir,
+    stdio: ["inherit", "inherit", "inherit"],
+    ipc(message, subprocess) {
+      subprocess.send({
+        files: entryPoints,
+      });
+      defer.resolve({
+        subprocess,
+        port: message.port,
+        hostname: message.hostname,
+      });
+    },
+  });
+
+  return defer.promise;
+}
+
+async function waitForDevNoHMRServer(
+  dir: string,
+  entryPoints: Record<string, string>,
+): Promise<{
+  subprocess: Subprocess;
+  port: number;
+  hostname: string;
+}> {
+  let defer = Promise.withResolvers<{
+    subprocess: Subprocess;
+    port: number;
+    hostname: string;
+  }>();
+
+  const process = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fixtures", "serve-dev-no-hmr.js")],
+    env: {
+      ...bunEnv,
+      NODE_ENV: undefined,
+    },
+    cwd: dir,
+    stdio: ["inherit", "inherit", "inherit"],
+    ipc(message, subprocess) {
+      subprocess.send({
+        files: entryPoints,
+      });
+      defer.resolve({
+        subprocess,
+        port: message.port,
+        hostname: message.hostname,
+      });
+    },
+  });
+
+  return defer.promise;
+}

--- a/test/js/bun/http/fixtures/serve-dev-no-hmr.js
+++ b/test/js/bun/http/fixtures/serve-dev-no-hmr.js
@@ -1,0 +1,31 @@
+let server = Bun.serve({
+  port: 0,
+  development: {
+    hmr: false,
+  },
+  async fetch(req) {
+    return new Response("Hello World", {
+      status: 404,
+    });
+  },
+});
+
+process.on("message", async message => {
+  const files = message.files || {};
+  const routes = {};
+  for (const [key, value] of Object.entries(files)) {
+    routes[key] = (await import(value)).default;
+  }
+
+  server.reload({
+    static: routes,
+    development: {
+      hmr: false,
+    },
+  });
+});
+
+process.send({
+  port: server.port,
+  hostname: server.hostname,
+});

--- a/test/js/bun/http/fixtures/serve-development.js
+++ b/test/js/bun/http/fixtures/serve-development.js
@@ -1,0 +1,27 @@
+let server = Bun.serve({
+  port: 0,
+  development: true,
+  async fetch(req) {
+    return new Response("Hello World", {
+      status: 404,
+    });
+  },
+});
+
+process.on("message", async message => {
+  const files = message.files || {};
+  const routes = {};
+  for (const [key, value] of Object.entries(files)) {
+    routes[key] = (await import(value)).default;
+  }
+
+  server.reload({
+    static: routes,
+    development: true,
+  });
+});
+
+process.send({
+  port: server.port,
+  hostname: server.hostname,
+});

--- a/test/js/bun/http/fixtures/serve-production.js
+++ b/test/js/bun/http/fixtures/serve-production.js
@@ -1,0 +1,27 @@
+let server = Bun.serve({
+  port: 0,
+  development: false,
+  async fetch(req) {
+    return new Response("Hello World", {
+      status: 404,
+    });
+  },
+});
+
+process.on("message", async message => {
+  const files = message.files || {};
+  const routes = {};
+  for (const [key, value] of Object.entries(files)) {
+    routes[key] = (await import(value)).default;
+  }
+
+  server.reload({
+    static: routes,
+    development: false,
+  });
+});
+
+process.send({
+  port: server.port,
+  hostname: server.hostname,
+});


### PR DESCRIPTION
## Summary

Fixes the bug where sourcemaps were being generated and included in Bun.serve output even when `development: false` was set.

According to the [official Bun documentation](https://bun.sh/docs/bundler/fullstack#development-mode):

> When `development` is `true`, Bun will:
> 
> - Include the `SourceMap` header in the response so that devtools can show the original source code
> - Disable minification
> - Re-bundle assets on each request to a .html file

And for production mode:

> When serving your app in production, set `development: false` in `Bun.serve()`.
> 
> - Enable in-memory caching of bundled assets. Bun will bundle assets lazily on the first request to an `.html` file, and cache the result in memory until the server restarts.
> - Enables `Cache-Control` headers and `ETag` headers
> - Minifies JavaScript/TypeScript/TSX/JSX files

The documentation clearly states that sourcemaps should only be included when `development: true`, but the implementation was generating sourcemaps regardless of the development flag.

## Changes

- Modified `src/bun.js/api/server/HTMLBundle.zig:282-290` to conditionally set `config.source_map` based on the development mode:
  - `development: false` → `config.source_map = .none` (no sourcemaps)
  - `development: true` → `config.source_map = .linked` (sourcemaps with comments)

## Test Plan

Added comprehensive tests in `test/js/bun/http/bun-serve-html-sourcemaps.test.ts`:

- [x] Verified test fails with `USE_SYSTEM_BUN=1` (confirms bug exists)
- [x] Verified test passes with `bun bd test` (confirms fix works)
- [x] Test 1: `development: false` does NOT include sourcemap comments or SourceMap headers
- [x] Test 2: `development: true` DOES include sourcemap comments and SourceMap headers  
- [x] Test 3: `development: { hmr: false }` DOES include sourcemap comments (still in dev mode)
- [x] Ran existing HTML serve tests - no regressions found

All tests pass:
```
bun bd test test/js/bun/http/bun-serve-html-sourcemaps.test.ts
 3 pass
 0 fail
 6 expect() calls
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)