### PR TITLE
Add uid/gid support for spawn and child_process on Linux

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5546,6 +5546,20 @@ declare module "bun" {
       argv0?: string;
 
       /**
+       * Sets the user identity of the process (POSIX only, Linux and macOS).
+       *
+       * On Windows, this will throw an error.
+       */
+      uid?: number;
+
+      /**
+       * Sets the group identity of the process (POSIX only, Linux and macOS).
+       *
+       * On Windows, this will throw an error.
+       */
+      gid?: number;
+
+      /**
        * An {@link AbortSignal} that can be used to abort the subprocess.
        *
        * This is useful for aborting a subprocess when some other part of the

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -543,6 +543,8 @@ function spawnSync(file, args, options) {
       timeout: options.timeout,
       killSignal: options.killSignal,
       maxBuffer: options.maxBuffer,
+      uid: options.uid,
+      gid: options.gid,
     });
   } catch (err) {
     error = err;
@@ -1333,6 +1335,8 @@ class ChildProcess extends EventEmitter {
         cwd: options.cwd || undefined,
         env: env,
         detached: typeof detachedOption !== "undefined" ? !!detachedOption : false,
+        uid: options.uid,
+        gid: options.gid,
         onExit: (handle, exitCode, signalCode, err) => {
           this.#handle = handle;
           this.pid = this.#handle.pid;

--- a/test/js/bun/spawn/spawn-uid-gid.test.ts
+++ b/test/js/bun/spawn/spawn-uid-gid.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+import { spawn, spawnSync } from "node:child_process";
+
+// uid/gid is only supported on Linux
+const describeLinux = isLinux ? describe : describe.skip;
+
+describeLinux("Bun.spawn with uid/gid", () => {
+  test("should spawn with uid option on Linux", async () => {
+    const currentUid = process.getuid!();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log(process.getuid())"],
+      env: bunEnv,
+      stdout: "pipe",
+      uid: currentUid,
+    });
+
+    const stdout = await proc.stdout.text();
+    const exitCode = await proc.exited;
+
+    expect(stdout.trim()).toBe(currentUid.toString());
+    expect(exitCode).toBe(0);
+  });
+
+  test("should spawn with gid option on Linux", async () => {
+    const currentGid = process.getgid!();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log(process.getgid())"],
+      env: bunEnv,
+      stdout: "pipe",
+      gid: currentGid,
+    });
+
+    const stdout = await proc.stdout.text();
+    const exitCode = await proc.exited;
+
+    expect(stdout.trim()).toBe(currentGid.toString());
+    expect(exitCode).toBe(0);
+  });
+
+  test("should spawn with both uid and gid options on Linux", async () => {
+    const currentUid = process.getuid!();
+    const currentGid = process.getgid!();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log(process.getuid(), process.getgid())"],
+      env: bunEnv,
+      stdout: "pipe",
+      uid: currentUid,
+      gid: currentGid,
+    });
+
+    const stdout = await proc.stdout.text();
+    const exitCode = await proc.exited;
+
+    expect(stdout.trim()).toBe(`${currentUid} ${currentGid}`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("spawnSync with uid option on Linux", () => {
+    const currentUid = process.getuid!();
+
+    const { exitCode, stdout } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.log(process.getuid())"],
+      env: bunEnv,
+      stdout: "pipe",
+      uid: currentUid,
+    });
+
+    expect(stdout.toString().trim()).toBe(currentUid.toString());
+    expect(exitCode).toBe(0);
+  });
+
+  test("spawnSync with gid option on Linux", () => {
+    const currentGid = process.getgid!();
+
+    const { exitCode, stdout } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.log(process.getgid())"],
+      env: bunEnv,
+      stdout: "pipe",
+      gid: currentGid,
+    });
+
+    expect(stdout.toString().trim()).toBe(currentGid.toString());
+    expect(exitCode).toBe(0);
+  });
+});
+
+describeLinux("child_process.spawn with uid/gid", () => {
+  test("should spawn with uid option", done => {
+    const currentUid = process.getuid!();
+
+    const child = spawn(bunExe(), ["-e", "console.log(process.getuid())"], {
+      env: bunEnv,
+      uid: currentUid,
+    });
+
+    let stdout = "";
+    child.stdout.on("data", data => {
+      stdout += data.toString();
+    });
+
+    child.on("close", code => {
+      expect(stdout.trim()).toBe(currentUid.toString());
+      expect(code).toBe(0);
+      done();
+    });
+  });
+
+  test("should spawn with gid option", done => {
+    const currentGid = process.getgid!();
+
+    const child = spawn(bunExe(), ["-e", "console.log(process.getgid())"], {
+      env: bunEnv,
+      gid: currentGid,
+    });
+
+    let stdout = "";
+    child.stdout.on("data", data => {
+      stdout += data.toString();
+    });
+
+    child.on("close", code => {
+      expect(stdout.trim()).toBe(currentGid.toString());
+      expect(code).toBe(0);
+      done();
+    });
+  });
+
+  test("should spawn with both uid and gid options", done => {
+    const currentUid = process.getuid!();
+    const currentGid = process.getgid!();
+
+    const child = spawn(bunExe(), ["-e", "console.log(process.getuid(), process.getgid())"], {
+      env: bunEnv,
+      uid: currentUid,
+      gid: currentGid,
+    });
+
+    let stdout = "";
+    child.stdout.on("data", data => {
+      stdout += data.toString();
+    });
+
+    child.on("close", code => {
+      expect(stdout.trim()).toBe(`${currentUid} ${currentGid}`);
+      expect(code).toBe(0);
+      done();
+    });
+  });
+
+  test("spawnSync with uid option", () => {
+    const currentUid = process.getuid!();
+
+    const { status, stdout } = spawnSync(bunExe(), ["-e", "console.log(process.getuid())"], {
+      env: bunEnv,
+      uid: currentUid,
+    });
+
+    expect(stdout.toString().trim()).toBe(currentUid.toString());
+    expect(status).toBe(0);
+  });
+
+  test("spawnSync with gid option", () => {
+    const currentGid = process.getgid!();
+
+    const { status, stdout } = spawnSync(bunExe(), ["-e", "console.log(process.getgid())"], {
+      env: bunEnv,
+      gid: currentGid,
+    });
+
+    expect(stdout.toString().trim()).toBe(currentGid.toString());
+    expect(status).toBe(0);
+  });
+
+  test("spawnSync with both uid and gid options", () => {
+    const currentUid = process.getuid!();
+    const currentGid = process.getgid!();
+
+    const { status, stdout } = spawnSync(bunExe(), ["-e", "console.log(process.getuid(), process.getgid())"], {
+      env: bunEnv,
+      uid: currentUid,
+      gid: currentGid,
+    });
+
+    expect(stdout.toString().trim()).toBe(`${currentUid} ${currentGid}`);
+    expect(status).toBe(0);
+  });
+});
+
+describe("uid/gid error handling", () => {
+  const itOnlyWindows = process.platform === "win32" ? test : test.skip;
+
+  itOnlyWindows("should throw error on Windows for uid", () => {
+    expect(() => {
+      Bun.spawn({
+        cmd: [bunExe(), "-e", "console.log('test')"],
+        uid: 1000,
+      });
+    }).toThrow();
+  });
+
+  itOnlyWindows("should throw error on Windows for gid", () => {
+    expect(() => {
+      Bun.spawn({
+        cmd: [bunExe(), "-e", "console.log('test')"],
+        gid: 1000,
+      });
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds support for the `uid` and `gid` options in `Bun.spawn()`, `Bun.spawnSync()`, `child_process.spawn()`, and `child_process.spawnSync()`.

## Implementation

- Added `uid` and `gid` fields to Bun.spawn TypeScript definitions
- Extended `PosixSpawnOptions` and `WindowsSpawnOptions` structs with `uid`/`gid` fields
- Added parsing and validation in `js_bun_spawn_bindings.zig` (throws error on Windows)
- Implemented uid/gid setting in `spawn.zig` for Linux via custom `BunSpawnRequest`
- Updated `bun-spawn.cpp` to call `setgid()` and `setuid()` in the child process
- Modified `child_process.ts` to pass uid/gid options through to `Bun.spawn`
- Added comprehensive tests for both Bun.spawn and child_process APIs

## Platform Support

- **Linux**: ✅ Full support via custom `posix_spawn_bun` implementation
- **macOS**: ❌ Throws error (posix_spawnattr_setuid/setgid not available)
- **Windows**: ❌ Throws error when uid/gid options are used

## Testing

All tests pass:
```
bun bd test test/js/bun/spawn/spawn-uid-gid.test.ts
```

11 tests covering:
- Bun.spawn with uid/gid options
- Bun.spawnSync with uid/gid options
- child_process.spawn with uid/gid options
- child_process.spawnSync with uid/gid options
- Error handling on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)