### PR TITLE
bug(ENG-21501): Fix integer overflow in hosted_git_info.zig

### DIFF
--- a/src/install/hosted_git_info.zig
+++ b/src/install/hosted_git_info.zig
@@ -518,7 +518,7 @@ pub fn isGitHubShorthand(npa_str: []const u8) bool {
     // Implements doesNotEndWithSlash
     const does_not_end_with_slash =
         if (pound_idx) |pi|
-            npa_str[pi - 1] != '/'
+            pi == 0 or npa_str[pi - 1] != '/'
         else
             npa_str.len >= 1 and npa_str[npa_str.len - 1] != '/';
 

--- a/test/cli/install/hosted-git-info/boundary-conditions.test.ts
+++ b/test/cli/install/hosted-git-info/boundary-conditions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("hosted-git-info boundary conditions", () => {
+  test.each([
+  { description: "git with pound", dependency: "https://github.com/#" },
+])("handle $description", async ({ description: _, dependency }) => {
+    using dir = tempDir("hosted-git-info-empty", {
+      "package.json": JSON.stringify({
+        name: "test",
+        dependencies: {
+          dependency,
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("panic");
+  });
+});

--- a/test/cli/install/hosted-git-info/boundary-conditions.test.ts
+++ b/test/cli/install/hosted-git-info/boundary-conditions.test.ts
@@ -2,28 +2,29 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("hosted-git-info boundary conditions", () => {
-  test.each([
-  { description: "git with pound", dependency: "https://github.com/#" },
-])("handle $description", async ({ description: _, dependency }) => {
-    using dir = tempDir("hosted-git-info-empty", {
-      "package.json": JSON.stringify({
-        name: "test",
-        dependencies: {
-          dependency,
-        },
-      }),
-    });
+  test.each([{ description: "git with pound", dependency: "https://github.com/#" }])(
+    "handle $description",
+    async ({ description: _, dependency }) => {
+      using dir = tempDir("hosted-git-info-empty", {
+        "package.json": JSON.stringify({
+          name: "test",
+          dependencies: {
+            dependency,
+          },
+        }),
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
 
-    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("panic");
-  });
+      expect(stderr).not.toContain("panic");
+    },
+  );
 });


### PR DESCRIPTION
### What does this PR do?

There was a bug in how I translated the JS to Zig. The original implementation was this:

```typescript
const arg = "#";
const firstHash = arg.indexOf("#");
const doesNotEndWithSlash = firstHash > -1 ? arg[firstHash - 1] !== '/' : !arg.endsWith('/');
```

What does `arg[firstHash - 1] !== '/'` evaluate to in JS if `firstHash` is zero? `true` is the answer.

https://www.typescriptlang.org/play/?ssl=3&ssc=94&pln=1&pc=1#code/MYewdgzgLgBAhgJwOYwLwwEQGIMG4BQoksAZgJYLQAScEAFmvMgHRlgAmApgB4DyJACmwYAlASLQY7EJwgA5EFACiHAOpkodAMoAbWg3TlKUGvRgA+GAFoAjDAD8TJAG0j1fdZg2AujACEqOgA5AD0QTAAXP6ISMycHBDqmgKhQWKE4BAgOpzMOiBIAtKyCspqGtp69CJAA

My code was buggy because `pi` could, indeed, be `0`, causing `pi - 1` to underflow.

### How did you verify your code works?

Added some tests and CI passed. Made sure tests crashed on mainline `bun-debug`.