### PR TITLE
docs: remove outdated version mentions (1.0.x and 1.1.x)

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -154,8 +154,8 @@ Using bytecode compilation, `tsc` starts 2x faster:
 Bytecode compilation moves parsing overhead for large input files from runtime to bundle time. Your app starts faster, in exchange for making the `bun build` command a little slower. It doesn't obscure source code.
 
 <Warning>
-  **Experimental:** Bytecode compilation is an experimental feature. Only `cjs` format is
-  supported (which means no top-level-await). Let us know if you run into any issues!
+  **Experimental:** Bytecode compilation is an experimental feature. Only `cjs` format is supported (which means no
+  top-level-await). Let us know if you run into any issues!
 </Warning>
 
 ### What do these flags do?

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -154,7 +154,7 @@ Using bytecode compilation, `tsc` starts 2x faster:
 Bytecode compilation moves parsing overhead for large input files from runtime to bundle time. Your app starts faster, in exchange for making the `bun build` command a little slower. It doesn't obscure source code.
 
 <Warning>
-  **Experimental:** Bytecode compilation is an experimental feature introduced in Bun v1.1.30. Only `cjs` format is
+  **Experimental:** Bytecode compilation is an experimental feature. Only `cjs` format is
   supported (which means no top-level-await). Let us know if you run into any issues!
 </Warning>
 
@@ -320,7 +320,7 @@ new Worker(new URL("./my-worker.ts", import.meta.url));
 new Worker(new URL("./my-worker.ts", import.meta.url).href);
 ```
 
-As of Bun v1.1.25, when you add multiple entrypoints to a standalone executable, they will be bundled separately into the executable.
+When you add multiple entrypoints to a standalone executable, they will be bundled separately into the executable.
 
 In the future, we may automatically detect usages of statically-known paths in `new Worker(path)` and then bundle those into the executable, but for now, you'll need to add it to the shell command manually like the above example.
 
@@ -395,7 +395,7 @@ This database is read-write, but all changes are lost when the executable exits 
 
 ### Embed N-API Addons
 
-As of Bun v1.0.23, you can embed `.node` files into executables.
+You can embed `.node` files into executables.
 
 ```ts index.ts icon="/icons/typescript.svg"
 const addon = require("./addon.node");

--- a/docs/guides/install/azure-artifacts.mdx
+++ b/docs/guides/install/azure-artifacts.mdx
@@ -25,7 +25,7 @@ To use it with `bun install`, add a `bunfig.toml` file to your project with the 
 [install.registry]
 url = "https://pkgs.dev.azure.com/my-azure-artifacts-user/_packaging/my-azure-artifacts-user/npm/registry"
 username = "my-azure-artifacts-user"
-# Bun v1.0.3+ supports using an environment variable here
+# You can use an environment variable here
 password = "$NPM_PASSWORD"
 ```
 

--- a/docs/guides/install/jfrog-artifactory.mdx
+++ b/docs/guides/install/jfrog-artifactory.mdx
@@ -17,7 +17,7 @@ Make sure to replace `MY_SUBDOMAIN` with your JFrog Artifactory subdomain, such 
 ```toml bunfig.toml icon="settings"
 [install.registry]
 url = "https://MY_SUBDOMAIN.jfrog.io/artifactory/api/npm/npm/_auth=MY_TOKEN"
-# Bun v1.0.3+ supports using an environment variable here
+# You can use an environment variable here
 # url = "$NPM_CONFIG_REGISTRY"
 ```
 

--- a/docs/guides/runtime/define-constant.mdx
+++ b/docs/guides/runtime/define-constant.mdx
@@ -120,7 +120,7 @@ console.log("abc");
 
 You can also pass properties to the `--define` flag.
 
-For example, to replace all usages of `console.write` with `console.log`, you can use the following command (requires Bun v1.1.5 or later)
+For example, to replace all usages of `console.write` with `console.log`, you can use the following command
 
 ```sh
 bun --define console.write=console.log src/index.ts

--- a/docs/guides/runtime/import-html.mdx
+++ b/docs/guides/runtime/import-html.mdx
@@ -13,5 +13,3 @@ console.log(html); // <!DOCTYPE html><html><head>...
 ```
 
 This can also be used with hot module reloading and/or watch mode to force Bun to reload whenever the `./file.html` file changes.
-
-This feature was added in Bun v1.1.5.

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -44,7 +44,7 @@ Instead of executing arbitrary scripts, Bun uses a "default-secure" approach. Yo
 
 Once added to `trustedDependencies`, install/re-install the package. Bun will read this field and run lifecycle scripts for `my-trusted-package`.
 
-As of Bun v1.0.16, the top 500 npm packages with lifecycle scripts are allowed by default. You can see the full list [here](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt).
+The top 500 npm packages with lifecycle scripts are allowed by default. You can see the full list [here](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt).
 
 ---
 

--- a/docs/runtime/networking/dns.mdx
+++ b/docs/runtime/networking/dns.mdx
@@ -23,7 +23,7 @@ dns.prefetch("bun.com", 443);
 
 ## DNS caching in Bun
 
-In Bun v1.1.9, we added support for DNS caching. This cache makes repeated connections to the same hosts faster.
+Bun supports DNS caching. This cache makes repeated connections to the same hosts faster.
 
 At the time of writing, we cache up to 255 entries for a maximum of 30 seconds (each). If any connections to a host fail, we remove the entry from the cache. When multiple connections are made to the same host simultaneously, DNS lookups are deduplicated to avoid making multiple requests for the same host.
 

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -359,8 +359,6 @@ for (const row of query) {
 }
 ```
 
-This feature was added in Bun v1.1.31.
-
 ### `.values()`
 
 Use `values()` to run a query and get back all results as an array of arrays.

--- a/docs/runtime/workers.mdx
+++ b/docs/runtime/workers.mdx
@@ -76,11 +76,9 @@ const worker = new Worker("./worker.ts", {
 });
 ```
 
-This feature was added in Bun v1.1.35.
-
 ### `blob:` URLs
 
-As of Bun v1.1.13, you can also pass a `blob:` URL to `Worker`. This is useful for creating workers from strings or other sources.
+You can also pass a `blob:` URL to `Worker`. This is useful for creating workers from strings or other sources.
 
 ```js
 const blob = new Blob(


### PR DESCRIPTION
## Summary

Remove outdated version mentions (1.0.x and 1.1.x) from documentation for better consistency. These versions are over a year old - you should be using a recent version of bun :).

## What changed

**Removed version mentions from:**
- `docs/pm/lifecycle.mdx` - v1.0.16 (trusted dependencies)
- `docs/bundler/executables.mdx` - v1.0.23, v1.1.25, v1.1.30 (various features)
- `docs/guides/install/jfrog-artifactory.mdx` - v1.0.3+ (env var comment)
- `docs/guides/install/azure-artifacts.mdx` - v1.0.3+ (env var comment)
- `docs/runtime/workers.mdx` - v1.1.13, v1.1.35 (blob URLs, preload)
- `docs/runtime/networking/dns.mdx` - v1.1.9 (DNS caching)
- `docs/guides/runtime/import-html.mdx` - v1.1.5
- `docs/guides/runtime/define-constant.mdx` - v1.1.5
- `docs/runtime/sqlite.mdx` - v1.1.31

**Kept version mentions in:**
- All 1.2.x versions (still recent, less than a year old)
- Benchmark version numbers (e.g., S3 performance comparison with v1.1.44)
- `docs/guides/install/yarnlock.mdx` (bun.lock introduction context)
- `docs/project/building-windows.mdx` (build requirements)
- `docs/runtime/http/websockets.mdx` (performance benchmarks)

## Why

The docs lack consistency around version mentions - we don't document every feature's version, so keeping scattered old version numbers looks inconsistent. These changes represent a small percentage of features added recently, and users on ancient versions have bigger problems than needing to know exactly when a feature landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>