### PR TITLE
fix: don't create empty node_modules when no dependencies exist

### DIFF
--- a/src/install/hoisted_install.zig
+++ b/src/install/hoisted_install.zig
@@ -43,6 +43,12 @@ pub fn installHoistedPackages(
         }
     }
 
+    // If there are no dependencies to install and the original lockfile had no dependencies either, don't create node_modules
+    // We still create node_modules if the original lockfile has packages (e.g., with --production filtering devDeps)
+    if (this.lockfile.buffers.hoisted_dependencies.items.len == 0 and original_tree_dep_ids.items.len == 0) {
+        return PackageInstall.Summary{};
+    }
+
     // If there was already a valid lockfile and so we did not resolve, i.e. there was zero network activity
     // the packages could still not be in the cache dir
     // this would be a common scenario in a CI environment

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -614,6 +614,12 @@ pub fn installIsolatedPackages(
         };
     };
 
+    // If there are no packages to install and no lockfile packages, don't create node_modules
+    // We still create node_modules if lockfile has packages (e.g., with --production filtering devDeps)
+    if (store.entries.len == 0 and lockfile.packages.len == 0) {
+        return PackageInstall.Summary{};
+    }
+
     // setup node_modules/.bun
     const is_new_bun_modules = is_new_bun_modules: {
         const node_modules_path = bun.OSPathLiteral("node_modules");

--- a/test/regression/issue/5392.test.ts
+++ b/test/regression/issue/5392.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import * as fs from "node:fs";
+
+test("bun install should not create node_modules when there are no dependencies - issue #5392", async () => {
+  using dir = tempDir("issue-5392", {
+    "package.json": JSON.stringify({
+      name: "bun-install-test",
+      module: "index.ts",
+      type: "module",
+      devDependencies: {},
+      peerDependencies: {},
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // node_modules should not exist
+  const nodeModulesPath = `${dir}/node_modules`;
+  const nodeModulesExists = fs.existsSync(nodeModulesPath);
+
+  expect(nodeModulesExists).toBe(false);
+  expect(exitCode).toBe(0);
+});
+
+test("bun install should create node_modules when there are dependencies", async () => {
+  using dir = tempDir("issue-5392-with-deps", {
+    "package.json": JSON.stringify({
+      name: "bun-install-test-with-deps",
+      dependencies: {
+        "is-odd": "^3.0.1",
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // node_modules should exist
+  const nodeModulesPath = `${dir}/node_modules`;
+  const nodeModulesExists = fs.existsSync(nodeModulesPath);
+
+  expect(nodeModulesExists).toBe(true);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes issue where `bun install` creates an empty `node_modules` folder when package.json has no dependencies
- Adds early return checks in both hoisted and isolated install strategies
- Adds regression test to verify the fix

## Changes
- **hoisted_install.zig**: Check if `hoisted_dependencies.items.len == 0` and return early
- **isolated_install.zig**: Check if `store.entries.len == 0` and return early
- **test/regression/issue/5392.test.ts**: Add test cases for both empty and non-empty dependencies

## Test plan
- [x] Verified test fails with `USE_SYSTEM_BUN=1 bun test test/regression/issue/5392.test.ts`
- [x] Verified test passes with `bun bd test test/regression/issue/5392.test.ts`
- [x] Manually tested with empty package.json - no `node_modules` created
- [x] Manually tested with actual dependencies - `node_modules` created correctly

Fixes #5392

🤖 Generated with [Claude Code](https://claude.com/claude-code)