### PR TITLE
Add interactive prompt for bun init in non-empty directories

### DIFF
--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -295,4 +295,83 @@ import path from "path";
     expect(fs.existsSync(path.join(temp, "src/components"))).toBe(true);
     expect(fs.existsSync(path.join(temp, "src/components/ui"))).toBe(true);
   }, 30_000);
+
+  test("bun init in non-empty directory with --yes skips prompt", async () => {
+    const temp = tempDirWithFiles("bun-init-non-empty-auto-yes", {
+      "existing-file.txt": "I exist",
+    });
+
+    const { exited } = Bun.spawn({
+      cmd: [bunExe(), "init", "-y"],
+      cwd: temp,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: bunEnv,
+    });
+
+    expect(await exited).toBe(0);
+
+    // With -y flag, should proceed in current directory without prompting
+    expect(fs.existsSync(path.join(temp, "existing-file.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
+  }, 30_000);
+
+  test("bun init --react in non-empty directory skips prompt (auto-yes)", async () => {
+    const temp = tempDirWithFiles("bun-init-react-non-empty", {
+      "existing-file.txt": "I exist",
+    });
+
+    const { exited } = Bun.spawn({
+      cmd: [bunExe(), "init", "--react"],
+      cwd: temp,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: bunEnv,
+    });
+
+    expect(await exited).toBe(0);
+
+    // --react flag implies auto-yes, should proceed in current directory
+    expect(fs.existsSync(path.join(temp, "existing-file.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
+  }, 30_000);
+
+  test("bun init with explicit folder ignores non-empty directory check", async () => {
+    const temp = tempDirWithFiles("bun-init-explicit-folder", {
+      "existing-file.txt": "I exist",
+    });
+
+    const { exited } = Bun.spawn({
+      cmd: [bunExe(), "init", "-y", "new-folder"],
+      cwd: temp,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: bunEnv,
+    });
+
+    expect(await exited).toBe(0);
+
+    // Should create in specified folder without prompting
+    expect(fs.existsSync(path.join(temp, "existing-file.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "new-folder"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "new-folder/package.json"))).toBe(true);
+  }, 30_000);
+
+  test("bun init in directory with only .DS_Store is considered empty", async () => {
+    const temp = tempDirWithFiles("bun-init-only-ds-store", {
+      ".DS_Store": "macOS metadata",
+    });
+
+    const { exited } = Bun.spawn({
+      cmd: [bunExe(), "init", "-y"],
+      cwd: temp,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: bunEnv,
+    });
+
+    expect(await exited).toBe(0);
+
+    // Should proceed without prompting since .DS_Store is ignored
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary
This PR adds an interactive prompt when running `bun init` (or any variant like `--react`) in a non-empty directory. The prompt asks users whether they want to:
1. **Create in a new subdirectory** (default option)
2. **Use current directory** (may overwrite files)  
3. **Cancel**

## Motivation
Fixes #24555

Users often accidentally run `bun init --react` or similar commands in directories that already contain files (like `/tmp` or `~/mycoolprojects`), resulting in unwanted file creation. This enhancement provides a safety net similar to what tools like `create-next-app` do.

## Implementation Details

### When the prompt appears:
- ✅ No folder was explicitly specified as an argument
- ✅ stdin is a TTY (not piped input)
- ✅ Not using auto-yes flags (`-y`, `--react`, `--react=tailwind`, `--react=shadcn`)
- ✅ The directory is not empty (ignores `.DS_Store` and `Thumbs.db`)

### When the prompt is skipped:
- Using `-y` or `--yes` flag → proceeds in current directory
- Using `--react` or other template flags → proceeds in current directory (these imply auto-yes)
- Explicitly specifying a folder → creates/uses that folder
- stdin is piped (not a TTY) → proceeds in current directory
- Directory is empty → proceeds normally

### User Experience

Running `bun init` in `/tmp` with existing files:
```bash
$ cd /tmp
$ bun init
⚠  The current directory is not empty.
? What would you like to do? - Press return to submit.
    ❯  Create in a new subdirectory
       Use current directory (may overwrite files)
       Cancel

? subdirectory name (my-app): my-project
# Creates project in /tmp/my-project
```

## Testing
- Added tests for non-empty directory behavior with various flags
- All existing tests pass
- Verified the prompt only appears in appropriate conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)