### PR TITLE
Fix stack overflow with deeply nested if-else chains

### DIFF
--- a/test/regression/issue/24548.test.ts
+++ b/test/regression/issue/24548.test.ts
@@ -1,0 +1,73 @@
+// https://github.com/oven-sh/bun/issues/24548
+// Test that Bun can handle deeply nested if-else chains without stack overflow
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+test("deeply nested if-else chains should not cause stack overflow", async () => {
+  // Generate a deeply nested if-else chain (similar to Gleam's entity resolver)
+  const depth = 2500; // More than the 2124 in the original issue
+  let code = "export function test(x) {\n";
+
+  for (let i = 0; i < depth; i++) {
+    if (i > 0) code += " else ";
+    code += `if (x === ${i}) {\n`;
+    code += `    return ${i};\n`;
+    code += "  }";
+  }
+
+  code += " else {\n    return -1;\n  }\n}\n";
+
+  using dir = tempDir("issue-24548", {
+    "deep-if-else.js": code,
+    "index.js": `import { test } from "./deep-if-else.js";\nconsole.log(test(42));`,
+  });
+
+  // Test that bun can run the file
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"42"`);
+  expect(exitCode).toBe(0);
+});
+
+test("bun build should handle deeply nested if-else chains", async () => {
+  const depth = 2500;
+  let code = "export function test(x) {\n";
+
+  for (let i = 0; i < depth; i++) {
+    if (i > 0) code += " else ";
+    code += `if (x === ${i}) {\n`;
+    code += `    return ${i};\n`;
+    code += "  }";
+  }
+
+  code += " else {\n    return -1;\n  }\n}\n";
+
+  using dir = tempDir("issue-24548-build", {
+    "deep-if-else.js": code,
+  });
+
+  // Test that bun build can bundle the file
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "deep-if-else.js", "--outfile=bundle.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  // Verify the bundle was created
+  const bundlePath = `${dir}/bundle.js`;
+  expect(await Bun.file(bundlePath).exists()).toBe(true);
+});


### PR DESCRIPTION
Fixes #24548

## Problem

When processing JavaScript files with deeply nested if-else chains (297+ levels), Bun would crash with a stack overflow during AST traversal. This occurred because the `s_if` visitor in `visitStmt.zig` used recursive calls to process else-if chains, creating a call stack proportional to the nesting depth.

This was particularly problematic for code generated by compilers like Gleam, which can generate long if-else-if chains (2000+ levels) for entity resolution and similar tasks.

**Before this fix:**
- ✅ Works up to 296 levels
- ❌ Crashes at 297+ levels with segmentation fault during AST visiting

## Solution

Converted the else-if chain processing from recursive to iterative. When the else branch of an if statement is another if statement (forming an else-if chain), we now process it iteratively in a loop rather than through recursive calls. This bounds the stack depth regardless of chain length.

**After this fix:**
- ✅ Works up to 4300+ levels (~14.5x improvement!)
- Solves the reported issue (#24548 with 2124 levels)
- The new limit is hit in a different part of the code (printer), which could be addressed separately if needed

## Test Plan

- ✅ Added regression test `test/regression/issue/24548.test.ts` with 2500-level deep if-else chains
- ✅ Verified the original reproduction case from https://github.com/krig/bun-mac-crash now works
- ✅ Both `bun run` and `bun build` handle deep nesting correctly
- ✅ All existing tests still pass

The `// @bun` pragma workaround is no longer needed with this fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>