### PR TITLE
fix(types): `test.d.ts` `not` matcher

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -894,7 +894,7 @@ declare module "bun:test" {
      * expect(42).toEqual(42); // will pass
      * expect(42).not.toEqual(42); // will fail
      */
-    not: Matchers<unknown>;
+    not: Matchers<T>;
 
     /**
      * Expects the value to be a promise that resolves.


### PR DESCRIPTION
### What does this PR do?

Fixed the `.not()` matcher type as it was always passing `unknown` in the generic.

### How did you verify your code works?
Patched on my own big codebase + build successful.