### PR TITLE
fix(DevServer) unconditional unwrap in IncrementalGraph

### DIFF
--- a/src/bake/DevServer/IncrementalGraph.zig
+++ b/src/bake/DevServer/IncrementalGraph.zig
@@ -1805,7 +1805,8 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
             for (g.current_chunk_parts.items) |entry| {
                 list.appendSliceAssumeCapacity(switch (side) {
                     // entry is an index into files
-                    .client => files[entry.get()].unpack().jsCode().?,
+                    // will return null if the chunk is a non-js (like css)
+                    .client => files[entry.get()].unpack().jsCode() orelse continue,
                     // entry is the '[]const u8' itself
                     .server => entry.get(),
                 });


### PR DESCRIPTION
### What does this PR do?
Fixes https://linear.app/oven/issue/ENG-21505/panic-attempt-to-use-null-value-at-incrementalgraph-by-misusing-jscode

When calling `takeJSBundleToList/takeJSBundle` the desired behavior is to get only JS chunks from the graph, and we can contain CSS chunks in the graph we can just continue and ignore in this case keeping the desired behavior in a safe way instead of unconditional unwrapping something that is not guaranteed to have a jsCode.

### How did you verify your code works?
CI