### PR TITLE
proper handle on_data if we receive null

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -635,7 +635,7 @@ ssl_on_writable(struct us_internal_ssl_socket_t *s) {
         (struct us_internal_ssl_socket_context_t *)us_socket_context(0, &s->s);
 
     // if this one fails to write data, it sets ssl_read_wants_write again
-    s = (struct us_internal_ssl_socket_t *)context->sc.on_data(&s->s, 0,
+    s = (struct us_internal_ssl_socket_t *)context->sc.on_data(&s->s, "",
                                                                0); // cast here!
   }
   // Do not call on_writable if the socket is closed.

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -897,7 +897,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     const res = Fields.onData(
                         getValue(socket),
                         ThisSocket.from(socket),
-                        buf.?[0..@as(usize, @intCast(len))],
+                        if (buf) |data_ptr| data_ptr[0..@as(usize, @intCast(len))] else "",
                     );
                     if (@TypeOf(res) != void) res catch |err| switch (err) {
                         error.JSTerminated => return null, // TODO: declare throw scope

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -183,7 +183,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     const res = Fields.onData(
                         getValue(socket),
                         TLSSocket.from(socket),
-                        buf.?[0..@as(usize, @intCast(len))],
+                        if (buf) |data_ptr| data_ptr[0..@as(usize, @intCast(len))] else "",
                     );
                     if (@TypeOf(res) != void) res catch |err| switch (err) {
                         error.JSTerminated => return null, // TODO: declare throw scope
@@ -731,7 +731,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
                     const res = Fields.onData(
                         getValue(socket),
                         SocketHandlerType.from(socket),
-                        buf.?[0..@as(usize, @intCast(len))],
+                        if (buf) |data_ptr| data_ptr[0..@as(usize, @intCast(len))] else "",
                     );
                     if (@TypeOf(res) != void) res catch |err| switch (err) {
                         error.JSTerminated => return null, // TODO: declare throw scope


### PR DESCRIPTION
### What does this PR do?
If for some reason data is null we should handle as empty
Fixes https://linear.app/oven/issue/ENG-21511/panic-attempt-to-use-null-value-in-socket-on-data
### How did you verify your code works?
Ci