### PR TITLE
fix(DevServer) remove panic in case of source type none

### DIFF
--- a/src/bake/DevServer/SourceMapStore.zig
+++ b/src/bake/DevServer/SourceMapStore.zig
@@ -278,7 +278,6 @@ pub const Entry = struct {
                 if (bun.Environment.enable_logs) {
                     mapLog("Skipping source map entry with missing line count at index {d}", .{i});
                 }
-                continue;
             },
         };
     }

--- a/src/bake/DevServer/SourceMapStore.zig
+++ b/src/bake/DevServer/SourceMapStore.zig
@@ -273,7 +273,10 @@ pub const Entry = struct {
             .none => {
                 // NOTE: It is too late to compute the line count since the bundled text may
                 // have been freed already. For example, a HMR chunk is never persisted.
-                @panic("Missing internal precomputed line count.");
+                // We could return an error here but what would be a better behavior for renderJSON and renderMappings?
+                // This is a dev server, crashing is not a good DX, we could fail the request but that's not a good DX either.
+                // @panic("Missing internal precomputed line count.");
+                continue;
             },
         };
     }

--- a/src/bake/DevServer/SourceMapStore.zig
+++ b/src/bake/DevServer/SourceMapStore.zig
@@ -275,7 +275,9 @@ pub const Entry = struct {
                 // have been freed already. For example, a HMR chunk is never persisted.
                 // We could return an error here but what would be a better behavior for renderJSON and renderMappings?
                 // This is a dev server, crashing is not a good DX, we could fail the request but that's not a good DX either.
-                // @panic("Missing internal precomputed line count.");
+                if (bun.Environment.enable_logs) {
+                    mapLog("Skipping source map entry with missing line count at index {d}", .{i});
+                }
                 continue;
             },
         };


### PR DESCRIPTION
### What does this PR do?
Remove panic in case of source type none, so we can handle it more gracefully, we can discuss if this is the best solution but looks sensible for me. This is really hard to repro but can happen when deleting files referred by dynamic imports.


Fixes https://linear.app/oven/issue/ENG-21513/panic-missing-internal-precomputed-line-count-in-renderjson-on
Fixes https://github.com/oven-sh/bun/issues/21714
### How did you verify your code works?
CI