### PR TITLE
Fix hang on repeated dynamic imports of modules with parse errors

### DIFF
--- a/test/regression/issue/23139.test.ts
+++ b/test/regression/issue/23139.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("repeated dynamic imports of file with parse error should not hang (#23139)", async () => {
+  using dir = tempDir("issue-23139", {
+    "repro.js": /* js */ `
+      try {
+        console.log("begin import 1");
+        await import("./invalid_code");
+      } catch(e) {
+        console.log("error 1");
+      }
+      try {
+        console.log("begin import 2");
+        await import("./invalid_code");
+      } catch(e) {
+        console.log("error 2");
+      }
+    `,
+    "invalid_code": /* js */ `
+      def hello():
+        print("Hello from Python!")
+        return "This is Python code"
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repro.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const timeout = setTimeout(() => {
+    proc.kill();
+  }, 5000);
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  clearTimeout(timeout);
+
+  // Should not hang - both imports should complete
+  expect(stdout).toContain("begin import 1");
+  expect(stdout).toContain("error 1");
+  expect(stdout).toContain("begin import 2");
+  expect(stdout).toContain("error 2");
+
+  // Should exit cleanly
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #23139 - When a module with parse errors is imported twice using `import()`, the second import hangs indefinitely.

## Root Cause

JSC's module loader caches module entries in `esmRegistryMap` after the first import attempt. When a parse error occurs:
1. First import: Module is fetched, parse error is encountered, promise is rejected, error is shown
2. Module entry remains in the registry with state > Fetch
3. Second import: JSC sees the entry exists and skips calling `moduleLoaderFetch`, waiting for a cached promise that never completes

## Solution

Remove failed modules from `esmRegistryMap` when the fetch promise is rejected. This allows subsequent import attempts to retry module loading from scratch, ensuring users always get proper error messages instead of hangs.

## Changes

- `ZigGlobalObject.cpp:moduleLoaderFetch`: Added logic to remove modules from registry when fetch promise is rejected
- Added regression test at `test/regression/issue/23139.test.ts`

## Test Plan

```bash
bun bd test test/regression/issue/23139.test.ts
```

The test verifies that both imports complete and show the error message without hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)