### PR TITLE
docs: format code blocks correctly

### DIFF
--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -242,16 +242,8 @@ Then, reference TailwindCSS in your HTML via `<link>` tag, `@import` in CSS, or 
     <link rel="stylesheet" href="tailwindcss" />
     ```
   </Tab>
-  <Tab title="styles.css">
-    ```css title="styles.css" icon="file-code"
-    @import "tailwindcss";
-    ```
-  </Tab>
-  <Tab title="app.ts">
-    ```ts title="app.ts" icon="/icons/typescript.svg"
-    import "tailwindcss";
-    ```
-  </Tab>
+  <Tab title="styles.css">```css title="styles.css" icon="file-code" @import "tailwindcss"; ```</Tab>
+  <Tab title="app.ts">```ts title="app.ts" icon="/icons/typescript.svg" import "tailwindcss"; ```</Tab>
 </Tabs>
 
 <Info>Only one of those are necessary, not all three.</Info>

--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -237,13 +237,27 @@ Then, reference TailwindCSS in your HTML via `<link>` tag, `@import` in CSS, or 
 
 <Tabs>
   <Tab title="index.html">
+
     ```html title="index.html" icon="file-code"
-    {/* Reference TailwindCSS in your HTML */}
+    <!-- Reference TailwindCSS in your HTML -->
     <link rel="stylesheet" href="tailwindcss" />
     ```
+
   </Tab>
-  <Tab title="styles.css">```css title="styles.css" icon="file-code" @import "tailwindcss"; ```</Tab>
-  <Tab title="app.ts">```ts title="app.ts" icon="/icons/typescript.svg" import "tailwindcss"; ```</Tab>
+  <Tab title="styles.css">
+
+    ```css title="styles.css" icon="file-code"
+    @import "tailwindcss";
+    ```
+
+  </Tab>
+  <Tab title="app.ts">
+
+    ```ts title="app.ts" icon="/icons/typescript.svg"
+    import "tailwindcss";
+    ```
+
+  </Tab>
 </Tabs>
 
 <Info>Only one of those are necessary, not all three.</Info>

--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -242,8 +242,16 @@ Then, reference TailwindCSS in your HTML via `<link>` tag, `@import` in CSS, or 
     <link rel="stylesheet" href="tailwindcss" />
     ```
   </Tab>
-  <Tab title="styles.css">```css title="styles.css" icon="file-code" @import "tailwindcss"; ```</Tab>
-  <Tab title="app.ts">```ts title="app.ts" icon="/icons/typescript.svg" import "tailwindcss"; ```</Tab>
+  <Tab title="styles.css">
+    ```css title="styles.css" icon="file-code"
+    @import "tailwindcss";
+    ```
+  </Tab>
+  <Tab title="app.ts">
+    ```ts title="app.ts" icon="/icons/typescript.svg"
+    import "tailwindcss";
+    ```
+  </Tab>
 </Tabs>
 
 <Info>Only one of those are necessary, not all three.</Info>


### PR DESCRIPTION
### What does this PR do?

The code blocks were not properly formatted, and did not render correctly

`main`:
<img width="699" height="196" alt="image" src="https://github.com/user-attachments/assets/c08bc29e-9481-47ae-bafe-dd94b22d0c09" />

this pr:
<img width="691" height="306" alt="image" src="https://github.com/user-attachments/assets/947fb9d7-04f3-42e8-aafe-0d70127fefd1" />

### How did you verify your code works?

ran docs locally with mint
