### PR TITLE
feat(run): add --prefix alias for --cwd in bun run

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -44,6 +44,7 @@ pub const base_params_ = (if (Environment.show_crash_trace) debug_params else [_
     clap.parseParam("--env-file <STR>...               Load environment variables from the specified file(s)") catch unreachable,
     clap.parseParam("--no-env-file                     Disable automatic loading of .env files") catch unreachable,
     clap.parseParam("--cwd <STR>                       Absolute path to resolve files & entry points from. This just changes the process' cwd.") catch unreachable,
+    clap.parseParam("--prefix <STR>                    Run the script from the specified directory (alias for --cwd, for bun run)") catch unreachable,
     clap.parseParam("-c, --config <PATH>?              Specify path to Bun config file. Default <d>$cwd<r>/bunfig.toml") catch unreachable,
     clap.parseParam("-h, --help                        Display this menu and exit") catch unreachable,
 } ++ (if (builtin.have_error_return_tracing) [_]ParamType{
@@ -148,7 +149,6 @@ pub const auto_params = auto_only_params ++ runtime_params_ ++ transpiler_params
 pub const run_only_params = [_]ParamType{
     clap.parseParam("--silent                          Don't print the script command") catch unreachable,
     clap.parseParam("--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines.") catch unreachable,
-    clap.parseParam("--prefix <STR>                    Run the script from the specified directory (alias for --cwd)") catch unreachable,
 } ++ auto_or_run_params;
 pub const run_params = run_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -305,37 +305,13 @@ describe.concurrent("bun run", () => {
     });
   }
 
-  it("should show the correct working directory when run with --cwd", async () => {
-    using dir = tempDir("bun-run-cwd", {
+  it.each(["--cwd", "--prefix"])("should show the correct working directory when run with %s", async (flag) => {
+    using dir = tempDir(`bun-run-${flag.replace("--", "")}`, {
       "subdir/test.js": `console.log(process.cwd());`,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "--cwd", "subdir", "test.js"],
-      cwd: String(dir),
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-      env: {
-        ...bunEnv,
-        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
-      },
-    });
-
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-
-    expect(stdout).toMatch(/subdir/);
-    // The exit code will not be 1 if it panics.
-    expect(exitCode).toBe(0);
-  });
-
-  it("should show the correct working directory when run with --prefix", async () => {
-    using dir = tempDir("bun-run-prefix", {
-      "subdir/test.js": `console.log(process.cwd());`,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "--prefix", "subdir", "test.js"],
+      cmd: [bunExe(), "run", flag, "subdir", "test.js"],
       cwd: String(dir),
       stdin: "ignore",
       stdout: "pipe",

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -329,6 +329,30 @@ describe.concurrent("bun run", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("should show the correct working directory when run with --prefix", async () => {
+    using dir = tempDir("bun-run-prefix", {
+      "subdir/test.js": `console.log(process.cwd());`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--prefix", "subdir", "test.js"],
+      cwd: String(dir),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+      },
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toMatch(/subdir/);
+    // The exit code will not be 1 if it panics.
+    expect(exitCode).toBe(0);
+  });
+
   it("DCE annotations are respected", async () => {
     using dir = tempDir("test", {
       "index.ts": `

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -305,7 +305,7 @@ describe.concurrent("bun run", () => {
     });
   }
 
-  it.each(["--cwd", "--prefix"])("should show the correct working directory when run with %s", async (flag) => {
+  it.each(["--cwd", "--prefix"])("should show the correct working directory when run with %s", async flag => {
     using dir = tempDir(`bun-run-${flag.replace("--", "")}`, {
       "subdir/test.js": `console.log(process.cwd());`,
     });


### PR DESCRIPTION
### What does this PR do?

Adds support for npm equivalent `--prefix` flag for `bun run` command. This allows users to run scripts from subdirectories without having to `cd` into them first.

- Add `--prefix` parameter to `run_only_params` in `Arguments.zig`
- Handle `--prefix` as alias for `--cwd` in argument parsing  
- Add test cases for `--prefix` functionality

### How did you verify your code works?

Added comprehensive test cases in `test/cli/install/bun-run.test.ts`:
- Test basic `--prefix` functionality
- Test with trailing slash support
- Test running package.json scripts with `--prefix`
- Verify `--prefix` and `--cwd` produce identical results

Fixes #15135