### PR TITLE
fix: Add missing SIGWINCH for windows

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -962,6 +962,7 @@ static void loadSignalNumberMap()
         signalNameToNumberMap->add(signalNames[2], SIGQUIT);
         signalNameToNumberMap->add(signalNames[9], SIGKILL);
         signalNameToNumberMap->add(signalNames[15], SIGTERM);
+        signalNameToNumberMap->add(signalNames[27], SIGWINCH);
 #else
         signalNameToNumberMap->add(signalNames[0], SIGHUP);
         signalNameToNumberMap->add(signalNames[1], SIGINT);


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/oven-sh/bun/issues/22288
Fixes #22402
Fixes https://github.com/oven-sh/bun/issues/23224
Fixes https://github.com/oven-sh/bun/issues/17803

cc: Should unblock opencode/opentui window resize on windows https://github.com/sst/opentui/issues/152

### How did you verify your code works?
Clone the linked repro, verified latest bun failed, node worked, then iterated till my local bun worked.

Here is a screenshot of the branch working with bun on windows

<img width="1427" height="891" alt="image" src="https://github.com/user-attachments/assets/18642db7-4cb6-4758-bb76-a38d277cbc23" />

Additionally using bun vs bun-debug on a little test for our downstream package proves this works

<img width="1137" height="679" alt="image" src="https://github.com/user-attachments/assets/4dbe7605-ced9-4bcb-84f0-ed793f8aa942" />
<img width="1138" height="684" alt="image" src="https://github.com/user-attachments/assets/f658b3b9-e4bc-4bfa-84f0-e1eb3af83d89" />


