### PR TITLE
docs: fix environment variable syntax in executable example

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -216,7 +216,7 @@ However, with the `BUN_BE_BUN=1` environment variable, it acts just like the `bu
 
 ```bash icon="terminal" terminal
 # With the env var, the executable acts like the `bun` CLI
-bun_BE_BUN=1 ./such-bun install
+BUN_BE_BUN=1 ./such-bun install
 ```
 
 ```txt


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the docs. 

`bun_BE_BUN=1` doesn't work, it has to be capitalized `BUN_BE_BUN=1`