### PR TITLE
fix(YAML.stringify): number-like strings prefixed with `0`

### DIFF
--- a/src/bun.js/api/YAMLObject.zig
+++ b/src/bun.js/api/YAMLObject.zig
@@ -843,14 +843,20 @@ const Stringifier = struct {
             '0' => {
                 if (i == start) {
                     if (i + 1 < str.length()) {
-                        const nc = str.charAt(i + 1);
-                        if (nc == 'x' or nc == 'X') {
-                            base = .hex;
-                        } else if (nc == 'o' or nc == 'O') {
-                            base = .oct;
-                        } else {
-                            offset.* = i;
-                            return false;
+                        switch (str.charAt(i + 1)) {
+                            'x', 'X' => {
+                                base = .hex;
+                            },
+                            'o', 'O' => {
+                                base = .oct;
+                            },
+                            '0'...'9' => {
+                                // 0 prefix allowed
+                            },
+                            else => {
+                                offset.* = i;
+                                return false;
+                            },
                         }
                         i += 1;
                     } else {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1332,6 +1332,8 @@ my_config:
 
         // Zero prefix
         expect(YAML.stringify({ a: "011", b: "110" })).toBe('{a: "011",b: "110"}');
+        expect(YAML.stringify(YAML.parse('"0123"'))).toBe('"0123"');
+        expect(YAML.stringify("0000123")).toBe('"0000123"');
       });
 
       test("quotes strings with colons followed by spaces", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1329,6 +1329,9 @@ my_config:
         // Octal numbers
         expect(YAML.stringify("0o777")).toBe('"0o777"');
         expect(YAML.stringify("0O644")).toBe('"0O644"');
+
+        // Zero prefix
+        expect(YAML.stringify({ a: "011", b: "110" })).toBe('{a: "011",b: "110"}');
       });
 
       test("quotes strings with colons followed by spaces", () => {


### PR DESCRIPTION
### What does this PR do?
Ensures strings that would parse as a number with leading zeroes aren't emitted without quotes.

fixes #23691

### How did you verify your code works?
Added a test