### PR TITLE
fix(bundler): avoid invalid syntax in void import() transformation

### DIFF
--- a/test/regression/issue/24709.test.ts
+++ b/test/regression/issue/24709.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("issue #24709 - void import() should generate valid JavaScript", async () => {
+  using dir = tempDir("issue-24709", {
+    "bug.ts": `
+export function main() {
+  void import("./bug.ts");
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "bug.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The output should not contain invalid syntax like .then(() => )
+  expect(stdout).not.toContain(".then(() => )");
+
+  // The output should contain valid syntax like .then(() => void 0)
+  expect(stdout).toContain(".then(() => void 0)");
+
+  // Verify the generated code is syntactically valid by parsing it
+  // We can't use new Function() because it has 'export' statements
+  // but we can check that it doesn't have the specific syntax error
+  expect(stdout).toMatch(/\.then\(\(\) => [^)]+\)/);
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #24709

When bundling code with `void import()` (side-effect only dynamic imports), the bundler was generating invalid JavaScript syntax like `.then(() => )` instead of `.then(() => void 0)`.

**Before:**
```javascript
function main() {
  Promise.resolve().then(() => );  // ❌ Invalid syntax
}
```

**After:**
```javascript
function main() {
  Promise.resolve().then(() => void 0);  // ✅ Valid syntax
}
```

## Root Cause

When the bundler transforms internal dynamic imports, it wraps them in `Promise.resolve().then(() => <content>)`. However, when the imported module has no exports or wrapper to call (e.g., pure side-effect imports that get tree-shaken), nothing was being printed in the callback body, resulting in invalid syntax.

## Solution

The fix tracks whether any content was printed in the dynamic import body and ensures we print `void 0` when nothing else needs to be printed, resulting in valid JavaScript syntax.

## Test Plan

- [x] Added regression test in `test/regression/issue/24709.test.ts`
- [x] Test fails with `USE_SYSTEM_BUN=1 bun test` (reproduces the bug)
- [x] Test passes with `bun bd test` (verifies the fix)
- [x] Manually verified the generated code is syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)