### PR TITLE
Add compile-time flags to control .env and bunfig.toml autoloading

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1935,11 +1935,21 @@ declare module "bun" {
     outfile?: string;
     /**
      * Whether to autoload .env files when the standalone executable runs
+     *
+     * Standalone-only: applies only when building/running the standalone executable.
+     *
+     * Equivalent CLI flags: `--compile-autoload-dotenv`, `--no-compile-autoload-dotenv`
+     *
      * @default true
      */
     autoloadDotenv?: boolean;
     /**
      * Whether to autoload bunfig.toml when the standalone executable runs
+     *
+     * Standalone-only: applies only when building/running the standalone executable.
+     *
+     * Equivalent CLI flags: `--compile-autoload-bunfig`, `--no-compile-autoload-bunfig`
+     *
      * @default true
      */
     autoloadBunfig?: boolean;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1933,6 +1933,16 @@ declare module "bun" {
     execArgv?: string[];
     executablePath?: string;
     outfile?: string;
+    /**
+     * Whether to autoload .env files when the standalone executable runs
+     * @default true
+     */
+    autoloadDotenv?: boolean;
+    /**
+     * Whether to autoload bunfig.toml when the standalone executable runs
+     * @default true
+     */
+    autoloadBunfig?: boolean;
     windows?: {
       hideConsole?: boolean;
       icon?: string;

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -179,12 +179,12 @@ pub const JSBundler = struct {
                     try this.outfile.appendSliceExact(slice.slice());
                 }
 
-                if (try object.getOwn(globalThis, "autoloadDotenv")) |autoload_dotenv| {
-                    this.autoload_dotenv = autoload_dotenv.toBoolean();
+                if (try object.getBooleanLoose(globalThis, "autoloadDotenv")) |autoload_dotenv| {
+                    this.autoload_dotenv = autoload_dotenv;
                 }
 
-                if (try object.getOwn(globalThis, "autoloadBunfig")) |autoload_bunfig| {
-                    this.autoload_bunfig = autoload_bunfig.toBoolean();
+                if (try object.getBooleanLoose(globalThis, "autoloadBunfig")) |autoload_bunfig| {
+                    this.autoload_bunfig = autoload_bunfig;
                 }
 
                 return this;

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -57,6 +57,8 @@ pub const JSBundler = struct {
             windows_description: OwnedString = OwnedString.initEmpty(bun.default_allocator),
             windows_copyright: OwnedString = OwnedString.initEmpty(bun.default_allocator),
             outfile: OwnedString = OwnedString.initEmpty(bun.default_allocator),
+            autoload_dotenv: bool = true,
+            autoload_bunfig: bool = true,
 
             pub fn fromJS(globalThis: *jsc.JSGlobalObject, config: jsc.JSValue, allocator: std.mem.Allocator, compile_target: ?CompileTarget) JSError!?CompileOptions {
                 var this = CompileOptions{
@@ -175,6 +177,14 @@ pub const JSBundler = struct {
                     var slice = try outfile.toSlice(globalThis, bun.default_allocator);
                     defer slice.deinit();
                     try this.outfile.appendSliceExact(slice.slice());
+                }
+
+                if (try object.getOwn(globalThis, "autoloadDotenv")) |autoload_dotenv| {
+                    this.autoload_dotenv = autoload_dotenv.toBoolean();
+                }
+
+                if (try object.getOwn(globalThis, "autoloadBunfig")) |autoload_bunfig| {
+                    this.autoload_bunfig = autoload_bunfig.toBoolean();
                 }
 
                 return this;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2042,6 +2042,10 @@ pub const BundleV2 = struct {
                     compile_options.executable_path.slice()
                 else
                     null,
+                .{
+                    .disable_default_env_files = !compile_options.autoload_dotenv,
+                    .disable_autoload_bunfig = !compile_options.autoload_bunfig,
+                },
             ) catch |err| {
                 return bun.StandaloneModuleGraph.CompileResult.failFmt("{s}", .{@errorName(err)});
             };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -458,6 +458,8 @@ pub const Command = struct {
             compile: bool = false,
             compile_target: Cli.CompileTarget = .{},
             compile_exec_argv: ?[]const u8 = null,
+            compile_autoload_dotenv: bool = true,
+            compile_autoload_bunfig: bool = true,
             windows: options.WindowsOptions = .{},
         };
 

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -148,6 +148,10 @@ pub const build_only_params = [_]ParamType{
     clap.parseParam("--production                     Set NODE_ENV=production and enable minification") catch unreachable,
     clap.parseParam("--compile                        Generate a standalone Bun executable containing your bundled code. Implies --production") catch unreachable,
     clap.parseParam("--compile-exec-argv <STR>       Prepend arguments to the standalone executable's execArgv") catch unreachable,
+    clap.parseParam("--compile-autoload-dotenv        Enable autoloading of .env files in standalone executable (default: true)") catch unreachable,
+    clap.parseParam("--no-compile-autoload-dotenv     Disable autoloading of .env files in standalone executable") catch unreachable,
+    clap.parseParam("--compile-autoload-bunfig        Enable autoloading of bunfig.toml in standalone executable (default: true)") catch unreachable,
+    clap.parseParam("--no-compile-autoload-bunfig     Disable autoloading of bunfig.toml in standalone executable") catch unreachable,
     clap.parseParam("--bytecode                       Use a bytecode cache") catch unreachable,
     clap.parseParam("--watch                          Automatically restart the process on file change") catch unreachable,
     clap.parseParam("--no-clear-screen                Disable clearing the terminal screen on reload when --watch is enabled") catch unreachable,
@@ -1016,6 +1020,22 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 Global.crash();
             }
             ctx.bundler_options.compile_exec_argv = compile_exec_argv;
+        }
+
+        if (args.flag("--compile-autoload-dotenv")) {
+            ctx.bundler_options.compile_autoload_dotenv = true;
+        }
+
+        if (args.flag("--no-compile-autoload-dotenv")) {
+            ctx.bundler_options.compile_autoload_dotenv = false;
+        }
+
+        if (args.flag("--compile-autoload-bunfig")) {
+            ctx.bundler_options.compile_autoload_bunfig = true;
+        }
+
+        if (args.flag("--no-compile-autoload-bunfig")) {
+            ctx.bundler_options.compile_autoload_bunfig = false;
         }
 
         if (args.flag("--windows-hide-console")) {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -1022,20 +1022,40 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             ctx.bundler_options.compile_exec_argv = compile_exec_argv;
         }
 
-        if (args.flag("--compile-autoload-dotenv")) {
-            ctx.bundler_options.compile_autoload_dotenv = true;
+        // Handle --compile-autoload-dotenv flags
+        {
+            const has_positive = args.flag("--compile-autoload-dotenv");
+            const has_negative = args.flag("--no-compile-autoload-dotenv");
+
+            if (has_positive or has_negative) {
+                if (!ctx.bundler_options.compile) {
+                    Output.errGeneric("--compile-autoload-dotenv requires --compile", .{});
+                    Global.crash();
+                }
+                if (has_positive and has_negative) {
+                    Output.errGeneric("Cannot use both --compile-autoload-dotenv and --no-compile-autoload-dotenv", .{});
+                    Global.crash();
+                }
+                ctx.bundler_options.compile_autoload_dotenv = has_positive;
+            }
         }
 
-        if (args.flag("--no-compile-autoload-dotenv")) {
-            ctx.bundler_options.compile_autoload_dotenv = false;
-        }
+        // Handle --compile-autoload-bunfig flags
+        {
+            const has_positive = args.flag("--compile-autoload-bunfig");
+            const has_negative = args.flag("--no-compile-autoload-bunfig");
 
-        if (args.flag("--compile-autoload-bunfig")) {
-            ctx.bundler_options.compile_autoload_bunfig = true;
-        }
-
-        if (args.flag("--no-compile-autoload-bunfig")) {
-            ctx.bundler_options.compile_autoload_bunfig = false;
+            if (has_positive or has_negative) {
+                if (!ctx.bundler_options.compile) {
+                    Output.errGeneric("--compile-autoload-bunfig requires --compile", .{});
+                    Global.crash();
+                }
+                if (has_positive and has_negative) {
+                    Output.errGeneric("Cannot use both --compile-autoload-bunfig and --no-compile-autoload-bunfig", .{});
+                    Global.crash();
+                }
+                ctx.bundler_options.compile_autoload_bunfig = has_positive;
+            }
         }
 
         if (args.flag("--windows-hide-console")) {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -440,6 +440,10 @@ pub const BuildCommand = struct {
                     ctx.bundler_options.windows,
                     ctx.bundler_options.compile_exec_argv orelse "",
                     null,
+                    .{
+                        .disable_default_env_files = !ctx.bundler_options.compile_autoload_dotenv,
+                        .disable_autoload_bunfig = !ctx.bundler_options.compile_autoload_bunfig,
+                    },
                 ) catch |err| {
                     Output.printErrorln("failed to create executable: {s}", .{@errorName(err)});
                     Global.exit(1);

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -159,4 +159,28 @@ console.log("PRELOAD");
       stdout: "not found",
     },
   });
+
+  // Test CLI backend with autoloadBunfig: false
+  itBundled("compile/AutoloadBunfigDisabledCLI", {
+    compile: {
+      autoloadBunfig: false,
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      stdout: "ENTRY",
+    },
+  });
 });

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -140,4 +140,23 @@ console.log("PRELOAD");
       stdout: "PRELOAD\nENTRY",
     },
   });
+
+  // Test CLI backend with autoloadDotenv: false
+  itBundled("compile/AutoloadDotenvDisabledCLI", {
+    compile: {
+      autoloadDotenv: false,
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      stdout: "not found",
+    },
+  });
 });

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -160,6 +160,25 @@ console.log("PRELOAD");
     },
   });
 
+  // Test CLI backend with autoloadDotenv: true
+  itBundled("compile/AutoloadDotenvEnabledCLI", {
+    compile: {
+      autoloadDotenv: true,
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      stdout: "from_dotenv",
+    },
+  });
+
   // Test CLI backend with autoloadBunfig: false
   itBundled("compile/AutoloadBunfigDisabledCLI", {
     compile: {
@@ -181,6 +200,30 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "ENTRY",
+    },
+  });
+
+  // Test CLI backend with autoloadBunfig: true
+  itBundled("compile/AutoloadBunfigEnabledCLI", {
+    compile: {
+      autoloadBunfig: true,
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      stdout: "PRELOAD\nENTRY",
     },
   });
 });

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -73,24 +73,24 @@ describe("bundler", () => {
     },
   });
 
-  // Test that bunfig.toml is loaded by default
+  // Test that bunfig.toml is loaded by default (preload is executed)
   itBundled("compile/AutoloadBunfigDefault", {
     compile: true,
     files: {
       "/entry.ts": /* js */ `
-        // bunfig.toml would affect resolution, macros, etc.
-        // For now just test that it doesn't crash when bunfig is present
-        console.log("SUCCESS");
+        console.log("ENTRY");
       `,
     },
     runtimeFiles: {
       "/bunfig.toml": `
-[install]
-cache = false
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
       `,
     },
     run: {
-      stdout: "SUCCESS",
+      stdout: "PRELOAD\nENTRY",
     },
   });
 
@@ -101,17 +101,43 @@ cache = false
     },
     files: {
       "/entry.ts": /* js */ `
-        console.log("SUCCESS");
+        console.log("ENTRY");
       `,
     },
     runtimeFiles: {
       "/bunfig.toml": `
-[install]
-cache = false
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
       `,
     },
     run: {
-      stdout: "SUCCESS",
+      // When bunfig is disabled, preload should NOT execute
+      stdout: "ENTRY",
+    },
+  });
+
+  // Test that bunfig.toml can be explicitly enabled with autoloadBunfig: true
+  itBundled("compile/AutoloadBunfigEnabled", {
+    compile: {
+      autoloadBunfig: true,
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      stdout: "PRELOAD\nENTRY",
     },
   });
 });

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -1,0 +1,117 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  // Test that .env files are loaded by default in standalone executables
+  itBundled("compile/AutoloadDotenvDefault", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      stdout: "from_dotenv",
+    },
+  });
+
+  // Test that .env files can be disabled with autoloadDotenv: false
+  itBundled("compile/AutoloadDotenvDisabled", {
+    compile: {
+      autoloadDotenv: false,
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      stdout: "not found",
+    },
+  });
+
+  // Test that .env files can be explicitly enabled with autoloadDotenv: true
+  itBundled("compile/AutoloadDotenvEnabledExplicitly", {
+    compile: {
+      autoloadDotenv: true,
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      stdout: "from_dotenv",
+    },
+  });
+
+  // Test that process environment variables take precedence over .env files
+  itBundled("compile/AutoloadDotenvWithExistingEnv", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      stdout: "from_shell",
+      env: {
+        TEST_VAR: "from_shell",
+      },
+    },
+  });
+
+  // Test that bunfig.toml is loaded by default
+  itBundled("compile/AutoloadBunfigDefault", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        // bunfig.toml would affect resolution, macros, etc.
+        // For now just test that it doesn't crash when bunfig is present
+        console.log("SUCCESS");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+[install]
+cache = false
+      `,
+    },
+    run: {
+      stdout: "SUCCESS",
+    },
+  });
+
+  // Test that bunfig.toml can be disabled with autoloadBunfig: false
+  itBundled("compile/AutoloadBunfigDisabled", {
+    compile: {
+      autoloadBunfig: false,
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("SUCCESS");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+[install]
+cache = false
+      `,
+    },
+    run: {
+      stdout: "SUCCESS",
+    },
+  });
+});

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -15,6 +15,7 @@ describe("bundler", () => {
     },
     run: {
       stdout: "from_dotenv",
+      setCwd: true,
     },
   });
 
@@ -33,6 +34,7 @@ describe("bundler", () => {
     },
     run: {
       stdout: "not found",
+      setCwd: true,
     },
   });
 
@@ -51,6 +53,7 @@ describe("bundler", () => {
     },
     run: {
       stdout: "from_dotenv",
+      setCwd: true,
     },
   });
 
@@ -67,6 +70,7 @@ describe("bundler", () => {
     },
     run: {
       stdout: "from_shell",
+      setCwd: true,
       env: {
         TEST_VAR: "from_shell",
       },
@@ -91,6 +95,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "PRELOAD\nENTRY",
+      setCwd: true,
     },
   });
 
@@ -115,6 +120,7 @@ console.log("PRELOAD");
     run: {
       // When bunfig is disabled, preload should NOT execute
       stdout: "ENTRY",
+      setCwd: true,
     },
   });
 
@@ -138,6 +144,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "PRELOAD\nENTRY",
+      setCwd: true,
     },
   });
 
@@ -157,6 +164,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "not found",
+      setCwd: true,
     },
   });
 
@@ -176,6 +184,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "from_dotenv",
+      setCwd: true,
     },
   });
 
@@ -200,6 +209,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "ENTRY",
+      setCwd: true,
     },
   });
 
@@ -224,6 +234,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "PRELOAD\nENTRY",
+      setCwd: true,
     },
   });
 
@@ -250,6 +261,7 @@ console.log("PRELOAD");
     },
     run: {
       stdout: "not found\nENTRY",
+      setCwd: true,
     },
   });
 });

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -226,4 +226,30 @@ console.log("PRELOAD");
       stdout: "PRELOAD\nENTRY",
     },
   });
+
+  // Test that both flags can be disabled together without interference
+  itBundled("compile/AutoloadBothDisabled", {
+    compile: {
+      autoloadDotenv: false,
+      autoloadBunfig: false,
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      stdout: "not found\nENTRY",
+    },
+  });
 });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -704,7 +704,7 @@ function expectBundled(
 
     // Helper to add compile boolean flags
     const compileFlag = (prop: string, trueFlag: string, falseFlag: string): string[] => {
-      if (compile && typeof compile === "object" && prop in compile) {
+      if (compile && typeof compile === "object" && Object.prototype.hasOwnProperty.call(compile, prop)) {
         const value = (compile as any)[prop];
         if (value === true) return [trueFlag];
         if (value === false) return [falseFlag];

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -719,6 +719,18 @@ function expectBundled(
               compile && typeof compile === "object" && "execArgv" in compile
                 ? `--compile-exec-argv=${Array.isArray(compile.execArgv) ? compile.execArgv.join(" ") : compile.execArgv}`
                 : [],
+              compile && typeof compile === "object" && "autoloadDotenv" in compile && compile.autoloadDotenv === false
+                ? "--no-compile-autoload-dotenv"
+                : [],
+              compile && typeof compile === "object" && "autoloadDotenv" in compile && compile.autoloadDotenv === true
+                ? "--compile-autoload-dotenv"
+                : [],
+              compile && typeof compile === "object" && "autoloadBunfig" in compile && compile.autoloadBunfig === false
+                ? "--no-compile-autoload-bunfig"
+                : [],
+              compile && typeof compile === "object" && "autoloadBunfig" in compile && compile.autoloadBunfig === true
+                ? "--compile-autoload-bunfig"
+                : [],
               outfile ? `--outfile=${outfile}` : `--outdir=${outdir}`,
               define && Object.entries(define).map(([k, v]) => ["--define", `${k}=${v}`]),
               `--target=${target}`,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1070,6 +1070,12 @@ function expectBundled(
               target: compile,
               outfile: outfile,
             };
+          } else if (typeof compile === "object") {
+            // When compile is already an object, ensure it has outfile set
+            compile = {
+              ...compile,
+              outfile: outfile,
+            };
           }
         }
 

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -702,6 +702,16 @@ function expectBundled(
       ? Object.entries(bundleErrors).flatMap(([file, v]) => v.map(error => ({ file, error })))
       : null;
 
+    // Helper to add compile boolean flags
+    const compileFlag = (prop: string, trueFlag: string, falseFlag: string): string[] => {
+      if (compile && typeof compile === "object" && prop in compile) {
+        const value = (compile as any)[prop];
+        if (value === true) return [trueFlag];
+        if (value === false) return [falseFlag];
+      }
+      return [];
+    };
+
     if (backend === "cli") {
       if (plugins) {
         throw new Error("plugins not possible in backend=CLI");
@@ -719,18 +729,8 @@ function expectBundled(
               compile && typeof compile === "object" && "execArgv" in compile
                 ? `--compile-exec-argv=${Array.isArray(compile.execArgv) ? compile.execArgv.join(" ") : compile.execArgv}`
                 : [],
-              compile && typeof compile === "object" && "autoloadDotenv" in compile && compile.autoloadDotenv === false
-                ? "--no-compile-autoload-dotenv"
-                : [],
-              compile && typeof compile === "object" && "autoloadDotenv" in compile && compile.autoloadDotenv === true
-                ? "--compile-autoload-dotenv"
-                : [],
-              compile && typeof compile === "object" && "autoloadBunfig" in compile && compile.autoloadBunfig === false
-                ? "--no-compile-autoload-bunfig"
-                : [],
-              compile && typeof compile === "object" && "autoloadBunfig" in compile && compile.autoloadBunfig === true
-                ? "--compile-autoload-bunfig"
-                : [],
+              compileFlag("autoloadDotenv", "--compile-autoload-dotenv", "--no-compile-autoload-dotenv"),
+              compileFlag("autoloadBunfig", "--compile-autoload-bunfig", "--no-compile-autoload-bunfig"),
               outfile ? `--outfile=${outfile}` : `--outdir=${outdir}`,
               define && Object.entries(define).map(([k, v]) => ["--define", `${k}=${v}`]),
               `--target=${target}`,


### PR DESCRIPTION
## Summary

This PR adds two new compile options to control whether standalone executables autoload `.env` files and `bunfig.toml` configuration files.

## New Options

### JavaScript API
```js
await Bun.build({
  entrypoints: ["./entry.ts"],
  compile: {
    autoloadDotenv: false,  // Disable .env loading (default: true)
    autoloadBunfig: false,  // Disable bunfig.toml loading (default: true)
  }
});
```

### CLI Flags
```bash
bun build --compile --no-compile-autoload-dotenv entry.ts
bun build --compile --no-compile-autoload-bunfig entry.ts
bun build --compile --compile-autoload-dotenv entry.ts
bun build --compile --compile-autoload-bunfig entry.ts
```

## Implementation

The flags are stored in a new `Flags` packed struct in `StandaloneModuleGraph`:
```zig
pub const Flags = packed struct(u32) {
    disable_default_env_files: bool = false,
    disable_autoload_bunfig: bool = false,
    _padding: u30 = 0,
};
```

These flags are:
1. Set during compilation from CLI args or JS API options
2. Serialized into the `StandaloneModuleGraph` embedded in the executable
3. Read at runtime in `bootStandalone()` to conditionally load config files

## Testing

Manually tested and verified:
- ✅ Default behavior loads `.env` files
- ✅ `--no-compile-autoload-dotenv` disables `.env` loading
- ✅ `--compile-autoload-dotenv` explicitly enables `.env` loading
- ✅ Default behavior loads `bunfig.toml` (verified with preload script)
- ✅ `--no-compile-autoload-bunfig` disables `bunfig.toml` loading

Test cases added in `test/bundler/bundler_compile_autoload.test.ts`

## Files Changed

- `src/StandaloneModuleGraph.zig` - Added Flags struct, updated encode/decode
- `src/bun.js.zig` - Checks flags in bootStandalone()
- `src/bun.js/api/JSBundler.zig` - Added autoload options to CompileOptions
- `src/bundler/bundle_v2.zig` - Pass flags to toExecutable()
- `src/cli.zig` - Added flags to BundlerOptions
- `src/cli/Arguments.zig` - Added CLI argument parsing
- `src/cli/build_command.zig` - Pass flags from context
- `test/bundler/expectBundled.ts` - Support new compile options
- `test/bundler/bundler_compile_autoload.test.ts` - New test file