### PR TITLE
fix(windows): close worker libuv loop

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -641,9 +641,9 @@ const WTFStringImpl = @import("../string.zig").WTFStringImpl;
 
 const bun = @import("bun");
 const Async = bun.Async;
+const Environment = bun.Environment;
 const Output = bun.Output;
 const assert = bun.assert;
-const Environment = bun.Environment;
 
 const jsc = bun.jsc;
 const JSValue = jsc.JSValue;

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -622,7 +622,7 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         arena_.deinit();
     }
 
-    bun.windows.libuv.Loop.closeIfExists();
+    bun.windows.libuv.Loop.close();
 
     bun.exitThread();
 }

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -622,7 +622,9 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         arena_.deinit();
     }
 
-    bun.windows.libuv.Loop.close();
+    if (comptime Environment.isWindows) {
+        bun.windows.libuv.Loop.shutdown();
+    }
 
     bun.exitThread();
 }
@@ -641,6 +643,7 @@ const bun = @import("bun");
 const Async = bun.Async;
 const Output = bun.Output;
 const assert = bun.assert;
+const Environment = bun.Environment;
 
 const jsc = bun.jsc;
 const JSValue = jsc.JSValue;

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -611,6 +611,10 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         loop_.internal_loop_data.jsc_vm = null;
     }
 
+    if (comptime Environment.isWindows) {
+        bun.windows.libuv.Loop.shutdown();
+    }
+
     this.deinit();
 
     if (vm_to_deinit) |vm| {
@@ -620,10 +624,6 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     bun.deleteAllPoolsForThreadExit();
     if (arena) |*arena_| {
         arena_.deinit();
-    }
-
-    if (comptime Environment.isWindows) {
-        bun.windows.libuv.Loop.shutdown();
     }
 
     bun.exitThread();

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -622,6 +622,8 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         arena_.deinit();
     }
 
+    bun.windows.libuv.Loop.closeIfExists();
+
     bun.exitThread();
 }
 

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -654,14 +654,29 @@ pub const Loop = extern struct {
         return null;
     }
 
-    pub fn close(ptr: *Loop) void {
-        _ = uv_loop_close(ptr);
+    fn closeWalkCb(handle: ?*uv_handle_t, data: ?*anyopaque) callconv(.c) void {
+        _ = data;
+        const h = handle.?;
+        if (uv_is_closing(h) == 0) {
+            uv_close(h, null);
+        }
     }
 
-    pub fn closeIfExists() void {
-        if (threadlocal_loop) |loop| {
-            loop.close();
+    pub fn close() void {
+        const loop = threadlocal_loop orelse {
+            return;
+        };
+
+        if (uv_loop_close(loop).errEnum()) |err| {
+            if (err == .BUSY) {
+                uv_stop(loop);
+                uv_walk(loop, &closeWalkCb, null);
+                _ = uv_run(loop, .default);
+                bun.debugAssert(uv_loop_close(loop) == .zero);
+            }
         }
+
+        threadlocal_loop = null;
     }
 
     threadlocal var threadlocal_loop_data: Loop = undefined;
@@ -2115,7 +2130,7 @@ pub const uv_free_func = ?*const fn (?*anyopaque) callconv(.c) void;
 pub extern fn uv_library_shutdown() void;
 pub extern fn uv_replace_allocator(malloc_func: uv_malloc_func, realloc_func: uv_realloc_func, calloc_func: uv_calloc_func, free_func: uv_free_func) c_int;
 pub extern fn uv_loop_init(loop: *uv_loop_t) ReturnCode;
-pub extern fn uv_loop_close(loop: *uv_loop_t) c_int;
+pub extern fn uv_loop_close(loop: *uv_loop_t) ReturnCode;
 pub extern fn uv_loop_new() *uv_loop_t;
 pub extern fn uv_loop_delete(*uv_loop_t) void;
 pub extern fn uv_loop_size() usize;

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -669,7 +669,6 @@ pub const Loop = extern struct {
 
         if (uv_loop_close(loop).errEnum()) |err| {
             if (err == .BUSY) {
-                uv_stop(loop);
                 uv_walk(loop, &closeWalkCb, null);
                 _ = uv_run(loop, .default);
                 bun.debugAssert(uv_loop_close(loop) == .zero);

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -662,7 +662,7 @@ pub const Loop = extern struct {
         }
     }
 
-    pub fn close() void {
+    pub fn shutdown() void {
         const loop = threadlocal_loop orelse {
             return;
         };

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -658,15 +658,10 @@ pub const Loop = extern struct {
         _ = uv_loop_close(ptr);
     }
 
-    pub fn new() ?*Loop {
-        const ptr = bun.default_allocator.create(Loop) catch return null;
-        if (init(ptr) != null) return null;
-        return ptr;
-    }
-
-    pub fn delete(ptr: *Loop) void {
-        close(ptr);
-        bun.default_allocator.destroy(ptr);
+    pub fn closeIfExists() void {
+        if (threadlocal_loop) |loop| {
+            loop.close();
+        }
     }
 
     threadlocal var threadlocal_loop_data: Loop = undefined;


### PR DESCRIPTION
### What does this PR do?
We need to call `uv_loop_close` in order to remove the threadlocal loop from a list in libuv so it won't be used later. This explains the crash reports because they have `workers_terminated` in features.

Fixes #24804
Closes BUN-3NV
Closes ENG-21523
### How did you verify your code works?
Manually. I'm not sure how to write a test yet other than manually clicking sleep