### PR TITLE
fix(usockets) remove resize, properly clean the linked list and balance context ref count in low priority queue

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -811,7 +811,7 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
 
     struct us_connecting_socket_t *c = s->connect_state;
     struct us_socket_t *new_s = s;
-    if (ext_size != -1 && old_ext_size < ext_size) {
+    if (ext_size != -1) {
         struct us_poll_t *pool_ref = &s->p;
         new_s = (struct us_socket_t *) us_poll_resize(pool_ref, loop, sizeof(struct us_socket_t) + ext_size, sizeof(struct us_socket_t) + old_ext_size);
         // previous socket is no longer valid, so we need to mark it as closed

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -813,7 +813,8 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
     struct us_socket_t *new_s = s;
     if (ext_size != -1) {
         struct us_poll_t *pool_ref = &s->p;
-        new_s = (struct us_socket_t *) us_poll_resize(pool_ref, loop, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + ext_size, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + old_ext_size);
+        new_s = (struct us_socket_t *) us_poll_resize(pool_ref, loop, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + ext_size,
+                                                        sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + old_ext_size);
         // previous socket is no longer valid, so we need to mark it as closed
         if(new_s != s) {
             /* Link this socket to the close-list and let it be deleted after this iteration */

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -819,8 +819,7 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
             /* Link this socket to the close-list and let it be deleted after this iteration */
             s->next = s->context->loop->data.closed_head;
             s->context->loop->data.closed_head = s;
-            // mark the old socket as closed (dont put it back in the event loop by mistake)
-            s->prev = (struct us_socket_t *) s->context;
+            s->flags.is_closed = 1;
         }
         if (c) {
             c->connecting_head = new_s;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -813,7 +813,7 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
     struct us_socket_t *new_s = s;
     if (ext_size != -1) {
         struct us_poll_t *pool_ref = &s->p;
-        new_s = (struct us_socket_t *) us_poll_resize(pool_ref, loop, sizeof(struct us_socket_t) + ext_size, sizeof(struct us_socket_t) + old_ext_size);
+        new_s = (struct us_socket_t *) us_poll_resize(pool_ref, loop, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + ext_size, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + old_ext_size);
         // previous socket is no longer valid, so we need to mark it as closed
         if(new_s != s) {
             /* Link this socket to the close-list and let it be deleted after this iteration */

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -53,9 +53,7 @@ void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls) {
         /* Link this socket to the close-list and let it be deleted after this iteration */
         s->next = loop->data.closed_head;
         loop->data.closed_head = s;
-
-        /* Any socket with prev = context is marked as closed */
-        s->prev = (struct us_socket_t *) context;
+        s->flags.is_closed = 1;
     }
 
     /* We cannot immediately free a listen socket as we can be inside an accept loop */
@@ -388,6 +386,7 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
     s->long_timeout = 255;
     s->flags.low_prio_state = 0;
     s->flags.is_paused = 0;
+    s->flags.is_closed = 0;
     s->flags.is_ipc = 0;
     s->next = 0;
     s->flags.allow_half_open = (options & LIBUS_SOCKET_ALLOW_HALF_OPEN);
@@ -424,6 +423,7 @@ struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_sock
     s->flags.low_prio_state = 0;
     s->flags.allow_half_open = (options & LIBUS_SOCKET_ALLOW_HALF_OPEN);
     s->flags.is_paused = 0;
+    s->flags.is_closed = 0;
     s->flags.is_ipc = 0;
     s->next = 0;
     us_internal_socket_context_link_listen_socket(ssl, context, ls);
@@ -455,6 +455,7 @@ struct us_socket_t* us_socket_context_connect_resolved_dns(struct us_socket_cont
     socket->flags.low_prio_state = 0;
     socket->flags.allow_half_open = (options & LIBUS_SOCKET_ALLOW_HALF_OPEN);
     socket->flags.is_paused = 0;
+    socket->flags.is_closed = 0;
     socket->flags.is_ipc = 0;
     socket->connect_state = NULL;
     socket->connect_next = NULL;
@@ -585,6 +586,7 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         flags->low_prio_state = 0;
         flags->allow_half_open = (c->options & LIBUS_SOCKET_ALLOW_HALF_OPEN);
         flags->is_paused = 0;
+        flags->is_closed = 0;
         flags->is_ipc = 0;
         /* Link it into context so that timeout fires properly */
         us_internal_socket_context_link_socket(0, context, s);
@@ -762,6 +764,7 @@ struct us_socket_t *us_socket_context_connect_unix(int ssl, struct us_socket_con
     connect_socket->flags.low_prio_state = 0;
     connect_socket->flags.allow_half_open = (options & LIBUS_SOCKET_ALLOW_HALF_OPEN);
     connect_socket->flags.is_paused = 0;
+    connect_socket->flags.is_closed = 0;
     connect_socket->flags.is_ipc = 0;
     connect_socket->connect_state = NULL;
     connect_socket->connect_next = NULL;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1857,10 +1857,8 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
     struct us_internal_ssl_socket_context_t *context,
     struct us_internal_ssl_socket_t *s, int ext_size, unsigned int old_ext_size) {
   // todo: this is completely untested
-  int new_ext_size = ext_size;
-  if (ext_size != -1) {
-    new_ext_size = sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + ext_size;
-  }
+  int new_ext_size = sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + (ext_size == -1 ? 0 : ext_size);
+  
   return (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
       0, &context->sc, &s->s,
       new_ext_size, old_ext_size);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1855,7 +1855,7 @@ void us_internal_ssl_socket_shutdown(struct us_internal_ssl_socket_t *s) {
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
     struct us_internal_ssl_socket_context_t *context,
-    struct us_internal_ssl_socket_t *s, int ext_size) {
+    struct us_internal_ssl_socket_t *s, int ext_size, unsigned int old_ext_size) {
   // todo: this is completely untested
   int new_ext_size = ext_size;
   if (ext_size != -1) {
@@ -1863,7 +1863,7 @@ struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
   }
   return (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
       0, &context->sc, &s->s,
-      new_ext_size);
+      new_ext_size, old_ext_size);
 }
 
 struct us_internal_ssl_socket_t *
@@ -2040,7 +2040,7 @@ struct us_socket_t *us_socket_upgrade_to_tls(us_socket_r s, us_socket_context_r 
   struct us_internal_ssl_socket_t *socket =
       (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
           0, new_context, s,
-          (sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t)) + sizeof(void*));
+          (sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t)) + sizeof(void*), sizeof(void*));
   socket->ssl = NULL;
   socket->ssl_write_wants_read = 0;
   socket->ssl_read_wants_write = 0;
@@ -2058,7 +2058,7 @@ struct us_socket_t *us_socket_upgrade_to_tls(us_socket_r s, us_socket_context_r 
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(
     struct us_socket_t *s, struct us_bun_socket_context_options_t options,
-    struct us_socket_events_t events, int socket_ext_size) {
+    struct us_socket_events_t events, int socket_ext_size, unsigned int old_socket_ext_size) {
   /* Cannot wrap a closed socket */
   if (us_socket_is_closed(0, s)) {
     return NULL;
@@ -2164,7 +2164,7 @@ us_socket_context_on_socket_connect_error(
       (struct us_internal_ssl_socket_t *)us_socket_context_adopt_socket(
           0, context, s,
           sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) +
-              socket_ext_size);
+              socket_ext_size, old_socket_ext_size);
   socket->ssl = NULL;
   socket->ssl_write_wants_read = 0;
   socket->ssl_read_wants_write = 0;

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -377,22 +377,25 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
 }
 #endif
 
-struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, unsigned int ext_size) {
+struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, unsigned int ext_size, unsigned int old_ext_size) {
+    if(old_ext_size >= ext_size) {
+        return p;
+    }
+
     int events = us_poll_events(p);
     
-
-    struct us_poll_t *new_p = us_realloc(p, sizeof(struct us_poll_t) + ext_size);
-    if (p != new_p) {
+    struct us_poll_t *new_p = calloc(1, sizeof(struct us_poll_t) + ext_size);
+    memcpy(new_p, p, old_ext_size);
 #ifdef LIBUS_USE_EPOLL
-        /* Hack: forcefully update poll by stripping away already set events */
-        new_p->state.poll_type = us_internal_poll_type(new_p);
-        us_poll_change(new_p, loop, events);
+    /* Hack: forcefully update poll by stripping away already set events */
+    new_p->state.poll_type = us_internal_poll_type(new_p);
+    us_poll_change(new_p, loop, events);
 #else
-        /* Forcefully update poll by resetting them with new_p as user data */
-        kqueue_change(loop->fd, new_p->state.fd, 0, LIBUS_SOCKET_WRITABLE | LIBUS_SOCKET_READABLE, new_p);
-#endif      /* This is needed for epoll also (us_change_poll doesn't update the old poll) */
-        us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
-    }
+    /* Forcefully update poll by resetting them with new_p as user data */
+    kqueue_change(loop->fd, new_p->state.fd, 0, LIBUS_SOCKET_WRITABLE | LIBUS_SOCKET_READABLE, new_p);
+#endif /* This is needed for epoll also (us_change_poll doesn't update the old poll) */
+    us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
+    
 
     return new_p;
 }

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -385,7 +385,7 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, un
     int events = us_poll_events(p);
     
     struct us_poll_t *new_p = calloc(1, sizeof(struct us_poll_t) + ext_size);
-    memcpy(new_p, p, old_ext_size);
+    memcpy(new_p, p, sizeof(struct us_poll_t) + old_ext_size);
 #ifdef LIBUS_USE_EPOLL
     /* Hack: forcefully update poll by stripping away already set events */
     new_p->state.poll_type = us_internal_poll_type(new_p);

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -217,8 +217,11 @@ struct us_poll_t *us_create_poll(struct us_loop_t *loop, int fallthrough,
 /* If we update our block position we have to update the uv_poll data to point
  * to us */
 struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop,
-                                 unsigned int ext_size) {
+                                 unsigned int ext_size, unsigned int old_ext_size) {
 
+  if(old_ext_size >= ext_size) {
+    return p;
+  }
   struct us_poll_t *new_p = realloc(p, sizeof(struct us_poll_t) + ext_size);
   new_p->uv_p->data = new_p;
 

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -222,7 +222,8 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop,
   if(old_ext_size >= ext_size) {
     return p;
   }
-  struct us_poll_t *new_p = realloc(p, sizeof(struct us_poll_t) + ext_size);
+  struct us_poll_t *new_p = calloc(1, sizeof(struct us_poll_t) + ext_size);
+  memcpy(new_p, p, sizeof(struct us_poll_t) + old_ext_size);
   new_p->uv_p->data = new_p;
 
   return new_p;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -170,6 +170,8 @@ struct us_socket_flags {
     unsigned char low_prio_state: 2;
     /* If true, the socket should be read using readmsg to support receiving file descriptors */
     bool is_ipc: 1;
+    /* If true, the socket is closed */
+    bool is_closed: 1;
 
 } __attribute__((packed));
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -435,11 +435,11 @@ void us_internal_ssl_socket_shutdown(us_internal_ssl_socket_r s);
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_adopt_socket(
     us_internal_ssl_socket_context_r context,
-    us_internal_ssl_socket_r s, int ext_size);
+    us_internal_ssl_socket_r s, int ext_size, unsigned int old_ext_size);
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_wrap_with_tls(
     us_socket_r s, struct us_bun_socket_context_options_t options,
-    struct us_socket_events_t events, int socket_ext_size);
+    struct us_socket_events_t events, int socket_ext_size, unsigned int old_socket_ext_size);
 struct us_internal_ssl_socket_context_t *
 us_internal_create_child_ssl_socket_context(
     us_internal_ssl_socket_context_r context, int context_ext_size);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -349,7 +349,7 @@ struct us_loop_t *us_socket_context_loop(int ssl, us_socket_context_r context) n
 
 /* Invalidates passed socket, returning a new resized socket which belongs to a different socket context.
  * Used mainly for "socket upgrades" such as when transitioning from HTTP to WebSocket. */
-struct us_socket_t *us_socket_context_adopt_socket(int ssl, us_socket_context_r context, us_socket_r s, int ext_size);
+struct us_socket_t *us_socket_context_adopt_socket(int ssl, us_socket_context_r context, us_socket_r s, int ext_size, unsigned int old_ext_size);
 
 struct us_socket_t *us_socket_upgrade_to_tls(us_socket_r s, us_socket_context_r new_context, const char *sni);
 
@@ -411,7 +411,7 @@ void *us_poll_ext(us_poll_r p) nonnull_fn_decl;
 LIBUS_SOCKET_DESCRIPTOR us_poll_fd(us_poll_r p) nonnull_fn_decl;
 
 /* Resize an active poll */
-struct us_poll_t *us_poll_resize(us_poll_r p, us_loop_r loop, unsigned int ext_size) nonnull_fn_decl;
+struct us_poll_t *us_poll_resize(us_poll_r p, us_loop_r loop, unsigned int ext_size, unsigned int old_ext_size) nonnull_fn_decl;
 
 /* Public interfaces for sockets */
 
@@ -470,7 +470,7 @@ void us_socket_local_address(int ssl, us_socket_r s, char *nonnull_arg buf, int 
 /* Bun extras */
 struct us_socket_t *us_socket_pair(struct us_socket_context_t *ctx, int socket_ext_size, LIBUS_SOCKET_DESCRIPTOR* fds);
 struct us_socket_t *us_socket_from_fd(struct us_socket_context_t *ctx, int socket_ext_size, LIBUS_SOCKET_DESCRIPTOR fd, int ipc);
-struct us_socket_t *us_socket_wrap_with_tls(int ssl, us_socket_r s, struct us_bun_socket_context_options_t options, struct us_socket_events_t events, int socket_ext_size);
+struct us_socket_t *us_socket_wrap_with_tls(int ssl, us_socket_r s, struct us_bun_socket_context_options_t options, struct us_socket_events_t events, int socket_ext_size, unsigned int old_socket_ext_size);
 int us_socket_raw_write(int ssl, us_socket_r s, const char *data, int length);
 struct us_socket_t* us_socket_open(int ssl, struct us_socket_t * s, int is_client, char* ip, int ip_length);
 int us_raw_root_certs(struct us_cert_string_t**out);

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -194,13 +194,14 @@ void us_internal_handle_low_priority_sockets(struct us_loop_t *loop) {
         loop_data->low_prio_head = s->next;
         if (s->next) s->next->prev = 0;
         s->next = 0;
-        if (us_socket_is_closed(0, s)) {
-            s->flags.low_prio_state = 2;
-            us_socket_context_unref(0, s->context);
-            continue;
-        }
+        // if (us_socket_is_closed(0, s)) {
+        //     s->flags.low_prio_state = 2;
+        //     us_socket_context_unref(0, s->context);
+        //     continue;
+        // }
         us_internal_socket_context_link_socket(0, s->context, s);
-        us_socket_context_unref(0, s->context);
+        //TODO: ssl flag is important when unrefing the context
+        // us_socket_context_unref(0, s->context);
         us_poll_change(&s->p, us_socket_context(0, s)->loop, us_poll_events(&s->p) | LIBUS_SOCKET_READABLE);
 
         s->flags.low_prio_state = 2;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -193,8 +193,13 @@ void us_internal_handle_low_priority_sockets(struct us_loop_t *loop) {
         loop_data->low_prio_head = s->next;
         if (s->next) s->next->prev = 0;
         s->next = 0;
-
+        if (us_socket_is_closed(0, s)) {
+            s->flags.low_prio_state = 2;
+            us_socket_context_unref(0, s->context);
+            continue;
+        }
         us_internal_socket_context_link_socket(0, s->context, s);
+        us_socket_context_unref(0, s->context);
         us_poll_change(&s->p, us_socket_context(0, s)->loop, us_poll_events(&s->p) | LIBUS_SOCKET_READABLE);
 
         s->flags.low_prio_state = 2;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -119,6 +119,7 @@ void us_internal_loop_unlink(struct us_loop_t *loop, struct us_socket_context_t 
             context->next->prev = context->prev;
         }
     }
+    context->next = context->prev = 0;
 }
 
 /* This functions should never run recursively */
@@ -351,6 +352,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         s->flags.low_prio_state = 0;
                         s->flags.allow_half_open = listen_socket->s.flags.allow_half_open;
                         s->flags.is_paused = 0;
+                        s->flags.is_closed = 0;
                         s->flags.is_ipc = 0;
 
                         /* We always use nodelay */

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -476,13 +476,13 @@ int us_connecting_socket_get_error(int ssl, struct us_connecting_socket_t *c) {
     Note: this assumes that the socket is non-TLS and will be adopted and wrapped with a new TLS context
           context ext will not be copied to the new context, new context will contain us_wrapped_socket_context_t on ext
 */
-struct us_socket_t *us_socket_wrap_with_tls(int ssl, struct us_socket_t *s, struct us_bun_socket_context_options_t options, struct us_socket_events_t events, int socket_ext_size) {
+struct us_socket_t *us_socket_wrap_with_tls(int ssl, struct us_socket_t *s, struct us_bun_socket_context_options_t options, struct us_socket_events_t events, int socket_ext_size, unsigned int old_socket_ext_size) {
     // only accepts non-TLS sockets
     if (ssl) {
         return NULL;
     }
 
-    return(struct us_socket_t *) us_internal_ssl_socket_wrap_with_tls(s, options, events, socket_ext_size);
+    return(struct us_socket_t *) us_internal_ssl_socket_wrap_with_tls(s, options, events, socket_ext_size, old_socket_ext_size);
 }
 
 // if a TLS socket calls this, it will start SSL call open event and TLS handshake if required

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -331,7 +331,7 @@ public:
         
 
         /* Adopting a socket invalidates it, do not rely on it directly to carry any data */
-        us_socket_t *usSocket = us_socket_context_adopt_socket(SSL, (us_socket_context_t *) webSocketContext, (us_socket_t *) this, sizeof(WebSocketData) + sizeof(UserData), sizeof(HttpContextData<SSL>));
+        us_socket_t *usSocket = us_socket_context_adopt_socket(SSL, (us_socket_context_t *) webSocketContext, (us_socket_t *) this, sizeof(WebSocketData) + sizeof(UserData), sizeof(HttpResponseData<SSL>));
         WebSocket<SSL, true, UserData> *webSocket = (WebSocket<SSL, true, UserData> *) usSocket;
 
         /* For whatever reason we were corked, update cork to the new socket */

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -331,7 +331,7 @@ public:
         
 
         /* Adopting a socket invalidates it, do not rely on it directly to carry any data */
-        us_socket_t *usSocket = us_socket_context_adopt_socket(SSL, (us_socket_context_t *) webSocketContext, (us_socket_t *) this, sizeof(WebSocketData) + sizeof(UserData));
+        us_socket_t *usSocket = us_socket_context_adopt_socket(SSL, (us_socket_context_t *) webSocketContext, (us_socket_t *) this, sizeof(WebSocketData) + sizeof(UserData), sizeof(HttpContextData<SSL>));
         WebSocket<SSL, true, UserData> *webSocket = (WebSocket<SSL, true, UserData> *) usSocket;
 
         /* For whatever reason we were corked, update cork to the new socket */

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1463,7 +1463,7 @@ pub fn NewSocket(comptime ssl: bool) type {
             // reconfigure context to use the new wrapper handlers
             Socket.unsafeConfigure(this.socket.context().?, true, true, WrappedSocket, TCPHandler);
             const TLSHandler = NewWrappedHandler(true);
-            const new_socket = this.socket.wrapTLS(options, ext_size, true, WrappedSocket, TLSHandler) orelse {
+            const new_socket = this.socket.wrapTLS(options, ext_size, @sizeOf(*anyopaque), true, WrappedSocket, TLSHandler) orelse {
                 const err = BoringSSL.ERR_get_error();
                 defer if (err != 0) BoringSSL.ERR_clear_error();
                 tls.wrapped = .none;

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -192,8 +192,8 @@ pub const SocketContext = opaque {
         c.us_socket_context_remove_server_name(@intFromBool(ssl), this, hostname_pattern);
     }
 
-    pub fn adoptSocket(this: *SocketContext, ssl: bool, s: *us_socket_t, ext_size: i32) ?*us_socket_t {
-        return c.us_socket_context_adopt_socket(@intFromBool(ssl), this, s, ext_size);
+    pub fn adoptSocket(this: *SocketContext, ssl: bool, s: *us_socket_t, ext_size: i32, old_ext_size: u32) ?*us_socket_t {
+        return c.us_socket_context_adopt_socket(@intFromBool(ssl), this, s, ext_size, old_ext_size);
     }
 
     pub fn connect(this: *SocketContext, ssl: bool, host: [*:0]const u8, port: i32, options: i32, socket_ext_size: i32, has_dns_resolved: *i32) ?*anyopaque {
@@ -252,7 +252,7 @@ pub const c = struct {
     pub extern fn us_create_bun_nossl_socket_context(loop: ?*Loop, ext_size: i32) ?*SocketContext;
     pub extern fn us_create_bun_ssl_socket_context(loop: ?*Loop, ext_size: i32, options: SocketContext.BunSocketContextOptions, err: *create_bun_socket_error_t) ?*SocketContext;
     pub extern fn us_create_child_socket_context(ssl: i32, context: ?*SocketContext, context_ext_size: i32) ?*SocketContext;
-    pub extern fn us_socket_context_adopt_socket(ssl: i32, context: *SocketContext, s: *us_socket_t, ext_size: i32) ?*us_socket_t;
+    pub extern fn us_socket_context_adopt_socket(ssl: i32, context: *SocketContext, s: *us_socket_t, ext_size: i32, old_ext_size: u32) ?*us_socket_t;
     pub extern fn us_socket_context_close(ssl: i32, ctx: *anyopaque) void;
     pub extern fn us_socket_context_connect(ssl: i32, context: *SocketContext, host: [*:0]const u8, port: i32, options: i32, socket_ext_size: i32, has_dns_resolved: *i32) ?*anyopaque;
     pub extern fn us_socket_context_connect_unix(ssl: i32, context: *SocketContext, path: [*:0]const u8, pathlen: usize, options: i32, socket_ext_size: i32) ?*us_socket_t;

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -126,6 +126,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             this: ThisSocket,
             options: SocketContext.BunSocketContextOptions,
             socket_ext_size: i32,
+            old_socket_ext_size: u32,
             comptime deref: bool,
             comptime ContextType: type,
             comptime Fields: anytype,
@@ -280,7 +281,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
 
             const this_socket = this.socket.get() orelse return null;
 
-            const socket = c.us_socket_wrap_with_tls(ssl_int, this_socket, options, events, socket_ext_size) orelse return null;
+            const socket = c.us_socket_wrap_with_tls(ssl_int, this_socket, options, events, socket_ext_size, old_socket_ext_size) orelse return null;
             return NewSocketHandler(true).from(socket);
         }
 
@@ -1066,7 +1067,7 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
         ) bool {
             // ext_size of -1 means we want to keep the current ext size
             // in particular, we don't want to allocate a new socket
-            const new_socket = socket_ctx.adoptSocket(comptime is_ssl, socket, -1) orelse return false;
+            const new_socket = socket_ctx.adoptSocket(comptime is_ssl, socket, -1, @sizeOf(*Context)) orelse return false;
             bun.assert(new_socket == socket);
             var adopted = ThisSocket.from(new_socket);
             if (adopted.ext(*anyopaque)) |holder| {
@@ -1326,7 +1327,7 @@ const c = struct {
         on_connect_error_connecting_socket: ?*const fn (*ConnectingSocket, i32) callconv(.c) ?*ConnectingSocket = null,
         on_handshake: ?*const fn (*us_socket_t, i32, uws.us_bun_verify_error_t, ?*anyopaque) callconv(.c) void = null,
     };
-    pub extern fn us_socket_wrap_with_tls(ssl: i32, s: *uws.us_socket_t, options: uws.SocketContext.BunSocketContextOptions, events: c.us_socket_events_t, socket_ext_size: i32) ?*uws.us_socket_t;
+    pub extern fn us_socket_wrap_with_tls(ssl: i32, s: *uws.us_socket_t, options: uws.SocketContext.BunSocketContextOptions, events: c.us_socket_events_t, socket_ext_size: i32, old_socket_ext_size: u32) ?*uws.us_socket_t;
 };
 
 const debug = bun.Output.scoped(.uws, .visible);


### PR DESCRIPTION
### What does this PR do?

1. Low priority queue fix:
- Balance context ref counting 
- Don't add a closed socket to the loop
2. Remove resize
- now we need to inform old ext size and only free the socket after is done with it so the loop can keep accessing the socket and avoid UAF
3. Clear prev/next when unlinking the linked list
- if we unlink and link multiple times the same socket without cleaning the prev/next this may cause to have invalid memory in the linked list, setting it to 0 will avoid that
- Add closed flag to avoid setting the context in prev to detect closed socket

Fixes ENG-21309

### How did you verify your code works?

Confirmed that we always ref the context when unlink the context so we should unref when linking again
Checked the code in loop.c after adopting a context if the pointer change and the same was not returned by ondata or the callbacks the loop would made a unsafe memory access

