### PR TITLE
Add .aikido configuration file to exclude test and scripts directories

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -1,0 +1,4 @@
+exclude:
+  paths:
+    - test
+    - scripts


### PR DESCRIPTION
## Summary

This PR adds an `.aikido` configuration file to exclude the `test/` and `scripts/` directories from Aikido security scanning.

- Excludes approximately 8,000+ files in test and scripts directories
- Prevents Aikido from scanning these directories for secrets, SAST issues, lockfiles, and code quality
- Test files and development scripts don't require security scanning as they're not part of the production codebase
- Follows Aikido's YAML configuration format as documented

## Test plan

- [x] Verify `.aikido` file is properly formatted YAML
- [x] Confirm exclusion paths match existing directory structure
- [ ] Test that Aikido scanning respects the exclusion rules when deployed

🤖 Generated with [Claude Code](https://claude.ai/code)