### PR TITLE
Use system locale for defaultLanguage (#24851)

### DIFF
--- a/src/bun.js/bindings/BunLocale.h
+++ b/src/bun.js/bindings/BunLocale.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+class JSGlobalObject;
+}
+
+namespace Bun {
+
+WTF::String defaultLanguage(JSC::JSGlobalObject*);
+
+} // namespace Bun
+

--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -8,6 +8,7 @@
 #include <JavaScriptCore/SourceProvider.h>
 
 #include "BunClientData.h"
+#include "BunLocale.h"
 #include "NodeVM.h"
 #include "NodeVMScript.h"
 #include "NodeVMModule.h"
@@ -62,10 +63,6 @@
 #include "../vm/SigintWatcher.h"
 
 #include "JavaScriptCore/GetterSetter.h"
-
-namespace Bun {
-WTF::String defaultLanguage(JSC::JSGlobalObject*);
-}
 
 namespace Bun {
 using namespace WebCore;
@@ -760,7 +757,7 @@ const JSC::GlobalObjectMethodTable& NodeVMGlobalObject::globalObjectMethodTable(
         &currentScriptExecutionOwner,
         &scriptExecutionStatus,
         &unsafeEvalNoop, // reportViolationForUnsafeEval
-        &defaultLanguage,
+        &Bun::defaultLanguage,
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
         nullptr,

--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -64,6 +64,10 @@
 #include "JavaScriptCore/GetterSetter.h"
 
 namespace Bun {
+WTF::String defaultLanguage(JSC::JSGlobalObject*);
+}
+
+namespace Bun {
 using namespace WebCore;
 
 static JSInternalPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, JSC::JSValue parameters, const JSC::SourceOrigin& sourceOrigin);
@@ -756,7 +760,7 @@ const JSC::GlobalObjectMethodTable& NodeVMGlobalObject::globalObjectMethodTable(
         &currentScriptExecutionOwner,
         &scriptExecutionStatus,
         &unsafeEvalNoop, // reportViolationForUnsafeEval
-        nullptr, // defaultLanguage
+        &defaultLanguage,
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
         nullptr,

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -59,6 +59,7 @@
 #include "AsyncContextFrame.h"
 #include "BunClientData.h"
 #include "BunIDLConvert.h"
+#include "BunLocale.h"
 #include "BunObject.h"
 #include "GeneratedBunObject.h"
 #include "BunPlugin.h"
@@ -342,7 +343,7 @@ static String localeFromEnvironment()
 {
     static constexpr const char* keys[] = { "LC_ALL", "LC_MESSAGES", "LANG" };
     for (auto* key : keys) {
-        if (const char* value = getenv(key)) {
+        if (const char* value = std::getenv(key)) {
             auto normalized = normalizedLocaleFromCString(value);
             if (!normalized.isEmpty())
                 return normalized;

--- a/test/regression/issue/24851.test.ts
+++ b/test/regression/issue/24851.test.ts
@@ -1,0 +1,24 @@
+import { bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
+
+test("issue 24851: default locale follows environment", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "console.log(new Intl.DateTimeFormat().resolvedOptions().locale);",
+    ],
+    env: { ...bunEnv, LANG: "en_IN.UTF-8", TZ: "UTC" },
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("en-IN");
+  expect(exitCode).toBe(0);
+});
+


### PR DESCRIPTION
## Summary
detect the system’s locale (first from LC_ALL/LANG, otherwise via platform APIs) and pass it to JavaScriptCore’s defaultLanguage hook so Date.toLocaleString() and other Intl APIs respect whatever the OS is configured to use
hook the same logic into NodeVMGlobalObject so sandboxed Node contexts inherit that locale too
add a regression test (test/regression/issue/24851.test.ts) that spawns Bun with LANG=en_IN.UTF-8 and confirms the default formatter becomes en-IN
Fixes #24851.
##Testing
bun bd test test/regression/issue/24851.test.ts (fails locally right now because macOS reports EPERM opening src/node-fallbacks/vendor; rerun once that directory is accessible)