### PR TITLE
chore(docker): use KEY=VALUE format in all `Dockerfile`s

### DIFF
--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -58,7 +58,7 @@ ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 COPY --from=build /usr/local/bin/bun /usr/local/bin/
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN mkdir -p /usr/local/bun-node-fallback-bin && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/node
-ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
+ENV PATH="${PATH}:/usr/local/bun-node-fallback-bin"
 
 # Temporarily use the `build`-stage /tmp folder to access the glibc APKs:
 RUN --mount=type=bind,from=build,source=/tmp,target=/tmp \

--- a/dockerhub/debian-slim/Dockerfile
+++ b/dockerhub/debian-slim/Dockerfile
@@ -69,7 +69,7 @@ ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 COPY docker-entrypoint.sh /usr/local/bin
 COPY --from=build /usr/local/bin/bun /usr/local/bin/bun
 RUN mkdir -p /usr/local/bun-node-fallback-bin && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/node
-ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
+ENV PATH="${PATH}:/usr/local/bun-node-fallback-bin"
 
 RUN groupadd bun \
       --gid 1000 \

--- a/dockerhub/debian/Dockerfile
+++ b/dockerhub/debian/Dockerfile
@@ -61,7 +61,7 @@ FROM debian:bookworm
 COPY docker-entrypoint.sh /usr/local/bin
 COPY --from=build /usr/local/bin/bun /usr/local/bin/bun
 RUN mkdir -p /usr/local/bun-node-fallback-bin && ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/node
-ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
+ENV PATH="${PATH}:/usr/local/bun-node-fallback-bin"
 
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -67,7 +67,7 @@ ARG BUN_INSTALL_BIN=/usr/local/bin
 ENV BUN_INSTALL_BIN=${BUN_INSTALL_BIN}
 
 COPY --from=build /usr/local/bin/bun /usr/local/bin/
-ENV PATH "${PATH}:/usr/local/bun-node-fallback-bin"
+ENV PATH="${PATH}:/usr/local/bun-node-fallback-bin"
 
 # Temporarily use the `build`-stage image binaries to create a symlink:
 RUN --mount=type=bind,from=build,source=/usr/bin,target=/usr/bin \


### PR DESCRIPTION
I noticed a deprecation warning while reviewing CI logs for this which is silenced by using `key=value` format.

Refs: https://github.com/oven-sh/bun/actions/runs/19572928538/job/56050773417#step:7:534