### PR TITLE
test: add security scanner integration tests for minimum-release-age

### DIFF
--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2390,14 +2390,10 @@ export const scanner = {
 
       const receivedPackages = await Bun.file(`${dir}/received-packages.json`).json();
 
-      // With stability checks, should select 1.0.0 (stable) instead of 1.0.1 (unstable)
+      // With stability checks, should select 1.0.0 (stable) instead of unstable versions
       const bugfixPkg = receivedPackages.find((p: { name: string }) => p.name === "bugfix-package");
       expect(bugfixPkg).toBeDefined();
       expect(bugfixPkg.version).toBe("1.0.0");
-      // Should NOT have received any of the newer unstable versions
-      expect(bugfixPkg.version).not.toBe("1.0.1");
-      expect(bugfixPkg.version).not.toBe("1.0.2");
-      expect(bugfixPkg.version).not.toBe("1.0.3");
     });
 
     test("scanner can report advisory on age-filtered package", async () => {


### PR DESCRIPTION
## Summary
- Add tests verifying minimum-release-age filtering works correctly with security scanner
- Scanner receives age-filtered package versions (not blocked newer ones)
- Scanner receives stability-downgraded versions when rapid bugfixes detected
- Excluded packages bypass age filtering but are still scanned

## Test plan
- [x] All 48 tests in `minimum-release-age.test.ts` pass with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)