### PR TITLE
Add `bun bdw` script for Windows development

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "watch-windows": "bun run zig build check-windows --watch -fincremental --prominent-compile-errors --global-cache-dir build/debug/zig-check-cache --zig-lib-dir vendor/zig/lib",
     "bd:v": "(bun run --silent build:debug &> /tmp/bun.debug.build.log || (cat /tmp/bun.debug.build.log && rm -rf /tmp/bun.debug.build.log && exit 1)) && rm -f /tmp/bun.debug.build.log && ./build/debug/bun-debug",
     "bd": "BUN_DEBUG_QUIET_LOGS=1 bun --silent bd:v",
+    "bdw:v": "pwsh -NoProfile -Command '& { $log = Join-Path $env:TEMP bun.build.log; bun run --silent build:debug *> $log; if ($LASTEXITCODE -ne 0) { Get-Content $log; Remove-Item $log -Force; exit 1 }; Remove-Item $log -Force; & .\\build\\debug\\bun-debug $args }'",
+    "bdw": "BUN_DEBUG_QUIET_LOGS=1 bun --silent bdw:v",
     "build:debug": "export COMSPEC=\"C:\\Windows\\System32\\cmd.exe\" && bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -B build/debug --log-level=NOTICE",
     "build:debug:fuzzilli": "export COMSPEC=\"C:\\Windows\\System32\\cmd.exe\" && bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -B build/debug-fuzz  -DENABLE_FUZZILLI=ON --log-level=NOTICE",
     "build:debug:noasan": "export COMSPEC=\"C:\\Windows\\System32\\cmd.exe\" && bun ./scripts/build.mjs -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=OFF -B build/debug --log-level=NOTICE",


### PR DESCRIPTION
## Summary

- Adds `bun bdw` script for Windows development
- Uses PowerShell to properly handle temp file paths and error capture
- Works from any shell (cmd, PowerShell, or Bun's shell)

## Why this matters

The existing `bun bd` script is broken on Windows:

```
$ bun bd --version
bun: No such file or directory: /tmp/bun.debug.build.logcat: C:\tmp/bun.debug.build.log: No such file or directory
error: script "bd" exited with code 1
```

Bun's shell converts POSIX absolute paths like `/tmp/foo` to Windows paths, but produces `C:\tmp/foo` (mixed separators) instead of `C:\tmp\foo`, which Windows cannot open.

This blocks Windows developers from using the standard `bun bd` workflow for building and testing changes.

## Solution

`bun bdw` uses PowerShell directly to:
- Build bun-debug with error capture to `%TEMP%\bun.build.log`
- Display build errors on failure
- Pass arguments through to bun-debug (e.g., `bun bdw --version`)

## Test plan

- [x] Verified `bun bdw --version` works on Windows
- [x] Verified `bun bdw --help` runs bun-debug correctly
- [x] Verified build errors are captured and displayed on failure
- [x] Verified it works when invoked from cmd, PowerShell, and Bun's shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)