### PR TITLE
feat: skip proto methods in console.log output

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5021,6 +5021,10 @@ restart:
             if (!propertyValue)
                 return true;
 
+            // Skip prototype methods (but keep instance properties that are functions)
+            if (objectToUse != object && propertyValue.isCallable())
+                return true;
+
             anyHits = true;
             JSC::EnsureStillAliveScope ensureStillAliveScope(propertyValue);
 
@@ -5141,6 +5145,10 @@ restart:
                     scope.clearException();
                     propertyValue = jsUndefined();
                 }
+
+                // Skip prototype methods (but keep instance properties that are functions)
+                if (iterating != object && propertyValue.isCallable())
+                    continue;
 
                 JSC::EnsureStillAliveScope ensureStillAliveScope(propertyValue);
 

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -138,7 +138,6 @@ NestedClass {
   foo: FooWithProp {
     a: 1,
   },
-  test: [Function: test],
 }
 myCustomName {
   [Symbol(Symbol.toStringTag)]: "myCustomName",
@@ -240,3 +239,6 @@ Hello NaN %j 1
 Hello \5 6,
 Hello %i 5 6
 %d 1
+FooBar {
+  abc: [Function],
+}

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -270,3 +270,18 @@ console.log("Hello %%i %i", 5, 6);
 
 // doesn't go out of bounds when printing
 console.log("%%d", 1);
+
+{
+  class FooBar {
+    constructor() {
+      this.abc = () => {};
+    }
+
+    method() {
+      return 123;
+    }
+  }
+
+  const f = new FooBar();
+  console.log(f);
+}


### PR DESCRIPTION
### What does this PR do?
In the cpp bindings, we exclude if the property comes from the prototype chain (`objectToUse != object` or `iterating != object`) and if it's a callable function.

close #4223

### How did you verify your code works?
Added a test to `console-log.js` with a class containing a proto method and an instance method. The test expects `console.log` of the class instance to output the instance method only. Also fixed a regression in an older test where it outputs a proto method.