### PR TITLE
refactor: dont skip unrecognized long flag in CLI

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -548,7 +548,6 @@ pub const Command = struct {
         }
 
         if (isNode(argv0)) {
-            @import("./deps/zig-clap/clap/streaming.zig").warn_on_unrecognized_flag = false;
             pretend_to_be_node = true;
             return .RunAsNodeCommand;
         }

--- a/src/deps/zig-clap/clap/streaming.zig
+++ b/src/deps/zig-clap/clap/streaming.zig
@@ -1,6 +1,3 @@
-// Disabled because not all CLI arguments are parsed with Clap.
-pub var warn_on_unrecognized_flag = false;
-
 /// The result returned from StreamingClap.next
 pub fn Arg(comptime Id: type) type {
     return struct {
@@ -87,22 +84,7 @@ pub fn StreamingClap(comptime Id: type, comptime ArgIterator: type) type {
                     }
 
                     // unrecognized command
-                    // if flag else arg
-                    if (arg_info.kind == .long or arg_info.kind == .short) {
-                        if (warn_on_unrecognized_flag) {
-                            Output.warn("unrecognized flag: {s}{s}\n", .{ if (arg_info.kind == .long) "--" else "-", name });
-                            Output.flush();
-                        }
-
-                        // continue parsing after unrecognized flag
-                        return parser.next();
-                    }
-
-                    if (warn_on_unrecognized_flag) {
-                        Output.warn("unrecognized argument: {s}\n", .{name});
-                        Output.flush();
-                    }
-                    return null;
+                    return parser.err(arg, .{ .long = name }, error.InvalidArgument);
                 },
                 .short => return try parser.chainging(.{
                     .arg = arg,

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -482,3 +482,29 @@ it("should support --recursive flag", async () => {
   // Should recognize the flag (either process workspaces or show error about missing lockfile)
   expect(out + err).toMatch(/bun update|missing lockfile|nothing to update/);
 });
+
+it("should reject unknown long flags", async () => {
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--exact"],
+    cwd: package_dir,
+    stderr: "pipe",
+    env,
+  });
+
+  const err = await new Response(stderr).text();
+  expect(err).toContain("error");
+  expect(await exited).toBe(1);
+});
+
+it("should reject unknown short capital flags", async () => {
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "-E"],
+    cwd: package_dir,
+    stderr: "pipe",
+    env,
+  });
+
+  const err = await new Response(stderr).text();
+  expect(err).toContain("error");
+  expect(await exited).toBe(1);
+});


### PR DESCRIPTION
### What does this PR do?
Previously, the parser would skip unrecognized long flags. Moving forward, we should output an error message on the first occurrence of an unrecognized flag. This behavior already exists when parsing short flags, and matches behavior from other tools such as `npm`, `yarn`, `cargo`, etc. The `warn_on_unrecognized_flag` variable is also unused after the changes, so I removed it altogether.

Close #7284.

### How did you verify your code works?
Added test cases to `bun-update` where we expect failures when passing in unrecognized long and short flags.