### PR TITLE
Remove node_modules file exclusion in html execution for plain path

### DIFF
--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -104,10 +104,6 @@ yourself with Bun.serve().
         resolved = Bun.resolveSync("./" + arg, cwd);
       }
 
-      if (resolved.includes(path.sep + "node_modules" + path.sep)) {
-        continue;
-      }
-
       args.push(resolved);
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR remove file exclusion in html execution for files with `node_modules` in the path but only for plain paths.

Likely command that don't work actually but will work :
- `bun run ./node_modules/module/index.html`
- `bun run ./index.html` with `CWD=/folder/node_modules/module`

Examples :
| Example | Before | After |
|---|---|---|
| `/folder/node_modules/module/index.html` | Exclude | Include |
| `/folder/*` | Exclude `node_modules` scan | Exclude `node_modules` scan |
| `/folder/**/index.html` | Exclude `node_modules` scan | Exclude `node_modules` scan |

close #24953

### How did you verify your code works?

Compiled bun and test :
- `bun run ./node_modules/module/index.html` (Work)
- `bun run ./index.html` with `CWD=/folder/node_modules/module` (Work)
- `bun run **/index.html` (don't include node_modules)
- `bun run *.html` with `CWD=/folder/node_modules/module` (don't include node_modules)

