### PR TITLE
fix: improve unrecognized arg handling in parser

### DIFF
--- a/src/deps/zig-clap/clap/streaming.zig
+++ b/src/deps/zig-clap/clap/streaming.zig
@@ -87,22 +87,15 @@ pub fn StreamingClap(comptime Id: type, comptime ArgIterator: type) type {
                     }
 
                     // unrecognized command
-                    // if flag else arg
-                    if (arg_info.kind == .long or arg_info.kind == .short) {
-                        if (warn_on_unrecognized_flag) {
-                            Output.warn("unrecognized flag: {s}{s}\n", .{ if (arg_info.kind == .long) "--" else "-", name });
-                            Output.flush();
-                        }
-
-                        // continue parsing after unrecognized flag
-                        return parser.next();
-                    }
-
                     if (warn_on_unrecognized_flag) {
-                        Output.warn("unrecognized argument: {s}\n", .{name});
+                        if (maybe_value) |v| {
+                            Output.warn("unrecognized argument: --{s}={s}\n", .{ name, v });
+                        } else {
+                            Output.warn("unrecognized flag: --{s}\n", .{name});
+                        }
                         Output.flush();
                     }
-                    return null;
+                    return parser.next();
                 },
                 .short => return try parser.chainging(.{
                     .arg = arg,


### PR DESCRIPTION
### What does this PR do?
Parser now distinguishes between unrecognized long args with and without values.

### How did you verify your code works?
Tested the changes to ensure correct warning messages are displayed for various input scenarios.