### PR TITLE
Don't use globalThis.takeException when rejecting Promise values

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1174,7 +1174,7 @@ pub const JSBundler = struct {
         pub fn runOnEndCallbacks(this: *Plugin, globalThis: *jsc.JSGlobalObject, build_promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: bun.JSError!jsc.JSValue) bun.JSError!jsc.JSValue {
             jsc.markBinding(@src());
 
-            const rejection_value = try rejection catch |err| globalThis.takeException(err);
+            const rejection_value = rejection catch |err| globalThis.takeError(err);
 
             var scope: jsc.CatchScope = undefined;
             scope.init(globalThis, @src());

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1171,7 +1171,7 @@ pub const JSBundler = struct {
         extern fn JSBundlerPlugin__tombstone(*Plugin) void;
         extern fn JSBundlerPlugin__runOnEndCallbacks(*Plugin, jsc.JSValue, jsc.JSValue, jsc.JSValue) jsc.JSValue;
 
-        pub fn runOnEndCallbacks(this: *Plugin, globalThis: *jsc.JSGlobalObject, build_promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: jsc.JSValue) JSError!jsc.JSValue {
+        pub fn runOnEndCallbacks(this: *Plugin, globalThis: *jsc.JSGlobalObject, build_promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: bun.JSError!jsc.JSValue) bun.JSError!jsc.JSValue {
             jsc.markBinding(@src());
 
             var scope: jsc.CatchScope = undefined;
@@ -1182,7 +1182,7 @@ pub const JSBundler = struct {
                 this,
                 build_promise.asValue(globalThis),
                 build_result,
-                rejection,
+                rejection catch |err| globalThis.takeException(err),
             );
 
             try scope.returnIfException();

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1174,7 +1174,11 @@ pub const JSBundler = struct {
         pub fn runOnEndCallbacks(this: *Plugin, globalThis: *jsc.JSGlobalObject, build_promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: bun.JSError!jsc.JSValue) bun.JSError!jsc.JSValue {
             jsc.markBinding(@src());
 
-            const rejection_value = rejection catch |err| globalThis.takeError(err);
+            const rejection_value = rejection catch |err| switch (err) {
+                error.OutOfMemory => globalThis.createOutOfMemoryError(),
+                error.JSError => globalThis.takeError(err),
+                error.JSTerminated => return error.JSTerminated,
+            };
 
             var scope: jsc.CatchScope = undefined;
             scope.init(globalThis, @src());

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1174,6 +1174,8 @@ pub const JSBundler = struct {
         pub fn runOnEndCallbacks(this: *Plugin, globalThis: *jsc.JSGlobalObject, build_promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: bun.JSError!jsc.JSValue) bun.JSError!jsc.JSValue {
             jsc.markBinding(@src());
 
+            const rejection_value = try rejection catch |err| globalThis.takeException(err);
+
             var scope: jsc.CatchScope = undefined;
             scope.init(globalThis, @src());
             defer scope.deinit();
@@ -1182,7 +1184,7 @@ pub const JSBundler = struct {
                 this,
                 build_promise.asValue(globalThis),
                 build_result,
-                rejection catch |err| globalThis.takeException(err),
+                rejection_value,
             );
 
             try scope.returnIfException();

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2069,7 +2069,7 @@ pub const BundleV2 = struct {
         }
 
         /// Returns true if the promises were handled and resolved from BundlePlugin.ts, returns false if the caller should imediately resolve
-        fn runOnEndCallbacks(globalThis: *jsc.JSGlobalObject, plugin: *bun.jsc.API.JSBundler.Plugin, promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: jsc.JSValue) bun.JSError!bool {
+        fn runOnEndCallbacks(globalThis: *jsc.JSGlobalObject, plugin: *bun.jsc.API.JSBundler.Plugin, promise: *jsc.JSPromise, build_result: jsc.JSValue, rejection: bun.JSError!jsc.JSValue) bun.JSError!bool {
             const value = try plugin.runOnEndCallbacks(globalThis, promise, build_result, rejection);
             return value != .js_undefined;
         }
@@ -2094,22 +2094,20 @@ pub const BundleV2 = struct {
 
             const didHandleCallbacks = if (this.plugins) |plugin| blk: {
                 if (throw_on_error) {
-                    const aggregate_error = this.log.toJSAggregateError(globalThis, bun.String.static("Bundle failed")) catch |e| globalThis.takeException(e);
+                    const aggregate_error = this.log.toJSAggregateError(globalThis, bun.String.static("Bundle failed"));
                     break :blk runOnEndCallbacks(globalThis, plugin, promise, build_result, aggregate_error) catch |err| {
-                        const exception = globalThis.takeException(err);
-                        return promise.reject(globalThis, exception);
+                        return promise.reject(globalThis, err);
                     };
                 } else {
                     break :blk runOnEndCallbacks(globalThis, plugin, promise, build_result, .js_undefined) catch |err| {
-                        const exception = globalThis.takeException(err);
-                        return promise.reject(globalThis, exception);
+                        return promise.reject(globalThis, err);
                     };
                 }
             } else false;
 
             if (!didHandleCallbacks) {
                 if (throw_on_error) {
-                    const aggregate_error = this.log.toJSAggregateError(globalThis, bun.String.static("Bundle failed")) catch |e| globalThis.takeException(e);
+                    const aggregate_error = this.log.toJSAggregateError(globalThis, bun.String.static("Bundle failed"));
                     return promise.reject(globalThis, aggregate_error);
                 } else {
                     return promise.resolve(globalThis, build_result);
@@ -2214,8 +2212,7 @@ pub const BundleV2 = struct {
                     );
 
                     const didHandleCallbacks = if (this.plugins) |plugin| runOnEndCallbacks(globalThis, plugin, promise, build_output, .js_undefined) catch |err| {
-                        const exception = globalThis.takeException(err);
-                        return promise.reject(globalThis, exception);
+                        return promise.reject(globalThis, err);
                     } else false;
 
                     if (!didHandleCallbacks) {


### PR DESCRIPTION
### What does this PR do?

We can't use globalThis.takeException() because it throws out of memory error when we instead need to take the exception.

### How did you verify your code works?
