### PR TITLE
fix: use >= instead of > for String.max_length() check

### DIFF
--- a/src/string.zig
+++ b/src/string.zig
@@ -420,7 +420,7 @@ pub const String = extern struct {
         comptime if (@typeInfo(Ctx) != .pointer) @compileError("context must be a pointer");
         bun.assert(bytes.len > 0);
         jsc.markBinding(@src());
-        if (bytes.len > max_length()) {
+        if (bytes.len >= max_length()) {
             if (callback) |cb| {
                 cb(ctx, @ptrCast(@constCast(bytes.ptr)), @truncate(bytes.len));
             }
@@ -460,7 +460,7 @@ pub const String = extern struct {
         jsc.markBinding(@src());
         bun.assert(bytes.len > 0);
 
-        if (bytes.len > max_length()) {
+        if (bytes.len >= max_length()) {
             bun.default_allocator.free(bytes);
             return dead;
         }


### PR DESCRIPTION
## Summary

- Fixed boundary check in `String.zig` to use `>=` instead of `>` for `max_length()` comparisons
- Strings fail when the length is exactly equal to `max_length()`, not just when exceeding it
- This affects both `createExternal` and `createExternalGloballyAllocated` functions

## Test plan

- Existing tests should continue to pass
- Strings with length exactly equal to `max_length()` will now be properly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)