### PR TITLE
fix(windows): close handles immediately on shutdown notification to p…

### DIFF
--- a/src/watcher/WindowsWatcher.zig
+++ b/src/watcher/WindowsWatcher.zig
@@ -196,7 +196,7 @@ pub fn next(this: *WindowsWatcher, timeout: Timeout) bun.sys.Maybe(?EventIterato
 
 /// Close handles if they haven't been closed already.
 /// This function is idempotent and safe to call multiple times.
-/// 
+///
 /// When a shutdown notification is received from the IOCP, we need to close
 /// handles immediately to prevent resource leaks. This function ensures handles
 /// are properly closed and marked as invalid to prevent double-close errors.


### PR DESCRIPTION
prevent resource leak

When a shutdown notification is received from the IOCP (nbytes == 0), the Windows watcher was not closing handles immediately, leading to resource leaks. This fix:

- Adds handle tracking with handles_closed flag
- Implements idempotent closeHandles() function
- Closes handles immediately when shutdown notification is received
- Makes stop() function use the idempotent cleanup
- Prevents double-close errors by marking handles as INVALID_HANDLE_VALUE

This ensures proper resource cleanup and prevents handle leaks on Windows.
