### PR TITLE
fix(workspaces): treat leading slashes as relative paths for npm compatibility

### DIFF
--- a/src/cli/filter_arg.zig
+++ b/src/cli/filter_arg.zig
@@ -69,10 +69,12 @@ pub fn getCandidatePackagePatterns(allocator: std.mem.Allocator, log: *bun.logge
         for (json_array.slice()) |expr| {
             switch (expr.data) {
                 .e_string => |pattern_expr| {
-                    const size = pattern_expr.data.len + "/package.json".len;
+                    // Strip leading slashes to treat workspace patterns as relative paths (npm compatibility)
+                    const workspace_pattern = strings.withoutLeadingSlash(pattern_expr.data);
+                    const size = workspace_pattern.len + "/package.json".len;
                     var pattern = try allocator.alloc(u8, size);
-                    @memcpy(pattern[0..pattern_expr.data.len], pattern_expr.data);
-                    @memcpy(pattern[pattern_expr.data.len..size], "/package.json");
+                    @memcpy(pattern[0..workspace_pattern.len], workspace_pattern);
+                    @memcpy(pattern[workspace_pattern.len..size], "/package.json");
 
                     try out_patterns.append(pattern);
                 },

--- a/src/install/lockfile/Package/WorkspaceMap.zig
+++ b/src/install/lockfile/Package/WorkspaceMap.zig
@@ -118,7 +118,7 @@ pub fn processNamesArray(
 
     for (arr.slice()) |item| {
         // TODO: when does this get deallocated?
-        const input_path = try item.asStringZ(allocator) orelse {
+        const input_path_raw = try item.asStringZ(allocator) orelse {
             log.addErrorFmt(source, item.loc, allocator,
                 \\Workspaces expects an array of strings, like:
                 \\  <r><green>"workspaces"<r>: [
@@ -127,6 +127,9 @@ pub fn processNamesArray(
             , .{}) catch {};
             return error.InvalidPackageJSON;
         };
+
+        // Strip leading slashes to treat workspace patterns as relative paths (npm compatibility)
+        const input_path = strings.withoutLeadingSlash(input_path_raw);
 
         if (input_path.len == 0 or input_path.len == 1 and input_path[0] == '.' or strings.eqlComptime(input_path, "./") or strings.eqlComptime(input_path, ".\\")) continue;
 

--- a/test/cli/install/workspace-leading-slash.test.ts
+++ b/test/cli/install/workspace-leading-slash.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun install works with leading slash in workspace pattern", async () => {
+  using dir = tempDir("ws-leading-slash", {
+    "packages/foo/package.json": JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+    }),
+    "package.json": JSON.stringify({
+      name: "leading-slash-test",
+      private: true,
+      workspaces: ["/packages/*"],
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});
+
+test("bun run --filter works with leading slash in workspace pattern", async () => {
+  using dir = tempDir("ws-leading-slash-filter", {
+    "packages/bar/package.json": JSON.stringify({
+      name: "bar",
+      version: "1.0.0",
+      scripts: {
+        build: "echo building bar",
+      },
+    }),
+    "package.json": JSON.stringify({
+      name: "leading-slash-filter-test",
+      private: true,
+      workspaces: ["/packages/*"],
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--filter", "*", "build"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("ENOENT");
+  expect(stdout).toContain("building bar");
+  expect(exitCode).toBe(0);
+});
+
+test("bun install works with multiple leading slashes in workspace pattern", async () => {
+  using dir = tempDir("ws-multi-slash", {
+    "packages/baz/package.json": JSON.stringify({
+      name: "baz",
+      version: "1.0.0",
+    }),
+    "package.json": JSON.stringify({
+      name: "multi-slash-test",
+      private: true,
+      workspaces: ["///packages/*"],
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});
+
+test("normal workspace patterns still work (regression check)", async () => {
+  using dir = tempDir("ws-normal", {
+    "packages/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      version: "1.0.0",
+      scripts: {
+        test: "echo testing pkg",
+      },
+    }),
+    "package.json": JSON.stringify({
+      name: "normal-test",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+  });
+
+  // Test install
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const installExitCode = await installProc.exited;
+  expect(installExitCode).toBe(0);
+
+  // Test filter
+  await using filterProc = Bun.spawn({
+    cmd: [bunExe(), "run", "--filter", "*", "test"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [filterStdout, filterStderr, filterExitCode] = await Promise.all([
+    new Response(filterProc.stdout).text(),
+    new Response(filterProc.stderr).text(),
+    filterProc.exited,
+  ]);
+
+  expect(filterStderr).not.toContain("ENOENT");
+  expect(filterStdout).toContain("testing pkg");
+  expect(filterExitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes workspace patterns with leading slashes (e.g., `"/packages/*"`) that were causing ENOENT errors
- npm treats these as relative to the workspace root, but bun was treating them as absolute filesystem paths
- Strips leading slashes from workspace patterns in both `bun install` and `bun run --filter`

## Test plan

- [x] Added test in `test/cli/install/workspace-leading-slash.test.ts`
- [x] Test passes with `bun bd test test/cli/install/workspace-leading-slash.test.ts`
- [x] Test fails with `USE_SYSTEM_BUN=1 bun test test/cli/install/workspace-leading-slash.test.ts`
- [x] Verified npm accepts leading slashes and treats them as relative

🤖 Generated with [Claude Code](https://claude.com/claude-code)