### PR TITLE
fix(Bun.write): ensure synchronous write ordering on Windows

### DIFF
--- a/test/regression/issue/11117.test.ts
+++ b/test/regression/issue/11117.test.ts
@@ -20,11 +20,7 @@ test("Bun.write to stdout maintains write order", async () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(stdout).toBe(testString);
@@ -48,11 +44,7 @@ test("Bun.write to stderr maintains write order", async () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("");
     expect(stderr).toBe(testString);

--- a/test/regression/issue/11117.test.ts
+++ b/test/regression/issue/11117.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/11117
+// On Windows, Bun.write() to stdout in a loop would produce scrambled output
+// because async writes were not serialized properly.
+test("Bun.write to stdout maintains write order", async () => {
+  const testString = "This is a test\n";
+
+  // Run the test multiple times to catch any race conditions
+  for (let run = 0; run < 10; run++) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const test = (s) => { const l = s.length; for (let i = 0; i < l; i++) { Bun.write(Bun.stdout, s[i]); } }; test(${JSON.stringify(testString)});`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe(testString);
+    expect(exitCode).toBe(0);
+  }
+});
+
+test("Bun.write to stderr maintains write order", async () => {
+  const testString = "Error message test\n";
+
+  // Run the test multiple times to catch any race conditions
+  for (let run = 0; run < 10; run++) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const test = (s) => { const l = s.length; for (let i = 0; i < l; i++) { Bun.write(Bun.stderr, s[i]); } }; test(${JSON.stringify(testString)});`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toBe(testString);
+    expect(exitCode).toBe(0);
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #11117

On Windows, when `Bun.write(Bun.stdout, s[i])` was called multiple times in a loop, the output was scrambled/out-of-order about 15% of the time.

**Repro:**
```ts
const test = (s: string) => {
  const l = s.length;
  for (let i = 0; i < l; i++) {
    Bun.write(Bun.stdout, s[i]);
  }
};
test('This is a test\n');
```

**Expected:** `This is a test`
**Actual (before fix):** `Thisi s a test`, `T is a test\nshi`, etc.

## Root Cause

Each call went through the async `WriteFileWindows` path which used `uv_fs_write` asynchronously via libuv. Multiple async operations issued in quick succession could complete out of order.

## Solution

Enable the synchronous fast path for file descriptor-based writes (like stdout/stderr) on Windows, while still using the async path for path-based writes that need mkdirp support. On Windows, `bun.sys.write()` uses `kernel32.WriteFile()` which is synchronous, guaranteeing write order.

## Test Plan

- [x] Added regression test `test/regression/issue/11117.test.ts`
- [x] Test fails with system bun (v1.3.3): 2 failures, scrambled output
- [x] Test passes with fix: 2 pass, correct output
- [x] Manual verification: ran repro 20 times, all correct with fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)