### PR TITLE
fix(install): use >= instead of > for resolution bounds check

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -481,7 +481,7 @@ fn preprocessUpdateRequests(old: *Lockfile, manager: *PackageManager, updates: [
                 if (update.package_id == invalid_package_id) {
                     for (root_deps, old_resolutions) |dep, old_resolution| {
                         if (dep.name_hash == String.Builder.stringHash(update.name)) {
-                            if (old_resolution > old.packages.len) continue;
+                            if (old_resolution >= old.packages.len) continue;
                             const res = resolutions_of_yore[old_resolution];
                             if (res.tag != .npm or update.version.tag != .dist_tag) continue;
 
@@ -519,7 +519,7 @@ fn preprocessUpdateRequests(old: *Lockfile, manager: *PackageManager, updates: [
                 if (update.package_id == invalid_package_id) {
                     for (root_deps, old_resolutions) |*dep, old_resolution| {
                         if (dep.name_hash == String.Builder.stringHash(update.name)) {
-                            if (old_resolution > old.packages.len) continue;
+                            if (old_resolution >= old.packages.len) continue;
                             const res = resolutions_of_yore[old_resolution];
                             if (res.tag != .npm or update.version.tag != .dist_tag) continue;
 


### PR DESCRIPTION
## Summary

- Fix off-by-one error in `preprocessUpdateRequests` where the bounds check used `>` instead of `>=` when validating package IDs from the resolution buffer
- When `old_resolution == packages.len`, the check `> packages.len` passes but `resolutions_of_yore[old_resolution]` is out of bounds since valid indices are `0` to `packages.len-1`
- This causes an internal assertion failure during `bun install` with update requests

## The Bug

```zig
// BEFORE (buggy) - at lockfile.zig:484 and :522
if (old_resolution > old.packages.len) continue;
const res = resolutions_of_yore[old_resolution];  // OOB when old_resolution == packages.len

// AFTER (fixed)
if (old_resolution >= old.packages.len) continue;
const res = resolutions_of_yore[old_resolution];  // Now safe
```

## Crash Report

From [bun.report](https://bun.report/1.3.3/wi1274e01cAggkggB+rt/F+pvBiw3rDqul/Doyi4Emzi5Ewj44FuvbgjMog00yDCYKERNEL32.DLLut0LCSntdll.dll4zijBA0eNrzzCtJLcpLzFFILC5OLSrJzM9TSEvMzCktSgUAiSkKPg/view):

```
panic: Internal assertion failure
- lockfile.zig:523: preprocessUpdateRequests
- install_with_manager.zig:605: installWithManager
- updatePackageJSONAndInstall.zig:340
Features: extracted_packages, text_lockfile
```

## Test plan

- [x] `bun run zig:check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)