### PR TITLE
fix: Windows UNC path validation in dirInfoCachedMaybeLog

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2662,7 +2662,8 @@ pub const Resolver = struct {
                     return null;
                 // Look for a second slash after the first one to ensure there's a share name
                 // We need +1 to skip past the first slash itself
-                _ = bun.strings.indexOfChar(input_path[2 + first_slash + 1 ..], '\\') orelse
+                const offset = 2 + first_slash + 1;
+                if (offset >= input_path.len or !bun.strings.containsChar(input_path[offset..], '\\'))
                     return null;
             }
         }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2655,10 +2655,14 @@ pub const Resolver = struct {
 
             // Filter out \\hello\, a UNC server path but without a share.
             // When there isn't a share name, such path is not considered to exist.
+            // Valid UNC paths have the format: \\server\share\...
             if (bun.strings.hasPrefixComptime(input_path, "\\\\")) {
+                // Find the first slash after \\, which separates server from share
                 const first_slash = bun.strings.indexOfChar(input_path[2..], '\\') orelse
                     return null;
-                _ = bun.strings.indexOfChar(input_path[2 + first_slash ..], '\\') orelse
+                // Look for a second slash after the first one to ensure there's a share name
+                // We need +1 to skip past the first slash itself
+                _ = bun.strings.indexOfChar(input_path[2 + first_slash + 1 ..], '\\') orelse
                     return null;
             }
         }

--- a/test/js/bun/resolve/windows-unc-path.test.ts
+++ b/test/js/bun/resolve/windows-unc-path.test.ts
@@ -22,6 +22,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stdout: "pipe",
         stderr: "pipe",
       });
 
@@ -53,6 +54,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stdout: "pipe",
         stderr: "pipe",
       });
 
@@ -83,6 +85,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stdout: "pipe",
         stderr: "pipe",
       });
 
@@ -110,6 +113,7 @@ if (isWindows) {
         cmd: [bunExe(), "test", "test.test.js"],
         env: bunEnv,
         cwd: String(dir),
+        stdout: "pipe",
         stderr: "pipe",
       });
 
@@ -135,6 +139,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stdout: "pipe",
         stderr: "pipe",
       });
 

--- a/test/js/bun/resolve/windows-unc-path.test.ts
+++ b/test/js/bun/resolve/windows-unc-path.test.ts
@@ -11,9 +11,9 @@ if (isWindows) {
       // Create a temporary directory to work with
       using dir = tempDir("unc-test", {
         "package.json": JSON.stringify({ name: "test", type: "module" }),
-        "index.js": `
+        "index.js": String.raw`
           // This test verifies that UNC paths with proper server and share work
-          const result = Bun.resolveSync("./foo.js", "\\\\\\\\server\\\\share\\\\path\\\\to\\\\file.js");
+          const result = Bun.resolveSync("./foo.js", "\\\\server\\share\\path\\to\\file.js");
           console.log("SUCCESS: resolved", result);
         `,
       });
@@ -25,21 +25,21 @@ if (isWindows) {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [_, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // The test should not crash with an assertion failure
-      expect(stderr).not.toContain("panic");
-      expect(stderr).not.toContain("Internal assertion failure");
+      // Verify the process completed successfully without errors
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
     });
 
     test("Bun.resolve should handle UNC paths without share gracefully", async () => {
       // Create a temporary directory to work with
       using dir = tempDir("unc-test-no-share", {
         "package.json": JSON.stringify({ name: "test", type: "module" }),
-        "index.js": `
+        "index.js": String.raw`
           // This test verifies that incomplete UNC paths (server without share) are handled gracefully
           try {
-            const result = Bun.resolveSync("./foo.js", "\\\\\\\\server\\\\");
+            const result = Bun.resolveSync("./foo.js", "\\\\server\\");
             console.log("Resolved:", result);
           } catch (error) {
             // It's okay to throw an error, but should not panic
@@ -55,21 +55,20 @@ if (isWindows) {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [_, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // The test should not crash with an assertion failure
-      expect(stderr).not.toContain("panic");
-      expect(stderr).not.toContain("Internal assertion failure");
+      // Verify the process completed successfully
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
 
     test("Bun.resolve should handle UNC server without trailing slash", async () => {
       using dir = tempDir("unc-test-no-trailing", {
         "package.json": JSON.stringify({ name: "test", type: "module" }),
-        "index.js": `
+        "index.js": String.raw`
           // Test UNC path with just server name (no trailing slash)
           try {
-            const result = Bun.resolveSync("./foo.js", "\\\\\\\\server");
+            const result = Bun.resolveSync("./foo.js", "\\\\server");
             console.log("Resolved:", result);
           } catch (error) {
             // It's okay to throw an error, but should not panic
@@ -85,11 +84,10 @@ if (isWindows) {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [_, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // The test should not crash with an assertion failure
-      expect(stderr).not.toContain("panic");
-      expect(stderr).not.toContain("Internal assertion failure");
+      // Verify the process completed successfully
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
 
@@ -114,9 +112,10 @@ if (isWindows) {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Should not crash with panic
-      expect(stderr).not.toContain("panic");
-      expect(stderr).not.toContain("Internal assertion failure");
+      // Verify the test suite passed
+      expect(stdout).toContain("1 pass");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
     });
 
     test("drive letter paths should still work correctly", async () => {
@@ -139,6 +138,7 @@ if (isWindows) {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stdout).toContain("foo = 42");
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
   });

--- a/test/js/bun/resolve/windows-unc-path.test.ts
+++ b/test/js/bun/resolve/windows-unc-path.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import path from "path";
+
+// Tests for Windows UNC path handling in resolver
+// Related to issues #17233 and #25000
+
+if (isWindows) {
+  describe("Windows UNC path handling", () => {
+    test("Bun.resolve should handle UNC paths with server and share", async () => {
+      // Create a temporary directory to work with
+      using dir = tempDir("unc-test", {
+        "package.json": JSON.stringify({ name: "test", type: "module" }),
+        "index.js": `
+          // This test verifies that UNC paths with proper server and share work
+          const result = Bun.resolveSync("./foo.js", "\\\\\\\\server\\\\share\\\\path\\\\to\\\\file.js");
+          console.log("SUCCESS: resolved", result);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(String(dir), "index.js")],
+        env: bunEnv,
+        cwd: String(dir),
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The test should not crash with an assertion failure
+      expect(stderr).not.toContain("panic");
+      expect(stderr).not.toContain("Internal assertion failure");
+    });
+
+    test("Bun.resolve should handle UNC paths without share gracefully", async () => {
+      // Create a temporary directory to work with
+      using dir = tempDir("unc-test-no-share", {
+        "package.json": JSON.stringify({ name: "test", type: "module" }),
+        "index.js": `
+          // This test verifies that incomplete UNC paths (server without share) are handled gracefully
+          try {
+            const result = Bun.resolveSync("./foo.js", "\\\\\\\\server\\\\");
+            console.log("Resolved:", result);
+          } catch (error) {
+            // It's okay to throw an error, but should not panic
+            console.log("Error (expected):", error.message);
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(String(dir), "index.js")],
+        env: bunEnv,
+        cwd: String(dir),
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The test should not crash with an assertion failure
+      expect(stderr).not.toContain("panic");
+      expect(stderr).not.toContain("Internal assertion failure");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.resolve should handle UNC server without trailing slash", async () => {
+      using dir = tempDir("unc-test-no-trailing", {
+        "package.json": JSON.stringify({ name: "test", type: "module" }),
+        "index.js": `
+          // Test UNC path with just server name (no trailing slash)
+          try {
+            const result = Bun.resolveSync("./foo.js", "\\\\\\\\server");
+            console.log("Resolved:", result);
+          } catch (error) {
+            // It's okay to throw an error, but should not panic
+            console.log("Error (expected):", error.message);
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(String(dir), "index.js")],
+        env: bunEnv,
+        cwd: String(dir),
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The test should not crash with an assertion failure
+      expect(stderr).not.toContain("panic");
+      expect(stderr).not.toContain("Internal assertion failure");
+      expect(exitCode).toBe(0);
+    });
+
+    test("module loader should not crash on Windows with UNC-like paths", async () => {
+      using dir = tempDir("unc-module-loader", {
+        "package.json": JSON.stringify({ name: "test", type: "module" }),
+        "test.test.js": `
+          import { test, expect } from "bun:test";
+
+          test("dummy test", () => {
+            expect(1).toBe(1);
+          });
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "test.test.js"],
+        env: bunEnv,
+        cwd: String(dir),
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // Should not crash with panic
+      expect(stderr).not.toContain("panic");
+      expect(stderr).not.toContain("Internal assertion failure");
+    });
+
+    test("drive letter paths should still work correctly", async () => {
+      using dir = tempDir("drive-letter-test", {
+        "package.json": JSON.stringify({ name: "test", type: "module" }),
+        "foo.js": `export const foo = 42;`,
+        "index.js": `
+          import { foo } from "./foo.js";
+          console.log("foo =", foo);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(String(dir), "index.js")],
+        env: bunEnv,
+        cwd: String(dir),
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("foo = 42");
+      expect(exitCode).toBe(0);
+    });
+  });
+} else {
+  test.skip("Windows UNC path tests only run on Windows", () => {});
+}

--- a/test/js/bun/resolve/windows-unc-path.test.ts
+++ b/test/js/bun/resolve/windows-unc-path.test.ts
@@ -25,9 +25,10 @@ if (isWindows) {
         stderr: "pipe",
       });
 
-      const [_, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Verify the process completed successfully without errors
+      // Verify the resolve succeeded
+      expect(stdout).toContain("SUCCESS: resolved");
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
@@ -55,9 +56,10 @@ if (isWindows) {
         stderr: "pipe",
       });
 
-      const [_, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Verify the process completed successfully
+      // Verify the error was caught (not a crash)
+      expect(stdout).toContain("Error (expected):");
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
@@ -84,9 +86,10 @@ if (isWindows) {
         stderr: "pipe",
       });
 
-      const [_, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Verify the process completed successfully
+      // Verify the error was caught (not a crash)
+      expect(stdout).toContain("Error (expected):");
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });

--- a/test/js/bun/resolve/windows-unc-path.test.ts
+++ b/test/js/bun/resolve/windows-unc-path.test.ts
@@ -22,6 +22,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stderr: "pipe",
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -51,6 +52,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stderr: "pipe",
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -80,6 +82,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stderr: "pipe",
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -106,6 +109,7 @@ if (isWindows) {
         cmd: [bunExe(), "test", "test.test.js"],
         env: bunEnv,
         cwd: String(dir),
+        stderr: "pipe",
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -129,6 +133,7 @@ if (isWindows) {
         cmd: [bunExe(), path.join(String(dir), "index.js")],
         env: bunEnv,
         cwd: String(dir),
+        stderr: "pipe",
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);


### PR DESCRIPTION
## Summary

Fixed a bug in `dirInfoCachedMaybeLog` where Windows UNC paths like `\\server\` (server without share) were incorrectly accepted as valid, causing assertion failures later in the resolver.

## The Bug

The UNC path validation code was searching for a second slash starting from the first slash itself, rather than after it:

```zig
// Before (buggy):
const first_slash = bun.strings.indexOfChar(input_path[2..], '\\') orelse return null;
_ = bun.strings.indexOfChar(input_path[2 + first_slash ..], '\\') orelse return null;
```

For a path like `\\server\`:
1. `first_slash` = 6 (position of `\` in "server\")
2. `input_path[2 + first_slash ..]` = `input_path[8..]` = `\`
3. Searching for `\` in `\` finds it at index 0 (the slash itself!)
4. Path incorrectly passes validation ❌

## The Fix

Added `+1` offset to search after the first slash:

```zig
// After (fixed):
const first_slash = bun.strings.indexOfChar(input_path[2..], '\\') orelse return null;
_ = bun.strings.indexOfChar(input_path[2 + first_slash + 1 ..], '\\') orelse return null;
```

Now for `\\server\`:
1. `first_slash` = 6
2. `input_path[2 + first_slash + 1 ..]` = `input_path[9..]` = `` (empty)
3. Searching for `\` in empty string returns null
4. Path correctly fails validation ✅

## Changes

- Fixed the index calculation in UNC path validation
- Added clarifying comments explaining the logic
- Added comprehensive tests for Windows UNC path handling (skipped on non-Windows)

## Testing

Added tests in `test/js/bun/resolve/windows-unc-path.test.ts` that verify:
- Valid UNC paths (`\\server\share\path`) work correctly
- Invalid UNC paths (`\\server\`) are rejected gracefully without panicking
- Drive letter paths continue to work
- Module loader doesn't crash on edge cases

These tests will run on Windows CI to verify the fix works correctly.

## Related Issues

Fixes #17233
Fixes #25000

🤖 Generated with [Claude Code](https://claude.com/claude-code)