### PR TITLE
Add analytics tracking for HTTP client proxy usage

### DIFF
--- a/src/analytics.zig
+++ b/src/analytics.zig
@@ -51,6 +51,7 @@ pub const Features = struct {
     pub var tls_server: usize = 0;
     pub var http_server: usize = 0;
     pub var https_server: usize = 0;
+    pub var http_client_proxy: usize = 0;
     /// Set right before JSC::initialize is called
     pub var jsc: usize = 0;
     /// Set when bake.DevServer is initialized

--- a/src/http/ProxyTunnel.zig
+++ b/src/http/ProxyTunnel.zig
@@ -19,6 +19,7 @@ const ProxyTunnelWrapper = SSLWrapper(*HTTPClient);
 
 fn onOpen(this: *HTTPClient) void {
     log("ProxyTunnel onOpen", .{});
+    bun.analytics.Features.http_client_proxy += 1;
     this.state.response_stage = .proxy_handshake;
     this.state.request_stage = .proxy_handshake;
     if (this.proxy_tunnel) |proxy| {


### PR DESCRIPTION
## Summary
- Added `http_client_proxy` counter to `analytics.Features` struct
- Incremented counter in `ProxyTunnel.onOpen()` when proxy tunnel connection opens successfully

This allows tracking HTTP client proxy usage in analytics/crash reports alongside other features like `fetch`, `WebSocket`, `http_server`, etc.

## Test plan
- [x] Build completes successfully (`bun bd`)
- [x] Existing proxy tests pass (`bun bd test test/js/bun/http/proxy.test.ts`)
- [x] Counter is properly integrated into the analytics framework

🤖 Generated with [Claude Code](https://claude.com/claude-code)