### PR TITLE
feat(bundler): support optional chaining and import.meta.env in env:inline

### DIFF
--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -116,5 +116,109 @@ for (let backend of ["api", "cli"] as const) {
           stdout: "process.env.BASE_URL\n$BASE_URL",
         },
       });
+
+    // Test optional chaining with process?.env?.VAR
+    if (backend === "cli")
+      itBundled("env/optional-chaining", {
+        env: {
+          MY_VAR: "my_value",
+          ANOTHER: "another_value",
+        },
+        backend: backend,
+        dotenv: "inline",
+        files: {
+          "/a.js": `
+        // Test optional chaining patterns
+        console.log(process?.env?.MY_VAR);
+        console.log(process?.env?.ANOTHER);
+        // Mixed optional chaining
+        console.log(process?.env.MY_VAR);
+        console.log(process.env?.MY_VAR);
+      `,
+        },
+        run: {
+          env: {
+            MY_VAR: "wrong",
+            ANOTHER: "wrong",
+          },
+          stdout: "my_value\nanother_value\nmy_value\nmy_value\n",
+        },
+      });
+
+    // Test optional chaining with bracket notation
+    if (backend === "cli")
+      itBundled("env/optional-chaining-bracket", {
+        env: {
+          BRACKET_VAR: "bracket_value",
+        },
+        backend: backend,
+        dotenv: "inline",
+        files: {
+          "/a.js": `
+        // Test optional chaining with bracket notation
+        console.log(process?.env?.["BRACKET_VAR"]);
+        console.log(process?.env["BRACKET_VAR"]);
+        console.log(process.env?.["BRACKET_VAR"]);
+      `,
+        },
+        run: {
+          env: {
+            BRACKET_VAR: "wrong",
+          },
+          stdout: "bracket_value\nbracket_value\nbracket_value\n",
+        },
+      });
+
+    // Test import.meta.env.* inlining
+    if (backend === "cli")
+      itBundled("env/import-meta-env", {
+        env: {
+          VITE_API_URL: "https://api.example.com",
+          MY_SECRET: "secret123",
+        },
+        backend: backend,
+        dotenv: "inline",
+        files: {
+          "/a.js": `
+        // Test import.meta.env.* inlining (Vite compatibility)
+        console.log(import.meta.env.VITE_API_URL);
+        console.log(import.meta.env.MY_SECRET);
+      `,
+        },
+        run: {
+          env: {
+            VITE_API_URL: "wrong",
+            MY_SECRET: "wrong",
+          },
+          stdout: "https://api.example.com\nsecret123\n",
+        },
+      });
+
+    // Test import.meta.env with prefix matching
+    if (backend === "cli")
+      itBundled("env/import-meta-env-prefix", {
+        env: {
+          VITE_PUBLIC: "public_value",
+          VITE_PRIVATE: "private_value",
+          OTHER_VAR: "other_value",
+        },
+        backend: backend,
+        dotenv: "VITE_*",
+        files: {
+          "/a.js": `
+        // Test import.meta.env with prefix matching
+        console.log(import.meta.env.VITE_PUBLIC);
+        console.log(import.meta.env.VITE_PRIVATE);
+        console.log(import.meta.env.OTHER_VAR);
+      `,
+        },
+        run: {
+          env: {
+            VITE_PUBLIC: "wrong",
+            VITE_PRIVATE: "wrong",
+          },
+          stdout: "public_value\nprivate_value\nundefined\n",
+        },
+      });
   });
 }


### PR DESCRIPTION
## Summary

- Allow `process?.env?.VAR` and `process?.env?.["VAR"]` to be inlined when using `env:inline` in bun.build (matches esbuild behavior)
- Add `import.meta.env.*` inlining for Vite compatibility - environment variables are now exposed via both `process.env.*` and `import.meta.env.*`
- Add define checking for `e_index` (bracket notation) with optional chains

## Test plan

- [x] `env/optional-chaining` - tests `process?.env?.VAR` patterns
- [x] `env/optional-chaining-bracket` - tests `process?.env?.["VAR"]` patterns  
- [x] `env/import-meta-env` - tests `import.meta.env.*` inlining
- [x] `env/import-meta-env-prefix` - tests prefix matching (e.g. `VITE_*`) with `import.meta.env`
- [x] Verified tests fail with `USE_SYSTEM_BUN=1`
- [x] Verified esbuild has same behavior for optional chaining defines

🤖 Generated with [Claude Code](https://claude.com/claude-code)