### PR TITLE
refactor(init): migrate to .claude/skills structure

### DIFF
--- a/src/init/claude-md-reference.md
+++ b/src/init/claude-md-reference.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+## Package Manager
+
+**IMPORTANT**: Always use Bun instead of Node.js, npm, pnpm, or Vite in this project.
+
+When working with this codebase, invoke the `{{SKILL_NAME}}` skill to ensure proper tooling is used.

--- a/src/init/rule.md
+++ b/src/init/rule.md
@@ -1,4 +1,5 @@
 ---
+name: {{SKILL_NAME}}
 description: Use Bun instead of Node.js, npm, pnpm, or vite.
 globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
 alwaysApply: false


### PR DESCRIPTION
## Summary

Migrates `bun init` to use the `.claude/skills/` structure as the primary source for agent rules, aligning with [Claude Code's official skills format](https://code.claude.com/docs/en/skills).

## Motivation

The previous structure created `CLAUDE.md` as the main source with Cursor rules as symlinks. The new structure is more efficient because:

- **Single source of truth**: `.claude/skills/SKILL.md` is the authoritative source, eliminating duplication
- **Better organization**: Skills are organized in dedicated directories under `.claude/skills/`
- **Official standard**: Follows Claude Code's documented skills structure with proper frontmatter (`name`, `description`, etc.)
- **Clearer separation**: `CLAUDE.md` becomes a lightweight reference document pointing to the skill, making its purpose explicit
- **Future-proof**: Easier to extend with multiple skills as the skill directory structure is already in place

## Changes

- Creates `.claude/skills/use-bun-instead-of-node-vite-npm-pnpm/SKILL.md` as the main source
- Cursor rules (`.cursor/rules/*.mdc`) become symlinks to SKILL.md
- `CLAUDE.md` becomes a reference document (not symlink) that points to the skill
- Adds comptime string replacement for skill name consistency across files
- Skill frontmatter now includes `name` field for Claude Code compatibility

## Structure

```
project/
├── .claude/skills/use-bun-instead-of-node-vite-npm-pnpm/SKILL.md  # Main source
├── .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc       # Symlink → SKILL.md
└── CLAUDE.md                                                      # Reference text
```

## Test Results

Manual testing confirms the implementation works correctly:

```bash
$ bun init -y
# Creates:
# - .claude/skills/use-bun-instead-of-node-vite-npm-pnpm/SKILL.md
# - .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc (symlink)
# - CLAUDE.md (reference document)

$ cat .claude/skills/use-bun-instead-of-node-vite-npm-pnpm/SKILL.md | head -6
---
name: use-bun-instead-of-node-vite-npm-pnpm
description: Use Bun instead of Node.js, npm, pnpm, or vite.
globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
alwaysApply: false
---

$ readlink .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
../../.claude/skills/use-bun-instead-of-node-vite-npm-pnpm/SKILL.md
```

Automated tests added:
- ✅ Test skill file creation
- ✅ Test CLAUDE.md reference document
- ✅ Test Cursor rules symlink
- ✅ Verify comptime string replacement works correctly (no `{{SKILL_NAME}}` placeholders remain)

## Test Plan

- [x] Build succeeds
- [x] Manual test: `bun init` creates correct file structure
- [x] Verify symlinks work on macOS/Linux
- [x] Verify comptime string replacement works
- [x] Add automated tests
- [ ] Verify file copying fallback works on Windows

## References

- [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)