### PR TITLE
ci: unregress tart image gen for macos

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -103,10 +103,10 @@ function getTargetLabel(target) {
  * @type {Platform[]}
  */
 const buildPlatforms = [
-  { os: "darwin", arch: "aarch64", distro: "macos", release: "13" },
-  { os: "darwin", arch: "aarch64", distro: "macos", release: "14" },
-  { os: "darwin", arch: "aarch64", distro: "macos", release: "15" },
-  { os: "darwin", arch: "aarch64", distro: "macos", release: "26" },
+  { os: "darwin", arch: "aarch64", release: "13" },
+  { os: "darwin", arch: "aarch64", release: "14" },
+  { os: "darwin", arch: "aarch64", release: "15" },
+  { os: "darwin", arch: "aarch64", release: "26" },
   { os: "darwin", arch: "x64", release: "14" },
   { os: "linux", arch: "aarch64", distro: "amazonlinux", release: "2023", features: ["docker"] },
   { os: "linux", arch: "x64", distro: "amazonlinux", release: "2023", features: ["docker"] },
@@ -1076,7 +1076,9 @@ async function getPipeline(options = {}) {
   const { buildPlatforms = [], testPlatforms = [], buildImages, publishImages } = options;
   const imagePlatforms = new Map(
     buildImages || publishImages
-      ? [...buildPlatforms, ...testPlatforms].map(platform => [getImageKey(platform), platform])
+      ? [...buildPlatforms, ...testPlatforms]
+          .filter(({ os, arch }) => !(os === "darwin" && arch === "x64"))
+          .map(platform => [getImageKey(platform), platform])
       : [],
   );
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -664,7 +664,9 @@ function getReleaseStep(buildPlatforms, options) {
     agents: {
       queue: "test-darwin",
     },
-    depends_on: buildPlatforms.filter(p => p.os !== "freebsd").map(platform => `${getTargetKey(platform)}-build-bun`),
+    depends_on: buildPlatforms
+      .filter(p => !(p.os === "freebsd" || p.os === "darwin"))
+      .map(platform => `${getTargetKey(platform)}-build-bun`),
     env: {
       CANARY: revision,
     },

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -103,7 +103,10 @@ function getTargetLabel(target) {
  * @type {Platform[]}
  */
 const buildPlatforms = [
-  { os: "darwin", arch: "aarch64", release: "14" },
+  { os: "darwin", arch: "aarch64", distro: "macos", release: "13" },
+  { os: "darwin", arch: "aarch64", distro: "macos", release: "14" },
+  { os: "darwin", arch: "aarch64", distro: "macos", release: "15" },
+  { os: "darwin", arch: "aarch64", distro: "macos", release: "26" },
   { os: "darwin", arch: "x64", release: "14" },
   { os: "linux", arch: "aarch64", distro: "amazonlinux", release: "2023", features: ["docker"] },
   { os: "linux", arch: "x64", distro: "amazonlinux", release: "2023", features: ["docker"] },
@@ -612,6 +615,7 @@ function getBuildImageStep(platform, options) {
   const { os, arch, distro, release, features } = platform;
   const { publishImages } = options;
   const action = publishImages ? "publish-image" : "create-image";
+  const cloud = os == "darwin" ? "tart" : "aws";
 
   const command = [
     "node",
@@ -621,7 +625,7 @@ function getBuildImageStep(platform, options) {
     `--arch=${arch}`,
     distro && `--distro=${distro}`,
     `--release=${release}`,
-    "--cloud=aws",
+    `--cloud=${cloud}`,
     "--ci",
     "--authorized-org=oven-sh",
   ];

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1079,7 +1079,7 @@ async function getPipeline(options = {}) {
   const imagePlatforms = new Map(
     buildImages || publishImages
       ? [...buildPlatforms, ...testPlatforms]
-          .filter(({ os, arch }) => !(os === "darwin" && arch === "x64"))
+          .filter(({ os, arch }) => !(os === "darwin"))
           .map(platform => [getImageKey(platform), platform])
       : [],
   );

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1076,9 +1076,7 @@ async function getPipeline(options = {}) {
   const { buildPlatforms = [], testPlatforms = [], buildImages, publishImages } = options;
   const imagePlatforms = new Map(
     buildImages || publishImages
-      ? [...buildPlatforms, ...testPlatforms]
-          .filter(({ os }) => os !== "darwin")
-          .map(platform => [getImageKey(platform), platform])
+      ? [...buildPlatforms, ...testPlatforms].map(platform => [getImageKey(platform), platform])
       : [],
   );
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
     "machine:linux:amazonlinux": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=linux --distro=amazonlinux --release=2023",
     "machine:windows:2019": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=windows --release=2019",
     "machine:freebsd": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=freebsd --release=14.3",
+    "machine:macos:13": "./scripts/machine.mjs ssh --cloud=tart --arch=arm64 --os=darwin --distro=macos --release=13",
+    "machine:macos:14": "./scripts/machine.mjs ssh --cloud=tart --arch=arm64 --os=darwin --distro=macos --release=14",
+    "machine:macos:15": "./scripts/machine.mjs ssh --cloud=tart --arch=arm64 --os=darwin --distro=macos --release=15",
+    "machine:macos:26": "./scripts/machine.mjs ssh --cloud=tart --arch=arm64 --os=darwin --distro=macos --release=26",
     "sync-webkit-source": "bun ./scripts/sync-webkit-source.ts"
   }
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 21
+# Version: 20
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -1219,11 +1219,6 @@ async function main() {
     }
   }
 
-  if (isBuildkite && os === "darwin") {
-    // they don't have it preinstalled in the hosted image
-    await spawnSafe($`apt install tart sshpass`);
-  }
-
   /** @type {Machine} */
   const machine = await startGroup("Creating machine...", async () => {
     console.log("Creating machine:");

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -18,7 +18,6 @@ import {
   getSecret,
   getUsernameForDistro,
   homedir,
-  isBuildkite,
   isCI,
   isMacOS,
   isWindows,

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -18,6 +18,7 @@ import {
   getSecret,
   getUsernameForDistro,
   homedir,
+  isBuildkite,
   isCI,
   isMacOS,
   isWindows,
@@ -1216,6 +1217,11 @@ async function main() {
         throw new Error(`Dockerfile not found: ${dockerfilePath}`);
       }
     }
+  }
+
+  if (isBuildkite && os === "darwin") {
+    // they don't have it preinstalled in the hosted image
+    await spawnSafe($`apt install tart sshpass`);
   }
 
   /** @type {Machine} */

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -31,6 +31,7 @@ import {
   sha256,
   spawn,
   spawnSafe,
+  spawnScp,
   spawnSsh,
   spawnSshSafe,
   spawnSyncSafe,
@@ -942,64 +943,6 @@ async function getGithubOrgSshKeys(organization) {
  * @property {string[]} [identityPaths]
  * @property {number} [retries]
  */
-
-/**
- * @typedef ScpOptions
- * @property {string} hostname
- * @property {string} source
- * @property {string} destination
- * @property {string[]} [identityPaths]
- * @property {string} [port]
- * @property {string} [username]
- * @property {number} [retries]
- */
-
-/**
- * @param {ScpOptions} options
- * @returns {Promise<void>}
- */
-async function spawnScp(options) {
-  const { hostname, port, username, identityPaths, password, source, destination, retries = 3 } = options;
-  await waitForPort({ hostname, port: port || 22 });
-
-  const command = ["scp", "-o", "StrictHostKeyChecking=no"];
-  command.push("-O"); // use SCP instead of SFTP
-  if (!password) {
-    command.push("-o", "BatchMode=yes");
-  }
-  if (port) {
-    command.push("-P", port);
-  }
-  if (password) {
-    const sshPass = which("sshpass", { required: true });
-    command.unshift(sshPass, "-p", password);
-  } else if (identityPaths) {
-    command.push(...identityPaths.flatMap(path => ["-i", path]));
-  }
-  command.push(resolve(source));
-  if (username) {
-    command.push(`${username}@${hostname}:${destination}`);
-  } else {
-    command.push(`${hostname}:${destination}`);
-  }
-
-  let cause;
-  for (let i = 0; i < retries; i++) {
-    const result = await spawn(command, { stdio: "inherit" });
-    const { exitCode, stderr } = result;
-    if (exitCode === 0) {
-      return;
-    }
-
-    cause = stderr.trim() || undefined;
-    if (/(bad configuration option)|(no such file or directory)/i.test(stderr)) {
-      break;
-    }
-    await new Promise(resolve => setTimeout(resolve, Math.pow(2, i) * 1000));
-  }
-
-  throw new Error(`SCP failed: ${source} -> ${username}@${hostname}:${destination}`, { cause });
-}
 
 /**
  * @param {string} passwordData

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -37,7 +37,6 @@ import {
   spawnSyncSafe,
   startGroup,
   tmpdir,
-  waitForPort,
   which,
   writeFile,
 } from "./utils.mjs";

--- a/scripts/tart.mjs
+++ b/scripts/tart.mjs
@@ -84,14 +84,14 @@ export const tart = {
    * @returns {Promise<TartVm | undefined>}
    */
   async getVm(name) {
-    const { promise, resolve } = Promise.withResolvers();
-    const result = await this.spawn(["get", name], {
-      json: true,
-      throwOnError: error => !/does not exist/i.test(inspect(error)),
+    return new Promise(async resolve => {
+      const result = await this.spawn(["get", name], {
+        json: true,
+        throwOnError: error => !/does not exist/i.test(inspect(error)),
+      });
+      if (!result) resolve(undefined);
+      else resolve({ Name: name, ...result });
     });
-    if (!result) resolve(undefined);
-    else resolve({ Name: name, ...result });
-    return promise;
   },
 
   /**

--- a/scripts/tart.mjs
+++ b/scripts/tart.mjs
@@ -1,5 +1,5 @@
 import { inspect } from "node:util";
-import { isPrivileged, spawnSafe, which } from "./utils.mjs";
+import { isPrivileged, spawnSafe, spawnScp, spawnSshSafe, which } from "./utils.mjs";
 
 /**
  * @link https://tart.run/
@@ -48,6 +48,7 @@ export const tart = {
       throw new Error(`Unsupported platform: ${inspect(platform)}`);
     }
     const distros = {
+      "26": "tahoe",
       "15": "sequoia",
       "14": "sonoma",
       "13": "ventura",
@@ -83,14 +84,14 @@ export const tart = {
    * @returns {Promise<TartVm | undefined>}
    */
   async getVm(name) {
+    const { promise, resolve } = Promise.withResolvers();
     const result = await this.spawn(["get", name], {
       json: true,
       throwOnError: error => !/does not exist/i.test(inspect(error)),
     });
-    return {
-      Name: name,
-      ...result,
-    };
+    if (!result) resolve(undefined);
+    else resolve({ Name: name, ...result });
+    return promise;
   },
 
   /**
@@ -265,6 +266,15 @@ export const tart = {
       await spawnRdp({ ...connectOptions });
     };
 
+    const snapshot = async tag => {
+      // https://tart.run/integrations/vm-management/#working-with-a-remote-oci-container-registry
+      // https://tart.run/integrations/vm-management/#pushing-a-local-image
+      // https://tart.run/integrations/buildkite/
+      // tart push ${name} ghcr.io/oven-sh/macos-${major_version}-tart-base:${tag}
+      // TODO: push to ghcr and return that full remote_image_name:tag
+      return tag;
+    };
+
     const close = async () => {
       await this.deleteVm(name);
     };
@@ -274,8 +284,10 @@ export const tart = {
       id: name,
       spawn: exec,
       spawnSafe: execSafe,
+      rdp,
       attach,
       upload,
+      snapshot,
       close,
       [Symbol.asyncDispose]: close,
     };


### PR DESCRIPTION
as is this gets `bun run machine:macos:14` working when you have `tart` and `sshpass` installed.
given the links in the comment for `tart.Machine.snapshot` it looks like this would be integratabtle into CI proper without too much followup work, at least for arm64.

testing with `[build images]` but no need to `[publish images]` on merge yet

<details>
<summary> 13 screenshot </summary>
<img width="900" height="290" alt="image" src="https://github.com/user-attachments/assets/e62f19da-96ab-4d83-abc5-21bb983a5d7f" />
</details>

<details>
<summary> 15 screenshot </summary>
<img width="900" height="291" alt="image" src="https://github.com/user-attachments/assets/496bf855-6a59-461e-8d76-d31ce1ece6b5" />
</details>

<details>
<summary> 26 screenshot </summary>
<img width="900" height="286" alt="image" src="https://github.com/user-attachments/assets/0ba07f96-038c-47b0-b863-b1657c661f0b" />
</details>

----

`tart` can only be installed on macOS so darwin image builds will need to run on a macos queue
that should be easy to setup (can be another hosted queue) but feels outside the scope of this pr