### PR TITLE
fix(cli): correct --dry-run help text for bun publish

### DIFF
--- a/packages/bun-types/wasm.d.ts
+++ b/packages/bun-types/wasm.d.ts
@@ -100,8 +100,8 @@ declare module "bun" {
 
 declare namespace WebAssembly {
   interface ValueTypeMap extends Bun.WebAssembly.ValueTypeMap {}
-  interface GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap>
-    extends Bun.WebAssembly.GlobalDescriptor<T> {}
+  interface GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> extends Bun.WebAssembly
+    .GlobalDescriptor<T> {}
   interface MemoryDescriptor extends Bun.WebAssembly.MemoryDescriptor {}
   interface ModuleExportDescriptor extends Bun.WebAssembly.ModuleExportDescriptor {}
   interface ModuleImportDescriptor extends Bun.WebAssembly.ModuleImportDescriptor {}

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -27,7 +27,7 @@ const shared_params = [_]ParamType{
     clap.parseParam("--save                                Save to package.json (true by default)") catch unreachable,
     clap.parseParam("--ca <STR>...                         Provide a Certificate Authority signing certificate") catch unreachable,
     clap.parseParam("--cafile <STR>                        The same as `--ca`, but is a file path to the certificate") catch unreachable,
-    clap.parseParam("--dry-run                             Don't install anything") catch unreachable,
+    clap.parseParam("--dry-run                             Perform a dry run without making changes") catch unreachable,
     clap.parseParam("--frozen-lockfile                     Disallow changes to lockfile") catch unreachable,
     clap.parseParam("-f, --force                           Always request the latest versions from the registry & reinstall all dependencies") catch unreachable,
     clap.parseParam("--cache-dir <PATH>                    Store & load cached data from a specific directory path") catch unreachable,

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1941,7 +1941,7 @@ test("no assertion failures 3", () => {
     ],
     [
       class // Random { // comments /* */ are part of the toString() result
-        äß /**/
+      äß /**/
         extends /*{*/ TypeError {},
       "[class äß extends TypeError]",
     ],

--- a/test/regression/issue/24806.test.ts
+++ b/test/regression/issue/24806.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("bun publish --help shows correct message for --dry-run", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "publish", "--help"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The --dry-run flag should have a generic description that works for all commands
+  // It should NOT say "Don't install anything" when used with "bun publish"
+  expect(stdout).toContain("--dry-run");
+  expect(stdout).toContain("Perform a dry run without making changes");
+
+  // Make sure it doesn't contain the old incorrect message
+  expect(stdout).not.toContain("Don't install anything");
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix `bun publish --help` showing incorrect `--dry-run` description ("Don't install anything" → "Perform a dry run without making changes")
- The `--dry-run` flag is in a shared params array used by multiple commands, so the new generic message works for all of them

Fixes #24806

## Test plan
- [x] Verify `bun publish --help` shows "Perform a dry run without making changes" for --dry-run
- [x] Regression test added that validates the correct help text is shown
- [x] Test passes with debug build, fails with system bun (validating it tests the right thing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)