### PR TITLE
fix(url): preserve auth credentials in url.format for WHATWG URLs

### DIFF
--- a/packages/bun-types/wasm.d.ts
+++ b/packages/bun-types/wasm.d.ts
@@ -100,8 +100,8 @@ declare module "bun" {
 
 declare namespace WebAssembly {
   interface ValueTypeMap extends Bun.WebAssembly.ValueTypeMap {}
-  interface GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap>
-    extends Bun.WebAssembly.GlobalDescriptor<T> {}
+  interface GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> extends Bun.WebAssembly
+    .GlobalDescriptor<T> {}
   interface MemoryDescriptor extends Bun.WebAssembly.MemoryDescriptor {}
   interface ModuleExportDescriptor extends Bun.WebAssembly.ModuleExportDescriptor {}
   interface ModuleImportDescriptor extends Bun.WebAssembly.ModuleImportDescriptor {}

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -484,7 +484,19 @@ function urlFormat(urlObject: unknown) {
 
 Url.prototype.format = function format() {
   var auth: string = this.auth || "";
-  if (auth) {
+
+  // Handle WHATWG URL objects which have username/password instead of auth
+  if (!auth && (this.username || this.password)) {
+    if (this.username) {
+      auth = this.username;
+    }
+    if (this.password) {
+      auth += ":" + this.password;
+    }
+    if (auth) {
+      auth += "@";
+    }
+  } else if (auth) {
     auth = encodeURIComponent(auth);
     auth = auth.replace(/%3A/i, ":");
     auth += "@";

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1941,7 +1941,7 @@ test("no assertion failures 3", () => {
     ],
     [
       class // Random { // comments /* */ are part of the toString() result
-        äß /**/
+      äß /**/
         extends /*{*/ TypeError {},
       "[class äß extends TypeError]",
     ],

--- a/test/regression/issue/24343.test.ts
+++ b/test/regression/issue/24343.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import url from "node:url";
+
+test("url.format with WHATWG URL preserves username and password", () => {
+  const result = url.format(new URL("https://a:b@example.org/"));
+  expect(result).toBe("https://a:b@example.org/");
+});
+
+test("url.format with WHATWG URL preserves username only", () => {
+  const result = url.format(new URL("https://user@example.org/"));
+  expect(result).toBe("https://user@example.org/");
+});
+
+test("url.format with WHATWG URL without auth", () => {
+  const result = url.format(new URL("https://example.org/"));
+  expect(result).toBe("https://example.org/");
+});
+
+test("url.format with WHATWG URL preserves username, password, and path", () => {
+  const result = url.format(new URL("https://user:pass@example.org/path?query=1#hash"));
+  expect(result).toBe("https://user:pass@example.org/path?query=1#hash");
+});
+
+test("url.format with WHATWG URL with special characters in credentials", () => {
+  // When creating a URL, special characters in credentials are already percent-encoded
+  // url.format should preserve the encoding from the URL object
+  const result = url.format(new URL("https://us%40er:p%40ss@example.org/"));
+  // The username and password are already encoded by the URL object, so we should preserve them as-is
+  expect(result).toBe("https://us%40er:p%40ss@example.org/");
+});
+
+test("url.format with legacy Url object still works", () => {
+  const parsed = url.parse("https://a:b@example.org/path");
+  const result = url.format(parsed);
+  expect(result).toBe("https://a:b@example.org/path");
+});


### PR DESCRIPTION
## Summary
- Fix `url.format()` to preserve username and password when given a WHATWG URL object
- WHATWG URLs use `username`/`password` properties instead of the legacy `auth` property
- Credentials are already percent-encoded by the URL API, so we use them directly

Fixes #24343

## Test plan
- [x] Test `url.format(new URL('https://a:b@example.org/'))` returns full URL with auth
- [x] Test username-only URLs work correctly
- [x] Test percent-encoded credentials are preserved (no double-encoding)
- [x] Test legacy URL objects still work
- [x] Tests pass with debug build, fail with system bun

🤖 Generated with [Claude Code](https://claude.com/claude-code)