### PR TITLE
fix(install): resolve GitHub override when package.json name differs

### DIFF
--- a/packages/bun-types/wasm.d.ts
+++ b/packages/bun-types/wasm.d.ts
@@ -100,8 +100,8 @@ declare module "bun" {
 
 declare namespace WebAssembly {
   interface ValueTypeMap extends Bun.WebAssembly.ValueTypeMap {}
-  interface GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap>
-    extends Bun.WebAssembly.GlobalDescriptor<T> {}
+  interface GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> extends Bun.WebAssembly
+    .GlobalDescriptor<T> {}
   interface MemoryDescriptor extends Bun.WebAssembly.MemoryDescriptor {}
   interface ModuleExportDescriptor extends Bun.WebAssembly.ModuleExportDescriptor {}
   interface ModuleImportDescriptor extends Bun.WebAssembly.ModuleImportDescriptor {}

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1941,7 +1941,7 @@ test("no assertion failures 3", () => {
     ],
     [
       class // Random { // comments /* */ are part of the toString() result
-        äß /**/
+      äß /**/
         extends /*{*/ TypeError {},
       "[class äß extends TypeError]",
     ],


### PR DESCRIPTION
## Summary
- Fix install failing with "failed to resolve" when using resolutions/overrides to override a semver dependency with a GitHub dependency from a monorepo
- The bug occurred when the GitHub repo's root package.json has a different name than the requested package

## Problem
When you override a dependency like this:
```json
{
  "dependencies": { "discord.js": "^14.14.1" },
  "resolutions": { "discord.js": "github:discordjs/discord.js#8dd69cf..." }
}
```

The install would fail with:
```
error: discord.js@^14.14.1 failed to resolve
```

This happened because discord.js is a monorepo where the root package.json has `"name": "@discordjs/discord.js"`, not `"discord.js"`. After downloading and extracting the GitHub tarball:
1. The package was stored with name hash for `@discordjs/discord.js`
2. When trying to resolve the dependency, it looked up by name hash for `discord.js`
3. No match was found, and the resolution was never assigned

## Fix
In `runTasks.zig`, when processing dependencies from an extracted tarball, if the dependency's version tag doesn't match the resolution type (indicating it came from an override), directly assign the resolution instead of calling `processDependencyListItem` which would try to re-resolve and fail.

## Test plan
- [x] Added tests for resolutions and overrides with GitHub dependencies from monorepos
- [x] All existing override tests pass
- [x] New tests fail with system bun (without fix) and pass with debug build (with fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)