### PR TITLE
Fix incorrect file name in React component test example 🌟

### DIFF
--- a/docs/guides/test/testing-library.mdx
+++ b/docs/guides/test/testing-library.mdx
@@ -76,7 +76,7 @@ declare module "bun:test" {
 
 You should now be able to use Testing Library in your tests
 
-```ts matchers.d.ts icon="/icons/typescript.svg"
+```tsx myComponent.test.tsx icon="/icons/typescript.svg"
 import { test, expect } from "bun:test";
 import { screen, render } from "@testing-library/react";
 import { MyComponent } from "./myComponent";


### PR DESCRIPTION
# What does this PR do?

Nyaa~ This PR fixes a small mistake in the documentation where the code block for a React component test example was using the wrong filename! (；ω；)💦

It was previously labeled as `matchers.d.ts`, but it should be something like `myComponent.test.tsx` to properly reflect a test file for a React component using `@testing-library/react`. 🧁✨

This makes the example clearer and more accurate for developers using Bun to test their React components~! 💻🌸💕

# How did you verify your code works?

It's just docs, one single line 🥺

Pwease review and merge it when you can, senpai~~! UwU 🌈🫧