### PR TITLE
fix(node:url): return empty string for invalid domains in domainToASCII/domainToUnicode

### DIFF
--- a/src/bun.js/bindings/NodeURL.cpp
+++ b/src/bun.js/bindings/NodeURL.cpp
@@ -68,8 +68,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToASCIIErrors) && numCharactersConverted) {
         return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
     }
-    throwTypeError(globalObject, scope, "domainToASCII failed"_s);
-    return {};
+    return JSC::JSValue::encode(jsEmptyString(vm));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -139,8 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject,
     if (U_SUCCESS(error) && !(processingDetails.errors & ~allowedNameToUnicodeErrors) && numCharactersConverted) {
         return JSC::JSValue::encode(JSC::jsString(vm, WTF::String(std::span { hostnameBuffer, static_cast<unsigned int>(numCharactersConverted) })));
     }
-    throwTypeError(globalObject, scope, "domainToUnicode failed"_s);
-    return {};
+    return JSC::JSValue::encode(jsEmptyString(vm));
 }
 
 JSC::JSValue createNodeURLBinding(Zig::GlobalObject* globalObject)

--- a/test/regression/issue/24191.test.ts
+++ b/test/regression/issue/24191.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import url from "node:url";
+
+// Regression test for issue #24191
+// url.domainToASCII should return empty string for invalid domains, not throw
+test("url.domainToASCII returns empty string for invalid domains", () => {
+  // Invalid punycode with non-ASCII characters should return empty string, not throw
+  expect(url.domainToASCII("xn--iñvalid.com")).toBe("");
+
+  // Valid domains should still work
+  expect(url.domainToASCII("example.com")).toBe("example.com");
+  expect(url.domainToASCII("münchen.de")).toBe("xn--mnchen-3ya.de");
+});
+
+test("url.domainToUnicode returns empty string for invalid domains", () => {
+  // Invalid punycode with non-ASCII characters should return empty string, not throw
+  expect(url.domainToUnicode("xn--iñvalid.com")).toBe("");
+
+  // Valid domains should still work
+  expect(url.domainToUnicode("example.com")).toBe("example.com");
+  expect(url.domainToUnicode("xn--mnchen-3ya.de")).toBe("münchen.de");
+});


### PR DESCRIPTION
## Summary
- Fixes `url.domainToASCII` and `url.domainToUnicode` to return empty string instead of throwing `TypeError` when given invalid domains
- Per Node.js docs: "if `domain` is an invalid domain, the empty string is returned"

## Test plan
- [x] Run `bun bd test test/regression/issue/24191.test.ts` - all 2 tests pass
- [x] Verify tests fail with system Bun (`USE_SYSTEM_BUN=1`) to confirm fix validity
- [x] Manual verification: `url.domainToASCII('xn--iñvalid.com')` returns `""`

## Example

Before (bug):
```
$ bun -e "import url from 'node:url'; console.log(url.domainToASCII('xn--iñvalid.com'))"
TypeError: domainToASCII failed
```

After (fixed):
```
$ bun -e "import url from 'node:url'; console.log(url.domainToASCII('xn--iñvalid.com'))"
(empty string output)
```

Closes #24191

🤖 Generated with [Claude Code](https://claude.com/claude-code)