### PR TITLE
fix(runtime): prevent globalThis.onmessage from hanging process

### DIFF
--- a/src/bun.js/bindings/BunWorkerGlobalScope.cpp
+++ b/src/bun.js/bindings/BunWorkerGlobalScope.cpp
@@ -17,24 +17,33 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
 {
     if (eventType == eventNames().messageEvent) {
         auto& global = static_cast<WorkerGlobalScope&>(self);
+        auto* context = global.scriptExecutionContext();
+
+        // Only keep the event loop alive if we're in a Worker context.
+        // In the main thread, setting globalThis.onmessage should not prevent exit
+        // since there's no actual message passing mechanism.
+        if (!context || !context->isWorker) {
+            return;
+        }
+
         switch (kind) {
         case Add:
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->refEventLoop();
+                context->refEventLoop();
             }
             global.m_messageEventCount++;
             break;
         case Remove:
             global.m_messageEventCount--;
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
+                context->unrefEventLoop();
             }
             break;
         // I dont think clear in this context is ever called. If it is (search OnDidChangeListenerKind::Clear for the impl),
         // it may actually call once per event, in a way the Remove code above would suffice.
         case Clear:
             if (global.m_messageEventCount > 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
+                context->unrefEventLoop();
             }
             global.m_messageEventCount = 0;
             break;

--- a/test/regression/issue/24256.test.ts
+++ b/test/regression/issue/24256.test.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { Worker } from "node:worker_threads";
+
+test("globalThis.onmessage should not prevent process exit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'console.log("hello world"); globalThis.onmessage = () => {}'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toBe("hello world\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("globalThis.onmessage can be set to a function", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      globalThis.onmessage = () => {
+        console.log("message handler set");
+      };
+      console.log(typeof globalThis.onmessage);
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toBe("function\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("globalThis.onmessage can be set to null", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      globalThis.onmessage = () => {};
+      globalThis.onmessage = null;
+      console.log(globalThis.onmessage);
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toBe("null\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("Workers with onmessage should still work properly", async () => {
+  using dir = tempDir("worker-onmessage-test", {
+    "worker.js": `
+      const { parentPort } = require("node:worker_threads");
+      parentPort.onmessage = (event) => {
+        parentPort.postMessage({ received: event.data });
+      };
+    `,
+  });
+
+  const worker = new Worker(String(dir) + "/worker.js");
+  const { promise, resolve } = Promise.withResolvers();
+
+  worker.on("message", (msg) => {
+    resolve(msg);
+  });
+
+  worker.postMessage("hello");
+
+  const result = await promise;
+  expect(result).toEqual({ received: "hello" });
+
+  await worker.terminate();
+});

--- a/test/regression/issue/24256.test.ts
+++ b/test/regression/issue/24256.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { Worker } from "node:worker_threads";
 
@@ -10,11 +10,7 @@ test("globalThis.onmessage should not prevent process exit", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("hello world\n");
   expect(stderr).toBe("");
@@ -38,11 +34,7 @@ test("globalThis.onmessage can be set to a function", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("function\n");
   expect(stderr).toBe("");
@@ -65,11 +57,7 @@ test("globalThis.onmessage can be set to null", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("null\n");
   expect(stderr).toBe("");
@@ -89,7 +77,7 @@ test("Workers with onmessage should still work properly", async () => {
   const worker = new Worker(String(dir) + "/worker.js");
   const { promise, resolve } = Promise.withResolvers();
 
-  worker.on("message", (msg) => {
+  worker.on("message", msg => {
     resolve(msg);
   });
 


### PR DESCRIPTION
## Summary
- Fixes `globalThis.onmessage` incorrectly keeping the event loop alive in the main thread
- Only refs the event loop for message handlers when in a Worker context
- Matches Node.js behavior where setting `globalThis.onmessage` doesn't prevent exit

## Test plan
- [x] Added regression test in `test/regression/issue/24256.test.ts`
- [x] Test verifies process exits cleanly when `globalThis.onmessage` is set
- [x] Test verifies Workers with `onmessage` still work properly
- [x] Test passes with debug build, fails with system bun (proving it catches the bug)

Fixes #24256

🤖 Generated with [Claude Code](https://claude.com/claude-code)