### PR TITLE
fix(bindings): handle pending exceptions in ReadableStream__empty and ReadableStream__used

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2919,17 +2919,23 @@ JSC::EncodedJSValue JSC__JSModuleLoader__evaluate(JSC::JSGlobalObject* globalObj
 JSC::EncodedJSValue ReadableStream__empty(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto clientData = WebCore::clientData(vm);
     auto* function = globalObject->getDirect(vm, clientData->builtinNames().createEmptyReadableStreamPrivateName()).getObject();
-    return JSValue::encode(JSC::call(globalObject, function, JSC::ArgList(), "ReadableStream.create"_s));
+    auto result = JSC::call(globalObject, function, JSC::ArgList(), "ReadableStream.create"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(result);
 }
 
 JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto clientData = WebCore::clientData(vm);
     auto* function = globalObject->getDirect(vm, clientData->builtinNames().createUsedReadableStreamPrivateName()).getObject();
-    return JSValue::encode(JSC::call(globalObject, function, JSC::ArgList(), "ReadableStream.create"_s));
+    auto result = JSC::call(globalObject, function, JSC::ArgList(), "ReadableStream.create"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(result);
 }
 
 JSC::EncodedJSValue JSC__JSValue__createRangeError(const ZigString* message, const ZigString* arg1,

--- a/test/regression/issue/response-body-crash-after-stack-overflow.test.ts
+++ b/test/regression/issue/response-body-crash-after-stack-overflow.test.ts
@@ -1,0 +1,25 @@
+import { test } from "bun:test";
+
+// Fixes: ENG-23921
+// Accessing Response.json().body after catching a stack overflow exception
+// should not crash the runtime.
+test(
+  "Response.json().body should not crash after catching stack overflow",
+  () => {
+    function F0() {
+      if (!new.target) {
+        throw "must be called with new";
+      }
+      const v3 = this.constructor;
+      try {
+        new v3();
+      } catch (e) {}
+      // This should not crash - it used to trigger an assertion failure
+      // due to a pending exception not being properly handled
+      Response.json().body;
+    }
+    // This should not crash
+    new F0();
+  },
+  { timeout: 60000 },
+);


### PR DESCRIPTION
## Summary

- Fix crash when accessing `Response.json().body` after catching a stack overflow exception
- Add proper exception handling with `DECLARE_THROW_SCOPE` and `RETURN_IF_EXCEPTION` to `ReadableStream__empty` and `ReadableStream__used` functions

## Root Cause

When JavaScript code catches an exception with try/catch, the C++ VM still has the "exception pending" flag set. If a C++ function subsequently calls JavaScript code without explicitly checking/handling the exception state, JavaScriptCore's exception scope asserts: "Unexpected exception observed".

The `ReadableStream__empty` and `ReadableStream__used` functions were calling JavaScript functions via `JSC::call` without proper throw scope handling.

## Test plan

- Added regression test `test/regression/issue/response-body-crash-after-stack-overflow.test.ts`
- Verified fix with `bun bd test test/regression/issue/response-body-crash-after-stack-overflow.test.ts`

Fixes: ENG-23921

🤖 Generated with [Claude Code](https://claude.com/claude-code)