### PR TITLE
Fix inotify for directory watches

### DIFF
--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -843,7 +843,7 @@ pub const PathWatcher = struct {
                 const time_diff = time_stamp - this.last_change_event.time_stamp;
                 if (!(this.last_change_event.time_stamp == 0 or time_diff > 1) or
                     (this.last_change_event.event_type == event_type and
-                    this.last_change_event.hash == hash))
+                        this.last_change_event.hash == hash))
                 {
                     // skip consecutive duplicates
                     return;

--- a/src/watcher/INotifyWatcher.zig
+++ b/src/watcher/INotifyWatcher.zig
@@ -77,7 +77,7 @@ pub fn watchDir(this: *INotifyWatcher, pathname: [:0]const u8) bun.sys.Maybe(Eve
     bun.assert(this.loaded);
     const old_count = this.watch_count.fetchAdd(1, .release);
     defer if (old_count == 0) Futex.wake(&this.watch_count, 10);
-    const watch_dir_mask = IN.EXCL_UNLINK | IN.DELETE | IN.DELETE_SELF | IN.CREATE | IN.MOVE_SELF | IN.ONLYDIR | IN.MOVED_TO;
+    const watch_dir_mask = IN.EXCL_UNLINK | IN.DELETE | IN.DELETE_SELF | IN.CREATE | IN.MOVE_SELF | IN.ONLYDIR | IN.MOVED_TO | IN.MODIFY;
     const rc = system.inotify_add_watch(this.fd.cast(), pathname, watch_dir_mask);
     log("inotify_add_watch({f}) = {}", .{ this.fd, rc });
     return bun.sys.Maybe(EventListIndex).errnoSysP(rc, .watch, pathname) orelse
@@ -361,7 +361,7 @@ pub fn watchEventFromInotifyEvent(event: *align(1) const INotifyWatcher.Event, i
     return .{
         .op = .{
             .delete = (event.mask & IN.DELETE_SELF) > 0 or (event.mask & IN.DELETE) > 0,
-            .rename = (event.mask & IN.MOVE_SELF) > 0,
+            .rename = (event.mask & IN.MOVE_SELF) > 0 or (event.mask & IN.CREATE) > 0,
             .move_to = (event.mask & IN.MOVED_TO) > 0,
             .write = (event.mask & IN.MODIFY) > 0,
         },


### PR DESCRIPTION
### What does this PR do?

There are two core changes to how we use inotify itself:
1. Register IN_MODIFY interest when watching a directory. This gives access to `change` events on files inside the watched directory. Because we want access to these events, this also removes the blanket `rename` casting in the directory register path.
2. Treat the `IN_CREATE` bit as `rename`. This is to preserve existing behavior from when we casted all events in the directory registration path to `rename`.

This also changes the core logic for consecutive duplicate event detection. The previous directory watch implementation would emit events if `current_event.type != last_event.type AND current_event.hash != last_event.hash`. This was fine previously since we didn't register IN_MODIFY and thus would cast all events on a watched directory to a `rename`. Now that we register with IN_MODIFY,  we have to pick up `change` events as well. If we emit a `rename` followed by a `change` for the same file, under the previous logic we'd miss the `change` since the hash is based on the file path.

Lastly, this properly updates the last event's hash. It seems that got lost in a refactor (see 006575a0f10).

NOTE: this _DOES NOT YET_ start picking up consecutive duplicate events

TODO:
- [ ] Remove consecutive event deduplication
- [ ] Run https://github.com/oven-sh/bun/issues/3657 repro script(s)
- [ ] Run https://github.com/oven-sh/bun/issues/24875 repro script

### How did you verify your code works?

Wrote a new test