### PR TITLE
fix(bake): correct source count in sourcemap parsing for error remapping

### DIFF
--- a/src/bake/DevServer/SourceMapStore.zig
+++ b/src/bake/DevServer/SourceMapStore.zig
@@ -526,7 +526,7 @@ pub fn getParsedSourceMap(store: *Self, script_id: Key, arena: Allocator, gpa: A
         gpa,
         vlq_bytes,
         null,
-        @intCast(entry.paths.len),
+        @intCast(entry.paths.len + 1), // +1 for HMR Runtime at source index 0
         0, // unused
         .{},
     )) {


### PR DESCRIPTION
## Summary

- Fixes off-by-one error in `getParsedSourceMap` when passing source count to the sourcemap parser
- The combined sourcemap has `paths.len + 1` sources (HMR Runtime at index 0 + all user files), but only `paths.len` was being passed

## Details

In `SourceMapStore.zig`, when error remapping parses the combined sourcemap:
- The sources array contains: `["bun://Bun/Bun HMR Runtime", ...paths]`  
- VLQ mappings reference source indices 0 (HMR Runtime) through `paths.len` (last file)
- The parser was told there are only `paths.len` sources, causing source index `paths.len` to fail validation

This could cause error remapping to fail for the last file(s) in bundles with many files.

## Test plan

- [x] Existing sourcemap tests pass
- The fix is a simple off-by-one correction with clear reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)