### PR TITLE
pnpm migrate: copy some settings to bunfig.toml too

### DIFF
--- a/src/install/pnpm.zig
+++ b/src/install/pnpm.zig
@@ -1763,8 +1763,6 @@ fn migrateSettingsAfterLockfileMigration(allocator: Allocator, manager: *Package
     }
 }
 
-const TOML = bun.interchange.toml.TOML;
-
 const Dependency = @import("./dependency.zig");
 const Npm = @import("./npm.zig");
 const Bin = @import("./bin.zig").Bin;
@@ -1780,6 +1778,7 @@ const OOM = bun.OOM;
 const logger = bun.logger;
 const strings = bun.strings;
 const sys = bun.sys;
+const TOML = bun.interchange.toml.TOML;
 const YAML = bun.interchange.yaml.YAML;
 
 const Semver = bun.Semver;

--- a/test/cli/install/migration/pnpm-migration.test.ts
+++ b/test/cli/install/migration/pnpm-migration.test.ts
@@ -216,7 +216,8 @@ describe("pnpm settings migration", () => {
       stderr: "pipe",
     });
 
-    const [exitCode] = await Promise.all([proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
     const pkgJson = await file(join(packageDir, "package.json")).json();
@@ -236,7 +237,8 @@ describe("pnpm settings migration", () => {
       stderr: "pipe",
     });
 
-    const [exitCode] = await Promise.all([proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
     const bunfigText = await file(join(packageDir, "bunfig.toml")).text();
@@ -262,7 +264,8 @@ describe("pnpm settings migration", () => {
       stderr: "pipe",
     });
 
-    const [exitCode] = await Promise.all([proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
     const bunfigText = await file(join(packageDir, "bunfig.toml")).text();
@@ -288,7 +291,8 @@ describe("pnpm settings migration", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    let [exitCode] = await Promise.all([proc.exited]);
+    let [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
     const bunfigAfterFirst = await file(join(packageDir, "bunfig.toml")).text();
@@ -303,7 +307,8 @@ describe("pnpm settings migration", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    [exitCode] = await Promise.all([proc.exited]);
+    [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 
     const bunfigAfterSecond = await file(join(packageDir, "bunfig.toml")).text();
@@ -312,7 +317,7 @@ describe("pnpm settings migration", () => {
     // Should still have the same value, not duplicated
     expect(secondParsed.install?.minimumReleaseAge).toBe(86400);
     // Key should only appear once since we check if it exists before appending
-    // Use word boundary to not match minimumReleaseAgeExcludes
+    // Pattern requires '=' to avoid matching minimumReleaseAgeExcludes
     const matches = bunfigAfterSecond.match(/minimumReleaseAge\s*=/g);
     expect(matches?.length).toBe(1);
   });

--- a/test/cli/install/migration/pnpm/settings-existing/bunfig.toml
+++ b/test/cli/install/migration/pnpm/settings-existing/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+minimumReleaseAge = 3600

--- a/test/cli/install/migration/pnpm/settings-existing/package.json
+++ b/test/cli/install/migration/pnpm/settings-existing/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-settings-trusted",
+  "dependencies": {
+    "no-deps": "~1.0.0"
+  }
+}

--- a/test/cli/install/migration/pnpm/settings-existing/pnpm-lock.yaml
+++ b/test/cli/install/migration/pnpm/settings-existing/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ~1.0.0
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A==}
+
+snapshots:
+
+  no-deps@1.0.1: {}

--- a/test/cli/install/migration/pnpm/settings-existing/pnpm-workspace.yaml
+++ b/test/cli/install/migration/pnpm/settings-existing/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 1440

--- a/test/cli/install/migration/pnpm/settings-hoist/package.json
+++ b/test/cli/install/migration/pnpm/settings-hoist/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-settings-trusted",
+  "dependencies": {
+    "no-deps": "~1.0.0"
+  }
+}

--- a/test/cli/install/migration/pnpm/settings-hoist/package.json
+++ b/test/cli/install/migration/pnpm/settings-hoist/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-settings-trusted",
+  "name": "test-settings-hoist",
   "dependencies": {
     "no-deps": "~1.0.0"
   }

--- a/test/cli/install/migration/pnpm/settings-hoist/pnpm-lock.yaml
+++ b/test/cli/install/migration/pnpm/settings-hoist/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ~1.0.0
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A==}
+
+snapshots:
+
+  no-deps@1.0.1: {}

--- a/test/cli/install/migration/pnpm/settings-hoist/pnpm-workspace.yaml
+++ b/test/cli/install/migration/pnpm/settings-hoist/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+shamefullyHoist: true
+hoistPattern:
+  - "*eslint*"
+  - "*babel*"
+publicHoistPattern:
+  - "*plugin*"

--- a/test/cli/install/migration/pnpm/settings-minage/package.json
+++ b/test/cli/install/migration/pnpm/settings-minage/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-settings-trusted",
+  "dependencies": {
+    "no-deps": "~1.0.0"
+  }
+}

--- a/test/cli/install/migration/pnpm/settings-minage/package.json
+++ b/test/cli/install/migration/pnpm/settings-minage/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-settings-trusted",
+  "name": "test-settings-minage",
   "dependencies": {
     "no-deps": "~1.0.0"
   }

--- a/test/cli/install/migration/pnpm/settings-minage/pnpm-lock.yaml
+++ b/test/cli/install/migration/pnpm/settings-minage/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ~1.0.0
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A==}
+
+snapshots:
+
+  no-deps@1.0.1: {}

--- a/test/cli/install/migration/pnpm/settings-minage/pnpm-workspace.yaml
+++ b/test/cli/install/migration/pnpm/settings-minage/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - webpack
+  - react

--- a/test/cli/install/migration/pnpm/settings-trusted/package.json
+++ b/test/cli/install/migration/pnpm/settings-trusted/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-settings-trusted",
+  "dependencies": {
+    "no-deps": "~1.0.0"
+  }
+}

--- a/test/cli/install/migration/pnpm/settings-trusted/pnpm-lock.yaml
+++ b/test/cli/install/migration/pnpm/settings-trusted/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      no-deps:
+        specifier: ~1.0.0
+        version: 1.0.1
+
+packages:
+
+  no-deps@1.0.1:
+    resolution: {integrity: sha512-3X6cn4+UJdXJuLPu11v8i/fGLe2PdI6v1yKTELam04lY5esCAFdG/qQts6N6rLrL6g1YRq+MKBAwxbmUQk355A==}
+
+snapshots:
+
+  no-deps@1.0.1: {}

--- a/test/cli/install/migration/pnpm/settings-trusted/pnpm-workspace.yaml
+++ b/test/cli/install/migration/pnpm/settings-trusted/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - fsevents


### PR DESCRIPTION
i wish we had a `TOML.stringify` api though

- `onlyBuiltDependencies` → `trustedDependencies` (package.json)
- `minimumReleaseAge` → `minimumReleaseAge` (bunfig.toml, minutes → seconds)
- `minimumReleaseAgeExclude` → `minimumReleaseAgeExcludes` (bunfig.toml)
- `publicHoistPattern` → `publicHoistPattern` (bunfig.toml)
- `hoistPattern` → `hoistPattern` (bunfig.toml)
- `shamefullyHoist` → prepends `"*"` to `publicHoistPattern` (bunfig.toml)