### PR TITLE
fix(windows): use GetConsoleCP() instead of GetConsoleOutputCP() for input codepage

### DIFF
--- a/src/output.zig
+++ b/src/output.zig
@@ -190,7 +190,7 @@ pub const Source = struct {
             console_output_codepage = c.GetConsoleOutputCP();
             _ = c.SetConsoleOutputCP(CP_UTF8);
 
-            console_codepage = c.GetConsoleOutputCP();
+            console_codepage = c.GetConsoleCP();
             _ = c.SetConsoleCP(CP_UTF8);
 
             var mode: w.DWORD = undefined;

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3478,6 +3478,7 @@ pub const ENABLE_PROCESSED_OUTPUT = 0x0001;
 
 pub extern fn SetStdHandle(nStdHandle: u32, hHandle: *anyopaque) u32;
 pub extern fn GetConsoleOutputCP() u32;
+pub extern fn GetConsoleCP() u32;
 pub extern "kernel32" fn SetConsoleCP(wCodePageID: std.os.windows.UINT) callconv(.winapi) std.os.windows.BOOL;
 
 pub const DeleteFileOptions = struct {


### PR DESCRIPTION
## Summary

- Fix typo where `GetConsoleOutputCP()` was called twice instead of calling `GetConsoleCP()` for the input codepage
- Add missing `GetConsoleCP()` extern declaration in windows.zig

The code was saving the output codepage twice, meaning the input codepage was never properly saved and thus couldn't be correctly restored.

## Note

This fix corrects a bug in the codepage save/restore logic, but **may not fully resolve the garbled text issue** in #25151. The garbled text problem occurs when `bunx` (without `--bun`) runs a package via Node.js, and that package tries to spawn `bun`. The error message from cmd.exe gets garbled on non-English Windows systems.

Further investigation may be needed to determine if additional codepage handling is required when spawning processes.

Related to #25151

🤖 Generated with [Claude Code](https://claude.com/claude-code)