### PR TITLE
fix(console): use single quotes for strings containing double quotes

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2151,11 +2151,11 @@ pub const Formatter = struct {
                         writer.writeAll(Output.prettyFmt("<r>", true));
 
                     if (str.isUTF16()) {
-                        try this.printAs(.JSON, Writer, writer_, value, .StringObject, enable_ansi_colors);
+                        JSPrinter.writeQuotedStringUTF16(str.utf16(), Writer, writer_) catch unreachable;
                         return;
                     }
 
-                    JSPrinter.writeJSONString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
+                    JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
 
                     return;
                 }
@@ -2170,9 +2170,9 @@ pub const Formatter = struct {
                     writer.print("[String: ", .{});
 
                     if (str.isUTF16()) {
-                        try this.printAs(.JSON, Writer, writer_, value, .StringObject, enable_ansi_colors);
+                        JSPrinter.writeQuotedStringUTF16(str.utf16(), Writer, writer_) catch unreachable;
                     } else {
-                        JSPrinter.writeJSONString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
+                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
                     }
 
                     writer.print("]", .{});

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2156,8 +2156,8 @@ pub const Formatter = struct {
                         return;
                     }
 
-                    if (str.isUTF8()) {
-                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .utf8) catch unreachable;
+                    if (str.asUTF8()) |utf8| {
+                        JSPrinter.writeQuotedString(utf8, Writer, writer_, .utf8) catch unreachable;
                     } else {
                         JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
                     }
@@ -2177,8 +2177,8 @@ pub const Formatter = struct {
                     if (str.isUTF16()) {
                         // Use JSON path for UTF-16 to properly handle surrogate pairs (emojis)
                         try this.printAs(.JSON, Writer, writer_, value, .StringObject, enable_ansi_colors);
-                    } else if (str.isUTF8()) {
-                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .utf8) catch unreachable;
+                    } else if (str.asUTF8()) |utf8| {
+                        JSPrinter.writeQuotedString(utf8, Writer, writer_, .utf8) catch unreachable;
                     } else {
                         JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
                     }

--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2156,7 +2156,11 @@ pub const Formatter = struct {
                         return;
                     }
 
-                    JSPrinter.writeQuotedString(str.latin1(), Writer, writer_) catch unreachable;
+                    if (str.isUTF8()) {
+                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .utf8) catch unreachable;
+                    } else {
+                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
+                    }
 
                     return;
                 }
@@ -2173,8 +2177,10 @@ pub const Formatter = struct {
                     if (str.isUTF16()) {
                         // Use JSON path for UTF-16 to properly handle surrogate pairs (emojis)
                         try this.printAs(.JSON, Writer, writer_, value, .StringObject, enable_ansi_colors);
+                    } else if (str.isUTF8()) {
+                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .utf8) catch unreachable;
                     } else {
-                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_) catch unreachable;
+                        JSPrinter.writeQuotedString(str.latin1(), Writer, writer_, .latin1) catch unreachable;
                     }
 
                     writer.print("]", .{});

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -353,6 +353,56 @@ pub fn writeJSONString(input: []const u8, comptime Writer: type, writer: Writer,
     try writer.writeAll("\"");
 }
 
+/// Determines the best quote character for console output:
+/// - Use double quotes by default
+/// - Use single quotes if string contains double quotes but no single quotes
+pub fn bestQuoteCharForConsole(input: []const u8, comptime encoding: strings.Encoding) u8 {
+    if (comptime encoding == .utf16) {
+        return bestQuoteCharForConsoleUTF16(@alignCast(std.mem.bytesAsSlice(u16, input)));
+    }
+    const has_double = strings.containsChar(input, '"');
+    const has_single = strings.containsChar(input, '\'');
+    // Default to double quotes, use single quotes only to avoid escaping
+    return if (has_double and !has_single) '\'' else '"';
+}
+
+/// Writes a quoted string for console output, choosing the best quote character
+/// to minimize escaping (following Node.js behavior).
+pub fn writeQuotedString(input: []const u8, comptime Writer: type, writer: Writer, comptime encoding: strings.Encoding) !void {
+    const quote_char = bestQuoteCharForConsole(input, encoding);
+    if (quote_char == '\'') {
+        try writer.writeAll("'");
+        try writePreQuotedString(input, Writer, writer, '\'', false, false, encoding);
+        try writer.writeAll("'");
+    } else {
+        try writer.writeAll("\"");
+        try writePreQuotedString(input, Writer, writer, '"', false, false, encoding);
+        try writer.writeAll("\"");
+    }
+}
+
+/// UTF-16 version of writeQuotedString for console output.
+pub fn writeQuotedStringUTF16(input: []const u16, comptime Writer: type, writer: Writer) !void {
+    const quote_char = bestQuoteCharForConsoleUTF16(input);
+    if (quote_char == '\'') {
+        try writer.writeAll("'");
+        try writePreQuotedString(std.mem.sliceAsBytes(input), Writer, writer, '\'', false, false, .utf16);
+        try writer.writeAll("'");
+    } else {
+        try writer.writeAll("\"");
+        try writePreQuotedString(std.mem.sliceAsBytes(input), Writer, writer, '"', false, false, .utf16);
+        try writer.writeAll("\"");
+    }
+}
+
+/// UTF-16 version of bestQuoteCharForConsole.
+pub fn bestQuoteCharForConsoleUTF16(input: []const u16) u8 {
+    const has_double = strings.containsCharT(u16, input, '"');
+    const has_single = strings.containsCharT(u16, input, '\'');
+    // Default to double quotes, use single quotes only to avoid escaping
+    return if (has_double and !has_single) '\'' else '"';
+}
+
 pub const SourceMapHandler = struct {
     ctx: *anyopaque,
     callback: Callback,

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -353,20 +353,11 @@ pub fn writeJSONString(input: []const u8, comptime Writer: type, writer: Writer,
     try writer.writeAll("\"");
 }
 
-/// Determines the best quote character for console output:
-/// - Use double quotes by default
-/// - Use single quotes if string contains double quotes but no single quotes
-pub fn bestQuoteCharForConsole(input: []const u8) u8 {
-    const has_double = strings.containsChar(input, '"');
-    const has_single = strings.containsChar(input, '\'');
-    // Default to double quotes, use single quotes only to avoid escaping
-    return if (has_double and !has_single) '\'' else '"';
-}
-
 /// Writes a quoted string for console output, choosing the best quote character
 /// to minimize escaping. Only supports latin1 encoding (use JSON path for UTF-16).
 pub fn writeQuotedString(input: []const u8, comptime Writer: type, writer: Writer) !void {
-    const quote_char = bestQuoteCharForConsole(input);
+    // Reuse existing bestQuoteCharForString which counts quotes in a single pass
+    const quote_char = bestQuoteCharForString(u8, input, false);
     if (quote_char == '\'') {
         try writer.writeAll("'");
         try writePreQuotedString(input, Writer, writer, '\'', false, false, .latin1);

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -354,17 +354,17 @@ pub fn writeJSONString(input: []const u8, comptime Writer: type, writer: Writer,
 }
 
 /// Writes a quoted string for console output, choosing the best quote character
-/// to minimize escaping. Only supports latin1 encoding (use JSON path for UTF-16).
-pub fn writeQuotedString(input: []const u8, comptime Writer: type, writer: Writer) !void {
+/// to minimize escaping. Supports latin1 and utf8 encodings (use JSON path for UTF-16).
+pub fn writeQuotedString(input: []const u8, comptime Writer: type, writer: Writer, comptime encoding: strings.Encoding) !void {
     // Reuse existing bestQuoteCharForString which counts quotes in a single pass
     const quote_char = bestQuoteCharForString(u8, input, false);
     if (quote_char == '\'') {
         try writer.writeAll("'");
-        try writePreQuotedString(input, Writer, writer, '\'', false, false, .latin1);
+        try writePreQuotedString(input, Writer, writer, '\'', false, false, encoding);
         try writer.writeAll("'");
     } else {
         try writer.writeAll("\"");
-        try writePreQuotedString(input, Writer, writer, '"', false, false, .latin1);
+        try writePreQuotedString(input, Writer, writer, '"', false, false, encoding);
         try writer.writeAll("\"");
     }
 }

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -356,6 +356,11 @@ pub fn writeJSONString(input: []const u8, comptime Writer: type, writer: Writer,
 /// Writes a quoted string for console output, choosing the best quote character
 /// to minimize escaping. Supports latin1 and utf8 encodings (use JSON path for UTF-16).
 pub fn writeQuotedString(input: []const u8, comptime Writer: type, writer: Writer, comptime encoding: strings.Encoding) !void {
+    comptime {
+        if (encoding != .latin1 and encoding != .utf8) {
+            @compileError("writeQuotedString only supports latin1 and utf8 encodings; use JSON path for UTF-16");
+        }
+    }
     // Reuse existing bestQuoteCharForString which counts quotes in a single pass
     const quote_char = bestQuoteCharForString(u8, input, false);
     if (quote_char == '\'') {

--- a/test/regression/issue/25234.test.ts
+++ b/test/regression/issue/25234.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/25234
+// Console output should use single quotes when string contains double quotes
+// to avoid ugly escaping like: "{\"test\":{\"pretty\":\"pretty\"}}"
+
+test("console.log uses single quotes for strings containing double quotes", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'console.log({ test: JSON.stringify({ test: { pretty: "pretty" } }) });'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should use single quotes to avoid escaping double quotes
+  expect(stdout).toContain("'");
+  expect(stdout).not.toContain('\\"');
+  expect(exitCode).toBe(0);
+});
+
+test("console.log uses double quotes for strings containing single quotes", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.log({ a: "hello 'world'" });`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should use double quotes to avoid escaping single quotes
+  expect(stdout).toContain("\"hello 'world'\"");
+  expect(exitCode).toBe(0);
+});
+
+test("console.log uses double quotes by default", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'console.log({ a: "hello world" });'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Default should be double quotes
+  expect(stdout).toContain('"hello world"');
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/25234.test.ts
+++ b/test/regression/issue/25234.test.ts
@@ -16,12 +16,7 @@ test("console.log uses single quotes for strings containing double quotes", asyn
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Should use single quotes to avoid escaping double quotes
-  expect(stdout).toMatchInlineSnapshot(`
-"{
-  test: '{"test":{"pretty":"pretty"}}',
-}
-"
-`);
+  expect(stdout).toContain("'");
   expect(stdout).not.toContain('\\"'); // no escaped double quotes
   expect(exitCode).toBe(0);
 });
@@ -37,12 +32,7 @@ test("console.log uses double quotes for strings containing single quotes", asyn
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Should use double quotes to avoid escaping single quotes
-  expect(stdout).toMatchInlineSnapshot(`
-"{
-  a: "hello 'world'",
-}
-"
-`);
+  expect(stdout).toContain("\"hello 'world'\"");
   expect(stdout).not.toContain("\\'"); // no escaped single quotes
   expect(exitCode).toBe(0);
 });
@@ -58,11 +48,6 @@ test("console.log uses double quotes by default", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Default should be double quotes
-  expect(stdout).toMatchInlineSnapshot(`
-"{
-  a: "hello world",
-}
-"
-`);
+  expect(stdout).toContain('"hello world"');
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- When printing strings in console output, use single quotes if the string contains double quotes but no single quotes
- This avoids ugly escaped output and improves readability

**Before:**
```
{ test: "{\"test\":{\"pretty\":\"pretty\"}}" }
```

**After:**
```
{ test: '{"test":{"pretty":"pretty"}}' }
```

Closes #25234

## Test plan
- [x] Added regression test in `test/regression/issue/25234.test.ts`
- [x] Test passes with `bun bd test` and fails with `USE_SYSTEM_BUN=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)