### PR TITLE
Add protocol property to serve.d.ts

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1092,7 +1092,7 @@ declare module "bun" {
      * "http"
      * ```
      */
-    readonly protocol: string | undefined;
+    readonly protocol: "http" | "https" | null;
 
     /**
      * Is the server running in development mode?

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1085,12 +1085,9 @@ declare module "bun" {
     /**
      * The protocol the server is listening on.
      *
-     * This will be `undefined` when the server is listening on a unix socket.
-     *
-     * @example
-     * ```js
-     * "http"
-     * ```
+     * - "http" for normal servers
+     * - "https" when TLS is enabled
+     * - null for unix sockets or when unavailable
      */
     readonly protocol: "http" | "https" | null;
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1081,6 +1081,18 @@ declare module "bun" {
      * ```
      */
     readonly hostname: string | undefined;
+    
+    /**
+     * The protocol the server is listening on.
+     *
+     * This will be `undefined` when the server is listening on a unix socket.
+     *
+     * @example
+     * ```js
+     * "http"
+     * ```
+     */
+    readonly protocol: string | undefined;
 
     /**
      * Is the server running in development mode?

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1081,7 +1081,7 @@ declare module "bun" {
      * ```
      */
     readonly hostname: string | undefined;
-    
+
     /**
      * The protocol the server is listening on.
      *


### PR DESCRIPTION
Add protocol property to server type definition

The protocol property is already present on the runtime server object, but missing from `serve.d.ts`.
This adds the missing type so TypeScript consumers get accurate typings and no longer see Property 'protocol' does not exist on type 'Server'.

No runtime changes, only type alignment.

<img width="592" height="393" alt="image" src="https://github.com/user-attachments/assets/61c2bc8f-bf2d-4d35-83a1-b0a514542220" />
<img width="786" height="204" alt="image" src="https://github.com/user-attachments/assets/444b22e9-719d-407d-ac30-7ce51207307a" />