### PR TITLE
fix(node:http): emit 'upgrade' event for HTTP 101 Switching Protocols (#25278)

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -423,7 +423,11 @@ function ClientRequest(input, options, cb) {
                 return;
               }
               try {
-                if (self.aborted || !self.emit("response", res)) {
+                // HTTP 101 Switching Protocols: emit 'upgrade' instead of 'response'
+                // if there are listeners for the 'upgrade' event (Node.js compatibility)
+                if (res.statusCode === 101 && self.listenerCount("upgrade") > 0) {
+                  self.emit("upgrade", res, self.socket, Buffer.alloc(0));
+                } else if (self.aborted || !self.emit("response", res)) {
                   res._dump();
                 }
               } finally {

--- a/test/js/node/http/node-http-upgrade-event.test.ts
+++ b/test/js/node/http/node-http-upgrade-event.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+
+describe("HTTP ClientRequest upgrade event", () => {
+  test("should emit 'upgrade' event instead of 'response' for HTTP 101 Switching Protocols", async () => {
+    // Create a raw TCP server that responds with 101 Switching Protocols
+    await using server = net.createServer(socket => {
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: tcp\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        socket.write("upgraded data");
+      });
+    });
+
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port, address } = server.address() as AddressInfo;
+
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      event: "upgrade" | "response";
+      statusCode: number;
+    }>();
+
+    const req = http.request({
+      hostname: address,
+      port,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Connection: "Upgrade",
+        Upgrade: "tcp",
+      },
+    });
+
+    req.on("upgrade", (res, socket) => {
+      resolve({ event: "upgrade", statusCode: res.statusCode! });
+      socket.destroy();
+    });
+
+    req.on("response", res => {
+      resolve({ event: "response", statusCode: res.statusCode! });
+      res.destroy();
+    });
+
+    req.on("error", reject);
+    req.end();
+
+    const result = await promise;
+
+    // Node.js behavior: should emit 'upgrade' event for 101 status
+    expect(result.event).toBe("upgrade");
+    expect(result.statusCode).toBe(101);
+  });
+
+  test("should emit 'upgrade' event with socket and head arguments", async () => {
+    await using server = net.createServer(socket => {
+      socket.once("data", () => {
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+    });
+
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port, address } = server.address() as AddressInfo;
+
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      hasSocket: boolean;
+      hasHead: boolean;
+      headIsBuffer: boolean;
+    }>();
+
+    const req = http.request({
+      hostname: address,
+      port,
+      method: "GET",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+      },
+    });
+
+    req.on("upgrade", (_res, socket, head) => {
+      resolve({
+        hasSocket: socket != null,
+        hasHead: head != null,
+        headIsBuffer: Buffer.isBuffer(head),
+      });
+      socket.destroy();
+    });
+
+    req.on("response", () => {
+      reject(new Error("Should not emit 'response' event for 101 status"));
+    });
+
+    req.on("error", reject);
+    req.end();
+
+    const result = await promise;
+
+    expect(result.hasSocket).toBe(true);
+    expect(result.hasHead).toBe(true);
+    expect(result.headIsBuffer).toBe(true);
+  });
+
+  test("should emit 'response' event for non-101 status even with Upgrade header", async () => {
+    await using server = net.createServer(socket => {
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello");
+        socket.end();
+      });
+    });
+
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port, address } = server.address() as AddressInfo;
+
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      event: "upgrade" | "response";
+      statusCode: number;
+    }>();
+
+    const req = http.request({
+      hostname: address,
+      port,
+      method: "GET",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "tcp",
+      },
+    });
+
+    req.on("upgrade", (res, socket) => {
+      resolve({ event: "upgrade", statusCode: res.statusCode! });
+      socket.destroy();
+    });
+
+    req.on("response", res => {
+      resolve({ event: "response", statusCode: res.statusCode! });
+      res.resume();
+    });
+
+    req.on("error", reject);
+    req.end();
+
+    const result = await promise;
+
+    expect(result.event).toBe("response");
+    expect(result.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Closes #25278
Closes #18982

> **Note:** This is a minimal fix that emits the `'upgrade'` event with the existing `FakeSocket`. For a more complete implementation with a fully functional duplex socket, see #22412. This PR can serve as a quick fix while that more comprehensive solution is reviewed.

Fixes `node:http` `ClientRequest` to emit the `'upgrade'` event instead of `'response'` when the server responds with HTTP 101 Switching Protocols.

Previously, Bun incorrectly fired the `'response'` event for 101 status codes, which broke libraries that rely on the upgrade event:
- `docker-modem` / `dockerode` - Docker client for Node.js
- `testcontainers` - Integration testing library
- Any custom HTTP upgrade handling via `node:http`

The fix checks if the response status is 101 and there are listeners for the `'upgrade'` event, then emits `'upgrade'` with `(response, socket, head)` arguments as per [Node.js documentation](https://nodejs.org/api/http.html#event-upgrade).

### How did you verify your code works?

Added tests in `test/js/node/http/node-http-upgrade-event.test.ts` that:
1. Verify `'upgrade'` event is emitted (not `'response'`) for HTTP 101 status
2. Verify socket and head (Buffer) arguments are provided to the handler
3. Verify non-101 responses still correctly emit `'response'` event

Tests use a raw TCP server to simulate 101 Switching Protocols responses.

```bash
# Fails with system Bun (before fix):
USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http-upgrade-event.test.ts

# Passes with debug build (after fix):
bun bd test test/js/node/http/node-http-upgrade-event.test.ts
```