### PR TITLE
fix(jest): handle null SourceOrigin in jest.mock() to prevent crash

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -523,6 +523,8 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     auto resolveSpecifier = [&]() -> void {
         JSC::SourceOrigin sourceOrigin = callframe->callerSourceOrigin(vm);
+        if (sourceOrigin.isNull())
+            return;
         const URL& url = sourceOrigin.url();
 
         if (specifier.startsWith("file:"_s)) {

--- a/test/regression/issue/ENG-24434.test.ts
+++ b/test/regression/issue/ENG-24434.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+
+// Regression test for ENG-24434
+// jest.mock() with invalid arguments should throw TypeError, not crash
+test("jest.mock() with non-string first argument should throw TypeError", () => {
+  const jestObj = Bun.jest(import.meta.path).jest;
+
+  // Passing the jest object itself as the first argument should throw
+  // a TypeError, not crash with stack-buffer-overflow
+  expect(() => {
+    jestObj.mock(jestObj);
+  }).toThrow(TypeError);
+});
+
+test("jest.mock() with object as first argument should throw TypeError", () => {
+  const jestObj = Bun.jest(import.meta.path).jest;
+
+  expect(() => {
+    jestObj.mock({});
+  }).toThrow(TypeError);
+});
+
+test("jest.mock() with missing callback should throw TypeError", () => {
+  const jestObj = Bun.jest(import.meta.path).jest;
+
+  expect(() => {
+    jestObj.mock("some-module");
+  }).toThrow(TypeError);
+});


### PR DESCRIPTION
## Summary
- Added null check for `sourceOrigin` before accessing its URL in `jest.mock()`
- When `callerSourceOrigin()` returns null (e.g., when called with invalid arguments), the code now safely returns early instead of crashing

## Test plan
- [x] Added regression test `test/regression/issue/ENG-24434.test.ts`
- [x] `bun bd test test/regression/issue/ENG-24434.test.ts` passes

Fixes ENG-24434

🤖 Generated with [Claude Code](https://claude.com/claude-code)