### PR TITLE
chore: Unify eqlCaseInsensitiveASCIIPlaceholders of the world

### DIFF
--- a/src/bun.js/api/bun/socket/SocketAddress.zig
+++ b/src/bun.js/api/bun/socket/SocketAddress.zig
@@ -511,8 +511,8 @@ pub const AF = enum(inet.sa_family_t) {
 
             if (fam_str.is8Bit()) {
                 const slice = fam_str.latin1();
-                if (std.ascii.eqlIgnoreCase(slice[0..4], "ipv4")) return AF.INET;
-                if (std.ascii.eqlIgnoreCase(slice[0..4], "ipv6")) return AF.INET6;
+                if (bun.strings.eqlCaseInsensitiveASCII(slice[0..4], "ipv4")) return AF.INET;
+                if (bun.strings.eqlCaseInsensitiveASCII(slice[0..4], "ipv6")) return AF.INET6;
                 return global.throwInvalidArgumentPropertyValue("options.family", "'ipv4' or 'ipv6'", value);
             } else {
                 // not full ignore-case since that would require converting

--- a/src/bun.js/api/crypto/EVP.zig
+++ b/src/bun.js/api/crypto/EVP.zig
@@ -179,7 +179,7 @@ pub fn copy(this: *const EVP, engine: *BoringSSL.ENGINE) error{OutOfMemory}!EVP 
 }
 
 pub fn byNameAndEngine(engine: *BoringSSL.ENGINE, name: []const u8) ?EVP {
-    if (Algorithm.map.getWithEql(name, strings.eqlCaseInsensitiveASCIIIgnoreLength)) |algorithm| {
+    if (Algorithm.map.getWithEql(name, strings.eqlCaseInsensitiveASCII)) |algorithm| {
         if (algorithm.md()) |md| {
             return EVP.init(algorithm, md, engine);
         }

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -19,7 +19,7 @@ const stack_fallback_size_small = switch (Environment.os) {
 /// Compares ASCII values case-insensitively, non-ASCII values are compared directly
 fn eqlIgnoreCaseT(comptime T: type, a: []const T, b: []const T) bool {
     if (T != u16) {
-        return bun.strings.eqlCaseInsensitiveASCII(a, b, true);
+        return bun.strings.eqlCaseInsensitiveASCII(a, b);
     }
 }
 

--- a/src/bun.js/uuid.zig
+++ b/src/bun.js/uuid.zig
@@ -205,13 +205,13 @@ pub const UUID5 = struct {
         pub const x500: *const [16]u8 = &.{ 0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8 };
 
         pub fn get(namespace: []const u8) ?*const [16]u8 {
-            if (bun.strings.eqlCaseInsensitiveASCII(namespace, "dns", true)) {
+            if (bun.strings.eqlCaseInsensitiveASCII(namespace, "dns")) {
                 return dns;
-            } else if (bun.strings.eqlCaseInsensitiveASCII(namespace, "url", true)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(namespace, "url")) {
                 return url;
-            } else if (bun.strings.eqlCaseInsensitiveASCII(namespace, "oid", true)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(namespace, "oid")) {
                 return oid;
-            } else if (bun.strings.eqlCaseInsensitiveASCII(namespace, "x500", true)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(namespace, "x500")) {
                 return x500;
             }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -830,7 +830,7 @@ pub fn getenvZAnyCase(key: [:0]const u8) ?[]const u8 {
     for (std.os.environ) |lineZ| {
         const line = sliceTo(lineZ, 0);
         const key_end = strings.indexOfCharUsize(line, '=') orelse line.len;
-        if (strings.eqlCaseInsensitiveASCII(line[0..key_end], key, true)) {
+        if (strings.eqlCaseInsensitiveASCII(line[0..key_end], key)) {
             return line[@min(key_end + 1, line.len)..];
         }
     }
@@ -940,7 +940,7 @@ pub const CaseInsensitiveASCIIStringContext = struct {
     }
 
     pub fn eql(_: @This(), a: []const u8, b: []const u8, _: usize) bool {
-        return strings.eqlCaseInsensitiveASCIIICheckLength(a, b);
+        return strings.eqlCaseInsensitiveASCII(a, b);
     }
 
     pub fn pre(input: []const u8) Prehashed {
@@ -961,7 +961,7 @@ pub const CaseInsensitiveASCIIStringContext = struct {
         }
 
         pub fn eql(_: @This(), a: []const u8, b: []const u8) bool {
-            return strings.eqlCaseInsensitiveASCIIICheckLength(a, b);
+            return strings.eqlCaseInsensitiveASCII(a, b);
         }
     };
 };
@@ -1016,7 +1016,7 @@ pub const StringHashMapContext = struct {
         }
 
         pub fn eql(_: @This(), a: []const u8, b: []const u8) bool {
-            return strings.eqlCaseInsensitiveASCIIICheckLength(a, b);
+            return strings.eqlCaseInsensitiveASCII(a, b);
         }
     };
 };

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -2027,7 +2027,7 @@ pub const Example = struct {
         var is_expected_content_type = false;
         var content_type: string = "";
         for (response.headers.list) |header| {
-            if (strings.eqlCaseInsensitiveASCII(header.name, "content-type", true)) {
+            if (strings.eqlCaseInsensitiveASCII(header.name, "content-type")) {
                 content_type = header.value;
 
                 if (strings.eqlComptime(header.value, "application/x-gzip")) {

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -2543,7 +2543,7 @@ pub const PackCommand = struct {
     const stringsEql = if (Environment.isLinux)
         strings.eqlComptime
     else
-        strings.eqlCaseInsensitiveASCIIICheckLength;
+        strings.eqlCaseInsensitiveASCII;
 
     fn isSpecialFileOrVariant(filename: []const u8, comptime name: []const u8) callconv(bun.callconv_inline) bool {
         return switch (filename.len) {

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -626,10 +626,10 @@ pub const PublishCommand = struct {
                         var iter = strings.split(@"www-authenticate", ",");
                         while (iter.next()) |part| {
                             const trimmed = strings.trim(part, &strings.whitespace_chars);
-                            if (strings.eqlCaseInsensitiveASCII(trimmed, "ipaddress", true)) {
+                            if (strings.eqlCaseInsensitiveASCII(trimmed, "ipaddress")) {
                                 Output.errGeneric("login is not allowed from your IP address", .{});
                                 Global.crash();
-                            } else if (strings.eqlCaseInsensitiveASCII(trimmed, "otp", true)) {
+                            } else if (strings.eqlCaseInsensitiveASCII(trimmed, "otp")) {
                                 break :prompt_for_otp true;
                             }
                         }

--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -4842,7 +4842,7 @@ const Tokenizer = struct {
 
     pub fn seeFunction(this: *Tokenizer, name: []const u8) void {
         if (this.var_or_env_functions == .looking_for_them) {
-            if (std.ascii.eqlIgnoreCase(name, "var") and std.ascii.eqlIgnoreCase(name, "env")) {
+            if (bun.strings.eqlCaseInsensitiveASCII(name, "var") and bun.strings.eqlCaseInsensitiveASCII(name, "env")) {
                 this.var_or_env_functions = .seen_at_least_one;
             }
         }
@@ -5188,7 +5188,7 @@ const Tokenizer = struct {
         const value = this.consumeName();
         if (!this.isEof() and this.nextByteUnchecked() == '(') {
             this.advance(1);
-            if (std.ascii.eqlIgnoreCase(value, "url")) return if (this.consumeUnquotedUrl()) |tok| return tok else .{ .function = value };
+            if (bun.strings.eqlCaseInsensitiveASCII(value, "url")) return if (this.consumeUnquotedUrl()) |tok| return tok else .{ .function = value };
             this.seeFunction(value);
             return .{ .function = value };
         }

--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -873,7 +873,7 @@ pub const enum_property_util = struct {
         const Map = comptime bun.ComptimeEnumMap(T);
         if (Map.getASCIIICaseInsensitive(ident)) |x| return .{ .result = x };
         // inline for (std.meta.fields(T)) |field| {
-        //     if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, field.name)) return .{ .result = @enumFromInt(field.value) };
+        //     if (bun.strings.eqlCaseInsensitiveASCII(ident, field.name)) return .{ .result = @enumFromInt(field.value) };
         // }
 
         return .{ .err = location.newUnexpectedTokenError(.{ .ident = ident }) };
@@ -901,7 +901,7 @@ pub fn DefineEnumProperty(comptime T: type) type {
 
             // todo_stuff.match_ignore_ascii_case
             inline for (fields) |field| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, field.name)) return .{ .result = @enumFromInt(field.value) };
+                if (bun.strings.eqlCaseInsensitiveASCII(ident, field.name)) return .{ .result = @enumFromInt(field.value) };
             }
 
             return .{ .err = location.newUnexpectedTokenError(.{ .ident = ident }) };
@@ -2848,7 +2848,7 @@ pub fn StyleSheetParser(comptime P: type) type {
                     const first_stylesheet_rule = !this.any_rule_so_far;
                     this.any_rule_so_far = true;
 
-                    if (first_stylesheet_rule and bun.strings.eqlCaseInsensitiveASCII(name, "charset", true)) {
+                    if (first_stylesheet_rule and bun.strings.eqlCaseInsensitiveASCII(name, "charset")) {
                         const delimiters = Delimiters{
                             .semicolon = true,
                             .close_curly_bracket = true,
@@ -4194,7 +4194,7 @@ pub const Parser = struct {
             .result => |v| v,
         };
         switch (tok.*) {
-            .ident => |i| if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, i)) return .success,
+            .ident => |i| if (bun.strings.eqlCaseInsensitiveASCII(name, i)) return .success,
             else => {},
         }
         return .{ .err = start_location.newUnexpectedTokenError(tok.*) };
@@ -4220,7 +4220,7 @@ pub const Parser = struct {
             .result => |v| v,
         };
         switch (tok.*) {
-            .function => |fn_name| if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, fn_name)) return .success,
+            .function => |fn_name| if (bun.strings.eqlCaseInsensitiveASCII(name, fn_name)) return .success,
             else => {},
         }
         return .{ .err = start_location.newUnexpectedTokenError(tok.*) };
@@ -4260,7 +4260,7 @@ pub const Parser = struct {
         switch (tok.*) {
             .unquoted_url => |value| return .{ .result = value },
             .function => |name| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("url", name)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("url", name)) {
                     const result = this.parseNestedBlock([]const u8, {}, struct {
                         fn parse(_: void, parser: *Parser) Result([]const u8) {
                             return switch (parser.expectString()) {
@@ -4291,7 +4291,7 @@ pub const Parser = struct {
             .unquoted_url => |value| return .{ .result = value },
             .quoted_string => |value| return .{ .result = value },
             .function => |name| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("url", name)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("url", name)) {
                     const result = this.parseNestedBlock([]const u8, {}, struct {
                         fn parse(_: void, parser: *Parser) Result([]const u8) {
                             return switch (parser.expectString()) {
@@ -4616,9 +4616,9 @@ pub const nth = struct {
                 if (tok.dimension.num.int_value) |a| {
                     // @compileError(todo_stuff.match_ignore_ascii_case);
                     const unit = tok.dimension.unit;
-                    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "n")) {
+                    if (bun.strings.eqlCaseInsensitiveASCII(unit, "n")) {
                         return parse_b(input, a);
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "n-")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(unit, "n-")) {
                         return parse_signless_b(input, a, -1);
                     } else {
                         if (parse_n_dash_digits(input.allocator(), unit).asValue()) |b| {
@@ -4632,17 +4632,17 @@ pub const nth = struct {
             .ident => {
                 const value = tok.ident;
                 // @compileError(todo_stuff.match_ignore_ascii_case);
-                if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(value, "even")) {
+                if (bun.strings.eqlCaseInsensitiveASCII(value, "even")) {
                     return .{ .result = .{ 2, 0 } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(value, "odd")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(value, "odd")) {
                     return .{ .result = .{ 2, 1 } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(value, "n")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(value, "n")) {
                     return parse_b(input, 1);
-                } else if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(value, "-n")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(value, "-n")) {
                     return parse_b(input, -1);
-                } else if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(value, "n-")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(value, "n-")) {
                     return parse_signless_b(input, 1, -1);
-                } else if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(value, "-n-")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(value, "-n-")) {
                     return parse_signless_b(input, -1, -1);
                 } else {
                     const slice, const a: i32 = if (bun.strings.startsWithChar(value, '-')) .{ value[1..], -1 } else .{ value, 1 };
@@ -4657,9 +4657,9 @@ pub const nth = struct {
                 };
                 if (next_tok.* == .ident) {
                     const value = next_tok.ident;
-                    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(value, "n")) {
+                    if (bun.strings.eqlCaseInsensitiveASCII(value, "n")) {
                         return parse_b(input, 1);
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(value, "-n")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(value, "-n")) {
                         return parse_signless_b(input, 1, -1);
                     } else {
                         if (parse_n_dash_digits(input.allocator(), value).asValue()) |b| {
@@ -4709,7 +4709,7 @@ pub const nth = struct {
     fn parse_n_dash_digits(allocator: Allocator, str: []const u8) Maybe(i32, void) {
         const bytes = str;
         if (bytes.len >= 3 and
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength(bytes[0..2], "n-") and
+            bun.strings.eqlCaseInsensitiveASCII(bytes[0..2], "n-") and
             brk: {
                 for (bytes[2..]) |b| {
                     if (b < '0' or b > '9') break :brk false;

--- a/src/css/media_query.zig
+++ b/src/css/media_query.zig
@@ -473,11 +473,11 @@ pub fn parseQueryCondition(
         switch (tok.*) {
             .open_paren => break :brk .{ false, false },
             .ident => |ident| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "not")) break :brk .{ true, false };
+                if (bun.strings.eqlCaseInsensitiveASCII(ident, "not")) break :brk .{ true, false };
             },
             .function => |f| {
                 if (flags.allow_style and
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "style"))
+                    bun.strings.eqlCaseInsensitiveASCII(f, "style"))
                 {
                     break :brk .{ false, true };
                 }
@@ -576,7 +576,7 @@ pub fn parseParensOrFunction(
         .open_paren => return parseParenBlock(QueryCondition, input, flags),
         .function => |f| {
             if (flags.allow_style and
-                bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "style"))
+                bun.strings.eqlCaseInsensitiveASCII(f, "style"))
             {
                 return QueryCondition.parseStyleQuery(input);
             }

--- a/src/css/properties/animation.zig
+++ b/src/css/properties/animation.zig
@@ -185,7 +185,7 @@ pub const Animation = struct {
                 }
 
                 if (!this.fill_mode.eql(&AnimationFillMode.default()) or
-                    (!bun.strings.eqlCaseInsensitiveASCII(name_str, "none") and css.parse_utility.parseString(dest.allocator, AnimationFillMode, name_str, AnimationFillMode.parse).isOk()))
+                    (!bun.strings.eqlCaseInsensitiveASCII(name_str, "none") and css.parse_utility.parseString(dest.allocator).isOk()))
                 {
                     try this.fill_mode.toCss(dest);
                     try dest.writeChar(' ');
@@ -256,13 +256,13 @@ pub const AnimationName = union(enum) {
                 }
 
                 // CSS-wide keywords and `none` cannot remove quotes
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "none") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "initial") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "inherit") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "unset") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "default") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "revert") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "revert-layer"))
+                if (bun.strings.eqlCaseInsensitiveASCII(s, "none") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "initial") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "inherit") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "unset") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "default") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "revert") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "revert-layer"))
                 {
                     css.serializer.serializeString(s, dest) catch return dest.addFmtError();
                     return;

--- a/src/css/properties/background.zig
+++ b/src/css/properties/background.zig
@@ -273,9 +273,9 @@ pub const BackgroundSize = union(enum) {
             .err => |e| return .{ .err = e },
         };
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "cover")) {
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, "cover")) {
             return .{ .result = .cover };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "contain")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "contain")) {
             return .{ .result = .contain };
         } else {
             return .{ .err = location.newBasicUnexpectedTokenError(.{ .ident = ident }) };
@@ -380,9 +380,9 @@ pub const BackgroundRepeat = struct {
             .err => |e| return .{ .err = e },
         };
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "repeat-x")) {
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, "repeat-x")) {
             return .{ .result = .{ .x = .repeat, .y = .@"no-repeat" } };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "repeat-y")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "repeat-y")) {
             return .{ .result = .{ .x = .@"no-repeat", .y = .repeat } };
         }
 

--- a/src/css/properties/css_modules.zig
+++ b/src/css/properties/css_modules.zig
@@ -67,7 +67,7 @@ pub const Composes = struct {
             .err => |e| return .{ .err = e },
         };
 
-        if (bun.strings.eqlCaseInsensitiveASCII(name.v, "from", true)) return .{ .err = input.newErrorForNextToken() };
+        if (bun.strings.eqlCaseInsensitiveASCII(name.v, "from")) return .{ .err = input.newErrorForNextToken() };
 
         return .{ .result = name };
     }

--- a/src/css/properties/custom.zig
+++ b/src/css/properties/custom.zig
@@ -876,7 +876,7 @@ pub const UnresolvedColor = union(enum) {
     ) Result(UnresolvedColor) {
         var parser = ComponentParser.new(false);
         // css.todo_stuff.match_ignore_ascii_case
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "rgb")) {
+        if (bun.strings.eqlCaseInsensitiveASCII(f, "rgb")) {
             const Closure = struct {
                 options: *const css.ParserOptions,
                 parser: *ComponentParser,
@@ -911,7 +911,7 @@ pub const UnresolvedColor = union(enum) {
                 .parser = &parser,
             };
             return input.parseNestedBlock(UnresolvedColor, &closure, Closure.parsefn);
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "hsl")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(f, "hsl")) {
             const Closure = struct {
                 options: *const css.ParserOptions,
                 parser: *ComponentParser,
@@ -946,7 +946,7 @@ pub const UnresolvedColor = union(enum) {
                 .parser = &parser,
             };
             return input.parseNestedBlock(UnresolvedColor, &closure, Closure.parsefn);
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "light-dark")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(f, "light-dark")) {
             const Closure = struct {
                 options: *const css.ParserOptions,
                 parser: *ComponentParser,
@@ -1519,18 +1519,18 @@ pub const CustomPropertyName = union(enum) {
 
 pub fn tryParseColorToken(f: []const u8, state: *const css.ParserState, input: *css.Parser) ?CssColor {
     // css.todo_stuff.match_ignore_ascii_case
-    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "rgb") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "rgba") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "hsl") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "hsla") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "hwb") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "lab") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "lch") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "oklab") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "oklch") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "color") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "color-mix") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(f, "light-dark"))
+    if (bun.strings.eqlCaseInsensitiveASCII(f, "rgb") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "rgba") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "hsl") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "hsla") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "hwb") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "lab") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "lch") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "oklab") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "oklch") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "color") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "color-mix") or
+        bun.strings.eqlCaseInsensitiveASCII(f, "light-dark"))
     {
         const s = input.state();
         input.reset(state);

--- a/src/css/properties/font.zig
+++ b/src/css/properties/font.zig
@@ -457,11 +457,11 @@ pub const FontStyle = union(enum) {
             .err => |e| return .{ .err = e },
         };
         // todo_stuff.match_ignore_ascii_case
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("normal", ident)) {
+        if (bun.strings.eqlCaseInsensitiveASCII("normal", ident)) {
             return .{ .result = .normal };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("italic", ident)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("italic", ident)) {
             return .{ .result = .italic };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("oblique", ident)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("oblique", ident)) {
             const angle = input.tryParse(Angle.parse, .{}).unwrapOr(FontStyle.defaultObliqueAngle());
             return .{ .result = .{ .oblique = angle } };
         } else {

--- a/src/css/properties/generate_properties.ts
+++ b/src/css/properties/generate_properties.ts
@@ -119,7 +119,7 @@ function generatePropertyImpl(property_defs: Record<string, PropertyDef>): strin
   // - eql()
   // - parse()
   // - toCss()
-  // 
+  //
   // We do this string concatenation thing so we get all the errors at once,
   // instead of relying on Zig semantic analysis which usually stops at the first error.
   comptime {
@@ -491,7 +491,7 @@ function generatePropertyIdImplFromNameAndPrefix(property_defs: Record<string, P
   return Object.entries(property_defs)
     .map(([name, meta]) => {
       if (name === "unparsed") return "";
-      return `if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name1, "${name}")) {
+      return `if (bun.strings.eqlCaseInsensitiveASCII(name1, "${name}")) {
   const allowed_prefixes = ${constructVendorPrefix(meta.valid_prefixes)};
   if (allowed_prefixes.contains(pre)) return ${meta.valid_prefixes === undefined ? `.${escapeIdent(name)}` : `.{ .${escapeIdent(name)} = pre }`};
 } else `;

--- a/src/css/properties/grid.zig
+++ b/src/css/properties/grid.zig
@@ -247,11 +247,11 @@ pub const TrackBreadth = union(enum) {
             .err => |e| return .{ .err = e },
         };
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "auto")) {
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, "auto")) {
             return .{ .result = .auto };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "min-content")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "min-content")) {
             return .{ .result = .min_content };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "max-content")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "max-content")) {
             return .{ .result = .max_content };
         }
 
@@ -266,7 +266,7 @@ pub const TrackBreadth = union(enum) {
         };
 
         if (token == .dimension) {
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(token.dimension.unit, "fr") and token.dimension.value >= 0.0) {
+            if (bun.strings.eqlCaseInsensitiveASCII(token.dimension.unit, "fr") and token.dimension.value >= 0.0) {
                 return .{ .result = token.dimension.value };
             }
         }

--- a/src/css/properties/transform.zig
+++ b/src/css/properties/transform.zig
@@ -212,7 +212,7 @@ pub const Transform = union(enum) {
             struct {
                 fn parse(closure: Closure, i: *css.Parser) css.Result(Transform) {
                     const location = i.currentSourceLocation();
-                    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "matrix")) {
+                    if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "matrix")) {
                         const a = switch (css.CSSNumberFns.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -243,7 +243,7 @@ pub const Transform = union(enum) {
                             .err => |ee| return .{ .err = ee },
                         };
                         return .{ .result = .{ .matrix = .{ .a = a, .b = b, .c = c, .d = d, .e = e, .f = f } } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "matrix3d")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "matrix3d")) {
                         const m11 = switch (css.CSSNumberFns.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -341,7 +341,7 @@ pub const Transform = union(enum) {
                             .m43 = m43,
                             .m44 = m44,
                         } } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "translate")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "translate")) {
                         const x = switch (LengthPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -359,25 +359,25 @@ pub const Transform = union(enum) {
                         } else {
                             return .{ .result = .{ .translate = .{ .x = x, .y = LengthPercentage.zero() } } };
                         }
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "translatex")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "translatex")) {
                         const x = switch (LengthPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .translate_x = x } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "translatey")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "translatey")) {
                         const y = switch (LengthPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .translate_y = y } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "translatez")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "translatez")) {
                         const z = switch (Length.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .translate_z = z } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "translate3d")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "translate3d")) {
                         const x = switch (LengthPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -393,7 +393,7 @@ pub const Transform = union(enum) {
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .translate_3d = .{ .x = x, .y = y, .z = z } } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "scale")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "scale")) {
                         const x = switch (NumberOrPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -411,25 +411,25 @@ pub const Transform = union(enum) {
                         } else {
                             return .{ .result = .{ .scale = .{ .x = x, .y = x.deepClone(i.allocator()) } } };
                         }
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "scalex")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "scalex")) {
                         const x = switch (NumberOrPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .scale_x = x } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "scaley")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "scaley")) {
                         const y = switch (NumberOrPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .scale_y = y } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "scalez")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "scalez")) {
                         const z = switch (NumberOrPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .scale_z = z } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "scale3d")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "scale3d")) {
                         const x = switch (NumberOrPercentage.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -445,31 +445,31 @@ pub const Transform = union(enum) {
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .scale_3d = .{ .x = x, .y = y, .z = z } } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "rotate")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "rotate")) {
                         const angle = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .rotate = angle } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "rotatex")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "rotatex")) {
                         const angle = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .rotate_x = angle } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "rotatey")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "rotatey")) {
                         const angle = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .rotate_y = angle } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "rotatez")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "rotatez")) {
                         const angle = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .rotate_z = angle } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "rotate3d")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "rotate3d")) {
                         const x = switch (css.CSSNumberFns.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -490,7 +490,7 @@ pub const Transform = union(enum) {
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .rotate_3d = .{ .x = x, .y = y, .z = z, .angle = angle } } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "skew")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "skew")) {
                         const x = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -508,19 +508,19 @@ pub const Transform = union(enum) {
                         } else {
                             return .{ .result = .{ .skew = .{ .x = x, .y = Angle{ .deg = 0.0 } } } };
                         }
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "skewx")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "skewx")) {
                         const angle = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .skew_x = angle } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "skewy")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "skewy")) {
                         const angle = switch (Angle.parseWithUnitlessZero(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = .{ .skew_y = angle } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "perspective")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "perspective")) {
                         const len = switch (Length.parse(i)) {
                             .result => |v| v,
                             .err => |e| return .{ .err = e },
@@ -1016,11 +1016,11 @@ pub const Rotate = struct {
                     .result => |v| v,
                     .err => |e| return .{ .err = e },
                 };
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "x")) {
+                if (bun.strings.eqlCaseInsensitiveASCII(ident, "x")) {
                     return .{ .result = .{ .x = 1.0, .y = 0.0, .z = 0.0 } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "y")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "y")) {
                     return .{ .result = .{ .x = 0.0, .y = 1.0, .z = 0.0 } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "z")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "z")) {
                     return .{ .result = .{ .x = 0.0, .y = 0.0, .z = 1.0 } };
                 }
                 return .{ .err = location.newUnexpectedTokenError(.{ .ident = ident }) };

--- a/src/css/rules/container.zig
+++ b/src/css/rules/container.zig
@@ -18,10 +18,10 @@ pub const ContainerName = struct {
         };
 
         // todo_stuff.match_ignore_ascii_case;
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("none", ident.v) or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength("and", ident.v) or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength("not", ident.v) or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength("or", ident.v))
+        if (bun.strings.eqlCaseInsensitiveASCII("none", ident.v) or
+            bun.strings.eqlCaseInsensitiveASCII("and", ident.v) or
+            bun.strings.eqlCaseInsensitiveASCII("not", ident.v) or
+            bun.strings.eqlCaseInsensitiveASCII("or", ident.v))
             return .{ .err = input.newUnexpectedTokenError(.{ .ident = ident.v }) };
 
         return .{ .result = ContainerName{ .v = ident } };

--- a/src/css/rules/font_face.zig
+++ b/src/css/rules/font_face.zig
@@ -377,19 +377,19 @@ pub const FontFormat = union(enum) {
             .err => |e| return .{ .err = e },
         };
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("woff", s)) {
+        if (bun.strings.eqlCaseInsensitiveASCII("woff", s)) {
             return .{ .result = .woff };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("woff2", s)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("woff2", s)) {
             return .{ .result = .woff2 };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("truetype", s)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("truetype", s)) {
             return .{ .result = .truetype };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("opentype", s)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("opentype", s)) {
             return .{ .result = .opentype };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("embedded-opentype", s)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("embedded-opentype", s)) {
             return .{ .result = .embedded_opentype };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("collection", s)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("collection", s)) {
             return .{ .result = .collection };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("svg", s)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("svg", s)) {
             return .{ .result = .svg };
         } else {
             return .{ .result = .{ .string = s } };
@@ -668,35 +668,35 @@ pub const FontFaceDeclarationParser = struct {
             _ = this; // autofix
             const state = input.state();
             // todo_stuff.match_ignore_ascii_case
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "src")) {
+            if (bun.strings.eqlCaseInsensitiveASCII(name, "src")) {
                 if (input.parseCommaSeparated(Source, Source.parse).asValue()) |sources| {
                     return .{ .result = .{ .source = sources } };
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "font-family")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "font-family")) {
                 if (FontFamily.parse(input).asValue()) |c| {
                     if (input.expectExhausted().isOk()) {
                         return .{ .result = .{ .font_family = c } };
                     }
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "font-weight")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "font-weight")) {
                 if (Size2D(FontWeight).parse(input).asValue()) |c| {
                     if (input.expectExhausted().isOk()) {
                         return .{ .result = .{ .font_weight = c } };
                     }
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "font-style")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "font-style")) {
                 if (FontStyle.parse(input).asValue()) |c| {
                     if (input.expectExhausted().isOk()) {
                         return .{ .result = .{ .font_style = c } };
                     }
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "font-stretch")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "font-stretch")) {
                 if (Size2D(FontStretch).parse(input).asValue()) |c| {
                     if (input.expectExhausted().isOk()) {
                         return .{ .result = .{ .font_stretch = c } };
                     }
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "unicode-renage")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "unicode-renage")) {
                 if (input.parseList(UnicodeRange, UnicodeRange.parse).asValue()) |c| {
                     if (input.expectExhausted().isOk()) {
                         return .{ .result = .{ .unicode_range = c } };

--- a/src/css/rules/font_palette_values.zig
+++ b/src/css/rules/font_palette_values.zig
@@ -180,9 +180,9 @@ pub const BasePalette = union(enum) {
             .result => |vv| vv,
             .err => |e| return .{ .err = e },
         };
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("light", ident)) {
+        if (bun.strings.eqlCaseInsensitiveASCII("light", ident)) {
             return .{ .result = .light };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("dark", ident)) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII("dark", ident)) {
             return .{ .result = .dark };
         } else return .{ .err = location.newUnexpectedTokenError(.{ .ident = ident }) };
     }
@@ -210,7 +210,7 @@ pub const FontPaletteValuesDeclarationParser = struct {
             _ = this; // autofix
             const state = input.state();
             // todo_stuff.match_ignore_ascii_case
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("font-family", name)) {
+            if (bun.strings.eqlCaseInsensitiveASCII("font-family", name)) {
                 // https://drafts.csswg.org/css-fonts-4/#font-family-2-desc
                 if (FontFamily.parse(input).asValue()) |font_family| {
                     if (font_family == .generic) {
@@ -218,12 +218,12 @@ pub const FontPaletteValuesDeclarationParser = struct {
                     }
                     return .{ .result = .{ .font_family = font_family } };
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("base-palette", name)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("base-palette", name)) {
                 // https://drafts.csswg.org/css-fonts-4/#base-palette-desc
                 if (BasePalette.parse(input).asValue()) |base_palette| {
                     return .{ .result = .{ .base_palette = base_palette } };
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("override-colors", name)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("override-colors", name)) {
                 // https://drafts.csswg.org/css-fonts-4/#override-color
                 if (input.parseCommaSeparated(OverrideColors, OverrideColors.parse).asValue()) |override_colors| {
                     return .{ .result = .{ .override_colors = override_colors } };

--- a/src/css/rules/keyframes.zig
+++ b/src/css/rules/keyframes.zig
@@ -108,13 +108,13 @@ pub const KeyframesName = union(enum) {
             .ident => |s| {
                 // todo_stuff.match_ignore_ascii_case
                 // CSS-wide keywords without quotes throws an error.
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "none") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "initial") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "inherit") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "unset") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "default") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "revert") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "revert-layer"))
+                if (bun.strings.eqlCaseInsensitiveASCII(s, "none") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "initial") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "inherit") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "unset") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "default") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "revert") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "revert-layer"))
                 {
                     return .{ .err = input.newUnexpectedTokenError(.{ .ident = s }) };
                 } else {
@@ -138,13 +138,13 @@ pub const KeyframesName = union(enum) {
             .custom => |s| {
                 // todo_stuff.match_ignore_ascii_case
                 // CSS-wide keywords and `none` cannot remove quotes.
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "none") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "initial") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "inherit") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "unset") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "default") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "revert") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(s, "revert-layer"))
+                if (bun.strings.eqlCaseInsensitiveASCII(s, "none") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "initial") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "inherit") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "unset") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "default") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "revert") or
+                    bun.strings.eqlCaseInsensitiveASCII(s, "revert-layer"))
                 {
                     css.serializer.serializeString(s, dest) catch return dest.addFmtError();
                 } else {

--- a/src/css/rules/property.zig
+++ b/src/css/rules/property.zig
@@ -147,26 +147,26 @@ pub const PropertyRuleDeclarationParser = struct {
             //     return switch (field) {
             //         .syntax => |syntax| {
 
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("syntax", name)) {
+            if (bun.strings.eqlCaseInsensitiveASCII("syntax", name)) {
                 const syntax = switch (SyntaxString.parse(input)) {
                     .result => |vv| vv,
                     .err => |e| return .{ .err = e },
                 };
                 this.syntax = syntax;
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("inherits", name)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("inherits", name)) {
                 const location = input.currentSourceLocation();
                 const ident = switch (input.expectIdent()) {
                     .result => |vv| vv,
                     .err => |e| return .{ .err = e },
                 };
-                const inherits = if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("true", ident))
+                const inherits = if (bun.strings.eqlCaseInsensitiveASCII("true", ident))
                     true
-                else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("false", ident))
+                else if (bun.strings.eqlCaseInsensitiveASCII("false", ident))
                     false
                 else
                     return .{ .err = location.newUnexpectedTokenError(.{ .ident = ident }) };
                 this.inherits = inherits;
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("initial-value", name)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("initial-value", name)) {
                 // Buffer the value into a string. We will parse it later.
                 const start = input.position();
                 while (input.next().isOk()) {}

--- a/src/css/rules/supports.zig
+++ b/src/css/rules/supports.zig
@@ -147,8 +147,8 @@ pub const SupportsCondition = union(enum) {
                     };
                     const found_type: i32 = found_type: {
                         // todo_stuff.match_ignore_ascii_case
-                        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("and", s)) break :found_type 1;
-                        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("or", s)) break :found_type 2;
+                        if (bun.strings.eqlCaseInsensitiveASCII("and", s)) break :found_type 1;
+                        if (bun.strings.eqlCaseInsensitiveASCII("or", s)) break :found_type 2;
                         return .{ .err = location.newUnexpectedTokenError(.{ .ident = s }) };
                     };
 
@@ -250,7 +250,7 @@ pub const SupportsCondition = union(enum) {
         };
         switch (tok.*) {
             .function => |f| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("selector", f)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("selector", f)) {
                     const Fn = struct {
                         pub fn tryParseFn(i: *css.Parser) Result(SupportsCondition) {
                             return i.parseNestedBlock(SupportsCondition, {}, @This().parseNestedBlockFn);

--- a/src/css/selectors/parser.zig
+++ b/src/css/selectors/parser.zig
@@ -1214,7 +1214,7 @@ pub const SelectorParser = struct {
             } else {
                 if (bun.strings.startsWithChar(name, '_')) {
                     this.options.warn(loc.newCustomError(SelectorParseErrorKind{ .unsupported_pseudo_class_or_element = name }));
-                } else if (this.options.css_modules != null and bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "local") or bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "global")) {
+                } else if (this.options.css_modules != null and bun.strings.eqlCaseInsensitiveASCII(name, "local") or bun.strings.eqlCaseInsensitiveASCII(name, "global")) {
                     return .{ .err = loc.newCustomError(SelectorParseErrorKind{ .ambiguous_css_module_class = name }) };
                 }
                 return .{ .result = PseudoClass{ .custom = .{ .name = name } } };
@@ -1236,7 +1236,7 @@ pub const SelectorParser = struct {
 
         // todo_stuff.match_ignore_ascii_case
         const pseudo_class = pseudo_class: {
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "lang")) {
+            if (bun.strings.eqlCaseInsensitiveASCII(name, "lang")) {
                 const languages = switch (parser.parseCommaSeparated([]const u8, css.Parser.expectIdentOrString)) {
                     .err => |e| return .{ .err = e },
                     .result => |v| v,
@@ -1244,7 +1244,7 @@ pub const SelectorParser = struct {
                 return .{ .result = PseudoClass{
                     .lang = .{ .languages = languages },
                 } };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "dir")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "dir")) {
                 break :pseudo_class PseudoClass{
                     .dir = .{
                         .direction = switch (Direction.parse(parser)) {
@@ -1253,7 +1253,7 @@ pub const SelectorParser = struct {
                         },
                     },
                 };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "local") and this.options.css_modules != null) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "local") and this.options.css_modules != null) {
                 break :pseudo_class PseudoClass{
                     .local = .{
                         .selector = brk: {
@@ -1266,7 +1266,7 @@ pub const SelectorParser = struct {
                         },
                     },
                 };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "global") and this.options.css_modules != null) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(name, "global") and this.options.css_modules != null) {
                 break :pseudo_class PseudoClass{
                     .global = .{
                         .selector = brk: {
@@ -2724,7 +2724,7 @@ pub fn parse_one_simple_selector(
                     return .{ .err = input.newCustomError(SelectorParseErrorKind.intoDefaultParserError(.invalid_state)) };
                 }
                 const pseudo_element: Impl.SelectorImpl.PseudoElement = if (is_functional) pseudo_element: {
-                    if (parser.parsePart() and bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "part")) {
+                    if (parser.parsePart() and bun.strings.eqlCaseInsensitiveASCII(name, "part")) {
                         if (!state.allowsPart()) {
                             return .{ .err = input.newCustomError(SelectorParseErrorKind.intoDefaultParserError(.invalid_state)) };
                         }
@@ -2772,7 +2772,7 @@ pub fn parse_one_simple_selector(
                         return .{ .result = .{ .part_pseudo = names } };
                     }
 
-                    if (parser.parseSlotted() and bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "slotted")) {
+                    if (parser.parseSlotted() and bun.strings.eqlCaseInsensitiveASCII(name, "slotted")) {
                         if (!state.allowsSlotted()) {
                             return .{ .err = input.newCustomError(SelectorParseErrorKind.intoDefaultParserError(.invalid_state)) };
                         }
@@ -3048,10 +3048,10 @@ pub fn parse_attribute_selector(comptime Impl: type, parser: *SelectorParser, in
 pub fn is_css2_pseudo_element(name: []const u8) bool {
     // ** Do not add to this list! **
     // TODO: todo_stuff.match_ignore_ascii_case
-    return bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "before") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "after") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "first-line") or
-        bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "first-letter");
+    return bun.strings.eqlCaseInsensitiveASCII(name, "before") or
+        bun.strings.eqlCaseInsensitiveASCII(name, "after") or
+        bun.strings.eqlCaseInsensitiveASCII(name, "first-line") or
+        bun.strings.eqlCaseInsensitiveASCII(name, "first-letter");
 }
 
 /// Parses one compound selector suitable for nested stuff like :-moz-any, etc.
@@ -3173,7 +3173,7 @@ pub fn parse_simple_pseudo_class(
     // The view-transition pseudo elements accept the :only-child pseudo class.
     // https://w3c.github.io/csswg-drafts/css-view-transitions-1/#pseudo-root
     if (state.after_view_transition) {
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "only-child")) {
+        if (bun.strings.eqlCaseInsensitiveASCII(name, "only-child")) {
             return .{ .result = .{ .nth = NthSelectorData.only(false) } };
         }
     }
@@ -3644,9 +3644,9 @@ pub fn parse_attribute_flags(input: *css.Parser) Result(AttributeFlags) {
 
     const ident = if (token.* == .ident) token.ident else return .{ .err = location.newBasicUnexpectedTokenError(token.*) };
 
-    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "i")) {
+    if (bun.strings.eqlCaseInsensitiveASCII(ident, "i")) {
         return .{ .result = AttributeFlags.ascii_case_insensitive };
-    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "s")) {
+    } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "s")) {
         return .{ .result = AttributeFlags.case_sensitive };
     } else {
         return .{ .err = location.newBasicUnexpectedTokenError(token.*) };

--- a/src/css/targets.zig
+++ b/src/css/targets.zig
@@ -28,7 +28,7 @@ pub const Targets = struct {
     fn parseDebugTarget(val_: []const u8) ?u32 {
         const val = bun.strings.trim(val_, " \n\r\t");
         if (val.len == 0) return null;
-        if (bun.strings.eqlCaseInsensitiveASCII(val, "null", true)) return null;
+        if (bun.strings.eqlCaseInsensitiveASCII(val, "null")) return null;
 
         var lhs: u32 = 0;
         var rhs: u32 = 0;

--- a/src/css/values/angle.zig
+++ b/src/css/values/angle.zig
@@ -51,13 +51,13 @@ pub const Angle = union(Tag) {
                 const value = dim.num.value;
                 const unit = dim.unit;
                 // todo_stuff.match_ignore_ascii_case
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("deg", unit)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("deg", unit)) {
                     return .{ .result = Angle{ .deg = value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("grad", unit)) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII("grad", unit)) {
                     return .{ .result = Angle{ .grad = value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("turn", unit)) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII("turn", unit)) {
                     return .{ .result = Angle{ .turn = value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("rad", unit)) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII("rad", unit)) {
                     return .{ .result = Angle{ .rad = value } };
                 } else {
                     return .{ .err = location.newUnexpectedTokenError(token.*) };
@@ -112,13 +112,13 @@ pub const Angle = union(Tag) {
         if (token.* == .dimension) {
             const value = token.dimension.num.value;
             const unit = token.dimension.unit;
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "deg")) {
+            if (bun.strings.eqlCaseInsensitiveASCII(unit, "deg")) {
                 return .{ .result = .{ .deg = value } };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "grad")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(unit, "grad")) {
                 return .{ .result = .{ .grad = value } };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "turn")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(unit, "turn")) {
                 return .{ .result = .{ .turn = value } };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "rad")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII(unit, "rad")) {
                 return .{ .result = .{ .rad = value } };
             }
         }

--- a/src/css/values/color.zig
+++ b/src/css/values/color.zig
@@ -256,9 +256,9 @@ pub const CssColor = union(enum) {
                 } };
             },
             .ident => |value| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(value, "currentcolor")) {
+                if (bun.strings.eqlCaseInsensitiveASCII(value, "currentcolor")) {
                     return .{ .result = .current_color };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(value, "transparent")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(value, "transparent")) {
                     return .{ .result = .{
                         .rgba = RGBA.transparent(),
                     } };
@@ -2705,25 +2705,25 @@ const RelativeComponentParser = struct {
         ident: []const u8,
         allowed_types: ChannelType,
     ) ?f32 {
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, this.names[0]) and
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, this.names[0]) and
             bits.intersects(ChannelType, allowed_types, this.types[0]))
         {
             return this.components[0];
         }
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, this.names[1]) and
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, this.names[1]) and
             bits.intersects(ChannelType, allowed_types, this.types[1]))
         {
             return this.components[1];
         }
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, this.names[2]) and
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, this.names[2]) and
             bits.intersects(ChannelType, allowed_types, this.types[2]))
         {
             return this.components[2];
         }
 
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "alpha") and allowed_types.percentage) {
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, "alpha") and allowed_types.percentage) {
             return this.components[3];
         }
 
@@ -2813,36 +2813,36 @@ pub fn parsePredefinedRelative(
     if (_from) |from| {
         parser.from = set_from: {
             // todo_stuff.match_ignore_ascii_case
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("srgb", colorspace)) {
+            if (bun.strings.eqlCaseInsensitiveASCII("srgb", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (SRGB.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("srgb-linear", colorspace)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("srgb-linear", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (SRGBLinear.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("display-p3", colorspace)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("display-p3", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (P3.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("a98-rgb", colorspace)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("a98-rgb", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (A98.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("prophoto-rgb", colorspace)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("prophoto-rgb", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (ProPhoto.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("rec2020", colorspace)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("rec2020", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (Rec2020.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("xyz-d50", colorspace)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("xyz-d50", colorspace)) {
                 break :set_from RelativeComponentParser.new(
                     if (XYZd50.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },
                 );
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("xyz", colorspace) or
-                bun.strings.eqlCaseInsensitiveASCIIICheckLength("xyz-d65", colorspace))
+            } else if (bun.strings.eqlCaseInsensitiveASCII("xyz", colorspace) or
+                bun.strings.eqlCaseInsensitiveASCII("xyz-d65", colorspace))
             {
                 break :set_from RelativeComponentParser.new(
                     if (XYZd65.tryFromCssColor(from)) |v| v.resolveMissing() else return .{ .err = input.newCustomError(css.ParserError.invalid_value) },

--- a/src/css/values/easing.zig
+++ b/src/css/values/easing.zig
@@ -101,7 +101,7 @@ pub const EasingFunction = union(enum) {
                     closure: *const Closure,
                     i: *css.Parser,
                 ) Result(EasingFunction) {
-                    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "cubic-bezier")) {
+                    if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "cubic-bezier")) {
                         const x1 = switch (CSSNumberFns.parse(i)) {
                             .result => |vv| vv,
                             .err => |e| return .{ .err = e },
@@ -122,7 +122,7 @@ pub const EasingFunction = union(enum) {
                             .err => |e| return .{ .err = e },
                         };
                         return .{ .result = EasingFunction{ .cubic_bezier = .{ .x1 = x1, .y1 = y1, .x2 = x2, .y2 = y2 } } };
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "steps")) {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "steps")) {
                         const count = switch (CSSIntegerFns.parse(i)) {
                             .result => |vv| vv,
                             .err => |e| return .{ .err = e },

--- a/src/css/values/gradient.zig
+++ b/src/css/values/gradient.zig
@@ -702,7 +702,7 @@ pub const WebKitGradient = union(enum) {
         if (input.expectComma().asErr()) |e| return .{ .err = e };
 
         // todo_stuff.match_ignore_ascii_case
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "linear")) {
+        if (bun.strings.eqlCaseInsensitiveASCII(ident, "linear")) {
             // todo_stuff.depth
             const from = switch (WebKitGradientPoint.parse(input)) {
                 .result => |vv| vv,
@@ -723,7 +723,7 @@ pub const WebKitGradient = union(enum) {
                 .to = to,
                 .stops = stops,
             } } };
-        } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "radial")) {
+        } else if (bun.strings.eqlCaseInsensitiveASCII(ident, "radial")) {
             const from = switch (WebKitGradientPoint.parse(input)) {
                 .result => |vv| vv,
                 .err => |e| return .{ .err = e },
@@ -1248,16 +1248,16 @@ pub const WebKitColorStop = struct {
                     i: *css.Parser,
                 ) Result(WebKitColorStop) {
                     // todo_stuff.match_ignore_ascii_case
-                    const position: f32 = if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "color-stop")) position: {
+                    const position: f32 = if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "color-stop")) position: {
                         const p: NumberOrPercentage = switch (@call(.auto, @field(NumberOrPercentage, "parse"), .{i})) {
                             .result => |vv| vv,
                             .err => |e| return .{ .err = e },
                         };
                         if (i.expectComma().asErr()) |e| return .{ .err = e };
                         break :position p.intoF32();
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "from")) position: {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "from")) position: {
                         break :position 0.0;
-                    } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(closure.function, "to")) position: {
+                    } else if (bun.strings.eqlCaseInsensitiveASCII(closure.function, "to")) position: {
                         break :position 1.0;
                     } else {
                         return .{ .err = closure.loc.newUnexpectedTokenError(.{ .ident = closure.function }) };

--- a/src/css/values/ident.zig
+++ b/src/css/values/ident.zig
@@ -275,12 +275,12 @@ pub const CustomIdent = struct {
             .err => |e| return .{ .err = e },
         };
         // css.todo_stuff.match_ignore_ascii_case
-        const valid = !(bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "initial") or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "inherit") or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "unset") or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "default") or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "revert") or
-            bun.strings.eqlCaseInsensitiveASCIIICheckLength(ident, "revert-layer"));
+        const valid = !(bun.strings.eqlCaseInsensitiveASCII(ident, "initial") or
+            bun.strings.eqlCaseInsensitiveASCII(ident, "inherit") or
+            bun.strings.eqlCaseInsensitiveASCII(ident, "unset") or
+            bun.strings.eqlCaseInsensitiveASCII(ident, "default") or
+            bun.strings.eqlCaseInsensitiveASCII(ident, "revert") or
+            bun.strings.eqlCaseInsensitiveASCII(ident, "revert-layer"));
 
         if (!valid) return .{ .err = location.newUnexpectedTokenError(.{ .ident = ident }) };
         return .{ .result = .{ .v = ident } };

--- a/src/css/values/image.zig
+++ b/src/css/values/image.zig
@@ -215,9 +215,9 @@ pub const ImageSet = struct {
         };
         const vendor_prefix = vendor_prefix: {
             // todo_stuff.match_ignore_ascii_case
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("image-set", f)) {
+            if (bun.strings.eqlCaseInsensitiveASCII("image-set", f)) {
                 break :vendor_prefix VendorPrefix{ .none = true };
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("-webkit-image-set", f)) {
+            } else if (bun.strings.eqlCaseInsensitiveASCII("-webkit-image-set", f)) {
                 break :vendor_prefix VendorPrefix{ .webkit = true };
             } else return .{ .err = location.newUnexpectedTokenError(.{ .ident = f }) };
         };

--- a/src/css/values/length.zig
+++ b/src/css/values/length.zig
@@ -271,7 +271,7 @@ pub const LengthValue = union(enum) {
             .dimension => |*dim| {
                 // todo_stuff.match_ignore_ascii_case
                 inline for (std.meta.fields(@This())) |field| {
-                    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(field.name, dim.unit)) {
+                    if (bun.strings.eqlCaseInsensitiveASCII(field.name, dim.unit)) {
                         return .{ .result = @unionInit(LengthValue, field.name, dim.num.value) };
                     }
                 }
@@ -363,7 +363,7 @@ pub const LengthValue = union(enum) {
         switch (token.*) {
             .dimension => |*dim| {
                 inline for (std.meta.fields(@This())) |field| {
-                    if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(field.name, dim.unit)) {
+                    if (bun.strings.eqlCaseInsensitiveASCII(field.name, dim.unit)) {
                         return .{ .result = @unionInit(LengthValue, field.name, dim.num.value) };
                     }
                 }

--- a/src/css/values/resolution.zig
+++ b/src/css/values/resolution.zig
@@ -35,9 +35,9 @@ pub const Resolution = union(enum) {
             const value = tok.dimension.num.value;
             const unit = tok.dimension.unit;
             // css.todo_stuff.match_ignore_ascii_case
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "dpi")) return .{ .result = .{ .dpi = value } };
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "dpcm")) return .{ .result = .{ .dpcm = value } };
-            if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "dppx") or bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "x")) return .{ .result = .{ .dppx = value } };
+            if (bun.strings.eqlCaseInsensitiveASCII(unit, "dpi")) return .{ .result = .{ .dpi = value } };
+            if (bun.strings.eqlCaseInsensitiveASCII(unit, "dpcm")) return .{ .result = .{ .dpcm = value } };
+            if (bun.strings.eqlCaseInsensitiveASCII(unit, "dppx") or bun.strings.eqlCaseInsensitiveASCII(unit, "x")) return .{ .result = .{ .dppx = value } };
             return .{ .err = location.newUnexpectedTokenError(.{ .ident = unit }) };
         }
         return .{ .err = location.newUnexpectedTokenError(tok.*) };
@@ -49,12 +49,12 @@ pub const Resolution = union(enum) {
                 const value = dim.num.value;
                 const unit = dim.unit;
                 // todo_stuff.match_ignore_ascii_case
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "dpi")) {
+                if (bun.strings.eqlCaseInsensitiveASCII(unit, "dpi")) {
                     return .{ .result = .{ .dpi = value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "dpcm")) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII(unit, "dpcm")) {
                     return .{ .result = .{ .dpcm = value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "dppx") or
-                    bun.strings.eqlCaseInsensitiveASCIIICheckLength(unit, "x"))
+                } else if (bun.strings.eqlCaseInsensitiveASCII(unit, "dppx") or
+                    bun.strings.eqlCaseInsensitiveASCII(unit, "x"))
                 {
                     return .{ .result = .{ .dppx = value } };
                 } else {

--- a/src/css/values/syntax.zig
+++ b/src/css/values/syntax.zig
@@ -336,33 +336,33 @@ pub const SyntaxComponentKind = union(enum) {
             const end_idx = std.mem.indexOfScalar(u8, input.*, '>') orelse return .{ .err = {} };
             const name = input.*[1..end_idx];
             // todo_stuff.match_ignore_ascii_case
-            const component: SyntaxComponentKind = if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "length"))
+            const component: SyntaxComponentKind = if (bun.strings.eqlCaseInsensitiveASCII(name, "length"))
                 .length
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "number"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "number"))
                 .number
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "percentage"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "percentage"))
                 .percentage
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "length-percentage"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "length-percentage"))
                 .length_percentage
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "color"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "color"))
                 .color
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "image"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "image"))
                 .image
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "url"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "url"))
                 .url
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "integer"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "integer"))
                 .integer
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "angle"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "angle"))
                 .angle
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "time"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "time"))
                 .time
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "resolution"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "resolution"))
                 .resolution
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "transform-function"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "transform-function"))
                 .transform_function
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "transform-list"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "transform-list"))
                 .transform_list
-            else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "custom-ident"))
+            else if (bun.strings.eqlCaseInsensitiveASCII(name, "custom-ident"))
                 .custom_ident
             else
                 return .{ .err = {} };

--- a/src/css/values/time.zig
+++ b/src/css/values/time.zig
@@ -54,9 +54,9 @@ pub const Time = union(Tag) {
         };
         switch (token.*) {
             .dimension => |*dim| {
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("s", dim.unit)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("s", dim.unit)) {
                     return .{ .result = .{ .seconds = dim.num.value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("ms", dim.unit)) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII("ms", dim.unit)) {
                     return .{ .result = .{ .milliseconds = dim.num.value } };
                 } else {
                     return .{ .err = location.newUnexpectedTokenError(css.Token{ .ident = dim.unit }) };
@@ -110,9 +110,9 @@ pub const Time = union(Tag) {
         switch (token.*) {
             .dimension => |*dim| {
                 // todo_stuff.match_ignore_ascii_case
-                if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("s", dim.unit)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("s", dim.unit)) {
                     return .{ .result = .{ .seconds = dim.num.value } };
-                } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength("ms", dim.unit)) {
+                } else if (bun.strings.eqlCaseInsensitiveASCII("ms", dim.unit)) {
                     return .{ .result = .{ .milliseconds = dim.num.value } };
                 }
             },

--- a/src/deps/picohttp.zig
+++ b/src/deps/picohttp.zig
@@ -7,7 +7,7 @@ pub const Header = struct {
 
         pub fn get(this: *const List, name: string) ?string {
             for (this.list) |header| {
-                if (strings.eqlCaseInsensitiveASCII(header.name, name, true)) {
+                if (strings.eqlCaseInsensitiveASCII(header.name, name)) {
                     return header.value;
                 }
             }
@@ -17,11 +17,11 @@ pub const Header = struct {
         pub fn getIfOtherIsAbsent(this: *const List, name: string, other: string) ?string {
             var value: ?string = null;
             for (this.list) |header| {
-                if (strings.eqlCaseInsensitiveASCII(header.name, other, true)) {
+                if (strings.eqlCaseInsensitiveASCII(header.name, other)) {
                     return null;
                 }
 
-                if (value == null and strings.eqlCaseInsensitiveASCII(header.name, name, true)) {
+                if (value == null and strings.eqlCaseInsensitiveASCII(header.name, name)) {
                     value = header.value;
                 }
             }
@@ -129,14 +129,14 @@ pub const Request = struct {
             for (request.headers) |*header| {
                 _ = try writer.writeAll(" ");
                 if (content_type.len == 0) {
-                    if (bun.strings.eqlCaseInsensitiveASCII("content-type", header.name, true)) {
+                    if (bun.strings.eqlCaseInsensitiveASCII("content-type", header.name)) {
                         content_type = header.value;
                     }
                 }
 
                 try header.curl().format(writer);
 
-                if (bun.strings.eqlCaseInsensitiveASCII("accept-encoding", header.name, true)) {
+                if (bun.strings.eqlCaseInsensitiveASCII("accept-encoding", header.name)) {
                     _ = try writer.writeAll(" --compressed");
                 }
             }

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -292,7 +292,7 @@ const kind = struct {
             const false_values = .{ "", "0", "false", "no", "off" };
 
             inline for (false_values) |tv| {
-                if (std.ascii.eqlIgnoreCase(s, tv)) {
+                if (bun.strings.eqlCaseInsensitiveASCII(s, tv)) {
                     return false;
                 }
             }

--- a/src/http.zig
+++ b/src/http.zig
@@ -2356,7 +2356,7 @@ pub fn handleResponseMetadata(
                             const normalized_url_str = try normalized_url.toOwnedSlice(bun.default_allocator);
 
                             const new_url = URL.parse(normalized_url_str);
-                            is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin), true);
+                            is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin));
                             this.url = new_url;
                             this.redirect = normalized_url_str;
                         } else if (strings.hasPrefixComptime(location, "//")) {
@@ -2396,7 +2396,7 @@ pub fn handleResponseMetadata(
                             const normalized_url_str = try normalized_url.toOwnedSlice(bun.default_allocator);
 
                             const new_url = URL.parse(normalized_url_str);
-                            is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin), true);
+                            is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin));
                             this.url = new_url;
                             this.redirect = normalized_url_str;
                         } else {
@@ -2416,7 +2416,7 @@ pub fn handleResponseMetadata(
                                 return error.RedirectURLTooLong;
                             };
                             this.url = URL.parse(new_url);
-                            is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(this.url.origin), strings.withoutTrailingSlash(original_url.origin), true);
+                            is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(this.url.origin), strings.withoutTrailingSlash(original_url.origin));
                             this.redirect = new_url;
                         }
                     }

--- a/src/http.zig
+++ b/src/http.zig
@@ -586,7 +586,7 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
             hashHeaderConst("Connection") => {
                 override_connection_header = true;
                 const connection_value = this.headerStr(header_values[i]);
-                if (std.ascii.eqlIgnoreCase(connection_value, "close")) {
+                if (bun.strings.eqlCaseInsensitiveASCII(connection_value, "close")) {
                     this.flags.disable_keepalive = true;
                 }
             },
@@ -609,7 +609,7 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
             },
             hashHeaderConst("Upgrade") => {
                 const value = this.headerStr(header_values[i]);
-                if (!std.ascii.eqlIgnoreCase(value, "h2") and !std.ascii.eqlIgnoreCase(value, "h2c")) {
+                if (!bun.strings.eqlCaseInsensitiveASCII(value, "h2") and !bun.strings.eqlCaseInsensitiveASCII(value, "h2c")) {
                     this.flags.upgrade_state = .pending;
                 }
             },

--- a/src/http/Headers.zig
+++ b/src/http/Headers.zig
@@ -42,7 +42,7 @@ pub fn get(this: *const Headers, name: []const u8) ?[]const u8 {
     const names = entries.items(.name);
     const values = entries.items(.value);
     for (names, 0..) |name_ptr, i| {
-        if (bun.strings.eqlCaseInsensitiveASCII(this.asStr(name_ptr), name, true)) {
+        if (bun.strings.eqlCaseInsensitiveASCII(this.asStr(name_ptr), name)) {
             return this.asStr(values[i]);
         }
     }
@@ -84,7 +84,7 @@ pub fn getContentType(this: *const Headers) ?[]const u8 {
     const header_values = header_entries.items(.value);
 
     for (header_names, 0..header_names.len) |name, i| {
-        if (bun.strings.eqlCaseInsensitiveASCII(this.asStr(name), "content-type", true)) {
+        if (bun.strings.eqlCaseInsensitiveASCII(this.asStr(name), "content-type")) {
             return this.asStr(header_values[i]);
         }
     }

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -94,7 +94,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             // Check if user provided a custom protocol for subprotocols validation
             var protocol_for_subprotocols = client_protocol.*;
             for (extra_headers.names, extra_headers.values) |name, value| {
-                if (strings.eqlCaseInsensitiveASCII(name.slice(), "sec-websocket-protocol", true)) {
+                if (strings.eqlCaseInsensitiveASCII(name.slice(), "sec-websocket-protocol")) {
                     protocol_for_subprotocols = value;
                     break;
                 }
@@ -375,17 +375,17 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             for (response.headers.list) |header| {
                 switch (header.name.len) {
                     "Connection".len => {
-                        if (connection_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Connection", false)) {
+                        if (connection_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Connection")) {
                             connection_header = header;
                         }
                     },
                     "Upgrade".len => {
-                        if (upgrade_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Upgrade", false)) {
+                        if (upgrade_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Upgrade")) {
                             upgrade_header = header;
                         }
                     },
                     "Sec-WebSocket-Version".len => {
-                        if (strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Version", false)) {
+                        if (strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Version")) {
                             if (!strings.eqlComptimeIgnoreLen(header.value, "13")) {
                                 this.terminate(ErrorCode.invalid_websocket_version);
                                 return;
@@ -393,12 +393,12 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                         }
                     },
                     "Sec-WebSocket-Accept".len => {
-                        if (websocket_accept_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Accept", false)) {
+                        if (websocket_accept_header.name.len == 0 and strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Accept")) {
                             websocket_accept_header = header;
                         }
                     },
                     "Sec-WebSocket-Protocol".len => {
-                        if (strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Protocol", false)) {
+                        if (strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Protocol")) {
                             const valid = brk: {
                                 // Can't have multiple protocol headers in the response.
                                 if (protocol_header_seen) break :brk false;
@@ -432,7 +432,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                         }
                     },
                     "Sec-WebSocket-Extensions".len => {
-                        if (strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Extensions", false)) {
+                        if (strings.eqlCaseInsensitiveASCII(header.name, "Sec-WebSocket-Extensions")) {
                             // This is a simplified parser. A full parser would handle multiple extensions and quoted values.
                             var it = std.mem.splitScalar(u8, header.value, ',');
                             while (it.next()) |ext_str| {
@@ -511,12 +511,12 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 return;
             }
 
-            if (!strings.eqlCaseInsensitiveASCII(connection_header.value, "Upgrade", true)) {
+            if (!strings.eqlCaseInsensitiveASCII(connection_header.value, "Upgrade")) {
                 this.terminate(ErrorCode.invalid_connection_header);
                 return;
             }
 
-            if (!strings.eqlCaseInsensitiveASCII(upgrade_header.value, "websocket", true)) {
+            if (!strings.eqlCaseInsensitiveASCII(upgrade_header.value, "websocket")) {
                 this.terminate(ErrorCode.invalid_upgrade_header);
                 return;
             }
@@ -670,11 +670,11 @@ fn buildRequestBody(
 
     for (extra_headers.names, extra_headers.values) |name, value| {
         const name_slice = name.slice();
-        if (user_host == null and strings.eqlCaseInsensitiveASCII(name_slice, "host", true)) {
+        if (user_host == null and strings.eqlCaseInsensitiveASCII(name_slice, "host")) {
             user_host = value;
-        } else if (user_key == null and strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-key", true)) {
+        } else if (user_key == null and strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-key")) {
             user_key = value;
-        } else if (user_protocol == null and strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-protocol", true)) {
+        } else if (user_protocol == null and strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-protocol")) {
             user_protocol = value;
         }
     }
@@ -734,13 +734,13 @@ fn buildRequestBody(
 
     for (extra_headers.names, extra_headers.values) |name, value| {
         const name_slice = name.slice();
-        if (strings.eqlCaseInsensitiveASCII(name_slice, "host", true) or
-            strings.eqlCaseInsensitiveASCII(name_slice, "connection", true) or
-            strings.eqlCaseInsensitiveASCII(name_slice, "upgrade", true) or
-            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-version", true) or
-            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-extensions", true) or
-            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-key", true) or
-            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-protocol", true))
+        if (strings.eqlCaseInsensitiveASCII(name_slice, "host") or
+            strings.eqlCaseInsensitiveASCII(name_slice, "connection") or
+            strings.eqlCaseInsensitiveASCII(name_slice, "upgrade") or
+            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-version") or
+            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-extensions") or
+            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-key") or
+            strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-protocol"))
         {
             continue;
         }

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -53,7 +53,7 @@ const SloppyGlobalGitConfig = struct {
 
             if (@"[core]") {
                 if (!found_askpass) {
-                    if (line.len > "askpass".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."askpass".len], "askpass") and switch (line["askpass".len]) {
+                    if (line.len > "askpass".len and strings.eqlCaseInsensitiveASCII(line[0.."askpass".len], "askpass") and switch (line["askpass".len]) {
                         ' ', '\t', '=' => true,
                         else => false,
                     }) {
@@ -63,7 +63,7 @@ const SloppyGlobalGitConfig = struct {
                 }
 
                 if (!found_ssh_command) {
-                    if (line.len > "sshCommand".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."sshCommand".len], "sshCommand") and switch (line["sshCommand".len]) {
+                    if (line.len > "sshCommand".len and strings.eqlCaseInsensitiveASCII(line[0.."sshCommand".len], "sshCommand") and switch (line["sshCommand".len]) {
                         ' ', '\t', '=' => true,
                         else => false,
                     }) {
@@ -72,7 +72,7 @@ const SloppyGlobalGitConfig = struct {
                 }
             } else {
                 if (!found_askpass) {
-                    if (line.len > "core.askpass".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.askpass".len], "core.askpass") and switch (line["core.askpass".len]) {
+                    if (line.len > "core.askpass".len and strings.eqlCaseInsensitiveASCII(line[0.."core.askpass".len], "core.askpass") and switch (line["core.askpass".len]) {
                         ' ', '\t', '=' => true,
                         else => false,
                     }) {
@@ -82,7 +82,7 @@ const SloppyGlobalGitConfig = struct {
                 }
 
                 if (!found_ssh_command) {
-                    if (line.len > "core.sshCommand".len and strings.eqlCaseInsensitiveASCIIIgnoreLength(line[0.."core.sshCommand".len], "core.sshCommand") and switch (line["core.sshCommand".len]) {
+                    if (line.len > "core.sshCommand".len and strings.eqlCaseInsensitiveASCII(line[0.."core.sshCommand".len], "core.sshCommand") and switch (line["core.sshCommand".len]) {
                         ' ', '\t', '=' => true,
                         else => false,
                     }) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -839,7 +839,7 @@ pub const Loader = enum(u8) {
             slice = slice[1..];
         }
 
-        return names.getWithEql(slice, strings.eqlCaseInsensitiveASCIIICheckLength);
+        return names.getWithEql(slice, strings.eqlCaseInsensitiveASCII);
     }
 
     pub fn supportsClientEntryPoint(this: Loader) bool {

--- a/src/output.zig
+++ b/src/output.zig
@@ -829,10 +829,10 @@ fn ScopedLogger(comptime tagname: []const u8, comptime visibility: Visibility) t
                 really_disable.store(really_disable.load(.monotonic) or val, .monotonic);
             } else {
                 for (bun.argv) |arg| {
-                    if (strings.eqlCaseInsensitiveASCII(arg, comptime "--debug-" ++ tagname, true)) {
+                    if (strings.eqlCaseInsensitiveASCII(arg, comptime "--debug-" ++ tagname)) {
                         really_disable.store(false, .monotonic);
                         break;
-                    } else if (strings.eqlCaseInsensitiveASCII(arg, comptime "--debug-all", true)) {
+                    } else if (strings.eqlCaseInsensitiveASCII(arg, comptime "--debug-all")) {
                         really_disable.store(false, .monotonic);
                         break;
                     }

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -211,7 +211,7 @@ pub fn longestCommonPathGeneric(input: []const []const u8, comptime platform: Pl
                 comptime var i = 1;
                 inline while (i < n) : (i += 1) {
                     const root = windowsFilesystemRoot(input[i]);
-                    if (!strings.eqlCaseInsensitiveASCIIICheckLength(first_root, root)) {
+                    if (!strings.eqlCaseInsensitiveASCII(first_root, root)) {
                         return "";
                     }
                 }
@@ -233,7 +233,7 @@ pub fn longestCommonPathGeneric(input: []const []const u8, comptime platform: Pl
                 var i: usize = 1;
                 while (i < input.len) : (i += 1) {
                     const root = windowsFilesystemRoot(input[i]);
-                    if (!strings.eqlCaseInsensitiveASCIIICheckLength(first_root, root)) {
+                    if (!strings.eqlCaseInsensitiveASCII(first_root, root)) {
                         return "";
                     }
                 }
@@ -328,7 +328,7 @@ pub fn relativeToCommonPath(
 
         if (common_path_.len == 0) {
             // the only case path.relative can return not a relative string
-            if (!strings.eqlCaseInsensitiveASCIIICheckLength(from_root, to_root)) {
+            if (!strings.eqlCaseInsensitiveASCII(from_root, to_root)) {
                 if (normalized_to_.len > to_root.len and normalized_to_[normalized_to_.len - 1] == '\\') {
                     if (always_copy) {
                         bun.copy(u8, buf, normalized_to_[0 .. normalized_to_.len - 1]);
@@ -464,7 +464,7 @@ pub fn relativeToCommonPath(
 
 pub fn relativeNormalizedBuf(buf: []u8, from: []const u8, to: []const u8, comptime platform: Platform, comptime always_copy: bool) []const u8 {
     if ((if (platform == .windows)
-        strings.eqlCaseInsensitiveASCII(from, to, true)
+        strings.eqlCaseInsensitiveASCII(from, to)
     else
         from.len == to.len and strings.eqlLong(from, to, true)))
     {

--- a/src/sql/postgres/DataCell.zig
+++ b/src/sql/postgres/DataCell.zig
@@ -307,7 +307,7 @@ fn parseArray(bytes: []const u8, bigint: bool, comptime arrayType: types.Tag, gl
                                 // infinity
                                 if (slice.len < 8) return error.UnsupportedArrayFormat;
 
-                                if (bun.strings.eqlCaseInsensitiveASCII(slice[0..8], "Infinity", false)) {
+                                if (bun.strings.eqlCaseInsensitiveASCII(slice[0..8], "Infinity")) {
                                     if (arrayType == .date_array or arrayType == .timestamp_array or arrayType == .timestamptz_array) {
                                         try array.append(bun.default_allocator, SQLDataCell{ .tag = .date, .value = .{ .date = std.math.inf(f64) } });
                                     } else {
@@ -373,7 +373,7 @@ fn parseArray(bytes: []const u8, bigint: bool, comptime arrayType: types.Tag, gl
                                             is_infinity = true;
                                             const element = if (is_negative) slice[1..] else slice;
                                             if (element.len < 8) return error.UnsupportedArrayFormat;
-                                            if (bun.strings.eqlCaseInsensitiveASCII(element[0..8], "Infinity", false)) {
+                                            if (bun.strings.eqlCaseInsensitiveASCII(element[0..8], "Infinity")) {
                                                 if (arrayType == .date_array or arrayType == .timestamp_array or arrayType == .timestamptz_array) {
                                                     try array.append(bun.default_allocator, SQLDataCell{ .tag = .date, .value = .{ .date = if (is_negative) -std.math.inf(f64) else std.math.inf(f64) } });
                                                 } else {
@@ -593,7 +593,7 @@ pub fn fromBytes(binary: bool, bigint: bool, oid: types.Tag, bytes: []const u8, 
                     else => unreachable,
                 }
             } else {
-                if (bun.strings.eqlCaseInsensitiveASCII(bytes, "NULL", true)) {
+                if (bun.strings.eqlCaseInsensitiveASCII(bytes, "NULL")) {
                     return SQLDataCell{ .tag = .null, .value = .{ .null = 0 } };
                 }
                 var str = bun.String.init(bytes);

--- a/src/string.zig
+++ b/src/string.zig
@@ -1002,7 +1002,7 @@ pub const String = extern struct {
 
             inline for (0..values.len) |i| {
                 bun.assert(bytes.len == values[i].len);
-                if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(bytes, values[i])) {
+                if (bun.strings.eqlCaseInsensitiveASCII(bytes, values[i])) {
                     return i;
                 }
             }
@@ -1023,7 +1023,7 @@ pub const String = extern struct {
         };
 
         inline for (0..values.len) |i| {
-            if (bun.strings.eqlCaseInsensitiveASCIIIgnoreLength(&buffer, values[i])) {
+            if (bun.strings.eqlCaseInsensitiveASCII(&buffer, values[i])) {
                 return i;
             }
         }

--- a/src/string/immutable.zig
+++ b/src/string/immutable.zig
@@ -973,15 +973,7 @@ pub fn eqlComptimeCheckLenWithType(comptime Type: type, a: []const Type, comptim
 /// Note that this function performs bound checks, but is marked as inline, so the caller may also
 /// perform bounds checks without a performance penalty.
 pub inline fn eqlCaseInsensitiveASCII(a: string, b: string) bool {
-    // This is separated into a slow path to reduce code size of the fast path. We're letting LLVM
-    // decide whether it inlines it or not.
-    const SlowPathNs = struct {
-        pub fn eqlCaseInsensitiveASCII(as: string, bs: string) bool {
-            return bun.c.strncasecmp(as.ptr, bs.ptr, @min(as.len, bs.len)) == 0;
-        }
-    };
-
-    return a.len == b.len and (a.len == 0 or SlowPathNs.eqlCaseInsensitiveASCII(a, b));
+    return std.ascii.eqlIgnoreCase(a, b);
 }
 
 pub fn eqlCaseInsensitiveT(comptime T: type, a: []const T, b: []const u8) bool {

--- a/src/url.zig
+++ b/src/url.zig
@@ -1192,7 +1192,7 @@ pub const FormData = struct {
 
                 const key = line[0..colon];
                 var value = if (line.len > colon + 1) line[colon + 1 ..] else "";
-                if (strings.eqlCaseInsensitiveASCII(key, "content-disposition", true)) {
+                if (strings.eqlCaseInsensitiveASCII(key, "content-disposition")) {
                     value = strings.trim(value, " ");
                     if (strings.hasPrefixComptime(value, "form-data;")) {
                         value = value["form-data;".len..];
@@ -1225,9 +1225,9 @@ pub const FormData = struct {
                             value = value[@min(i + 1, value.len)..];
                         }
 
-                        if (strings.eqlCaseInsensitiveASCII(eql_key, "name", true)) {
+                        if (strings.eqlCaseInsensitiveASCII(eql_key, "name")) {
                             name = subslicer.sub(field_value).value();
-                        } else if (strings.eqlCaseInsensitiveASCII(eql_key, "filename", true)) {
+                        } else if (strings.eqlCaseInsensitiveASCII(eql_key, "filename")) {
                             filename = subslicer.sub(field_value).value();
                             is_file = true;
                         }
@@ -1242,7 +1242,7 @@ pub const FormData = struct {
                             break;
                         }
                     }
-                } else if (value.len > 0 and field.content_type.isEmpty() and strings.eqlCaseInsensitiveASCII(key, "content-type", true)) {
+                } else if (value.len > 0 and field.content_type.isEmpty() and strings.eqlCaseInsensitiveASCII(key, "content-type")) {
                     field.content_type = subslicer.sub(strings.trim(value, "; \t")).value();
                 }
             }

--- a/src/which.zig
+++ b/src/which.zig
@@ -82,7 +82,7 @@ pub fn endsWithExtension(str: []const u8) bool {
     const file_ext = str[str.len - 3 ..];
     inline for (win_extensions) |ext| {
         comptime bun.assert(ext.len == 3);
-        if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(file_ext, ext)) return true;
+        if (bun.strings.eqlCaseInsensitiveASCII(file_ext, ext)) return true;
     }
     return false;
 }


### PR DESCRIPTION
### What does this PR do?

Removes redundant `eqlCaseInsensitiveASCII` variants.

### How did you verify your code works?

CI.
