### PR TITLE
npm package: don't move binary from optional one & instead link (or copy if can't hardlink)

### DIFF
--- a/packages/bun-release/src/npm/install.ts
+++ b/packages/bun-release/src/npm/install.ts
@@ -124,8 +124,8 @@ export function optimizeBun(path: string): void {
   const installScript =
     os === "win32" ? 'powershell -c "irm bun.sh/install.ps1 | iex"' : "curl -fsSL https://bun.com/install | bash";
   try {
-    rename(path, join(__dirname, "bin", "bun.exe"));
-    link(join(__dirname, "bin", "bun.exe"), join(__dirname, "bin", "bunx.exe"));
+    link(path, join(__dirname, "bin", "bun.exe"));
+    link(path, join(__dirname, "bin", "bunx.exe"));
     return;
   } catch (error) {
     debug("optimizeBun failed", error);


### PR DESCRIPTION
In theory fixes https://github.com/oven-sh/bun/issues/25031 because the original file will still be present. This isn't a perfect solution as it is a lot of wasted effort in checking and moving again, but it should fix the intimidate issue.