### PR TITLE
fix(console): properly identify Generator and AsyncGenerator in conso…

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1096,6 +1096,8 @@ pub const Formatter = struct {
         MapIterator,
         SetIterator,
         Set,
+        Generator,
+        AsyncGenerator,
         BigInt,
         Symbol,
 
@@ -1330,6 +1332,8 @@ pub const Formatter = struct {
                     .MapIterator => .MapIterator,
                     .SetIterator => .SetIterator,
                     .WeakSet, JSValue.JSType.Set => .Set,
+                    .Generator => .Generator,
+                    .AsyncGenerator => .AsyncGenerator,
                     .JSDate => .JSON,
                     .JSPromise => .Promise,
 
@@ -2819,6 +2823,12 @@ pub const Formatter = struct {
                     this.writeIndent(Writer, writer_) catch {};
                 }
                 writer.writeAll("}");
+            },
+            .Generator => {
+                writer.writeAll("Object [Generator] {}");
+            },
+            .AsyncGenerator => {
+                writer.writeAll("Object [AsyncGenerator] {}");
             },
             .SetIterator => {
                 const prev_quote_strings = this.quote_strings;


### PR DESCRIPTION
…le.log

Fixes #18324

Previously, Generator and AsyncGenerator objects were falling through to the default JSON formatter, causing them to display as '{}' instead of their proper type identifiers.

Node.js displays these as:
- Generator: 'Object [Generator] {}'
- AsyncGenerator: 'Object [AsyncGenerator] {}'

This change adds:
1. Generator and AsyncGenerator tags to the Formatter.Tag enum
2. Type mappings from JSType.Generator/AsyncGenerator to the new tags
3. Formatters that output the proper 'Object [Generator/AsyncGenerator] {}' format

This matches Node.js behavior for consistency.

### What does this PR do?

Adds proper console.log formatting for Generator and AsyncGenerator objects to match Node.js behavior. Previously these displayed as `{}`, now they display as `Object [Generator] {}` and `Object [AsyncGenerator] {}`.

### How did you verify your code works?

Code analysis of the existing patterns in ConsoleObject.zig - the fix follows the same pattern used for MapIterator, SetIterator, and other similar types. CI tests will verify the implementation.
