### PR TITLE
Allow defining a custom web inspector domain

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -122,10 +122,11 @@ export default function (
     if (debug.url) {
       const { protocol, href, host, pathname } = debug.url;
       if (!protocol.includes("unix")) {
+        const debugHost = process.env.BUN_DEBUG_HOST || 'https://debug.bun.sh'
         Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
         Bun.write(Bun.stderr, `Listening:\n  ${dim(href)}\n`);
         if (protocol.includes("ws")) {
-          Bun.write(Bun.stderr, `Inspect in browser:\n  ${link(`https://debug.bun.sh/#${host}${pathname}`)}\n`);
+          Bun.write(Bun.stderr, `Inspect in browser:\n  ${link(`${debugHost}/#${host}${pathname}`)}\n`);
         }
         Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
       }

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -110,7 +110,7 @@ function getInspectorHost() {
   }
 
   // Validate that the debug host includes a protocol
-  if (!inspectorHost.match(/^https?:\/\//)) {
+  if (!inspectorHost.match(/^https?:\/\//i)) {
     Bun.write(Bun.stderr, `Warning: BUN_INSPECTOR_HOST should include a protocol (http:// or https://). Got: ${inspectorHost}\n`);
     return DEFAULT_INSPECTOR_HOST
   }

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -95,6 +95,29 @@ type CreateBackendFn = (
   receive: (...messages: string[]) => void,
 ) => unknown;
 
+function getInspectorHost() {
+  const DEFAULT_INSPECTOR_HOST = 'https://debug.bun.sh'
+
+  if (!process.env.BUN_INSPECTOR_HOST) {
+    return DEFAULT_INSPECTOR_HOST
+  }
+
+  let inspectorHost = process.env.BUN_INSPECTOR_HOST
+
+  // Remove trailing slash to avoid double slashes in the final URL
+  if (inspectorHost.endsWith('/')) {
+    inspectorHost = inspectorHost.slice(0, -1);
+  }
+
+  // Validate that the debug host includes a protocol
+  if (!inspectorHost.match(/^https?:\/\//)) {
+    Bun.write(Bun.stderr, `Warning: BUN_INSPECTOR_HOST should include a protocol (http:// or https://). Got: ${inspectorHost}\n`);
+    return DEFAULT_INSPECTOR_HOST
+  }
+
+  return inspectorHost
+}
+
 export default function (
   executionContextId: number,
   url: string,
@@ -122,11 +145,10 @@ export default function (
     if (debug.url) {
       const { protocol, href, host, pathname } = debug.url;
       if (!protocol.includes("unix")) {
-        const debugHost = process.env.BUN_DEBUG_HOST || 'https://debug.bun.sh'
         Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
         Bun.write(Bun.stderr, `Listening:\n  ${dim(href)}\n`);
         if (protocol.includes("ws")) {
-          Bun.write(Bun.stderr, `Inspect in browser:\n  ${link(`${debugHost}/#${host}${pathname}`)}\n`);
+          Bun.write(Bun.stderr, `Inspect in browser:\n  ${link(`${getInspectorHost()}/#${host}${pathname}`)}\n`);
         }
         Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
       }


### PR DESCRIPTION
### What does this PR do?

The default web inspector is self-hostable however the inspection output is permanently pointed to `https://debug.bun.sh`. Development in closed environments and systems can neither access nor trust the publicly hosted web inspector. This introduces a new environment variable named `BUN_INSPECTOR_HOST` that when defined will replace the default inspection output domain. It also fails gracefully when encountering trailing slashes, and warns of invalid protocols.

### How did you verify your code works?
* Build Bun from this branch
* `touch test.js`
* Run `BUN_INSPECTOR_HOST='https://debug.example.com' build/debug/bun-debug --inspect-wait test.js`
* Ensure that the inspector domain output instead references the `BUN_INSPECTOR_HOST` variable replacing the default of `https://debug.bun.sh` such as below.

```
Inspect in browser:
  https://debug.example.com/#localhost:6499/dqy5c9ihdl
```