### PR TITLE
docs: clarify SQLite embed example requires existing database

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -429,7 +429,9 @@ bun build --compile ./index.ts --outfile mycli
 ```
 
 <Note>
-The database file must exist on disk when you run `bun build --compile`. The `embed: "true"` attribute tells the bundler to include the database contents inside the compiled executable. When running normally with `bun run`, the database file is loaded from disk just like a regular SQLite import.
+  The database file must exist on disk when you run `bun build --compile`. The `embed: "true"` attribute tells the
+  bundler to include the database contents inside the compiled executable. When running normally with `bun run`, the
+  database file is loaded from disk just like a regular SQLite import.
 </Note>
 
 In the compiled executable, the embedded database is read-write, but all changes are lost when the executable exits (since it's stored in memory).

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -412,7 +412,9 @@ const bytes = await file(icon).arrayBuffer();
 
 ### Embed SQLite databases
 
-If your application wants to embed a SQLite database, set `type: "sqlite"` in the import attribute and the `embed` attribute to `"true"`.
+If your application wants to embed a SQLite database into the compiled executable, set `type: "sqlite"` in the import attribute and the `embed` attribute to `"true"`.
+
+The database file must already exist on disk. Then, import it in your code:
 
 ```ts index.ts icon="/icons/typescript.svg"
 import myEmbeddedDb from "./my.db" with { type: "sqlite", embed: "true" };
@@ -420,7 +422,17 @@ import myEmbeddedDb from "./my.db" with { type: "sqlite", embed: "true" };
 console.log(myEmbeddedDb.query("select * from users LIMIT 1").get());
 ```
 
-This database is read-write, but all changes are lost when the executable exits (since it's stored in memory).
+Finally, compile it into a standalone executable:
+
+```bash terminal icon="terminal"
+bun build --compile ./index.ts --outfile mycli
+```
+
+<Note>
+The database file must exist on disk when you run `bun build --compile`. The `embed: "true"` attribute tells the bundler to include the database contents inside the compiled executable. When running normally with `bun run`, the database file is loaded from disk just like a regular SQLite import.
+</Note>
+
+In the compiled executable, the embedded database is read-write, but all changes are lost when the executable exits (since it's stored in memory).
 
 ### Embed N-API Addons
 


### PR DESCRIPTION
## Summary

- Clarified that the database file must already exist on disk before building
- Added the `bun build --compile` workflow example
- Added a note explaining that `embed: "true"` only takes effect during `bun build --compile`, and that running with `bun run` loads the database from disk like a regular SQLite import

Fixes #25328

🤖 Generated with [Claude Code](https://claude.com/claude-code)