### PR TITLE
[docs] Fix formatting of bash command in documentation

### DIFF
--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -189,7 +189,7 @@ Isolated installs are conceptually similar to pnpm, so migration should be strai
 
 ```bash terminal icon="terminal"
 # Remove pnpm files
-$ rm -rf node_modules pnpm-lock.yaml
+rm -rf node_modules pnpm-lock.yaml
 
 # Install with Bun's isolated linker
 bun install --linker isolated


### PR DESCRIPTION
### What does this PR do?

Fix formatting of bash command in documentation.

<img width="335" height="76" alt="Screenshot 2025-12-04 at 11 20 09" src="https://github.com/user-attachments/assets/1e8e748d-f20a-4f34-a024-1519a0af4778" />