### PR TITLE
fix: add stack trace to AbortSignal.timeout errorsfix: add stack trace to AbortSignal.timeout errors

### DIFF
--- a/src/bun.js/bindings/webcore/AbortSignal.h
+++ b/src/bun.js/bindings/webcore/AbortSignal.h
@@ -55,7 +55,7 @@ enum class CommonAbortReason : uint8_t {
     ConnectionClosed,
 };
 
-JSC::JSValue toJS(JSC::JSGlobalObject*, CommonAbortReason);
+JSC::JSValue toJS(JSC::JSGlobalObject*, CommonAbortReason, JSC::JSObject* capturedStack = nullptr);
 
 typedef void* AbortSignalTimeout;
 
@@ -125,6 +125,7 @@ public:
     size_t memoryCost() const;
 
     AbortSignalTimeout getTimeout() const { return m_timeout; }
+    const JSValueInWrappedObject& timeoutCreationStack() const { return m_timeoutCreationStack; }
 
 private:
     enum class Aborted : bool {
@@ -189,6 +190,7 @@ private:
     std::atomic<uint32_t> pendingActivityCount { 0 };
     uint32_t m_algorithmIdentifier { 0 };
     AbortSignalTimeout m_timeout { nullptr };
+    JSValueInWrappedObject m_timeoutCreationStack; // Captured stack at AbortSignal.timeout() call site
     uint8_t m_flags { 0 };
 };
 

--- a/src/bun.js/bindings/webcore/AbortSignal.h
+++ b/src/bun.js/bindings/webcore/AbortSignal.h
@@ -55,6 +55,7 @@ enum class CommonAbortReason : uint8_t {
     ConnectionClosed,
 };
 
+// Implemented in ErrorCode.cpp
 JSC::JSValue toJS(JSC::JSGlobalObject*, CommonAbortReason, JSC::JSObject* capturedStack = nullptr);
 
 typedef void* AbortSignalTimeout;
@@ -190,6 +191,8 @@ private:
     std::atomic<uint32_t> pendingActivityCount { 0 };
     uint32_t m_algorithmIdentifier { 0 };
     AbortSignalTimeout m_timeout { nullptr };
+    // FIXME: m_timeoutCreationStack uses JSValueInWrappedObject + setWeakly like m_reason;
+    // both need proper write-barrier handling for GC safety.
     JSValueInWrappedObject m_timeoutCreationStack; // Captured stack at AbortSignal.timeout() call site
     uint8_t m_flags { 0 };
 };

--- a/test/js/bun/abort-signal-timeout-stack.test.ts
+++ b/test/js/bun/abort-signal-timeout-stack.test.ts
@@ -1,0 +1,51 @@
+import { expect, test, describe } from "bun:test";
+
+describe("AbortSignal.timeout stack trace", () => {
+    test("should include stack trace pointing to where AbortSignal.timeout() was called", async () => {
+        // This test verifies fix for issue #25182
+        // The stack trace should point to where AbortSignal.timeout() was called,
+        // not just where the timeout was triggered internally
+        
+        async function myFunction() {
+            const signal = AbortSignal.timeout(50);
+            await new Promise((resolve, reject) => {
+                signal.addEventListener('abort', () => {
+                    reject(signal.reason);
+                });
+                setTimeout(resolve, 1000);
+            });
+        }
+        
+        try {
+            await myFunction();
+            expect.unreachable("Should have thrown");
+        } catch (e: any) {
+            expect(e instanceof DOMException).toBe(true);
+            expect(e.name).toBe("TimeoutError");
+            expect(e.message).toBe("The operation timed out.");
+            
+            // The stack trace should include 'myFunction' 
+            // since that's where AbortSignal.timeout() was called
+            const stack = e.stack;
+            expect(stack).toBeDefined();
+            expect(typeof stack).toBe("string");
+            
+            // Check that stack trace includes the calling function
+            // This is the key fix - previously this would be empty or only have internals
+            expect(stack).toInclude("myFunction");
+        }
+    });
+    
+    test("stack trace should include the test file name", async () => {
+        try {
+            const signal = AbortSignal.timeout(10);
+            await new Promise((resolve, reject) => {
+                signal.addEventListener('abort', () => reject(signal.reason));
+                setTimeout(resolve, 1000);
+            });
+        } catch (e: any) {
+            // Stack should reference this test file
+            expect(e.stack).toInclude("abort-signal-timeout-stack.test.ts");
+        }
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #25182: No stack trace on AbortSignal.timeout error

This PR adds stack trace capture to `AbortSignal.timeout()` so that when the timeout fires and throws a `TimeoutError`, the stack trace points to where `AbortSignal.timeout()` was called in user code.

## Changes
- **`src/bun.js/bindings/webcore/AbortSignal.h`**: Added `m_timeoutCreationStack` member variable and `timeoutCreationStack()` accessor. Updated `toJS()` signature with optional captured stack parameter.
- **`src/bun.js/bindings/webcore/AbortSignal.cpp`**: Modified `timeout()` to capture the current stack trace at creation. Modified `signalAbort()` to pass the captured stack to `toJS()`.
- **`src/bun.js/bindings/ErrorCode.cpp`**: Modified `toJS()` for `CommonAbortReason::Timeout` to copy the stack from the captured error to the new TimeoutError.
- **`test/js/bun/abort-signal-timeout-stack.test.ts`**: Added test cases verifying stack trace includes calling function name and file name.

## How It Works
1. When `AbortSignal.timeout()` is called, we create an error object and capture its stack trace at that point
2. We store this error in `m_timeoutCreationStack`
3. When the timeout fires and we create the `TimeoutError`, we copy the stack from the stored error
4. The result is a `TimeoutError` with a stack trace pointing to user code

## Before/After
Before: Error has no stack trace or only internal frames
After: Error.stack shows where `AbortSignal.timeout()` was calledCapture the stack trace at the point where AbortSignal.timeout() is called and attach it to the TimeoutError that is thrown when the timeout fires.

Previously, the TimeoutError had no stack trace (or only internal frames), making it difficult to debug where the timeout originated in user code.

Now the error's stack property points to the user code that called AbortSignal.timeout(), matching Node.js behavior.

Changes:
- AbortSignal.h: Added m_timeoutCreationStack member and accessor
- AbortSignal.cpp: Capture stack in timeout(), pass to signalAbort()
- ErrorCode.cpp: Copy captured stack to TimeoutError in toJS()
- Added test case for stack trace verification

Closes #25182

### What does this PR do?

### How did you verify your code works?
