### PR TITLE
Add zstd support to the package manager

### DIFF
--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -183,68 +183,8 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
         defer extract_destination.close();
 
         const Archiver = bun.libarchive.Archiver;
-        const Zlib = @import("../zlib.zig");
-        var zlib_pool = Npm.Registry.BodyPool.get(default_allocator);
-        zlib_pool.data.reset();
-        defer Npm.Registry.BodyPool.release(zlib_pool);
-
-        var esimated_output_size: usize = 0;
 
         const time_started_for_verbose_logs: u64 = if (PackageManager.verbose_install) bun.getRoughTickCount(.allow_mocked_time).ns() else 0;
-
-        {
-            // Last 4 bytes of a gzip-compressed file are the uncompressed size.
-            if (tgz_bytes.len > 16) {
-                // If the file claims to be larger than 16 bytes and smaller than 64 MB, we'll preallocate the buffer.
-                // If it's larger than that, we'll do it incrementally. We want to avoid OOMing.
-                const last_4_bytes: u32 = @bitCast(tgz_bytes[tgz_bytes.len - 4 ..][0..4].*);
-                if (last_4_bytes > 16 and last_4_bytes < 64 * 1024 * 1024) {
-                    // It's okay if this fails. We will just allocate as we go and that will error if we run out of memory.
-                    esimated_output_size = last_4_bytes;
-                    if (zlib_pool.data.list.capacity == 0) {
-                        zlib_pool.data.list.ensureTotalCapacityPrecise(zlib_pool.data.allocator, last_4_bytes) catch {};
-                    } else {
-                        zlib_pool.data.ensureUnusedCapacity(last_4_bytes) catch {};
-                    }
-                }
-            }
-        }
-
-        var needs_to_decompress = true;
-        if (bun.FeatureFlags.isLibdeflateEnabled() and zlib_pool.data.list.capacity > 16 and esimated_output_size > 0) use_libdeflate: {
-            const decompressor = bun.libdeflate.Decompressor.alloc() orelse break :use_libdeflate;
-            defer decompressor.deinit();
-
-            const result = decompressor.gzip(tgz_bytes, zlib_pool.data.list.allocatedSlice());
-
-            if (result.status == .success) {
-                zlib_pool.data.list.items.len = result.written;
-                needs_to_decompress = false;
-            }
-
-            // If libdeflate fails for any reason, fallback to zlib.
-        }
-
-        if (needs_to_decompress) {
-            zlib_pool.data.list.clearRetainingCapacity();
-            var zlib_entry = try Zlib.ZlibReaderArrayList.init(tgz_bytes, &zlib_pool.data.list, default_allocator);
-            zlib_entry.readAll(true) catch |err| {
-                log.addErrorFmt(
-                    null,
-                    logger.Loc.Empty,
-                    bun.default_allocator,
-                    "{s} decompressing \"{s}\" to \"{f}\"",
-                    .{ @errorName(err), name, bun.fmt.fmtPath(u8, tmpname, .{}) },
-                ) catch unreachable;
-                return error.InstallFailed;
-            };
-        }
-
-        if (PackageManager.verbose_install) {
-            const decompressing_ended_at: u64 = bun.getRoughTickCount(.allow_mocked_time).ns();
-            const elapsed = decompressing_ended_at - time_started_for_verbose_logs;
-            Output.prettyErrorln("[{s}] Extract {s}<r> (decompressed {f} tgz file in {D})", .{ name, tmpname, bun.fmt.size(tgz_bytes.len, .{}), elapsed });
-        }
 
         switch (this.resolution.tag) {
             .github => {
@@ -261,7 +201,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
                 switch (PackageManager.verbose_install) {
                     inline else => |verbose_log| _ = try Archiver.extractToDir(
-                        zlib_pool.data.list.items,
+                        tgz_bytes,
                         extract_destination,
                         null,
                         *DirnameReader,
@@ -287,7 +227,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
             },
             else => switch (PackageManager.verbose_install) {
                 inline else => |verbose_log| _ = try Archiver.extractToDir(
-                    zlib_pool.data.list.items,
+                    tgz_bytes,
                     extract_destination,
                     null,
                     void,

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -41,9 +41,8 @@ pub const BufferReadStream = struct {
         // // lib.archive_read_set_switch_callback(this.archive, this.archive_s);
         // _ = lib.archive_read_set_callback_data(this.archive, this);
 
-        _ = this.archive.readSupportFormatTar();
-        _ = this.archive.readSupportFormatGnutar();
-        _ = this.archive.readSupportFilterGzip();
+        _ = this.archive.readSupportFormatAll();
+        _ = this.archive.readSupportFilterAll();
 
         // Ignore zeroed blocks in the archive, which occurs when multiple tar archives
         // have been concatenated together.


### PR DESCRIPTION
### What does this PR do?

Adds zstd compression support to the Bun package manager. I also allowed other formats to be installed besides tarballs. In terms of code size it shouldn't really impact it since zstd is already included and libarchive is still only built with minimal features. 

I removed the zlib wrapper to let libarchive handle it, however ideally it'd be streaming the tarball instead of the current approach in memory.

### How did you verify your code works?

I confirmed the package manager still works in my personal website project.
