### PR TITLE
docs: Fixed plugin configuration properties, Svelte file syntax

### DIFF
--- a/docs/guides/test/svelte-test.mdx
+++ b/docs/guides/test/svelte-test.mdx
@@ -30,14 +30,14 @@ afterEach(async () => {
 });
 
 plugin({
-  title: "svelte loader",
+  name: "svelte loader",
   setup(builder) {
     builder.onLoad({ filter: /\.svelte(\?[^.]+)?$/ }, ({ path }) => {
       try {
         const source = readFileSync(path.substring(0, path.includes("?") ? path.indexOf("?") : path.length), "utf-8");
 
         const result = compile(source, {
-          filetitle: path,
+          filename: path,
           generate: "client",
           dev: false,
         });
@@ -77,7 +77,7 @@ Add an example `.svelte` file in your project.
   let count = initialCount;
 </script>
 
-<button on:click="{()" ="">(count += 1)}>+1</button>
+<button on:click={() => count++}>+1</button>
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

Fixes Svelte Testing documentation syntaxes.

- Changes the `name` and `filename` properties instead of `title` and `filetitle` properties to in plugin configuration.
- Fixes incorrect Svelte file syntax.

### How did you verify your code works?
https://github.com/oven-sh/bun/blob/4d60b6f69d2ade569a5f231f87dc5ff56dea7196/packages/bun-types/bun.d.ts#L4355

---

I didn't understand why are there weird `"` characters in Svelte file.