### PR TITLE
update flake to new apple sdk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759831965,
-        "narHash": "sha256-vgPm2xjOmKdZ0xKA6yLXPJpjOtQPHfaZDRtH+47XEBo=",
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9b6fb798541223bbb396d287d16f43520250518",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -119,10 +119,8 @@
           pkgs.xorg.libxshmfence
           pkgs.gdk-pixbuf
         ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-          # macOS specific dependencies
-          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-          pkgs.darwin.apple_sdk.frameworks.CoreServices
-          pkgs.darwin.apple_sdk.frameworks.Security
+          # macOS specific dependencies - use latest supported Apple SDK
+          pkgs.apple-sdk
         ];
 
       in


### PR DESCRIPTION
### What does this PR do?
`nix develop` was failing with errors mentioning that the apple sdk was outdated. This PR updates the referenced version of the apple SDK, along with the flake more generally.

### How did you verify your code works?
ran `nix develop` and confirmed that the error no longer occurs. However, in the nix shell `bun bd` still fails; I think we are waiting on [this PR](https://github.com/NixOS/nixpkgs/pull/465669) and another flake update to resolve that.