### PR TITLE
fix(test): disable Puppeteer pipe mode on macOS to prevent flaky test

### DIFF
--- a/test/integration/next-pages/test/dev-server-puppeteer.ts
+++ b/test/integration/next-pages/test/dev-server-puppeteer.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
+import { which } from "bun";
 import { copyFileSync } from "fs";
 import { join } from "path";
 import type { ConsoleMessage, Page } from "puppeteer";
 import { launch } from "puppeteer";
-import { which } from "bun";
 const root = join(import.meta.dir, "../");
 
 copyFileSync(join(root, "src/Counter1.txt"), join(root, "src/Counter.tsx"));
@@ -25,7 +25,8 @@ const b = await launch({
   // Inherit the stdout and stderr of the browser process.
   dumpio: true,
   // Prefer to use a pipe to connect to the browser, instead of a WebSocket.
-  pipe: true,
+  // On macOS, pipe mode can cause "TargetCloseError: Protocol error (Target.setDiscoverTargets): Target closed"
+  pipe: process.platform !== "darwin",
   // Disable timeouts.
   timeout: 0,
   protocolTimeout: 0,


### PR DESCRIPTION
## Summary

- Fixes flaky `dev-server.test.ts` test on macOS aarch64 by disabling `pipe: true` on macOS
- The error `TargetCloseError: Protocol error (Target.setDiscoverTargets): Target closed` is a known Puppeteer issue with pipe-based communication on macOS

## Root Cause

When using `pipe: true` in Puppeteer on macOS, the browser can fail to launch with:
```
TargetCloseError: Protocol error (Target.setDiscoverTargets): Target closed
```

This is an intermittent issue related to how Puppeteer communicates with Chrome via stdio pipes. On macOS, using WebSocket communication (the default when `pipe: false`) is more reliable.

## Test plan

- [ ] CI passes on macOS aarch64
- [ ] `test/integration/next-pages/test/dev-server.test.ts` no longer flaky

Fixes the flaky test in #25360

🤖 Generated with [Claude Code](https://claude.com/claude-code)