### PR TITLE
fix(compile): use 8-byte header for embedded section to ensure bytecode alignment

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -119,7 +119,7 @@ pub const StandaloneModuleGraph = struct {
     };
 
     const Macho = struct {
-        pub extern "C" fn Bun__getStandaloneModuleGraphMachoLength() ?*align(1) u32;
+        pub extern "C" fn Bun__getStandaloneModuleGraphMachoLength() ?*align(1) u64;
 
         pub fn getData() ?[]const u8 {
             if (Bun__getStandaloneModuleGraphMachoLength()) |length| {
@@ -127,8 +127,10 @@ pub const StandaloneModuleGraph = struct {
                     return null;
                 }
 
+                // BlobHeader has 8 bytes size (u64), so data starts at offset 8.
+                const data_offset = @sizeOf(u64);
                 const slice_ptr: [*]const u8 = @ptrCast(length);
-                return slice_ptr[4..][0..length.*];
+                return slice_ptr[data_offset..][0..length.*];
             }
 
             return null;
@@ -136,7 +138,7 @@ pub const StandaloneModuleGraph = struct {
     };
 
     const PE = struct {
-        pub extern "C" fn Bun__getStandaloneModuleGraphPELength() u32;
+        pub extern "C" fn Bun__getStandaloneModuleGraphPELength() u64;
         pub extern "C" fn Bun__getStandaloneModuleGraphPEData() ?[*]u8;
 
         pub fn getData() ?[]const u8 {

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -910,14 +910,14 @@ extern "C" void Bun__signpost_emit(os_log_t log, os_signpost_type_t type, os_sig
 
 extern "C" {
 struct BlobHeader {
-    uint32_t size;
+    uint64_t size; // 64-bit to ensure data[] starts at 8-byte aligned offset (required for bytecode cache)
     uint8_t data[];
 } __attribute__((aligned(BLOB_HEADER_ALIGNMENT)));
 }
 
 extern "C" BlobHeader __attribute__((section("__BUN,__bun"))) BUN_COMPILED = { 0, 0 };
 
-extern "C" uint32_t* Bun__getStandaloneModuleGraphMachoLength()
+extern "C" uint64_t* Bun__getStandaloneModuleGraphMachoLength()
 {
     return &BUN_COMPILED.size;
 }
@@ -927,7 +927,7 @@ extern "C" uint32_t* Bun__getStandaloneModuleGraphMachoLength()
 #include <windows.h>
 #include <winnt.h>
 
-static uint32_t* pe_section_size = nullptr;
+static uint64_t* pe_section_size = nullptr;
 static uint8_t* pe_section_data = nullptr;
 
 // Helper function to find and map the .bun section
@@ -949,9 +949,10 @@ static bool initializePESection()
     for (int i = 0; i < ntHeaders->FileHeader.NumberOfSections; i++) {
         if (strncmp((char*)sectionHeader->Name, ".bun", 4) == 0) {
             // Found the .bun section
+            // Section format: 8 bytes size (uint64_t) + data
             BYTE* sectionData = (BYTE*)hModule + sectionHeader->VirtualAddress;
-            pe_section_size = (uint32_t*)sectionData;
-            pe_section_data = sectionData + sizeof(uint32_t);
+            pe_section_size = (uint64_t*)sectionData;
+            pe_section_data = sectionData + sizeof(uint64_t); // Skip size (8)
             return true;
         }
         sectionHeader++;
@@ -960,7 +961,7 @@ static bool initializePESection()
     return false;
 }
 
-extern "C" uint32_t Bun__getStandaloneModuleGraphPELength()
+extern "C" uint64_t Bun__getStandaloneModuleGraphPELength()
 {
     if (!initializePESection()) return 0;
     return pe_section_size ? *pe_section_size : 0;

--- a/test/regression/issue/pe-codesigning-integrity.test.ts
+++ b/test/regression/issue/pe-codesigning-integrity.test.ts
@@ -119,8 +119,8 @@ describe.if(isWindows)("PE codesigning integrity", () => {
       // Read the .bun section data
       const sectionData = new Uint8Array(this.buffer, bunSection.pointerToRawData, bunSection.sizeOfRawData);
 
-      // First 4 bytes should be the data size
-      const dataSize = new DataView(sectionData.buffer, bunSection.pointerToRawData).getUint32(0, true);
+      // First 8 bytes should be the data size (u64 for 8-byte alignment)
+      const dataSize = Number(new DataView(sectionData.buffer, bunSection.pointerToRawData).getBigUint64(0, true));
 
       // Validate the size is reasonable - it should match or be close to virtual size
       if (dataSize > bunSection.sizeOfRawData || dataSize === 0) {
@@ -133,8 +133,8 @@ describe.if(isWindows)("PE codesigning integrity", () => {
         throw new Error(`Invalid .bun section: data size ${dataSize} exceeds virtual size ${bunSection.virtualSize}`);
       }
 
-      // Extract the actual embedded data (skip the 4-byte size header)
-      const embeddedData = sectionData.slice(4, 4 + dataSize);
+      // Extract the actual embedded data (skip the 8-byte size header)
+      const embeddedData = sectionData.slice(8, 8 + dataSize);
 
       return {
         section: bunSection,


### PR DESCRIPTION
## Summary
- Change the size header in embedded Mach-O and PE sections from `u32` (4 bytes) to `u64` (8 bytes)
- Ensures the data payload starts at an 8-byte aligned offset, which is required for the bytecode cache

## Test plan
- [x] Test standalone compilation on macOS
- [ ] Test standalone compilation on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)