### PR TITLE
fix(docs): correct mock documentation examples

### DIFF
--- a/docs/guides/test/mock-functions.mdx
+++ b/docs/guides/test/mock-functions.mdx
@@ -60,7 +60,7 @@ test("random", async () => {
 
   expect(random).toHaveBeenCalled();
   expect(random).toHaveBeenCalledTimes(3);
-  expect(random.mock.args).toEqual([[1], [2], [3]]);
+  expect(random.mock.calls).toEqual([[1], [2], [3]]);
   expect(random.mock.results[0]).toEqual({ type: "return", value: a });
 });
 ```

--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -428,26 +428,26 @@ test("foo, bar, baz", () => {
   const barSpy = spyOn(barModule, "bar");
   const bazSpy = spyOn(bazModule, "baz");
 
-  // Original values
-  expect(fooSpy).toBe("foo");
-  expect(barSpy).toBe("bar");
-  expect(bazSpy).toBe("baz");
+  // Original implementations still work
+  expect(fooModule.foo()).toBe("foo");
+  expect(barModule.bar()).toBe("bar");
+  expect(bazModule.baz()).toBe("baz");
 
   // Mock implementations
   fooSpy.mockImplementation(() => 42);
   barSpy.mockImplementation(() => 43);
   bazSpy.mockImplementation(() => 44);
 
-  expect(fooSpy()).toBe(42);
-  expect(barSpy()).toBe(43);
-  expect(bazSpy()).toBe(44);
+  expect(fooModule.foo()).toBe(42);
+  expect(barModule.bar()).toBe(43);
+  expect(bazModule.baz()).toBe(44);
 
   // Restore all
   mock.restore();
 
-  expect(fooSpy()).toBe("foo");
-  expect(barSpy()).toBe("bar");
-  expect(bazSpy()).toBe("baz");
+  expect(fooModule.foo()).toBe("foo");
+  expect(barModule.bar()).toBe("bar");
+  expect(bazModule.baz()).toBe("baz");
 });
 ```
 
@@ -455,10 +455,10 @@ Using `mock.restore()` can reduce the amount of code in your tests by adding it 
 
 ## Vitest Compatibility
 
-For added compatibility with tests written for Vitest, Bun provides the `vi` global object as an alias for parts of the Jest mocking API:
+For added compatibility with tests written for Vitest, Bun provides the `vi` object as an alias for parts of the Jest mocking API:
 
 ```ts title="test.ts" icon="/icons/typescript.svg"
-import { test, expect } from "bun:test";
+import { test, expect, vi } from "bun:test";
 
 // Using the 'vi' alias similar to Vitest
 test("vitest compatibility", () => {


### PR DESCRIPTION
## Summary

- Fix `mock.mock.args` to `mock.mock.calls` in mock-functions.mdx (the `.args` property doesn't exist)
- Fix mock.restore example to use module methods instead of spy functions (calling spy functions after restore returns `undefined`)
- Add missing `vi` import in Vitest compatibility example

## Test plan

- [x] Verified each code block works by running tests against the debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)