### PR TITLE
fix(vm): delete internal Loader property from node:vm global object

### DIFF
--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -772,6 +772,13 @@ void NodeVMGlobalObject::finishCreation(JSC::VM& vm)
     Base::finishCreation(vm);
     setEvalEnabled(m_contextOptions.allowStrings, "Code generation from strings disallowed for this context"_s);
     setWebAssemblyEnabled(m_contextOptions.allowWasm, "Wasm code generation disallowed by embedder"_s);
+
+    // Delete the internal Loader property from the VM global object.
+    // This is exposed by JSC when exposeInternalModuleLoader() is true,
+    // but it should not be visible in node:vm contexts.
+    JSC::DeletePropertySlot slot;
+    JSC::JSObject::deleteProperty(this, this, vm.propertyNames->Loader, slot);
+
     vm.ensureTerminationException();
 }
 


### PR DESCRIPTION
## Summary
- Delete the internal JSC `Loader` property from node:vm global objects during creation
- The internal `Loader` was leaking into vm contexts when `exposeInternalModuleLoader()` is true, which should not be visible in sandboxed contexts

## Test plan
- Added test that verifies `Loader` is `undefined` in empty vm contexts
- Added test that verifies user-provided `Loader` property on context is preserved
- Run `bun test test/js/node/vm/vm.test.ts -t "Loader is not defined"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)