### PR TITLE
Add missing setSystemTime function for Vitest compatibility

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -198,6 +198,7 @@ declare module "bun:test" {
     getTimerCount: typeof jest.getTimerCount;
     clearAllTimers: typeof jest.clearAllTimers;
     isFakeTimers: typeof jest.isFakeTimers;
+    setSystemTime: typeof jest.setSystemTime;
   };
 
   interface FunctionLike {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -239,13 +239,14 @@ pub const Jest = struct {
         module.put(globalObject, ZigString.static("spyOn"), spyOn);
         module.put(globalObject, ZigString.static("expect"), Expect.js.getConstructor(globalObject));
 
-        const vi = JSValue.createEmptyObject(globalObject, 6 + bun_test.FakeTimers.timerFnsCount);
+        const vi = JSValue.createEmptyObject(globalObject, 7 + bun_test.FakeTimers.timerFnsCount);
         vi.put(globalObject, ZigString.static("fn"), mockFn);
         vi.put(globalObject, ZigString.static("mock"), mockModuleFn);
         vi.put(globalObject, ZigString.static("spyOn"), spyOn);
         vi.put(globalObject, ZigString.static("restoreAllMocks"), restoreAllMocks);
         vi.put(globalObject, ZigString.static("resetAllMocks"), clearAllMocks);
         vi.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
+        vi.put(globalObject, ZigString.static("setSystemTime"), setSystemTime);
         module.put(globalObject, ZigString.static("vi"), vi);
 
         bun_test.FakeTimers.putTimersFns(globalObject, jest, vi);

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -447,3 +447,34 @@ describe("useFakeTimers with options", () => {
     expect(Date.now()).toBe(targetTime + 500);
   });
 });
+
+describe("vi.setSystemTime", () => {
+  test("can set system time with Date object", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("1995-12-19T00:00:00.000Z"));
+
+    expect(new Date().toISOString()).toBe("1995-12-19T00:00:00.000Z");
+    expect(Date.now()).toBe(819331200000);
+  });
+
+  test("can set system time with timestamp", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2020-01-01T00:00:00.000Z").getTime());
+
+    expect(new Date().toISOString()).toBe("2020-01-01T00:00:00.000Z");
+    expect(Date.now()).toBe(1577836800000);
+  });
+
+  test("can update system time multiple times", () => {
+    vi.useFakeTimers();
+
+    vi.setSystemTime(new Date("1995-12-19T00:00:00.000Z"));
+    expect(Date.now()).toBe(819331200000);
+
+    vi.setSystemTime(new Date("2020-01-01T00:00:00.000Z"));
+    expect(Date.now()).toBe(1577836800000);
+
+    vi.setSystemTime(new Date("2025-06-15T12:00:00.000Z"));
+    expect(Date.now()).toBe(1749988800000);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

The `vi` object has nearly every function in the new Jest fake timers APIs. But `setSystemTime` was missing. This PR adds the TS declaration, Zig binding, and some unit tests for it.

Related issue: #16142

### How did you verify your code works?

Added some unit tests for the `setSystemTime` function. Built the bun-debug binary locally and ran the tests with it. Made sure all tests passed.