### PR TITLE
feat(sql): support custom database adapters

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -28,6 +28,9 @@ interface TransactionState {
 }
 
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
+  if (typeof options.adapter === "object") {
+    return options.adapter;
+  }
   switch (options.adapter) {
     case "postgres":
       return new PostgresAdapter(options);

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -481,6 +481,10 @@ function parseConnectionDetailsFromOptionsOrEnvironment(
 
   // Step 5: Return early if adapter is explicitly specified
   if (options.adapter) {
+    if (typeof options.adapter === "object") {
+      return [urlToProcess, sslMode, options as Bun.SQL.__internal.OptionsWithDefinedAdapter];
+    }
+
     // Validate that the adapter is supported
     const supportedAdapters = ["postgres", "sqlite", "mysql", "mariadb"];
     if (!supportedAdapters.includes(options.adapter)) {
@@ -536,6 +540,10 @@ function parseOptions(
   );
 
   const adapter = options.adapter;
+
+  if (typeof adapter === "object") {
+    return options as Bun.SQL.__internal.DefinedOptions;
+  }
 
   if (adapter === "sqlite") {
     return parseSQLiteOptions(_url, options);

--- a/test/js/bun/sql/custom-adapter.test.ts
+++ b/test/js/bun/sql/custom-adapter.test.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "bun:test";
+import { SQL } from "bun";
+
+test("custom adapter", async () => {
+  const customAdapter = {
+    normalizeQuery(strings, values) {
+      // Simple implementation for testing
+      let sql = "";
+      for (let i = 0; i < strings.length; i++) {
+        sql += strings[i];
+        if (i < values.length) {
+          sql += "?";
+        }
+      }
+      return [sql, values];
+    },
+    createQueryHandle(sql, values, flags) {
+      return {
+        run(connection, query) {
+          // Mock execution
+          // Custom adapters can return plain arrays with metadata properties
+          const result = [{ sql, values }];
+          result.count = 1;
+          result.command = "SELECT";
+          result.lastInsertRowid = null;
+          result.affectedRows = null;
+          query.resolve(result);
+        },
+        setMode() {},
+      };
+    },
+    connect(onConnected) {
+      onConnected(null, {}); // Connected mock
+    },
+    release() {},
+    close() {
+      return Promise.resolve();
+    },
+    flush() {},
+    isConnected() {
+      return true;
+    },
+    get closed() {
+      return false;
+    },
+    getTransactionCommands() {
+      return {
+        BEGIN: "BEGIN",
+        COMMIT: "COMMIT",
+        ROLLBACK: "ROLLBACK",
+        SAVEPOINT: "SAVEPOINT",
+        RELEASE_SAVEPOINT: "RELEASE SAVEPOINT",
+        ROLLBACK_TO_SAVEPOINT: "ROLLBACK TO SAVEPOINT",
+      };
+    },
+    array() {
+      return null;
+    },
+    escapeIdentifier(name) {
+      return `"${name}"`;
+    },
+    notTaggedCallError() {
+      return new Error("Not tagged");
+    },
+    connectionClosedError() {
+      return new Error("Connection closed");
+    },
+    queryCancelledError() {
+      return new Error("Query cancelled");
+    },
+    invalidTransactionStateError(msg) {
+      return new Error(msg);
+    },
+  };
+
+  const sql = new SQL({ adapter: customAdapter });
+  const result = await sql`SELECT ${1}`;
+  expect(result).toHaveLength(1);
+  expect(result[0].sql).toBe("SELECT ?");
+  expect(result[0].values).toEqual([1]);
+
+  await sql.close();
+});


### PR DESCRIPTION
## Summary

- Enables custom database adapter support for `Bun.SQL`
- Allows integration with databases not natively supported (DuckDB, CockroachDB, TiDB, etc.)
- No new exports needed - adapters use plain arrays with metadata properties

## Changes

- Updated `src/js/internal/sql/shared.ts` to accept adapter objects implementing `DatabaseAdapter` interface
- Updated `src/js/bun/sql.ts` to return adapter object directly when provided
- Added unit test for custom adapter interface
- Total: 11 lines added to core

## Example Usage

```typescript
const sql = new SQL({ adapter: customAdapter });
const result = await sql\`SELECT * FROM users WHERE id = \${userId}\`;
```

## Demo Implementation

For a complete working example integrating DuckDB, see:
**https://github.com/abelcha/bun-duckdb-adapter**

The demo includes:
- Full DatabaseAdapter implementation
- SQLHelper support (INSERT, UPDATE, WHERE IN)
- Type conversions (DECIMAL, BIGINT)
- 14 comprehensive tests covering all features

## Test Plan

- [x] Unit test for custom adapter interface passes
- [x] Verified with full DuckDB integration (14 tests, all passing)
- [x] Tests cover: basic queries, parameterized queries, sql() helpers, type conversions