### PR TITLE
docs: fix code highlight

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -427,8 +427,8 @@ This will allow you to use TailwindCSS utility classes in your HTML and CSS file
 <!doctype html>
 <html>
   <head>
-    <link rel="stylesheet" href="tailwindcss" />
     <!-- [!code ++] -->
+    <link rel="stylesheet" href="tailwindcss" />
   </head>
   <!-- the rest of your HTML... -->
 </html>
@@ -448,8 +448,8 @@ Alternatively, you can import TailwindCSS in your CSS file:
 <!doctype html>
 <html>
   <head>
-    <link rel="stylesheet" href="./style.css" />
     <!-- [!code ++] -->
+    <link rel="stylesheet" href="./style.css" />
   </head>
   <!-- the rest of your HTML... -->
 </html>


### PR DESCRIPTION
### What does this PR do?

Fix code highlight line, see problem:
<img width="684" height="663" alt="Screenshot 2025-12-08 at 11 40 39 AM" src="https://github.com/user-attachments/assets/9894a7b7-ddd6-4bad-b7de-3e0e55ecd8cd" />


### How did you verify your code works?
