### PR TITLE
docs: Fix and extend "Hash a Password" page code snippets

### DIFF
--- a/docs/guides/util/hash-a-password.mdx
+++ b/docs/guides/util/hash-a-password.mdx
@@ -38,6 +38,9 @@ const bcryptHash = await Bun.password.hash(password, {
   algorithm: "bcrypt",
   cost: 4, // number between 4-31
 });
+
+// shorthand without custom cost
+const anotherBcrypt = await Bun.password.hash(password, "bcrypt");
 ```
 
 ---

--- a/docs/guides/util/hash-a-password.mdx
+++ b/docs/guides/util/hash-a-password.mdx
@@ -20,8 +20,9 @@ By default, this uses the [Argon2id](https://en.wikipedia.org/wiki/Argon2) algor
 ```ts
 const password = "super-secure-pa$$word";
 
-// use argon2 (default)
+// use argon2id (default)
 const argonHash = await Bun.password.hash(password, {
+  algorithm: "argon2id",
   memoryCost: 4, // memory usage in kibibytes
   timeCost: 3, // the number of iterations
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the code-snippet for adding custom parameters to argon2id on the "Hash a Password" page. The previous version did not specify the `algorithm` field in the second argument object to `Bun.password.hash`, which actually causes a `TypeError`.

Also adds an example of the "shorthand" notation for changing the algorithm without specifying custom cost parameters.

### How did you verify your code works?

I wrote it in a `.ts` file, ran it locally, and then copy-pasted the snippets into the documentation file.