### PR TITLE
fix(s3): presign url encoding

### DIFF
--- a/test/regression/issue/24422.test.ts
+++ b/test/regression/issue/24422.test.ts
@@ -1,0 +1,130 @@
+import { S3Client } from "bun";
+import { expect, test, describe } from "bun:test";
+
+// GitHub Issue #24422: S3 presign does not percent-encode X-Amz-Credential (colon :)
+// https://github.com/oven-sh/bun/issues/24422
+//
+// When accessKeyId contains special characters like colons (e.g., "TENANT_ID:KEY_ID"
+// used by Cloud.ru Object Storage and other S3-compatible providers), the colon
+// should be percent-encoded as %3A in the X-Amz-Credential query parameter.
+// Without proper encoding, SigV4 validation fails with "Request signature does not match".
+
+describe("S3 presign X-Amz-Credential encoding", () => {
+  test("should percent-encode colon in accessKeyId within X-Amz-Credential", () => {
+    // Access key in the format TENANT_ID:KEY_ID (used by Cloud.ru Object Storage)
+    const accessKeyWithColon = "8439f167:f5cf173e";
+
+    const s3 = new S3Client({
+      accessKeyId: accessKeyWithColon,
+      secretAccessKey: "test-secret-key",
+      endpoint: "https://s3.cloud.ru",
+      bucket: "test-bucket",
+      region: "ru-central-1",
+    });
+
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 3600,
+    });
+
+    // Parse the URL and get the X-Amz-Credential parameter
+    const urlObj = new URL(url);
+    const credential = urlObj.searchParams.get("X-Amz-Credential");
+
+    expect(credential).not.toBeNull();
+
+    // The raw URL should contain %3A (encoded colon) instead of raw colon
+    // AWS CLI produces: X-Amz-Credential=8439f167%3Af5cf173e/20251105/ru-central-1/s3/aws4_request
+    // Bun currently produces: X-Amz-Credential=8439f167:f5cf173e/20251105/ru-central-1/s3/aws4_request
+    expect(url).toContain("X-Amz-Credential=8439f167%3Af5cf173e");
+    expect(url).not.toContain("X-Amz-Credential=8439f167:f5cf173e");
+
+    // The decoded credential should still contain the original accessKeyId
+    expect(credential).toContain("8439f167:f5cf173e");
+  });
+
+  test("should percent-encode multiple special characters in accessKeyId", () => {
+    // Test with multiple special characters that need encoding
+    const accessKeyWithSpecialChars = "tenant:key=value+test";
+
+    const s3 = new S3Client({
+      accessKeyId: accessKeyWithSpecialChars,
+      secretAccessKey: "test-secret-key",
+      endpoint: "https://s3.example.com",
+      bucket: "test-bucket",
+    });
+
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 3600,
+    });
+
+    const urlObj = new URL(url);
+    const credential = urlObj.searchParams.get("X-Amz-Credential");
+
+    expect(credential).not.toBeNull();
+
+    // Colons should be encoded as %3A
+    expect(url).not.toMatch(/X-Amz-Credential=[^&]*:[^&]*/);
+
+    // After decoding, the credential should have the original accessKeyId
+    expect(credential).toContain("tenant:key=value+test");
+  });
+
+  test("should work correctly with standard accessKeyId without special characters", () => {
+    // Standard AWS-style access key (no special characters)
+    const standardAccessKey = "AKIAIOSFODNN7EXAMPLE";
+
+    const s3 = new S3Client({
+      accessKeyId: standardAccessKey,
+      secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      endpoint: "https://s3.amazonaws.com",
+      bucket: "test-bucket",
+      region: "us-east-1",
+    });
+
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 3600,
+    });
+
+    const urlObj = new URL(url);
+    const credential = urlObj.searchParams.get("X-Amz-Credential");
+
+    expect(credential).not.toBeNull();
+    expect(credential).toContain(standardAccessKey);
+    expect(url).toContain(`X-Amz-Credential=${standardAccessKey}`);
+  });
+
+  test("should percent-encode accessKeyId in X-Amz-Credential for S3File.presign()", () => {
+    const { s3 } = require("bun");
+
+    const accessKeyWithColon = "tenant_id:access_key_id";
+
+    const s3file = s3.file("test-file.txt", {
+      accessKeyId: accessKeyWithColon,
+      secretAccessKey: "test-secret-key",
+      endpoint: "https://s3.example.com",
+      bucket: "test-bucket",
+    });
+
+    const url = s3file.presign({ expiresIn: 3600 });
+
+    // Verify the colon is percent-encoded
+    expect(url).toContain("X-Amz-Credential=tenant_id%3Aaccess_key_id");
+    expect(url).not.toContain("X-Amz-Credential=tenant_id:access_key_id");
+  });
+
+  test("should percent-encode accessKeyId in static S3Client.presign()", () => {
+    const accessKeyWithColon = "my_tenant:my_key";
+
+    const url = S3Client.presign("test-file.txt", {
+      accessKeyId: accessKeyWithColon,
+      secretAccessKey: "test-secret-key",
+      endpoint: "https://s3.example.com",
+      bucket: "test-bucket",
+      expiresIn: 3600,
+    });
+
+    // Verify the colon is percent-encoded
+    expect(url).toContain("X-Amz-Credential=my_tenant%3Amy_key");
+    expect(url).not.toContain("X-Amz-Credential=my_tenant:my_key");
+  });
+});

--- a/test/regression/issue/24422.test.ts
+++ b/test/regression/issue/24422.test.ts
@@ -1,5 +1,5 @@
 import { S3Client } from "bun";
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 // GitHub Issue #24422: S3 presign does not percent-encode X-Amz-Credential (colon :)
 // https://github.com/oven-sh/bun/issues/24422
@@ -33,7 +33,7 @@ describe("S3 presign X-Amz-Credential encoding", () => {
 
     // The raw URL should contain %3A (encoded colon) instead of raw colon
     // AWS CLI produces: X-Amz-Credential=8439f167%3Af5cf173e/20251105/eu-central-1/s3/aws4_request
-    // Bun currently produces: X-Amz-Credential=8439f167:f5cf173e/20251105/eu-central-1/s3/aws4_request
+    // Previously, Bun produced: X-Amz-Credential=8439f167:f5cf173e/20251105/eu-central-1/s3/aws4_request
     expect(url).toContain("X-Amz-Credential=8439f167%3Af5cf173e");
     expect(url).not.toContain("X-Amz-Credential=8439f167:f5cf173e");
 
@@ -92,8 +92,8 @@ describe("S3 presign X-Amz-Credential encoding", () => {
     expect(url).toContain(`X-Amz-Credential=${standardAccessKey}`);
   });
 
-  test("should percent-encode accessKeyId in X-Amz-Credential for S3File.presign()", () => {
-    const { s3 } = require("bun");
+  test("should percent-encode accessKeyId in X-Amz-Credential for S3File.presign()", async () => {
+    const { s3 } = await import("bun");
 
     const accessKeyWithColon = "tenant_id:access_key_id";
 


### PR DESCRIPTION
## Summary

Fixes #24422 - `S3Client.presign()` now correctly percent-encodes the `accessKeyId` in the `X-Amz-Credential` query parameter.

## Problem

When using S3-compatible providers that issue access keys in the format `TENANT_ID:KEY_ID`, the colon character was not being URL-encoded in presigned URLs. This caused AWS SigV4 signature validation to fail because the canonical request didn't match.

**Before (broken):**
```
X-Amz-Credential=8439f167:f5cf173e/20251105/eu-central-1/s3/aws4_request
```

**After (fixed):**
```
X-Amz-Credential=8439f167%3Af5cf173e/20251105/eu-central-1/s3/aws4_request
```

## Solution

Added URL encoding for `accessKeyId` using the existing `encodeURIComponent` function in `src/s3/credentials.zig`. This matches the behavior of AWS CLI/SDK and ensures SigV4 validation succeeds.

The fix applies the encoding in both places where `X-Amz-Credential` is constructed:
1. The canonical request (used for signature computation)
2. The final presigned URL

## Verification

Added 5 regression tests in `test/regression/issue/24422.test.ts`:

1. `should percent-encode colon in accessKeyId within X-Amz-Credential` - Tests the main bug with `TENANT_ID:KEY_ID` format
2. `should percent-encode multiple special characters in accessKeyId` - Tests keys with multiple special characters
3. `should work correctly with standard accessKeyId without special characters` - Regression guard for normal AWS keys
4. `should percent-encode accessKeyId in X-Amz-Credential for S3File.presign()` - Tests via `s3.file()` API
5. `should percent-encode accessKeyId in static S3Client.presign()` - Tests via static `S3Client.presign()` API

All 5 tests pass with the debug build:
```
bun test v1.3.5 (2028e21d)
 5 pass
 0 fail
 14 expect() calls
Ran 5 tests across 1 file. [359.00ms]
```
