### PR TITLE
fix(yaml): quote strings ending with colons

### DIFF
--- a/src/bun.js/api/YAMLObject.zig
+++ b/src/bun.js/api/YAMLObject.zig
@@ -607,6 +607,9 @@ const Stringifier = struct {
             '\t',
             '\n',
             '\r',
+            // trailing colon can be misinterpreted as a mapping indicator
+            // https://github.com/oven-sh/bun/issues/25439
+            ':',
             => return true,
             else => {},
         }


### PR DESCRIPTION
## Summary
- Fixes strings ending with colons (e.g., `"tin:"`) not being quoted in YAML.stringify output
- This caused YAML.parse to fail with "Unexpected token" when parsing the output back

## Test plan
- Added regression tests in `test/regression/issue/25439.test.ts`
- Verified round-trip works for various strings ending with colons
- Ran existing YAML tests to ensure no regressions

Fixes #25439

🤖 Generated with [Claude Code](https://claude.com/claude-code)