### PR TITLE
(docs) remove extraneous `>` in PS command blocks

### DIFF
--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -13,24 +13,24 @@ It is strongly recommended to use [PowerShell 7 (`pwsh.exe`)](https://learn.micr
 
 By default, running unverified scripts are blocked.
 
-```ps1
-> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
+```ps1 terminal icon="terminal"
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
 ```
 
 ### System Dependencies
 
 Bun v1.1 or later. We use Bun to run it's own code generators.
 
-```ps1
-> irm bun.sh/install.ps1 | iex
+```ps1 terminal icon="terminal"
+irm bun.sh/install.ps1 | iex
 ```
 
 [Visual Studio](https://visualstudio.microsoft.com) with the "Desktop Development with C++" workload. While installing, make sure to install Git as well, if Git for Windows is not already installed.
 
 Visual Studio can be installed graphically using the wizard or through WinGet:
 
-```ps1
-> winget install "Visual Studio Community 2022" --override "--add Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Git " -s msstore
+```ps1 terminal icon="terminal"
+winget install "Visual Studio Community 2022" --override "--add Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Git " -s msstore
 ```
 
 After Visual Studio, you need the following:
@@ -48,10 +48,10 @@ After Visual Studio, you need the following:
 [Scoop](https://scoop.sh) can be used to install these remaining tools easily.
 
 ```ps1 Scoop
-> irm https://get.scoop.sh | iex
-> scoop install nodejs-lts go rust nasm ruby perl sccache
+irm https://get.scoop.sh | iex
+scoop install nodejs-lts go rust nasm ruby perl sccache
 # scoop seems to be buggy if you install llvm and the rest at the same time
-> scoop install llvm@19.1.7
+scoop install llvm@19.1.7
 ```
 
 <Note>
@@ -63,19 +63,19 @@ After Visual Studio, you need the following:
 If you intend on building WebKit locally (optional), you should install these packages:
 
 ```ps1 Scoop
-> scoop install make cygwin python
+scoop install make cygwin python
 ```
 
 From here on out, it is **expected you use a PowerShell Terminal with `.\scripts\vs-shell.ps1` sourced**. This script is available in the Bun repository and can be loaded by executing it:
 
-```ps1
-> .\scripts\vs-shell.ps1
+```ps1 terminal icon="terminal"
+.\scripts\vs-shell.ps1
 ```
 
 To verify, you can check for an MSVC-only command line such as `mt.exe`
 
-```ps1
-> Get-Command mt
+```ps1 terminal icon="terminal"
+Get-Command mt
 ```
 
 <Note>
@@ -85,17 +85,17 @@ To verify, you can check for an MSVC-only command line such as `mt.exe`
 
 ## Building
 
-```ps1
-> bun run build
+```ps1 terminal icon="terminal"
+bun run build
 
 # after the initial `bun run build` you can use the following to build
-> ninja -Cbuild/debug
+ninja -Cbuild/debug
 ```
 
 If this was successful, you should have a `bun-debug.exe` in the `build/debug` folder.
 
-```ps1
-> .\build\debug\bun-debug.exe --revision
+```ps1 terminal icon="terminal"
+.\build\debug\bun-debug.exe --revision
 ```
 
 You should add this to `$Env:PATH`. The simplest way to do so is to open the start menu, type "Path", and then navigate the environment variables menu to add `C:\.....\bun\build\debug` to the user environment variable `PATH`. You should then restart your editor (if it does not update still, log out and log back in).
@@ -109,17 +109,17 @@ You should add this to `$Env:PATH`. The simplest way to do so is to open the sta
 
 You can run the test suite either using `bun test <path>` or by using the wrapper script `bun node:test <path>`. The `bun node:test` command runs every test file in a separate instance of bun.exe, to prevent a crash in the test runner from stopping the entire suite.
 
-```ps1
+```ps1 terminal icon="terminal"
 # Setup
-> bun i --cwd packages\bun-internal-test
+bun i --cwd packages\bun-internal-test
 
 # Run the entire test suite with reporter
 # the package.json script "test" uses "build/debug/bun-debug.exe" by default
-> bun run test
+bun run test
 
 # Run an individual test file:
-> bun-debug test node\fs
-> bun-debug test "C:\bun\test\js\bun\resolve\import-meta.test.js"
+bun-debug test node\fs
+bun-debug test "C:\bun\test\js\bun\resolve\import-meta.test.js"
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
When viewed on the [Bun website](https://bun.com/docs/project/building-windows), some PowerShell command blocks appear with a double prompt (`> >`):

<img width="254" height="297" alt="image" src="https://github.com/user-attachments/assets/cbf477a8-1bbf-45a8-bc13-d4f64dead7aa" />

Copy-paste also includes the first `> `.

