### PR TITLE
@types/bun: Update to @types/node@25, fallback to PropertyKey in test expect matchers when `keyof unknown` is used

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
   },
   "overrides": {
     "@types/bun": "workspace:packages/@types/bun",
+    "@types/node": "25.0.0",
     "bun-types": "workspace:packages/bun-types",
   },
   "packages": {
@@ -155,7 +156,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+    "@types/node": ["@types/node@25.0.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew=="],
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "resolutions": {
     "bun-types": "workspace:packages/bun-types",
-    "@types/bun": "workspace:packages/@types/bun"
+    "@types/bun": "workspace:packages/@types/bun",
+    "@types/node": "25.0.0"
   },
   "scripts": {
     "build": "bun --silent run build:debug",

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1,8 +1,11 @@
 declare module "bun" {
   namespace __internal {
-    type NodeCryptoWebcryptoSubtleCrypto = import("crypto").webcrypto.SubtleCrypto;
     type NodeCryptoWebcryptoCryptoKey = import("crypto").webcrypto.CryptoKey;
     type NodeCryptoWebcryptoCryptoKeyPair = import("crypto").webcrypto.CryptoKeyPair;
+
+    type LibEmptyOrNodeCryptoWebcryptoSubtleCrypto = LibDomIsLoaded extends true
+      ? {}
+      : import("crypto").webcrypto.SubtleCrypto;
 
     type LibWorkerOrBunWorker = LibDomIsLoaded extends true ? {} : Bun.Worker;
     type LibEmptyOrBunWebSocket = LibDomIsLoaded extends true ? {} : Bun.WebSocket;
@@ -954,7 +957,7 @@ declare function alert(message?: string): void;
 declare function confirm(message?: string): boolean;
 declare function prompt(message?: string, _default?: string): string | null;
 
-interface SubtleCrypto extends Bun.__internal.NodeCryptoWebcryptoSubtleCrypto {}
+interface SubtleCrypto extends Bun.__internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto {}
 declare var SubtleCrypto: {
   prototype: SubtleCrypto;
   new (): SubtleCrypto;

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -224,7 +224,7 @@ interface TextEncoder extends Bun.__internal.LibEmptyOrNodeUtilTextEncoder {
    * @param src The text to encode.
    * @param dest The array to hold the encode result.
    */
-  encodeInto(src?: string, dest?: Bun.BufferSource): import("util").EncodeIntoResult;
+  encodeInto(src?: string, dest?: Bun.BufferSource): import("node:util").TextEncoderEncodeIntoResult;
 }
 declare var TextEncoder: Bun.__internal.UseLibDomIfAvailable<
   "TextEncoder",

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -14,7 +14,12 @@ declare module "bun" {
       ? {}
       : import("node:stream/web").DecompressionStream;
 
-    type LibPerformanceOrNodePerfHooksPerformance = LibDomIsLoaded extends true ? {} : import("perf_hooks").Performance;
+    type LibPerformanceOrNodePerfHooksPerformance = LibDomIsLoaded extends true
+      ? {}
+      : import("node:perf_hooks").Performance;
+    type NodePerfHooksPerformanceConstructor = LibDomIsLoaded extends true
+      ? {}
+      : typeof import("node:perf_hooks").Performance;
     type LibEmptyOrPerformanceEntry = LibDomIsLoaded extends true ? {} : import("node:perf_hooks").PerformanceEntry;
     type LibEmptyOrPerformanceMark = LibDomIsLoaded extends true ? {} : import("node:perf_hooks").PerformanceMark;
     type LibEmptyOrPerformanceMeasure = LibDomIsLoaded extends true ? {} : import("node:perf_hooks").PerformanceMeasure;
@@ -1688,6 +1693,7 @@ declare var EventSource: Bun.__internal.UseLibDomIfAvailable<
 
 interface Performance extends Bun.__internal.LibPerformanceOrNodePerfHooksPerformance {}
 declare var performance: Bun.__internal.UseLibDomIfAvailable<"performance", Performance>;
+declare var Performance: Bun.__internal.NodePerfHooksPerformanceConstructor;
 
 interface PerformanceEntry extends Bun.__internal.LibEmptyOrPerformanceEntry {}
 declare var PerformanceEntry: Bun.__internal.UseLibDomIfAvailable<

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -17,9 +17,6 @@ declare module "bun" {
     type LibPerformanceOrNodePerfHooksPerformance = LibDomIsLoaded extends true
       ? {}
       : import("node:perf_hooks").Performance;
-    type NodePerfHooksPerformanceConstructor = LibDomIsLoaded extends true
-      ? {}
-      : typeof import("node:perf_hooks").Performance;
     type LibEmptyOrPerformanceEntry = LibDomIsLoaded extends true ? {} : import("node:perf_hooks").PerformanceEntry;
     type LibEmptyOrPerformanceMark = LibDomIsLoaded extends true ? {} : import("node:perf_hooks").PerformanceMark;
     type LibEmptyOrPerformanceMeasure = LibDomIsLoaded extends true ? {} : import("node:perf_hooks").PerformanceMeasure;
@@ -1693,7 +1690,10 @@ declare var EventSource: Bun.__internal.UseLibDomIfAvailable<
 
 interface Performance extends Bun.__internal.LibPerformanceOrNodePerfHooksPerformance {}
 declare var performance: Bun.__internal.UseLibDomIfAvailable<"performance", Performance>;
-declare var Performance: Bun.__internal.NodePerfHooksPerformanceConstructor;
+declare var Performance: Bun.__internal.UseLibDomIfAvailable<
+  "Performance",
+  { new (): Performance; prototype: Performance }
+>;
 
 interface PerformanceEntry extends Bun.__internal.LibEmptyOrPerformanceEntry {}
 declare var PerformanceEntry: Bun.__internal.UseLibDomIfAvailable<

--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -308,11 +308,11 @@ declare global {
   }
 }
 
-declare module "fs/promises" {
+declare module "node:fs/promises" {
   function exists(path: Bun.PathLike): Promise<boolean>;
 }
 
-declare module "tls" {
+declare module "node:tls" {
   interface BunConnectionOptions extends Omit<ConnectionOptions, "key" | "ca" | "tls" | "cert"> {
     /**
      * Optionally override the trusted CA certificates. Default is to trust
@@ -358,4 +358,19 @@ declare module "tls" {
   }
 
   function connect(options: BunConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+}
+
+declare module "console" {
+  interface Console {
+    /**
+     * Asynchronously read lines from standard input (fd 0)
+     *
+     * ```ts
+     * for await (const line of console) {
+     *   console.log(line);
+     * }
+     * ```
+     */
+    [Symbol.asyncIterator](): AsyncIterableIterator<string>;
+  }
 }

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -428,6 +428,8 @@ declare module "bun:test" {
   }
 
   namespace __internal {
+    type IfNeverThenElse<T, Else> = [T] extends [never] ? Else : T;
+
     type IsTuple<T> = T extends readonly unknown[]
       ? number extends T["length"]
         ? false // It's an array with unknown length, not a tuple
@@ -1097,8 +1099,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainKey(expected: keyof T): void;
-    toContainKey<X = T>(expected: NoInfer<keyof X>): void;
+    toContainKey(expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void;
+    toContainKey<X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void;
 
     /**
      * Asserts that an `object` contains all the provided keys.
@@ -1114,8 +1116,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainAllKeys(expected: Array<keyof T>): void;
-    toContainAllKeys<X = T>(expected: NoInfer<Array<keyof X>>): void;
+    toContainAllKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void;
+    toContainAllKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void;
 
     /**
      * Asserts that an `object` contains at least one of the provided keys.
@@ -1131,8 +1133,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainAnyKeys(expected: Array<keyof T>): void;
-    toContainAnyKeys<X = T>(expected: NoInfer<Array<keyof X>>): void;
+    toContainAnyKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void;
+    toContainAnyKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void;
 
     /**
      * Asserts that an `object` contain the provided value.
@@ -1224,8 +1226,8 @@ declare module "bun:test" {
      *
      * @param expected the expected value
      */
-    toContainKeys(expected: Array<keyof T>): void;
-    toContainKeys<X = T>(expected: NoInfer<Array<keyof X>>): void;
+    toContainKeys(expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void;
+    toContainKeys<X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void;
 
     /**
      * Asserts that a value contains and equals what is expected.

--- a/test/bun.lock
+++ b/test/bun.lock
@@ -120,6 +120,7 @@
     },
   },
   "overrides": {
+    "@types/node": "25.0.0",
     "react": "../node_modules/react",
   },
   "packages": {
@@ -711,7 +712,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@20.14.6", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw=="],
+    "@types/node": ["@types/node@25.0.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew=="],
 
     "@types/oboe": ["@types/oboe@2.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-bXt4BXSQy0N/buSIak1o0TjYAk2SAeK1aZV9xKcb+xVGWYP8NcMOFy2T7Um3kIvEcQJzrdgJ8R6fpbRcp/LEww=="],
 
@@ -2561,7 +2562,7 @@
 
     "undici": ["undici@5.20.0", "", { "dependencies": { "busboy": "^1.6.0" } }, "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g=="],
 
-    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -2863,7 +2864,7 @@
 
     "@remix-run/react/@remix-run/server-runtime": ["@remix-run/server-runtime@2.10.3", "", { "dependencies": { "@remix-run/router": "1.18.0", "@types/cookie": "^0.6.0", "@web3-storage/multipart-parser": "^1.0.0", "cookie": "^0.6.0", "set-cookie-parser": "^2.4.8", "source-map": "^0.7.3", "turbo-stream": "2.2.0" }, "peerDependencies": { "typescript": "^5.1.0" }, "optionalPeers": ["typescript"] }, "sha512-vUl5jONUI6Lj0ICg9FSRFhoPzQdZ/7dpT1m7ID13DF5BEeF3t/9uCJS61XXWgQ/JEu7YRiwvZiwSRTrgM7zeWw=="],
 
-    "@remix-run/react/react": ["react@file:../node_modules/react", { "dependencies": { "loose-envify": "^1.1.0" } }],
+    "@remix-run/react/react": ["react@file:../node_modules/react", {}],
 
     "@remix-run/serve/@remix-run/node": ["@remix-run/node@2.10.3", "", { "dependencies": { "@remix-run/server-runtime": "2.10.3", "@remix-run/web-fetch": "^4.4.2", "@web3-storage/multipart-parser": "^1.0.0", "cookie-signature": "^1.1.0", "source-map-support": "^0.5.21", "stream-slice": "^0.1.2", "undici": "^6.11.1" }, "peerDependencies": { "typescript": "^5.1.0" }, "optionalPeers": ["typescript"] }, "sha512-LBqsgADJKW7tYdJZZi2wu20gfMm6UcOXbvb5U70P2jCNxjJvuIw1gXVvNXRJKAdxPKLonjm8cSpfoI6HeQKEDg=="],
 
@@ -2885,7 +2886,7 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
-    "@testing-library/react/react": ["react@file:../node_modules/react", { "dependencies": { "loose-envify": "^1.1.0" } }],
+    "@testing-library/react/react": ["react@file:../node_modules/react", {}],
 
     "@types/eslint/@types/estree": ["@types/estree@1.0.5", "", {}, "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="],
 
@@ -3125,8 +3126,6 @@
 
     "https-proxy-agent/debug": ["debug@4.3.5", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg=="],
 
-    "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
-
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "jest-diff/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -3249,11 +3248,11 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
-    "react-dom/react": ["react@file:../node_modules/react", { "dependencies": { "loose-envify": "^1.1.0" } }],
+    "react-dom/react": ["react@file:../node_modules/react", {}],
 
-    "react-router/react": ["react@file:../node_modules/react", { "dependencies": { "loose-envify": "^1.1.0" } }],
+    "react-router/react": ["react@file:../node_modules/react", {}],
 
-    "react-router-dom/react": ["react@file:../node_modules/react", { "dependencies": { "loose-envify": "^1.1.0" } }],
+    "react-router-dom/react": ["react@file:../node_modules/react", {}],
 
     "readable-web-to-node-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -3372,8 +3371,6 @@
     "upper-case/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "upper-case-first/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "v8-heapsnapshot/@types/node": ["@types/node@18.19.69", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ=="],
 
     "verdaccio/@verdaccio/config": ["@verdaccio/config@8.0.0-next-8.1", "", { "dependencies": { "@verdaccio/core": "8.0.0-next-8.1", "@verdaccio/utils": "7.0.1-next-8.1", "debug": "4.3.7", "js-yaml": "4.1.0", "lodash": "4.17.21", "minimatch": "7.4.6" } }, "sha512-goDVOH4e8xMUxjHybJpi5HwIecVFqzJ9jeNFrRUgtUUn0PtFuNMHgxOeqDKRVboZhc5HK90yed8URK/1O6VsUw=="],
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -253,7 +253,10 @@ afterAll(async () => {
   if (TEMP_DIR) {
     if (Bun.env.TYPES_INTEGRATION_TEST_KEEP_TEMP_DIR === "true") {
       console.log(`Keeping temp dir ${TEMP_DIR}/fixture for debugging`);
-      await cp(TSCONFIG_SOURCE_PATH, join(TEMP_DIR, "fixture", "tsconfig.json"));
+      // Write tsconfig with skipLibCheck disabled for proper type checking
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.compilerOptions.skipLibCheck = false;
+      await Bun.write(join(TEMP_DIR, "fixture", "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
     } else {
       await rm(TEMP_DIR, { recursive: true, force: true });
     }
@@ -435,7 +438,7 @@ describe("@types/bun integration test", () => {
         code: 2322,
         line: "24154.ts:11:3",
         message:
-          "Type 'Blob' is not assignable to type 'import(\"buffer\").Blob'.\nThe types returned by 'stream()' are incompatible between these types.\nType 'ReadableStream<Uint8Array<ArrayBuffer>>' is missing the following properties from type 'ReadableStream<any>': blob, text, bytes, json",
+          "Type 'Blob' is not assignable to type 'import(\"node:buffer\").Blob'.\nThe types returned by 'stream()' are incompatible between these types.\nType 'ReadableStream<Uint8Array<ArrayBuffer>>' is missing the following properties from type 'ReadableStream<NonSharedUint8Array>': blob, text, bytes, json",
       },
       {
         code: 2769,

--- a/test/integration/bun-types/fixture/console.ts
+++ b/test/integration/bun-types/fixture/console.ts
@@ -14,6 +14,7 @@ async () => {
   for await (const line of c2) {
     console.log("Received:", line);
   }
+
   // tslint:disable-next-line:await-promise
   for await (const line of console) {
     console.log("Received:", line);

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -7,7 +7,7 @@ import {
   expect,
   expectTypeOf,
   jest,
-  Matchers,
+  type Matchers,
   mock,
   type Mock,
   spyOn,
@@ -344,7 +344,7 @@ myNormalSpiedMethod("asdf");
 expectType<Mock<(name: string) => string>>(myNormalSpiedMethod);
 
 const spy = spyOn(console, "log");
-expectType(spy.mock.calls).is<[message?: any, ...optionalParams: any[]][]>();
+expectType(spy.mock.calls).is<any[][]>();
 
 jest.spyOn(console, "log");
 jest.fn(() => 123 as const);

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -7,6 +7,7 @@ import {
   expect,
   expectTypeOf,
   jest,
+  Matchers,
   mock,
   type Mock,
   spyOn,
@@ -244,32 +245,39 @@ describe("Matcher Overload Type Tests", () => {
 
   test("toContainKey", () => {
     expect(obj).toContainKey("a");
+    expect(obj).toContainKey("b");
+    // @ts-expect-error simple check for key does not exist
+    expect(obj).toContainKey("c");
     expect(obj).toContainKey(10); // object key is number
     // @ts-expect-error - Argument of type '"c"' is not assignable to parameter of type 'number | "a" | "b"'.
-    expect(obj).toContainKey<keyof typeof obj>("c");
+    expect(obj).toContainKey<typeof obj>("c");
     // @ts-expect-error - Argument of type 'boolean' is not assignable to parameter of type 'string | number'.
-    expect(obj).toContainKey<keyof typeof obj>(true);
+    expect(obj).toContainKey<typeof obj>(true);
     // @ts-expect-error - Too many arguments for specific overload
-    expect(obj).toContainKey<keyof typeof obj>("a", "b");
+    expect(obj).toContainKey<typeof obj>("a", "b");
     // @ts-expect-error - Argument of type 'symbol' is not assignable to parameter of type 'string | number'.
-    expect(obj).toContainKey<keyof typeof obj>(Symbol("a"));
+    expect(obj).toContainKey<typeof obj>(Symbol("a"));
   });
 
   test("toContainAllKeys", () => {
     expect(obj).toContainAllKeys(["a", "b"]);
     expect(obj).toContainAllKeys([10, "a"]);
+    // @ts-expect-error simple check for key does not exist
+    expect(obj).toContainAllKeys(["c"]);
     // @ts-expect-error - Type '"c"' is not assignable to type 'number | "a" | "b"'.
-    expect(obj).toContainAllKeys<(keyof typeof obj)[]>(["a", "c"]);
+    expect(obj).toContainAllKeys<(typeof obj)[]>(["a", "c"]);
     // @ts-expect-error - Type 'boolean' is not assignable to type 'string | number'.
-    expect(obj).toContainAllKeys<(keyof typeof obj)[]>(["a", true]);
+    expect(obj).toContainAllKeys<(typeof obj)[]>(["a", true]);
     // @ts-expect-error - Argument must be an array
-    expect(obj).toContainAllKeys<Array<keyof typeof obj>>("a");
+    expect(obj).toContainAllKeys<Array<typeof obj>>("a");
     // @ts-expect-error - Array element type 'symbol' is not assignable to 'string | number'.
-    expect(obj).toContainAllKeys<(keyof typeof obj)[]>(["a", Symbol("b")]);
+    expect(obj).toContainAllKeys<(typeof obj)[]>(["a", Symbol("b")]);
   });
 
   test("toContainAnyKeys", () => {
     expect(obj).toContainAnyKeys(["a", "b", 10]);
+    // @ts-expect-error simple check for key does not exist
+    expect(obj).toContainAnyKeys(["c"]);
     // @ts-expect-error - 11 is not a key
     expect(obj).toContainAnyKeys(["a", "b", 11]);
     // @ts-expect-error - c is not a key
@@ -277,27 +285,29 @@ describe("Matcher Overload Type Tests", () => {
     // @ts-expect-error d is not a key
     expect(obj).toContainAnyKeys([10, "d"]);
     // @ts-expect-error - Type '"c"' is not assignable to type 'number | "a" | "b"'. Type '"d"' is not assignable to type 'number | "a" | "b"'.
-    expect(obj).toContainAnyKeys<(keyof typeof obj)[]>(["c", "d"]);
+    expect(obj).toContainAnyKeys<(typeof obj)[]>(["c", "d"]);
     // @ts-expect-error - Type 'boolean' is not assignable to type 'string | number'.
-    expect(obj).toContainAnyKeys<(keyof typeof obj)[]>([true, false]);
+    expect(obj).toContainAnyKeys<(typeof obj)[]>([true, false]);
     // @ts-expect-error - Argument must be an array
-    expect(obj).toContainAnyKeys<Array<keyof typeof obj>>("a");
+    expect(obj).toContainAnyKeys<Array<typeof obj>>("a");
     // @ts-expect-error - Array element type 'symbol' is not assignable to 'string | number'.
-    expect(obj).toContainAnyKeys<(keyof typeof obj)[]>([Symbol("a")]);
+    expect(obj).toContainAnyKeys<(typeof obj)[]>([Symbol("a")]);
   });
 
   test("toContainKeys", () => {
     // Alias for toContainAllKeys
     expect(obj).toContainKeys(["a", "b"]);
     expect(obj).toContainKeys([10, "a"]);
+    // @ts-expect-error simple check for key does not exist
+    expect(obj).toContainKeys(["c"]);
     // @ts-expect-error - Type '"c"' is not assignable to type 'number | "a" | "b"'.
-    expect(obj).toContainKeys<(keyof typeof obj)[]>(["a", "c"]);
+    expect(obj).toContainKeys<(typeof obj)[]>(["a", "c"]);
     // @ts-expect-error - Type 'boolean' is not assignable to type 'string | number'.
-    expect(obj).toContainKeys<(keyof typeof obj)[]>(["a", true]);
+    expect(obj).toContainKeys<(typeof obj)[]>(["a", true]);
     // @ts-expect-error - Argument must be an array
-    expect(obj).toContainKeys<Array<keyof typeof obj>>("a");
+    expect(obj).toContainKeys<Array<typeof obj>>("a");
     // @ts-expect-error - Array element type 'symbol' is not assignable to 'string | number'.
-    expect(obj).toContainKeys<(keyof typeof obj)[]>(["a", Symbol("b")]);
+    expect(obj).toContainKeys<(typeof obj)[]>(["a", Symbol("b")]);
   });
 
   test("toContainEqual", () => {
@@ -400,3 +410,14 @@ declare const setOfStrings: Set<string>;
 /** 1. **/ expect(setOfStrings).toBe(new Set()); // this is inferrable to Set<string> so this should pass
 /** 2. **/ expect(setOfStrings).toBe(new Set<string>()); // exact, so we are happy!
 /** 3. **/ expect(setOfStrings).toBe<Set<string>>(new Set()); // happy! We opted out of type safety for this expectation
+
+// Cases for #24591
+declare const unknownMatchers: Matchers<unknown>;
+unknownMatchers.toContainKeys(["a", "b"]);
+unknownMatchers.toContainAnyKeys(["a", "b"]);
+unknownMatchers.toContainAllKeys(["a", "b"]);
+unknownMatchers.toContainKey("a");
+unknownMatchers.toContainEqual([""]);
+unknownMatchers.toEqual(["a", "b"]);
+unknownMatchers.toBeCloseTo(2);
+unknownMatchers.toBe("a");

--- a/test/integration/next-pages/bun.lock
+++ b/test/integration/next-pages/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "default-create-template",
       "dependencies": {
-        "@types/node": "24.2.1",
+        "@types/node": "25.0.0",
         "@types/react": "19.1.9",
         "@types/react-dom": "19.1.7",
         "autoprefixer": "10.4.21",
@@ -165,7 +165,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@24.2.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ=="],
+    "@types/node": ["@types/node@25.0.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew=="],
 
     "@types/react": ["@types/react@19.1.9", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA=="],
 
@@ -931,7 +931,7 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
@@ -989,11 +989,15 @@
 
     "@puppeteer/browsers/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
+    "@types/yauzl/@types/node": ["@types/node@24.2.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "bun-types/@types/node": ["@types/node@24.2.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1031,7 +1035,11 @@
 
     "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "@types/yauzl/@types/node/undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
   }

--- a/test/integration/next-pages/package.json
+++ b/test/integration/next-pages/package.json
@@ -10,7 +10,7 @@
     "postinstall": "cd node_modules/puppeteer && bun install.mjs"
   },
   "dependencies": {
-    "@types/node": "24.2.1",
+    "@types/node": "25.0.0",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
     "autoprefixer": "10.4.21",

--- a/test/integration/next-pages/test/__snapshots__/dev-server-ssr-100.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/dev-server-ssr-100.test.ts.snap
@@ -8,11 +8,11 @@ exports[`ssr works for 100-ish requests 1`] = `
         "prod": true,
       },
       "id": 0,
-      "literal": "24.2.1",
+      "literal": "25.0.0",
       "name": "@types/node",
       "npm": {
         "name": "@types/node",
-        "version": "==24.2.1",
+        "version": "==25.0.0",
       },
       "package_id": 72,
     },
@@ -1012,11 +1012,11 @@ exports[`ssr works for 100-ish requests 1`] = `
         "prod": true,
       },
       "id": 77,
-      "literal": "~7.10.0",
+      "literal": "~7.16.0",
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.16.0 <7.17.0",
       },
       "package_id": 453,
     },
@@ -1057,7 +1057,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -1148,7 +1148,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "ignore",
         "version": ">=7.0.0 <8.0.0",
       },
-      "package_id": 481,
+      "package_id": 482,
     },
     {
       "behavior": {
@@ -1590,7 +1590,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -2737,7 +2737,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -2932,7 +2932,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <5.2.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -5275,7 +5275,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -5446,7 +5446,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -5524,7 +5524,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -6109,7 +6109,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "resolve",
         "version": ">=2.0.0-next.5 <3.0.0",
       },
-      "package_id": 485,
+      "package_id": 486,
     },
     {
       "behavior": {
@@ -6356,7 +6356,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -6916,7 +6916,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -8229,7 +8229,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "postcss",
         "version": "==8.4.31",
       },
-      "package_id": 486,
+      "package_id": 487,
     },
     {
       "behavior": {
@@ -8961,7 +8961,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "lru-cache",
         "version": ">=10.2.0 <11.0.0",
       },
-      "package_id": 487,
+      "package_id": 488,
     },
     {
       "behavior": {
@@ -10666,7 +10666,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "is-arrayish",
         "version": ">=0.3.1 <0.4.0",
       },
-      "package_id": 488,
+      "package_id": 489,
     },
     {
       "behavior": {
@@ -10809,7 +10809,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "emoji-regex",
         "version": ">=8.0.0 <9.0.0",
       },
-      "package_id": 489,
+      "package_id": 490,
     },
     {
       "behavior": {
@@ -11888,7 +11888,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "picomatch",
         "version": ">=4.0.2 <5.0.0",
       },
-      "package_id": 490,
+      "package_id": 491,
     },
     {
       "behavior": {
@@ -13281,7 +13281,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "ansi-regex",
         "version": ">=6.0.1 <7.0.0",
       },
-      "package_id": 491,
+      "package_id": 492,
     },
     {
       "behavior": {
@@ -13294,7 +13294,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "ansi-styles",
         "version": ">=6.1.0 <7.0.0",
       },
-      "package_id": 492,
+      "package_id": 493,
     },
     {
       "behavior": {
@@ -13359,7 +13359,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -13392,19 +13392,45 @@ exports[`ssr works for 100-ish requests 1`] = `
         "prod": true,
       },
       "id": 1028,
-      "literal": "^2.0.1",
-      "name": "brace-expansion",
+      "literal": "~7.10.0",
+      "name": "undici-types",
       "npm": {
-        "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
       },
-      "package_id": 493,
+      "package_id": 494,
     },
     {
       "behavior": {
         "prod": true,
       },
       "id": 1029,
+      "literal": "^2.0.1",
+      "name": "brace-expansion",
+      "npm": {
+        "name": "brace-expansion",
+        "version": ">=2.0.1 <3.0.0",
+      },
+      "package_id": 495,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1030,
+      "literal": "~7.10.0",
+      "name": "undici-types",
+      "npm": {
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1031,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13417,7 +13443,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1030,
+      "id": 1032,
       "literal": "^2.1.1",
       "name": "ms",
       "npm": {
@@ -13430,33 +13456,33 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1031,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
-      "id": 1032,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
       "id": 1033,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1034,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1035,
       "literal": "^2.13.0",
       "name": "is-core-module",
       "npm": {
@@ -13469,7 +13495,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1034,
+      "id": 1036,
       "literal": "^1.0.7",
       "name": "path-parse",
       "npm": {
@@ -13482,7 +13508,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1035,
+      "id": 1037,
       "literal": "^1.0.0",
       "name": "supports-preserve-symlinks-flag",
       "npm": {
@@ -13495,7 +13521,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1036,
+      "id": 1038,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13508,7 +13534,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1037,
+      "id": 1039,
       "literal": "^2.0.1",
       "name": "brace-expansion",
       "npm": {
@@ -13521,7 +13547,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1038,
+      "id": 1040,
       "literal": "^3.3.6",
       "name": "nanoid",
       "npm": {
@@ -13534,7 +13560,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1039,
+      "id": 1041,
       "literal": "^1.0.0",
       "name": "picocolors",
       "npm": {
@@ -13547,7 +13573,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1040,
+      "id": 1042,
       "literal": "^1.0.2",
       "name": "source-map-js",
       "npm": {
@@ -13560,7 +13586,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1041,
+      "id": 1043,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13573,7 +13599,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1042,
+      "id": 1044,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -13586,7 +13612,7 @@ exports[`ssr works for 100-ish requests 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1043,
+      "id": 1045,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -13673,7 +13699,10 @@ exports[`ssr works for 100-ish requests 1`] = `
     "@types/estree": 69,
     "@types/json-schema": 70,
     "@types/json5": 71,
-    "@types/node": 72,
+    "@types/node": [
+      72,
+      481,
+    ],
     "@types/react": 73,
     "@types/react-dom": 74,
     "@types/yauzl": 75,
@@ -13711,11 +13740,11 @@ exports[`ssr works for 100-ish requests 1`] = `
     "agent-base": 107,
     "ajv": 108,
     "ansi-regex": [
-      491,
+      492,
       109,
     ],
     "ansi-styles": [
-      492,
+      493,
       110,
     ],
     "any-promise": 111,
@@ -13748,7 +13777,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "basic-ftp": 138,
     "binary-extensions": 139,
     "brace-expansion": [
-      493,
+      495,
       140,
     ],
     "braces": 141,
@@ -13783,7 +13812,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "data-view-byte-offset": 170,
     "debug": [
       171,
-      484,
+      485,
     ],
     "deep-is": 172,
     "default-create-template": 0,
@@ -13800,7 +13829,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "electron-to-chromium": 183,
     "emoji-regex": [
       184,
-      489,
+      490,
     ],
     "end-of-stream": 185,
     "env-paths": 186,
@@ -13870,7 +13899,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "glob": 244,
     "glob-parent": [
       245,
-      483,
+      484,
     ],
     "globals": 246,
     "globalthis": 247,
@@ -13886,7 +13915,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "http-proxy-agent": 257,
     "https-proxy-agent": 258,
     "ignore": [
-      481,
+      482,
       259,
     ],
     "import-fresh": 260,
@@ -13895,7 +13924,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "ip-address": 263,
     "is-array-buffer": 264,
     "is-arrayish": [
-      488,
+      489,
       265,
     ],
     "is-async-function": 266,
@@ -13949,14 +13978,14 @@ exports[`ssr works for 100-ish requests 1`] = `
     "lodash.merge": 314,
     "loose-envify": 315,
     "lru-cache": [
-      487,
+      488,
       316,
     ],
     "math-intrinsics": 317,
     "merge2": 318,
     "micromatch": 319,
     "minimatch": [
-      482,
+      483,
       320,
     ],
     "minimist": 321,
@@ -13998,7 +14027,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "pend": 357,
     "picocolors": 358,
     "picomatch": [
-      490,
+      491,
       359,
     ],
     "pify": 360,
@@ -14006,7 +14035,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "possible-typed-array-names": 362,
     "postcss": [
       363,
-      486,
+      487,
     ],
     "postcss-import": 364,
     "postcss-js": 365,
@@ -14033,7 +14062,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     "regexp.prototype.flags": 386,
     "require-directory": 387,
     "resolve": [
-      485,
+      486,
       388,
     ],
     "resolve-from": 389,
@@ -14109,7 +14138,10 @@ exports[`ssr works for 100-ish requests 1`] = `
     "typed-query-selector": 450,
     "typescript": 451,
     "unbox-primitive": 452,
-    "undici-types": 453,
+    "undici-types": [
+      453,
+      494,
+    ],
     "unrs-resolver": 454,
     "update-browserslist-db": 455,
     "uri-js": 456,
@@ -15579,15 +15611,15 @@ exports[`ssr works for 100-ish requests 1`] = `
         77,
       ],
       "id": 72,
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "integrity": "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==",
       "man_dir": "",
       "name": "@types/node",
       "name_hash": "4124652010926124945",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.0.tgz",
         "tag": "npm",
-        "value": "24.2.1",
+        "value": "25.0.0",
       },
       "scripts": {},
     },
@@ -22931,15 +22963,15 @@ exports[`ssr works for 100-ish requests 1`] = `
       "bin": null,
       "dependencies": [],
       "id": 453,
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "man_dir": "",
       "name": "undici-types",
       "name_hash": "13518207300296011529",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
         "tag": "npm",
-        "value": "7.10.0",
+        "value": "7.16.0",
       },
       "scripts": {},
     },
@@ -23485,8 +23517,26 @@ exports[`ssr works for 100-ish requests 1`] = `
     },
     {
       "bin": null,
-      "dependencies": [],
+      "dependencies": [
+        1028,
+      ],
       "id": 481,
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "man_dir": "",
+      "name": "@types/node",
+      "name_hash": "4124652010926124945",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "tag": "npm",
+        "value": "24.2.1",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
+      "dependencies": [],
+      "id": 482,
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "man_dir": "",
       "name": "ignore",
@@ -23502,9 +23552,9 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1028,
+        1029,
       ],
-      "id": 482,
+      "id": 483,
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "man_dir": "",
       "name": "minimatch",
@@ -23520,9 +23570,9 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1029,
+        1031,
       ],
-      "id": 483,
+      "id": 484,
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "man_dir": "",
       "name": "glob-parent",
@@ -23538,9 +23588,9 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1030,
+        1032,
       ],
-      "id": 484,
+      "id": 485,
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "man_dir": "",
       "name": "debug",
@@ -23559,11 +23609,11 @@ exports[`ssr works for 100-ish requests 1`] = `
         "name": "resolve",
       },
       "dependencies": [
-        1033,
-        1034,
         1035,
+        1036,
+        1037,
       ],
-      "id": 485,
+      "id": 486,
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "man_dir": "",
       "name": "resolve",
@@ -23579,11 +23629,11 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1038,
-        1039,
         1040,
+        1041,
+        1042,
       ],
-      "id": 486,
+      "id": 487,
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "man_dir": "",
       "name": "postcss",
@@ -23599,7 +23649,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 487,
+      "id": 488,
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "man_dir": "",
       "name": "lru-cache",
@@ -23615,7 +23665,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 488,
+      "id": 489,
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "man_dir": "",
       "name": "is-arrayish",
@@ -23631,7 +23681,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 489,
+      "id": 490,
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "man_dir": "",
       "name": "emoji-regex",
@@ -23647,7 +23697,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 490,
+      "id": 491,
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "man_dir": "",
       "name": "picomatch",
@@ -23663,7 +23713,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 491,
+      "id": 492,
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "man_dir": "",
       "name": "ansi-regex",
@@ -23679,7 +23729,7 @@ exports[`ssr works for 100-ish requests 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 492,
+      "id": 493,
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "man_dir": "",
       "name": "ansi-styles",
@@ -23694,10 +23744,26 @@ exports[`ssr works for 100-ish requests 1`] = `
     },
     {
       "bin": null,
+      "dependencies": [],
+      "id": 494,
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "man_dir": "",
+      "name": "undici-types",
+      "name_hash": "13518207300296011529",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "tag": "npm",
+        "value": "7.10.0",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
       "dependencies": [
-        1042,
+        1044,
       ],
-      "id": 493,
+      "id": 495,
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "man_dir": "",
       "name": "brace-expansion",
@@ -25625,14 +25691,36 @@ exports[`ssr works for 100-ish requests 1`] = `
     },
     {
       "dependencies": {
-        "postcss": {
-          "id": 631,
-          "package_id": 486,
+        "@types/node": {
+          "id": 209,
+          "package_id": 481,
         },
       },
       "depth": 1,
       "id": 1,
+      "path": "node_modules/bun-types/node_modules",
+    },
+    {
+      "dependencies": {
+        "postcss": {
+          "id": 631,
+          "package_id": 487,
+        },
+      },
+      "depth": 1,
+      "id": 2,
       "path": "node_modules/next/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 3,
+      "path": "node_modules/bun-types/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -25642,7 +25730,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 2,
+      "id": 4,
       "path": "node_modules/@eslint-community/eslint-utils/node_modules",
     },
     {
@@ -25653,7 +25741,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 3,
+      "id": 5,
       "path": "node_modules/@humanfs/node/node_modules",
     },
     {
@@ -25664,51 +25752,51 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 4,
+      "id": 6,
       "path": "node_modules/@next/eslint-plugin-next/node_modules",
     },
     {
       "dependencies": {
         "ignore": {
           "id": 87,
-          "package_id": 481,
+          "package_id": 482,
         },
       },
       "depth": 1,
-      "id": 5,
+      "id": 7,
       "path": "node_modules/@typescript-eslint/eslint-plugin/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 404,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 6,
+      "id": 8,
       "path": "node_modules/eslint-import-resolver-node/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 423,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 7,
+      "id": 9,
       "path": "node_modules/eslint-plugin-import/node_modules",
     },
     {
       "dependencies": {
         "resolve": {
           "id": 468,
-          "package_id": 485,
+          "package_id": 486,
         },
       },
       "depth": 1,
-      "id": 8,
+      "id": 10,
       "path": "node_modules/eslint-plugin-react/node_modules",
     },
     {
@@ -25719,7 +25807,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 9,
+      "id": 11,
       "path": "node_modules/sharp/node_modules",
     },
     {
@@ -25730,47 +25818,47 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 10,
+      "id": 12,
       "path": "node_modules/@puppeteer/browsers/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 224,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 11,
+      "id": 13,
       "path": "node_modules/chokidar/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 487,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 12,
+      "id": 14,
       "path": "node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 1025,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 2,
-      "id": 13,
+      "id": 15,
       "path": "node_modules/@next/eslint-plugin-next/node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 121,
-          "package_id": 482,
+          "package_id": 483,
         },
         "semver": {
           "id": 122,
@@ -25778,7 +25866,7 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 14,
+      "id": 16,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules",
     },
     {
@@ -25789,96 +25877,118 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 15,
+      "id": 17,
       "path": "node_modules/is-bun-module/node_modules",
     },
     {
       "dependencies": {
         "picomatch": {
           "id": 912,
-          "package_id": 490,
+          "package_id": 491,
         },
       },
       "depth": 1,
-      "id": 16,
+      "id": 18,
       "path": "node_modules/tinyglobby/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 417,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 17,
+      "id": 19,
       "path": "node_modules/eslint-module-utils/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 530,
-          "package_id": 482,
+          "package_id": 483,
         },
       },
       "depth": 1,
-      "id": 18,
+      "id": 20,
       "path": "node_modules/glob/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 19,
+      "id": 21,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules",
+    },
+    {
+      "dependencies": {
+        "@types/node": {
+          "id": 80,
+          "package_id": 481,
+        },
+      },
+      "depth": 1,
+      "id": 22,
+      "path": "node_modules/@types/yauzl/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 20,
+      "id": 23,
       "path": "node_modules/string-width/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 21,
+      "id": 24,
       "path": "node_modules/glob/node_modules/minimatch/node_modules",
     },
     {
       "dependencies": {
         "lru-cache": {
           "id": 687,
-          "package_id": 487,
+          "package_id": 488,
         },
       },
       "depth": 1,
-      "id": 22,
+      "id": 25,
       "path": "node_modules/path-scurry/node_modules",
     },
     {
       "dependencies": {
         "is-arrayish": {
           "id": 818,
-          "package_id": 488,
+          "package_id": 489,
         },
       },
       "depth": 1,
-      "id": 23,
+      "id": 26,
       "path": "node_modules/simple-swizzle/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 27,
+      "path": "node_modules/@types/yauzl/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -25896,40 +26006,40 @@ exports[`ssr works for 100-ish requests 1`] = `
         },
       },
       "depth": 1,
-      "id": 24,
+      "id": 28,
       "path": "node_modules/@isaacs/cliui/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 25,
+      "id": 29,
       "path": "node_modules/string-width-cjs/node_modules",
     },
     {
       "dependencies": {
         "ansi-regex": {
           "id": 1019,
-          "package_id": 491,
+          "package_id": 492,
         },
       },
       "depth": 2,
-      "id": 26,
+      "id": 30,
       "path": "node_modules/@isaacs/cliui/node_modules/strip-ansi/node_modules",
     },
     {
       "dependencies": {
         "ansi-styles": {
           "id": 1020,
-          "package_id": 492,
+          "package_id": 493,
         },
       },
       "depth": 2,
-      "id": 27,
+      "id": 31,
       "path": "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules",
     },
   ],

--- a/test/integration/next-pages/test/__snapshots__/dev-server.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/dev-server.test.ts.snap
@@ -8,11 +8,11 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "prod": true,
       },
       "id": 0,
-      "literal": "24.2.1",
+      "literal": "25.0.0",
       "name": "@types/node",
       "npm": {
         "name": "@types/node",
-        "version": "==24.2.1",
+        "version": "==25.0.0",
       },
       "package_id": 72,
     },
@@ -1012,11 +1012,11 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "prod": true,
       },
       "id": 77,
-      "literal": "~7.10.0",
+      "literal": "~7.16.0",
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.16.0 <7.17.0",
       },
       "package_id": 453,
     },
@@ -1057,7 +1057,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -1148,7 +1148,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "ignore",
         "version": ">=7.0.0 <8.0.0",
       },
-      "package_id": 481,
+      "package_id": 482,
     },
     {
       "behavior": {
@@ -1590,7 +1590,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -2737,7 +2737,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -2932,7 +2932,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <5.2.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -5275,7 +5275,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -5446,7 +5446,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -5524,7 +5524,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -6109,7 +6109,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "resolve",
         "version": ">=2.0.0-next.5 <3.0.0",
       },
-      "package_id": 485,
+      "package_id": 486,
     },
     {
       "behavior": {
@@ -6356,7 +6356,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -6916,7 +6916,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -8229,7 +8229,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "postcss",
         "version": "==8.4.31",
       },
-      "package_id": 486,
+      "package_id": 487,
     },
     {
       "behavior": {
@@ -8961,7 +8961,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "lru-cache",
         "version": ">=10.2.0 <11.0.0",
       },
-      "package_id": 487,
+      "package_id": 488,
     },
     {
       "behavior": {
@@ -10666,7 +10666,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "is-arrayish",
         "version": ">=0.3.1 <0.4.0",
       },
-      "package_id": 488,
+      "package_id": 489,
     },
     {
       "behavior": {
@@ -10809,7 +10809,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "emoji-regex",
         "version": ">=8.0.0 <9.0.0",
       },
-      "package_id": 489,
+      "package_id": 490,
     },
     {
       "behavior": {
@@ -11888,7 +11888,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "picomatch",
         "version": ">=4.0.2 <5.0.0",
       },
-      "package_id": 490,
+      "package_id": 491,
     },
     {
       "behavior": {
@@ -13281,7 +13281,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "ansi-regex",
         "version": ">=6.0.1 <7.0.0",
       },
-      "package_id": 491,
+      "package_id": 492,
     },
     {
       "behavior": {
@@ -13294,7 +13294,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "ansi-styles",
         "version": ">=6.1.0 <7.0.0",
       },
-      "package_id": 492,
+      "package_id": 493,
     },
     {
       "behavior": {
@@ -13359,7 +13359,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -13392,19 +13392,45 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "prod": true,
       },
       "id": 1028,
-      "literal": "^2.0.1",
-      "name": "brace-expansion",
+      "literal": "~7.10.0",
+      "name": "undici-types",
       "npm": {
-        "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
       },
-      "package_id": 493,
+      "package_id": 494,
     },
     {
       "behavior": {
         "prod": true,
       },
       "id": 1029,
+      "literal": "^2.0.1",
+      "name": "brace-expansion",
+      "npm": {
+        "name": "brace-expansion",
+        "version": ">=2.0.1 <3.0.0",
+      },
+      "package_id": 495,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1030,
+      "literal": "~7.10.0",
+      "name": "undici-types",
+      "npm": {
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1031,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13417,7 +13443,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1030,
+      "id": 1032,
       "literal": "^2.1.1",
       "name": "ms",
       "npm": {
@@ -13430,33 +13456,33 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1031,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
-      "id": 1032,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
       "id": 1033,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1034,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1035,
       "literal": "^2.13.0",
       "name": "is-core-module",
       "npm": {
@@ -13469,7 +13495,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1034,
+      "id": 1036,
       "literal": "^1.0.7",
       "name": "path-parse",
       "npm": {
@@ -13482,7 +13508,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1035,
+      "id": 1037,
       "literal": "^1.0.0",
       "name": "supports-preserve-symlinks-flag",
       "npm": {
@@ -13495,7 +13521,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1036,
+      "id": 1038,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13508,7 +13534,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1037,
+      "id": 1039,
       "literal": "^2.0.1",
       "name": "brace-expansion",
       "npm": {
@@ -13521,7 +13547,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1038,
+      "id": 1040,
       "literal": "^3.3.6",
       "name": "nanoid",
       "npm": {
@@ -13534,7 +13560,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1039,
+      "id": 1041,
       "literal": "^1.0.0",
       "name": "picocolors",
       "npm": {
@@ -13547,7 +13573,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1040,
+      "id": 1042,
       "literal": "^1.0.2",
       "name": "source-map-js",
       "npm": {
@@ -13560,7 +13586,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1041,
+      "id": 1043,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13573,7 +13599,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1042,
+      "id": 1044,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -13586,7 +13612,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1043,
+      "id": 1045,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -13673,7 +13699,10 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "@types/estree": 69,
     "@types/json-schema": 70,
     "@types/json5": 71,
-    "@types/node": 72,
+    "@types/node": [
+      72,
+      481,
+    ],
     "@types/react": 73,
     "@types/react-dom": 74,
     "@types/yauzl": 75,
@@ -13711,11 +13740,11 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "agent-base": 107,
     "ajv": 108,
     "ansi-regex": [
-      491,
+      492,
       109,
     ],
     "ansi-styles": [
-      492,
+      493,
       110,
     ],
     "any-promise": 111,
@@ -13748,7 +13777,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "basic-ftp": 138,
     "binary-extensions": 139,
     "brace-expansion": [
-      493,
+      495,
       140,
     ],
     "braces": 141,
@@ -13783,7 +13812,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "data-view-byte-offset": 170,
     "debug": [
       171,
-      484,
+      485,
     ],
     "deep-is": 172,
     "default-create-template": 0,
@@ -13800,7 +13829,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "electron-to-chromium": 183,
     "emoji-regex": [
       184,
-      489,
+      490,
     ],
     "end-of-stream": 185,
     "env-paths": 186,
@@ -13870,7 +13899,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "glob": 244,
     "glob-parent": [
       245,
-      483,
+      484,
     ],
     "globals": 246,
     "globalthis": 247,
@@ -13886,7 +13915,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "http-proxy-agent": 257,
     "https-proxy-agent": 258,
     "ignore": [
-      481,
+      482,
       259,
     ],
     "import-fresh": 260,
@@ -13895,7 +13924,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "ip-address": 263,
     "is-array-buffer": 264,
     "is-arrayish": [
-      488,
+      489,
       265,
     ],
     "is-async-function": 266,
@@ -13949,14 +13978,14 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "lodash.merge": 314,
     "loose-envify": 315,
     "lru-cache": [
-      487,
+      488,
       316,
     ],
     "math-intrinsics": 317,
     "merge2": 318,
     "micromatch": 319,
     "minimatch": [
-      482,
+      483,
       320,
     ],
     "minimist": 321,
@@ -13998,7 +14027,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "pend": 357,
     "picocolors": 358,
     "picomatch": [
-      490,
+      491,
       359,
     ],
     "pify": 360,
@@ -14006,7 +14035,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "possible-typed-array-names": 362,
     "postcss": [
       363,
-      486,
+      487,
     ],
     "postcss-import": 364,
     "postcss-js": 365,
@@ -14033,7 +14062,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "regexp.prototype.flags": 386,
     "require-directory": 387,
     "resolve": [
-      485,
+      486,
       388,
     ],
     "resolve-from": 389,
@@ -14109,7 +14138,10 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     "typed-query-selector": 450,
     "typescript": 451,
     "unbox-primitive": 452,
-    "undici-types": 453,
+    "undici-types": [
+      453,
+      494,
+    ],
     "unrs-resolver": 454,
     "update-browserslist-db": 455,
     "uri-js": 456,
@@ -15579,15 +15611,15 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         77,
       ],
       "id": 72,
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "integrity": "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==",
       "man_dir": "",
       "name": "@types/node",
       "name_hash": "4124652010926124945",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.0.tgz",
         "tag": "npm",
-        "value": "24.2.1",
+        "value": "25.0.0",
       },
       "scripts": {},
     },
@@ -22931,15 +22963,15 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
       "bin": null,
       "dependencies": [],
       "id": 453,
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "man_dir": "",
       "name": "undici-types",
       "name_hash": "13518207300296011529",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
         "tag": "npm",
-        "value": "7.10.0",
+        "value": "7.16.0",
       },
       "scripts": {},
     },
@@ -23485,8 +23517,26 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     },
     {
       "bin": null,
-      "dependencies": [],
+      "dependencies": [
+        1028,
+      ],
       "id": 481,
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "man_dir": "",
+      "name": "@types/node",
+      "name_hash": "4124652010926124945",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "tag": "npm",
+        "value": "24.2.1",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
+      "dependencies": [],
+      "id": 482,
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "man_dir": "",
       "name": "ignore",
@@ -23502,9 +23552,9 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1028,
+        1029,
       ],
-      "id": 482,
+      "id": 483,
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "man_dir": "",
       "name": "minimatch",
@@ -23520,9 +23570,9 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1029,
+        1031,
       ],
-      "id": 483,
+      "id": 484,
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "man_dir": "",
       "name": "glob-parent",
@@ -23538,9 +23588,9 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1030,
+        1032,
       ],
-      "id": 484,
+      "id": 485,
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "man_dir": "",
       "name": "debug",
@@ -23559,11 +23609,11 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         "name": "resolve",
       },
       "dependencies": [
-        1033,
-        1034,
         1035,
+        1036,
+        1037,
       ],
-      "id": 485,
+      "id": 486,
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "man_dir": "",
       "name": "resolve",
@@ -23579,11 +23629,11 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1038,
-        1039,
         1040,
+        1041,
+        1042,
       ],
-      "id": 486,
+      "id": 487,
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "man_dir": "",
       "name": "postcss",
@@ -23599,7 +23649,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 487,
+      "id": 488,
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "man_dir": "",
       "name": "lru-cache",
@@ -23615,7 +23665,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 488,
+      "id": 489,
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "man_dir": "",
       "name": "is-arrayish",
@@ -23631,7 +23681,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 489,
+      "id": 490,
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "man_dir": "",
       "name": "emoji-regex",
@@ -23647,7 +23697,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 490,
+      "id": 491,
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "man_dir": "",
       "name": "picomatch",
@@ -23663,7 +23713,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 491,
+      "id": 492,
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "man_dir": "",
       "name": "ansi-regex",
@@ -23679,7 +23729,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 492,
+      "id": 493,
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "man_dir": "",
       "name": "ansi-styles",
@@ -23694,10 +23744,26 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     },
     {
       "bin": null,
+      "dependencies": [],
+      "id": 494,
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "man_dir": "",
+      "name": "undici-types",
+      "name_hash": "13518207300296011529",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "tag": "npm",
+        "value": "7.10.0",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
       "dependencies": [
-        1042,
+        1044,
       ],
-      "id": 493,
+      "id": 495,
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "man_dir": "",
       "name": "brace-expansion",
@@ -25625,14 +25691,36 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
     },
     {
       "dependencies": {
-        "postcss": {
-          "id": 631,
-          "package_id": 486,
+        "@types/node": {
+          "id": 209,
+          "package_id": 481,
         },
       },
       "depth": 1,
       "id": 1,
+      "path": "node_modules/bun-types/node_modules",
+    },
+    {
+      "dependencies": {
+        "postcss": {
+          "id": 631,
+          "package_id": 487,
+        },
+      },
+      "depth": 1,
+      "id": 2,
       "path": "node_modules/next/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 3,
+      "path": "node_modules/bun-types/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -25642,7 +25730,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 2,
+      "id": 4,
       "path": "node_modules/@eslint-community/eslint-utils/node_modules",
     },
     {
@@ -25653,7 +25741,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 3,
+      "id": 5,
       "path": "node_modules/@humanfs/node/node_modules",
     },
     {
@@ -25664,51 +25752,51 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 4,
+      "id": 6,
       "path": "node_modules/@next/eslint-plugin-next/node_modules",
     },
     {
       "dependencies": {
         "ignore": {
           "id": 87,
-          "package_id": 481,
+          "package_id": 482,
         },
       },
       "depth": 1,
-      "id": 5,
+      "id": 7,
       "path": "node_modules/@typescript-eslint/eslint-plugin/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 404,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 6,
+      "id": 8,
       "path": "node_modules/eslint-import-resolver-node/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 423,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 7,
+      "id": 9,
       "path": "node_modules/eslint-plugin-import/node_modules",
     },
     {
       "dependencies": {
         "resolve": {
           "id": 468,
-          "package_id": 485,
+          "package_id": 486,
         },
       },
       "depth": 1,
-      "id": 8,
+      "id": 10,
       "path": "node_modules/eslint-plugin-react/node_modules",
     },
     {
@@ -25719,7 +25807,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 9,
+      "id": 11,
       "path": "node_modules/sharp/node_modules",
     },
     {
@@ -25730,47 +25818,47 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 10,
+      "id": 12,
       "path": "node_modules/@puppeteer/browsers/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 224,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 11,
+      "id": 13,
       "path": "node_modules/chokidar/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 487,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 12,
+      "id": 14,
       "path": "node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 1025,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 2,
-      "id": 13,
+      "id": 15,
       "path": "node_modules/@next/eslint-plugin-next/node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 121,
-          "package_id": 482,
+          "package_id": 483,
         },
         "semver": {
           "id": 122,
@@ -25778,7 +25866,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 14,
+      "id": 16,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules",
     },
     {
@@ -25789,96 +25877,118 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 15,
+      "id": 17,
       "path": "node_modules/is-bun-module/node_modules",
     },
     {
       "dependencies": {
         "picomatch": {
           "id": 912,
-          "package_id": 490,
+          "package_id": 491,
         },
       },
       "depth": 1,
-      "id": 16,
+      "id": 18,
       "path": "node_modules/tinyglobby/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 417,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 17,
+      "id": 19,
       "path": "node_modules/eslint-module-utils/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 530,
-          "package_id": 482,
+          "package_id": 483,
         },
       },
       "depth": 1,
-      "id": 18,
+      "id": 20,
       "path": "node_modules/glob/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 19,
+      "id": 21,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules",
+    },
+    {
+      "dependencies": {
+        "@types/node": {
+          "id": 80,
+          "package_id": 481,
+        },
+      },
+      "depth": 1,
+      "id": 22,
+      "path": "node_modules/@types/yauzl/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 20,
+      "id": 23,
       "path": "node_modules/string-width/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 21,
+      "id": 24,
       "path": "node_modules/glob/node_modules/minimatch/node_modules",
     },
     {
       "dependencies": {
         "lru-cache": {
           "id": 687,
-          "package_id": 487,
+          "package_id": 488,
         },
       },
       "depth": 1,
-      "id": 22,
+      "id": 25,
       "path": "node_modules/path-scurry/node_modules",
     },
     {
       "dependencies": {
         "is-arrayish": {
           "id": 818,
-          "package_id": 488,
+          "package_id": 489,
         },
       },
       "depth": 1,
-      "id": 23,
+      "id": 26,
       "path": "node_modules/simple-swizzle/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 27,
+      "path": "node_modules/@types/yauzl/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -25896,40 +26006,40 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
         },
       },
       "depth": 1,
-      "id": 24,
+      "id": 28,
       "path": "node_modules/@isaacs/cliui/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 25,
+      "id": 29,
       "path": "node_modules/string-width-cjs/node_modules",
     },
     {
       "dependencies": {
         "ansi-regex": {
           "id": 1019,
-          "package_id": 491,
+          "package_id": 492,
         },
       },
       "depth": 2,
-      "id": 26,
+      "id": 30,
       "path": "node_modules/@isaacs/cliui/node_modules/strip-ansi/node_modules",
     },
     {
       "dependencies": {
         "ansi-styles": {
           "id": 1020,
-          "package_id": 492,
+          "package_id": 493,
         },
       },
       "depth": 2,
-      "id": 27,
+      "id": 31,
       "path": "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules",
     },
   ],

--- a/test/integration/next-pages/test/__snapshots__/next-build.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/next-build.test.ts.snap
@@ -8,11 +8,11 @@ exports[`next build works: bun 1`] = `
         "prod": true,
       },
       "id": 0,
-      "literal": "24.2.1",
+      "literal": "25.0.0",
       "name": "@types/node",
       "npm": {
         "name": "@types/node",
-        "version": "==24.2.1",
+        "version": "==25.0.0",
       },
       "package_id": 72,
     },
@@ -1012,11 +1012,11 @@ exports[`next build works: bun 1`] = `
         "prod": true,
       },
       "id": 77,
-      "literal": "~7.10.0",
+      "literal": "~7.16.0",
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.16.0 <7.17.0",
       },
       "package_id": 453,
     },
@@ -1057,7 +1057,7 @@ exports[`next build works: bun 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -1148,7 +1148,7 @@ exports[`next build works: bun 1`] = `
         "name": "ignore",
         "version": ">=7.0.0 <8.0.0",
       },
-      "package_id": 481,
+      "package_id": 482,
     },
     {
       "behavior": {
@@ -1590,7 +1590,7 @@ exports[`next build works: bun 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -2737,7 +2737,7 @@ exports[`next build works: bun 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -2932,7 +2932,7 @@ exports[`next build works: bun 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <5.2.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -5275,7 +5275,7 @@ exports[`next build works: bun 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -5446,7 +5446,7 @@ exports[`next build works: bun 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -5524,7 +5524,7 @@ exports[`next build works: bun 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -6109,7 +6109,7 @@ exports[`next build works: bun 1`] = `
         "name": "resolve",
         "version": ">=2.0.0-next.5 <3.0.0",
       },
-      "package_id": 485,
+      "package_id": 486,
     },
     {
       "behavior": {
@@ -6356,7 +6356,7 @@ exports[`next build works: bun 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -6916,7 +6916,7 @@ exports[`next build works: bun 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -8229,7 +8229,7 @@ exports[`next build works: bun 1`] = `
         "name": "postcss",
         "version": "==8.4.31",
       },
-      "package_id": 486,
+      "package_id": 487,
     },
     {
       "behavior": {
@@ -8961,7 +8961,7 @@ exports[`next build works: bun 1`] = `
         "name": "lru-cache",
         "version": ">=10.2.0 <11.0.0",
       },
-      "package_id": 487,
+      "package_id": 488,
     },
     {
       "behavior": {
@@ -10666,7 +10666,7 @@ exports[`next build works: bun 1`] = `
         "name": "is-arrayish",
         "version": ">=0.3.1 <0.4.0",
       },
-      "package_id": 488,
+      "package_id": 489,
     },
     {
       "behavior": {
@@ -10809,7 +10809,7 @@ exports[`next build works: bun 1`] = `
         "name": "emoji-regex",
         "version": ">=8.0.0 <9.0.0",
       },
-      "package_id": 489,
+      "package_id": 490,
     },
     {
       "behavior": {
@@ -11888,7 +11888,7 @@ exports[`next build works: bun 1`] = `
         "name": "picomatch",
         "version": ">=4.0.2 <5.0.0",
       },
-      "package_id": 490,
+      "package_id": 491,
     },
     {
       "behavior": {
@@ -13281,7 +13281,7 @@ exports[`next build works: bun 1`] = `
         "name": "ansi-regex",
         "version": ">=6.0.1 <7.0.0",
       },
-      "package_id": 491,
+      "package_id": 492,
     },
     {
       "behavior": {
@@ -13294,7 +13294,7 @@ exports[`next build works: bun 1`] = `
         "name": "ansi-styles",
         "version": ">=6.1.0 <7.0.0",
       },
-      "package_id": 492,
+      "package_id": 493,
     },
     {
       "behavior": {
@@ -13359,7 +13359,7 @@ exports[`next build works: bun 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -13392,19 +13392,45 @@ exports[`next build works: bun 1`] = `
         "prod": true,
       },
       "id": 1028,
-      "literal": "^2.0.1",
-      "name": "brace-expansion",
+      "literal": "~7.10.0",
+      "name": "undici-types",
       "npm": {
-        "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
       },
-      "package_id": 493,
+      "package_id": 494,
     },
     {
       "behavior": {
         "prod": true,
       },
       "id": 1029,
+      "literal": "^2.0.1",
+      "name": "brace-expansion",
+      "npm": {
+        "name": "brace-expansion",
+        "version": ">=2.0.1 <3.0.0",
+      },
+      "package_id": 495,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1030,
+      "literal": "~7.10.0",
+      "name": "undici-types",
+      "npm": {
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1031,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13417,7 +13443,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1030,
+      "id": 1032,
       "literal": "^2.1.1",
       "name": "ms",
       "npm": {
@@ -13430,33 +13456,33 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1031,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
-      "id": 1032,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
       "id": 1033,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1034,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1035,
       "literal": "^2.13.0",
       "name": "is-core-module",
       "npm": {
@@ -13469,7 +13495,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1034,
+      "id": 1036,
       "literal": "^1.0.7",
       "name": "path-parse",
       "npm": {
@@ -13482,7 +13508,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1035,
+      "id": 1037,
       "literal": "^1.0.0",
       "name": "supports-preserve-symlinks-flag",
       "npm": {
@@ -13495,7 +13521,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1036,
+      "id": 1038,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13508,7 +13534,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1037,
+      "id": 1039,
       "literal": "^2.0.1",
       "name": "brace-expansion",
       "npm": {
@@ -13521,7 +13547,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1038,
+      "id": 1040,
       "literal": "^3.3.6",
       "name": "nanoid",
       "npm": {
@@ -13534,7 +13560,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1039,
+      "id": 1041,
       "literal": "^1.0.0",
       "name": "picocolors",
       "npm": {
@@ -13547,7 +13573,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1040,
+      "id": 1042,
       "literal": "^1.0.2",
       "name": "source-map-js",
       "npm": {
@@ -13560,7 +13586,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1041,
+      "id": 1043,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -13573,7 +13599,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1042,
+      "id": 1044,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -13586,7 +13612,7 @@ exports[`next build works: bun 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1043,
+      "id": 1045,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -13673,7 +13699,10 @@ exports[`next build works: bun 1`] = `
     "@types/estree": 69,
     "@types/json-schema": 70,
     "@types/json5": 71,
-    "@types/node": 72,
+    "@types/node": [
+      72,
+      481,
+    ],
     "@types/react": 73,
     "@types/react-dom": 74,
     "@types/yauzl": 75,
@@ -13711,11 +13740,11 @@ exports[`next build works: bun 1`] = `
     "agent-base": 107,
     "ajv": 108,
     "ansi-regex": [
-      491,
+      492,
       109,
     ],
     "ansi-styles": [
-      492,
+      493,
       110,
     ],
     "any-promise": 111,
@@ -13748,7 +13777,7 @@ exports[`next build works: bun 1`] = `
     "basic-ftp": 138,
     "binary-extensions": 139,
     "brace-expansion": [
-      493,
+      495,
       140,
     ],
     "braces": 141,
@@ -13783,7 +13812,7 @@ exports[`next build works: bun 1`] = `
     "data-view-byte-offset": 170,
     "debug": [
       171,
-      484,
+      485,
     ],
     "deep-is": 172,
     "default-create-template": 0,
@@ -13800,7 +13829,7 @@ exports[`next build works: bun 1`] = `
     "electron-to-chromium": 183,
     "emoji-regex": [
       184,
-      489,
+      490,
     ],
     "end-of-stream": 185,
     "env-paths": 186,
@@ -13870,7 +13899,7 @@ exports[`next build works: bun 1`] = `
     "glob": 244,
     "glob-parent": [
       245,
-      483,
+      484,
     ],
     "globals": 246,
     "globalthis": 247,
@@ -13886,7 +13915,7 @@ exports[`next build works: bun 1`] = `
     "http-proxy-agent": 257,
     "https-proxy-agent": 258,
     "ignore": [
-      481,
+      482,
       259,
     ],
     "import-fresh": 260,
@@ -13895,7 +13924,7 @@ exports[`next build works: bun 1`] = `
     "ip-address": 263,
     "is-array-buffer": 264,
     "is-arrayish": [
-      488,
+      489,
       265,
     ],
     "is-async-function": 266,
@@ -13949,14 +13978,14 @@ exports[`next build works: bun 1`] = `
     "lodash.merge": 314,
     "loose-envify": 315,
     "lru-cache": [
-      487,
+      488,
       316,
     ],
     "math-intrinsics": 317,
     "merge2": 318,
     "micromatch": 319,
     "minimatch": [
-      482,
+      483,
       320,
     ],
     "minimist": 321,
@@ -13998,7 +14027,7 @@ exports[`next build works: bun 1`] = `
     "pend": 357,
     "picocolors": 358,
     "picomatch": [
-      490,
+      491,
       359,
     ],
     "pify": 360,
@@ -14006,7 +14035,7 @@ exports[`next build works: bun 1`] = `
     "possible-typed-array-names": 362,
     "postcss": [
       363,
-      486,
+      487,
     ],
     "postcss-import": 364,
     "postcss-js": 365,
@@ -14033,7 +14062,7 @@ exports[`next build works: bun 1`] = `
     "regexp.prototype.flags": 386,
     "require-directory": 387,
     "resolve": [
-      485,
+      486,
       388,
     ],
     "resolve-from": 389,
@@ -14109,7 +14138,10 @@ exports[`next build works: bun 1`] = `
     "typed-query-selector": 450,
     "typescript": 451,
     "unbox-primitive": 452,
-    "undici-types": 453,
+    "undici-types": [
+      453,
+      494,
+    ],
     "unrs-resolver": 454,
     "update-browserslist-db": 455,
     "uri-js": 456,
@@ -15579,15 +15611,15 @@ exports[`next build works: bun 1`] = `
         77,
       ],
       "id": 72,
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "integrity": "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==",
       "man_dir": "",
       "name": "@types/node",
       "name_hash": "4124652010926124945",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.0.tgz",
         "tag": "npm",
-        "value": "24.2.1",
+        "value": "25.0.0",
       },
       "scripts": {},
     },
@@ -22931,15 +22963,15 @@ exports[`next build works: bun 1`] = `
       "bin": null,
       "dependencies": [],
       "id": 453,
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "man_dir": "",
       "name": "undici-types",
       "name_hash": "13518207300296011529",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
         "tag": "npm",
-        "value": "7.10.0",
+        "value": "7.16.0",
       },
       "scripts": {},
     },
@@ -23485,8 +23517,26 @@ exports[`next build works: bun 1`] = `
     },
     {
       "bin": null,
-      "dependencies": [],
+      "dependencies": [
+        1028,
+      ],
       "id": 481,
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "man_dir": "",
+      "name": "@types/node",
+      "name_hash": "4124652010926124945",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "tag": "npm",
+        "value": "24.2.1",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
+      "dependencies": [],
+      "id": 482,
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "man_dir": "",
       "name": "ignore",
@@ -23502,9 +23552,9 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1028,
+        1029,
       ],
-      "id": 482,
+      "id": 483,
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "man_dir": "",
       "name": "minimatch",
@@ -23520,9 +23570,9 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1029,
+        1031,
       ],
-      "id": 483,
+      "id": 484,
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "man_dir": "",
       "name": "glob-parent",
@@ -23538,9 +23588,9 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1030,
+        1032,
       ],
-      "id": 484,
+      "id": 485,
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "man_dir": "",
       "name": "debug",
@@ -23559,11 +23609,11 @@ exports[`next build works: bun 1`] = `
         "name": "resolve",
       },
       "dependencies": [
-        1033,
-        1034,
         1035,
+        1036,
+        1037,
       ],
-      "id": 485,
+      "id": 486,
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "man_dir": "",
       "name": "resolve",
@@ -23579,11 +23629,11 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1038,
-        1039,
         1040,
+        1041,
+        1042,
       ],
-      "id": 486,
+      "id": 487,
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "man_dir": "",
       "name": "postcss",
@@ -23599,7 +23649,7 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 487,
+      "id": 488,
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "man_dir": "",
       "name": "lru-cache",
@@ -23615,7 +23665,7 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 488,
+      "id": 489,
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "man_dir": "",
       "name": "is-arrayish",
@@ -23631,7 +23681,7 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 489,
+      "id": 490,
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "man_dir": "",
       "name": "emoji-regex",
@@ -23647,7 +23697,7 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 490,
+      "id": 491,
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "man_dir": "",
       "name": "picomatch",
@@ -23663,7 +23713,7 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 491,
+      "id": 492,
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "man_dir": "",
       "name": "ansi-regex",
@@ -23679,7 +23729,7 @@ exports[`next build works: bun 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 492,
+      "id": 493,
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "man_dir": "",
       "name": "ansi-styles",
@@ -23694,10 +23744,26 @@ exports[`next build works: bun 1`] = `
     },
     {
       "bin": null,
+      "dependencies": [],
+      "id": 494,
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "man_dir": "",
+      "name": "undici-types",
+      "name_hash": "13518207300296011529",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "tag": "npm",
+        "value": "7.10.0",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
       "dependencies": [
-        1042,
+        1044,
       ],
-      "id": 493,
+      "id": 495,
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "man_dir": "",
       "name": "brace-expansion",
@@ -25625,14 +25691,36 @@ exports[`next build works: bun 1`] = `
     },
     {
       "dependencies": {
-        "postcss": {
-          "id": 631,
-          "package_id": 486,
+        "@types/node": {
+          "id": 209,
+          "package_id": 481,
         },
       },
       "depth": 1,
       "id": 1,
+      "path": "node_modules/bun-types/node_modules",
+    },
+    {
+      "dependencies": {
+        "postcss": {
+          "id": 631,
+          "package_id": 487,
+        },
+      },
+      "depth": 1,
+      "id": 2,
       "path": "node_modules/next/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 3,
+      "path": "node_modules/bun-types/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -25642,7 +25730,7 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 2,
+      "id": 4,
       "path": "node_modules/@eslint-community/eslint-utils/node_modules",
     },
     {
@@ -25653,7 +25741,7 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 3,
+      "id": 5,
       "path": "node_modules/@humanfs/node/node_modules",
     },
     {
@@ -25664,51 +25752,51 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 4,
+      "id": 6,
       "path": "node_modules/@next/eslint-plugin-next/node_modules",
     },
     {
       "dependencies": {
         "ignore": {
           "id": 87,
-          "package_id": 481,
+          "package_id": 482,
         },
       },
       "depth": 1,
-      "id": 5,
+      "id": 7,
       "path": "node_modules/@typescript-eslint/eslint-plugin/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 404,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 6,
+      "id": 8,
       "path": "node_modules/eslint-import-resolver-node/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 423,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 7,
+      "id": 9,
       "path": "node_modules/eslint-plugin-import/node_modules",
     },
     {
       "dependencies": {
         "resolve": {
           "id": 468,
-          "package_id": 485,
+          "package_id": 486,
         },
       },
       "depth": 1,
-      "id": 8,
+      "id": 10,
       "path": "node_modules/eslint-plugin-react/node_modules",
     },
     {
@@ -25719,7 +25807,7 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 9,
+      "id": 11,
       "path": "node_modules/sharp/node_modules",
     },
     {
@@ -25730,47 +25818,47 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 10,
+      "id": 12,
       "path": "node_modules/@puppeteer/browsers/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 224,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 11,
+      "id": 13,
       "path": "node_modules/chokidar/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 487,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 12,
+      "id": 14,
       "path": "node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 1025,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 2,
-      "id": 13,
+      "id": 15,
       "path": "node_modules/@next/eslint-plugin-next/node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 121,
-          "package_id": 482,
+          "package_id": 483,
         },
         "semver": {
           "id": 122,
@@ -25778,7 +25866,7 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 14,
+      "id": 16,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules",
     },
     {
@@ -25789,96 +25877,118 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 15,
+      "id": 17,
       "path": "node_modules/is-bun-module/node_modules",
     },
     {
       "dependencies": {
         "picomatch": {
           "id": 912,
-          "package_id": 490,
+          "package_id": 491,
         },
       },
       "depth": 1,
-      "id": 16,
+      "id": 18,
       "path": "node_modules/tinyglobby/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 417,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 17,
+      "id": 19,
       "path": "node_modules/eslint-module-utils/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 530,
-          "package_id": 482,
+          "package_id": 483,
         },
       },
       "depth": 1,
-      "id": 18,
+      "id": 20,
       "path": "node_modules/glob/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 19,
+      "id": 21,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules",
+    },
+    {
+      "dependencies": {
+        "@types/node": {
+          "id": 80,
+          "package_id": 481,
+        },
+      },
+      "depth": 1,
+      "id": 22,
+      "path": "node_modules/@types/yauzl/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 20,
+      "id": 23,
       "path": "node_modules/string-width/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 21,
+      "id": 24,
       "path": "node_modules/glob/node_modules/minimatch/node_modules",
     },
     {
       "dependencies": {
         "lru-cache": {
           "id": 687,
-          "package_id": 487,
+          "package_id": 488,
         },
       },
       "depth": 1,
-      "id": 22,
+      "id": 25,
       "path": "node_modules/path-scurry/node_modules",
     },
     {
       "dependencies": {
         "is-arrayish": {
           "id": 818,
-          "package_id": 488,
+          "package_id": 489,
         },
       },
       "depth": 1,
-      "id": 23,
+      "id": 26,
       "path": "node_modules/simple-swizzle/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 27,
+      "path": "node_modules/@types/yauzl/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -25896,40 +26006,40 @@ exports[`next build works: bun 1`] = `
         },
       },
       "depth": 1,
-      "id": 24,
+      "id": 28,
       "path": "node_modules/@isaacs/cliui/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 25,
+      "id": 29,
       "path": "node_modules/string-width-cjs/node_modules",
     },
     {
       "dependencies": {
         "ansi-regex": {
           "id": 1019,
-          "package_id": 491,
+          "package_id": 492,
         },
       },
       "depth": 2,
-      "id": 26,
+      "id": 30,
       "path": "node_modules/@isaacs/cliui/node_modules/strip-ansi/node_modules",
     },
     {
       "dependencies": {
         "ansi-styles": {
           "id": 1020,
-          "package_id": 492,
+          "package_id": 493,
         },
       },
       "depth": 2,
-      "id": 27,
+      "id": 31,
       "path": "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules",
     },
   ],
@@ -25946,11 +26056,11 @@ exports[`next build works: node 1`] = `
         "prod": true,
       },
       "id": 0,
-      "literal": "24.2.1",
+      "literal": "25.0.0",
       "name": "@types/node",
       "npm": {
         "name": "@types/node",
-        "version": "==24.2.1",
+        "version": "==25.0.0",
       },
       "package_id": 72,
     },
@@ -26950,11 +27060,11 @@ exports[`next build works: node 1`] = `
         "prod": true,
       },
       "id": 77,
-      "literal": "~7.10.0",
+      "literal": "~7.16.0",
       "name": "undici-types",
       "npm": {
         "name": "undici-types",
-        "version": ">=7.10.0 <7.11.0",
+        "version": ">=7.16.0 <7.17.0",
       },
       "package_id": 453,
     },
@@ -26995,7 +27105,7 @@ exports[`next build works: node 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -27086,7 +27196,7 @@ exports[`next build works: node 1`] = `
         "name": "ignore",
         "version": ">=7.0.0 <8.0.0",
       },
-      "package_id": 481,
+      "package_id": 482,
     },
     {
       "behavior": {
@@ -27528,7 +27638,7 @@ exports[`next build works: node 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -28675,7 +28785,7 @@ exports[`next build works: node 1`] = `
         "name": "@types/node",
         "version": ">=0.0.0",
       },
-      "package_id": 72,
+      "package_id": 481,
     },
     {
       "behavior": {
@@ -28870,7 +28980,7 @@ exports[`next build works: node 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <5.2.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -31213,7 +31323,7 @@ exports[`next build works: node 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -31384,7 +31494,7 @@ exports[`next build works: node 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -31462,7 +31572,7 @@ exports[`next build works: node 1`] = `
         "name": "debug",
         "version": ">=3.2.7 <4.0.0",
       },
-      "package_id": 484,
+      "package_id": 485,
     },
     {
       "behavior": {
@@ -32047,7 +32157,7 @@ exports[`next build works: node 1`] = `
         "name": "resolve",
         "version": ">=2.0.0-next.5 <3.0.0",
       },
-      "package_id": 485,
+      "package_id": 486,
     },
     {
       "behavior": {
@@ -32294,7 +32404,7 @@ exports[`next build works: node 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -32854,7 +32964,7 @@ exports[`next build works: node 1`] = `
         "name": "minimatch",
         "version": ">=9.0.4 <10.0.0",
       },
-      "package_id": 482,
+      "package_id": 483,
     },
     {
       "behavior": {
@@ -34167,7 +34277,7 @@ exports[`next build works: node 1`] = `
         "name": "postcss",
         "version": "==8.4.31",
       },
-      "package_id": 486,
+      "package_id": 487,
     },
     {
       "behavior": {
@@ -34899,7 +35009,7 @@ exports[`next build works: node 1`] = `
         "name": "lru-cache",
         "version": ">=10.2.0 <11.0.0",
       },
-      "package_id": 487,
+      "package_id": 488,
     },
     {
       "behavior": {
@@ -36604,7 +36714,7 @@ exports[`next build works: node 1`] = `
         "name": "is-arrayish",
         "version": ">=0.3.1 <0.4.0",
       },
-      "package_id": 488,
+      "package_id": 489,
     },
     {
       "behavior": {
@@ -36747,7 +36857,7 @@ exports[`next build works: node 1`] = `
         "name": "emoji-regex",
         "version": ">=8.0.0 <9.0.0",
       },
-      "package_id": 489,
+      "package_id": 490,
     },
     {
       "behavior": {
@@ -37826,7 +37936,7 @@ exports[`next build works: node 1`] = `
         "name": "picomatch",
         "version": ">=4.0.2 <5.0.0",
       },
-      "package_id": 490,
+      "package_id": 491,
     },
     {
       "behavior": {
@@ -39219,7 +39329,7 @@ exports[`next build works: node 1`] = `
         "name": "ansi-regex",
         "version": ">=6.0.1 <7.0.0",
       },
-      "package_id": 491,
+      "package_id": 492,
     },
     {
       "behavior": {
@@ -39232,7 +39342,7 @@ exports[`next build works: node 1`] = `
         "name": "ansi-styles",
         "version": ">=6.1.0 <7.0.0",
       },
-      "package_id": 492,
+      "package_id": 493,
     },
     {
       "behavior": {
@@ -39297,7 +39407,7 @@ exports[`next build works: node 1`] = `
         "name": "glob-parent",
         "version": ">=5.1.2 <6.0.0",
       },
-      "package_id": 483,
+      "package_id": 484,
     },
     {
       "behavior": {
@@ -39330,19 +39440,45 @@ exports[`next build works: node 1`] = `
         "prod": true,
       },
       "id": 1028,
-      "literal": "^2.0.1",
-      "name": "brace-expansion",
+      "literal": "~7.10.0",
+      "name": "undici-types",
       "npm": {
-        "name": "brace-expansion",
-        "version": ">=2.0.1 <3.0.0",
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
       },
-      "package_id": 493,
+      "package_id": 494,
     },
     {
       "behavior": {
         "prod": true,
       },
       "id": 1029,
+      "literal": "^2.0.1",
+      "name": "brace-expansion",
+      "npm": {
+        "name": "brace-expansion",
+        "version": ">=2.0.1 <3.0.0",
+      },
+      "package_id": 495,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1030,
+      "literal": "~7.10.0",
+      "name": "undici-types",
+      "npm": {
+        "name": "undici-types",
+        "version": ">=7.10.0 <7.11.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1031,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -39355,7 +39491,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1030,
+      "id": 1032,
       "literal": "^2.1.1",
       "name": "ms",
       "npm": {
@@ -39368,33 +39504,33 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1031,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
-      "id": 1032,
-      "literal": "^2.1.1",
-      "name": "ms",
-      "npm": {
-        "name": "ms",
-        "version": ">=2.1.1 <3.0.0",
-      },
-      "package_id": null,
-    },
-    {
-      "behavior": {
-        "prod": true,
-      },
       "id": 1033,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1034,
+      "literal": "^2.1.1",
+      "name": "ms",
+      "npm": {
+        "name": "ms",
+        "version": ">=2.1.1 <3.0.0",
+      },
+      "package_id": null,
+    },
+    {
+      "behavior": {
+        "prod": true,
+      },
+      "id": 1035,
       "literal": "^2.13.0",
       "name": "is-core-module",
       "npm": {
@@ -39407,7 +39543,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1034,
+      "id": 1036,
       "literal": "^1.0.7",
       "name": "path-parse",
       "npm": {
@@ -39420,7 +39556,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1035,
+      "id": 1037,
       "literal": "^1.0.0",
       "name": "supports-preserve-symlinks-flag",
       "npm": {
@@ -39433,7 +39569,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1036,
+      "id": 1038,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -39446,7 +39582,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1037,
+      "id": 1039,
       "literal": "^2.0.1",
       "name": "brace-expansion",
       "npm": {
@@ -39459,7 +39595,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1038,
+      "id": 1040,
       "literal": "^3.3.6",
       "name": "nanoid",
       "npm": {
@@ -39472,7 +39608,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1039,
+      "id": 1041,
       "literal": "^1.0.0",
       "name": "picocolors",
       "npm": {
@@ -39485,7 +39621,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1040,
+      "id": 1042,
       "literal": "^1.0.2",
       "name": "source-map-js",
       "npm": {
@@ -39498,7 +39634,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1041,
+      "id": 1043,
       "literal": "^4.0.1",
       "name": "is-glob",
       "npm": {
@@ -39511,7 +39647,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1042,
+      "id": 1044,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -39524,7 +39660,7 @@ exports[`next build works: node 1`] = `
       "behavior": {
         "prod": true,
       },
-      "id": 1043,
+      "id": 1045,
       "literal": "^1.0.0",
       "name": "balanced-match",
       "npm": {
@@ -39611,7 +39747,10 @@ exports[`next build works: node 1`] = `
     "@types/estree": 69,
     "@types/json-schema": 70,
     "@types/json5": 71,
-    "@types/node": 72,
+    "@types/node": [
+      72,
+      481,
+    ],
     "@types/react": 73,
     "@types/react-dom": 74,
     "@types/yauzl": 75,
@@ -39649,11 +39788,11 @@ exports[`next build works: node 1`] = `
     "agent-base": 107,
     "ajv": 108,
     "ansi-regex": [
-      491,
+      492,
       109,
     ],
     "ansi-styles": [
-      492,
+      493,
       110,
     ],
     "any-promise": 111,
@@ -39686,7 +39825,7 @@ exports[`next build works: node 1`] = `
     "basic-ftp": 138,
     "binary-extensions": 139,
     "brace-expansion": [
-      493,
+      495,
       140,
     ],
     "braces": 141,
@@ -39721,7 +39860,7 @@ exports[`next build works: node 1`] = `
     "data-view-byte-offset": 170,
     "debug": [
       171,
-      484,
+      485,
     ],
     "deep-is": 172,
     "default-create-template": 0,
@@ -39738,7 +39877,7 @@ exports[`next build works: node 1`] = `
     "electron-to-chromium": 183,
     "emoji-regex": [
       184,
-      489,
+      490,
     ],
     "end-of-stream": 185,
     "env-paths": 186,
@@ -39808,7 +39947,7 @@ exports[`next build works: node 1`] = `
     "glob": 244,
     "glob-parent": [
       245,
-      483,
+      484,
     ],
     "globals": 246,
     "globalthis": 247,
@@ -39824,7 +39963,7 @@ exports[`next build works: node 1`] = `
     "http-proxy-agent": 257,
     "https-proxy-agent": 258,
     "ignore": [
-      481,
+      482,
       259,
     ],
     "import-fresh": 260,
@@ -39833,7 +39972,7 @@ exports[`next build works: node 1`] = `
     "ip-address": 263,
     "is-array-buffer": 264,
     "is-arrayish": [
-      488,
+      489,
       265,
     ],
     "is-async-function": 266,
@@ -39887,14 +40026,14 @@ exports[`next build works: node 1`] = `
     "lodash.merge": 314,
     "loose-envify": 315,
     "lru-cache": [
-      487,
+      488,
       316,
     ],
     "math-intrinsics": 317,
     "merge2": 318,
     "micromatch": 319,
     "minimatch": [
-      482,
+      483,
       320,
     ],
     "minimist": 321,
@@ -39936,7 +40075,7 @@ exports[`next build works: node 1`] = `
     "pend": 357,
     "picocolors": 358,
     "picomatch": [
-      490,
+      491,
       359,
     ],
     "pify": 360,
@@ -39944,7 +40083,7 @@ exports[`next build works: node 1`] = `
     "possible-typed-array-names": 362,
     "postcss": [
       363,
-      486,
+      487,
     ],
     "postcss-import": 364,
     "postcss-js": 365,
@@ -39971,7 +40110,7 @@ exports[`next build works: node 1`] = `
     "regexp.prototype.flags": 386,
     "require-directory": 387,
     "resolve": [
-      485,
+      486,
       388,
     ],
     "resolve-from": 389,
@@ -40047,7 +40186,10 @@ exports[`next build works: node 1`] = `
     "typed-query-selector": 450,
     "typescript": 451,
     "unbox-primitive": 452,
-    "undici-types": 453,
+    "undici-types": [
+      453,
+      494,
+    ],
     "unrs-resolver": 454,
     "update-browserslist-db": 455,
     "uri-js": 456,
@@ -41517,15 +41659,15 @@ exports[`next build works: node 1`] = `
         77,
       ],
       "id": 72,
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "integrity": "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==",
       "man_dir": "",
       "name": "@types/node",
       "name_hash": "4124652010926124945",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.0.tgz",
         "tag": "npm",
-        "value": "24.2.1",
+        "value": "25.0.0",
       },
       "scripts": {},
     },
@@ -48869,15 +49011,15 @@ exports[`next build works: node 1`] = `
       "bin": null,
       "dependencies": [],
       "id": 453,
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "man_dir": "",
       "name": "undici-types",
       "name_hash": "13518207300296011529",
       "origin": "npm",
       "resolution": {
-        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
         "tag": "npm",
-        "value": "7.10.0",
+        "value": "7.16.0",
       },
       "scripts": {},
     },
@@ -49423,8 +49565,26 @@ exports[`next build works: node 1`] = `
     },
     {
       "bin": null,
-      "dependencies": [],
+      "dependencies": [
+        1028,
+      ],
       "id": 481,
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "man_dir": "",
+      "name": "@types/node",
+      "name_hash": "4124652010926124945",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+        "tag": "npm",
+        "value": "24.2.1",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
+      "dependencies": [],
+      "id": 482,
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "man_dir": "",
       "name": "ignore",
@@ -49440,9 +49600,9 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1028,
+        1029,
       ],
-      "id": 482,
+      "id": 483,
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "man_dir": "",
       "name": "minimatch",
@@ -49458,9 +49618,9 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1029,
+        1031,
       ],
-      "id": 483,
+      "id": 484,
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "man_dir": "",
       "name": "glob-parent",
@@ -49476,9 +49636,9 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1030,
+        1032,
       ],
-      "id": 484,
+      "id": 485,
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "man_dir": "",
       "name": "debug",
@@ -49497,11 +49657,11 @@ exports[`next build works: node 1`] = `
         "name": "resolve",
       },
       "dependencies": [
-        1033,
-        1034,
         1035,
+        1036,
+        1037,
       ],
-      "id": 485,
+      "id": 486,
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "man_dir": "",
       "name": "resolve",
@@ -49517,11 +49677,11 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [
-        1038,
-        1039,
         1040,
+        1041,
+        1042,
       ],
-      "id": 486,
+      "id": 487,
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "man_dir": "",
       "name": "postcss",
@@ -49537,7 +49697,7 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 487,
+      "id": 488,
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "man_dir": "",
       "name": "lru-cache",
@@ -49553,7 +49713,7 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 488,
+      "id": 489,
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "man_dir": "",
       "name": "is-arrayish",
@@ -49569,7 +49729,7 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 489,
+      "id": 490,
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "man_dir": "",
       "name": "emoji-regex",
@@ -49585,7 +49745,7 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 490,
+      "id": 491,
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "man_dir": "",
       "name": "picomatch",
@@ -49601,7 +49761,7 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 491,
+      "id": 492,
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "man_dir": "",
       "name": "ansi-regex",
@@ -49617,7 +49777,7 @@ exports[`next build works: node 1`] = `
     {
       "bin": null,
       "dependencies": [],
-      "id": 492,
+      "id": 493,
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "man_dir": "",
       "name": "ansi-styles",
@@ -49632,10 +49792,26 @@ exports[`next build works: node 1`] = `
     },
     {
       "bin": null,
+      "dependencies": [],
+      "id": 494,
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "man_dir": "",
+      "name": "undici-types",
+      "name_hash": "13518207300296011529",
+      "origin": "npm",
+      "resolution": {
+        "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+        "tag": "npm",
+        "value": "7.10.0",
+      },
+      "scripts": {},
+    },
+    {
+      "bin": null,
       "dependencies": [
-        1042,
+        1044,
       ],
-      "id": 493,
+      "id": 495,
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "man_dir": "",
       "name": "brace-expansion",
@@ -51563,14 +51739,36 @@ exports[`next build works: node 1`] = `
     },
     {
       "dependencies": {
-        "postcss": {
-          "id": 631,
-          "package_id": 486,
+        "@types/node": {
+          "id": 209,
+          "package_id": 481,
         },
       },
       "depth": 1,
       "id": 1,
+      "path": "node_modules/bun-types/node_modules",
+    },
+    {
+      "dependencies": {
+        "postcss": {
+          "id": 631,
+          "package_id": 487,
+        },
+      },
+      "depth": 1,
+      "id": 2,
       "path": "node_modules/next/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 3,
+      "path": "node_modules/bun-types/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -51580,7 +51778,7 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 2,
+      "id": 4,
       "path": "node_modules/@eslint-community/eslint-utils/node_modules",
     },
     {
@@ -51591,7 +51789,7 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 3,
+      "id": 5,
       "path": "node_modules/@humanfs/node/node_modules",
     },
     {
@@ -51602,51 +51800,51 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 4,
+      "id": 6,
       "path": "node_modules/@next/eslint-plugin-next/node_modules",
     },
     {
       "dependencies": {
         "ignore": {
           "id": 87,
-          "package_id": 481,
+          "package_id": 482,
         },
       },
       "depth": 1,
-      "id": 5,
+      "id": 7,
       "path": "node_modules/@typescript-eslint/eslint-plugin/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 404,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 6,
+      "id": 8,
       "path": "node_modules/eslint-import-resolver-node/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 423,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 7,
+      "id": 9,
       "path": "node_modules/eslint-plugin-import/node_modules",
     },
     {
       "dependencies": {
         "resolve": {
           "id": 468,
-          "package_id": 485,
+          "package_id": 486,
         },
       },
       "depth": 1,
-      "id": 8,
+      "id": 10,
       "path": "node_modules/eslint-plugin-react/node_modules",
     },
     {
@@ -51657,7 +51855,7 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 9,
+      "id": 11,
       "path": "node_modules/sharp/node_modules",
     },
     {
@@ -51668,47 +51866,47 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 10,
+      "id": 12,
       "path": "node_modules/@puppeteer/browsers/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 224,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 11,
+      "id": 13,
       "path": "node_modules/chokidar/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 487,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 1,
-      "id": 12,
+      "id": 14,
       "path": "node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "glob-parent": {
           "id": 1025,
-          "package_id": 483,
+          "package_id": 484,
         },
       },
       "depth": 2,
-      "id": 13,
+      "id": 15,
       "path": "node_modules/@next/eslint-plugin-next/node_modules/fast-glob/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 121,
-          "package_id": 482,
+          "package_id": 483,
         },
         "semver": {
           "id": 122,
@@ -51716,7 +51914,7 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 14,
+      "id": 16,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules",
     },
     {
@@ -51727,96 +51925,118 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 15,
+      "id": 17,
       "path": "node_modules/is-bun-module/node_modules",
     },
     {
       "dependencies": {
         "picomatch": {
           "id": 912,
-          "package_id": 490,
+          "package_id": 491,
         },
       },
       "depth": 1,
-      "id": 16,
+      "id": 18,
       "path": "node_modules/tinyglobby/node_modules",
     },
     {
       "dependencies": {
         "debug": {
           "id": 417,
-          "package_id": 484,
+          "package_id": 485,
         },
       },
       "depth": 1,
-      "id": 17,
+      "id": 19,
       "path": "node_modules/eslint-module-utils/node_modules",
     },
     {
       "dependencies": {
         "minimatch": {
           "id": 530,
-          "package_id": 482,
+          "package_id": 483,
         },
       },
       "depth": 1,
-      "id": 18,
+      "id": 20,
       "path": "node_modules/glob/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 19,
+      "id": 21,
       "path": "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules",
+    },
+    {
+      "dependencies": {
+        "@types/node": {
+          "id": 80,
+          "package_id": 481,
+        },
+      },
+      "depth": 1,
+      "id": 22,
+      "path": "node_modules/@types/yauzl/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 20,
+      "id": 23,
       "path": "node_modules/string-width/node_modules",
     },
     {
       "dependencies": {
         "brace-expansion": {
-          "id": 1028,
-          "package_id": 493,
+          "id": 1029,
+          "package_id": 495,
         },
       },
       "depth": 2,
-      "id": 21,
+      "id": 24,
       "path": "node_modules/glob/node_modules/minimatch/node_modules",
     },
     {
       "dependencies": {
         "lru-cache": {
           "id": 687,
-          "package_id": 487,
+          "package_id": 488,
         },
       },
       "depth": 1,
-      "id": 22,
+      "id": 25,
       "path": "node_modules/path-scurry/node_modules",
     },
     {
       "dependencies": {
         "is-arrayish": {
           "id": 818,
-          "package_id": 488,
+          "package_id": 489,
         },
       },
       "depth": 1,
-      "id": 23,
+      "id": 26,
       "path": "node_modules/simple-swizzle/node_modules",
+    },
+    {
+      "dependencies": {
+        "undici-types": {
+          "id": 1028,
+          "package_id": 494,
+        },
+      },
+      "depth": 2,
+      "id": 27,
+      "path": "node_modules/@types/yauzl/node_modules/@types/node/node_modules",
     },
     {
       "dependencies": {
@@ -51834,40 +52054,40 @@ exports[`next build works: node 1`] = `
         },
       },
       "depth": 1,
-      "id": 24,
+      "id": 28,
       "path": "node_modules/@isaacs/cliui/node_modules",
     },
     {
       "dependencies": {
         "emoji-regex": {
           "id": 829,
-          "package_id": 489,
+          "package_id": 490,
         },
       },
       "depth": 1,
-      "id": 25,
+      "id": 29,
       "path": "node_modules/string-width-cjs/node_modules",
     },
     {
       "dependencies": {
         "ansi-regex": {
           "id": 1019,
-          "package_id": 491,
+          "package_id": 492,
         },
       },
       "depth": 2,
-      "id": 26,
+      "id": 30,
       "path": "node_modules/@isaacs/cliui/node_modules/strip-ansi/node_modules",
     },
     {
       "dependencies": {
         "ansi-styles": {
           "id": 1020,
-          "package_id": 492,
+          "package_id": 493,
         },
       },
       "depth": 2,
-      "id": 27,
+      "id": 31,
       "path": "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules",
     },
   ],

--- a/test/js/third_party/next-auth/fixture/bun.lock
+++ b/test/js/third_party/next-auth/fixture/bun.lock
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
+        "@types/node": "25.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -182,7 +182,7 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@20.17.36", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-Tg//WZ9Jk/vhzB5AhL/8nW+2IwHGLN0nhh/gvIEDqBhVJ+ST930PoQASdHTjuZG/k57LghpPa5RopUGf4wVdFA=="],
+    "@types/node": ["@types/node@25.0.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew=="],
 
     "@types/react": ["@types/react@19.1.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw=="],
 
@@ -854,7 +854,7 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 

--- a/test/js/third_party/next-auth/fixture/package.json
+++ b/test/js/third_party/next-auth/fixture/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "25.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/test/package.json
+++ b/test/package.json
@@ -120,6 +120,7 @@
     "bd": "BUN_DEBUG_QUIET_LOGS=1 bun --silent bd:v"
   },
   "resolutions": {
-    "react": "../node_modules/react"
+    "react": "../node_modules/react",
+    "@types/node": "25.0.0"
   }
 }


### PR DESCRIPTION
more accurately, developers cannot pass a value when expect values resolve to never. this is easy to fall into when using the `toContainKey*` matchers. falling back to PropertyKey when this happens is a sensible/reasonable default

### What does this PR do?

fixes #25456, cc @MonsterDeveloper
fixes #25461

### How did you verify your code works?

bun types integration test