### PR TITLE
feat(bundler): restrict feature() to sole condition of if/ternary

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1194,10 +1194,31 @@ var mode = "free";
 **Key behaviors:**
 
 - `feature()` requires a string literal argument — dynamic values are not supported
+- `feature()` can only be used as the **sole condition** of an `if` statement or ternary expression — this guarantees dead-code elimination
 - The `bun:bundle` import is completely removed from the output
 - Works with `bun build`, `bun run`, and `bun test`
 - Multiple flags can be enabled: `--feature FLAG_A --feature FLAG_B`
 - For type safety, augment the `Registry` interface to restrict `feature()` to known flags (see below)
+
+**Important restrictions:**
+
+For security, `feature()` must be used directly as a condition to ensure reliable dead-code elimination. The following patterns are **not allowed** and will produce an error:
+
+```ts
+// Variable assignment - NOT ALLOWED
+const FLAG = feature("SECRET");
+
+// Complex expressions - NOT ALLOWED
+if (feature("FLAG") || isAdmin) { ... }
+
+// Function arguments - NOT ALLOWED
+if (check(feature("FLAG"))) { ... }
+
+// Re-exporting - NOT ALLOWED
+export const FLAG = feature("SECRET");
+```
+
+These restrictions ensure that when a feature flag is disabled, the gated code is guaranteed to be completely removed from the bundle.
 
 **Use cases:**
 

--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -190,6 +190,13 @@ pub fn NewParser_(
         /// a boolean based on whether the feature flag is enabled.
         bundler_feature_flag_ref: Ref = Ref.None,
 
+        /// Tracks the specific E.Call that is allowed to be a feature() call. This is set to
+        /// the condition's call expression when visiting an if/ternary whose condition IS directly
+        /// a call expression. When maybeReplaceBundlerFeatureCall runs, it verifies the call
+        /// matches this pointer. This ensures feature() can only be used as the direct condition,
+        /// not nested inside other expressions or as an argument to another function.
+        feature_flag_allowed_call: ?*E.Call = null,
+
         scopes_in_order_visitor_index: usize = 0,
         has_classic_runtime_warned: bool = false,
         macro_call_count: MacroCallCountType = 0,


### PR DESCRIPTION
## Summary

For security, `feature()` from `bun:bundle` can now only be used as the direct condition of an `if` statement or ternary expression. This ensures guaranteed dead-code elimination when features are disabled, preventing accidental exposure of feature-gated code.

### Disallowed patterns that now produce an error:

```ts
// Variable assignment - NOT ALLOWED
const FLAG = feature("SECRET");

// Complex expressions - NOT ALLOWED
if (feature("FLAG") || isAdmin) { ... }

// Function arguments - NOT ALLOWED
if (check(feature("FLAG"))) { ... }

// Re-exporting - NOT ALLOWED
export const FLAG = feature("SECRET");

// Importing and using through a variable in another module - NOT ALLOWED
// a.ts: export const FLAG = feature("TEST");
// b.ts: import { FLAG } from './a.ts'; if (FLAG) ...
```

### Allowed patterns:

```ts
// Direct if condition - ALLOWED
if (feature("FLAG")) { ... }

// Direct ternary condition - ALLOWED  
const result = feature("FLAG") ? "yes" : "no";

// Multiple separate if statements - ALLOWED
if (feature("FLAG_A")) { ... }
if (feature("FLAG_B")) { ... }
```

## Implementation

- Added `feature_flag_allowed_call: ?*E.Call` field to parser to track the specific call expression that is allowed to be a feature() call
- Modified `s_if` (statement visitor) and `e_if` (ternary visitor) to set this field when the condition IS a direct call expression
- Updated `maybeReplaceBundlerFeatureCall` to verify the current call matches the allowed call pointer

## Test plan

- [x] Added 10 new error case tests for disallowed patterns
- [x] Updated existing tests that used disallowed patterns (MultipleFlags, ImportRemoved) to use allowed patterns
- [x] All 36 tests pass
- [x] Updated documentation with restrictions section

🤖 Generated with [Claude Code](https://claude.com/claude-code)