### PR TITLE
fix: use LLVM unstable repo for Debian trixie/forky [build images]

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1157,7 +1157,18 @@ install_llvm() {
 	apt)
 		bash="$(require bash)"
 		llvm_script="$(download_file "https://apt.llvm.org/llvm.sh")"
-		execute_sudo "$bash" "$llvm_script" "$(llvm_version)" all
+
+		# Debian trixie and newer don't have their own LLVM apt repo, use unstable
+		llvm_codename_arg=""
+		if [ "$distro" = "debian" ]; then
+			case "$VERSION_CODENAME" in
+			trixie|forky)
+				llvm_codename_arg="-n=unstable"
+				;;
+			esac
+		fi
+
+		execute_sudo "$bash" "$llvm_script" "$(llvm_version)" all $llvm_codename_arg
 
 		# Install llvm-symbolizer explicitly to ensure it's available for ASAN
 		install_packages "llvm-$(llvm_version)-tools"


### PR DESCRIPTION
## Summary
- Fix Docker image build failure on Debian trixie by using LLVM's `unstable` repository instead of the non-existent `trixie` repository
- The LLVM apt repository (`apt.llvm.org`) doesn't have packages for Debian trixie (13) or forky - attempts to access `llvm-toolchain-trixie-19` return 404
- Pass `-n=unstable` flag to `llvm.sh` when running on these Debian versions

## Test plan
- [ ] Verify the Docker image build succeeds at https://github.com/oven-sh/bun-development-docker-image/actions

Fixes the build failure from: https://github.com/oven-sh/bun-development-docker-image/actions/runs/20105199193

Error was:
```
E: The repository 'http://apt.llvm.org/trixie llvm-toolchain-trixie-19 Release' does not have a Release file.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)