### PR TITLE
feat(shell): add AbortSignal support via .signal() method

### DIFF
--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -202,6 +202,42 @@ declare module "bun" {
        * By default, this is configured to `true`.
        */
       throws(shouldThrow: boolean): this;
+
+      /**
+       * Attach an AbortSignal to cancel this shell command.
+       *
+       * When the signal aborts:
+       * - All processes in the pipeline are terminated with SIGTERM
+       * - The promise rejects with an AbortError (DOMException)
+       * - If `.nothrow()` was used, resolves with exit code 143 (128 + SIGTERM)
+       *
+       * @param signal - The AbortSignal to attach
+       * @returns this - for method chaining
+       * @throws Error if the shell has already started executing
+       *
+       * @example
+       * **Timeout after 5 seconds**
+       * ```ts
+       * await $`long-running-command`.signal(AbortSignal.timeout(5000));
+       * ```
+       *
+       * @example
+       * **Manual cancellation**
+       * ```ts
+       * const controller = new AbortController();
+       * const promise = $`sleep 100`.signal(controller.signal);
+       * setTimeout(() => controller.abort(), 1000);
+       * await promise; // Rejects with AbortError after 1 second
+       * ```
+       *
+       * @example
+       * **With nothrow - returns exit code instead of throwing**
+       * ```ts
+       * const result = await $`sleep 100`.nothrow().signal(AbortSignal.timeout(1000));
+       * console.log(result.exitCode); // 143 (128 + 15)
+       * ```
+       */
+      signal(signal: AbortSignal): this;
     }
 
     /**

--- a/src/bun.js/api/ParsedShellScript.classes.ts
+++ b/src/bun.js/api/ParsedShellScript.classes.ts
@@ -25,6 +25,10 @@ export default [
         fn: "setQuiet",
         length: 1,
       },
+      setSignal: {
+        fn: "setSignal",
+        length: 1,
+      },
     },
   }),
 ];

--- a/src/shell/builtin/cat.zig
+++ b/src/shell/builtin/cat.zig
@@ -69,6 +69,11 @@ pub fn start(this: *Cat) Yield {
 }
 
 pub fn next(this: *Cat) Yield {
+    // Check for abort before processing next file
+    if (this.bltn().parentCmd().base.interpreter.isAborted()) {
+        return this.bltn().done(128 + @intFromEnum(bun.SignalCode.SIGTERM));
+    }
+
     switch (this.state) {
         .idle => @panic("Invalid state"),
         .exec_stdin => {

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -125,6 +125,11 @@ pub fn ignoreEbusyErrorIfPossible(this: *Cp) Yield {
 
 pub fn next(this: *Cp) Yield {
     while (this.state != .done) {
+        // Check for abort before continuing
+        if (this.bltn().parentCmd().base.interpreter.isAborted()) {
+            return this.bltn().done(128 + @intFromEnum(bun.SignalCode.SIGTERM));
+        }
+
         switch (this.state) {
             .idle => @panic("Invalid state for \"Cp\": idle, this indicates a bug in Bun. Please file a GitHub issue"),
             .exec => {

--- a/src/shell/builtin/seq.zig
+++ b/src/shell/builtin/seq.zig
@@ -86,6 +86,11 @@ fn do(this: *@This()) Yield {
     defer arena.deinit();
 
     while (if (this.increment > 0) current <= this._end else current >= this._end) : (current += this.increment) {
+        // Check for abort before continuing
+        if (this.bltn().parentCmd().base.interpreter.isAborted()) {
+            return this.bltn().done(128 + @intFromEnum(bun.SignalCode.SIGTERM));
+        }
+
         const str = bun.handleOom(std.fmt.allocPrint(arena.allocator(), "{d}", .{current}));
         defer _ = arena.reset(.retain_capacity);
         _ = this.print(str);

--- a/src/shell/builtin/yes.zig
+++ b/src/shell/builtin/yes.zig
@@ -84,6 +84,11 @@ pub fn start(this: *@This()) Yield {
 /// We write 4 8kb chunks and then suspend execution to the task.
 /// This is to avoid blocking the main thread forever.
 fn writeNoIO(this: *@This()) Yield {
+    // Check for abort before continuing the infinite loop
+    if (this.bltn().parentCmd().base.interpreter.isAborted()) {
+        return this.bltn().done(128 + @intFromEnum(bun.SignalCode.SIGTERM));
+    }
+
     if (this.writeOnceNoIO(this.buffer[0..this.buffer_used])) |yield| return yield;
     if (this.writeOnceNoIO(this.buffer[0..this.buffer_used])) |yield| return yield;
     if (this.writeOnceNoIO(this.buffer[0..this.buffer_used])) |yield| return yield;

--- a/test/js/bun/shell/shell-abort.test.ts
+++ b/test/js/bun/shell/shell-abort.test.ts
@@ -1,0 +1,265 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("Shell AbortSignal", () => {
+  describe("Basic abort tests", () => {
+    test("AbortController.abort() rejects with AbortError", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 10`.signal(controller.signal);
+
+      // Abort after a short delay
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      // Use try/catch pattern instead of expect().rejects to avoid deadlock
+      let caught: any;
+      try {
+        await promise;
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("AbortError");
+      expect(caught.message).toBe("The operation was aborted.");
+    });
+
+    test("AbortSignal.timeout() rejects with TimeoutError", async () => {
+      const sig = AbortSignal.timeout(100);
+
+      let caught: any;
+      try {
+        await $`sleep 10`.signal(sig);
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("TimeoutError");
+    });
+
+    test("nothrow() resolves with exit code 143 on abort", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 10`.nothrow().signal(controller.signal);
+
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      const result = await promise;
+      expect(result.exitCode).toBe(143); // 128 + SIGTERM (15)
+    });
+
+    test("custom abort reason is preserved", async () => {
+      const controller = new AbortController();
+      const customError = new Error("Custom abort reason");
+
+      const promise = $`sleep 10`.signal(controller.signal);
+
+      setTimeout(() => {
+        controller.abort(customError);
+      }, 50);
+
+      let caught: any;
+      try {
+        await promise;
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBe(customError);
+    });
+  });
+
+  describe("Already-aborted signal tests", () => {
+    test("already-aborted signal rejects immediately without spawning", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const start = Date.now();
+
+      let caught: any;
+      try {
+        await $`sleep 10`.signal(controller.signal);
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      // Should be nearly instant since no process was spawned
+      expect(Date.now() - start).toBeLessThan(1000);
+      expect(caught.name).toBe("AbortError");
+    });
+
+    test("already-aborted signal with nothrow resolves with exit code 143", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await $`sleep 10`.nothrow().signal(controller.signal);
+      expect(result.exitCode).toBe(143);
+    });
+  });
+
+  describe("Pipeline tests", () => {
+    test("abort kills all processes in pipeline", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 10 | cat | cat`.signal(controller.signal);
+
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      let caught: any;
+      try {
+        await promise;
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("AbortError");
+    });
+  });
+
+  describe("Helper method tests", () => {
+    test(".text() rejects on abort", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 10`.signal(controller.signal).text();
+
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      let caught: any;
+      try {
+        await promise;
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("AbortError");
+    });
+
+    test(".lines() rejects on abort", async () => {
+      const controller = new AbortController();
+
+      const shellPromise = $`sleep 10`.signal(controller.signal);
+      const linesPromise = (async () => {
+        const lines: string[] = [];
+        for await (const line of shellPromise.lines()) {
+          lines.push(line);
+        }
+        return lines;
+      })();
+
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      let caught: any;
+      try {
+        await linesPromise;
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("AbortError");
+    });
+
+    test(".json() rejects on abort", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 10 && echo '{"test": true}'`.signal(controller.signal).json();
+
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      let caught: any;
+      try {
+        await promise;
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("AbortError");
+    });
+  });
+
+  describe("Edge case tests", () => {
+    test("signal fires after process exits normally - not treated as abort", async () => {
+      const controller = new AbortController();
+
+      // Fast command that should complete before abort
+      const result = await $`echo hello`.nothrow().signal(controller.signal);
+
+      // Abort after command completes
+      controller.abort();
+
+      // Should have exit code 0, not 143
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.toString().trim()).toBe("hello");
+    });
+
+    test("calling signal() after shell has started throws", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 1`;
+      promise.run(); // Start the shell
+
+      expect(() => {
+        promise.signal(controller.signal);
+      }).toThrow("Shell is already running");
+    });
+  });
+
+  describe("Promise combinator tests", () => {
+    test("Promise.race() does not cancel shell command", async () => {
+      const controller = new AbortController();
+      const start = Date.now();
+
+      // Shell command takes 2 seconds, other promise resolves immediately
+      const result = await Promise.race([$`sleep 2`.nothrow().signal(controller.signal), Promise.resolve("fast")]);
+
+      expect(result).toBe("fast");
+
+      // The shell should still be running in the background
+      // This just verifies Promise.race doesn't cancel the shell
+      expect(Date.now() - start).toBeLessThan(500);
+
+      // Now abort to clean up
+      controller.abort();
+    });
+  });
+
+  describe("AbortError properties tests", () => {
+    test("AbortError has correct name property", async () => {
+      const controller = new AbortController();
+
+      const promise = $`sleep 10`.signal(controller.signal);
+      setTimeout(() => {
+        controller.abort();
+      }, 50);
+
+      let caught: any;
+      try {
+        await promise;
+        expect.unreachable("Should have thrown");
+      } catch (e: any) {
+        caught = e;
+      }
+
+      expect(caught.name).toBe("AbortError");
+      expect(caught instanceof DOMException).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds AbortSignal support to the Bun shell API (`$`) via a new `.signal()` fluent method, enabling cancellation and timeout support for shell commands.

Closes #18247

## Motivation

The Bun shell API (`$`) exposes a high-level, ergonomic interface for spawning pipelines of shell commands. However, it previously lacked the ability to integrate with `AbortSignal`, making it difficult to:

- Implement timeouts for shell commands
- Implement cancellable shell operations  
- Participate in user-driven abort workflows
- Compose shell commands with modern async patterns involving cancellation

Lower-level APIs like `Bun.spawn` already support `AbortSignal`, but the `$` shell layer did not—until now.

## API

```typescript
// Timeout after 5 seconds
await $`long-running-command`.signal(AbortSignal.timeout(5000));

// Manual cancellation
const controller = new AbortController();
const promise = $`sleep 100`.signal(controller.signal);
setTimeout(() => controller.abort(), 1000);
await promise; // Rejects with AbortError after 1 second

// With nothrow - returns exit code instead of throwing
const result = await $`sleep 100`.nothrow().signal(AbortSignal.timeout(1000));
console.log(result.exitCode); // 143 (128 + SIGTERM)
```

## Behavioral Semantics

### Default behavior (throwing)
When the signal aborts, the `ShellPromise` rejects with an `AbortError` (`DOMException`), matching the behavior of `fetch` and `Bun.spawn`:

```typescript
try {
  await $`sleep 20`.signal(AbortSignal.timeout(100));
} catch (err) {
  // err.name === "AbortError"
  // err.message === "The operation was aborted."
}
```

### With `.nothrow()`
The command resolves normally with exit code 143 (128 + SIGTERM):

```typescript
const result = await $`sleep 20`.nothrow().signal(AbortSignal.timeout(100));
// result.exitCode === 143
```

### Custom abort reasons
Custom abort reasons are preserved:

```typescript
const controller = new AbortController();
controller.abort(new Error("Custom reason"));
// The promise rejects with the custom Error
```

### Already-aborted signals
Passing an already-aborted signal rejects immediately without spawning any processes.

### Pipelines
Aborting kills all processes in the pipeline (`cmd1 | cmd2 | cmd3`).

### Helper methods
Works with `.text()`, `.lines()`, `.json()` - they propagate the abort rejection.

## Implementation Details

### JavaScript Layer (`src/js/builtins/shell.ts`)
- Added `#signal`, `#abortedByUs`, and `#alreadyAborted` private fields to `ShellPromise`
- Added `.signal()` method that:
  - Validates the shell hasn't started yet (`#throwIfRunning()`)
  - Detects already-aborted signals and short-circuits without spawning
  - Registers an abort listener that sets `#abortedByUs` flag
  - Passes the signal to Zig via `setSignal()`
- Modified the resolve callback to check for abort conditions and reject with `AbortError` when appropriate

### Zig Layer (`src/shell/interpreter.zig`)
- Added `abort_signal` field and `aborted` flag to `Interpreter` struct
- Added `active_subprocesses` registry (using `ArrayListUnmanaged`)
- Implemented `registerSubprocess()` / `unregisterSubprocess()` methods
- Implemented `onAbortSignal()` callback that:
  - Sets the `aborted` flag
  - Calls `abortAllCommands()` to SIGTERM all registered subprocesses
  - Cleans up the signal reference
- Added `isAborted()` check used by builtins and spawn points

### Subprocess Management (`src/shell/states/Cmd.zig`)
- Added abort check before spawning new processes
- Registered subprocesses with interpreter after successful spawn
- Unregistered subprocesses in `deinit()`

### Async Commands (`src/shell/states/Async.zig`)
- Added abort checks to prevent spawning background commands after abort

### Builtin Cooperative Cancellation
Added `isAborted()` checks at yield points in long-running builtins:
- `yes.zig` - in the infinite write loop
- `cat.zig` - in the file read loop
- `cp.zig` - before copy tasks
- `seq.zig` - in the number generation loop

### Type Definitions (`packages/bun-types/shell.d.ts`)
- Added `.signal()` method with full JSDoc documentation

## Test Plan

Added comprehensive test suite in `test/js/bun/shell/shell-abort.test.ts` (14 tests):

- **Basic abort tests**
  - `AbortController.abort()` rejects with `AbortError`
  - `AbortSignal.timeout()` rejects with `TimeoutError`
  - `.nothrow()` resolves with exit code 143 on abort
  - Custom abort reason is preserved

- **Already-aborted signal tests**
  - Already-aborted signal rejects immediately without spawning
  - Already-aborted signal with `.nothrow()` resolves with exit code 143

- **Pipeline tests**
  - Abort kills all processes in pipeline

- **Helper method tests**
  - `.text()` rejects on abort
  - `.lines()` rejects on abort  
  - `.json()` rejects on abort

- **Edge case tests**
  - Signal fires after process exits normally - not treated as abort
  - Calling `.signal()` after shell has started throws

- **Promise combinator tests**
  - `Promise.race()` does not cancel shell command (preserves JS semantics)

- **AbortError properties tests**
  - `AbortError` has correct `name` property and is instance of `DOMException`

## Files Changed

| File | Changes |
|------|---------|
| `packages/bun-types/shell.d.ts` | TypeScript type definitions for `.signal()` |
| `src/bun.js/api/ParsedShellScript.classes.ts` | Added `setSignal` binding |
| `src/js/builtins/shell.ts` | JS layer signal handling |
| `src/shell/ParsedShellScript.zig` | Signal storage and transfer |
| `src/shell/interpreter.zig` | Core abort infrastructure |
| `src/shell/states/Async.zig` | Background command abort checks |
| `src/shell/states/Cmd.zig` | Subprocess registration/abort checks |
| `src/shell/builtin/yes.zig` | Cooperative cancellation |
| `src/shell/builtin/cat.zig` | Cooperative cancellation |
| `src/shell/builtin/cp.zig` | Cooperative cancellation |
| `src/shell/builtin/seq.zig` | Cooperative cancellation |
| `test/js/bun/shell/shell-abort.test.ts` | Comprehensive test suite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)