### PR TITLE
Add WebSocket support for Unix domain sockets

### DIFF
--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -583,7 +583,7 @@ ZIG_DECL WebSocketHTTPClient* Bun__WebSocketHTTPClient__connect(
     const ZigString* proxyAuthorization,
     ZigString* proxyHeaderNames, ZigString* proxyHeaderValues, size_t proxyHeaderCount,
     void* sslConfig, bool targetIsSecure,
-    const ZigString* targetAuthorization);
+    const ZigString* targetAuthorization, bool isUnix);
 ZIG_DECL void Bun__WebSocketHTTPClient__register(JSC::JSGlobalObject* arg0, void* arg1, void* arg2);
 ZIG_DECL size_t Bun__WebSocketHTTPClient__memoryCost(WebSocketHTTPClient* arg0);
 #endif
@@ -599,7 +599,7 @@ ZIG_DECL WebSocketHTTPSClient* Bun__WebSocketHTTPSClient__connect(
     const ZigString* proxyAuthorization,
     ZigString* proxyHeaderNames, ZigString* proxyHeaderValues, size_t proxyHeaderCount,
     void* sslConfig, bool targetIsSecure,
-    const ZigString* targetAuthorization);
+    const ZigString* targetAuthorization, bool isUnix);
 ZIG_DECL void Bun__WebSocketHTTPSClient__register(JSC::JSGlobalObject* arg0, void* arg1, void* arg2);
 ZIG_DECL size_t Bun__WebSocketHTTPSClient__memoryCost(WebSocketHTTPSClient* arg0);
 

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -592,8 +592,9 @@ pub fn NewSocketHandler(comptime is_ssl: bool) type {
             comptime Context: type,
             ctx: *Context,
             comptime socket_field_name: []const u8,
+            allowHalfOpen: bool,
         ) !*Context {
-            const this_socket = try connectUnixAnon(path, socket_ctx, ctx);
+            const this_socket = try connectUnixAnon(path, socket_ctx, ctx, allowHalfOpen);
             @field(ctx, socket_field_name) = this_socket;
             return ctx;
         }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -102,6 +102,12 @@ function normalizeData(data, opts) {
     data = Buffer.from(data);
   } else if (isBinary === false && $isTypedArrayView(data)) {
     data = new Buffer(data.buffer, data.byteOffset, data.byteLength).toString("utf-8");
+  } else if ($isTypedArrayView(data) && data.buffer instanceof SharedArrayBuffer) {
+    // Native WebSocket.send() doesn't accept SharedArrayBuffer-backed views.
+    // v8.serialize() returns a Buffer backed by SharedArrayBuffer, so we need
+    // to copy the data to a regular ArrayBuffer-backed Uint8Array.
+    // For DataView, construct Uint8Array using buffer+offset+length, then slice to copy.
+    data = new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice();
   }
 
   return data;

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -7,6 +7,7 @@ import { bunEnv, bunExe } from "harness";
 import { createServer } from "http";
 import { AddressInfo, connect } from "net";
 import path from "node:path";
+import * as v8 from "node:v8";
 import { Server, WebSocket, WebSocketServer } from "ws";
 
 const strings = [
@@ -144,6 +145,19 @@ describe("WebSocket", () => {
         });
       });
     }
+    test("SharedArrayBuffer-backed Buffer (v8.serialize)", (ws, done) => {
+      ws.on("open", () => {
+        const data = v8.serialize({ test: "hello" });
+        expect(data.buffer).toBeInstanceOf(SharedArrayBuffer);
+        ws.send(data);
+      });
+      ws.on("message", (data, isBinary) => {
+        expect(isBinary).toBeTrue();
+        const decoded = v8.deserialize(data);
+        expect(decoded).toEqual({ test: "hello" });
+        done();
+      });
+    });
   });
   describe("ping()", () => {
     test("(no argument)", (ws, done) => {

--- a/test/js/web/websocket/websocket-unix.test.ts
+++ b/test/js/web/websocket/websocket-unix.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+describe("WebSocket over Unix domain sockets", () => {
+  test("should connect using ws+unix:// URL scheme", async () => {
+    using dir = tempDir("websocket-unix", {});
+    const socketPath = join(String(dir), "test.sock");
+
+    const server = Bun.serve({
+      port: 0,
+      unix: socketPath,
+      websocket: {
+        open(ws) {
+          ws.send("Hello from server");
+        },
+        message(ws, message) {
+          ws.send(`Echo: ${message}`);
+        },
+      },
+      fetch(req, server) {
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Expected WebSocket upgrade", { status: 400 });
+      },
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const ws = new WebSocket(`ws+unix://${socketPath.replaceAll("\\", "/")}:/`);
+
+      let messagesReceived: string[] = [];
+
+      ws.onopen = () => {
+        ws.send("Hello from client");
+      };
+
+      ws.onmessage = event => {
+        messagesReceived.push(event.data);
+        if (messagesReceived.length === 2) {
+          resolve("success");
+        }
+      };
+
+      ws.onerror = event => {
+        reject(new Error(`WebSocket error: ${event}`));
+      };
+
+      await promise;
+
+      expect(messagesReceived).toEqual(["Hello from server", "Echo: Hello from client"]);
+
+      ws.close();
+    } finally {
+      server.stop();
+      try {
+        unlinkSync(socketPath);
+      } catch {}
+    }
+  });
+
+  test("should fail gracefully on invalid ws+unix:// URL", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const ws = new WebSocket("ws+unix:///nonexistent/socket.sock:/");
+
+    ws.onerror = () => {
+      resolve();
+    };
+
+    ws.onopen = () => {
+      reject(new Error("Should not have connected to nonexistent socket"));
+    };
+
+    await promise;
+  });
+
+  test("should handle query string in ws+unix:// URL", async () => {
+    using dir = tempDir("websocket-unix-query", {});
+    const socketPath = join(String(dir), "test.sock");
+
+    let receivedUrl = "";
+    const server = Bun.serve({
+      port: 0,
+      unix: socketPath,
+      websocket: {
+        open(ws) {
+          ws.send("connected");
+        },
+      },
+      fetch(req, server) {
+        receivedUrl = req.url;
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Expected WebSocket upgrade", { status: 400 });
+      },
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const ws = new WebSocket(`ws+unix://${socketPath.replaceAll("\\", "/")}:/api/endpoint?foo=bar&baz=qux`);
+
+      ws.onmessage = () => {
+        resolve();
+      };
+
+      ws.onerror = event => {
+        reject(new Error(`WebSocket error: ${event}`));
+      };
+
+      await promise;
+
+      expect(receivedUrl).toContain("/api/endpoint?foo=bar&baz=qux");
+
+      ws.close();
+    } finally {
+      server.stop();
+      try {
+        unlinkSync(socketPath);
+      } catch {}
+    }
+  });
+
+  test("should handle empty path after colon in ws+unix:// URL", async () => {
+    using dir = tempDir("websocket-unix-empty-path", {});
+    const socketPath = join(String(dir), "test.sock");
+
+    let receivedPath = "";
+    const server = Bun.serve({
+      port: 0,
+      unix: socketPath,
+      websocket: {
+        open(ws) {
+          ws.send("connected");
+        },
+      },
+      fetch(req, server) {
+        const url = new URL(req.url);
+        receivedPath = url.pathname + url.search;
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Expected WebSocket upgrade", { status: 400 });
+      },
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const ws = new WebSocket(`ws+unix://${socketPath.replaceAll("\\", "/")}:`);
+
+      ws.onmessage = () => {
+        resolve();
+      };
+
+      ws.onerror = event => {
+        reject(new Error(`WebSocket error: ${event}`));
+      };
+
+      await promise;
+
+      expect(receivedPath).toMatch(/\/$/);
+
+      ws.close();
+    } finally {
+      server.stop();
+      try {
+        unlinkSync(socketPath);
+      } catch {}
+    }
+  });
+
+  test("should handle path without leading slash in ws+unix:// URL", async () => {
+    using dir = tempDir("websocket-unix-no-slash", {});
+    const socketPath = join(String(dir), "test.sock");
+
+    let receivedPath = "";
+    const server = Bun.serve({
+      port: 0,
+      unix: socketPath,
+      websocket: {
+        open(ws) {
+          ws.send("connected");
+        },
+      },
+      fetch(req, server) {
+        const url = new URL(req.url);
+        receivedPath = url.pathname + url.search;
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Expected WebSocket upgrade", { status: 400 });
+      },
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const ws = new WebSocket(`ws+unix://${socketPath.replaceAll("\\", "/")}:api/test`);
+
+      ws.onmessage = () => {
+        resolve();
+      };
+
+      ws.onerror = event => {
+        reject(new Error(`WebSocket error: ${event}`));
+      };
+
+      await promise;
+
+      expect(receivedPath).toMatch(/\/api\/test$/);
+
+      ws.close();
+    } finally {
+      server.stop();
+      try {
+        unlinkSync(socketPath);
+      } catch {}
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds WebSocket support for Unix sockets using `ws+unix://` URLs. Follows the [websockets/ws standard](https://github.com/websockets/ws/blob/master/doc/ws.md#ipc-connections) format: `ws+unix://socket_path:request_path`.

### How did you verify your code works?

Tested on existing non-public node-based project with workers, and it succeeded.

Added tests in `test/js/web/websocket/websocket-unix.test.ts`:

Before
```
> BUN_DEBUG_QUIET_LOGS=1 bun test test/js/web/websocket/websocket-unix.test.ts
bun test v1.2.23 (cf136713)

test/js/web/websocket/websocket-unix.test.ts:
27 |       },
28 |     });
29 | 
30 |     try {
31 |       const { promise, resolve, reject } = Promise.withResolvers<string>();
32 |       const ws = new WebSocket(`ws+unix://${socketPath}:/`);
                      ^
SyntaxError: Wrong url scheme for WebSocket ws+unix:///tmp/nix-shell.hDqnPp/websocket-unix_JoXXrM/test.sock:/
      at <anonymous> (bun/test/js/web/websocket/websocket-unix.test.ts:32:18)
      at <anonymous> (bun/test/js/web/websocket/websocket-unix.test.ts:7:54)
✗ WebSocket over Unix domain sockets > should connect using ws+unix:// URL scheme [6.00ms]
61 |     }
62 |   });
63 | 
64 |   test("should fail gracefully on invalid ws+unix:// URL", async () => {
65 |     const { promise, resolve, reject } = Promise.withResolvers<void>();
66 |     const ws = new WebSocket("ws+unix:///nonexistent/socket.sock:/");
                    ^
SyntaxError: Wrong url scheme for WebSocket ws+unix:///nonexistent/socket.sock:/
      at <anonymous> (bun/test/js/web/websocket/websocket-unix.test.ts:66:16)
      at <anonymous> (bun/test/js/web/websocket/websocket-unix.test.ts:64:60)
✗ WebSocket over Unix domain sockets > should fail gracefully on invalid ws+unix:// URL

 0 pass
 2 fail
Ran 2 tests across 1 file. [132.00ms]
```

After
```
> BUN_DEBUG_QUIET_LOGS=1 build/debug/bun-debug test test/js/web/websocket/websocket-unix.test.ts
bun test v1.3.5 (7dcd49f8)
WARNING: ASAN interferes with JSC signal handlers; useWasmFastMemory and useWasmFaultSignalHandler will be disabled.

test/js/web/websocket/websocket-unix.test.ts:
✓ WebSocket over Unix domain sockets > should connect using ws+unix:// URL scheme [128.00ms]
✓ WebSocket over Unix domain sockets > should fail gracefully on invalid ws+unix:// URL [10.00ms]

 2 pass
 0 fail
 1 expect() calls
Ran 2 tests across 1 file. [3.56s]
```

fixes https://github.com/oven-sh/bun/issues/4423

