### PR TITLE
fix(vscode): debugger not working on Windows when application is running in Docker

### DIFF
--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -581,8 +581,8 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
 
   async breakpointLocations(request: DAP.BreakpointLocationsRequest): Promise<DAP.BreakpointLocationsResponse> {
     const { line, endLine, column, endColumn, source: source0 } = request;
-    if (process.platform === "win32") {
-      source0.path = source0.path ? normalizeWindowsPath(source0.path) : source0.path;
+    if (process.platform === "win32" && source0.path && !source0.path.startsWith("/")) {
+      source0.path = normalizeWindowsPath(source0.path);
     }
     const source = await this.#getSource(sourceToId(source0));
 
@@ -688,8 +688,8 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
   }
 
   async #setBreakpointsByUrl(url: string, requests: DAP.SourceBreakpoint[], unsetOld?: boolean): Promise<Breakpoint[]> {
-    if (process.platform === "win32") {
-      url = url ? normalizeWindowsPath(url) : url;
+    if (process.platform === "win32" && url && !url.startsWith("/")) {
+      url = normalizeWindowsPath(url);
     }
     const source = this.#getSourceIfPresent(url);
 
@@ -1081,8 +1081,8 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
 
   async gotoTargets(request: DAP.GotoTargetsRequest): Promise<DAP.GotoTargetsResponse> {
     const { source: source0 } = request;
-    if (process.platform === "win32") {
-      source0.path = source0.path ? normalizeWindowsPath(source0.path) : source0.path;
+    if (process.platform === "win32" && source0.path && !source0.path.startsWith("/")) {
+      source0.path = normalizeWindowsPath(source0.path);
     }
     const source = await this.#getSource(sourceToId(source0));
 


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/24590

Supersedes https://github.com/oven-sh/bun/pull/24126
In my previous PR I only made `debugger;` statements work. Now breakpoints work as well.

### What does this PR do?

In https://github.com/oven-sh/bun/pull/19884 the vscode extension got the localRoot/remoteRoot debugger settings, but these options have no effect on Windows.

Since my team uses Windows and our code has to run in a Docker container it's impossible for us to debug using Bun. This fixes it.


### Details

#### mapRemoteToLocal
Before rebasing the path, this function makes sure that the target (`p`) starts with the `remoteRoot`.
This didn't work because of mixed path separators:
- the `p` argument on Windows is a relative path using backslashes
- `remoteRoot` is using forward-slashes for non-Windows remotes

-> The fix here was to do the comparison with normalized path separators.

#### mapLocalToRemote
Here, the mapping didn't work because of Windows drive-letters.
A typical `localRoot` configuration like `"${workspaceFolder}/backend"` comes out as `C:\Users\user\example-repository/backend`.
The mixed path separators aren't a problem here because on Windows, `path.normalize` replaces backslashes. But the drive-letter is uppercased, while the path in the `p` parameter has a lower-case drive letter.

-> So I made the `startsWith`-check case-insensitive.

I think that also helps with Windows paths being case-insensitive, but I'm not 100% sure if it's the correct behavior here - maybe we should only normalize the casing of the drive-letter?


#### breakpoints

The function `normalizeWindowsPath` assumes it's a Windows path, which is not the case when the code is running in a Docker container. Making sure to not call this function with non-Windows paths was the missing piece in my previous PR.





### How did you verify your code works?


I tested the extension with these files:

launch.json:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "bun",
            "request": "attach",
            "name": "Attach Bun",
            "url": "ws://localhost:6499/debug",
            "localRoot": "${workspaceFolder}/backend",
            "remoteRoot": "/app/backend",
        }
    ]
}
```
Dockerfile:
```Dockerfile
FROM oven/bun:1.3.4
WORKDIR /app/backend
COPY backend/ ./
CMD [ "bun", "run", "--inspect=0.0.0.0:6499/debug", "src/main.ts" ]
```

docker-compose.yml
```yml
services:
  bun-debug-test:
    build: .
    ports:
      - "6499:6499"
```

backend/src/main.ts:
```ts
console.log('hello world!');
setInterval(() => {
  debugger;
  const date = new Date();
  console.log(date);
}, 5000);
```

1. Start application
    ```sh
    docker compose up --build
    ```
2. Attach debugger with `F5`
3. Verified that the debugger stops on `debugger;` statements
4. Verified that setting breakpoints works and the debugger stops on them

_Side-note_: (I noticed that sometimes the breakpoints don't get verified when you create them before the debugger is attached. That's unrelated to this issue. So make sure you create them with the debugger already attached).


I only tested this on Windows. But my changes should have no effect on other platforms.

