### PR TITLE
fix(vscode): reliable breakpoint loading when attaching debugger

### DIFF
--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -725,7 +725,7 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
         }
       }
 
-      if (placeholderExists) {
+      if (placeholderExists || !source) {
         return requests.map(request =>
           this.#addFutureBreakpoint({
             breakpointId,

--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -711,9 +711,9 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
 
       const { breakpointId, locations } = result;
       if (locations.length) {
-        // If the locations-array is non-empty, it means the source was loaded
-        // while the placeholder breakpoint was being set.
-        // In that case we can discard this line-0 breakpoint and continue like normal.
+        // The source was loaded while the placeholder breakpoint was being set (race condition).
+        // In that case we need to discard the placeholder breakpoint and continue processing
+        // the breakpoints, or else they will stay unverified.
         source = this.#getSourceIfPresent(url);
         if (source) { // (should always be true here)
           try {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where existing breakpoints are sometimes not loaded properly when you attach the debugger.


#### Reproduction

My Bun version is `1.3.4+5eb2145b3`
The platform I'm using is `Microsoft Windows NT 10.0.26100.0 x64`
The vscode version I'm using is `0.0.32`

I'm attaching a debugger with this configuration:
`launch.json`:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "bun",
            "request": "attach",
            "name": "Attach Bun",
            "url": "ws://localhost:6499/debug"
        }
    ]
}
```

It should be reproducable with any code, example:
```ts
console.log('hello world!');
setInterval(() => {
  const date = new Date();
  console.log(date);
}, 5000);
```

Do this:
1. Run the code with inspector listening:
    ```ts
    bun run --inspect=:6499/debug main.ts
    ```
2. Place a breakpoint somewhere inside the `setInterval`-callback where it will be hit
3. Attach the debugger (with F5)
4. If it works, detach it (with Shift+F5) and re-attach it again

You might need to repeat the re-attachment a few times. Sometimes it works, sometimes it doesn't.  
- When it works, the breakpoint has a red fill-color and the debugger stops on it
- You can immediately tell that it doesn't work when the breakpoint isn't red after the debugger is active

It is crucial for reproduction that you attach the debugger with existing breakpoints; adding breakpoints with an already attached debugger works fine,
On my computer, about half of the time it doesn't work.


### How did you verify your code works?

I tested the extension with the reproduction steps above. With these changes, it works always.

