### PR TITLE
Fix s3 leak tests run wrong times. Related to #20487

### DIFF
--- a/test/js/bun/s3/bun-write-leak-fixture.js
+++ b/test/js/bun/s3/bun-write-leak-fixture.js
@@ -13,14 +13,14 @@ async function writeLargeFile() {
 async function run() {
   {
     // base line
-    await Promise.all(new Array(10).fill(writeLargeFile()));
+    await Promise.all(Array.from({ length: 10 }, () => writeLargeFile()));
     await Bun.sleep(10);
     Bun.gc(true);
   }
   MAX_ALLOWED_MEMORY_USAGE = ((process.memoryUsage.rss() / 1024 / 1024) | 0) + MAX_ALLOWED_MEMORY_USAGE_INCREMENT;
 
   {
-    await Promise.all(new Array(100).fill(writeLargeFile()));
+    await Promise.all(Array.from({ length: 100 }, () => writeLargeFile()));
     Bun.gc(true);
   }
   const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;

--- a/test/js/bun/s3/s3-stream-leak-fixture.js
+++ b/test/js/bun/s3/s3-stream-leak-fixture.js
@@ -21,13 +21,13 @@ async function run(inputType) {
 
   {
     // base line
-    await Promise.all(new Array(10).fill(readLargeFile()));
+    await Promise.all(Array.from({ length: 10 }, () => readLargeFile()));
     await Bun.sleep(10);
     Bun.gc(true);
   }
   MAX_ALLOWED_MEMORY_USAGE = ((process.memoryUsage.rss() / 1024 / 1024) | 0) + MAX_ALLOWED_MEMORY_USAGE_INCREMENT;
   {
-    await Promise.all(new Array(100).fill(readLargeFile()));
+    await Promise.all(Array.from({ length: 100 }, () => readLargeFile()));
     Bun.gc(true);
   }
   const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;

--- a/test/js/bun/s3/s3-text-leak-fixture.js
+++ b/test/js/bun/s3/s3-text-leak-fixture.js
@@ -16,13 +16,13 @@ async function run(inputType) {
 
   {
     // base line
-    await Promise.all(new Array(10).fill(readLargeFile()));
+    await Promise.all(Array.from({ length: 10 }, () => readLargeFile()));
     await Bun.sleep(10);
     Bun.gc(true);
   }
   MAX_ALLOWED_MEMORY_USAGE = ((process.memoryUsage.rss() / 1024 / 1024) | 0) + MAX_ALLOWED_MEMORY_USAGE_INCREMENT;
   {
-    await Promise.all(new Array(100).fill(readLargeFile()));
+    await Promise.all(Array.from({ length: 100 }, () => readLargeFile()));
     Bun.gc(true);
   }
   const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;

--- a/test/js/bun/s3/s3-write-leak-fixture.js
+++ b/test/js/bun/s3/s3-write-leak-fixture.js
@@ -13,14 +13,14 @@ async function writeLargeFile() {
 async function run() {
   {
     // base line
-    await Promise.all(new Array(10).fill(writeLargeFile()));
+    await Promise.all(Array.from({ length: 10 }, () => writeLargeFile()));
     await Bun.sleep(10);
     Bun.gc(true);
   }
   MAX_ALLOWED_MEMORY_USAGE = ((process.memoryUsage.rss() / 1024 / 1024) | 0) + MAX_ALLOWED_MEMORY_USAGE_INCREMENT;
 
   {
-    await Promise.all(new Array(100).fill(writeLargeFile()));
+    await Promise.all(Array.from({ length: 100 }, () => writeLargeFile()));
     Bun.gc(true);
   }
   const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;

--- a/test/js/bun/s3/s3-writer-leak-fixture.js
+++ b/test/js/bun/s3/s3-writer-leak-fixture.js
@@ -21,14 +21,14 @@ async function writeLargeFile() {
 async function run() {
   {
     // base line
-    await Promise.all(new Array(10).fill(writeLargeFile()));
+    await Promise.all(Array.from({ length: 10 }, () => writeLargeFile()));
     await Bun.sleep(10);
     Bun.gc(true);
   }
   MAX_ALLOWED_MEMORY_USAGE = ((process.memoryUsage.rss() / 1024 / 1024) | 0) + MAX_ALLOWED_MEMORY_USAGE_INCREMENT;
 
   {
-    await Promise.all(new Array(100).fill(writeLargeFile()));
+    await Promise.all(Array.from({ length: 100 }, () => writeLargeFile()));
     Bun.gc(true);
   }
   const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;


### PR DESCRIPTION
### What does this PR do?
Fix s3 leak tests run wrong times.

### How did you verify your code works?
```shell
bun test/js/bun/s3/bun-write-leak-fixture.js
bun test/js/bun/s3/s3-stream-leak-fixture.js
bun test/js/bun/s3/s3-text-leak-fixture.js
bun test/js/bun/s3/s3-write-leak-fixture.js
bun test/js/bun/s3/s3-writer-leak-fixture.js
```

For example this test unit using below code to run `writeLargeFile` with 10 times. But `writeLargeFile` just run once:
```js
await Promise.all(new Array(10).fill(writeLargeFile()));
```

So I change it to:
```js
await Promise.all(Array.from({ length: 10 }, () => writeLargeFile()));
```

Related to #20487