### PR TITLE
docs: clarify bun init behavior with and without folder argument

### DIFF
--- a/docs/snippets/cli/init.mdx
+++ b/docs/snippets/cli/init.mdx
@@ -4,6 +4,8 @@
 bun init <folder?>
 ```
 
+Initialize a new project in the current directory, or in a newly created subdirectory if a folder name is provided.
+
 ### Initialization Options
 
 <ParamField path="--yes" type="boolean">


### PR DESCRIPTION
### Adds behavior clarification of the `bun init` command for when a folder name is passed and when it is not.
