### PR TITLE
Add bun_version to link metadata

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1210,6 +1210,7 @@ if(BUN_LINK_ONLY)
       "Uploading link metadata"
     COMMAND
       ${CMAKE_COMMAND} -E env
+        BUN_VERSION=${VERSION}
         WEBKIT_DOWNLOAD_URL=${WEBKIT_DOWNLOAD_URL}
         WEBKIT_VERSION=${WEBKIT_VERSION}
         ZIG_COMMIT=${ZIG_COMMIT}

--- a/scripts/create-link-metadata.mjs
+++ b/scripts/create-link-metadata.mjs
@@ -31,6 +31,7 @@ const symbolsTxt = await Bun.file(join(repoRoot, "src", "symbols.txt")).text();
 
 // Create metadata JSON with link command included
 const metadata = {
+  bun_version: process.env.BUN_VERSION || "",
   webkit_url: process.env.WEBKIT_DOWNLOAD_URL || "",
   webkit_version: process.env.WEBKIT_VERSION || "",
   zig_commit: process.env.ZIG_COMMIT || "",


### PR DESCRIPTION
## Summary
- Add `bun_version` field to `link-metadata.json`
- Pass `VERSION` CMake variable to the metadata script as `BUN_VERSION` env var

This ensures the build version is captured in the link metadata JSON file, which is useful for tracking which version produced a given build artifact.

## Test plan
- Build with `bun bd` and verify `link-metadata.json` includes `bun_version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)