### PR TITLE
Docs: fix --sourcemap param format

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -606,7 +606,7 @@ Specifies the type of sourcemap to generate.
   </Tab>
   <Tab title="CLI">
     ```bash terminal icon="terminal"
-    bun build ./index.tsx --outdir ./out --sourcemap linked
+    bun build ./index.tsx --outdir ./out --sourcemap=linked
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect example command in the docs.

### How did you verify your code works?
```
$ bun build ./index.tsx --outdir ./out --sourcemap linked # current command
error: ModuleNotFound resolving "linked" (entry point)

$ bun build ./index.tsx --outdir ./out --sourcemap=linked # updated command
Bundled 1 module in 323ms

  index.js      18.74 KB  (entry point)
  index.js.map  39.95 KB  (source map)
```
