### PR TITLE
fix: correct inverted buffer allocation logic in Postgres array parsing

### DIFF
--- a/src/sql/postgres/DataCell.zig
+++ b/src/sql/postgres/DataCell.zig
@@ -151,8 +151,8 @@ fn parseArray(bytes: []const u8, bigint: bool, comptime arrayType: types.Tag, gl
                     .jsonb_array,
                     => {
                         const str_bytes = slice[1..current_idx];
-                        const needs_dynamic_buffer = str_bytes.len < stack_buffer.len;
-                        const buffer = if (needs_dynamic_buffer) try bun.default_allocator.alloc(u8, str_bytes.len) else stack_buffer[0..];
+                        const needs_dynamic_buffer = str_bytes.len > stack_buffer.len;
+                        const buffer = if (needs_dynamic_buffer) try bun.default_allocator.alloc(u8, str_bytes.len) else stack_buffer[0..str_bytes.len];
                         defer if (needs_dynamic_buffer) bun.default_allocator.free(buffer);
                         const unescaped = unescapePostgresString(str_bytes, buffer) catch return error.InvalidByteSequence;
                         try array.append(bun.default_allocator, SQLDataCell{ .tag = .json, .value = .{ .json = if (unescaped.len > 0) String.cloneUTF8(unescaped).value.WTFStringImpl else null }, .free_value = 1 });
@@ -168,8 +168,8 @@ fn parseArray(bytes: []const u8, bigint: bool, comptime arrayType: types.Tag, gl
                     slice = trySlice(slice, current_idx + 1);
                     continue;
                 }
-                const needs_dynamic_buffer = str_bytes.len < stack_buffer.len;
-                const buffer = if (needs_dynamic_buffer) try bun.default_allocator.alloc(u8, str_bytes.len) else stack_buffer[0..];
+                const needs_dynamic_buffer = str_bytes.len > stack_buffer.len;
+                const buffer = if (needs_dynamic_buffer) try bun.default_allocator.alloc(u8, str_bytes.len) else stack_buffer[0..str_bytes.len];
                 defer if (needs_dynamic_buffer) bun.default_allocator.free(buffer);
                 const string_bytes = unescapePostgresString(str_bytes, buffer) catch return error.InvalidByteSequence;
                 try array.append(bun.default_allocator, SQLDataCell{ .tag = .string, .value = .{ .string = if (string_bytes.len > 0) String.cloneUTF8(string_bytes).value.WTFStringImpl else null }, .free_value = 1 });


### PR DESCRIPTION
## Summary

- Fix inverted buffer allocation logic when parsing strings in Postgres arrays
- Strings larger than 16KB were incorrectly using the stack buffer instead of dynamically allocating
- This caused spurious `InvalidByteSequence` errors for valid data

## The Bug

In `src/sql/postgres/DataCell.zig`, the condition for when to use dynamic allocation was inverted:

```zig
// BEFORE (buggy):
const needs_dynamic_buffer = str_bytes.len < stack_buffer.len;  // TRUE when SMALL

// AFTER (fixed):
const needs_dynamic_buffer = str_bytes.len > stack_buffer.len;  // TRUE when LARGE
```

## What happened with large strings (>16KB):

1. `needs_dynamic_buffer` = false (e.g., 20000 < 16384 is false)
2. Uses `stack_buffer[0..]` which is only 16KB
3. `unescapePostgresString` hits bounds check and returns `BufferTooSmall`
4. Error converted to `InvalidByteSequence`
5. User gets error even though data is valid

## User Impact

Users with Postgres arrays containing JSON or string elements larger than 16KB would get spurious InvalidByteSequence errors even though their data was perfectly valid.

## Test plan

- Code inspection confirms the logic was inverted
- The fix aligns with the intended behavior: use stack buffer for small strings, dynamic allocation for large strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)