### PR TITLE
fix(patch) replace / with + instead of %2F

### DIFF
--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -500,7 +500,7 @@ fn escapePatchFilename(allocator: std.mem.Allocator, name: []const u8) ?[]const 
 
         pub fn escaped(this: @This()) ?[]const u8 {
             return switch (this) {
-                .@"/" => "%2F",
+                .@"/" => "+",
                 .@"\\" => "%5c",
                 .@" " => "%20",
                 .@"\n" => "%0A",

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -87,7 +87,7 @@ describe("bun patch <pkg>", async () => {
 
           expect(
             (await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies["@types/ws@8.5.4"],
-          ).toEqual("patches/@types%2Fws@8.5.4.patch");
+          ).toEqual("patches/@types+ws@8.5.4.patch");
         });
       }
     });
@@ -165,7 +165,7 @@ describe("bun patch <pkg>", async () => {
 
           expect(
             (await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies["@types/ws@8.5.4"],
-          ).toEqual("patches/@types%2Fws@8.5.4.patch");
+          ).toEqual("patches/@types+ws@8.5.4.patch");
         });
       }
     });
@@ -240,7 +240,7 @@ describe("bun patch <pkg>", async () => {
 
           expect(
             (await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies["@types/ws@8.5.4"],
-          ).toEqual("patches/@types%2Fws@8.5.4.patch");
+          ).toEqual("patches/@types+ws@8.5.4.patch");
         });
       }
     });
@@ -251,15 +251,15 @@ describe("bun patch <pkg>", async () => {
           "packages/eslint-config/node_modules/@types/ws",
           "packages/eslint-config/node_modules/@types/ws",
           "@types/ws@8.5.4",
-          "patches/@types%2Fws@8.5.4.patch",
+          "patches/@types+ws@8.5.4.patch",
         ],
         [
           "@types/ws@8.5.4",
           "node_modules/@repo/eslint-config/node_modules/@types/ws",
           "@types/ws@8.5.4",
-          "patches/@types%2Fws@8.5.4.patch",
+          "patches/@types+ws@8.5.4.patch",
         ],
-        ["@types/ws@7.4.7", "node_modules/@types/ws", "@types/ws@7.4.7", "patches/@types%2Fws@7.4.7.patch"],
+        ["@types/ws@7.4.7", "node_modules/@types/ws", "@types/ws@7.4.7", "patches/@types+ws@7.4.7.patch"],
       ];
       for (const [arg, path, version, patch_path] of args) {
         test(arg, async () => {


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/12090

### What does this PR do?

When patching a package with a `/` in its name, replace it with `+` instead of `%2F`, following convention from `patch-package`

I'm pretty sure the other cases in this switch can never happen so they could probably be removed for a miniscule perf boost, left them in just in case

### How did you verify your code works?

Updated `bun-patch.test.ts`