### PR TITLE
fix: `$.cwd('.')` no longer throws "undefined" path error

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -149,7 +149,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     cwd(newCwd?: string): this {
       this.#throwIfRunning();
       if (typeof newCwd === "undefined" || newCwd === "." || newCwd === "" || newCwd === "./") {
-        newCwd = defaultCwd;
+        newCwd = "";
       }
       this.#args!.setCwd(newCwd);
       return this;
@@ -251,7 +251,6 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
   var defaultEnv = process.env || {};
   const originalDefaultEnv = defaultEnv;
-  var defaultCwd: string | undefined = undefined;
 
   const cwdSymbol = Symbol("cwd");
   const envSymbol = Symbol("env");
@@ -277,7 +276,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     cwd(newCwd: string | undefined) {
       if (typeof newCwd === "undefined" || typeof newCwd === "string") {
         if (newCwd === "." || newCwd === "" || newCwd === "./") {
-          newCwd = defaultCwd;
+          newCwd = "";
         }
 
         this[cwdSymbol] = newCwd;
@@ -344,7 +343,6 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
   Object.setPrototypeOf(Shell, ShellPrototype);
   Object.setPrototypeOf(BunShell, ShellPrototype.prototype);
 
-  BunShell[cwdSymbol] = defaultCwd;
   BunShell[envSymbol] = defaultEnv;
   BunShell[throwsSymbol] = true;
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -803,6 +803,7 @@ booga"
     });
 
     test(".cwd(undefined) uses current working directory", async () => {
+      // @ts-expect-error
       const result = await $`pwd`.cwd(undefined).text();
       expect(result.trim()).toBe(process.cwd());
     });
@@ -831,9 +832,9 @@ booga"
       expect(resetResult.trim()).toBe(process.cwd());
 
       // Reset to original cwd for other tests
-      $.cwd(process.cwd());
+      $.cwd(process.cwd().replaceAll("\\", "/"));
       const finalResult = await $`pwd`.text();
-      expect(finalResult.trim()).toBe(process.cwd());
+      expect(finalResult.trim()).toBe(process.cwd().replaceAll("\\", "/"));
     });
   });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -786,6 +786,55 @@ booga"
       const { stdout } = await $`cd ${temp_dir} && pwd && cd - && pwd`;
       expect(stdout.toString()).toEqual(`${temp_dir}\n${process.cwd().replaceAll("\\", "/")}\n`);
     });
+
+    test(".cwd('.') uses current working directory", async () => {
+      const result = await $`pwd`.cwd(".").text();
+      expect(result.trim()).toBe(process.cwd());
+    });
+
+    test(".cwd('') uses current working directory", async () => {
+      const result = await $`pwd`.cwd("").text();
+      expect(result.trim()).toBe(process.cwd());
+    });
+
+    test(".cwd('./') uses current working directory", async () => {
+      const result = await $`pwd`.cwd("./").text();
+      expect(result.trim()).toBe(process.cwd());
+    });
+
+    test(".cwd(undefined) uses current working directory", async () => {
+      const result = await $`pwd`.cwd(undefined).text();
+      expect(result.trim()).toBe(process.cwd());
+    });
+
+    test(".cwd(temp_dir).cwd('.') resets to current working directory", async () => {
+      const tmpResult = await $`pwd`.cwd(temp_dir).text();
+      expect(tmpResult.trim()).toBe(temp_dir);
+
+      const resetResult = await $`pwd`.cwd(temp_dir).cwd(".").text();
+      expect(resetResult.trim()).toBe(process.cwd());
+    });
+
+    test("$.cwd('.') sets default cwd to current working directory", async () => {
+      $.cwd(".");
+      const result = await $`pwd`.text();
+      expect(result.trim()).toBe(process.cwd());
+    });
+
+    test("$.cwd(temp_dir) then $.cwd('.') resets default cwd", async () => {
+      $.cwd(temp_dir);
+      const tmpResult = await $`pwd`.text();
+      expect(tmpResult.trim()).toBe(temp_dir);
+
+      $.cwd(".");
+      const resetResult = await $`pwd`.text();
+      expect(resetResult.trim()).toBe(process.cwd());
+
+      // Reset to original cwd for other tests
+      $.cwd(process.cwd());
+      const finalResult = await $`pwd`.text();
+      expect(finalResult.trim()).toBe(process.cwd());
+    });
   });
 
   test("which", async () => {


### PR DESCRIPTION
## Summary

Fixes #25579

- `.cwd(".")`, `.cwd("")`, `.cwd("./")`, and `.cwd(undefined)` no longer throw `No such file or directory: .../undefined`
- Previously, `defaultCwd` was always `undefined`, which got passed to Zig setCwd() and converted to the literal string "undefined"
- Fix: pass empty string `""` instead, which tells the Zig code to use the shell current working directory
- Removed the unused `defaultCwd` variable

## Test plan

- [x] Added tests for `.cwd(".")`, `.cwd("")`, `.cwd("./")`, `.cwd(undefined)`
- [x] Added test for chaining `.cwd(temp_dir).cwd(".")` to reset to shell cwd
- [x] Added tests for `$.cwd(".")` and `$.cwd(temp_dir)` then `$.cwd(".")` reset
- [x] Added Windows path normalization in tests for cross-platform compatibility
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)