### PR TITLE
perf(linux): add memfd optimizations and typed flags

### DIFF
--- a/src/allocators/LinuxMemFdAllocator.zig
+++ b/src/allocators/LinuxMemFdAllocator.zig
@@ -132,7 +132,7 @@ pub fn create(bytes: []const u8) bun.sys.Maybe(bun.webcore.Blob.Store.Bytes) {
     const label = std.fmt.bufPrintZ(&label_buf, "memfd-num-{d}", .{memfd_counter.fetchAdd(1, .monotonic)}) catch "";
 
     // Using huge pages was slower.
-    const fd = switch (bun.sys.memfd_create(label, std.os.linux.MFD.CLOEXEC)) {
+    const fd = switch (bun.sys.memfd_create(label, .non_executable)) {
         .err => |err| return .{ .err = bun.sys.Error.fromCode(err.getErrno(), .open) },
         .result => |fd| fd,
     };

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1346,7 +1346,7 @@ pub fn spawnProcessPosix(
                             else => "spawn_stdio_generic",
                         };
 
-                        const fd = bun.sys.memfd_create(label, 0).unwrap() catch break :use_memfd;
+                        const fd = bun.sys.memfd_create(label, .cross_process).unwrap() catch break :use_memfd;
 
                         to_close_on_error.append(fd) catch {};
                         to_set_cloexec.append(fd) catch {};

--- a/src/bun.js/api/bun/spawn/stdio.zig
+++ b/src/bun.js/api/bun/spawn/stdio.zig
@@ -100,7 +100,7 @@ pub const Stdio = union(enum) {
             else => "spawn_stdio_memory_file",
         };
 
-        const fd = bun.sys.memfd_create(label, 0).unwrap() catch return false;
+        const fd = bun.sys.memfd_create(label, .cross_process).unwrap() catch return false;
 
         var remain = this.byteSlice();
 

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -1004,6 +1004,15 @@ pub const FFI = struct {
         var filepath_buf = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(filepath_buf);
         var linux_memfd_to_close: i32 = -1;
+        defer {
+            if (Environment.isLinux) {
+                if (linux_memfd_to_close != -1) {
+                    _ = bun.FD.fromSystem(linux_memfd_to_close).close();
+                }
+            } else {
+                bun.debugAssert(linux_memfd_to_close == -1);
+            }
+        }
         const name = brk: {
             if (jsc.ModuleLoader.resolveEmbeddedFile(
                 vm,

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -296,7 +296,7 @@ JSC_DEFINE_CUSTOM_SETTER(Process_defaultSetter, (JSC::JSGlobalObject * globalObj
     return true;
 }
 
-extern "C" bool Bun__resolveEmbeddedNodeFile(void*, BunString*);
+extern "C" bool Bun__resolveEmbeddedNodeFile(void*, BunString*, int32_t*);
 #if OS(WINDOWS)
 extern "C" HMODULE Bun__LoadLibraryBunString(BunString*);
 #endif
@@ -434,6 +434,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     }
 
     CString utf8;
+    int32_t linuxMemfdToClose = -1;
 
     // Support embedded .node files
     // See StandaloneModuleGraph.zig for what this "$bunfs" thing is
@@ -445,8 +446,8 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     bool deleteAfter = false;
     if (filename.startsWith(StandaloneModuleGraph__base_path)) {
         BunString bunStr = Bun::toString(filename);
-        if (Bun__resolveEmbeddedNodeFile(globalObject->bunVM(), &bunStr)) {
-            filename = bunStr.toWTFString(BunString::ZeroCopy);
+        if (Bun__resolveEmbeddedNodeFile(globalObject->bunVM(), &bunStr, &linuxMemfdToClose)) {
+            filename = bunStr.transferToWTFString();
             deleteAfter = !filename.startsWith("/proc/"_s);
         }
     }
@@ -481,11 +482,20 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
                 delete[] dupeZ;
             }
         }
+        ASSERT(linuxMemfdToClose == -1);
 #else
         if (deleteAfter) {
             deleteAfter = false;
             Bun__unlink(utf8.data(), utf8.length());
         }
+#if OS(LINUX)
+        if (linuxMemfdToClose != -1) {
+            close(linuxMemfdToClose);
+            linuxMemfdToClose = -1;
+        }
+#else
+        ASSERT(linuxMemfdToClose == -1);
+#endif
 #endif
     };
 

--- a/src/bun.js/node/node_fs_binding.zig
+++ b/src/bun.js/node/node_fs_binding.zig
@@ -221,7 +221,7 @@ pub fn createMemfdForTesting(globalObject: *jsc.JSGlobalObject, callFrame: *jsc.
     }
 
     const size = arguments.ptr[0].toInt64();
-    switch (bun.sys.memfd_create("my_memfd", std.os.linux.MFD.CLOEXEC)) {
+    switch (bun.sys.memfd_create("my_memfd", .non_executable)) {
         .result => |fd| {
             _ = bun.sys.ftruncate(fd, size);
             return jsc.JSValue.jsNumber(fd.cast());

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2971,15 +2971,51 @@ pub fn munmap(memory: []align(page_size_min) const u8) Maybe(void) {
     } else return .success;
 }
 
-pub fn memfd_create(name: [:0]const u8, flags: u32) Maybe(bun.FileDescriptor) {
+pub const MemfdFlags = enum(u32) {
+    // Recent Linux kernel versions require MFD_EXEC.
+    executable = MFD_EXEC | MFD_ALLOW_SEALING | MFD_CLOEXEC,
+    non_executable = MFD_NOEXEC_SEAL | MFD_ALLOW_SEALING,
+    cross_process = MFD_NOEXEC_SEAL,
+
+    pub fn olderKernelFlag(this: MemfdFlags) u32 {
+        return switch (this) {
+            .non_executable, .executable => MFD_CLOEXEC,
+            .cross_process => 0,
+        };
+    }
+
+    const MFD_NOEXEC_SEAL: u32 = 0x0008;
+    const MFD_EXEC: u32 = 0x0010;
+    const MFD_CLOEXEC: u32 = std.os.linux.MFD.CLOEXEC;
+    const MFD_ALLOW_SEALING: u32 = std.os.linux.MFD.ALLOW_SEALING;
+};
+pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FileDescriptor) {
     if (comptime !Environment.isLinux) @compileError("linux only!");
+    var flags: u32 = @intFromEnum(flags_);
+    while (true) {
+        const rc = std.os.linux.memfd_create(name, flags);
+        log("memfd_create({s}, {s}) = {d}", .{ name, @tagName(flags_), rc });
 
-    const rc = std.os.linux.memfd_create(name, flags);
+        if (Maybe(bun.FileDescriptor).errnoSys(rc, .memfd_create)) |err| {
+            switch (err.getErrno()) {
+                .INTR => continue,
+                .INVAL => {
+                    // MFD_EXEC / MFD_NOEXEC_SEAL require Linux 6.3.
+                    if (@intFromEnum(flags_) == flags) {
+                        flags = flags_.olderKernelFlag();
+                        log("memfd_create retrying without exec/noexec flag, using {d}", .{flags});
+                        continue;
+                    }
+                },
+                else => {},
+            }
 
-    log("memfd_create({s}, {d}) = {d}", .{ name, flags, rc });
+            return err;
+        }
 
-    return Maybe(bun.FileDescriptor).errnoSys(rc, .memfd_create) orelse
-        .{ .result = .fromNative(@intCast(rc)) };
+        return .{ .result = .fromNative(@intCast(rc)) };
+    }
+    unreachable;
 }
 
 pub fn setPipeCapacityOnLinux(fd: bun.FileDescriptor, capacity: usize) Maybe(usize) {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2974,7 +2974,7 @@ pub fn munmap(memory: []align(page_size_min) const u8) Maybe(void) {
 pub const MemfdFlags = enum(u32) {
     // Recent Linux kernel versions require MFD_EXEC.
     executable = MFD_EXEC | MFD_ALLOW_SEALING | MFD_CLOEXEC,
-    non_executable = MFD_NOEXEC_SEAL | MFD_ALLOW_SEALING,
+    non_executable = MFD_NOEXEC_SEAL | MFD_ALLOW_SEALING | MFD_CLOEXEC,
     cross_process = MFD_NOEXEC_SEAL,
 
     pub fn olderKernelFlag(this: MemfdFlags) u32 {


### PR DESCRIPTION
## Summary

- Add `MemfdFlags` enum to replace raw integer flags for `memfd_create`, providing semantic clarity for different use cases (`executable`, `non_executable`, `cross_process`)
- Add support for `MFD_EXEC` and `MFD_NOEXEC_SEAL` flags (Linux 6.3+) with automatic fallback to older kernel flags when `EINVAL` is returned
- Use memfd + `/proc/self/fd/{fd}` path for loading embedded `.node` files in standalone builds, avoiding disk writes entirely on Linux

## Test plan

- [ ] Verify standalone builds with embedded `.node` files work on Linux
- [ ] Verify fallback works on older kernels (pre-6.3)
- [ ] Verify subprocess stdio memfd still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)