### PR TITLE
feat(diff): add bun:diff module with SIMD-optimized Myers diff

### DIFF
--- a/src/bun.js/HardcodedModule.zig
+++ b/src/bun.js/HardcodedModule.zig
@@ -10,6 +10,7 @@ pub const HardcodedModule = enum {
     @"bun:test",
     @"bun:wrap",
     @"bun:sqlite",
+    @"bun:diff",
     @"node:assert",
     @"node:assert/strict",
     @"node:async_hooks",
@@ -97,6 +98,7 @@ pub const HardcodedModule = enum {
         .{ "bun:main", .@"bun:main" },
         .{ "bun:test", .@"bun:test" },
         .{ "bun:sqlite", .@"bun:sqlite" },
+        .{ "bun:diff", .@"bun:diff" },
         .{ "bun:wrap", .@"bun:wrap" },
         .{ "bun:internal-for-testing", .@"bun:internal-for-testing" },
         // Node.js
@@ -362,6 +364,7 @@ pub const HardcodedModule = enum {
             .{ "bun:ffi", .{ .path = "bun:ffi" } },
             .{ "bun:jsc", .{ .path = "bun:jsc" } },
             .{ "bun:sqlite", .{ .path = "bun:sqlite" } },
+            .{ "bun:diff", .{ .path = "bun:diff" } },
             .{ "bun:wrap", .{ .path = "bun:wrap" } },
             .{ "bun:internal-for-testing", .{ .path = "bun:internal-for-testing" } },
             .{ "ffi", .{ .path = "bun:ffi" } },

--- a/src/bun.js/api/diff/bun_diff_binding.zig
+++ b/src/bun.js/api/diff/bun_diff_binding.zig
@@ -1,0 +1,146 @@
+//! bun:diff - SIMD-optimized Myers diff engine
+//!
+//! Provides high-performance text diffing and patching capabilities.
+//! Designed for AI coding assistants like Claude Code.
+
+const std = @import("std");
+const bun = @import("bun");
+const jsc = bun.jsc;
+
+const line = @import("bun_diff_line.zig");
+const myers = @import("bun_diff_myers.zig");
+
+const LineIndex = line.LineIndex;
+const Edit = myers.Edit;
+
+/// JS binding: diff(a, b) -> DiffResult
+fn jsDiff(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    if (callframe.argumentsCount() < 2) {
+        return global.throwNotEnoughArguments("diff", 2, callframe.argumentsCount());
+    }
+
+    const a_val = callframe.argument(0);
+    const b_val = callframe.argument(1);
+
+    if (!a_val.isString() or !b_val.isString()) {
+        return global.throwInvalidArguments("diff() arguments must be strings", .{});
+    }
+
+    const a_str = try a_val.toBunString(global);
+    defer a_str.deref();
+    const b_str = try b_val.toBunString(global);
+    defer b_str.deref();
+
+    const a_slice = a_str.toUTF8(bun.default_allocator);
+    defer a_slice.deinit();
+    const b_slice = b_str.toUTF8(bun.default_allocator);
+    defer b_slice.deinit();
+
+    // Create line indices
+    var a_lines = LineIndex.init(a_slice.slice(), bun.default_allocator) catch {
+        return global.throw("Failed to index lines in first argument", .{});
+    };
+    defer a_lines.deinit();
+
+    var b_lines = LineIndex.init(b_slice.slice(), bun.default_allocator) catch {
+        return global.throw("Failed to index lines in second argument", .{});
+    };
+    defer b_lines.deinit();
+
+    // Compute diff
+    const edits = myers.diff(a_lines, b_lines, bun.default_allocator) catch {
+        return global.throw("Failed to compute diff", .{});
+    };
+    defer bun.default_allocator.free(edits);
+
+    // Build result object
+    return buildResultObject(global, edits);
+}
+
+fn buildResultObject(
+    global: *jsc.JSGlobalObject,
+    edits: []const Edit,
+) bun.JSError!jsc.JSValue {
+    const result = jsc.JSValue.createEmptyObject(global, 2);
+
+    // Create edits array
+    const edits_array = try jsc.JSValue.createEmptyArray(global, edits.len);
+
+    var lines_added: u32 = 0;
+    var lines_deleted: u32 = 0;
+
+    for (edits, 0..) |edit, i| {
+        const edit_obj = jsc.JSValue.createEmptyObject(global, 5);
+
+        switch (edit) {
+            .equal => |r| {
+                edit_obj.put(global, bun.String.static("type"), bun.String.static("equal").toJS(global));
+                edit_obj.put(global, bun.String.static("oldStart"), jsc.JSValue.jsNumber(r.old_start));
+                edit_obj.put(global, bun.String.static("oldEnd"), jsc.JSValue.jsNumber(r.old_end));
+                edit_obj.put(global, bun.String.static("newStart"), jsc.JSValue.jsNumber(r.new_start));
+                edit_obj.put(global, bun.String.static("newEnd"), jsc.JSValue.jsNumber(r.new_end));
+            },
+            .insert => |r| {
+                edit_obj.put(global, bun.String.static("type"), bun.String.static("insert").toJS(global));
+                edit_obj.put(global, bun.String.static("oldStart"), jsc.JSValue.jsNumber(r.old_start));
+                edit_obj.put(global, bun.String.static("oldEnd"), jsc.JSValue.jsNumber(r.old_end));
+                edit_obj.put(global, bun.String.static("newStart"), jsc.JSValue.jsNumber(r.new_start));
+                edit_obj.put(global, bun.String.static("newEnd"), jsc.JSValue.jsNumber(r.new_end));
+                lines_added += r.new_end - r.new_start;
+            },
+            .delete => |r| {
+                edit_obj.put(global, bun.String.static("type"), bun.String.static("delete").toJS(global));
+                edit_obj.put(global, bun.String.static("oldStart"), jsc.JSValue.jsNumber(r.old_start));
+                edit_obj.put(global, bun.String.static("oldEnd"), jsc.JSValue.jsNumber(r.old_end));
+                edit_obj.put(global, bun.String.static("newStart"), jsc.JSValue.jsNumber(r.new_start));
+                edit_obj.put(global, bun.String.static("newEnd"), jsc.JSValue.jsNumber(r.new_end));
+                lines_deleted += r.old_end - r.old_start;
+            },
+        }
+
+        try edits_array.putIndex(global, @truncate(i), edit_obj);
+    }
+
+    result.put(global, bun.String.static("edits"), edits_array);
+
+    // Create stats object
+    const stats = jsc.JSValue.createEmptyObject(global, 3);
+    stats.put(global, bun.String.static("linesAdded"), jsc.JSValue.jsNumber(lines_added));
+    stats.put(global, bun.String.static("linesDeleted"), jsc.JSValue.jsNumber(lines_deleted));
+    stats.put(global, bun.String.static("hunks"), jsc.JSValue.jsNumber(countHunks(edits)));
+    result.put(global, bun.String.static("stats"), stats);
+
+    return result;
+}
+
+fn countHunks(edits: []const Edit) u32 {
+    var hunks: u32 = 0;
+    var in_change = false;
+
+    for (edits) |edit| {
+        const is_change = switch (edit) {
+            .equal => false,
+            .insert, .delete => true,
+        };
+
+        if (is_change and !in_change) {
+            hunks += 1;
+        }
+        in_change = is_change;
+    }
+
+    return hunks;
+}
+
+/// Generate exports object for $zig binding
+pub fn generate(global: *jsc.JSGlobalObject) jsc.JSValue {
+    const exports = jsc.JSValue.createEmptyObject(global, 1);
+
+    exports.put(
+        global,
+        bun.String.static("diff"),
+        jsc.JSFunction.create(global, bun.String.static("diff"), jsDiff, 2, .{}),
+    );
+
+    return exports;
+}

--- a/src/bun.js/api/diff/bun_diff_line.zig
+++ b/src/bun.js/api/diff/bun_diff_line.zig
@@ -1,0 +1,182 @@
+//! Line indexing for diff operations
+//!
+//! Provides zero-copy line indexing with hash computation for fast comparison.
+//! Uses SIMD-accelerated operations where beneficial.
+
+const std = @import("std");
+// Note: This module does not need bun imports
+const simd = @import("bun_diff_simd.zig");
+
+/// A line is a view into the original buffer
+pub const Line = struct {
+    /// Offset from buffer start
+    start: u32,
+    /// Length of line (excluding newline)
+    len: u32,
+    /// Precomputed hash for fast comparison
+    hash: u64,
+};
+
+/// Line index for a file - zero-copy view with precomputed hashes
+pub const LineIndex = struct {
+    /// Original content (not owned)
+    content: []const u8,
+    /// Array of line descriptors
+    lines: []Line,
+    /// Allocator used for lines array
+    allocator: std.mem.Allocator,
+
+    pub fn init(content: []const u8, allocator: std.mem.Allocator) !LineIndex {
+        var lines = std.array_list.Managed(Line).init(allocator);
+        errdefer lines.deinit();
+
+        // Use SIMD-accelerated newline finding for large content
+        if (content.len > 64) {
+            var positions = std.array_list.Managed(u32).init(allocator);
+            defer positions.deinit();
+
+            try simd.findNewlines(content, &positions);
+
+            var start: u32 = 0;
+            for (positions.items) |newline_pos| {
+                const line_len = newline_pos - start;
+                const line_content = content[start..][0..line_len];
+                try lines.append(.{
+                    .start = start,
+                    .len = line_len,
+                    .hash = std.hash.Wyhash.hash(0, line_content),
+                });
+                start = newline_pos + 1;
+            }
+
+            // Handle last line without trailing newline
+            if (start < content.len) {
+                const last_len: u32 = @intCast(content.len - start);
+                const line_content = content[start..][0..last_len];
+                try lines.append(.{
+                    .start = start,
+                    .len = last_len,
+                    .hash = std.hash.Wyhash.hash(0, line_content),
+                });
+            }
+        } else {
+            // Scalar path for small content
+            var start: u32 = 0;
+            var i: u32 = 0;
+
+            while (i < content.len) : (i += 1) {
+                if (content[i] == '\n') {
+                    const line_len: u32 = i - start;
+                    const line_content = content[start..][0..line_len];
+                    try lines.append(.{
+                        .start = start,
+                        .len = line_len,
+                        .hash = std.hash.Wyhash.hash(0, line_content),
+                    });
+                    start = i + 1;
+                }
+            }
+
+            // Handle last line without trailing newline
+            if (start < content.len) {
+                const last_len: u32 = @intCast(content.len - start);
+                const line_content = content[start..][0..last_len];
+                try lines.append(.{
+                    .start = start,
+                    .len = last_len,
+                    .hash = std.hash.Wyhash.hash(0, line_content),
+                });
+            }
+        }
+
+        return .{
+            .content = content,
+            .lines = try lines.toOwnedSlice(),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *LineIndex) void {
+        self.allocator.free(self.lines);
+    }
+
+    /// Get the content of a line by index
+    pub fn getLine(self: LineIndex, idx: usize) []const u8 {
+        const l = self.lines[idx];
+        return self.content[l.start..][0..l.len];
+    }
+
+    /// Check if two lines are equal (hash first, then SIMD comparison)
+    pub fn linesEqual(self: LineIndex, other: LineIndex, self_idx: usize, other_idx: usize) bool {
+        const a = self.lines[self_idx];
+        const b = other.lines[other_idx];
+
+        // Fast path: hash mismatch
+        if (a.hash != b.hash) return false;
+
+        // Fast path: length mismatch
+        if (a.len != b.len) return false;
+
+        // SIMD comparison for actual content
+        return simd.slicesEqual(self.getLine(self_idx), other.getLine(other_idx));
+    }
+
+    /// Number of lines
+    pub fn len(self: LineIndex) usize {
+        return self.lines.len;
+    }
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "LineIndex empty string" {
+    const content = "";
+    var idx = try LineIndex.init(content, std.testing.allocator);
+    defer idx.deinit();
+    try std.testing.expectEqual(@as(usize, 0), idx.len());
+}
+
+test "LineIndex single line no newline" {
+    const content = "hello";
+    var idx = try LineIndex.init(content, std.testing.allocator);
+    defer idx.deinit();
+    try std.testing.expectEqual(@as(usize, 1), idx.len());
+    try std.testing.expectEqualStrings("hello", idx.getLine(0));
+}
+
+test "LineIndex multiple lines" {
+    const content = "line1\nline2\nline3\n";
+    var idx = try LineIndex.init(content, std.testing.allocator);
+    defer idx.deinit();
+    try std.testing.expectEqual(@as(usize, 3), idx.len());
+    try std.testing.expectEqualStrings("line1", idx.getLine(0));
+    try std.testing.expectEqualStrings("line2", idx.getLine(1));
+    try std.testing.expectEqualStrings("line3", idx.getLine(2));
+}
+
+test "LineIndex equality" {
+    const a_content = "same\ndifferent1\n";
+    const b_content = "same\ndifferent2\n";
+
+    var a = try LineIndex.init(a_content, std.testing.allocator);
+    defer a.deinit();
+    var b = try LineIndex.init(b_content, std.testing.allocator);
+    defer b.deinit();
+
+    try std.testing.expect(a.linesEqual(b, 0, 0)); // "same" == "same"
+    try std.testing.expect(!a.linesEqual(b, 1, 1)); // "different1" != "different2"
+}
+
+test "LineIndex long content uses SIMD path" {
+    // Content longer than 64 bytes to trigger SIMD path
+    const content = "a" ** 30 ++ "\n" ++ "b" ** 30 ++ "\n" ++ "c" ** 30 ++ "\n";
+    var idx = try LineIndex.init(content, std.testing.allocator);
+    defer idx.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), idx.len());
+    try std.testing.expectEqual(@as(usize, 30), idx.getLine(0).len);
+    try std.testing.expectEqual(@as(usize, 30), idx.getLine(1).len);
+    try std.testing.expectEqual(@as(usize, 30), idx.getLine(2).len);
+}

--- a/src/bun.js/api/diff/bun_diff_myers.zig
+++ b/src/bun.js/api/diff/bun_diff_myers.zig
@@ -1,0 +1,341 @@
+//! Myers diff algorithm implementation
+//!
+//! Based on Eugene Myers' "An O(ND) Difference Algorithm and Its Variations" (1986).
+//! Produces minimal edit scripts (shortest sequence of insertions and deletions).
+
+const std = @import("std");
+const LineIndex = @import("bun_diff_line.zig").LineIndex;
+
+/// Range of lines affected by an edit
+pub const Range = struct {
+    old_start: u32,
+    old_end: u32,
+    new_start: u32,
+    new_end: u32,
+};
+
+/// A single edit operation
+pub const Edit = union(enum) {
+    /// Lines are equal in both versions
+    equal: Range,
+    /// Lines were deleted from old version
+    delete: Range,
+    /// Lines were inserted in new version
+    insert: Range,
+};
+
+/// Compute shortest edit script using Myers algorithm
+pub fn diff(
+    old: LineIndex,
+    new: LineIndex,
+    allocator: std.mem.Allocator,
+) ![]Edit {
+    const n: isize = @intCast(old.len());
+    const m: isize = @intCast(new.len());
+
+    // Edge cases
+    if (n == 0 and m == 0) {
+        return try allocator.alloc(Edit, 0);
+    }
+
+    if (n == 0) {
+        const edits = try allocator.alloc(Edit, 1);
+        edits[0] = .{ .insert = .{
+            .old_start = 0,
+            .old_end = 0,
+            .new_start = 0,
+            .new_end = @intCast(m),
+        } };
+        return edits;
+    }
+
+    if (m == 0) {
+        const edits = try allocator.alloc(Edit, 1);
+        edits[0] = .{ .delete = .{
+            .old_start = 0,
+            .old_end = @intCast(n),
+            .new_start = 0,
+            .new_end = 0,
+        } };
+        return edits;
+    }
+
+    const max: isize = n + m;
+    const max_usize: usize = @intCast(max);
+
+    // V array: stores furthest reaching x for each diagonal k
+    // Index as v[offset + k] where offset = max
+    const v_size = 2 * max_usize + 1;
+    var v = try allocator.alloc(isize, v_size);
+    defer allocator.free(v);
+    @memset(v, 0);
+
+    // Trace for backtracking - store V state at each step
+    var trace = std.array_list.Managed([]isize).init(allocator);
+    defer {
+        for (trace.items) |t| allocator.free(t);
+        trace.deinit();
+    }
+
+    // Find shortest edit script
+    var found_d: usize = 0;
+    outer: for (0..max_usize + 1) |d_usize| {
+        const d: isize = @intCast(d_usize);
+
+        // Save V for backtracking
+        const v_copy = try allocator.dupe(isize, v);
+        try trace.append(v_copy);
+
+        // k ranges from -d to d in steps of 2
+        var k: isize = -d;
+        while (k <= d) : (k += 2) {
+            // Determine x from previous step
+            var x: isize = undefined;
+
+            // Decide whether to move down (insert) or right (delete)
+            // At the edges we have no choice, in the middle compare furthest x
+            const go_down = if (k == -d) true else if (k == d) false else blk: {
+                const k_minus_1_idx: usize = @intCast(max + k - 1);
+                const k_plus_1_idx: usize = @intCast(max + k + 1);
+                break :blk v[k_minus_1_idx] < v[k_plus_1_idx];
+            };
+
+            if (go_down) {
+                // Move down (insert)
+                const k_plus_1_idx: usize = @intCast(max + k + 1);
+                x = v[k_plus_1_idx];
+            } else {
+                // Move right (delete)
+                const k_minus_1_idx: usize = @intCast(max + k - 1);
+                x = v[k_minus_1_idx] + 1;
+            }
+
+            var y = x - k;
+
+            // Follow diagonal (matching lines)
+            while (x < n and y < m and old.linesEqual(new, @intCast(x), @intCast(y))) {
+                x += 1;
+                y += 1;
+            }
+
+            const k_idx: usize = @intCast(max + k);
+            v[k_idx] = x;
+
+            // Check if we reached the end
+            if (x >= n and y >= m) {
+                found_d = d_usize;
+                break :outer;
+            }
+        }
+    }
+
+    // Backtrack to build edit script
+    const raw_edits = try backtrack(trace.items, n, m, max, found_d, allocator);
+    defer allocator.free(raw_edits);
+
+    // Coalesce adjacent edits of the same type
+    return coalesce(raw_edits, allocator);
+}
+
+fn backtrack(
+    trace: []const []isize,
+    n: isize,
+    m: isize,
+    max: isize,
+    found_d: usize,
+    allocator: std.mem.Allocator,
+) ![]Edit {
+    var edits = std.array_list.Managed(Edit).init(allocator);
+
+    var x = n;
+    var y = m;
+
+    var d_iter: isize = @intCast(found_d);
+    while (d_iter >= 0) : (d_iter -= 1) {
+        const d_usize: usize = @intCast(d_iter);
+        const v_d = trace[d_usize];
+        const k = x - y;
+
+        var prev_k: isize = undefined;
+
+        if (d_iter == 0) {
+            // At d=0, we started at (0,0)
+            prev_k = 0;
+        } else {
+            // Decide whether we came from insert (k+1) or delete (k-1)
+            const came_from_insert = if (k == -d_iter) true else if (k == d_iter) false else blk: {
+                const k_minus_1_idx: usize = @intCast(max + k - 1);
+                const k_plus_1_idx: usize = @intCast(max + k + 1);
+                break :blk v_d[k_minus_1_idx] < v_d[k_plus_1_idx];
+            };
+
+            if (came_from_insert) {
+                prev_k = k + 1;
+            } else {
+                prev_k = k - 1;
+            }
+        }
+
+        const prev_x = v_d[@intCast(max + prev_k)];
+        const prev_y = prev_x - prev_k;
+
+        // Add diagonal moves (equals)
+        while (x > prev_x and y > prev_y) {
+            x -= 1;
+            y -= 1;
+            try edits.append(.{ .equal = .{
+                .old_start = @intCast(x),
+                .old_end = @intCast(x + 1),
+                .new_start = @intCast(y),
+                .new_end = @intCast(y + 1),
+            } });
+        }
+
+        if (d_iter > 0) {
+            if (x == prev_x) {
+                // Insert
+                y -= 1;
+                try edits.append(.{ .insert = .{
+                    .old_start = @intCast(x),
+                    .old_end = @intCast(x),
+                    .new_start = @intCast(y),
+                    .new_end = @intCast(y + 1),
+                } });
+            } else {
+                // Delete
+                x -= 1;
+                try edits.append(.{ .delete = .{
+                    .old_start = @intCast(x),
+                    .old_end = @intCast(x + 1),
+                    .new_start = @intCast(y),
+                    .new_end = @intCast(y),
+                } });
+            }
+        }
+    }
+
+    const result = try edits.toOwnedSlice();
+    std.mem.reverse(Edit, result);
+    return result;
+}
+
+/// Coalesce adjacent edits of the same type into single ranges
+fn coalesce(edits: []const Edit, allocator: std.mem.Allocator) ![]Edit {
+    if (edits.len == 0) return try allocator.alloc(Edit, 0);
+
+    var result = std.array_list.Managed(Edit).init(allocator);
+
+    var current = edits[0];
+
+    for (edits[1..]) |edit| {
+        const can_merge = switch (current) {
+            .equal => |c| switch (edit) {
+                .equal => |e| c.old_end == e.old_start and c.new_end == e.new_start,
+                else => false,
+            },
+            .insert => |c| switch (edit) {
+                .insert => |e| c.old_end == e.old_start and c.new_end == e.new_start,
+                else => false,
+            },
+            .delete => |c| switch (edit) {
+                .delete => |e| c.old_end == e.old_start and c.new_end == e.new_start,
+                else => false,
+            },
+        };
+
+        if (can_merge) {
+            // Extend current range
+            switch (current) {
+                .equal => |*c| {
+                    c.old_end = edit.equal.old_end;
+                    c.new_end = edit.equal.new_end;
+                },
+                .insert => |*c| {
+                    c.old_end = edit.insert.old_end;
+                    c.new_end = edit.insert.new_end;
+                },
+                .delete => |*c| {
+                    c.old_end = edit.delete.old_end;
+                    c.new_end = edit.delete.new_end;
+                },
+            }
+        } else {
+            // Save current, start new
+            try result.append(current);
+            current = edit;
+        }
+    }
+
+    // Don't forget the last one
+    try result.append(current);
+
+    return result.toOwnedSlice();
+}
+
+test "diff empty strings" {
+    const a = "";
+    const b = "";
+
+    var a_lines = try LineIndex.init(a, std.testing.allocator);
+    defer a_lines.deinit();
+    var b_lines = try LineIndex.init(b, std.testing.allocator);
+    defer b_lines.deinit();
+
+    const edits = try diff(a_lines, b_lines, std.testing.allocator);
+    defer std.testing.allocator.free(edits);
+
+    try std.testing.expectEqual(@as(usize, 0), edits.len);
+}
+
+test "diff identical" {
+    const content = "line1\nline2\n";
+
+    var a_lines = try LineIndex.init(content, std.testing.allocator);
+    defer a_lines.deinit();
+    var b_lines = try LineIndex.init(content, std.testing.allocator);
+    defer b_lines.deinit();
+
+    const edits = try diff(a_lines, b_lines, std.testing.allocator);
+    defer std.testing.allocator.free(edits);
+
+    // All lines should be equal
+    try std.testing.expectEqual(@as(usize, 1), edits.len);
+    try std.testing.expectEqual(Edit{ .equal = .{
+        .old_start = 0,
+        .old_end = 2,
+        .new_start = 0,
+        .new_end = 2,
+    } }, edits[0]);
+}
+
+test "diff insertion" {
+    const a = "a\nc\n";
+    const b = "a\nb\nc\n";
+
+    var a_lines = try LineIndex.init(a, std.testing.allocator);
+    defer a_lines.deinit();
+    var b_lines = try LineIndex.init(b, std.testing.allocator);
+    defer b_lines.deinit();
+
+    const edits = try diff(a_lines, b_lines, std.testing.allocator);
+    defer std.testing.allocator.free(edits);
+
+    // Should have: equal(a), insert(b), equal(c)
+    try std.testing.expectEqual(@as(usize, 3), edits.len);
+}
+
+test "diff deletion" {
+    const a = "a\nb\nc\n";
+    const b = "a\nc\n";
+
+    var a_lines = try LineIndex.init(a, std.testing.allocator);
+    defer a_lines.deinit();
+    var b_lines = try LineIndex.init(b, std.testing.allocator);
+    defer b_lines.deinit();
+
+    const edits = try diff(a_lines, b_lines, std.testing.allocator);
+    defer std.testing.allocator.free(edits);
+
+    // Should have: equal(a), delete(b), equal(c)
+    try std.testing.expectEqual(@as(usize, 3), edits.len);
+}

--- a/src/bun.js/api/diff/bun_diff_simd.zig
+++ b/src/bun.js/api/diff/bun_diff_simd.zig
@@ -1,0 +1,149 @@
+//! SIMD utilities for diff operations
+//!
+//! Provides vectorized operations for fast byte comparison and newline scanning.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Get the optimal vector length for the current CPU
+pub fn getVectorLen(comptime T: type) comptime_int {
+    return std.simd.suggestVectorLengthForCpu(T, builtin.cpu) orelse 16;
+}
+
+/// SIMD-accelerated byte equality check
+/// Returns the index of the first differing byte, or the length if equal
+pub fn firstDifference(a: []const u8, b: []const u8) usize {
+    const min_len = @min(a.len, b.len);
+    if (min_len == 0) return 0;
+
+    const vec_len = comptime getVectorLen(u8);
+    const Vec = @Vector(vec_len, u8);
+
+    var i: usize = 0;
+
+    // SIMD comparison for full vectors
+    while (i + vec_len <= min_len) {
+        const va: Vec = a[i..][0..vec_len].*;
+        const vb: Vec = b[i..][0..vec_len].*;
+
+        const ne = va != vb;
+        const mask = @as(std.meta.Int(.unsigned, vec_len), @bitCast(ne));
+
+        if (mask != 0) {
+            // Found mismatch - find exact position
+            return i + @ctz(mask);
+        }
+        i += vec_len;
+    }
+
+    // Scalar comparison for remainder
+    while (i < min_len) : (i += 1) {
+        if (a[i] != b[i]) return i;
+    }
+
+    return min_len;
+}
+
+/// SIMD-accelerated check if two slices are equal
+pub fn slicesEqual(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    if (a.len == 0) return true;
+    return firstDifference(a, b) == a.len;
+}
+
+/// SIMD-accelerated common prefix length
+pub fn commonPrefixLen(a: []const u8, b: []const u8) usize {
+    return firstDifference(a, b);
+}
+
+/// SIMD-accelerated newline finder
+/// Appends indices of all '\n' characters to the output list
+pub fn findNewlines(data: []const u8, positions: *std.array_list.Managed(u32)) !void {
+    const vec_len = comptime getVectorLen(u8);
+    const Vec = @Vector(vec_len, u8);
+    const newline: Vec = @splat('\n');
+
+    var i: usize = 0;
+
+    // SIMD scan for full vectors
+    while (i + vec_len <= data.len) {
+        const chunk: Vec = data[i..][0..vec_len].*;
+        const matches = chunk == newline;
+        var mask = @as(std.meta.Int(.unsigned, vec_len), @bitCast(matches));
+
+        while (mask != 0) {
+            const offset = @ctz(mask);
+            try positions.append(@intCast(i + offset));
+            mask &= mask - 1; // Clear lowest set bit
+        }
+
+        i += vec_len;
+    }
+
+    // Scalar scan for remainder
+    while (i < data.len) : (i += 1) {
+        if (data[i] == '\n') {
+            try positions.append(@intCast(i));
+        }
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "firstDifference identical" {
+    const a = "hello world";
+    const b = "hello world";
+    try std.testing.expectEqual(a.len, firstDifference(a, b));
+}
+
+test "firstDifference early mismatch" {
+    const a = "hello";
+    const b = "hallo";
+    try std.testing.expectEqual(@as(usize, 1), firstDifference(a, b));
+}
+
+test "firstDifference late mismatch" {
+    const a = "hello world!";
+    const b = "hello world?";
+    try std.testing.expectEqual(@as(usize, 11), firstDifference(a, b));
+}
+
+test "firstDifference long strings" {
+    const a = "a" ** 100 ++ "X" ++ "b" ** 100;
+    const b = "a" ** 100 ++ "Y" ++ "b" ** 100;
+    try std.testing.expectEqual(@as(usize, 100), firstDifference(a, b));
+}
+
+test "slicesEqual" {
+    try std.testing.expect(slicesEqual("hello", "hello"));
+    try std.testing.expect(!slicesEqual("hello", "hallo"));
+    try std.testing.expect(!slicesEqual("hello", "hell"));
+    try std.testing.expect(slicesEqual("", ""));
+}
+
+test "findNewlines" {
+    var positions = std.array_list.Managed(u32).init(std.testing.allocator);
+    defer positions.deinit();
+
+    try findNewlines("line1\nline2\nline3\n", &positions);
+
+    try std.testing.expectEqual(@as(usize, 3), positions.items.len);
+    try std.testing.expectEqual(@as(u32, 5), positions.items[0]);
+    try std.testing.expectEqual(@as(u32, 11), positions.items[1]);
+    try std.testing.expectEqual(@as(u32, 17), positions.items[2]);
+}
+
+test "findNewlines long content" {
+    // Test with content longer than SIMD vector size
+    const content = "a" ** 50 ++ "\n" ++ "b" ** 50 ++ "\n";
+    var positions = std.array_list.Managed(u32).init(std.testing.allocator);
+    defer positions.deinit();
+
+    try findNewlines(content, &positions);
+
+    try std.testing.expectEqual(@as(usize, 2), positions.items.len);
+    try std.testing.expectEqual(@as(u32, 50), positions.items[0]);
+    try std.testing.expectEqual(@as(u32, 101), positions.items[1]);
+}

--- a/src/js/bun/diff.ts
+++ b/src/js/bun/diff.ts
@@ -1,0 +1,57 @@
+// Hardcoded module "diff"
+//
+// SIMD-optimized Myers diff engine for text comparison.
+// Designed for AI coding assistants like Claude Code.
+
+/** A single edit operation */
+export interface Edit {
+  type: "equal" | "insert" | "delete";
+  oldStart: number;
+  oldEnd: number;
+  newStart: number;
+  newEnd: number;
+}
+
+/** Statistics about the diff */
+export interface DiffStats {
+  linesAdded: number;
+  linesDeleted: number;
+  hunks: number;
+}
+
+/** Result of a diff operation */
+export interface DiffResult {
+  edits: Edit[];
+  stats: DiffStats;
+}
+
+// Import native diff binding from Zig
+const { diff: nativeDiff } = $zig("bun_diff_binding.zig", "generate") as {
+  diff: (a: string, b: string) => DiffResult;
+};
+
+/**
+ * Compute the difference between two strings.
+ *
+ * Uses the Myers O(ND) diff algorithm with SIMD-accelerated comparison.
+ *
+ * @example
+ * ```ts
+ * import { diff } from "bun:diff";
+ *
+ * const result = diff("hello\nworld\n", "hello\nearth\n");
+ * console.log(result.stats); // { linesAdded: 1, linesDeleted: 1, hunks: 1 }
+ * ```
+ *
+ * @param a - The original string
+ * @param b - The modified string
+ * @returns The diff result containing edits and statistics
+ */
+function diff(a: string, b: string): DiffResult {
+  if (typeof a !== "string" || typeof b !== "string") {
+    throw new TypeError("diff() arguments must be strings");
+  }
+  return nativeDiff(a, b);
+}
+
+export default { diff };

--- a/test/js/bun/diff/diff.test.ts
+++ b/test/js/bun/diff/diff.test.ts
@@ -1,0 +1,473 @@
+import { diff } from "bun:diff";
+import { describe, expect, test } from "bun:test";
+
+describe("bun:diff", () => {
+  describe("basic functionality", () => {
+    test("identical strings return all equal edits", () => {
+      const result = diff("hello\nworld\n", "hello\nworld\n");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.stats.hunks).toBe(0);
+      expect(result.edits).toHaveLength(1);
+      expect(result.edits[0].type).toBe("equal");
+      expect(result.edits[0].oldStart).toBe(0);
+      expect(result.edits[0].oldEnd).toBe(2);
+      expect(result.edits[0].newStart).toBe(0);
+      expect(result.edits[0].newEnd).toBe(2);
+    });
+
+    test("empty strings return no edits", () => {
+      const result = diff("", "");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.stats.hunks).toBe(0);
+      expect(result.edits).toHaveLength(0);
+    });
+
+    test("single line change", () => {
+      const result = diff("hello\nworld\n", "hello\nearth\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+
+      // Find the edits by type
+      const equalEdits = result.edits.filter(e => e.type === "equal");
+      const deleteEdits = result.edits.filter(e => e.type === "delete");
+      const insertEdits = result.edits.filter(e => e.type === "insert");
+
+      expect(equalEdits.length).toBeGreaterThanOrEqual(1);
+      expect(deleteEdits).toHaveLength(1);
+      expect(insertEdits).toHaveLength(1);
+    });
+  });
+
+  describe("insertions", () => {
+    test("insert at beginning", () => {
+      const result = diff("b\nc\n", "a\nb\nc\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.stats.hunks).toBe(1);
+
+      const insertEdits = result.edits.filter(e => e.type === "insert");
+      expect(insertEdits).toHaveLength(1);
+    });
+
+    test("insert at end", () => {
+      const result = diff("a\nb\n", "a\nb\nc\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.stats.hunks).toBe(1);
+
+      const insertEdits = result.edits.filter(e => e.type === "insert");
+      expect(insertEdits).toHaveLength(1);
+    });
+
+    test("insert in middle", () => {
+      const result = diff("a\nc\n", "a\nb\nc\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.stats.hunks).toBe(1);
+
+      const insertEdits = result.edits.filter(e => e.type === "insert");
+      expect(insertEdits).toHaveLength(1);
+    });
+
+    test("insert multiple lines", () => {
+      const result = diff("a\nd\n", "a\nb\nc\nd\n");
+
+      expect(result.stats.linesAdded).toBe(2);
+      expect(result.stats.linesDeleted).toBe(0);
+    });
+
+    test("insert into empty", () => {
+      const result = diff("", "a\nb\nc\n");
+
+      expect(result.stats.linesAdded).toBe(3);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.stats.hunks).toBe(1);
+    });
+  });
+
+  describe("deletions", () => {
+    test("delete from beginning", () => {
+      const result = diff("a\nb\nc\n", "b\nc\n");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+
+      const deleteEdits = result.edits.filter(e => e.type === "delete");
+      expect(deleteEdits).toHaveLength(1);
+    });
+
+    test("delete from end", () => {
+      const result = diff("a\nb\nc\n", "a\nb\n");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+
+      const deleteEdits = result.edits.filter(e => e.type === "delete");
+      expect(deleteEdits).toHaveLength(1);
+    });
+
+    test("delete from middle", () => {
+      const result = diff("a\nb\nc\n", "a\nc\n");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+
+      const deleteEdits = result.edits.filter(e => e.type === "delete");
+      expect(deleteEdits).toHaveLength(1);
+    });
+
+    test("delete multiple lines", () => {
+      const result = diff("a\nb\nc\nd\n", "a\nd\n");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(2);
+    });
+
+    test("delete all lines", () => {
+      const result = diff("a\nb\nc\n", "");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(3);
+      expect(result.stats.hunks).toBe(1);
+    });
+  });
+
+  describe("replacements", () => {
+    test("replace single line", () => {
+      const result = diff("old\n", "new\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+    });
+
+    test("replace all lines", () => {
+      const result = diff("a\nb\nc\n", "x\ny\nz\n");
+
+      expect(result.stats.linesAdded).toBe(3);
+      expect(result.stats.linesDeleted).toBe(3);
+    });
+
+    test("replace with different count", () => {
+      const result = diff("a\nb\n", "x\ny\nz\n");
+
+      expect(result.stats.linesAdded).toBe(3);
+      expect(result.stats.linesDeleted).toBe(2);
+    });
+  });
+
+  describe("multiple hunks", () => {
+    test("two separate changes", () => {
+      const oldText = "a\nb\nc\nd\ne\n";
+      const newText = "a\nX\nc\nY\ne\n";
+      const result = diff(oldText, newText);
+
+      expect(result.stats.linesAdded).toBe(2);
+      expect(result.stats.linesDeleted).toBe(2);
+      expect(result.stats.hunks).toBe(2);
+    });
+
+    test("changes at both ends", () => {
+      const oldText = "a\nb\nc\n";
+      const newText = "X\nb\nY\n";
+      const result = diff(oldText, newText);
+
+      expect(result.stats.linesAdded).toBe(2);
+      expect(result.stats.linesDeleted).toBe(2);
+      expect(result.stats.hunks).toBe(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("single line without newline", () => {
+      const result = diff("hello", "hello");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.edits).toHaveLength(1);
+      expect(result.edits[0].type).toBe("equal");
+    });
+
+    test("add newline to end", () => {
+      const result = diff("hello", "hello\n");
+
+      // The content "hello" vs "hello\n" - "hello" is one line without newline
+      // "hello\n" means "hello" line followed by empty after newline
+      expect(result.edits.length).toBeGreaterThan(0);
+    });
+
+    test("very long identical lines", () => {
+      const longLine = "x".repeat(10000);
+      const result = diff(longLine + "\n", longLine + "\n");
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.edits).toHaveLength(1);
+      expect(result.edits[0].type).toBe("equal");
+    });
+
+    test("many lines", () => {
+      const lines = Array.from({ length: 1000 }, (_, i) => `line ${i}`).join("\n") + "\n";
+      const result = diff(lines, lines);
+
+      expect(result.stats.linesAdded).toBe(0);
+      expect(result.stats.linesDeleted).toBe(0);
+      expect(result.edits).toHaveLength(1);
+      expect(result.edits[0].type).toBe("equal");
+      expect(result.edits[0].oldEnd).toBe(1000);
+    });
+
+    test("unicode content", () => {
+      const result = diff("hello\n世界\n", "hello\n地球\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+    });
+
+    test("empty lines", () => {
+      const result = diff("a\n\nb\n", "a\n\n\nb\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(0);
+    });
+
+    test("whitespace-only differences", () => {
+      const result = diff("hello world\n", "hello  world\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(1);
+    });
+
+    test("tabs vs spaces", () => {
+      const result = diff("hello\tworld\n", "hello world\n");
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(1);
+    });
+  });
+
+  describe("edit structure", () => {
+    test("edits have correct structure", () => {
+      const result = diff("a\nb\n", "a\nc\n");
+
+      for (const edit of result.edits) {
+        expect(typeof edit.type).toBe("string");
+        expect(["equal", "insert", "delete"]).toContain(edit.type);
+        expect(typeof edit.oldStart).toBe("number");
+        expect(typeof edit.oldEnd).toBe("number");
+        expect(typeof edit.newStart).toBe("number");
+        expect(typeof edit.newEnd).toBe("number");
+        expect(edit.oldStart).toBeLessThanOrEqual(edit.oldEnd);
+        expect(edit.newStart).toBeLessThanOrEqual(edit.newEnd);
+      }
+    });
+
+    test("edits are in order", () => {
+      const result = diff("a\nb\nc\nd\n", "a\nX\nc\nY\n");
+
+      let lastOldEnd = 0;
+      for (const edit of result.edits) {
+        expect(edit.oldStart).toBeGreaterThanOrEqual(lastOldEnd);
+        lastOldEnd = edit.oldEnd;
+      }
+    });
+
+    test("equal edits have matching ranges", () => {
+      const result = diff("a\nb\nc\n", "a\nX\nc\n");
+
+      const equalEdits = result.edits.filter(e => e.type === "equal");
+      for (const edit of equalEdits) {
+        expect(edit.oldEnd - edit.oldStart).toBe(edit.newEnd - edit.newStart);
+      }
+    });
+
+    test("delete edits have zero new range", () => {
+      const result = diff("a\nb\nc\n", "a\nc\n");
+
+      const deleteEdits = result.edits.filter(e => e.type === "delete");
+      for (const edit of deleteEdits) {
+        expect(edit.newEnd).toBe(edit.newStart);
+      }
+    });
+
+    test("insert edits have zero old range", () => {
+      const result = diff("a\nc\n", "a\nb\nc\n");
+
+      const insertEdits = result.edits.filter(e => e.type === "insert");
+      for (const edit of insertEdits) {
+        expect(edit.oldEnd).toBe(edit.oldStart);
+      }
+    });
+  });
+
+  describe("stats structure", () => {
+    test("stats have correct structure", () => {
+      const result = diff("a\n", "b\n");
+
+      expect(typeof result.stats.linesAdded).toBe("number");
+      expect(typeof result.stats.linesDeleted).toBe("number");
+      expect(typeof result.stats.hunks).toBe("number");
+      expect(result.stats.linesAdded).toBeGreaterThanOrEqual(0);
+      expect(result.stats.linesDeleted).toBeGreaterThanOrEqual(0);
+      expect(result.stats.hunks).toBeGreaterThanOrEqual(0);
+    });
+
+    test("stats match edit counts", () => {
+      const result = diff("a\nb\nc\n", "a\nX\nY\nc\n");
+
+      let insertCount = 0;
+      let deleteCount = 0;
+
+      for (const edit of result.edits) {
+        if (edit.type === "insert") {
+          insertCount += edit.newEnd - edit.newStart;
+        } else if (edit.type === "delete") {
+          deleteCount += edit.oldEnd - edit.oldStart;
+        }
+      }
+
+      expect(result.stats.linesAdded).toBe(insertCount);
+      expect(result.stats.linesDeleted).toBe(deleteCount);
+    });
+  });
+
+  describe("error handling", () => {
+    test("throws on non-string first argument", () => {
+      expect(() => {
+        // @ts-expect-error - testing runtime behavior
+        diff(123, "hello");
+      }).toThrow();
+    });
+
+    test("throws on non-string second argument", () => {
+      expect(() => {
+        // @ts-expect-error - testing runtime behavior
+        diff("hello", 123);
+      }).toThrow();
+    });
+
+    test("throws on null arguments", () => {
+      expect(() => {
+        // @ts-expect-error - testing runtime behavior
+        diff(null, "hello");
+      }).toThrow();
+    });
+
+    test("throws on undefined arguments", () => {
+      expect(() => {
+        // @ts-expect-error - testing runtime behavior
+        diff(undefined, "hello");
+      }).toThrow();
+    });
+
+    test("throws with too few arguments", () => {
+      expect(() => {
+        // @ts-expect-error - testing runtime behavior
+        diff("hello");
+      }).toThrow();
+    });
+
+    test("throws with no arguments", () => {
+      expect(() => {
+        // @ts-expect-error - testing runtime behavior
+        diff();
+      }).toThrow();
+    });
+  });
+
+  describe("real-world scenarios", () => {
+    test("code change - add function", () => {
+      const oldCode = `function hello() {
+  console.log("hello");
+}
+`;
+      const newCode = `function hello() {
+  console.log("hello");
+}
+
+function goodbye() {
+  console.log("goodbye");
+}
+`;
+      const result = diff(oldCode, newCode);
+
+      expect(result.stats.linesAdded).toBeGreaterThan(0);
+      expect(result.stats.linesDeleted).toBe(0);
+    });
+
+    test("code change - modify function", () => {
+      const oldCode = `function greet(name) {
+  console.log("Hello, " + name);
+}
+`;
+      const newCode = `function greet(name) {
+  console.log(\`Hello, \${name}!\`);
+}
+`;
+      const result = diff(oldCode, newCode);
+
+      expect(result.stats.linesAdded).toBe(1);
+      expect(result.stats.linesDeleted).toBe(1);
+    });
+
+    test("config file change", () => {
+      const oldConfig = `{
+  "name": "my-app",
+  "version": "1.0.0",
+  "dependencies": {}
+}
+`;
+      const newConfig = `{
+  "name": "my-app",
+  "version": "1.1.0",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}
+`;
+      const result = diff(oldConfig, newConfig);
+
+      expect(result.stats.linesAdded).toBeGreaterThan(0);
+      expect(result.stats.linesDeleted).toBeGreaterThan(0);
+    });
+
+    test("markdown document edit", () => {
+      const oldDoc = `# My Document
+
+This is a paragraph.
+
+## Section 1
+
+Content here.
+`;
+      const newDoc = `# My Document
+
+This is an updated paragraph.
+
+## Section 1
+
+Content here.
+
+## Section 2
+
+New section.
+`;
+      const result = diff(oldDoc, newDoc);
+
+      expect(result.stats.linesAdded).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements a new `bun:diff` module providing high-performance text diffing
- Myers O(ND) diff algorithm for minimal edit distance
- SIMD-accelerated byte comparison and newline scanning
- Zero-copy line indexing with Wyhash for fast comparison

## API
```ts
import { diff } from "bun:diff";
const result = diff(oldText, newText);
// result.edits: Edit[] - array of edit operations
// result.stats: { linesAdded, linesDeleted, hunks }
```

## Test plan
- [x] 43 unit tests covering basic functionality, edge cases, and error handling
- [x] Tests pass locally with `bun bd test test/js/bun/diff/diff.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)