### PR TITLE
Increase max size of server.idleTimeout to u16 and set higher default

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -55,7 +55,7 @@ public:
         return (HttpResponseData<SSL> *) us_socket_ext(SSL, s);
     }
 
-    void setTimeout(uint8_t seconds) {
+    void setTimeout(u_int16_t seconds) {
         auto* data = getHttpResponseData();
         data->idleTimeout = seconds;
         Super::timeout(data->idleTimeout);
@@ -318,17 +318,17 @@ public:
         /* Move any backpressure out of HttpResponse */
         auto* responseData = getHttpResponseData();
         BackPressure backpressure(std::move(((AsyncSocketData<SSL> *) responseData)->buffer));
-        
+
         auto* socketData = responseData->socketData;
         HttpContextData<SSL> *httpContextData = httpContext->getSocketContextData();
-        
+
         /* Destroy HttpResponseData */
         responseData->~HttpResponseData();
 
         /* Before we adopt and potentially change socket, check if we are corked */
         bool wasCorked = Super::isCorked();
 
-        
+
 
         /* Adopting a socket invalidates it, do not rely on it directly to carry any data */
         us_socket_t *usSocket = us_socket_context_adopt_socket(SSL, (us_socket_context_t *) webSocketContext, (us_socket_t *) this, sizeof(HttpResponseData<SSL>), sizeof(WebSocketData) + sizeof(UserData));

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -678,7 +678,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         }
 
         pub fn setIdleTimeout(this: *ThisServer, seconds: c_uint) void {
-            this.config.idleTimeout = @truncate(@min(seconds, 255));
+            this.config.idleTimeout = @truncate(@min(seconds, 65535));
         }
 
         pub fn setFlags(this: *ThisServer, require_host_header: bool, use_strict_method_validation: bool) void {

--- a/src/bun.js/api/server/ServerConfig.zig
+++ b/src/bun.js/api/server/ServerConfig.zig
@@ -23,7 +23,7 @@ address: union(enum) {
 } = .{
     .tcp = .{},
 },
-idleTimeout: u8 = 10, //TODO: should we match websocket default idleTimeout of 120?
+idleTimeout: u16 = 3610, //TODO: should we match websocket default idleTimeout of 120?
 has_idleTimeout: bool = false,
 // TODO: use webkit URL parser instead of bun's
 base_url: URL = URL{},
@@ -727,8 +727,8 @@ pub fn fromJS(
                 args.has_idleTimeout = true;
 
                 const idleTimeout: u64 = @intCast(@max(value.toInt64(), 0));
-                if (idleTimeout > 255) {
-                    return global.throwInvalidArguments("Bun.serve expects idleTimeout to be 255 or less", .{});
+                if (idleTimeout > 65535) {
+                    return global.throwInvalidArguments("Bun.serve expects idleTimeout to be 65535 or less", .{});
                 }
 
                 args.idleTimeout = @truncate(idleTimeout);

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1312,7 +1312,7 @@ extern "C"
       uwsRes->resetTimeout();
     }
   }
-  void uws_res_timeout(int ssl, uws_res_r res, uint8_t seconds) {
+  void uws_res_timeout(int ssl, uws_res_r res, u_int16_t seconds) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
       uwsRes->setTimeout(seconds);

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -686,7 +686,7 @@ const c = struct {
     pub extern fn uws_res_write_header_int(ssl: i32, res: *c.uws_res, key: [*c]const u8, key_length: usize, value: u64) void;
     pub extern fn uws_res_end_without_body(ssl: i32, res: *c.uws_res, close_connection: bool) void;
     pub extern fn uws_res_end_sendfile(ssl: i32, res: *c.uws_res, write_offset: u64, close_connection: bool) void;
-    pub extern fn uws_res_timeout(ssl: i32, res: *c.uws_res, timeout: u8) void;
+    pub extern fn uws_res_timeout(ssl: i32, res: *c.uws_res, timeout: u16) void;
     pub extern fn uws_res_reset_timeout(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_get_buffered_amount(ssl: i32, res: *c.uws_res) u64;
     pub extern fn uws_res_write(ssl: i32, res: *c.uws_res, data: ?[*]const u8, length: *usize) bool;

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -90,8 +90,8 @@ pub fn NewResponse(ssl_flag: i32) type {
         pub fn endSendFile(res: *Response, write_offset: u64, close_connection: bool) void {
             c.uws_res_end_sendfile(ssl_flag, res.downcast(), write_offset, close_connection);
         }
-        pub fn timeout(res: *Response, seconds: u8) void {
-            c.uws_res_timeout(ssl_flag, res.downcast(), seconds);
+        pub fn timeout(res: *Response, seconds: u16) void {
+            c.uws_res_timeout(ssl_flag, res.downcast(), @truncate(seconds));
         }
         pub fn resetTimeout(res: *Response) void {
             c.uws_res_reset_timeout(ssl_flag, res.downcast());
@@ -431,7 +431,7 @@ pub const AnyResponse = union(enum) {
         };
     }
 
-    pub fn timeout(this: AnyResponse, seconds: u8) void {
+    pub fn timeout(this: AnyResponse, seconds: u16) void {
         switch (this) {
             inline else => |resp| resp.timeout(seconds),
         }

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -91,7 +91,7 @@ pub fn NewResponse(ssl_flag: i32) type {
             c.uws_res_end_sendfile(ssl_flag, res.downcast(), write_offset, close_connection);
         }
         pub fn timeout(res: *Response, seconds: u16) void {
-            c.uws_res_timeout(ssl_flag, res.downcast(), @truncate(seconds));
+            c.uws_res_timeout(ssl_flag, res.downcast(), seconds);
         }
         pub fn resetTimeout(res: *Response) void {
             c.uws_res_reset_timeout(ssl_flag, res.downcast());


### PR DESCRIPTION
### What does this PR do?
Increase max size of server.idleTimeout to u16 and set a higher default that works for most cloud vendors load balancer defaults: 3610 seconds.

Fix for this issue:
https://github.com/issues/recent?issue=oven-sh%7Cbun%7C15589

### How did you verify your code works?
Have not done that yet, but working on it.
