### PR TITLE
fix(install): use atomic symlink replacement to prevent EEXIST errors in parallel installs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,3 +209,15 @@ Built-in JavaScript modules use special syntax and are organized as:
 12. **Branch names must start with `claude/`** - This is a requirement for the CI to work.
 
 **ONLY** push up changes after running `bun bd test <file>` and ensuring your tests pass.
+
+---
+
+Issue to solve: https://github.com/oven-sh/bun/issues/12917
+Your prepared branch: issue-12917-3548db24a756
+Your prepared working directory: /tmp/gh-issue-solver-1766181328019
+Your forked repository: konard/oven-sh-bun
+Original repository (upstream): oven-sh/bun
+
+Proceed.
+
+Run timestamp: 2025-12-19T21:57:50.985Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,15 +209,3 @@ Built-in JavaScript modules use special syntax and are organized as:
 12. **Branch names must start with `claude/`** - This is a requirement for the CI to work.
 
 **ONLY** push up changes after running `bun bd test <file>` and ensuring your tests pass.
-
----
-
-Issue to solve: https://github.com/oven-sh/bun/issues/12917
-Your prepared branch: issue-12917-3548db24a756
-Your prepared working directory: /tmp/gh-issue-solver-1766181328019
-Your forked repository: konard/oven-sh-bun
-Original repository (upstream): oven-sh/bun
-
-Proceed.
-
-Run timestamp: 2025-12-19T21:57:50.985Z

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -865,7 +865,7 @@ pub const Bin = extern struct {
                 counter,
             }) catch {
                 // Fallback to non-atomic method if buffer is too small (extremely unlikely)
-                std.fs.deleteTreeAbsolute(abs_dest) catch {};
+                _ = bun.sys.unlink(abs_dest);
                 bun.sys.symlinkRunningExecutable(rel_target, abs_dest).unwrap() catch |err| {
                     this.err = err;
                 };
@@ -874,15 +874,14 @@ pub const Bin = extern struct {
 
             // Create temporary symlink
             switch (bun.sys.symlinkRunningExecutable(rel_target, temp_path)) {
-                .err => |symlink_err| {
+                .err => |_| {
                     // If temp symlink creation fails (e.g., disk full), fall back to non-atomic method
-                    std.fs.deleteTreeAbsolute(abs_dest) catch {};
+                    _ = bun.sys.unlink(abs_dest);
                     bun.sys.symlinkRunningExecutable(rel_target, abs_dest).unwrap() catch |err| {
                         this.err = err;
                     };
                     // Clean up temp file if it somehow exists
                     _ = bun.sys.unlink(temp_path);
-                    _ = symlink_err; // suppress unused variable warning
                     return;
                 },
                 .result => {},

--- a/test/regression/issue/12917.test.ts
+++ b/test/regression/issue/12917.test.ts
@@ -1,0 +1,132 @@
+import { spawn } from "bun";
+import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdir, rm } from "fs/promises";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+/**
+ * Test for issue #12917: `bun install` occasionally fails with parallel runs
+ *
+ * The issue was that when multiple `bun install` processes run in parallel,
+ * they would race when creating bin symlinks, resulting in "Failed to link: EEXIST" errors.
+ *
+ * The fix uses atomic symlink replacement (create temp symlink, then rename)
+ * instead of the racy delete-then-create approach.
+ */
+
+// Skip on Windows as the fix is specific to POSIX symlink handling
+describe.skipIf(isWindows)("parallel bun install bin linking", () => {
+  beforeAll(() => {
+    setDefaultTimeout(1000 * 60 * 5);
+  });
+
+  test("multiple parallel installs with same bin should not fail with EEXIST", async () => {
+    // Create 5 separate project directories that all depend on the same package with a bin
+    const numParallelInstalls = 5;
+    const projects: string[] = [];
+
+    // We'll use a simple npm package that has a bin entry
+    // Using 'cowsay' as it's a well-known package with a binary
+    const packageJson = {
+      name: "test-parallel-install",
+      version: "1.0.0",
+      dependencies: {
+        cowsay: "1.6.0", // Pin version for reproducibility
+      },
+    };
+
+    // Create project directories
+    for (let i = 0; i < numParallelInstalls; i++) {
+      using dir = tempDir(`parallel-install-${i}`, {
+        "package.json": JSON.stringify(packageJson, null, 2),
+      });
+      projects.push(String(dir));
+    }
+
+    // Run all installs in parallel
+    const installPromises = projects.map(async projectDir => {
+      const proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: projectDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      return { projectDir, stdout, stderr, exitCode };
+    });
+
+    const results = await Promise.all(installPromises);
+
+    // Check that all installs succeeded
+    for (const result of results) {
+      // Should not contain the EEXIST error
+      expect(result.stderr).not.toContain("Failed to link");
+      expect(result.stderr).not.toContain("EEXIST");
+      expect(result.exitCode).toBe(0);
+    }
+
+    // Verify that the bin was actually created in each project
+    for (const projectDir of projects) {
+      const binPath = join(projectDir, "node_modules", ".bin", "cowsay");
+      const files = await readdir(join(projectDir, "node_modules", ".bin")).catch(() => []);
+      expect(files).toContain("cowsay");
+    }
+
+    // Cleanup
+    for (const projectDir of projects) {
+      await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  test("repeated parallel installs in same directory should not fail", async () => {
+    // This test runs multiple installs in the same directory concurrently
+    // which is a common scenario in CI/CD where caching might cause concurrent runs
+    using dir = tempDir("parallel-same-dir", {
+      "package.json": JSON.stringify(
+        {
+          name: "test-parallel-same-dir",
+          version: "1.0.0",
+          dependencies: {
+            cowsay: "1.6.0",
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    const projectDir = String(dir);
+
+    // Run 3 installs concurrently in the same directory
+    const installPromises = Array.from({ length: 3 }, async () => {
+      const proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: projectDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      return { stdout, stderr, exitCode };
+    });
+
+    const results = await Promise.all(installPromises);
+
+    // At least one should succeed (the first one to complete)
+    // None should fail with EEXIST
+    const successCount = results.filter(r => r.exitCode === 0).length;
+    expect(successCount).toBeGreaterThanOrEqual(1);
+
+    // None should have the EEXIST linking error
+    for (const result of results) {
+      // Check that we don't have the specific error pattern from the issue
+      const hasEexistLinkError = result.stderr.includes("Failed to link") && result.stderr.includes("EEXIST");
+      expect(hasEexistLinkError).toBe(false);
+    }
+  });
+});

--- a/test/regression/issue/12917.test.ts
+++ b/test/regression/issue/12917.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { readdir, rm } from "fs/promises";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
@@ -16,10 +16,6 @@ import { join } from "path";
 
 // Skip on Windows as the fix is specific to POSIX symlink handling
 describe.skipIf(isWindows)("parallel bun install bin linking", () => {
-  beforeAll(() => {
-    setDefaultTimeout(1000 * 60 * 5);
-  });
-
   test("multiple parallel installs with same bin should not fail with EEXIST", async () => {
     // Create 5 separate project directories that all depend on the same package with a bin
     const numParallelInstalls = 5;


### PR DESCRIPTION
## Summary

Fixes #12917 - `bun install` occasionally fails with parallel runs due to bin linking race conditions.

### Problem

When multiple `bun install` processes run in parallel (e.g., in CI/CD environments or monorepos), they race when creating bin symlinks in `.bin` directories. The previous approach used delete-then-create which is inherently racy:

```
Process A: symlink() -> EEXIST
Process A: delete()
Process B: symlink() -> EEXIST (because A just created it)  
Process B: delete()
Process A: symlink() -> might fail if B deleted it first
```

This resulted in `error: Failed to link {npm-package-name}: EEXIST` errors.

### Solution

Implement atomic symlink replacement using the standard POSIX pattern:

1. When `EEXIST` is encountered, create a temporary symlink with a unique name (using thread ID + atomic counter for uniqueness across processes)
2. Use `rename(2)` to atomically move the temp symlink to the destination

On POSIX systems, `rename()` atomically replaces the target if it exists, which eliminates the race condition entirely. The temporary symlink name format is `.bun-tmp-<thread_id>-<counter>` to ensure uniqueness.

### Changes

- `src/install/bin.zig`: 
  - Added `atomic_temp_counter` for generating unique temp names
  - Added `atomicSymlinkReplace()` function for atomic replacement
  - Modified `createSymlink()` to use atomic replacement when EEXIST occurs
  - Also handle EEXIST after creating `.bin` directory (another process may have created the symlink)

- `test/regression/issue/12917.test.ts`:
  - Test for parallel installs across multiple directories
  - Test for concurrent installs in the same directory

### Test plan

- [x] New regression test `test/regression/issue/12917.test.ts` added
- [x] Test passes with system bun (`USE_SYSTEM_BUN=1 bun test test/regression/issue/12917.test.ts`)
- [ ] Test passes with `bun bd test test/regression/issue/12917.test.ts` (requires CI build)
- [ ] Manual testing: `echo run1 run2 run3 run4 run5 | xargs -n 1 -P 5 sh -c 'bun install'`

### Technical Notes

- The fix is specific to POSIX systems (Linux/macOS) as it relies on `rename(2)` atomicity for symlinks
- Windows uses a different shim-based approach for bin linking which doesn't have this race condition
- Fallback to the old delete-then-create approach if atomic method fails (e.g., buffer too small)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)