### PR TITLE
fix(create): crash when running postinstall task with --no-install

### DIFF
--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -80,7 +80,7 @@ fn execTask(allocator: std.mem.Allocator, task_: string, cwd: string, _: string,
         }
     }
 
-    if (strings.startsWith(task, "bun ")) {
+    if (npm_client != null and strings.startsWith(task, "bun ")) {
         argv = argv[2..];
     }
 


### PR DESCRIPTION
## Summary
- Fix segmentation fault in `bun create` when using `--no-install` with a template that has a `bun-create.postinstall` task starting with "bun "
- The bug was caused by unconditionally slicing `argv[2..]` which created an empty array when `npm_client` was null
- Added check for `npm_client != null` before slicing

## Reproduction
```bash
# Create template with bun-create.postinstall
mkdir -p ~/.bun-create/test-template
echo '{"name":"test","bun-create":{"postinstall":"bun install"}}' > ~/.bun-create/test-template/package.json

# This would crash before the fix
bun create test-template /tmp/my-app --no-install
```

## Test plan
- [x] Verified the reproduction case crashes before the fix
- [x] Verified the reproduction case works after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)