### PR TITLE
fix: prevent out-of-bounds access in NO_PROXY parsing

### DIFF
--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -189,22 +189,23 @@ pub const Loader = struct {
                     return http_proxy;
                 }
 
-                var no_proxy_list = std.mem.splitScalar(u8, no_proxy_text, ',');
-                var next = no_proxy_list.next();
-                while (next != null) {
-                    var host = strings.trim(next.?, &strings.whitespace_chars);
+                var no_proxy_iter = std.mem.splitScalar(u8, no_proxy_text, ',');
+                while (no_proxy_iter.next()) |no_proxy_item| {
+                    var host = strings.trim(no_proxy_item, &strings.whitespace_chars);
+                    if (host.len == 0) {
+                        continue;
+                    }
                     if (strings.eql(host, "*")) {
                         return null;
                     }
                     //strips .
-                    if (host[0] == '.') {
+                    if (strings.startsWithChar(host, '.')) {
                         host = host[1..];
                     }
                     //hostname ends with suffix
                     if (strings.endsWith(hostname.?, host)) {
                         return null;
                     }
-                    next = no_proxy_list.next();
                 }
             }
         }

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -201,6 +201,9 @@ pub const Loader = struct {
                     //strips .
                     if (strings.startsWithChar(host, '.')) {
                         host = host[1..];
+                        if (host.len == 0) {
+                            continue;
+                        }
                     }
                     //hostname ends with suffix
                     if (strings.endsWith(hostname.?, host)) {

--- a/test/js/bun/http/proxy.test.js
+++ b/test/js/bun/http/proxy.test.js
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import fs from "fs";
+import { bunEnv, bunExe, gc } from "harness";
+import { tmpdir } from "os";
+import path from "path";
 
 let proxy, auth_proxy, server;
 beforeAll(() => {


### PR DESCRIPTION
## Summary
- Fix out-of-bounds access when parsing `NO_PROXY` environment variable with empty entries
- Empty entries (e.g., `"localhost, , example.com"`) would cause a panic when checking if the host starts with a dot
- Skip empty entries after trimming whitespace

fixes BUN-110G
fixes BUN-128V

## Test plan
- [x] Verify `NO_PROXY="localhost, , example.com"` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)