### PR TITLE
docs: fix incorrect [env] section documentation in bunfig.toml

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -115,6 +115,26 @@ Currently we do not collect telemetry and this setting is only used for enabling
 telemetry = false
 ```
 
+### `env`
+
+Configure automatic `.env` file loading. By default, Bun automatically loads `.env` files. To disable this behavior:
+
+```toml title="bunfig.toml" icon="settings"
+# Disable automatic .env file loading
+env = false
+```
+
+You can also use object syntax with the `file` property:
+
+```toml title="bunfig.toml" icon="settings"
+[env]
+file = false
+```
+
+This is useful in production environments or CI/CD pipelines where you want to rely solely on system environment variables.
+
+Note: Explicitly provided environment files via `--env-file` will still be loaded even when default loading is disabled.
+
 ### `console`
 
 Configure console output behavior.

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -376,22 +376,15 @@ timeout = 10000
 
 ## Environment Variables
 
-Environment variables for tests should be set using `.env` files or preload scripts. Bun automatically loads `.env` files, or you can set them in a preload script:
+Environment variables for tests should be set using `.env` files. Bun automatically loads `.env` files from your project root. For test-specific variables, create a `.env.test` file:
 
-```ts title="test-setup.ts" icon="/icons/typescript.svg"
-// Set environment variables in a preload script
-process.env.NODE_ENV = "test";
-process.env.DATABASE_URL = "postgresql://localhost:5432/test_db";
-process.env.LOG_LEVEL = "error";
+```ini title=".env.test" icon="settings"
+NODE_ENV=test
+DATABASE_URL=postgresql://localhost:5432/test_db
+LOG_LEVEL=error
 ```
 
-```toml title="bunfig.toml" icon="settings"
-[test]
-preload = ["./test-setup.ts"]
-coverage = true
-```
-
-Alternatively, create a `.env.test` file and load it with `--env-file`:
+Then load it with `--env-file`:
 
 ```bash terminal icon="terminal"
 bun test --env-file=.env.test

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -376,16 +376,25 @@ timeout = 10000
 
 ## Environment Variables
 
-You can also set environment variables in your configuration that affect test behavior:
+Environment variables for tests should be set using `.env` files or preload scripts. Bun automatically loads `.env` files, or you can set them in a preload script:
+
+```ts title="test-setup.ts" icon="/icons/typescript.svg"
+// Set environment variables in a preload script
+process.env.NODE_ENV = "test";
+process.env.DATABASE_URL = "postgresql://localhost:5432/test_db";
+process.env.LOG_LEVEL = "error";
+```
 
 ```toml title="bunfig.toml" icon="settings"
-[env]
-NODE_ENV = "test"
-DATABASE_URL = "postgresql://localhost:5432/test_db"
-LOG_LEVEL = "error"
-
 [test]
+preload = ["./test-setup.ts"]
 coverage = true
+```
+
+Alternatively, create a `.env.test` file and load it with `--env-file`:
+
+```bash terminal icon="terminal"
+bun test --env-file=.env.test
 ```
 
 ## Complete Configuration Example
@@ -397,13 +406,6 @@ Here's a comprehensive example showing all available test configuration options:
 # Install settings inherited by tests
 registry = "https://registry.npmjs.org/"
 exact = true
-
-[env]
-# Environment variables for tests
-NODE_ENV = "test"
-DATABASE_URL = "postgresql://localhost:5432/test_db"
-API_URL = "http://localhost:3001"
-LOG_LEVEL = "error"
 
 [test]
 # Test discovery


### PR DESCRIPTION
## Summary
- Fixed documentation that incorrectly claimed you could use `[env]` as a TOML section to set environment variables directly
- The `env` option in bunfig.toml only controls whether automatic `.env` file loading is disabled (via `env = false`)
- Updated to show the correct approaches: using preload scripts or `.env` files with `--env-file`

## Test plan
- Documentation-only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)