### PR TITLE
perf: shrink ConcurrentTask from 24 bytes to 16 bytes

### DIFF
--- a/src/bake/DevServer/WatcherAtomics.zig
+++ b/src/bake/DevServer/WatcherAtomics.zig
@@ -132,8 +132,6 @@ pub fn watcherReleaseAndSubmitEvent(self: *Self, ev: *HotReloadEvent) void {
                 self.dbg_server_event = ev;
             }
             ev.concurrent_task = .{
-                .auto_delete = false,
-                .next = null,
                 .task = jsc.Task.init(ev),
             };
             ev.owner.vm.event_loop.enqueueTaskConcurrent(&ev.concurrent_task);

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -321,7 +321,7 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
             dest.deinit();
         }
 
-        if (task.auto_delete) {
+        if (task.autoDelete()) {
             to_destroy = task;
         }
 

--- a/src/bun.js/event_loop/ConcurrentTask.zig
+++ b/src/bun.js/event_loop/ConcurrentTask.zig
@@ -11,8 +11,63 @@
 const ConcurrentTask = @This();
 
 task: Task = undefined,
-next: ?*ConcurrentTask = null,
-auto_delete: bool = false,
+/// Packed representation of the next pointer and auto_delete flag.
+/// Uses the low bit to store auto_delete (since pointers are at least 2-byte aligned).
+next: PackedNextPtr = .none,
+
+/// Packed next pointer that encodes both the next ConcurrentTask pointer and the auto_delete flag.
+/// Uses the low bit for auto_delete since ConcurrentTask pointers are at least 2-byte aligned.
+pub const PackedNextPtr = enum(usize) {
+    none = 0,
+    auto_delete = 1,
+    _,
+
+    pub inline fn init(ptr: ?*ConcurrentTask, auto_del: bool) PackedNextPtr {
+        const ptr_bits = if (ptr) |p| @intFromPtr(p) else 0;
+        return @enumFromInt(ptr_bits | @intFromBool(auto_del));
+    }
+
+    pub inline fn getPtr(self: PackedNextPtr) ?*ConcurrentTask {
+        const addr = @intFromEnum(self) & ~@as(usize, 1);
+        return if (addr == 0) null else @ptrFromInt(addr);
+    }
+
+    pub inline fn setPtr(self: *PackedNextPtr, ptr: ?*ConcurrentTask) void {
+        const auto_del = @intFromEnum(self.*) & 1;
+        const ptr_bits = if (ptr) |p| @intFromPtr(p) else 0;
+        self.* = @enumFromInt(ptr_bits | auto_del);
+    }
+
+    pub inline fn isAutoDelete(self: PackedNextPtr) bool {
+        return (@intFromEnum(self) & 1) != 0;
+    }
+
+    pub inline fn atomicLoadPtr(self: *const PackedNextPtr, ordering: std.builtin.AtomicOrder) ?*ConcurrentTask {
+        const value = @atomicLoad(usize, @as(*const usize, @ptrCast(self)), ordering);
+        const addr = value & ~@as(usize, 1);
+        return if (addr == 0) null else @ptrFromInt(addr);
+    }
+
+    pub inline fn atomicStorePtr(self: *PackedNextPtr, ptr: ?*ConcurrentTask, ordering: std.builtin.AtomicOrder) void {
+        const ptr_bits = if (ptr) |p| @intFromPtr(p) else 0;
+        const self_ptr: *usize = @ptrCast(self);
+        var current = @atomicLoad(usize, self_ptr, .monotonic);
+        while (true) {
+            const new_value = ptr_bits | (current & 1);
+            if (@cmpxchgWeak(usize, self_ptr, current, new_value, ordering, .monotonic)) |updated| {
+                current = updated;
+            } else {
+                break;
+            }
+        }
+    }
+};
+
+comptime {
+    if (@sizeOf(ConcurrentTask) != 16) {
+        @compileError("ConcurrentTask should be 16 bytes, but is " ++ std.fmt.comptimePrint("{}", .{@sizeOf(ConcurrentTask)}) ++ " bytes");
+    }
+}
 
 pub const Queue = UnboundedQueue(ConcurrentTask, .next);
 pub const new = bun.TrivialNew(@This());
@@ -22,11 +77,11 @@ pub const AutoDeinit = enum {
     manual_deinit,
     auto_deinit,
 };
+
 pub fn create(task: Task) *ConcurrentTask {
     return ConcurrentTask.new(.{
         .task = task,
-        .next = null,
-        .auto_delete = true,
+        .next = .auto_delete,
     });
 }
 
@@ -46,16 +101,20 @@ pub fn from(this: *ConcurrentTask, of: anytype, auto_deinit: AutoDeinit) *Concur
 
     this.* = .{
         .task = Task.init(of),
-        .next = null,
-        .auto_delete = auto_deinit == .auto_deinit,
+        .next = if (auto_deinit == .auto_deinit) .auto_delete else .none,
     };
     return this;
+}
+
+/// Returns whether this task should be automatically deallocated after execution.
+pub fn autoDelete(this: *const ConcurrentTask) bool {
+    return this.next.isAutoDelete();
 }
 
 const std = @import("std");
 
 const bun = @import("bun");
-const UnboundedQueue = bun.threading.UnboundedQueue;
+const UnboundedQueue = bun.UnboundedQueue;
 
 const jsc = bun.jsc;
 const ManagedTask = jsc.ManagedTask;

--- a/src/bun.js/event_loop/JSCScheduler.zig
+++ b/src/bun.js/event_loop/JSCScheduler.zig
@@ -27,8 +27,7 @@ export fn Bun__queueJSCDeferredWorkTaskConcurrently(jsc_vm: *VirtualMachine, tas
     var loop = jsc_vm.eventLoop();
     loop.enqueueTaskConcurrent(ConcurrentTask.new(.{
         .task = Task.init(task),
-        .next = null,
-        .auto_delete = true,
+        .next = .auto_delete,
     }));
 }
 

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -225,7 +225,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                     .hashes = this.hashes,
                     .concurrent_task = undefined,
                 });
-                that.concurrent_task = .{ .task = jsc.Task.init(that), .auto_delete = false };
+                that.concurrent_task = .{ .task = jsc.Task.init(that) };
                 that.reloader.enqueueTaskConcurrent(&that.concurrent_task);
                 this.count = 0;
             }


### PR DESCRIPTION
## Summary

- Pack the `next` pointer and `auto_delete` flag into a single `usize` field using a packed struct
- Since ConcurrentTask pointers are at least 2-byte aligned, we use bit 0 to store the `auto_delete` boolean
- Implement custom Queue that works with the packed representation
- Add compile-time size check to ensure the struct stays at 16 bytes

## Test plan

- [x] `bun bd` builds successfully
- [x] `bun run zig:check-all` passes on all platforms (x86_64/aarch64 linux/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)