### PR TITLE
feat(debugger): add programmatic control for node:inspector support [1/4]

### DIFF
--- a/test/js/internal/debugger/programmatic-control.test.ts
+++ b/test/js/internal/debugger/programmatic-control.test.ts
@@ -1,0 +1,165 @@
+import { expect, test, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// PR1 tests: internal/debugger programmatic control
+//
+// PR1 adds these capabilities to internal/debugger.ts:
+// 1. setInspectorUrl callback (reports real URL when port=0)
+// 2. reportError callback (non-fatal error handling)
+// 3. fatalOnError parameter
+// 4. stop command (empty URL stops server)
+// 5. activeDebugger global for safe multi-call
+//
+// These new parameters are optional with defaults, so existing CLI --inspect
+// continues to work. The new callbacks will be used by node:inspector (PR2).
+//
+// These tests verify that:
+// 1. Existing --inspect CLI functionality is not broken
+// 2. port=0 works correctly (ephemeral port binding)
+// 3. Process exits cleanly with inspector active
+
+describe("internal/debugger programmatic control", () => {
+  test("--inspect with port=0 starts successfully", async () => {
+    using dir = tempDir("debugger-port0", {
+      "test.js": `
+        console.log("started");
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    // Should have started successfully
+    expect(stdout).toContain("started");
+    expect(exitCode).toBe(0);
+
+    // If stderr contains inspector URL, verify port > 0
+    const urlMatch = stderr.match(/ws:\/\/[\w.-]+:(\d+)\//);
+    if (urlMatch) {
+      const port = parseInt(urlMatch[1], 10);
+      expect(port).toBeGreaterThan(0);
+    }
+  });
+
+  test("--inspect starts without crashing", async () => {
+    using dir = tempDir("debugger-basic", {
+      "test.js": `
+        console.log("inspector started");
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("inspector started");
+    expect(exitCode).toBe(0);
+  });
+
+  test("process exits cleanly with inspector", async () => {
+    using dir = tempDir("debugger-exit", {
+      "test.js": `
+        setTimeout(() => {
+          console.log("done");
+          process.exit(0);
+        }, 100);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("done");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--inspect with specific host:port format works", async () => {
+    using dir = tempDir("debugger-host-port", {
+      "test.js": `
+        console.log("host port test");
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=127.0.0.1:0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("host port test");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiple sequential inspector processes work", async () => {
+    // This tests that inspector resources are properly cleaned up
+    // between process runs (no port conflicts, no crashes)
+    for (let i = 0; i < 2; i++) {
+      using dir = tempDir(`debugger-sequential-${i}`, {
+        "test.js": `
+          console.log("run ${i}");
+          process.exit(0);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--inspect=0", "test.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, _stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(stdout).toContain(`run ${i}`);
+      expect(exitCode).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
# feat(debugger): add programmatic control for node:inspector support [1/4]

> `node:inspector` implementation series:
> - **#25643** (this): internal/debugger programmatic control
> - **#25644**: node:inspector open/close/url/waitForDebugger
> - **#25645**: inspector.Session CDP support
> - **#25646**: fix inspector disconnect crash

## Summary

Add programmatic control capabilities to `src/js/internal/debugger.ts` to support the upcoming `node:inspector` API implementation.

## Changes

### `src/js/internal/debugger.ts`

**New types:**
```typescript
type SetInspectorUrlFn = (url?: string) => void;
type ReportErrorFn = (message: string) => void;
```

**New global state:**
```typescript
let activeDebugger: Debugger | undefined;
```

**New helper functions:**
- `safeCallSetInspectorUrl()` - Safely invoke URL callback with try/catch
- `safeCallReportError()` - Safely invoke error callback with try/catch

**Modified default export signature:**
```typescript
export default function (
  executionContextId: number,
  url: string,
  createBackend: CreateBackendFn,
  send: (message: string | string[]) => void,
  close: () => void,
  isAutomatic: boolean,
  urlIsServer: boolean,
  setInspectorUrl?: SetInspectorUrlFn,  // NEW
  reportError?: ReportErrorFn,           // NEW
  fatalOnError: boolean = true,          // NEW
): void
```

**New behaviors in main function:**
- Stop command: empty/whitespace URL stops active inspector and returns
- Multi-call safety: stops previous `activeDebugger` before starting new one
- Reports final URL via `setInspectorUrl` callback (handles port=0)
- Non-fatal error mode: when `fatalOnError=false`, errors go to `reportError` instead of `process.exit(1)`

**Debugger class changes:**
- Added `#server?: WebSocketServer` private field
- Added `stop(): void` method to stop the WebSocket server
- Store server reference in `#listen()` for both TCP and Unix socket modes

**connectToUnixServer changes:**
- Added `fatalOnError` and `reportError` parameters
- Non-fatal error handling for invalid URLs and connection failures
- Moved `backendRaw` declaration outside socket callbacks for proper error cleanup

**Minor cleanups:**
- Removed quotes from object keys where not needed (`"Upgrade"` → `Upgrade`, `"Browser"` → `Browser`)

### `test/js/internal/debugger/programmatic-control.test.ts` (NEW)

New test file with 5 tests:
- `--inspect=0` ephemeral port binding
- Basic `--inspect` startup without crash
- Clean process exit with inspector active
- `host:port` format support
- Multiple sequential inspector processes

## Backward Compatibility

All new parameters have default values, so existing callers (CLI `--inspect`, VSCode extension) continue to work without changes.

## Testing

```bash
bun bd test test/js/internal/debugger/programmatic-control.test.ts
```

## Related

This PR is part of the `node:inspector` implementation series:
- **#25643** (this): Adds programmatic control to internal/debugger
- **#25644**: Uses these APIs to implement `node:inspector` open/close/url/waitForDebugger
- **#25645**: Adds `inspector.Session` for CDP protocol support
- **#25646**: Fixes inspector disconnect crash

Once all four PRs are merged, Bun will have basic Node.js `node:inspector` API compatibility.

Relates to #2445
