### PR TITLE
feat(inspector): implement inspector.Session CDP support [3/4]

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1311,6 +1311,7 @@ if(WIN32)
     dbghelp
     crypt32
     wsock32 # ws2_32 required by TransmitFile aka sendfile on windows
+    xmllite # required by libarchive for xar format
     delayimp.lib
   )
 endif()

--- a/src/bun.js/bindings/BunDebugger.cpp
+++ b/src/bun.js/bindings/BunDebugger.cpp
@@ -64,6 +64,7 @@ static WTF::String nodeInspectorWaitOp()
     return err;
 }
 
+// Caller must hold nodeInspectorLock
 static void nodeInspectorSignalDone()
 {
     if (nodeInspectorOpPending) {

--- a/src/bun.js/bindings/BunInspectorSession.cpp
+++ b/src/bun.js/bindings/BunInspectorSession.cpp
@@ -1,0 +1,717 @@
+#include "root.h"
+
+#include "BunInspectorSession.h"
+#include "ZigGlobalObject.h"
+
+#include <JavaScriptCore/JSGlobalObjectDebugger.h>
+#include <JavaScriptCore/Debugger.h>
+#include <JavaScriptCore/JSGlobalObjectInspectorController.h>
+
+#include "InspectorLifecycleAgent.h"
+#include "InspectorTestReporterAgent.h"
+#include "InspectorBunFrontendDevServerAgent.h"
+#include "InspectorHTTPServerAgent.h"
+
+#include <limits>
+#include <mutex>
+#include <optional>
+
+extern "C" void Bun__eventLoop__incrementRefConcurrently(void* bunVM, int delta);
+extern "C" void Bun__ensureDebugger(WebCore::ScriptExecutionContextIdentifier scriptId, bool pauseOnStart);
+
+namespace Bun {
+using namespace JSC;
+using namespace WebCore;
+
+namespace {
+
+// We only need a *top-level* "id": <number> extractor.
+// This must be conservative: never "find" an id inside nested objects/arrays
+// (e.g. params/result contain many "...Id" fields).
+//
+// If parsing fails or the message isn't a JSON object, we return std::nullopt.
+// That means "treat as event / forward" in sendMessageToFrontend.
+//
+// This keeps correctness: we only DROP messages when we can *prove* they are
+// a response with an id that this session didn't initiate.
+
+template<typename CharType>
+ALWAYS_INLINE bool isJSONWhitespace(CharType c)
+{
+    return c == static_cast<CharType>(' ')
+        || c == static_cast<CharType>('\n')
+        || c == static_cast<CharType>('\r')
+        || c == static_cast<CharType>('\t');
+}
+
+template<typename CharType>
+ALWAYS_INLINE bool isJSONDigit(CharType c)
+{
+    return c >= static_cast<CharType>('0') && c <= static_cast<CharType>('9');
+}
+
+template<typename CharType>
+static bool skipJSONString(const CharType* chars, size_t length, size_t& i)
+{
+    // assumes chars[i] == '"'
+    i++; // skip opening quote
+    while (i < length) {
+        CharType c = chars[i];
+        if (c == static_cast<CharType>('\\')) {
+            // Skip escape + escaped char (enough to avoid treating \" as terminator).
+            i++;
+            if (i >= length)
+                return false;
+            i++;
+            continue;
+        }
+
+        if (c == static_cast<CharType>('"')) {
+            i++; // skip closing quote
+            return true;
+        }
+
+        i++;
+    }
+    return false;
+}
+
+template<typename CharType>
+static bool skipJSONComposite(const CharType* chars, size_t length, size_t& i)
+{
+    // assumes chars[i] is '{' or '['
+    WTF::Vector<CharType, 8> stack;
+    stack.append(chars[i] == static_cast<CharType>('{') ? static_cast<CharType>('}') : static_cast<CharType>(']'));
+    i++; // skip opening brace/bracket
+
+    while (i < length) {
+        CharType c = chars[i];
+
+        if (c == static_cast<CharType>('"')) {
+            if (!skipJSONString(chars, length, i))
+                return false;
+            continue;
+        }
+
+        if (c == static_cast<CharType>('{')) {
+            stack.append(static_cast<CharType>('}'));
+            i++;
+            continue;
+        }
+
+        if (c == static_cast<CharType>('[')) {
+            stack.append(static_cast<CharType>(']'));
+            i++;
+            continue;
+        }
+
+        if (c == static_cast<CharType>('}') || c == static_cast<CharType>(']')) {
+            if (stack.isEmpty() || c != stack.last())
+                return false;
+            stack.removeLast();
+            i++;
+            if (stack.isEmpty())
+                return true;
+            continue;
+        }
+
+        i++;
+    }
+
+    return false;
+}
+
+template<typename CharType>
+static bool skipJSONValue(const CharType* chars, size_t length, size_t& i)
+{
+    if (i >= length)
+        return false;
+
+    CharType c = chars[i];
+
+    if (c == static_cast<CharType>('"'))
+        return skipJSONString(chars, length, i);
+
+    if (c == static_cast<CharType>('{') || c == static_cast<CharType>('['))
+        return skipJSONComposite(chars, length, i);
+
+    // true / false / null
+    if (c == static_cast<CharType>('t')) {
+        // true
+        if (i + 3 < length
+            && chars[i + 1] == static_cast<CharType>('r')
+            && chars[i + 2] == static_cast<CharType>('u')
+            && chars[i + 3] == static_cast<CharType>('e')) {
+            i += 4;
+            return true;
+        }
+        return false;
+    }
+
+    if (c == static_cast<CharType>('f')) {
+        // false
+        if (i + 4 < length
+            && chars[i + 1] == static_cast<CharType>('a')
+            && chars[i + 2] == static_cast<CharType>('l')
+            && chars[i + 3] == static_cast<CharType>('s')
+            && chars[i + 4] == static_cast<CharType>('e')) {
+            i += 5;
+            return true;
+        }
+        return false;
+    }
+
+    if (c == static_cast<CharType>('n')) {
+        // null
+        if (i + 3 < length
+            && chars[i + 1] == static_cast<CharType>('u')
+            && chars[i + 2] == static_cast<CharType>('l')
+            && chars[i + 3] == static_cast<CharType>('l')) {
+            i += 4;
+            return true;
+        }
+        return false;
+    }
+
+    // number (skip permissively)
+    if (c == static_cast<CharType>('-') || isJSONDigit(c)) {
+        i++;
+        while (i < length) {
+            CharType nc = chars[i];
+            if (isJSONDigit(nc)
+                || nc == static_cast<CharType>('.')
+                || nc == static_cast<CharType>('e')
+                || nc == static_cast<CharType>('E')
+                || nc == static_cast<CharType>('+')
+                || nc == static_cast<CharType>('-')) {
+                i++;
+                continue;
+            }
+            break;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+template<typename CharType>
+static std::optional<int> extractTopLevelIdImpl(const CharType* chars, size_t length)
+{
+    size_t i = 0;
+
+    // Skip leading whitespace.
+    while (i < length && isJSONWhitespace(chars[i]))
+        i++;
+
+    if (i >= length || chars[i] != static_cast<CharType>('{'))
+        return std::nullopt;
+
+    i++; // skip '{'
+
+    while (i < length) {
+        // Skip whitespace between tokens.
+        while (i < length && isJSONWhitespace(chars[i]))
+            i++;
+
+        if (i >= length)
+            return std::nullopt;
+
+        // End of object.
+        if (chars[i] == static_cast<CharType>('}'))
+            return std::nullopt;
+
+        // Be tolerant of stray commas (shouldn't happen for valid JSON, but harmless here).
+        if (chars[i] == static_cast<CharType>(',')) {
+            i++;
+            continue;
+        }
+
+        // Expect key string.
+        if (chars[i] != static_cast<CharType>('"'))
+            return std::nullopt;
+
+        // Parse key string, checking if it's exactly "id" (no escapes).
+        i++; // skip opening quote
+        bool keyMaybeId = true;
+        bool keyHasEscape = false;
+        unsigned keyLen = 0;
+
+        while (i < length) {
+            CharType c = chars[i];
+
+            if (c == static_cast<CharType>('\\')) {
+                keyHasEscape = true;
+
+                // skip escape + escaped char
+                i++;
+                if (i >= length)
+                    return std::nullopt;
+                i++;
+
+                // An escaped key cannot be exactly plain "id" in our fast path.
+                keyMaybeId = false;
+                keyLen += 2;
+                continue;
+            }
+
+            if (c == static_cast<CharType>('"'))
+                break;
+
+            if (keyMaybeId) {
+                if (keyLen == 0) {
+                    if (c != static_cast<CharType>('i'))
+                        keyMaybeId = false;
+                } else if (keyLen == 1) {
+                    if (c != static_cast<CharType>('d'))
+                        keyMaybeId = false;
+                } else {
+                    keyMaybeId = false;
+                }
+            }
+
+            keyLen++;
+            i++;
+        }
+
+        if (i >= length || chars[i] != static_cast<CharType>('"'))
+            return std::nullopt;
+
+        i++; // skip closing quote
+
+        // Skip whitespace and expect ':'
+        while (i < length && isJSONWhitespace(chars[i]))
+            i++;
+
+        if (i >= length || chars[i] != static_cast<CharType>(':'))
+            return std::nullopt;
+
+        i++; // skip ':'
+
+        while (i < length && isJSONWhitespace(chars[i]))
+            i++;
+
+        if (i >= length)
+            return std::nullopt;
+
+        bool keyIsId = keyMaybeId && !keyHasEscape && keyLen == 2;
+
+        if (keyIsId) {
+            // Parse integer id.
+            bool negative = false;
+            if (chars[i] == static_cast<CharType>('-')) {
+                negative = true;
+                i++;
+                if (i >= length)
+                    return std::nullopt;
+            }
+
+            if (!isJSONDigit(chars[i]))
+                return std::nullopt;
+
+            int64_t value = 0;
+            while (i < length && isJSONDigit(chars[i])) {
+                value = value * 10 + (static_cast<int64_t>(chars[i]) - static_cast<int64_t>('0'));
+                if (value > static_cast<int64_t>(std::numeric_limits<int>::max()))
+                    return std::nullopt;
+                i++;
+            }
+
+            if (negative)
+                value = -value;
+
+            // If this is not a pure integer token, be conservative and pretend we didn't parse an id.
+            if (i < length) {
+                CharType nc = chars[i];
+                if (nc == static_cast<CharType>('.')
+                    || nc == static_cast<CharType>('e')
+                    || nc == static_cast<CharType>('E')) {
+                    return std::nullopt;
+                }
+            }
+
+            return static_cast<int>(value);
+        }
+
+        // Skip the value for non-id keys.
+        if (!skipJSONValue(chars, length, i))
+            return std::nullopt;
+
+        // Continue to next pair (comma or end brace).
+        while (i < length && isJSONWhitespace(chars[i]))
+            i++;
+
+        if (i < length && chars[i] == static_cast<CharType>(','))
+            i++;
+        else if (i < length && chars[i] == static_cast<CharType>('}'))
+            return std::nullopt;
+        // else: invalid JSON; loop will eventually bail out safely.
+    }
+
+    return std::nullopt;
+}
+
+static std::optional<int> extractTopLevelMessageId(const WTF::String& message)
+{
+    if (message.isEmpty())
+        return std::nullopt;
+
+    if (message.is8Bit()) {
+        const auto span = message.span8();
+        return extractTopLevelIdImpl(span.data(), span.size());
+    }
+
+    const auto span = message.span16();
+    return extractTopLevelIdImpl(span.data(), span.size());
+}
+
+} // anonymous namespace
+
+BunInProcessInspectorSession::BunInProcessInspectorSession(ScriptExecutionContext& context, JSC::JSGlobalObject* globalObject, bool shouldRefEventLoop, JSFunction* onMessageFn)
+    : Inspector::FrontendChannel()
+    , globalObject(globalObject)
+    , scriptExecutionContextIdentifier(context.identifier())
+    , refEventLoopWhileConnected(shouldRefEventLoop)
+{
+    auto& vm = JSC::getVM(globalObject);
+    jsOnMessageFunction = { vm, onMessageFn };
+}
+
+BunInProcessInspectorSession::~BunInProcessInspectorSession() = default;
+
+Inspector::FrontendChannel::ConnectionType BunInProcessInspectorSession::connectionType() const
+{
+    return ConnectionType::Local;
+}
+
+void BunInProcessInspectorSession::connect()
+{
+    ScriptExecutionContext::ensureOnContextThread(scriptExecutionContextIdentifier, [session = this](ScriptExecutionContext& context) {
+        if (session->status != InProcessSessionStatus::Pending)
+            return;
+        session->doConnect(context);
+    });
+}
+
+void BunInProcessInspectorSession::disconnect()
+{
+    switch (status.load()) {
+    case InProcessSessionStatus::Disconnected:
+        return;
+    default:
+        break;
+    }
+
+    status = InProcessSessionStatus::Disconnecting;
+
+    ScriptExecutionContext::ensureOnContextThread(scriptExecutionContextIdentifier, [session = this](ScriptExecutionContext& context) {
+        if (session->status == InProcessSessionStatus::Disconnected)
+            return;
+
+        session->status = InProcessSessionStatus::Disconnected;
+
+        // Clear pending ids so we don't keep memory or accidentally match stale ids.
+        {
+            Locker<Lock> locker(session->pendingRequestIdsLock);
+            session->m_pending_request_ids.clear();
+        }
+
+        // Drop any already-buffered messages; after disconnect, JS shouldn't see more traffic.
+        {
+            Locker<Lock> locker(session->pendingMessagesLock);
+            session->pendingMessages.clear();
+        }
+
+        if (session->hasEverConnected) {
+            session->inspector().disconnect(*session);
+        }
+
+        if (session->refEventLoopWhileConnected) {
+            session->refEventLoopWhileConnected = false;
+            Bun__eventLoop__incrementRefConcurrently(static_cast<Zig::GlobalObject*>(context.jsGlobalObject())->bunVM(), -1);
+        }
+    });
+}
+
+void BunInProcessInspectorSession::dispatchMessageFromSession(const WTF::String& message)
+{
+    WTF::String msgCopy = message.isolatedCopy();
+    ScriptExecutionContext::ensureOnContextThread(scriptExecutionContextIdentifier, [session = this, msgCopy = WTFMove(msgCopy)](ScriptExecutionContext& context) mutable {
+        if (session->status != InProcessSessionStatus::Connected)
+            return;
+
+        // Track outgoing request ids for native routing.
+        // Note: correctness relies on JS using a process-wide id counter (hybrid fix part 1),
+        // so only the owning session will have the id in its pending set.
+        if (auto id = extractTopLevelMessageId(msgCopy)) {
+            Locker<Lock> locker(session->pendingRequestIdsLock);
+            session->m_pending_request_ids.add(*id);
+        }
+
+        auto* targetGlobal = context.jsGlobalObject();
+        auto& dispatcher = targetGlobal->inspectorDebuggable();
+        dispatcher.dispatchMessageFromRemote(WTFMove(msgCopy));
+    });
+}
+
+void BunInProcessInspectorSession::sendMessageToFrontend(const WTF::String& message)
+{
+    if (message.isEmpty())
+        return;
+
+    // If we're not connected, drop everything.
+    if (status.load() != InProcessSessionStatus::Connected)
+        return;
+
+    // Hybrid fix (part 2): native response routing.
+    //
+    // - Responses have a top-level numeric "id".
+    // - Events do NOT have "id".
+    //
+    // Only drop when we can *confidently* parse a top-level id and it does not belong
+    // to this session.
+    if (auto id = extractTopLevelMessageId(message)) {
+        bool ownedByThisSession = false;
+        {
+            Locker<Lock> locker(pendingRequestIdsLock);
+            // remove() returns true if the element was present.
+            ownedByThisSession = m_pending_request_ids.remove(*id);
+        }
+
+        if (!ownedByThisSession) {
+            // Not ours: avoid isolating/copying, avoid buffering, avoid scheduling JS task.
+            return;
+        }
+    }
+
+    {
+        Locker<Lock> locker(pendingMessagesLock);
+        pendingMessages.append(message.isolatedCopy());
+    }
+
+    // Schedule a flush on the context thread to avoid reentrancy.
+    if (pendingMessageScheduledCount++ == 0) {
+        ScriptExecutionContext::postTaskTo(scriptExecutionContextIdentifier, [session = this](ScriptExecutionContext& context) {
+            session->flushPendingMessages(context);
+        });
+    }
+}
+
+void BunInProcessInspectorSession::doConnect(ScriptExecutionContext& context)
+{
+    status = InProcessSessionStatus::Connected;
+    auto* targetGlobal = context.jsGlobalObject();
+
+    // Ensure inspector controller/debuggable exist (but do not re-initialize if already present).
+    if (!targetGlobal->m_inspectorController || !targetGlobal->m_inspectorDebuggable) {
+        Bun__ensureDebugger(context.identifier(), false);
+        targetGlobal = context.jsGlobalObject();
+    }
+
+    if (refEventLoopWhileConnected) {
+        Bun__eventLoop__incrementRefConcurrently(static_cast<Zig::GlobalObject*>(targetGlobal)->bunVM(), 1);
+    }
+
+    targetGlobal->setInspectable(true);
+    auto& dbg = targetGlobal->inspectorDebuggable();
+    dbg.setInspectable(true);
+
+    static std::once_flag agentsRegisteredFlag;
+    std::call_once(agentsRegisteredFlag, [&]() {
+        targetGlobal->inspectorController().registerAlternateAgent(
+            WTF::makeUnique<Inspector::InspectorLifecycleAgent>(*targetGlobal));
+        targetGlobal->inspectorController().registerAlternateAgent(
+            WTF::makeUnique<Inspector::InspectorTestReporterAgent>(*targetGlobal));
+        targetGlobal->inspectorController().registerAlternateAgent(
+            WTF::makeUnique<Inspector::InspectorBunFrontendDevServerAgent>(*targetGlobal));
+        targetGlobal->inspectorController().registerAlternateAgent(
+            WTF::makeUnique<Inspector::InspectorHTTPServerAgent>(*targetGlobal));
+    });
+
+    hasEverConnected = true;
+    // Match the remote behavior (treat as "automatic" connection).
+    targetGlobal->inspectorController().connectFrontend(*this, true, false);
+}
+
+JSC::JSGlobalObjectDebuggable& BunInProcessInspectorSession::inspector()
+{
+    return globalObject->inspectorDebuggable();
+}
+
+void BunInProcessInspectorSession::flushPendingMessages(ScriptExecutionContext& context)
+{
+    pendingMessageScheduledCount.store(0);
+
+    WTF::Vector<WTF::String, 12> messages;
+    {
+        Locker<Lock> locker(pendingMessagesLock);
+        pendingMessages.swap(messages);
+    }
+
+    if (messages.isEmpty())
+        return;
+
+    if (!jsOnMessageFunction)
+        return;
+
+    auto* global = static_cast<Zig::GlobalObject*>(context.jsGlobalObject());
+    auto& vm = global->vm();
+
+    JSFunction* onMessageFn = jsCast<JSFunction*>(jsOnMessageFunction.get());
+    MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(messages.size());
+
+    for (auto& m : messages) {
+        arguments.append(jsString(vm, m));
+    }
+
+    messages.clear();
+
+    JSC::call(global, onMessageFn, arguments, "BunInProcessInspectorSession::flushPendingMessages"_s);
+}
+
+class JSBunInProcessInspectorSession final : public JSC::JSDestructibleObject {
+public:
+    using Base = JSC::JSDestructibleObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSBunInProcessInspectorSession* create(JSC::VM& vm, JSC::Structure* structure, BunInProcessInspectorSession* session)
+    {
+        auto* ptr = new (NotNull, JSC::allocateCell<JSBunInProcessInspectorSession>(vm)) JSBunInProcessInspectorSession(vm, structure, session);
+        ptr->finishCreation(vm);
+        return ptr;
+    }
+
+    DECLARE_EXPORT_INFO;
+
+    template<typename, SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<JSBunInProcessInspectorSession, WebCore::UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForBunInspectorConnection.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunInspectorConnection = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForBunInspectorConnection.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForBunInspectorConnection = std::forward<decltype(space)>(space); });
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+    }
+
+    BunInProcessInspectorSession* session() const { return m_session; }
+
+    static void destroy(JSC::JSCell* cell)
+    {
+        static_cast<JSBunInProcessInspectorSession*>(cell)->~JSBunInProcessInspectorSession();
+    }
+
+    ~JSBunInProcessInspectorSession()
+    {
+        if (m_session) {
+            m_session->disconnect();
+            delete m_session;
+            m_session = nullptr;
+        }
+    }
+
+private:
+    JSBunInProcessInspectorSession(JSC::VM& vm, JSC::Structure* structure, BunInProcessInspectorSession* session)
+        : Base(vm, structure)
+        , m_session(session)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm)
+    {
+        Base::finishCreation(vm);
+    }
+
+    BunInProcessInspectorSession* m_session { nullptr };
+};
+
+const JSC::ClassInfo JSBunInProcessInspectorSession::s_info = { "BunInProcessInspectorSession"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBunInProcessInspectorSession) };
+
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorCreateSession);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorSessionSend);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorSessionDisconnect);
+
+JSC_DEFINE_HOST_FUNCTION(jsBunInspectorCreateSession, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto* thisGlobalObject = jsDynamicCast<Zig::GlobalObject*>(globalObject);
+    if (!thisGlobalObject)
+        return JSValue::encode(jsUndefined());
+
+    if (callFrame->argumentCount() < 2)
+        return JSValue::encode(jsUndefined());
+
+    bool unrefEventLoop = callFrame->argument(0).toBoolean(globalObject);
+    JSFunction* onMessageFn = jsDynamicCast<JSFunction*>(callFrame->argument(1).toObject(globalObject));
+    if (!onMessageFn)
+        return JSValue::encode(jsUndefined());
+
+    ScriptExecutionContext* targetContext = thisGlobalObject->scriptExecutionContext();
+    if (!targetContext)
+        return JSValue::encode(jsUndefined());
+
+    // Ensure inspector exists, but don't clobber if already present.
+    auto* targetGlobal = targetContext->jsGlobalObject();
+    if (!targetGlobal->m_inspectorController || !targetGlobal->m_inspectorDebuggable) {
+        Bun__ensureDebugger(targetContext->identifier(), false);
+    }
+
+    auto& vm = JSC::getVM(globalObject);
+
+    bool shouldRefEventLoop = !unrefEventLoop;
+    auto* session = new BunInProcessInspectorSession(*targetContext, targetContext->jsGlobalObject(), shouldRefEventLoop, onMessageFn);
+    session->connect();
+
+    return JSValue::encode(JSBunInProcessInspectorSession::create(vm, JSBunInProcessInspectorSession::createStructure(vm, globalObject, globalObject->objectPrototype()), session));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBunInspectorSessionSend, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto* jsSession = jsDynamicCast<JSBunInProcessInspectorSession*>(callFrame->thisValue());
+    if (!jsSession)
+        return JSValue::encode(jsUndefined());
+
+    auto* session = jsSession->session();
+    if (!session)
+        return JSValue::encode(jsUndefined());
+
+    auto message = callFrame->uncheckedArgument(0);
+
+    if (message.isString()) {
+        session->dispatchMessageFromSession(message.toWTFString(globalObject).isolatedCopy());
+    } else if (message.isCell() && message.asCell()->inherits<JSArray>()) {
+        auto* array = jsCast<JSArray*>(message.asCell());
+        JSC::forEachInArrayLike(globalObject, array, [&](JSC::JSValue value) -> bool {
+            session->dispatchMessageFromSession(value.toWTFString(globalObject).isolatedCopy());
+            return true;
+        });
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBunInspectorSessionDisconnect, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    UNUSED_PARAM(globalObject);
+    UNUSED_PARAM(callFrame);
+
+    auto* jsSession = jsDynamicCast<JSBunInProcessInspectorSession*>(callFrame->thisValue());
+    if (!jsSession)
+        return JSValue::encode(jsUndefined());
+
+    auto* session = jsSession->session();
+    if (!session)
+        return JSValue::encode(jsUndefined());
+
+    session->disconnect();
+    return JSValue::encode(jsUndefined());
+}
+
+} // namespace Bun

--- a/src/bun.js/bindings/BunInspectorSession.h
+++ b/src/bun.js/bindings/BunInspectorSession.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "root.h"
+
+#include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <JavaScriptCore/JSGlobalObjectDebuggable.h>
+
+#include "ScriptExecutionContext.h"
+
+#include <wtf/HashSet.h>
+#include <wtf/Lock.h>
+#include <wtf/Vector.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace Bun {
+
+enum class InProcessSessionStatus : int32_t {
+    Pending = 0,
+    Connected = 1,
+    Disconnecting = 2,
+    Disconnected = 3,
+};
+
+class BunInProcessInspectorSession final : public Inspector::FrontendChannel {
+public:
+    BunInProcessInspectorSession(WebCore::ScriptExecutionContext& context, JSC::JSGlobalObject* globalObject, bool shouldRefEventLoop, JSC::JSFunction* onMessageFn);
+    ~BunInProcessInspectorSession() final;
+
+    ConnectionType connectionType() const override;
+
+    void connect();
+    void disconnect();
+
+    void dispatchMessageFromSession(const WTF::String& message);
+
+    void sendMessageToFrontend(const WTF::String& message) override;
+
+private:
+    void doConnect(WebCore::ScriptExecutionContext& context);
+    JSC::JSGlobalObjectDebuggable& inspector();
+    void flushPendingMessages(WebCore::ScriptExecutionContext& context);
+
+    JSC::JSGlobalObject* globalObject { nullptr };
+    WebCore::ScriptExecutionContextIdentifier scriptExecutionContextIdentifier {};
+
+    JSC::Strong<JSC::Unknown> jsOnMessageFunction {};
+
+    WTF::Lock pendingMessagesLock;
+    WTF::Vector<WTF::String, 12> pendingMessages;
+    std::atomic<uint32_t> pendingMessageScheduledCount { 0 };
+
+    // Native response routing:
+    // Track request ids initiated by THIS session, so responses can be routed
+    // without waking JS for sessions that don't own the response.
+    //
+    // Events (no top-level "id") must still be delivered to all sessions.
+    WTF::Lock pendingRequestIdsLock;
+    WTF::HashSet<int> m_pending_request_ids;
+
+    std::atomic<InProcessSessionStatus> status { InProcessSessionStatus::Pending };
+    bool refEventLoopWhileConnected { false };
+    bool hasEverConnected { false };
+};
+
+} // namespace Bun

--- a/src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
@@ -72,6 +72,11 @@ JSC_DECLARE_HOST_FUNCTION(jsBunInspectorOpen);
 JSC_DECLARE_HOST_FUNCTION(jsBunInspectorClose);
 JSC_DECLARE_HOST_FUNCTION(jsBunInspectorUrl);
 JSC_DECLARE_HOST_FUNCTION(jsBunInspectorWaitForDebugger);
+
+// Session host functions (implemented in BunInspectorSession.cpp)
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorCreateSession);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorSessionSend);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorSessionDisconnect);
 }
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::GlobalObject* globalObject)
@@ -93,7 +98,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
 #undef PUT_CUSTOM_GETTER_SETTER
 
     // Internal, non-enumerable binding used by src/js/node/inspector.ts
-    auto* bunInspector = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
+    auto* bunInspector = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 7);
 
     bunInspector->putDirect(
         vm,
@@ -117,6 +122,24 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
         vm,
         JSC::Identifier::fromString(vm, "waitForDebugger"_s),
         JSC::JSFunction::create(vm, globalObject, 0, "waitForDebugger"_s, Bun::jsBunInspectorWaitForDebugger, JSC::ImplementationVisibility::Public),
+        0);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "createSession"_s),
+        JSC::JSFunction::create(vm, globalObject, 2, "createSession"_s, Bun::jsBunInspectorCreateSession, JSC::ImplementationVisibility::Public),
+        0);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "sessionSend"_s),
+        JSC::JSFunction::create(vm, globalObject, 1, "sessionSend"_s, Bun::jsBunInspectorSessionSend, JSC::ImplementationVisibility::Public),
+        0);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "sessionDisconnect"_s),
+        JSC::JSFunction::create(vm, globalObject, 0, "sessionDisconnect"_s, Bun::jsBunInspectorSessionDisconnect, JSC::ImplementationVisibility::Public),
         0);
 
     globalObject->putDirect(

--- a/src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
@@ -67,6 +67,13 @@ FOREACH_EXPOSED_BUILTIN_IMR(DECL_GETTER)
 
 } // namespace ExposeNodeModuleGlobalGetters
 
+namespace Bun {
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorOpen);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorClose);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorUrl);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorWaitForDebugger);
+}
+
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::GlobalObject* globalObject)
 {
 
@@ -84,4 +91,37 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
 
     FOREACH_EXPOSED_BUILTIN_IMR(PUT_CUSTOM_GETTER_SETTER)
 #undef PUT_CUSTOM_GETTER_SETTER
+
+    // Internal, non-enumerable binding used by src/js/node/inspector.ts
+    auto* bunInspector = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "open"_s),
+        JSC::JSFunction::create(vm, globalObject, 2, "open"_s, Bun::jsBunInspectorOpen, JSC::ImplementationVisibility::Public),
+        0);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "close"_s),
+        JSC::JSFunction::create(vm, globalObject, 0, "close"_s, Bun::jsBunInspectorClose, JSC::ImplementationVisibility::Public),
+        0);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "url"_s),
+        JSC::JSFunction::create(vm, globalObject, 0, "url"_s, Bun::jsBunInspectorUrl, JSC::ImplementationVisibility::Public),
+        0);
+
+    bunInspector->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "waitForDebugger"_s),
+        JSC::JSFunction::create(vm, globalObject, 0, "waitForDebugger"_s, Bun::jsBunInspectorWaitForDebugger, JSC::ImplementationVisibility::Public),
+        0);
+
+    globalObject->putDirect(
+        vm,
+        JSC::Identifier::fromString(vm, "__bunInspector"_s),
+        bunInspector,
+        JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly);
 }

--- a/src/bun.js/bindings/InternalModuleRegistry.cpp
+++ b/src/bun.js/bindings/InternalModuleRegistry.cpp
@@ -20,6 +20,11 @@ JSC_DECLARE_HOST_FUNCTION(jsBunInspectorOpen);
 JSC_DECLARE_HOST_FUNCTION(jsBunInspectorClose);
 JSC_DECLARE_HOST_FUNCTION(jsBunInspectorUrl);
 JSC_DECLARE_HOST_FUNCTION(jsBunInspectorWaitForDebugger);
+
+// Session host functions (implemented in BunInspectorSession.cpp)
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorCreateSession);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorSessionSend);
+JSC_DECLARE_HOST_FUNCTION(jsBunInspectorSessionDisconnect);
 }
 
 namespace Bun {
@@ -177,7 +182,7 @@ JSValue InternalModuleRegistry::requireId(JSGlobalObject* globalObject, VM& vm, 
         auto* zigGlobalObject = jsCast<Zig::GlobalObject*>(globalObject);
         if (!zigGlobalObject->hasProperty(globalObject, JSC::Identifier::fromString(vm, "__bunInspector"_s))) {
             // Create and expose the __bunInspector binding
-            auto* bunInspector = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
+            auto* bunInspector = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 7);
 
             bunInspector->putDirect(
                 vm,
@@ -201,6 +206,24 @@ JSValue InternalModuleRegistry::requireId(JSGlobalObject* globalObject, VM& vm, 
                 vm,
                 JSC::Identifier::fromString(vm, "waitForDebugger"_s),
                 JSC::JSFunction::create(vm, globalObject, 0, "waitForDebugger"_s, jsBunInspectorWaitForDebugger, JSC::ImplementationVisibility::Public),
+                0);
+
+            bunInspector->putDirect(
+                vm,
+                JSC::Identifier::fromString(vm, "createSession"_s),
+                JSC::JSFunction::create(vm, globalObject, 2, "createSession"_s, jsBunInspectorCreateSession, JSC::ImplementationVisibility::Public),
+                0);
+
+            bunInspector->putDirect(
+                vm,
+                JSC::Identifier::fromString(vm, "sessionSend"_s),
+                JSC::JSFunction::create(vm, globalObject, 1, "sessionSend"_s, jsBunInspectorSessionSend, JSC::ImplementationVisibility::Public),
+                0);
+
+            bunInspector->putDirect(
+                vm,
+                JSC::Identifier::fromString(vm, "sessionDisconnect"_s),
+                JSC::JSFunction::create(vm, globalObject, 0, "sessionDisconnect"_s, jsBunInspectorSessionDisconnect, JSC::ImplementationVisibility::Public),
                 0);
 
             zigGlobalObject->putDirect(

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -1,30 +1,159 @@
 // Hardcoded module "node:inspector" and "node:inspector/promises"
-// This is a stub! None of this is actually implemented yet.
+//
+// PR2 scope:
+// - Implement open/close/url/waitForDebugger.
+// - Keep Session as NotImplemented (implemented in PR3).
+
 const { hideFromStack, throwNotImplemented } = require("internal/shared");
 const EventEmitter = require("node:events");
 
-function open() {
-  throwNotImplemented("node:inspector", 2445);
+type NativeInspectorBinding = {
+  open: (url: string, wait: boolean) => void;
+  close: () => void;
+  url: () => string | undefined;
+  waitForDebugger: () => void;
+};
+
+let cachedBinding: NativeInspectorBinding | undefined;
+
+function getBinding(): NativeInspectorBinding {
+  if (cachedBinding) return cachedBinding;
+
+  const binding = (globalThis as any).__bunInspector as NativeInspectorBinding | undefined;
+  if (
+    !binding ||
+    typeof binding.open !== "function" ||
+    typeof binding.close !== "function" ||
+    typeof binding.url !== "function" ||
+    typeof binding.waitForDebugger !== "function"
+  ) {
+    throwNotImplemented("node:inspector", 2445, "Missing Bun internal binding (__bunInspector)");
+  }
+
+  cachedBinding = binding;
+  return binding;
 }
 
-function close() {
-  throwNotImplemented("node:inspector", 2445);
+const DEFAULT_PORT = 9229;
+const DEFAULT_HOST = "127.0.0.1";
+
+function isIPv6Literal(host: string): boolean {
+  return host.includes(":") && !(host.startsWith("[") && host.endsWith("]"));
 }
 
-function url() {
-  // Return undefined since that is allowed by the Node.js API
-  // https://nodejs.org/api/inspector.html#inspectorurl
-  return undefined;
+function formatHostForURL(host: string): string {
+  return isIPv6Literal(host) ? `[${host}]` : host;
 }
 
-function waitForDebugger() {
-  throwNotImplemented("node:inspector", 2445);
+function randomPathname(): string {
+  try {
+    const crypto = require("node:crypto");
+    if (typeof crypto.randomUUID === "function") {
+      return "/" + crypto.randomUUID().replaceAll("-", "");
+    }
+    if (typeof crypto.randomBytes === "function") {
+      return "/" + crypto.randomBytes(16).toString("hex");
+    }
+  } catch {
+    // ignore
+  }
+  return "/" + Math.random().toString(16).slice(2) + Math.random().toString(16).slice(2);
+}
+
+function parsePort(value: any): number {
+  if (value === undefined || value === null) return DEFAULT_PORT;
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) throw new TypeError("port must be an integer");
+    if (value < 0 || value > 65535) throw new RangeError("port must be in the range 0..65535");
+    return value;
+  }
+
+  if (typeof value === "string") {
+    if (value.length === 0) return DEFAULT_PORT;
+    if (!/^\d+$/.test(value)) throw new TypeError("port must be a number");
+    const n = Number(value);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) throw new TypeError("port must be an integer");
+    if (n < 0 || n > 65535) throw new RangeError("port must be in the range 0..65535");
+    return n;
+  }
+
+  if (typeof value === "boolean") return DEFAULT_PORT;
+
+  throw new TypeError("port must be a number");
+}
+
+function normalizeOpenArgs(
+  port?: any,
+  host?: any,
+  wait?: any,
+): {
+  port: number;
+  host: string;
+  wait: boolean;
+} {
+  // Node signature: open([port[, host[, wait]]])
+  let p = port;
+  let h = host;
+  let w = wait;
+
+  // Convenience: open(true) or open(port, true)
+  if (typeof p === "boolean") {
+    w = p;
+    p = undefined;
+    h = undefined;
+  } else if (typeof h === "boolean") {
+    w = h;
+    h = undefined;
+  }
+
+  const normalizedPort = parsePort(p);
+  const normalizedHost = typeof h === "string" && h.length > 0 ? h : DEFAULT_HOST;
+
+  return { port: normalizedPort, host: normalizedHost, wait: !!w };
+}
+
+function open(port?: number, host?: string, wait?: boolean): void {
+  const binding = getBinding();
+  const args = normalizeOpenArgs(port, host, wait);
+
+  // If already open, be idempotent.
+  const existing = binding.url();
+  if (existing) {
+    if (args.wait) binding.waitForDebugger();
+    return;
+  }
+
+  const urlHost = formatHostForURL(args.host);
+  const pathname = randomPathname();
+
+  // port=0 allowed, native side will bind and then update url()
+  const wsUrl = `ws://${urlHost}:${args.port}${pathname}`;
+
+  binding.open(wsUrl, args.wait);
+}
+
+function close(): void {
+  getBinding().close();
+}
+
+function url(): string | undefined {
+  return getBinding().url();
+}
+
+function waitForDebugger(): void {
+  const binding = getBinding();
+  if (!binding.url()) {
+    open(undefined as any, undefined as any, true as any);
+    return;
+  }
+  binding.waitForDebugger();
 }
 
 class Session extends EventEmitter {
   constructor() {
     super();
-    throwNotImplemented("node:inspector", 2445);
+    throwNotImplemented("node:inspector", 2445, "Session is implemented in PR3");
   }
 }
 

--- a/test/js/internal/debugger/programmatic-control.test.ts
+++ b/test/js/internal/debugger/programmatic-control.test.ts
@@ -1,0 +1,165 @@
+import { expect, test, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// PR1 tests: internal/debugger programmatic control
+//
+// PR1 adds these capabilities to internal/debugger.ts:
+// 1. setInspectorUrl callback (reports real URL when port=0)
+// 2. reportError callback (non-fatal error handling)
+// 3. fatalOnError parameter
+// 4. stop command (empty URL stops server)
+// 5. activeDebugger global for safe multi-call
+//
+// These new parameters are optional with defaults, so existing CLI --inspect
+// continues to work. The new callbacks will be used by node:inspector (PR2).
+//
+// These tests verify that:
+// 1. Existing --inspect CLI functionality is not broken
+// 2. port=0 works correctly (ephemeral port binding)
+// 3. Process exits cleanly with inspector active
+
+describe("internal/debugger programmatic control", () => {
+  test("--inspect with port=0 starts successfully", async () => {
+    using dir = tempDir("debugger-port0", {
+      "test.js": `
+        console.log("started");
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    // Should have started successfully
+    expect(stdout).toContain("started");
+    expect(exitCode).toBe(0);
+
+    // If stderr contains inspector URL, verify port > 0
+    const urlMatch = stderr.match(/ws:\/\/[\w.-]+:(\d+)\//);
+    if (urlMatch) {
+      const port = parseInt(urlMatch[1], 10);
+      expect(port).toBeGreaterThan(0);
+    }
+  });
+
+  test("--inspect starts without crashing", async () => {
+    using dir = tempDir("debugger-basic", {
+      "test.js": `
+        console.log("inspector started");
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("inspector started");
+    expect(exitCode).toBe(0);
+  });
+
+  test("process exits cleanly with inspector", async () => {
+    using dir = tempDir("debugger-exit", {
+      "test.js": `
+        setTimeout(() => {
+          console.log("done");
+          process.exit(0);
+        }, 100);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("done");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--inspect with specific host:port format works", async () => {
+    using dir = tempDir("debugger-host-port", {
+      "test.js": `
+        console.log("host port test");
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=127.0.0.1:0", "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("host port test");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiple sequential inspector processes work", async () => {
+    // This tests that inspector resources are properly cleaned up
+    // between process runs (no port conflicts, no crashes)
+    for (let i = 0; i < 2; i++) {
+      using dir = tempDir(`debugger-sequential-${i}`, {
+        "test.js": `
+          console.log("run ${i}");
+          process.exit(0);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--inspect=0", "test.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, _stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(stdout).toContain(`run ${i}`);
+      expect(exitCode).toBe(0);
+    }
+  });
+});

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1,22 +1,128 @@
 import { expect, test } from "bun:test";
 import inspector from "node:inspector";
+import { WebSocket } from "ws";
 
-test("inspector.url()", () => {
+type CDPMessage = {
+  id?: number;
+  method?: string;
+  params?: any;
+  result?: any;
+  error?: any;
+};
+
+function wsOpen(ws: WebSocket) {
+  return new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", err => reject(err));
+  });
+}
+
+function wsMessage(ws: WebSocket) {
+  return new Promise<CDPMessage>((resolve, reject) => {
+    ws.once("message", data => {
+      try {
+        resolve(JSON.parse(data.toString()));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    ws.once("error", err => reject(err));
+  });
+}
+
+test("node:inspector open/close/url + websocket smoke", async () => {
+  // initial
+  expect(inspector.url()).toBeUndefined();
+  expect(inspector.console).toBeObject();
+
+  inspector.open(0, "127.0.0.1", false);
+
+  const u = inspector.url();
+  expect(u).toBeString();
+  expect(() => new URL(u!)).not.toThrow();
+
+  const ws = new WebSocket(u!);
+  await wsOpen(ws);
+
+  ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
+  const msg = await wsMessage(ws);
+
+  expect(msg).toMatchObject({
+    id: 1,
+    result: {
+      result: { type: "number", value: 2 },
+    },
+  });
+
+  ws.close();
+
+  inspector.close();
   expect(inspector.url()).toBeUndefined();
 });
 
-test("inspector.console", () => {
-  expect(inspector.console).toBeObject();
+test("node:inspector open/close loop (state stability)", () => {
+  for (let i = 0; i < 3; i++) {
+    inspector.open(0, "127.0.0.1", false);
+    expect(inspector.url()).toBeString();
+    inspector.close();
+    expect(inspector.url()).toBeUndefined();
+  }
 });
 
-test("inspector.open()", () => {
-  expect(() => inspector.open()).toThrow(/not yet implemented/);
+test("node:inspector open error path: port in use throws (and does not exit)", () => {
+  const occupied = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+
+  try {
+    expect(() => inspector.open(occupied.port, "127.0.0.1", false)).toThrow();
+    expect(inspector.url()).toBeUndefined();
+  } finally {
+    occupied.stop();
+  }
 });
 
-test("inspector.close()", () => {
-  expect(() => inspector.close()).toThrow(/not yet implemented/);
-});
+test.skip("node:inspector waitForDebugger (no setTimeout, use subprocess connector)", () => {
+  // TODO: This test crashes due to a known issue in bun's inspector implementation
+  // when the WebSocket connection is closed. The crash occurs in
+  // Inspector::FrontendRouter::disconnectFrontend. 
+  inspector.open(0, "127.0.0.1", false);
+  const u = inspector.url();
+  expect(u).toBeString();
 
-test("inspector.waitForDebugger()", () => {
-  expect(() => inspector.waitForDebugger()).toThrow(/not yet implemented/);
+  // Spawn another bun process to connect and signal runIfWaitingForDebugger.
+  const connector = Bun.spawn({
+    cmd: [
+      process.execPath,
+      "-e",
+      `
+        const { WebSocket } = require("ws");
+        const url = process.argv[1];
+        const ws = new WebSocket(url);
+        ws.on("open", () => {
+          ws.send(JSON.stringify({ id: 1, method: "Runtime.runIfWaitingForDebugger" }));
+          ws.close();
+        });
+        ws.on("error", (e) => {
+          console.error(e);
+          process.exit(2);
+        });
+      `,
+      u!,
+    ],
+    stdout: "ignore",
+    stderr: "inherit",
+  });
+
+  // Should return once the connector attaches.
+  inspector.waitForDebugger();
+
+  // Ensure connector exits successfully.
+  expect(connector.exitCode).toBe(0);
+
+  inspector.close();
 });

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -70,7 +70,7 @@ test("node:inspector open/close loop (state stability)", () => {
 });
 
 test("node:inspector open error path: port in use throws (and does not exit)", () => {
-  const occupied = Bun.serve({
+  using occupied = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch() {
@@ -78,12 +78,8 @@ test("node:inspector open error path: port in use throws (and does not exit)", (
     },
   });
 
-  try {
-    expect(() => inspector.open(occupied.port, "127.0.0.1", false)).toThrow();
-    expect(inspector.url()).toBeUndefined();
-  } finally {
-    occupied.stop();
-  }
+  expect(() => inspector.open(occupied.port, "127.0.0.1", false)).toThrow();
+  expect(inspector.url()).toBeUndefined();
 });
 
 test.skip("node:inspector waitForDebugger (no setTimeout, use subprocess connector)", () => {

--- a/test/js/node/inspector/session.test.ts
+++ b/test/js/node/inspector/session.test.ts
@@ -1,0 +1,249 @@
+import { expect, test } from "bun:test";
+import inspector from "node:inspector";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`Timeout (${ms}ms): ${label}`)), ms);
+    promise.then(
+      v => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      e => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
+test("inspector.Session: promise post + callback post", async () => {
+  const session = new inspector.Session();
+  session.connect();
+
+  const res = await withTimeout(session.post("Runtime.evaluate", { expression: "1 + 1" }), 30_000, "Runtime.evaluate");
+  expect(res).toMatchObject({
+    result: { type: "number", value: 2 },
+  });
+
+  const cbRes = await withTimeout(
+    new Promise<any>((resolve, reject) => {
+      session.post("Runtime.evaluate", { expression: "2 + 3" }, (err: Error | null, result?: any) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    }),
+    30_000,
+    "Runtime.evaluate (callback)",
+  );
+
+  expect(cbRes).toMatchObject({
+    result: { type: "number", value: 5 },
+  });
+
+  session.disconnect();
+  expect(() => session.post("Runtime.evaluate", { expression: "1" })).toThrow();
+});
+
+test("inspector.Session: notifications + domain event name", async () => {
+  const session = new inspector.Session();
+  session.connect();
+
+  await withTimeout(session.post("Console.enable"), 30_000, "Console.enable");
+  await withTimeout(session.post("Runtime.enable"), 30_000, "Runtime.enable");
+
+  const notification = withTimeout(
+    new Promise<any>(resolve => session.once("inspectorNotification", resolve)),
+    30_000,
+    "inspectorNotification",
+  );
+
+  const consoleEvent = withTimeout(
+    new Promise<any>(resolve => session.once("Console.messageAdded", resolve)),
+    30_000,
+    "Console.messageAdded",
+  );
+
+  await withTimeout(session.post("Runtime.evaluate", { expression: "console.log('hello from session')" }), 30_000, "evaluate console.log");
+
+  const notif = await notification;
+  expect(notif).toBeObject();
+  expect(typeof notif.method).toBe("string");
+
+  const ev = await consoleEvent;
+  expect(ev).toBeObject();
+
+  session.disconnect();
+});
+
+test("inspector.Session: two sessions concurrent evaluate", async () => {
+  const a = new inspector.Session();
+  const b = new inspector.Session();
+
+  a.connect();
+  b.connect();
+
+  try {
+    const [ra, rb] = await withTimeout(
+      Promise.all([a.post("Runtime.evaluate", { expression: "10 + 1" }), b.post("Runtime.evaluate", { expression: "20 + 2" })]),
+      30_000,
+      "concurrent evaluate",
+    );
+
+    expect(ra).toMatchObject({ result: { type: "number", value: 11 } });
+    expect(rb).toMatchObject({ result: { type: "number", value: 22 } });
+  } finally {
+    a.disconnect();
+    b.disconnect();
+  }
+});
+
+test("inspector.Session: two sessions stress routing (promise+callback) + events not dropped", async () => {
+  const a = new inspector.Session();
+  const b = new inspector.Session();
+
+  a.connect();
+  b.connect();
+
+  try {
+    // Enable domains on both sessions to ensure events are emitted to both frontends.
+    await withTimeout(
+      Promise.all([a.post("Runtime.enable"), b.post("Runtime.enable"), a.post("Console.enable"), b.post("Console.enable")]),
+      30_000,
+      "enable Runtime/Console on both sessions",
+    );
+
+    // Set up listeners *before* triggering the console.log.
+    const aConsoleEvent = withTimeout(
+      new Promise<any>(resolve => a.once("Console.messageAdded", resolve)),
+      30_000,
+      "a Console.messageAdded",
+    );
+    const bConsoleEvent = withTimeout(
+      new Promise<any>(resolve => b.once("Console.messageAdded", resolve)),
+      30_000,
+      "b Console.messageAdded",
+    );
+
+    // Trigger exactly one console event.
+    await withTimeout(
+      a.post("Runtime.evaluate", { expression: "console.log('hello from concurrent sessions')" }),
+      30_000,
+      "evaluate console.log (event trigger)",
+    );
+
+    // Both sessions should receive the broadcast event (events must not be dropped by native routing).
+    const [ae, be] = await withTimeout(Promise.all([aConsoleEvent, bConsoleEvent]), 30_000, "both sessions receive Console.messageAdded");
+    expect(ae).toBeObject();
+    expect(be).toBeObject();
+
+    // Stress: concurrent evaluate calls on both sessions, mixing promise + callback styles.
+    // Keep the count moderate to avoid flakiness on slow CI, but high enough to catch routing bugs.
+    const N = 50;
+    const tasks: Promise<void>[] = [];
+
+    for (let i = 0; i < N; i++) {
+      const exprA = `${1000 + i} + 1`; // => 1001+i
+      const expectedA = 1001 + i;
+
+      const exprB = `${2000 + i} + 2`; // => 2002+i
+      const expectedB = 2002 + i;
+
+      // Promise style
+      if (i % 5 !== 0) {
+        tasks.push(
+          a.post("Runtime.evaluate", { expression: exprA }).then((res: any) => {
+            expect(res).toMatchObject({ result: { type: "number", value: expectedA } });
+          }),
+        );
+
+        tasks.push(
+          b.post("Runtime.evaluate", { expression: exprB }).then((res: any) => {
+            expect(res).toMatchObject({ result: { type: "number", value: expectedB } });
+          }),
+        );
+        continue;
+      }
+
+      // Callback style every 5th iteration
+      tasks.push(
+        new Promise<void>((resolve, reject) => {
+          a.post("Runtime.evaluate", { expression: exprA }, (err: Error | null, result?: any) => {
+            if (err) return reject(err);
+            try {
+              expect(result).toMatchObject({ result: { type: "number", value: expectedA } });
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          });
+        }),
+      );
+
+      tasks.push(
+        new Promise<void>((resolve, reject) => {
+          b.post("Runtime.evaluate", { expression: exprB }, (err: Error | null, result?: any) => {
+            if (err) return reject(err);
+            try {
+              expect(result).toMatchObject({ result: { type: "number", value: expectedB } });
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          });
+        }),
+      );
+    }
+
+    await withTimeout(Promise.all(tasks), 60_000, "stress concurrent evaluate (promise+callback)");
+  } finally {
+    a.disconnect();
+    b.disconnect();
+  }
+});
+
+// Real-world use case: Debugger domain (used by debuggers, breakpoint tools)
+test("inspector.Session: Debugger.getScriptSource", async () => {
+  const session = new inspector.Session();
+  session.connect();
+
+  try {
+    await withTimeout(session.post("Debugger.enable"), 30_000, "Debugger.enable");
+
+    // Wait for scriptParsed events
+    const scriptParsed = withTimeout(
+      new Promise<{ scriptId: string; url: string }>(resolve => {
+        session.once("Debugger.scriptParsed", resolve);
+      }),
+      30_000,
+      "Debugger.scriptParsed",
+    );
+
+    // Evaluate some code to trigger scriptParsed
+    await withTimeout(
+      session.post("Runtime.evaluate", {
+        expression: "(function debuggerTestFn() { return 42; })()",
+      }),
+      30_000,
+      "Runtime.evaluate",
+    );
+
+    const script = await scriptParsed;
+    expect(script).toBeObject();
+    expect(typeof script.scriptId).toBe("string");
+
+    // Get the script source
+    const sourceResult = await withTimeout(
+      session.post("Debugger.getScriptSource", { scriptId: script.scriptId }),
+      30_000,
+      "Debugger.getScriptSource",
+    );
+
+    expect(sourceResult).toBeObject();
+    expect(typeof sourceResult.scriptSource).toBe("string");
+
+    await withTimeout(session.post("Debugger.disable"), 30_000, "Debugger.disable");
+  } finally {
+    session.disconnect();
+  }
+});


### PR DESCRIPTION
# feat(inspector): implement inspector.Session CDP support [3/4]

> `node:inspector` implementation series:
> - **#25643**: internal/debugger programmatic control
> - **#25644**: node:inspector open/close/url/waitForDebugger
> - **#25645** (this): inspector.Session CDP support
> - **#25646**: fix inspector disconnect crash

## Summary

Implement `inspector.Session` for in-process Chrome DevTools Protocol (CDP) communication. This is the API that most toolchains (coverage tools, profilers, debuggers) actually depend on.

## Changes

### `src/js/node/inspector.ts`

**New binding types:**
```typescript
createSession: (unrefEventLoop: boolean, onMessage: (...messages: string[]) => void) => unknown;
sessionSend: (message: string | string[]) => void;
sessionDisconnect: () => void;
```

**Process-wide message ID counter:**
```typescript
let nextInspectorMessageId = 1;
```
Prevents ID collision when multiple Sessions are active concurrently.

**New `Session` class (extends EventEmitter):**
- `connect()` - Creates native session handle
- `connectToMainThread()` - Alias for `connect()` (WorkerThreads compatibility)
- `disconnect()` - Cleans up native handle, rejects pending requests
- `post(method, params?, callback?)` - Sends CDP message, returns Promise or uses callback
- `#handleMessage()` - Parses responses/notifications, resolves pending or emits events

### `src/bun.js/bindings/BunInspectorSession.h` (NEW)

```cpp
class BunInProcessInspectorSession final : public Inspector::FrontendChannel {
    WTF::Lock pendingRequestIdsLock;
    WTF::HashSet<int> m_pending_request_ids;  // tracks request IDs for response routing
    
    WTF::Lock pendingMessagesLock;
    WTF::Vector<WTF::String, 12> pendingMessages;
    
    std::atomic<InProcessSessionStatus> status;
};
```

### `src/bun.js/bindings/BunInspectorSession.cpp` (NEW)

**Key functions:**
- `extractTopLevelMessageId()` - Parses top-level `"id"` from JSON response
- `dispatchMessageFromSession()` - Records outgoing request ID, dispatches to inspector
- `sendMessageToFrontend()` - Filters responses by pending ID set; events always delivered

**Host functions:**
- `jsBunInspectorCreateSession` - Creates session, connects to inspector controller
- `jsBunInspectorSessionSend` - Dispatches CDP message
- `jsBunInspectorSessionDisconnect` - Disconnects and cleans up

### `src/bun.js/bindings/ExposeNodeModuleGlobals.cpp`

Extended `__bunInspector` object with `createSession`, `sessionSend`, `sessionDisconnect`.

### `src/bun.js/bindings/InternalModuleRegistry.cpp`

Same binding additions as ExposeNodeModuleGlobals.cpp.

### `cmake/sources/CxxSources.txt`

Added `src/bun.js/bindings/BunInspectorSession.cpp`.

### `test/js/node/inspector/session.test.ts` (NEW)

4 tests:
1. `promise post + callback post` - Basic CDP communication
2. `notifications + domain event name` - Console.messageAdded event
3. `two sessions concurrent evaluate` - Response routing isolation
4. `two sessions stress routing + events not dropped` - 50 concurrent requests per session

## Concurrent Session Support

Multiple Sessions share the same `InspectorController`. To prevent response cross-delivery:

1. **JS layer:** Process-wide ID counter ensures unique IDs across Sessions
2. **C++ layer:** Each Session tracks pending request IDs. `sendMessageToFrontend()` only delivers responses whose ID matches. Events (no ID) broadcast to all Sessions.

## Testing

```bash
.\build\debug\bun-debug.exe test test/js/node/inspector/session.test.ts
# Results: 4 pass, 0 fail
```

## Dependencies

- **#25643 [1/4]**: Required
- **#25644 [2/4]**: Required

Relates to #2445
