### PR TITLE
fix(bundler): eliminate unused imports in dead code from feature flags

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -1075,7 +1075,13 @@ pub fn NewParser_(
             // The correctness of TypeScript-to-JavaScript conversion relies on accurate
             // symbol use counts for the whole file, including dead code regions. This is
             // tracked separately in a parser-only data structure.
-            if (is_typescript_enabled) {
+            //
+            // However, we also skip counting in dead code regions for ts_use_counts.
+            // This ensures that imports only used in dead code (e.g., code eliminated
+            // by feature flags from bun:bundle) are properly removed. This is safe because
+            // dead code will be eliminated anyway, so we don't need to preserve imports
+            // for type checking purposes in those regions.
+            if (is_typescript_enabled and !p.is_control_flow_dead) {
                 p.ts_use_counts.items[ref.innerIndex()] += 1;
             }
         }

--- a/test/bundler/bundler_feature_flag.test.ts
+++ b/test/bundler/bundler_feature_flag.test.ts
@@ -424,6 +424,30 @@ console.log(x);
         api.expectFile("out.js").not.toInclude("A");
       },
     });
+
+    // Test that unused imports with side effects are eliminated when feature flag is disabled
+    itBundled(`feature_flag/${backend}/UnusedImportWithSideEffectEliminated`, {
+      backend,
+      files: {
+        "/a.ts": `
+import { feature } from "bun:bundle";
+import { sideEffectFn } from "./side-effect.ts";
+
+if (feature("ENABLE_FEATURE")) {
+  sideEffectFn();
+}
+`,
+        "/side-effect.ts": `
+console.log(42);
+export function sideEffectFn() { return "side-effect"; }
+`,
+      },
+      // Feature is disabled, so the import should be completely eliminated
+      minifySyntax: true,
+      run: {
+        stdout: "", // No output - the side effect module should not be imported
+      },
+    });
   }
 
   // Runtime tests - these must remain as manual tests since they test bun run and bun test


### PR DESCRIPTION
## Summary

- Fixes unused imports not being eliminated when they're only used in dead code branches from `feature()` flags

When a feature flag from `bun:bundle` evaluates to false, code in the disabled branch is marked as dead and eliminated. However, imports that were only used in that dead code were incorrectly being kept.

**Before:** (with `feature("ENABLE_FEATURE")` returning false)
```ts
import { feature } from "bun:bundle";
import { sideEffectFn } from "./side-effect.ts"; // Has console.log(42)

if (feature("ENABLE_FEATURE")) {
  sideEffectFn();
}
```
The `side-effect.ts` module would still be imported, causing `42` to be logged.

**After:**
The import is completely eliminated, no output.

## Test plan

- Added test `UnusedImportWithSideEffectEliminated` that verifies a module with side effects is not imported when its only usage is in a disabled feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)