### PR TITLE
fix(node:https): make https.Server inherit from tls.Server

### DIFF
--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -1,5 +1,6 @@
 // Hardcoded module "node:https"
 const http = require("node:http");
+const tls = require("node:tls");
 const { urlToHttpOptions } = require("internal/url");
 
 const ArrayPrototypeShift = Array.prototype.shift;
@@ -44,11 +45,36 @@ function Agent(options) {
 $toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = http.createConnection;
 
+// https.Server extends tls.Server for Node.js compatibility
+// This allows methods like addContext() to work on https.Server instances
+function Server(options, requestListener): void {
+  if (!(this instanceof Server)) {
+    return new Server(options, requestListener);
+  }
+
+  // Call tls.Server constructor to set up TLS functionality (including addContext)
+  tls.Server.$call(this, options, requestListener);
+}
+$toClass(Server, "Server", tls.Server);
+
+// Copy over http.Server prototype methods that are needed
+Server.prototype.setTimeout = http.Server.prototype.setTimeout;
+Server.prototype.closeAllConnections = http.Server.prototype.closeAllConnections;
+Server.prototype.closeIdleConnections = http.Server.prototype.closeIdleConnections;
+
+function createServer(options, requestListener) {
+  if (typeof options === "function") {
+    requestListener = options;
+    options = {};
+  }
+  return new Server(options, requestListener);
+}
+
 var https = {
   Agent,
   globalAgent: new Agent({ keepAlive: true, scheduling: "lifo", timeout: 5000 }),
-  Server: http.Server,
-  createServer: http.createServer,
+  Server,
+  createServer,
   get,
   request,
 };

--- a/test/js/node/https/test-https-server-inheritance.test.ts
+++ b/test/js/node/https/test-https-server-inheritance.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, describe } from "bun:test";
+import https from "node:https";
+import tls from "node:tls";
+
+describe("https.Server", () => {
+  test("should be an instance of tls.Server", () => {
+    const server = https.createServer(() => {});
+    expect(server).toBeInstanceOf(tls.Server);
+  });
+
+  test("should have addContext method from tls.Server", () => {
+    const server = https.createServer(() => {});
+    expect(typeof server.addContext).toBe("function");
+  });
+
+  test("should have setSecureContext method from tls.Server", () => {
+    const server = https.createServer(() => {});
+    expect(typeof server.setSecureContext).toBe("function");
+  });
+
+  test("Server constructor should return instance when called without new", () => {
+    const server = https.Server({}, () => {});
+    expect(server).toBeInstanceOf(https.Server);
+    expect(server).toBeInstanceOf(tls.Server);
+  });
+
+  test("createServer should return https.Server instance", () => {
+    const server = https.createServer(() => {});
+    expect(server).toBeInstanceOf(https.Server);
+  });
+
+  test("createServer with options should work", () => {
+    const server = https.createServer({ key: "test", cert: "test" }, () => {});
+    expect(server).toBeInstanceOf(https.Server);
+    expect(typeof server.addContext).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes Node.js compatibility issue where `https.Server` should inherit from `tls.Server`.

### Problem

Currently, `https.Server` is just an alias for `http.Server`, which means TLS-specific methods like `addContext()` are not available:

```js
// Node.js
node -p "require('node:https').createServer(()=>{}).addContext"
// [Function (anonymous)]

// Bun (before this fix)
bun -p "require('node:https').createServer(()=>{}).addContext"
// undefined
```

### Solution

- Make `https.Server` extend `tls.Server` using `$toClass()`
- Call `tls.Server.$call()` in the constructor to properly set up TLS functionality
- Copy over necessary HTTP server methods (`setTimeout`, `closeAllConnections`, `closeIdleConnections`)

### Changes

- `src/js/node/https.ts`: Create proper `Server` class that extends `tls.Server`
- Added tests for the inheritance behavior

Fixes #24474

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.