### PR TITLE
docs: Fix import case for PrismaLibSql adapter

### DIFF
--- a/docs/guides/ecosystem/prisma.mdx
+++ b/docs/guides/ecosystem/prisma.mdx
@@ -102,9 +102,9 @@ mode: center
 
     	```ts prisma/db.ts icon="/icons/typescript.svg"
     	import { PrismaClient } from "./generated/client";
-    	import { PrismaLibSQL } from "@prisma/adapter-libsql";
+    	import { PrismaLibSql } from "@prisma/adapter-libsql";
 
-    	const adapter = new PrismaLibSQL({ url: process.env.DATABASE_URL || "" });
+    	const adapter = new PrismaLibSql({ url: process.env.DATABASE_URL || "" });
     	export const prisma = new PrismaClient({ adapter });
     	```
     </Step>


### PR DESCRIPTION

### What does this PR do?
The casing for import from prisma was wrong, now it's correct.

