### PR TITLE
fix(shell): resolve '.' to process.cwd() in cwd() method

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -149,7 +149,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     cwd(newCwd?: string): this {
       this.#throwIfRunning();
       if (typeof newCwd === "undefined" || newCwd === "." || newCwd === "" || newCwd === "./") {
-        newCwd = defaultCwd;
+        newCwd = defaultCwd ?? process.cwd();
       }
       this.#args!.setCwd(newCwd);
       return this;
@@ -277,7 +277,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     cwd(newCwd: string | undefined) {
       if (typeof newCwd === "undefined" || typeof newCwd === "string") {
         if (newCwd === "." || newCwd === "" || newCwd === "./") {
-          newCwd = defaultCwd;
+          newCwd = defaultCwd ?? process.cwd();
         }
 
         this[cwdSymbol] = newCwd;

--- a/test/regression/issue/25579.test.ts
+++ b/test/regression/issue/25579.test.ts
@@ -4,7 +4,7 @@
  *
  * @see https://github.com/oven-sh/bun/issues/25579
  */
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 describe("Shell cwd with dot", () => {
   test("$.cwd('.') should work and use current directory", async () => {

--- a/test/regression/issue/25579.test.ts
+++ b/test/regression/issue/25579.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for issue #25579
+ * $.cwd('.') does not work
+ *
+ * @see https://github.com/oven-sh/bun/issues/25579
+ */
+import { test, expect, describe } from "bun:test";
+
+describe("Shell cwd with dot", () => {
+  test("$.cwd('.') should work and use current directory", async () => {
+    const result = await Bun.$`pwd`.cwd(".").text();
+    expect(result.trim()).toBe(process.cwd());
+  });
+
+  test("$.cwd('./') should work and use current directory", async () => {
+    const result = await Bun.$`pwd`.cwd("./").text();
+    expect(result.trim()).toBe(process.cwd());
+  });
+
+  test("$.cwd('') should work and use current directory", async () => {
+    const result = await Bun.$`pwd`.cwd("").text();
+    expect(result.trim()).toBe(process.cwd());
+  });
+
+  test("$.cwd() without argument should work", async () => {
+    const result = await Bun.$`pwd`.cwd().text();
+    expect(result.trim()).toBe(process.cwd());
+  });
+
+  test("$.cwd('/tmp') should work with absolute path", async () => {
+    const result = await Bun.$`pwd`.cwd("/tmp").text();
+    // On macOS, /tmp is symlinked to /private/tmp
+    expect(result.trim()).toMatch(/^(\/tmp|\/private\/tmp)$/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed $.cwd('.'), $.cwd('./'), and $.cwd('') returning undefined path
- Now falls back to process.cwd() when defaultCwd is not set

## Test plan
- Added regression test in test/regression/issue/25579.test.ts
- Tests $.cwd('.'), $.cwd('./'), $.cwd(''), $.cwd(), and absolute paths

Fixes #25579