### PR TITLE
fix(node:fs): pass ENAMETOOLONG to callback instead of throwing

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -423,9 +423,14 @@ var access = function access(path, mode, callback) {
     callback ||= options;
     ensureCallback(callback);
 
-    fs.readFile(path, options).then(function (data) {
-      callback(null, data);
-    }, callback);
+    try {
+      fs.readFile(path, options).then(function (data) {
+        callback(null, data);
+      }, callback);
+    } catch (err) {
+      // Handle synchronous errors (e.g., path too long) by passing them to the callback
+      process.nextTick(callback, err);
+    }
   },
   writeFile = function writeFile(path, data, options, callback) {
     callback ||= options;

--- a/test/regression/issue/25659.test.ts
+++ b/test/regression/issue/25659.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readFile } from "fs";
+
+test("readFile with path too long should pass error to callback instead of throwing", async () => {
+  // Create a path that exceeds the OS path limit (typically 1024 on macOS)
+  const longPath = "a".repeat(10000);
+
+  const result = await new Promise<{ handled: boolean; code: string | null }>((resolve) => {
+    readFile(longPath, (err) => {
+      if (err) {
+        resolve({ handled: true, code: err.code });
+      } else {
+        resolve({ handled: true, code: null });
+      }
+    });
+  });
+
+  expect(result.handled).toBe(true);
+  expect(result.code).toBe("ENAMETOOLONG");
+});
+
+test("readFile with path too long should not throw synchronously", async () => {
+  using dir = tempDir("issue-25659", {
+    "test.ts": `
+import { readFile } from "fs";
+
+const filePath = "a".repeat(10000);
+readFile(filePath, (err) => {
+  if (err) console.log("Handled Error:", err.code);
+});
+console.log("Completed");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Should print "Completed" first (sync) then "Handled Error" (async)
+  expect(stdout).toContain("Completed");
+  expect(stdout).toContain("Handled Error: ENAMETOOLONG");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- When `fs.readFile()` is called with a path that exceeds the OS limit (typically 1024 chars), the error was thrown synchronously instead of being passed to the callback asynchronously
- Wraps the internal promise call in a try-catch and uses `process.nextTick` to pass synchronous errors to the callback

Fixes #25659

## Test plan
- Added regression test in `test/regression/issue/25659.test.ts`
- Test verifies error is passed to callback, not thrown