### PR TITLE
fix(node:net): handle null context in internalConnectMultipleTimeout

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1915,6 +1915,9 @@ function internalConnectMultiple(context, canceled?) {
 }
 
 function internalConnectMultipleTimeout(context, req, handle) {
+  // Guard against timeout firing after socket cleanup/destruction
+  if (!context || !context.socket) return;
+
   $debug("connect/multiple: connection to %s:%s timed out", req.address, req.port);
   context.socket.emit("connectionAttemptTimeout", req.address, req.port, req.addressType);
 

--- a/test/regression/issue/25633.test.ts
+++ b/test/regression/issue/25633.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// This tests that the socket timeout callback handles destroyed/cleaned up sockets gracefully
+// See: https://github.com/oven-sh/bun/issues/25633
+test("internalConnectMultipleTimeout should not crash when context is null", async () => {
+  using dir = tempDir("issue-25633", {
+    "test.ts": `
+import * as tls from "node:tls";
+
+// Create multiple rapid connections with very short timeouts
+// This can cause the timeout callback to fire after the socket is already cleaned up
+const promises: Promise<void>[] = [];
+
+for (let i = 0; i < 10; i++) {
+  promises.push(new Promise<void>((resolve) => {
+    const socket = tls.connect({
+      host: "localhost",
+      port: 65535, // Likely unreachable port
+      timeout: 1, // Very short timeout to trigger timeout callback race
+    });
+
+    socket.on("error", () => {
+      // Expected - port is not listening
+    });
+
+    socket.on("timeout", () => {
+      socket.destroy();
+    });
+
+    // Clean up after a reasonable time
+    setTimeout(() => {
+      socket.destroy();
+      resolve();
+    }, 100);
+  }));
+}
+
+await Promise.all(promises);
+console.log("All connections handled without crash");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Should complete without crashing due to null context
+  expect(stdout).toContain("All connections handled without crash");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- When making many simultaneous TLS connections with short timeouts, the timeout callback can fire after the socket has been cleaned up
- Adds a guard check to handle this race condition gracefully and prevent the crash

Fixes #25633

## Test plan
- Added regression test in `test/regression/issue/25633.test.ts`