### PR TITLE
fix(resolver): tsconfig paths should override parent, not merge

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -4235,9 +4235,10 @@ pub const Resolver = struct {
                             merged_config.preserve_imports_not_used_as_values = value;
                         }
 
-                        var iter = parent_config.paths.iterator();
-                        while (iter.next()) |c| {
-                            merged_config.paths.put(c.key_ptr.*, c.value_ptr.*) catch unreachable;
+                        // TypeScript behavior: paths completely override, not merge
+                        // If the child config has paths, use them exclusively; otherwise inherit from parent
+                        if (parent_config.paths.count() > 0) {
+                            merged_config.paths = parent_config.paths;
                         }
                         // todo deinit these parent configs somehow?
                     }

--- a/test/regression/issue/25622.test.ts
+++ b/test/regression/issue/25622.test.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Tests that tsconfig.json paths completely override extended paths instead of merging
+// See: https://github.com/oven-sh/bun/issues/25622
+test("tsconfig paths should override parent paths, not merge", async () => {
+  using dir = tempDir("issue-25622", {
+    "tsconfig.base.json": JSON.stringify({
+      compilerOptions: {
+        paths: {
+          "@helpers/*": ["./src/helpers/*"],
+        },
+      },
+    }),
+    "tsconfig.json": JSON.stringify({
+      extends: "./tsconfig.base.json",
+      compilerOptions: {
+        paths: {
+          "@/*": ["./src/*"],
+        },
+      },
+    }),
+    "src/helpers/x.ts": `export const message = "from helpers";`,
+    "src/index.ts": `
+// This import should FAIL because @helpers/* is from base config
+// and child's paths should completely override, not merge
+try {
+  const x = await import("@helpers/x");
+  console.log("FAIL: import succeeded");
+} catch (e) {
+  console.log("PASS: import failed as expected");
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "src/index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // The import should fail because @helpers/* from base is overridden
+  expect(stdout).toContain("PASS: import failed as expected");
+});
+
+test("tsconfig paths should inherit from parent when child has no paths", async () => {
+  using dir = tempDir("issue-25622-inherit", {
+    "tsconfig.base.json": JSON.stringify({
+      compilerOptions: {
+        paths: {
+          "@helpers/*": ["./src/helpers/*"],
+        },
+      },
+    }),
+    "tsconfig.json": JSON.stringify({
+      extends: "./tsconfig.base.json",
+      compilerOptions: {
+        // No paths defined - should inherit from base
+      },
+    }),
+    "src/helpers/x.ts": `console.log("from helpers");`,
+    "src/index.ts": `import "@helpers/x";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "src/index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // The import should succeed because paths are inherited from base
+  expect(stdout).toContain("from helpers");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- When a child tsconfig.json extends a parent and defines its own `compilerOptions.paths`, it should completely override the parent's paths, not merge with them
- Previously, Bun merged paths from both parent and child configs, allowing imports that should fail to succeed

Fixes #25622

## Test plan
- Added regression tests in `test/regression/issue/25622.test.ts`
- Test verifies that child's paths override parent's paths
- Test verifies that child inherits parent's paths when no paths are defined