### PR TITLE
Add microbench for `String#includes`

### DIFF
--- a/bench/snippets/string-includes.mjs
+++ b/bench/snippets/string-includes.mjs
@@ -1,0 +1,34 @@
+import { bench, run } from "../runner.mjs";
+
+const shortStr = "The quick brown fox jumps over the lazy dog";
+const longStr = shortStr.repeat(100);
+
+bench("String.includes - short, hit (middle)", () => {
+  return shortStr.includes("jumps");
+});
+
+bench("String.includes - short, hit (start)", () => {
+  return shortStr.includes("The");
+});
+
+bench("String.includes - short, hit (end)", () => {
+  return shortStr.includes("dog");
+});
+
+bench("String.includes - short, miss", () => {
+  return shortStr.includes("cat");
+});
+
+bench("String.includes - long, hit (middle)", () => {
+  return longStr.includes("jumps");
+});
+
+bench("String.includes - long, miss", () => {
+  return longStr.includes("cat");
+});
+
+bench("String.includes - with position", () => {
+  return shortStr.includes("fox", 10);
+});
+
+await run();


### PR DESCRIPTION
note: This is due to constant folding by the JIT. For `String#includes` on dynamic strings, the performance improvement is not this significant.

**before:**
```zig
$ bun ./bench/snippets/string-includes.mjs
cpu: Apple M4 Max
runtime: bun 1.3.5 (arm64-darwin)

benchmark                                  time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------------- -----------------------------
String.includes - short, hit (middle)   82.24 ns/iter     (14.95 ns … 881 ns)  84.98 ns    470 ns    791 ns
String.includes - short, hit (start)    37.44 ns/iter      (8.46 ns … 774 ns)  26.08 ns    379 ns    598 ns
String.includes - short, hit (end)      97.27 ns/iter     (16.93 ns … 823 ns)    107 ns    537 ns    801 ns
String.includes - short, miss             102 ns/iter       (0 ps … 1,598 µs)     42 ns    125 ns    167 ns
String.includes - long, hit (middle)    16.01 ns/iter     (14.34 ns … 115 ns)  16.03 ns   20.1 ns   53.1 ns
String.includes - long, miss              945 ns/iter       (935 ns … 972 ns)    948 ns    960 ns    972 ns
String.includes - with position          9.83 ns/iter    (8.44 ns … 58.45 ns)   9.83 ns  12.31 ns  15.69 ns
```

**after:**
```zig
$ ./build/release/bun bench/snippets/string-includes.mjs
cpu: Apple M4 Max
runtime: bun 1.3.6 (arm64-darwin)

benchmark                                  time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------------- -----------------------------
String.includes - short, hit (middle)     243 ps/iter     (203 ps … 10.13 ns)    244 ps    325 ps    509 ps !
String.includes - short, hit (start)      374 ps/iter     (244 ps … 19.78 ns)    387 ps    488 ps    691 ps
String.includes - short, hit (end)        708 ps/iter     (407 ps … 18.03 ns)    651 ps   2.62 ns   2.69 ns
String.includes - short, miss            1.49 ns/iter     (407 ps … 27.93 ns)   2.87 ns   3.09 ns   3.78 ns
String.includes - long, hit (middle)     3.28 ns/iter      (3.05 ns … 118 ns)   3.15 ns   8.75 ns  16.07 ns
String.includes - long, miss             7.28 ns/iter      (3.44 ns … 698 ns)   9.34 ns  42.85 ns    240 ns
String.includes - with position          7.97 ns/iter       (3.7 ns … 602 ns)   9.68 ns  52.19 ns    286 ns
```