### PR TITLE
fix(fs): handle ENAMETOOLONG for paths exceeding PATH_MAX

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -537,6 +537,28 @@ pub fn lstat(path: [:0]const u8) Maybe(bun.Stat) {
     }
 }
 
+/// Like stat() but accepts a non-null-terminated slice and handles ENAMETOOLONG.
+pub fn statA(file_path: []const u8) Maybe(bun.Stat) {
+    const pathZ = std.posix.toPosixPath(file_path) catch return Maybe(bun.Stat){
+        .err = .{
+            .errno = @intFromEnum(E.NAMETOOLONG),
+            .syscall = .stat,
+        },
+    };
+    return stat(&pathZ);
+}
+
+/// Like lstat() but accepts a non-null-terminated slice and handles ENAMETOOLONG.
+pub fn lstatA(file_path: []const u8) Maybe(bun.Stat) {
+    const pathZ = std.posix.toPosixPath(file_path) catch return Maybe(bun.Stat){
+        .err = .{
+            .errno = @intFromEnum(E.NAMETOOLONG),
+            .syscall = .lstat,
+        },
+    };
+    return lstat(&pathZ);
+}
+
 pub fn fstat(fd: bun.FileDescriptor) Maybe(bun.Stat) {
     if (Environment.isWindows) {
         // TODO: this is a bad usage of makeLibUVOwned
@@ -678,6 +700,28 @@ pub fn lstatx(path: [*:0]const u8, comptime fields: []const StatxField) Maybe(Po
         break :brk i;
     };
     return statxImpl(bun.FD.fromNative(std.posix.AT.FDCWD), path, linux.AT.SYMLINK_NOFOLLOW, mask);
+}
+
+/// Like statx() but accepts a non-null-terminated slice and handles ENAMETOOLONG.
+pub fn statxA(file_path: []const u8, comptime fields: []const StatxField) Maybe(PosixStat) {
+    const pathZ = std.posix.toPosixPath(file_path) catch return Maybe(PosixStat){
+        .err = .{
+            .errno = @intFromEnum(E.NAMETOOLONG),
+            .syscall = .stat,
+        },
+    };
+    return statx(&pathZ, fields);
+}
+
+/// Like lstatx() but accepts a non-null-terminated slice and handles ENAMETOOLONG.
+pub fn lstatxA(file_path: []const u8, comptime fields: []const StatxField) Maybe(PosixStat) {
+    const pathZ = std.posix.toPosixPath(file_path) catch return Maybe(PosixStat){
+        .err = .{
+            .errno = @intFromEnum(E.NAMETOOLONG),
+            .syscall = .lstat,
+        },
+    };
+    return lstatx(&pathZ, fields);
 }
 
 pub fn lutimes(path: [:0]const u8, atime: jsc.Node.TimeLike, mtime: jsc.Node.TimeLike) Maybe(void) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1012,6 +1012,55 @@ it("statSync throwIfNoEntry: true", () => {
   expect(() => lstatSync(path)).toThrow("no such file or directory");
 });
 
+it("statSync throws ENAMETOOLONG for path exceeding PATH_MAX", () => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  expect(() => statSync(longPath)).toThrow("name too long");
+});
+
+it("lstatSync throws ENAMETOOLONG for path exceeding PATH_MAX", () => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  expect(() => lstatSync(longPath)).toThrow("name too long");
+});
+
+it("promises.stat throws ENAMETOOLONG for path exceeding PATH_MAX", async () => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  await expect(promises.stat(longPath)).rejects.toThrow("name too long");
+});
+
+it("promises.lstat throws ENAMETOOLONG for path exceeding PATH_MAX", async () => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  await expect(promises.lstat(longPath)).rejects.toThrow("name too long");
+});
+
+it("readFileSync throws ENAMETOOLONG for path exceeding PATH_MAX", () => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  expect(() => readFileSync(longPath)).toThrow("name too long");
+});
+
+// TODO: This test requires fixing the callback-based fs.readFile to properly
+// pass ENAMETOOLONG to the callback instead of throwing synchronously.
+// See https://github.com/oven-sh/bun/issues/25659
+it.skip("readFile passes ENAMETOOLONG to callback for path exceeding PATH_MAX", (done) => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  readFile(longPath, (err) => {
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain("name too long");
+    done();
+  });
+});
+
+it("promises.readFile throws ENAMETOOLONG for path exceeding PATH_MAX", async () => {
+  // Create a path that exceeds PATH_MAX (4096 on most systems)
+  const longPath = "/" + Buffer.alloc(4097, "a").toString();
+  await expect(promises.readFile(longPath)).rejects.toThrow("name too long");
+});
+
 it("stat == statSync", async () => {
   const sync = statSync(import.meta.path);
   const async = await promises.stat(import.meta.path);


### PR DESCRIPTION
## Summary

Fix `fs.stat`, `fs.lstat`, `fs.readFile` (sync/promises) to properly return `ENAMETOOLONG` error when path exceeds `PATH_MAX` (4096 bytes), instead of crashing or undefined behavior.

- Add `statA`, `lstatA`, `statxA`, `lstatxA` functions to `sys.zig` following the existing `openatA` pattern
- Modify `stat()`, `lstat()`, `readFileWithOptions()` in `node_fs.zig` to use these new functions
- Add path length check before `sliceZ()` calls to prevent buffer overflow

Fixes #25659 (partial - callback-based `fs.readFile` still needs work)

## Test plan

- [x] `bun bd test test/js/node/fs/fs.test.ts -t "ENAMETOOLONG"` passes (8 pass, 2 skip)
- [x] Verify `statSync`, `lstatSync`, `readFileSync` throw ENAMETOOLONG
- [x] Verify `promises.stat`, `promises.lstat`, `promises.readFile` reject with ENAMETOOLONG

🤖 Generated with [Claude Code](https://claude.com/claude-code)