### PR TITLE
fix: show proper error for mixed ESM/CJS modules in dynamic imports

### DIFF
--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -442,6 +442,12 @@ pub const RuntimeTranspilerStore = struct {
                 return;
             };
 
+            // Check for errors logged during parsing (e.g., mixed ESM imports with CJS exports)
+            if (log.errors > 0) {
+                this.parse_error = error.ParseError;
+                return;
+            }
+
             if (vm.isWatcherEnabled()) {
                 if (input_file_fd.isValid()) {
                     if (!is_node_override and

--- a/test/regression/issue/25609.test.ts
+++ b/test/regression/issue/25609.test.ts
@@ -1,0 +1,100 @@
+// Regression test for https://github.com/oven-sh/bun/issues/25609
+// Files that mix ESM imports with CJS exports should throw a proper error,
+// not crash with "Expected CommonJS module to have a function wrapper".
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+test("dynamic import of mixed ESM/CJS file should throw proper error", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-25609", {
+    // This file dynamically imports b.ts - await it so unhandled rejection shows the error
+    "a.ts": `await import("./b.ts");`,
+    // This file mixes ESM imports with CJS exports - this is invalid
+    "b.ts": `import { foo } from "./c.ts";
+module.exports = { foo };`,
+    // A simple ESM module
+    "c.ts": `export const foo = "bar";`,
+  });
+
+  // Spawn Bun process
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "a.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should show the proper error about mixing ESM/CJS
+  expect(normalizeBunSnapshot(stderr)).toContain("Cannot use import statement with CommonJS-only features");
+
+  // Should NOT show the confusing "function wrapper" error
+  expect(stderr).not.toContain("Expected CommonJS module to have a function wrapper");
+
+  // Exit code should be 1
+  expect(exitCode).toBe(1);
+});
+
+test("static import of mixed ESM/CJS file should throw proper error", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-25609-static", {
+    // This file statically imports b.ts
+    "a.ts": `import b from "./b.ts"; console.log(b);`,
+    // This file mixes ESM imports with CJS exports - this is invalid
+    "b.ts": `import { foo } from "./c.ts";
+module.exports = { foo };`,
+    // A simple ESM module
+    "c.ts": `export const foo = "bar";`,
+  });
+
+  // Spawn Bun process
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "a.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should show the proper error about mixing ESM/CJS
+  expect(normalizeBunSnapshot(stderr)).toContain("Cannot use import statement with CommonJS-only features");
+
+  // Should NOT show the confusing "function wrapper" error
+  expect(stderr).not.toContain("Expected CommonJS module to have a function wrapper");
+
+  // Exit code should be 1
+  expect(exitCode).toBe(1);
+});
+
+test("pure CJS file works with dynamic import", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-25609-pure-cjs", {
+    // This file dynamically imports b.ts
+    "a.ts": `import("./b.ts").then(m => { console.log("Loaded:", m.default.foo); });`,
+    // This file uses pure CJS - this should work
+    "b.ts": `const c = require("./c.ts");
+module.exports = { foo: c.foo };`,
+    // A simple CJS module
+    "c.ts": `exports.foo = "bar";`,
+  });
+
+  // Spawn Bun process
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "a.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should work without errors
+  expect(normalizeBunSnapshot(stdout)).toContain("Loaded: bar");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix confusing "Expected CommonJS module to have a function wrapper" error when dynamically importing files that mix ESM imports with CJS exports
- Now properly shows "Cannot use import statement with CommonJS-only features" error message
- Add regression test for issue #25609

## Problem

When a file mixes ESM imports with CommonJS exports (e.g., `import { x } from 'y'; module.exports = ...`), the parser correctly detects this and logs an error. However, `RuntimeTranspilerStore` (used for dynamic imports) wasn't checking for logged parse errors after parsing, so the proper error message was never propagated to the user.

## Test plan

- [x] Added regression test at `test/regression/issue/25609.test.ts`
- [x] Test fails with system bun (shows confusing error)
- [x] Test passes with debug build (shows proper error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)