### PR TITLE
Fix DCE producing invalid syntax for empty objects in spreads

### DIFF
--- a/src/ast/Expr.zig
+++ b/src/ast/Expr.zig
@@ -617,7 +617,7 @@ pub fn joinAllWithCommaCallback(all: []Expr, comptime Context: type, ctx: Contex
             return callback(ctx, all[0]);
         },
         2 => {
-            return Expr.joinWithComma(
+            const result = Expr.joinWithComma(
                 callback(ctx, all[0]) orelse Expr{
                     .data = .{ .e_missing = .{} },
                     .loc = all[0].loc,
@@ -628,6 +628,10 @@ pub fn joinAllWithCommaCallback(all: []Expr, comptime Context: type, ctx: Contex
                 },
                 allocator,
             );
+            if (result.isMissing()) {
+                return null;
+            }
+            return result;
         },
         else => {
             var i: usize = 1;
@@ -643,6 +647,9 @@ pub fn joinAllWithCommaCallback(all: []Expr, comptime Context: type, ctx: Contex
                 }, allocator);
             }
 
+            if (expr.isMissing()) {
+                return null;
+            }
             return expr;
         },
     }

--- a/src/ast/SideEffects.zig
+++ b/src/ast/SideEffects.zig
@@ -315,6 +315,10 @@ pub const SideEffects = enum(u1) {
                     );
                 }
 
+                if (result.isMissing()) {
+                    return null;
+                }
+
                 return result;
             },
             .e_array => {

--- a/test/regression/issue/25609.test.ts
+++ b/test/regression/issue/25609.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/25609
+test("empty object in spread with DCE does not produce invalid syntax", async () => {
+  using dir = tempDir("25609", {
+    "chunk.js": `module.exports=()=>{var a,b=({...a,x:{}},0)};`,
+    "index.js": `require('./chunk.js');`,
+  });
+
+  // This should not throw a syntax error when requiring the module
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes dead code elimination producing invalid syntax like `{ ...a, x: }` when simplifying empty objects in spread contexts
- The issue was that `simplifyUnusedExpr` and `joinAllWithCommaCallback` could return `E.Missing` instead of `null` to indicate "no side effects"
- Added checks to return `null` when the result is `E.Missing`

Fixes #25609

## Test plan
- [x] Added regression test that fails on v1.3.5 and passes with fix
- [x] `bun bd test test/regression/issue/25609.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)