### PR TITLE
fix(process): share nextTick queue with default global in ShadowRealm

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3623,12 +3623,16 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 
 JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObject)
 {
+    // ShadowRealm should share process.nextTick queue with the default global object.
+    // This matches Node.js behavior where nextTick is per-isolate/event-loop.
+    auto* defaultGlobal = defaultGlobalObject();
+
     JSNextTickQueue* nextTickQueueObject;
-    if (!globalObject->m_nextTickQueue) {
-        nextTickQueueObject = JSNextTickQueue::create(globalObject);
-        globalObject->m_nextTickQueue.set(vm, globalObject, nextTickQueueObject);
+    if (!defaultGlobal->m_nextTickQueue) {
+        nextTickQueueObject = JSNextTickQueue::create(defaultGlobal);
+        defaultGlobal->m_nextTickQueue.set(vm, defaultGlobal, nextTickQueueObject);
     } else {
-        nextTickQueueObject = globalObject->m_nextTickQueue.get();
+        nextTickQueueObject = defaultGlobal->m_nextTickQueue.get();
     }
 
     JSC::JSFunction* initializer = JSC::JSFunction::create(vm, globalObject, processObjectInternalsInitializeNextTickQueueCodeGenerator(vm), globalObject);

--- a/test/regression/issue/25608.test.ts
+++ b/test/regression/issue/25608.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/25608
+// Node.js http/https response callback not called in ShadowRealm
+
+test("regression/issue/25608: http.request callback fires inside ShadowRealm", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+
+  const url = `http://127.0.0.1:${server.port}/`;
+
+  const realm = new ShadowRealm();
+  realm.evaluate(`
+    globalThis.__done = false;
+    globalThis.__status = 0;
+    globalThis.__err = "";
+
+    import("http").then(http => {
+      const req = http.request(${JSON.stringify(url)}, res => {
+        globalThis.__status = res.statusCode;
+        globalThis.__done = true;
+        res.resume();
+      });
+
+      req.on("error", e => {
+        globalThis.__err = String(e);
+        globalThis.__done = true;
+      });
+
+      req.end();
+    });
+
+    1;
+  `);
+
+  for (let i = 0; i < 5000; i++) {
+    if (realm.evaluate("globalThis.__done") === true) break;
+    await Bun.sleep(0);
+  }
+
+  expect(realm.evaluate("globalThis.__err")).toBe("");
+  expect(realm.evaluate("globalThis.__status")).toBe(200);
+});


### PR DESCRIPTION
## What does this PR do?

ShadowRealm now shares the `process.nextTick` queue with the default global object instead of creating its own queue.

## How did you verify your code works?

- Added regression test that creates HTTP request inside ShadowRealm and verifies callback fires
- Ran existing nextTick, http, and event-emitter test suites

## Why this works

Node.js http module uses `process.nextTick` internally for response callbacks. When ShadowRealm had its own queue, these callbacks were never drained by the main event loop. Sharing the queue matches Node behavior where nextTick is per-isolate, not per-realm

Fixes #25608