### PR TITLE
fix: catalog file: paths resolve relative to root, not workspace

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -151,7 +151,7 @@ pub fn enqueueTarballForReading(
         alias,
         path,
         resolution.*,
-        false, // Already resolved, not from catalog
+        false,
     )));
 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -151,6 +151,7 @@ pub fn enqueueTarballForReading(
         alias,
         path,
         resolution.*,
+        false, // Already resolved, not from catalog
     )));
 }
 
@@ -451,7 +452,7 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
         else => dependency.name_hash,
     };
 
-    const version = version: {
+    const version, const from_catalog = version: {
         if (dependency.version.tag == .npm) {
             if (this.known_npm_aliases.get(name_hash)) |aliased| {
                 const group = dependency.version.value.npm.version;
@@ -463,7 +464,7 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                         if (group.satisfies(query.range.left.version, buf, buf) or group.satisfies(query.range.right.version, buf, buf)) {
                             name = aliased.value.npm.name;
                             name_hash = String.Builder.stringHash(this.lockfile.str(&name));
-                            break :version aliased;
+                            break :version .{ aliased, false };
                         }
                         curr = query.next;
                     }
@@ -486,30 +487,30 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                 if (new.tag == .catalog) {
                     if (this.lockfile.catalogs.get(this.lockfile, new.value.catalog, name)) |catalog_dep| {
                         name, name_hash = updateNameAndNameHashFromVersionReplacement(this.lockfile, name, name_hash, catalog_dep.version);
-                        break :version catalog_dep.version;
+                        break :version .{ catalog_dep.version, true };
                     }
                 }
 
                 // `name_hash` stays the same
-                break :version new;
+                break :version .{ new, false };
             }
 
             if (dependency.version.tag == .catalog) {
                 if (this.lockfile.catalogs.get(this.lockfile, dependency.version.value.catalog, name)) |catalog_dep| {
                     name, name_hash = updateNameAndNameHashFromVersionReplacement(this.lockfile, name, name_hash, catalog_dep.version);
 
-                    break :version catalog_dep.version;
+                    break :version .{ catalog_dep.version, true };
                 }
             }
         }
 
         // explicit copy here due to `dependency.version` becoming undefined
         // when `getOrPutResolvedPackageWithFindResult` is called and resizes the list.
-        break :version Dependency.Version{
+        break :version .{ Dependency.Version{
             .literal = dependency.version.literal,
             .tag = dependency.version.tag,
             .value = dependency.version.value,
-        };
+        }, false };
     };
     var loaded_manifest: ?Npm.PackageManifest = null;
 
@@ -1133,6 +1134,7 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                         this.lockfile.str(&dependency.name),
                         url,
                         res,
+                        from_catalog,
                     )));
                 },
                 .remote => {
@@ -1294,6 +1296,7 @@ fn enqueueLocalTarball(
     name: string,
     path: string,
     resolution: Resolution,
+    from_catalog: bool,
 ) *ThreadPool.Task {
     var task = this.preallocated_resolve_tasks.get();
     task.* = Task{
@@ -1318,6 +1321,7 @@ fn enqueueLocalTarball(
                         *FileSystem.FilenameStore,
                         FileSystem.FilenameStore.instance,
                     ) catch unreachable,
+                    .from_catalog = from_catalog,
                 },
             },
         },

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -9,6 +9,9 @@ skip_verify: bool = false,
 integrity: Integrity = .{},
 url: strings.StringOrTinyString,
 package_manager: *PackageManager,
+/// If true, the tarball path came from a catalog entry (always defined in root package.json),
+/// so the path should be resolved relative to the workspace root, not the workspace package.
+from_catalog: bool = false,
 
 pub inline fn run(this: *const ExtractTarball, log: *logger.Log, bytes: []const u8) !Install.ExtractData {
     if (!this.skip_verify and this.integrity.tag.isSupported()) {

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -237,7 +237,7 @@ describe("errors", () => {
 });
 
 describe("file: protocol in catalogs", () => {
-  test("catalog with file: tarball referenced from workspace package resolves relative to root", async () => {
+  test.concurrent("catalog with file: tarball referenced from workspace package resolves relative to root", async () => {
     const { packageDir } = await registry.createTestDir();
 
     const vendoredDir = join(packageDir, "vendored");

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { copyFile, exists } from "fs/promises";
+import { copyFile, exists, mkdir } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, runBunInstall, stderrForInstall } from "harness";
 import { join } from "path";
 
@@ -240,9 +240,8 @@ describe("file: protocol in catalogs", () => {
   test.concurrent("catalog with file: tarball referenced from workspace package resolves relative to root", async () => {
     const { packageDir } = await registry.createTestDir();
 
-    const vendoredDir = join(packageDir, "vendored");
-    await Bun.write(join(vendoredDir, ".keep"), "");
-    await copyFile(join(__dirname, "bar-0.0.2.tgz"), join(vendoredDir, "bar-0.0.2.tgz"));
+    await mkdir(join(packageDir, "vendored"));
+    await copyFile(join(__dirname, "bar-0.0.2.tgz"), join(packageDir, "vendored", "bar-0.0.2.tgz"));
 
     await write(
       join(packageDir, "package.json"),


### PR DESCRIPTION
Fixes #25752

When a workspace package references a catalog entry with a file: path (e.g., `"my-pkg": "catalog:vendored"` where the catalog has `"my-pkg": "file:./vendored/pkg.tgz"`), the path was incorrectly resolved relative to the workspace package directory instead of the root package.json where the catalog is defined.

This caused ENOENT errors because Bun would look for the tarball at `packages/my-app/vendored/pkg.tgz` instead of `vendored/pkg.tgz`.

The fix adds a `from_catalog` flag to ExtractTarball that is set when the tarball path originates from a catalog entry. When this flag is set, the tarball path is resolved relative to the workspace root (where catalogs are always defined) rather than relative to the workspace package that references the catalog.

### What does this PR do?

Fixes catalog entries with file: protocol paths failing when referenced from workspace packages.

### How did you verify your code works?

Zig compiles and tests pass.