### PR TITLE
fix(node:http): handle single result in lookup

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -497,7 +497,7 @@ function ClientRequest(input, options, cb) {
           return;
         }
 
-        let candidates = results.sort((a, b) => b.family - a.family); // prefer IPv6
+        let candidates = !Array.isArray(results) ? [results] : results.sort((a, b) => b.family - a.family); // prefer IPv6
 
         const fail = (message, name, code, syscall) => {
           const error = new Error(message);


### PR DESCRIPTION
### What does this PR do?
A custom DNS lookup function in `http.request` can either return a single result as a string or multiple results as a string array. This PR handles the single result case correctly.

### How did you verify your code works?
The change is trivial enough that I have yet to verify it properly, let me know what the protocol is for this, and if I need to add a test.