### PR TITLE
fix(web): make URLSearchParams.prototype.size configurable

### DIFF
--- a/src/bun.js/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/bun.js/bindings/webcore/JSURLSearchParams.cpp
@@ -183,7 +183,7 @@ static const HashTableValue JSURLSearchParamsPrototypeTableValues[] = {
     { "toString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsURLSearchParamsPrototypeFunction_toString, 0 } },
     { "toJSON"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsURLSearchParamsPrototypeFunction_toJSON, 0 } },
     { "length"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsURLSearchParamsPrototype_getLength, 0 } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, jsURLSearchParamsPrototype_getLength, 0 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), NoIntrinsic, { HashTableValue::GetterSetterType, jsURLSearchParamsPrototype_getLength, 0 } },
 };
 
 const ClassInfo JSURLSearchParamsPrototype::s_info = { "URLSearchParams"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSURLSearchParamsPrototype) };

--- a/test/js/web/html/URLSearchParams.test.ts
+++ b/test/js/web/html/URLSearchParams.test.ts
@@ -212,6 +212,13 @@ describe("URLSearchParams", () => {
   });
 });
 
+it("size property should be configurable (issue #9251)", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(URLSearchParams.prototype, "size");
+  expect(descriptor).toBeDefined();
+  expect(descriptor!.configurable).toBe(true);
+  expect(descriptor!.enumerable).toBe(true);
+});
+
 it(".delete second argument", () => {
   const params = new URLSearchParams("a=1&a=2&b=3");
   params.delete("a", 1);


### PR DESCRIPTION
## Summary
- Make `URLSearchParams.prototype.size` configurable by removing the `DontDelete` attribute
- This aligns with the Web IDL specification which specifies that getters should be configurable

## Before
```javascript
Object.getOwnPropertyDescriptor(URLSearchParams.prototype, 'size').configurable
// false
```

## After
```javascript
Object.getOwnPropertyDescriptor(URLSearchParams.prototype, 'size').configurable
// true
```

## Test plan
- Added test case verifying that `size` property is configurable and enumerable
- Run: `bun bd test test/js/web/html/URLSearchParams.test.ts -t "size property should be configurable"`

Fixes #9251