### PR TITLE
Modify example query to include column in table creation

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -306,7 +306,7 @@ Internally, this calls [`sqlite3_reset`](https://www.sqlite.org/capi3ref.html#sq
 Use `.run()` to run a query and get back an object with execution metadata. This is useful for schema-modifying queries (e.g. `CREATE TABLE`) or bulk write operations.
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={2}
-const query = db.query(`create table foo;`);
+const query = db.query(`create table foo (bar);`);
 query.run();
 ```
 


### PR DESCRIPTION
### What does this PR do?

Updated the SQL query example to include a column definition. Otherwise, running the example can result in:

```
SQLiteError: near ";": syntax error
```

### How did you verify your code works?

Run the modified example.