### PR TITLE
Fix WebSocket upgrade with custom Sec-WebSocket-Protocol header

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -976,6 +976,13 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 resp.writeStatus("101 Switching Protocols");
 
                 if (fetch_headers_to_use) |headers| {
+                    // Remove Sec-WebSocket-Protocol header before writing to response.
+                    // This header will be written by the upgrade() function to avoid
+                    // sending duplicate headers which would cause the client to reject
+                    // the connection (RFC 6455 requires at most one protocol header).
+                    // The protocol value has already been extracted above (line 948).
+                    headers.fastRemove(.SecWebSocketProtocol);
+
                     headers.toUWSResponse(comptime ssl_enabled, resp);
                 }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -794,7 +794,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                 break :getter;
                             }
 
-                            var fetch_headers_to_use: *WebCore.FetchHeaders = headers_value.as(WebCore.FetchHeaders) orelse brk: {
+                            const maybe_fetch_headers_to_use: ?*WebCore.FetchHeaders = if (headers_value.as(WebCore.FetchHeaders)) |fetch_headers| brk: {
+                                // Clone caller-owned Headers so we can remove websocket-specific
+                                // headers without mutating the original Headers instance.
+                                if (try fetch_headers.cloneThis(globalThis)) |cloned_headers| {
+                                    fetch_headers_to_deref = cloned_headers;
+                                    break :brk cloned_headers;
+                                }
+                                break :brk null;
+                            } else brk: {
                                 if (headers_value.isObject()) {
                                     if (try WebCore.FetchHeaders.createFromJS(globalThis, headers_value)) |fetch_headers| {
                                         fetch_headers_to_deref = fetch_headers;
@@ -802,7 +810,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                     }
                                 }
                                 break :brk null;
-                            } orelse {
+                            };
+
+                            var fetch_headers_to_use: *WebCore.FetchHeaders = maybe_fetch_headers_to_use orelse {
                                 if (!globalThis.hasException()) {
                                     return globalThis.throwInvalidArguments("upgrade options.headers must be a Headers or an object", .{});
                                 }
@@ -815,10 +825,14 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                             if (fetch_headers_to_use.fastGet(.SecWebSocketProtocol)) |protocol| {
                                 sec_websocket_protocol = protocol;
+                                // Remove from headers so it's not written twice (once here and once by upgrade())
+                                fetch_headers_to_use.fastRemove(.SecWebSocketProtocol);
                             }
 
                             if (fetch_headers_to_use.fastGet(.SecWebSocketExtensions)) |protocol| {
                                 sec_websocket_extensions = protocol;
+                                // Remove from headers so it's not written twice (once here and once by upgrade())
+                                fetch_headers_to_use.fastRemove(.SecWebSocketExtensions);
                             }
                             if (nodeHttpResponse.raw_response) |raw_response| {
                                 // we must write the status first so that 200 OK isn't written
@@ -925,7 +939,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             break :getter;
                         }
 
-                        fetch_headers_to_use = headers_value.as(WebCore.FetchHeaders) orelse brk: {
+                        const maybe_fetch_headers_to_use: ?*WebCore.FetchHeaders = if (headers_value.as(WebCore.FetchHeaders)) |fetch_headers| brk: {
+                            // Clone caller-owned Headers so we can remove websocket-specific
+                            // headers without mutating the original Headers instance.
+                            if (try fetch_headers.cloneThis(globalThis)) |cloned_headers| {
+                                fetch_headers_to_deref = cloned_headers;
+                                break :brk cloned_headers;
+                            }
+                            break :brk null;
+                        } else brk: {
                             if (headers_value.isObject()) {
                                 if (try WebCore.FetchHeaders.createFromJS(globalThis, headers_value)) |fetch_headers| {
                                     fetch_headers_to_deref = fetch_headers;
@@ -933,7 +955,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                 }
                             }
                             break :brk null;
-                        } orelse {
+                        };
+
+                        fetch_headers_to_use = maybe_fetch_headers_to_use orelse {
                             if (!globalThis.hasException()) {
                                 return globalThis.throwInvalidArguments("upgrade options.headers must be a Headers or an object", .{});
                             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -770,6 +770,10 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                 var sec_websocket_protocol = ZigString.Empty;
                 var sec_websocket_extensions = ZigString.Empty;
+                var sec_websocket_protocol_owned = ZigString.Slice.empty;
+                defer sec_websocket_protocol_owned.deinit();
+                var sec_websocket_extensions_owned = ZigString.Slice.empty;
+                defer sec_websocket_extensions_owned.deinit();
 
                 if (optional) |opts| {
                     getter: {
@@ -833,13 +837,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             }
 
                             if (fetch_headers_to_use.fastGet(.SecWebSocketProtocol)) |protocol| {
-                                sec_websocket_protocol = protocol;
+                                // Copy before fastRemove() so upgrade() never reads freed header storage.
+                                sec_websocket_protocol_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                                sec_websocket_protocol = sec_websocket_protocol_owned.toZigString();
                                 // Remove from headers so it's not written twice (once here and once by upgrade())
                                 fetch_headers_to_use.fastRemove(.SecWebSocketProtocol);
                             }
 
                             if (fetch_headers_to_use.fastGet(.SecWebSocketExtensions)) |protocol| {
-                                sec_websocket_extensions = protocol;
+                                // Copy before fastRemove() so upgrade() never reads freed header storage.
+                                sec_websocket_extensions_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                                sec_websocket_extensions = sec_websocket_extensions_owned.toZigString();
                                 // Remove from headers so it's not written twice (once here and once by upgrade())
                                 fetch_headers_to_use.fastRemove(.SecWebSocketExtensions);
                             }
@@ -913,6 +921,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             }
 
             var data_value = jsc.JSValue.zero;
+            var sec_websocket_protocol_owned = ZigString.Slice.empty;
+            defer sec_websocket_protocol_owned.deinit();
 
             // If we created or cloned a Headers object, we need to free it.
             var fetch_headers_to_deref: ?*WebCore.FetchHeaders = null;
@@ -986,7 +996,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         }
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol)) |protocol| {
-                            sec_websocket_protocol = protocol;
+                            // Copy before fastRemove() below so the later upgrade() uses stable memory.
+                            sec_websocket_protocol_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                            sec_websocket_protocol = sec_websocket_protocol_owned.toZigString();
                         }
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketExtensions)) |protocol| {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -759,7 +759,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                 var data_value = jsc.JSValue.zero;
 
-                // if we converted a HeadersInit to a Headers object, we need to free it
+                // If we created or cloned a Headers object, we need to free it.
                 var fetch_headers_to_deref: ?*WebCore.FetchHeaders = null;
 
                 defer {
@@ -794,14 +794,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                 break :getter;
                             }
 
-                            const maybe_fetch_headers_to_use: ?*WebCore.FetchHeaders = if (headers_value.as(WebCore.FetchHeaders)) |fetch_headers| brk: {
-                                // Clone caller-owned Headers so we can remove websocket-specific
-                                // headers without mutating the original Headers instance.
-                                if (try fetch_headers.cloneThis(globalThis)) |cloned_headers| {
-                                    fetch_headers_to_deref = cloned_headers;
-                                    break :brk cloned_headers;
-                                }
-                                break :brk null;
+                            var fetch_headers_to_use: *WebCore.FetchHeaders = if (headers_value.as(WebCore.FetchHeaders)) |fetch_headers| brk: {
+                                break :brk fetch_headers;
                             } else brk: {
                                 if (headers_value.isObject()) {
                                     if (try WebCore.FetchHeaders.createFromJS(globalThis, headers_value)) |fetch_headers| {
@@ -810,9 +804,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                     }
                                 }
                                 break :brk null;
-                            };
-
-                            var fetch_headers_to_use: *WebCore.FetchHeaders = maybe_fetch_headers_to_use orelse {
+                            } orelse {
                                 if (!globalThis.hasException()) {
                                     return globalThis.throwInvalidArguments("upgrade options.headers must be a Headers or an object", .{});
                                 }
@@ -821,6 +813,23 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                             if (globalThis.hasException()) {
                                 return error.JSError;
+                            }
+
+                            if (fetch_headers_to_deref == null and
+                                (fetch_headers_to_use.fastGet(.SecWebSocketProtocol) != null or
+                                    fetch_headers_to_use.fastGet(.SecWebSocketExtensions) != null))
+                            {
+                                // Clone caller-owned Headers only when websocket-specific headers
+                                // need to be stripped before writing the upgrade response.
+                                fetch_headers_to_use = if (try fetch_headers_to_use.cloneThis(globalThis)) |cloned_headers| brk: {
+                                    fetch_headers_to_deref = cloned_headers;
+                                    break :brk cloned_headers;
+                                } else {
+                                    if (globalThis.hasException()) {
+                                        return error.JSError;
+                                    }
+                                    return globalThis.throwOutOfMemory();
+                                };
                             }
 
                             if (fetch_headers_to_use.fastGet(.SecWebSocketProtocol)) |protocol| {
@@ -905,7 +914,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             var data_value = jsc.JSValue.zero;
 
-            // if we converted a HeadersInit to a Headers object, we need to free it
+            // If we created or cloned a Headers object, we need to free it.
             var fetch_headers_to_deref: ?*WebCore.FetchHeaders = null;
 
             defer {
@@ -940,13 +949,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         }
 
                         const maybe_fetch_headers_to_use: ?*WebCore.FetchHeaders = if (headers_value.as(WebCore.FetchHeaders)) |fetch_headers| brk: {
-                            // Clone caller-owned Headers so we can remove websocket-specific
-                            // headers without mutating the original Headers instance.
-                            if (try fetch_headers.cloneThis(globalThis)) |cloned_headers| {
-                                fetch_headers_to_deref = cloned_headers;
-                                break :brk cloned_headers;
-                            }
-                            break :brk null;
+                            break :brk fetch_headers;
                         } else brk: {
                             if (headers_value.isObject()) {
                                 if (try WebCore.FetchHeaders.createFromJS(globalThis, headers_value)) |fetch_headers| {
@@ -966,6 +969,20 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                         if (globalThis.hasException()) {
                             return error.JSError;
+                        }
+
+                        if (fetch_headers_to_deref == null and fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol) != null) {
+                            // Clone caller-owned Headers only when we need to strip the
+                            // protocol header before writing the upgrade response.
+                            fetch_headers_to_use = if (try fetch_headers_to_use.?.cloneThis(globalThis)) |cloned_headers| brk: {
+                                fetch_headers_to_deref = cloned_headers;
+                                break :brk cloned_headers;
+                            } else {
+                                if (globalThis.hasException()) {
+                                    return error.JSError;
+                                }
+                                return globalThis.throwOutOfMemory();
+                            };
                         }
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol)) |protocol| {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -923,6 +923,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             var data_value = jsc.JSValue.zero;
             var sec_websocket_protocol_owned = ZigString.Slice.empty;
             defer sec_websocket_protocol_owned.deinit();
+            var sec_websocket_extensions_owned = ZigString.Slice.empty;
+            defer sec_websocket_extensions_owned.deinit();
 
             // If we created or cloned a Headers object, we need to free it.
             var fetch_headers_to_deref: ?*WebCore.FetchHeaders = null;
@@ -981,9 +983,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             return error.JSError;
                         }
 
-                        if (fetch_headers_to_deref == null and fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol) != null) {
-                            // Clone caller-owned Headers only when we need to strip the
-                            // protocol header before writing the upgrade response.
+                        if (fetch_headers_to_deref == null and
+                            (fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol) != null or
+                                fetch_headers_to_use.?.fastGet(.SecWebSocketExtensions) != null))
+                        {
+                            // Clone caller-owned Headers only when websocket-specific headers
+                            // need to be stripped before writing the upgrade response.
                             fetch_headers_to_use = if (try fetch_headers_to_use.?.cloneThis(globalThis)) |cloned_headers| brk: {
                                 fetch_headers_to_deref = cloned_headers;
                                 break :brk cloned_headers;
@@ -1002,7 +1007,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         }
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketExtensions)) |protocol| {
-                            sec_websocket_extensions = protocol;
+                            // Copy before fastRemove() below so the later upgrade() uses stable memory.
+                            sec_websocket_extensions_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                            sec_websocket_extensions = sec_websocket_extensions_owned.toZigString();
                         }
                     }
 
@@ -1029,12 +1036,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 resp.writeStatus("101 Switching Protocols");
 
                 if (fetch_headers_to_use) |headers| {
-                    // Remove Sec-WebSocket-Protocol header before writing to response.
-                    // This header will be written by the upgrade() function to avoid
-                    // sending duplicate headers which would cause the client to reject
-                    // the connection (RFC 6455 requires at most one protocol header).
-                    // The protocol value has already been extracted above (line 948).
+                    // Remove websocket-specific headers before writing to response.
+                    // These headers will be written by the upgrade() function to avoid
+                    // sending duplicate values in the 101 Switching Protocols response.
                     headers.fastRemove(.SecWebSocketProtocol);
+                    headers.fastRemove(.SecWebSocketExtensions);
 
                     headers.toUWSResponse(comptime ssl_enabled, resp);
                 }

--- a/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
+++ b/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
@@ -1,0 +1,174 @@
+// Test for https://github.com/oven-sh/bun/issues/25773
+// Verifies that server.upgrade() works correctly with custom Sec-WebSocket-Protocol header
+
+import { describe, expect, test } from "bun:test";
+import { serve } from "bun";
+
+describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
+  test("should work when selecting the first protocol", async () => {
+    const server = serve({
+      hostname: "localhost",
+      port: 0,
+      fetch(req, server) {
+        const protocols =
+          req.headers
+            .get("Sec-WebSocket-Protocol")
+            ?.split(",")
+            .map(p => p.trim()) || [];
+
+        server.upgrade(req, {
+          headers: { "Sec-WebSocket-Protocol": protocols[0] },
+        });
+      },
+      websocket: {
+        open(ws) {},
+        close(ws) {},
+      },
+    });
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`, ["ocpp1.6", "ocpp2.0.1"]);
+
+    await new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        expect(ws.protocol).toBe("ocpp1.6");
+        ws.close();
+        resolve();
+      };
+      ws.onerror = reject;
+      ws.onclose = e => {
+        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
+          reject(new Error("Connection failed with 'Mismatch client protocol'"));
+        }
+      };
+    });
+
+    server.stop();
+  });
+
+  test("should work when selecting the second protocol", async () => {
+    const server = serve({
+      hostname: "localhost",
+      port: 0,
+      fetch(req, server) {
+        const protocols =
+          req.headers
+            .get("Sec-WebSocket-Protocol")
+            ?.split(",")
+            .map(p => p.trim()) || [];
+
+        // Select the second protocol
+        server.upgrade(req, {
+          headers: { "Sec-WebSocket-Protocol": protocols[1] || protocols[0] },
+        });
+      },
+      websocket: {
+        open(ws) {},
+        close(ws) {},
+      },
+    });
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`, ["ocpp1.6", "ocpp2.0.1"]);
+
+    await new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        expect(ws.protocol).toBe("ocpp2.0.1");
+        ws.close();
+        resolve();
+      };
+      ws.onerror = reject;
+      ws.onclose = e => {
+        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
+          reject(new Error("Connection failed with 'Mismatch client protocol'"));
+        }
+      };
+    });
+
+    server.stop();
+  });
+
+  test("should work when selecting any protocol from the list", async () => {
+    const server = serve({
+      hostname: "localhost",
+      port: 0,
+      fetch(req, server) {
+        const protocols =
+          req.headers
+            .get("Sec-WebSocket-Protocol")
+            ?.split(",")
+            .map(p => p.trim()) || [];
+
+        // Select a specific protocol from the middle of the list
+        const selected = protocols.find(p => p === "chat");
+
+        server.upgrade(req, {
+          headers: { "Sec-WebSocket-Protocol": selected },
+        });
+      },
+      websocket: {
+        open(ws) {},
+        close(ws) {},
+      },
+    });
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`, ["echo", "chat", "binary"]);
+
+    await new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        expect(ws.protocol).toBe("chat");
+        ws.close();
+        resolve();
+      };
+      ws.onerror = reject;
+      ws.onclose = e => {
+        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
+          reject(new Error("Connection failed with 'Mismatch client protocol'"));
+        }
+      };
+    });
+
+    server.stop();
+  });
+
+  test("should work with other custom headers alongside Sec-WebSocket-Protocol", async () => {
+    const server = serve({
+      hostname: "localhost",
+      port: 0,
+      fetch(req, server) {
+        const protocols =
+          req.headers
+            .get("Sec-WebSocket-Protocol")
+            ?.split(",")
+            .map(p => p.trim()) || [];
+
+        server.upgrade(req, {
+          headers: {
+            "Sec-WebSocket-Protocol": protocols[0],
+            "X-Custom-Header": "custom-value",
+          },
+        });
+      },
+      websocket: {
+        open(ws) {},
+        close(ws) {},
+      },
+    });
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`, ["test-protocol"]);
+
+    await new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        expect(ws.protocol).toBe("test-protocol");
+        ws.close();
+        resolve();
+      };
+      ws.onerror = reject;
+      ws.onclose = e => {
+        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
+          reject(new Error("Connection failed with 'Mismatch client protocol'"));
+        }
+      };
+    });
+
+    server.stop();
+  });
+});

--- a/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
+++ b/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
@@ -6,7 +6,7 @@ import { serve } from "bun";
 
 describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
   test("should work when selecting the first protocol", async () => {
-    const server = serve({
+    using server = serve({
       hostname: "localhost",
       port: 0,
       fetch(req, server) {
@@ -41,12 +41,10 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         }
       };
     });
-
-    server.stop();
   });
 
   test("should work when selecting the second protocol", async () => {
-    const server = serve({
+    using server = serve({
       hostname: "localhost",
       port: 0,
       fetch(req, server) {
@@ -82,12 +80,10 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         }
       };
     });
-
-    server.stop();
   });
 
   test("should work when selecting any protocol from the list", async () => {
-    const server = serve({
+    using server = serve({
       hostname: "localhost",
       port: 0,
       fetch(req, server) {
@@ -125,12 +121,10 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         }
       };
     });
-
-    server.stop();
   });
 
   test("should work with other custom headers alongside Sec-WebSocket-Protocol", async () => {
-    const server = serve({
+    using server = serve({
       hostname: "localhost",
       port: 0,
       fetch(req, server) {
@@ -168,7 +162,5 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         }
       };
     });
-
-    server.stop();
   });
 });

--- a/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
+++ b/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
@@ -3,164 +3,243 @@
 
 import { describe, expect, test } from "bun:test";
 import { serve } from "bun";
+import net from "node:net";
+
+type UpgradeHeaders = Headers | Record<string, string>;
+
+const headerVariants = [
+  {
+    label: "plain object",
+    makeHeaders(protocol: string, extraHeaders?: Record<string, string>): UpgradeHeaders {
+      return {
+        "Sec-WebSocket-Protocol": protocol,
+        ...extraHeaders,
+      };
+    },
+    preservesOriginalHeaders: false,
+  },
+  {
+    label: "Headers instance",
+    makeHeaders(protocol: string, extraHeaders?: Record<string, string>): UpgradeHeaders {
+      return new Headers({
+        "Sec-WebSocket-Protocol": protocol,
+        ...extraHeaders,
+      });
+    },
+    preservesOriginalHeaders: true,
+  },
+] as const;
+
+function getClientProtocols(req: Request): string[] {
+  return req.headers
+    .get("Sec-WebSocket-Protocol")
+    ?.split(",")
+    .map(protocol => protocol.trim()) || [];
+}
+
+async function expectNegotiatedProtocol(port: number, clientProtocols: string[], expectedProtocol: string) {
+  const ws = new WebSocket(`ws://localhost:${port}`, clientProtocols);
+
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => {
+      expect(ws.protocol).toBe(expectedProtocol);
+      ws.close();
+      resolve();
+    };
+    ws.onerror = reject;
+    ws.onclose = event => {
+      if (event.code === 1002 && event.reason === "Mismatch client protocol") {
+        reject(new Error("Connection failed with 'Mismatch client protocol'"));
+      }
+    };
+  });
+}
+
+async function readUpgradeResponse(port: number, clientProtocols: string[]) {
+  const key = Buffer.from("0123456789abcdef").toString("base64");
+
+  return await new Promise<string>((resolve, reject) => {
+    const socket = net.createConnection({ host: "localhost", port });
+    let response = "";
+    let completed = false;
+
+    const finish = (callback: () => void) => {
+      if (completed) return;
+      completed = true;
+      socket.removeAllListeners();
+      socket.destroy();
+      callback();
+    };
+
+    socket.on("connect", () => {
+      socket.write(
+        [
+          "GET / HTTP/1.1",
+          `Host: localhost:${port}`,
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Key: ${key}`,
+          "Sec-WebSocket-Version: 13",
+          `Sec-WebSocket-Protocol: ${clientProtocols.join(", ")}`,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+
+    socket.on("data", chunk => {
+      response += chunk.toString("latin1");
+      const headerEnd = response.indexOf("\r\n\r\n");
+      if (headerEnd !== -1) {
+        finish(() => resolve(response.slice(0, headerEnd + 4)));
+      }
+    });
+
+    socket.on("error", error => {
+      finish(() => reject(error));
+    });
+
+    socket.on("end", () => {
+      if (!completed) {
+        finish(() => reject(new Error("Socket closed before receiving the full upgrade response")));
+      }
+    });
+  });
+}
+
+function getHeaderValues(response: string, headerName: string): string[] {
+  const lines = response.split("\r\n");
+  const headerPrefix = `${headerName.toLowerCase()}:`;
+
+  return lines
+    .slice(1)
+    .filter(line => line.toLowerCase().startsWith(headerPrefix))
+    .map(line => line.slice(line.indexOf(":") + 1).trim());
+}
 
 describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
-  test("should work when selecting the first protocol", async () => {
-    using server = serve({
-      hostname: "localhost",
-      port: 0,
-      fetch(req, server) {
-        const protocols =
-          req.headers
-            .get("Sec-WebSocket-Protocol")
-            ?.split(",")
-            .map(p => p.trim()) || [];
+  for (const { label, makeHeaders, preservesOriginalHeaders } of headerVariants) {
+    test(`${label}: should work when selecting the first protocol`, async () => {
+      let protocolHeaderAfterUpgrade: string | null = null;
 
-        server.upgrade(req, {
-          headers: { "Sec-WebSocket-Protocol": protocols[0] },
-        });
-      },
-      websocket: {
-        open(ws) {},
-        close(ws) {},
-      },
+      using server = serve({
+        hostname: "localhost",
+        port: 0,
+        fetch(req, server) {
+          const protocols = getClientProtocols(req);
+          const headers = makeHeaders(protocols[0]);
+
+          server.upgrade(req, { headers });
+
+          if (headers instanceof Headers) {
+            protocolHeaderAfterUpgrade = headers.get("Sec-WebSocket-Protocol");
+          }
+        },
+        websocket: {
+          open(ws) {},
+          close(ws) {},
+        },
+      });
+
+      await expectNegotiatedProtocol(server.port, ["ocpp1.6", "ocpp2.0.1"], "ocpp1.6");
+
+      if (preservesOriginalHeaders) {
+        expect(protocolHeaderAfterUpgrade).toBe("ocpp1.6");
+      }
     });
 
-    const ws = new WebSocket(`ws://localhost:${server.port}`, ["ocpp1.6", "ocpp2.0.1"]);
+    test(`${label}: should work when selecting the second protocol`, async () => {
+      let protocolHeaderAfterUpgrade: string | null = null;
 
-    await new Promise((resolve, reject) => {
-      ws.onopen = () => {
-        expect(ws.protocol).toBe("ocpp1.6");
-        ws.close();
-        resolve();
-      };
-      ws.onerror = reject;
-      ws.onclose = e => {
-        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
-          reject(new Error("Connection failed with 'Mismatch client protocol'"));
-        }
-      };
-    });
-  });
+      using server = serve({
+        hostname: "localhost",
+        port: 0,
+        fetch(req, server) {
+          const protocols = getClientProtocols(req);
+          const headers = makeHeaders(protocols[1] || protocols[0]);
 
-  test("should work when selecting the second protocol", async () => {
-    using server = serve({
-      hostname: "localhost",
-      port: 0,
-      fetch(req, server) {
-        const protocols =
-          req.headers
-            .get("Sec-WebSocket-Protocol")
-            ?.split(",")
-            .map(p => p.trim()) || [];
+          server.upgrade(req, { headers });
 
-        // Select the second protocol
-        server.upgrade(req, {
-          headers: { "Sec-WebSocket-Protocol": protocols[1] || protocols[0] },
-        });
-      },
-      websocket: {
-        open(ws) {},
-        close(ws) {},
-      },
+          if (headers instanceof Headers) {
+            protocolHeaderAfterUpgrade = headers.get("Sec-WebSocket-Protocol");
+          }
+        },
+        websocket: {
+          open(ws) {},
+          close(ws) {},
+        },
+      });
+
+      await expectNegotiatedProtocol(server.port, ["ocpp1.6", "ocpp2.0.1"], "ocpp2.0.1");
+
+      if (preservesOriginalHeaders) {
+        expect(protocolHeaderAfterUpgrade).toBe("ocpp2.0.1");
+      }
     });
 
-    const ws = new WebSocket(`ws://localhost:${server.port}`, ["ocpp1.6", "ocpp2.0.1"]);
+    test(`${label}: should work when selecting any protocol from the list`, async () => {
+      let protocolHeaderAfterUpgrade: string | null = null;
 
-    await new Promise((resolve, reject) => {
-      ws.onopen = () => {
-        expect(ws.protocol).toBe("ocpp2.0.1");
-        ws.close();
-        resolve();
-      };
-      ws.onerror = reject;
-      ws.onclose = e => {
-        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
-          reject(new Error("Connection failed with 'Mismatch client protocol'"));
-        }
-      };
-    });
-  });
+      using server = serve({
+        hostname: "localhost",
+        port: 0,
+        fetch(req, server) {
+          const protocols = getClientProtocols(req);
+          const selected = protocols.find(protocol => protocol === "chat");
+          const headers = makeHeaders(selected!);
 
-  test("should work when selecting any protocol from the list", async () => {
-    using server = serve({
-      hostname: "localhost",
-      port: 0,
-      fetch(req, server) {
-        const protocols =
-          req.headers
-            .get("Sec-WebSocket-Protocol")
-            ?.split(",")
-            .map(p => p.trim()) || [];
+          server.upgrade(req, { headers });
 
-        // Select a specific protocol from the middle of the list
-        const selected = protocols.find(p => p === "chat");
+          if (headers instanceof Headers) {
+            protocolHeaderAfterUpgrade = headers.get("Sec-WebSocket-Protocol");
+          }
+        },
+        websocket: {
+          open(ws) {},
+          close(ws) {},
+        },
+      });
 
-        server.upgrade(req, {
-          headers: { "Sec-WebSocket-Protocol": selected },
-        });
-      },
-      websocket: {
-        open(ws) {},
-        close(ws) {},
-      },
+      await expectNegotiatedProtocol(server.port, ["echo", "chat", "binary"], "chat");
+
+      if (preservesOriginalHeaders) {
+        expect(protocolHeaderAfterUpgrade).toBe("chat");
+      }
     });
 
-    const ws = new WebSocket(`ws://localhost:${server.port}`, ["echo", "chat", "binary"]);
+    test(`${label}: should preserve other custom headers in the upgrade response`, async () => {
+      let protocolHeaderAfterUpgrade: string | null = null;
 
-    await new Promise((resolve, reject) => {
-      ws.onopen = () => {
-        expect(ws.protocol).toBe("chat");
-        ws.close();
-        resolve();
-      };
-      ws.onerror = reject;
-      ws.onclose = e => {
-        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
-          reject(new Error("Connection failed with 'Mismatch client protocol'"));
-        }
-      };
-    });
-  });
-
-  test("should work with other custom headers alongside Sec-WebSocket-Protocol", async () => {
-    using server = serve({
-      hostname: "localhost",
-      port: 0,
-      fetch(req, server) {
-        const protocols =
-          req.headers
-            .get("Sec-WebSocket-Protocol")
-            ?.split(",")
-            .map(p => p.trim()) || [];
-
-        server.upgrade(req, {
-          headers: {
-            "Sec-WebSocket-Protocol": protocols[0],
+      using server = serve({
+        hostname: "localhost",
+        port: 0,
+        fetch(req, server) {
+          const protocols = getClientProtocols(req);
+          const headers = makeHeaders(protocols[0], {
             "X-Custom-Header": "custom-value",
-          },
-        });
-      },
-      websocket: {
-        open(ws) {},
-        close(ws) {},
-      },
-    });
+          });
 
-    const ws = new WebSocket(`ws://localhost:${server.port}`, ["test-protocol"]);
+          server.upgrade(req, { headers });
 
-    await new Promise((resolve, reject) => {
-      ws.onopen = () => {
-        expect(ws.protocol).toBe("test-protocol");
-        ws.close();
-        resolve();
-      };
-      ws.onerror = reject;
-      ws.onclose = e => {
-        if (e.code === 1002 && e.reason === "Mismatch client protocol") {
-          reject(new Error("Connection failed with 'Mismatch client protocol'"));
-        }
-      };
+          if (headers instanceof Headers) {
+            protocolHeaderAfterUpgrade = headers.get("Sec-WebSocket-Protocol");
+          }
+        },
+        websocket: {
+          open(ws) {},
+          close(ws) {},
+        },
+      });
+
+      const response = await readUpgradeResponse(server.port, ["test-protocol"]);
+
+      expect(response.startsWith("HTTP/1.1 101 Switching Protocols")).toBe(true);
+      expect(getHeaderValues(response, "Sec-WebSocket-Protocol")).toEqual(["test-protocol"]);
+      expect(getHeaderValues(response, "X-Custom-Header")).toEqual(["custom-value"]);
+
+      if (preservesOriginalHeaders) {
+        expect(protocolHeaderAfterUpgrade).toBe("test-protocol");
+      }
     });
-  });
+  }
 });

--- a/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
+++ b/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
@@ -38,21 +38,23 @@ function getClientProtocols(req: Request): string[] {
 }
 
 async function expectNegotiatedProtocol(port: number, clientProtocols: string[], expectedProtocol: string) {
+  const { promise: openPromise, resolve: resolveOpen, reject } = Promise.withResolvers<void>();
   const ws = new WebSocket(`ws://localhost:${port}`, clientProtocols);
 
-  await new Promise<void>((resolve, reject) => {
-    ws.onopen = () => {
-      expect(ws.protocol).toBe(expectedProtocol);
-      ws.close();
-      resolve();
-    };
+  try {
+    ws.onopen = () => resolveOpen();
     ws.onerror = reject;
     ws.onclose = event => {
       if (event.code === 1002 && event.reason === "Mismatch client protocol") {
         reject(new Error("Connection failed with 'Mismatch client protocol'"));
       }
     };
-  });
+
+    await openPromise;
+    expect(ws.protocol).toBe(expectedProtocol);
+  } finally {
+    ws.terminate();
+  }
 }
 
 async function readUpgradeResponse(port: number, clientProtocols: string[]) {

--- a/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
+++ b/test/js/web/websocket/websocket-server-upgrade-protocol.test.ts
@@ -1,5 +1,5 @@
 // Test for https://github.com/oven-sh/bun/issues/25773
-// Verifies that server.upgrade() works correctly with custom Sec-WebSocket-Protocol header
+// Verifies that server.upgrade() preserves websocket-specific headers without duplicates
 
 import { describe, expect, test } from "bun:test";
 import { serve } from "bun";
@@ -10,9 +10,9 @@ type UpgradeHeaders = Headers | Record<string, string>;
 const headerVariants = [
   {
     label: "plain object",
-    makeHeaders(protocol: string, extraHeaders?: Record<string, string>): UpgradeHeaders {
+    makeHeaders(webSocketHeaders: Record<string, string>, extraHeaders?: Record<string, string>): UpgradeHeaders {
       return {
-        "Sec-WebSocket-Protocol": protocol,
+        ...webSocketHeaders,
         ...extraHeaders,
       };
     },
@@ -20,9 +20,9 @@ const headerVariants = [
   },
   {
     label: "Headers instance",
-    makeHeaders(protocol: string, extraHeaders?: Record<string, string>): UpgradeHeaders {
+    makeHeaders(webSocketHeaders: Record<string, string>, extraHeaders?: Record<string, string>): UpgradeHeaders {
       return new Headers({
-        "Sec-WebSocket-Protocol": protocol,
+        ...webSocketHeaders,
         ...extraHeaders,
       });
     },
@@ -30,11 +30,16 @@ const headerVariants = [
   },
 ] as const;
 
-function getClientProtocols(req: Request): string[] {
+function getRequestHeaderValues(req: Request, headerName: string): string[] {
   return req.headers
-    .get("Sec-WebSocket-Protocol")
+    .get(headerName)
     ?.split(",")
-    .map(protocol => protocol.trim()) || [];
+    .map(value => value.trim())
+    .filter(Boolean) || [];
+}
+
+function getClientProtocols(req: Request): string[] {
+  return getRequestHeaderValues(req, "Sec-WebSocket-Protocol");
 }
 
 async function expectNegotiatedProtocol(port: number, clientProtocols: string[], expectedProtocol: string) {
@@ -57,7 +62,16 @@ async function expectNegotiatedProtocol(port: number, clientProtocols: string[],
   }
 }
 
-async function readUpgradeResponse(port: number, clientProtocols: string[]) {
+async function readUpgradeResponse(
+  port: number,
+  {
+    clientProtocols = [],
+    clientExtensions = [],
+  }: {
+    clientProtocols?: string[];
+    clientExtensions?: string[];
+  } = {},
+) {
   const key = Buffer.from("0123456789abcdef").toString("base64");
 
   return await new Promise<string>((resolve, reject) => {
@@ -74,19 +88,26 @@ async function readUpgradeResponse(port: number, clientProtocols: string[]) {
     };
 
     socket.on("connect", () => {
-      socket.write(
-        [
-          "GET / HTTP/1.1",
-          `Host: localhost:${port}`,
-          "Upgrade: websocket",
-          "Connection: Upgrade",
-          `Sec-WebSocket-Key: ${key}`,
-          "Sec-WebSocket-Version: 13",
-          `Sec-WebSocket-Protocol: ${clientProtocols.join(", ")}`,
-          "",
-          "",
-        ].join("\r\n"),
-      );
+      const requestLines = [
+        "GET / HTTP/1.1",
+        `Host: localhost:${port}`,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        `Sec-WebSocket-Key: ${key}`,
+        "Sec-WebSocket-Version: 13",
+      ];
+
+      if (clientProtocols.length > 0) {
+        requestLines.push(`Sec-WebSocket-Protocol: ${clientProtocols.join(", ")}`);
+      }
+
+      if (clientExtensions.length > 0) {
+        requestLines.push(`Sec-WebSocket-Extensions: ${clientExtensions.join(", ")}`);
+      }
+
+      requestLines.push("", "");
+
+      socket.write(requestLines.join("\r\n"));
     });
 
     socket.on("data", chunk => {
@@ -129,7 +150,9 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         port: 0,
         fetch(req, server) {
           const protocols = getClientProtocols(req);
-          const headers = makeHeaders(protocols[0]);
+          const headers = makeHeaders({
+            "Sec-WebSocket-Protocol": protocols[0],
+          });
 
           server.upgrade(req, { headers });
 
@@ -158,7 +181,9 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         port: 0,
         fetch(req, server) {
           const protocols = getClientProtocols(req);
-          const headers = makeHeaders(protocols[1] || protocols[0]);
+          const headers = makeHeaders({
+            "Sec-WebSocket-Protocol": protocols[1] || protocols[0],
+          });
 
           server.upgrade(req, { headers });
 
@@ -188,7 +213,9 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         fetch(req, server) {
           const protocols = getClientProtocols(req);
           const selected = protocols.find(protocol => protocol === "chat");
-          const headers = makeHeaders(selected!);
+          const headers = makeHeaders({
+            "Sec-WebSocket-Protocol": selected!,
+          });
 
           server.upgrade(req, { headers });
 
@@ -217,9 +244,10 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         port: 0,
         fetch(req, server) {
           const protocols = getClientProtocols(req);
-          const headers = makeHeaders(protocols[0], {
-            "X-Custom-Header": "custom-value",
-          });
+          const headers = makeHeaders(
+            { "Sec-WebSocket-Protocol": protocols[0] },
+            { "X-Custom-Header": "custom-value" },
+          );
 
           server.upgrade(req, { headers });
 
@@ -233,7 +261,9 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
         },
       });
 
-      const response = await readUpgradeResponse(server.port, ["test-protocol"]);
+      const response = await readUpgradeResponse(server.port, {
+        clientProtocols: ["test-protocol"],
+      });
 
       expect(response.startsWith("HTTP/1.1 101 Switching Protocols")).toBe(true);
       expect(getHeaderValues(response, "Sec-WebSocket-Protocol")).toEqual(["test-protocol"]);
@@ -241,6 +271,51 @@ describe("server.upgrade() with custom Sec-WebSocket-Protocol", () => {
 
       if (preservesOriginalHeaders) {
         expect(protocolHeaderAfterUpgrade).toBe("test-protocol");
+      }
+    });
+  }
+});
+
+describe("server.upgrade() with custom Sec-WebSocket-Extensions", () => {
+  for (const { label, makeHeaders, preservesOriginalHeaders } of headerVariants) {
+    test(`${label}: should preserve websocket extensions without duplicates`, async () => {
+      let extensionHeaderAfterUpgrade: string | null = null;
+
+      using server = serve({
+        hostname: "localhost",
+        port: 0,
+        fetch(req, server) {
+          const [extension = "permessage-deflate"] = getRequestHeaderValues(req, "Sec-WebSocket-Extensions");
+          const headers = makeHeaders(
+            { "Sec-WebSocket-Extensions": extension },
+            { "X-Custom-Header": "custom-value" },
+          );
+
+          server.upgrade(req, { headers });
+
+          if (headers instanceof Headers) {
+            extensionHeaderAfterUpgrade = headers.get("Sec-WebSocket-Extensions");
+          }
+        },
+        websocket: {
+          perMessageDeflate: true,
+          open(ws) {},
+          close(ws) {},
+        },
+      });
+
+      const response = await readUpgradeResponse(server.port, {
+        clientExtensions: ["permessage-deflate"],
+      });
+      const extensionHeaderValues = getHeaderValues(response, "Sec-WebSocket-Extensions");
+
+      expect(response.startsWith("HTTP/1.1 101 Switching Protocols")).toBe(true);
+      expect(extensionHeaderValues).toHaveLength(1);
+      expect(extensionHeaderValues[0]).toContain("permessage-deflate");
+      expect(getHeaderValues(response, "X-Custom-Header")).toEqual(["custom-value"]);
+
+      if (preservesOriginalHeaders) {
+        expect(extensionHeaderAfterUpgrade).toBe("permessage-deflate");
       }
     });
   }


### PR DESCRIPTION
## Problem

When using `server.upgrade()` with custom headers including `Sec-WebSocket-Protocol`, the WebSocket connection would fail with error code 1002 and reason "Mismatch client protocol", even when selecting a valid protocol from the client's offered list.

### Root Cause

The bug was caused by **duplicate `Sec-WebSocket-Protocol` headers** being sent in the HTTP 101 Switching Protocols response:

1. Custom headers (including `Sec-WebSocket-Protocol`) were written via `headers.toUWSResponse()` in `server.zig` line 979
2. The `resp.upgrade()` function was then called (line 1011), which **again** wrote the `Sec-WebSocket-Protocol` header in `HttpResponse.h` line 263

This resulted in duplicate headers:
```
HTTP/1.1 101 Switching Protocols
Upgrade: websocket
Connection: Upgrade
Sec-WebSocket-Accept: ...
Sec-WebSocket-Protocol: ocpp2.0.1
Sec-WebSocket-Protocol: ocpp2.0.1  <-- duplicate!
```

RFC 6455 Section 4.2.2 specifies that the server MUST include **at most one** `Sec-WebSocket-Protocol` header in the response. Bun's WebSocket client correctly validates this and rejects connections with duplicate headers.

## Solution

Remove `Sec-WebSocket-Protocol` from custom headers before writing them to the response, since the `upgrade()` function handles this header properly:

```zig
// Remove Sec-WebSocket-Protocol header before writing to response.
// This header will be written by the upgrade() function to avoid
// sending duplicate headers which would cause the client to reject
// the connection (RFC 6455 requires at most one protocol header).
// The protocol value has already been extracted above (line 948).
headers.fastRemove(.SecWebSocketProtocol);
```

The protocol value is preserved and passed to `upgrade()`, so the server's protocol selection is respected.

## Changes

- **Fix**: `src/bun.js/api/server.zig` - Remove duplicate header (7 lines)
- **Tests**: `test/js/web/websocket/websocket-server-upgrade-protocol.test.ts` - Comprehensive test coverage (174 lines)

## Test Coverage

Added 4 new tests covering:
1. ✅ Selecting the first protocol from the client's list
2. ✅ Selecting the second protocol from the client's list  
3. ✅ Selecting any specific protocol from the list
4. ✅ Using custom headers alongside `Sec-WebSocket-Protocol`

All existing WebSocket tests continue to pass (77/79 pass, 2 unrelated failures).

## Why Wasn't This Caught Before?

Existing tests like `websocket-subprotocol-strict.test.ts` and `websocket-custom-headers.test.ts` test:
- **Client-side** validation using mock servers with `net.createServer()`
- **Client** sending custom headers to servers

But no existing test covered the specific case of using **`Bun.serve()` with `server.upgrade()` and custom response headers**, which is the code path this bug affected.

## Impact

This fix allows servers to properly negotiate WebSocket subprotocols by selecting any protocol from the client's offered list, not just relying on automatic selection. This is essential for protocols like OCPP (Open Charge Point Protocol) where clients may offer multiple protocol versions and the server needs to select the most appropriate one.

## How did you verify your code works?

A debug build of bun was executed locally and the existing and new tests are passing.
All the new tests fail when Bun 1.3.5 is used.

Fixes #25773, #18243

_This is my first, open-source contribution. Please let me know if any changes are needed_