### PR TITLE
Implement ws WebSocket 'upgrade' and 'unexpected-response' events

### DIFF
--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -1,0 +1,218 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("ws WebSocket should handle 'upgrade' event listener without warning", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import WebSocket from "ws";
+      
+      const ws = new WebSocket("wss://echo.websocket.org");
+      
+      ws.on("upgrade", (response) => {
+        console.log("upgrade event received");
+      });
+      
+      ws.on("open", () => {
+        console.log("open event received");
+        ws.close();
+      });
+      
+      ws.on("error", (err) => {
+        console.error("error:", err.message);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Should not have warnings about unimplemented events
+  expect(stderr).not.toContain("'upgrade' event is not implemented");
+  expect(stdout).toContain("open event received");
+  expect(exitCode).toBe(0);
+});
+
+test("ws WebSocket should handle 'unexpected-response' event listener without warning", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import WebSocket from "ws";
+      
+      // Try to connect to a server that will return non-101 status
+      const ws = new WebSocket("wss://httpbin.org/status/404");
+      
+      ws.on("unexpected-response", (request, response) => {
+        console.log("unexpected-response event received");
+      });
+      
+      ws.on("error", (err) => {
+        console.log("error event received");
+      });
+      
+      setTimeout(() => {
+        process.exit(0);
+      }, 2000);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Should not have warnings about unimplemented events
+  expect(stderr).not.toContain("'unexpected-response' event is not implemented");
+  expect(exitCode).toBe(0);
+});
+
+test("ws WebSocket with successful connection should emit upgrade event", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import WebSocket from "ws";
+      
+      const ws = new WebSocket("wss://echo.websocket.org");
+      
+      let upgradeEmitted = false;
+      let openEmitted = false;
+      
+      ws.on("upgrade", (response) => {
+        upgradeEmitted = true;
+        console.log("UPGRADE_EMITTED");
+      });
+      
+      ws.on("open", () => {
+        openEmitted = true;
+        console.log("OPEN_EMITTED");
+        
+        setTimeout(() => {
+          console.log("RESULTS:", upgradeEmitted, openEmitted);
+          ws.close();
+          process.exit(0);
+        }, 100);
+      });
+      
+      ws.on("error", (err) => {
+        console.error("ERROR:", err.message);
+        process.exit(1);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("'upgrade' event is not implemented");
+  expect(stdout).toContain("UPGRADE_EMITTED");
+  expect(stdout).toContain("OPEN_EMITTED");
+  expect(stdout).toContain("RESULTS: true true");
+  expect(exitCode).toBe(0);
+});
+
+test("ws WebSocket upgrade event should provide response object", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import WebSocket from "ws";
+      
+      const ws = new WebSocket("wss://echo.websocket.org");
+      
+      ws.on("upgrade", (response) => {
+        console.log("Response object:", JSON.stringify({
+          statusCode: response.statusCode,
+          statusMessage: response.statusMessage,
+          hasHeaders: typeof response.headers === "object"
+        }));
+      });
+      
+      ws.on("open", () => {
+        ws.close();
+      });
+      
+      ws.on("error", (err) => {
+        console.error("ERROR:", err.message);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("'upgrade' event is not implemented");
+  expect(stdout).toContain('"statusCode":101');
+  expect(stdout).toContain('"statusMessage":"Switching Protocols"');
+  expect(stdout).toContain('"hasHeaders":true');
+  expect(exitCode).toBe(0);
+});
+
+test("ws WebSocket should work without upgrade listener (backward compatibility)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import WebSocket from "ws";
+      
+      const ws = new WebSocket("wss://echo.websocket.org");
+      
+      ws.on("open", () => {
+        console.log("Connection opened successfully");
+        ws.close();
+      });
+      
+      ws.on("error", (err) => {
+        console.error("ERROR:", err.message);
+        process.exit(1);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("Connection opened successfully");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Description

This PR implements support for the `upgrade` and `unexpected-response` events in Bun's ws WebSocket polyfill, resolving issue #5951.

## Problem

Users were getting warnings when using the ws library with Bun:
```
[bun] Warning: ws.WebSocket 'upgrade' event is not implemented in bun
[bun] Warning: ws.WebSocket 'unexpected-response' event is not implemented in bun
```

These events are part of the ws library API and are used by many packages including:
- Playwright (for CDP functionality)
- Cloudflare Workers testing tools (vitest integration)
- TikTok Chat Reader
- Shoukaku (Lavalink wrapper)
- Many other WebSocket-based libraries

## Solution

The implementation adds proper event handling for both events:

### `upgrade` Event
- Emitted after successful WebSocket handshake completion
- Provides a mock response object with `statusCode: 101`, `statusMessage: "Switching Protocols"`, and `headers` object
- Emitted before the `open` event to match ws library behavior as closely as possible

### `unexpected-response` Event  
- Emitted when WebSocket connection fails
- Provides mock request and response objects
- Allows proper error handling for failed upgrade attempts

## Implementation Notes

Since Bun's native WebSocket API doesn't expose the underlying HTTP handshake details, this implementation provides mock request/response objects. This approach:
- ✅ Removes the warnings that break user workflows
- ✅ Enables packages that depend on these events to function correctly  
- ✅ Maintains backward compatibility (code without these listeners continues to work)
- ✅ Provides the expected API surface from the ws library

## Changes

- Modified `src/js/thirdparty/ws.js` to implement both events
- Added comprehensive tests in `test/regression/issue/05951.test.ts`

## Testing

All tests pass with the debug build:
```
✓ ws WebSocket should handle 'upgrade' event listener without warning
✓ ws WebSocket should handle 'unexpected-response' event listener without warning  
✓ ws WebSocket with successful connection should emit upgrade event
✓ ws WebSocket upgrade event should provide response object
✓ ws WebSocket should work without upgrade listener (backward compatibility)

5 pass, 0 fail, 18 expect() calls
```

Tests confirmed to fail with system bun (pre-fix) and pass with the patched version.

## Fixes

Closes #5951