### PR TITLE
feat: de-emphasize node_modules frames in stack traces

### DIFF
--- a/src/bake/client/overlay.css
+++ b/src/bake/client/overlay.css
@@ -240,6 +240,18 @@ header {
   font-style: italic;
 }
 
+/* De-emphasize library frames (node_modules) */
+.library-frame {
+  opacity: 0.5;
+}
+.library-frame .function-name {
+  color: var(--modal-text-faded);
+}
+.library-frame .file-name {
+  color: var(--modal-text-faded);
+  font-weight: normal;
+}
+
 /* Code View + Message Highlighting (Underline) */
 .code {
   display: flex;

--- a/src/bake/client/overlay.css
+++ b/src/bake/client/overlay.css
@@ -244,13 +244,6 @@ header {
 .library-frame {
   opacity: 0.5;
 }
-.library-frame .function-name {
-  color: var(--modal-text-faded);
-}
-.library-frame .file-name {
-  color: var(--modal-text-faded);
-  font-weight: normal;
-}
 
 /* Code View + Message Highlighting (Underline) */
 .code {

--- a/src/bake/client/overlay.ts
+++ b/src/bake/client/overlay.ts
@@ -587,9 +587,16 @@ function renderBundlerMessage(msg: BundlerMessage) {
   );
 }
 
+function isNodeModulesFrame(file: string | undefined): boolean {
+  if (!file) return false;
+  return file.includes("node_modules");
+}
+
 function renderTraceFrame(frame: Frame, className: string) {
   const hasFn = !!frame.fn;
-  return elem("div", { class: className }, [
+  const isLibrary = isNodeModulesFrame(frame.file);
+  const frameClass = isLibrary ? className + " library-frame" : className;
+  return elem("div", { class: frameClass }, [
     elemText("span", { class: "muted" }, "at "),
     ...(hasFn
       ? [

--- a/src/bake/client/overlay.ts
+++ b/src/bake/client/overlay.ts
@@ -589,7 +589,14 @@ function renderBundlerMessage(msg: BundlerMessage) {
 
 function isNodeModulesFrame(file: string | undefined): boolean {
   if (!file) return false;
-  return file.includes("node_modules");
+  // Check for path separator boundaries to avoid false positives
+  // e.g. "/node_modules/", "\node_modules\", or path starting with "node_modules/"
+  return (
+    file.includes("/node_modules/") ||
+    file.includes("\\node_modules\\") ||
+    file.startsWith("node_modules/") ||
+    file.startsWith("node_modules\\")
+  );
 }
 
 function renderTraceFrame(frame: Frame, className: string) {

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -2542,8 +2542,11 @@ pub fn printStackTrace(comptime Writer: type, writer: Writer, trace: ZigStackTra
             if (file.len == 0 and func.len == 0) continue;
 
             const has_name = std.fmt.count("{f}", .{frame.nameFormatter(false)}) > 0;
-            // De-emphasize frames from node_modules
-            const is_library_frame = std.mem.indexOf(u8, file, "node_modules") != null;
+            // De-emphasize frames from node_modules (check path separator boundaries)
+            const is_library_frame = std.mem.indexOf(u8, file, "/node_modules/") != null or
+                std.mem.indexOf(u8, file, "\\node_modules\\") != null or
+                std.mem.startsWith(u8, file, "node_modules/") or
+                std.mem.startsWith(u8, file, "node_modules\\");
 
             if (has_name and !frame.position.isInvalid()) {
                 if (is_library_frame) {

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -2542,67 +2542,119 @@ pub fn printStackTrace(comptime Writer: type, writer: Writer, trace: ZigStackTra
             if (file.len == 0 and func.len == 0) continue;
 
             const has_name = std.fmt.count("{f}", .{frame.nameFormatter(false)}) > 0;
+            // De-emphasize frames from node_modules
+            const is_library_frame = std.mem.indexOf(u8, file, "node_modules") != null;
 
             if (has_name and !frame.position.isInvalid()) {
-                try writer.print(
-                    comptime Output.prettyFmt(
-                        "<r>      <d>at <r>{f}<d> (<r>{f}<d>)<r>\n",
-                        allow_ansi_colors,
-                    ),
-                    .{
-                        frame.nameFormatter(
+                if (is_library_frame) {
+                    // Library frame: entire line is dim
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at {f} ({f})<r>\n",
                             allow_ansi_colors,
                         ),
-                        frame.sourceURLFormatter(
-                            dir,
-                            origin,
-                            false,
+                        .{
+                            frame.nameFormatter(false),
+                            frame.sourceURLFormatter(dir, origin, false, false),
+                        },
+                    );
+                } else {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at <r>{f}<d> (<r>{f}<d>)<r>\n",
                             allow_ansi_colors,
                         ),
-                    },
-                );
+                        .{
+                            frame.nameFormatter(
+                                allow_ansi_colors,
+                            ),
+                            frame.sourceURLFormatter(
+                                dir,
+                                origin,
+                                false,
+                                allow_ansi_colors,
+                            ),
+                        },
+                    );
+                }
             } else if (!frame.position.isInvalid()) {
-                try writer.print(
-                    comptime Output.prettyFmt(
-                        "<r>      <d>at <r>{f}\n",
-                        allow_ansi_colors,
-                    ),
-                    .{
-                        frame.sourceURLFormatter(
-                            dir,
-                            origin,
-                            false,
+                if (is_library_frame) {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at {f}<r>\n",
                             allow_ansi_colors,
                         ),
-                    },
-                );
+                        .{
+                            frame.sourceURLFormatter(dir, origin, false, false),
+                        },
+                    );
+                } else {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at <r>{f}\n",
+                            allow_ansi_colors,
+                        ),
+                        .{
+                            frame.sourceURLFormatter(
+                                dir,
+                                origin,
+                                false,
+                                allow_ansi_colors,
+                            ),
+                        },
+                    );
+                }
             } else if (has_name) {
-                try writer.print(
-                    comptime Output.prettyFmt(
-                        "<r>      <d>at <r>{f}<d>\n",
-                        allow_ansi_colors,
-                    ),
-                    .{
-                        frame.nameFormatter(
+                if (is_library_frame) {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at {f}<r>\n",
                             allow_ansi_colors,
                         ),
-                    },
-                );
+                        .{
+                            frame.nameFormatter(false),
+                        },
+                    );
+                } else {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at <r>{f}<d>\n",
+                            allow_ansi_colors,
+                        ),
+                        .{
+                            frame.nameFormatter(
+                                allow_ansi_colors,
+                            ),
+                        },
+                    );
+                }
             } else {
-                try writer.print(
-                    comptime Output.prettyFmt(
-                        "<r>      <d>at <r>{f}<d>\n",
-                        allow_ansi_colors,
-                    ),
-                    .{
-                        frame.sourceURLFormatter(
-                            dir,
-                            origin,
-                            false,
+                if (is_library_frame) {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at {f}<r>\n",
                             allow_ansi_colors,
                         ),
-                    },
-                );
+                        .{
+                            frame.sourceURLFormatter(dir, origin, false, false),
+                        },
+                    );
+                } else {
+                    try writer.print(
+                        comptime Output.prettyFmt(
+                            "<r>      <d>at <r>{f}<d>\n",
+                            allow_ansi_colors,
+                        ),
+                        .{
+                            frame.sourceURLFormatter(
+                                dir,
+                                origin,
+                                false,
+                                allow_ansi_colors,
+                            ),
+                        },
+                    );
+                }
             }
         }
     }

--- a/test/regression/issue/17507.test.ts
+++ b/test/regression/issue/17507.test.ts
@@ -100,9 +100,12 @@ userCode();
     // Library frame should NOT have a reset after "at " - it stays dim
     // The entire line after "at " should be in dim mode
     const libraryFrameStaysDim = !nodeModulesLine!.includes("at \x1b[0m");
+    // Also verify library frame actually has dim mode enabled
+    const libraryFrameHasDim = nodeModulesLine!.includes("\x1b[2m");
 
     expect(userFrameHasHighlight).toBe(true);
     expect(libraryFrameStaysDim).toBe(true);
+    expect(libraryFrameHasDim).toBe(true);
   });
 
   test("web overlay CSS includes library-frame class with opacity", async () => {

--- a/test/regression/issue/17507.test.ts
+++ b/test/regression/issue/17507.test.ts
@@ -65,16 +65,20 @@ userCode();
     const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
 
     // Find user code frame (contains "userCode" and starts with whitespace + "at ")
-    const userCodeLine = lines.find(
-      (l) => stripAnsi(l).trim().startsWith("at ") && l.includes("userCode")
-    );
+    const userCodeLine = lines.find((l) => {
+      const stripped = stripAnsi(l);
+      return stripped.trim().startsWith("at ") && stripped.includes("userCode");
+    });
     // Find node_modules frame (contains "/node_modules/" or "\\node_modules\\" path in stack trace)
     // Handle both Unix and Windows path separators
-    const nodeModulesLine = lines.find(
-      (l) =>
-        stripAnsi(l).trim().startsWith("at ") &&
-        (l.includes("/node_modules/") || l.includes("\\node_modules\\"))
-    );
+    // Use stripAnsi for path matching too, in case ANSI codes get inserted around path segments
+    const nodeModulesLine = lines.find((l) => {
+      const stripped = stripAnsi(l);
+      return (
+        stripped.trim().startsWith("at ") &&
+        (stripped.includes("/node_modules/") || stripped.includes("\\node_modules\\"))
+      );
+    });
 
     expect(userCodeLine).toBeDefined();
     expect(nodeModulesLine).toBeDefined();

--- a/test/regression/issue/17507.test.ts
+++ b/test/regression/issue/17507.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("DevServer: de-emphasize node_modules frames in stack traces", () => {
+  test("console output de-emphasizes node_modules frames", async () => {
+    // Create a test project with a node_modules dependency that throws an error
+    using dir = tempDir("devserver-deemphasize", {
+      "node_modules/my-lib/index.js": `
+        export function throwError() {
+          throw new Error("Error from node_modules");
+        }
+      `,
+      "index.ts": `
+        import { throwError } from "my-lib";
+        throwError();
+      `,
+      "package.json": JSON.stringify({
+        name: "test-app",
+        dependencies: {
+          "my-lib": "*",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "index.ts"],
+      env: {
+        ...bunEnv,
+        FORCE_COLOR: "1", // Enable ANSI colors
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    // The process should fail with an error
+    expect(exitCode).not.toBe(0);
+
+    // Check that the error message contains the node_modules path
+    expect(stderr).toContain("node_modules");
+    expect(stderr).toContain("Error from node_modules");
+
+    // The node_modules frame should be dimmed (ANSI escape code \x1b[2m is dim)
+    // When colors are enabled, node_modules frames should use dim styling
+    // The format for library frames is: "<r>      <d>at {f} ({f})<r>\n"
+    // which means the entire line after "at " is dim
+
+    // Regular frames have the pattern: "at <r>functionName<d> (<r>file<d>)"
+    // Library frames have: "at functionName (file)" all in dim
+
+    // Check that we have a stack trace
+    expect(stderr).toContain("at ");
+  });
+
+  test("web overlay CSS includes library-frame class", async () => {
+    // Read the overlay.css file and verify the library-frame styles exist
+    const cssFile = Bun.file(
+      new URL(
+        "../../../src/bake/client/overlay.css",
+        import.meta.url,
+      ).pathname,
+    );
+    const css = await cssFile.text();
+
+    // Check for library-frame class
+    expect(css).toContain(".library-frame");
+    expect(css).toContain("opacity: 0.5");
+
+    // Check for de-emphasized function and file name colors
+    expect(css).toContain(".library-frame .function-name");
+    expect(css).toContain(".library-frame .file-name");
+    expect(css).toContain("--modal-text-faded");
+  });
+
+  test("overlay.ts includes node_modules detection logic", async () => {
+    // Read the overlay.ts file and verify the node_modules detection exists
+    const tsFile = Bun.file(
+      new URL(
+        "../../../src/bake/client/overlay.ts",
+        import.meta.url,
+      ).pathname,
+    );
+    const ts = await tsFile.text();
+
+    // Check for node_modules detection function
+    expect(ts).toContain("isNodeModulesFrame");
+    expect(ts).toContain("node_modules");
+
+    // Check for library-frame class application
+    expect(ts).toContain("library-frame");
+  });
+});

--- a/test/regression/issue/17507.test.ts
+++ b/test/regression/issue/17507.test.ts
@@ -68,11 +68,12 @@ userCode();
     const userCodeLine = lines.find(
       (l) => stripAnsi(l).trim().startsWith("at ") && l.includes("userCode")
     );
-    // Find node_modules frame (contains "/node_modules/" path in stack trace)
+    // Find node_modules frame (contains "/node_modules/" or "\\node_modules\\" path in stack trace)
+    // Handle both Unix and Windows path separators
     const nodeModulesLine = lines.find(
       (l) =>
         stripAnsi(l).trim().startsWith("at ") &&
-        l.includes("/node_modules/")
+        (l.includes("/node_modules/") || l.includes("\\node_modules\\"))
     );
 
     expect(userCodeLine).toBeDefined();


### PR DESCRIPTION
## Summary

- De-emphasize stack trace frames from `node_modules` in both console output and DevServer web UI
- Makes user code more prominent when debugging, improving the debugging experience

## Changes

**Console output (VirtualMachine.zig):**
- Detect frames with `/node_modules/` or `\node_modules\` in the file path (with proper boundary checks)
- Use dim ANSI styling for the entire line instead of highlighting function/file names
- Affects all stack traces printed via `printStackTrace`, not just DevServer

**Web UI (overlay.ts/css):**
- Add `isNodeModulesFrame()` helper with proper path boundary detection
- Apply `library-frame` CSS class to frames from node_modules
- Style with 50% opacity (simple, no double-dim)

## Test Plan

- [x] Added regression test in `test/regression/issue/17507.test.ts`
- [x] Test asserts ANSI escape sequence differences between user frames and library frames
- [x] Test fails on unmodified bun (`USE_SYSTEM_BUN=1`) and passes with changes

## Edge Cases Handled

- Path boundary detection prevents false positives (e.g. user directory named `my_node_modules_backup`)
- Both Unix (`/node_modules/`) and Windows (`\node_modules\`) paths supported
- Handles paths starting with `node_modules/` (relative paths)

Fixes #17507

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.