### PR TITLE
fix(console): route console.trace() to stderr instead of stdout

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -187,10 +187,11 @@ it("console.trace() outputs to stderr", () => {
     env: bunEnv,
     stdio: ["inherit", "pipe", "pipe"],
   });
-  expect(proc.exitCode).toBe(0);
+  // Check stdout/stderr before exit code for better debugging on failure
   // stdout should be empty since trace goes to stderr
   expect(proc.stdout.toString("utf8")).toBeEmpty();
   // stderr should contain the trace output
   const stderr = proc.stderr.toString("utf8");
   expect(stderr).toContain("Trace: hello");
+  expect(proc.exitCode).toBe(0);
 });

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -179,3 +179,18 @@ it("console.log with SharedArrayBuffer", () => {
     "
   `);
 });
+
+it("console.trace() outputs to stderr", () => {
+  // https://github.com/oven-sh/bun/issues/19952
+  const proc = Bun.spawnSync({
+    cmd: [bunExe(), join(import.meta.dir, "console-trace.fixture.js")],
+    env: bunEnv,
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+  expect(proc.exitCode).toBe(0);
+  // stdout should be empty since trace goes to stderr
+  expect(proc.stdout.toString("utf8")).toBeEmpty();
+  // stderr should contain the trace output
+  const stderr = proc.stderr.toString("utf8");
+  expect(stderr).toContain("Trace: hello");
+});

--- a/test/js/web/console/console-trace.fixture.js
+++ b/test/js/web/console/console-trace.fixture.js
@@ -1,0 +1,3 @@
+'use strict';
+// Test that console.trace() outputs to stderr, not stdout
+console.trace("hello");


### PR DESCRIPTION
## Summary

Fixes #19952 - `console.trace()` now outputs to stderr instead of stdout, matching Node.js behavior.

### Changes

Added `message_type == .Trace` checks alongside the existing `.Warning`, `.Error`, and `.Assert` checks in `ConsoleObject.zig`:

1. **Mutex selection** - Trace now uses the stderr mutex for thread safety
2. **Writer selection** - Trace now uses `error_writer` (stderr) instead of `writer` (stdout)
3. **ANSI color settings** - Trace now respects `enable_ansi_colors_stderr`

### Test

Added a test case in `console-log.test.ts` that verifies:
- stdout is empty when running `console.trace()`
- stderr contains the trace output

### Verification

**Before (incorrect - goes to stdout):**
```bash
$ bun trace.js >/dev/null
$ # no output (trace went to stdout which was redirected)
```

**After (correct - goes to stderr):**
```bash
$ bun trace.js >/dev/null
Trace: hello
    at <anonymous> (trace.js:1:9)
```

This matches Node.js behavior:
```bash
$ node trace.js >/dev/null
Trace: hello
    at Object.<anonymous> (trace.js:1:9)
    ...
```