### PR TITLE
docs: fix shell prompt rendering and remove hardcoded prompts

### DIFF
--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -189,7 +189,7 @@ Isolated installs are conceptually similar to pnpm, so migration should be strai
 
 ```bash terminal icon="terminal"
 # Remove pnpm files
-$ rm -rf node_modules pnpm-lock.yaml
+rm -rf node_modules pnpm-lock.yaml
 
 # Install with Bun's isolated linker
 bun install --linker isolated

--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -14,7 +14,7 @@ It is strongly recommended to use [PowerShell 7 (`pwsh.exe`)](https://learn.micr
 By default, running unverified scripts are blocked.
 
 ```ps1
-> Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
 ```
 
 ### System Dependencies
@@ -22,7 +22,7 @@ By default, running unverified scripts are blocked.
 Bun v1.1 or later. We use Bun to run it's own code generators.
 
 ```ps1
-> irm bun.sh/install.ps1 | iex
+irm bun.sh/install.ps1 | iex
 ```
 
 [Visual Studio](https://visualstudio.microsoft.com) with the "Desktop Development with C++" workload. While installing, make sure to install Git as well, if Git for Windows is not already installed.
@@ -30,7 +30,7 @@ Bun v1.1 or later. We use Bun to run it's own code generators.
 Visual Studio can be installed graphically using the wizard or through WinGet:
 
 ```ps1
-> winget install "Visual Studio Community 2022" --override "--add Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Git " -s msstore
+winget install "Visual Studio Community 2022" --override "--add Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Git " -s msstore
 ```
 
 After Visual Studio, you need the following:
@@ -48,10 +48,10 @@ After Visual Studio, you need the following:
 [Scoop](https://scoop.sh) can be used to install these remaining tools easily.
 
 ```ps1 Scoop
-> irm https://get.scoop.sh | iex
-> scoop install nodejs-lts go rust nasm ruby perl ccache
+irm https://get.scoop.sh | iex
+scoop install nodejs-lts go rust nasm ruby perl ccache
 # scoop seems to be buggy if you install llvm and the rest at the same time
-> scoop install llvm@19.1.7
+scoop install llvm@19.1.7
 ```
 
 <Note>
@@ -63,19 +63,19 @@ After Visual Studio, you need the following:
 If you intend on building WebKit locally (optional), you should install these packages:
 
 ```ps1 Scoop
-> scoop install make cygwin python
+scoop install make cygwin python
 ```
 
 From here on out, it is **expected you use a PowerShell Terminal with `.\scripts\vs-shell.ps1` sourced**. This script is available in the Bun repository and can be loaded by executing it:
 
 ```ps1
-> .\scripts\vs-shell.ps1
+.\scripts\vs-shell.ps1
 ```
 
 To verify, you can check for an MSVC-only command line such as `mt.exe`
 
 ```ps1
-> Get-Command mt
+Get-Command mt
 ```
 
 <Note>
@@ -86,16 +86,16 @@ To verify, you can check for an MSVC-only command line such as `mt.exe`
 ## Building
 
 ```ps1
-> bun run build
+bun run build
 
 # after the initial `bun run build` you can use the following to build
-> ninja -Cbuild/debug
+ninja -Cbuild/debug
 ```
 
 If this was successful, you should have a `bun-debug.exe` in the `build/debug` folder.
 
 ```ps1
-> .\build\debug\bun-debug.exe --revision
+.\build\debug\bun-debug.exe --revision
 ```
 
 You should add this to `$Env:PATH`. The simplest way to do so is to open the start menu, type "Path", and then navigate the environment variables menu to add `C:\.....\bun\build\debug` to the user environment variable `PATH`. You should then restart your editor (if it does not update still, log out and log back in).
@@ -111,15 +111,15 @@ You can run the test suite either using `bun test <path>` or by using the wrappe
 
 ```ps1
 # Setup
-> bun i --cwd packages\bun-internal-test
+bun i --cwd packages\bun-internal-test
 
 # Run the entire test suite with reporter
 # the package.json script "test" uses "build/debug/bun-debug.exe" by default
-> bun run test
+bun run test
 
 # Run an individual test file:
-> bun-debug test node\fs
-> bun-debug test "C:\bun\test\js\bun\resolve\import-meta.test.js"
+bun-debug test node\fs
+bun-debug test "C:\bun\test\js\bun\resolve\import-meta.test.js"
 ```
 
 ## Troubleshooting

--- a/docs/project/contributing.mdx
+++ b/docs/project/contributing.mdx
@@ -28,23 +28,23 @@ Using your system's package manager, install Bun's dependencies:
 <CodeGroup>
 
 ```bash macOS (Homebrew)
-$ brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool ninja pkg-config rust ruby
+brew install automake ccache cmake coreutils gnu-sed go icu4c libiconv libtool ninja pkg-config rust ruby
 ```
 
 ```bash Ubuntu/Debian
-$ sudo apt install curl wget lsb-release software-properties-common cargo cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
+sudo apt install curl wget lsb-release software-properties-common cargo cmake git golang libtool ninja-build pkg-config rustc ruby-full xz-utils
 ```
 
 ```bash Arch
-$ sudo pacman -S base-devel cmake git go libiconv libtool make ninja pkg-config python rust sed unzip ruby
+sudo pacman -S base-devel cmake git go libiconv libtool make ninja pkg-config python rust sed unzip ruby
 ```
 
 ```bash Fedora
-$ sudo dnf install cargo clang19 llvm19 lld19 cmake git golang libtool ninja-build pkg-config rustc ruby libatomic-static libstdc++-static sed unzip which libicu-devel 'perl(Math::BigInt)'
+sudo dnf install cargo clang19 llvm19 lld19 cmake git golang libtool ninja-build pkg-config rustc ruby libatomic-static libstdc++-static sed unzip which libicu-devel 'perl(Math::BigInt)'
 ```
 
 ```bash openSUSE Tumbleweed
-$ sudo zypper install go cmake ninja automake git icu rustup && rustup toolchain install stable
+sudo zypper install go cmake ninja automake git icu rustup && rustup toolchain install stable
 ```
 
 </CodeGroup>
@@ -56,16 +56,16 @@ Before starting, you will need to already have a release build of Bun installed,
 <CodeGroup>
 
 ```bash Native
-$ curl -fsSL https://bun.com/install | bash
+curl -fsSL https://bun.com/install | bash
 ```
 
 ```bash npm
-$ npm install -g bun
+npm install -g bun
 ```
 
 ```bash Homebrew
-$ brew tap oven-sh/bun
-$ brew install bun
+brew tap oven-sh/bun
+brew install bun
 ```
 
 </CodeGroup>
@@ -76,19 +76,19 @@ ccache is used to cache compilation artifacts, significantly speeding up builds:
 
 ```bash
 # For macOS
-$ brew install ccache
+brew install ccache
 
 # For Ubuntu/Debian
-$ sudo apt install ccache
+sudo apt install ccache
 
 # For Arch
-$ sudo pacman -S ccache
+sudo pacman -S ccache
 
 # For Fedora
-$ sudo dnf install ccache
+sudo dnf install ccache
 
 # For openSUSE
-$ sudo zypper install ccache
+sudo zypper install ccache
 ```
 
 Our build scripts will automatically detect and use `ccache` if available. You can check cache statistics with `ccache --show-stats`.
@@ -100,24 +100,24 @@ Bun requires LLVM 19 (`clang` is part of LLVM). This version requirement is to m
 <CodeGroup>
 
 ```bash macOS (Homebrew)
-$ brew install llvm@19
+brew install llvm@19
 ```
 
 ```bash Ubuntu/Debian
-$ # LLVM has an automatic installation script that is compatible with all versions of Ubuntu
-$ wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 19 all
+# LLVM has an automatic installation script that is compatible with all versions of Ubuntu
+wget https://apt.llvm.org/llvm.sh -O - | sudo bash -s -- 19 all
 ```
 
 ```bash Arch
-$ sudo pacman -S llvm clang lld
+sudo pacman -S llvm clang lld
 ```
 
 ```bash Fedora
-$ sudo dnf install llvm clang lld-devel
+sudo dnf install llvm clang lld-devel
 ```
 
 ```bash openSUSE Tumbleweed
-$ sudo zypper install clang19 lld19 llvm19
+sudo zypper install clang19 lld19 llvm19
 ```
 
 </CodeGroup>
@@ -127,7 +127,7 @@ If none of the above solutions apply, you will have to install it [manually](htt
 Make sure Clang/LLVM 19 is in your path:
 
 ```bash
-$ which clang-19
+which clang-19
 ```
 
 If not, run this to manually add it:
@@ -137,12 +137,12 @@ If not, run this to manually add it:
 ```bash macOS (Homebrew)
 # use fish_add_path if you're using fish
 # use path+="$(brew --prefix llvm@19)/bin" if you are using zsh
-$ export PATH="$(brew --prefix llvm@19)/bin:$PATH"
+export PATH="$(brew --prefix llvm@19)/bin:$PATH"
 ```
 
 ```bash Arch
 # use fish_add_path if you're using fish
-$ export PATH="$PATH:/usr/lib/llvm19/bin"
+export PATH="$PATH:/usr/lib/llvm19/bin"
 ```
 
 </CodeGroup>
@@ -162,7 +162,7 @@ bun run build
 The binary will be located at `./build/debug/bun-debug`. It is recommended to add this to your `$PATH`. To verify the build worked, let's print the version number on the development build of Bun.
 
 ```bash
-$ build/debug/bun-debug --version
+build/debug/bun-debug --version
 x.y.z_debug
 ```
 
@@ -261,17 +261,17 @@ WebKit is not cloned by default (to save time and disk space). To clone and buil
 
 ```bash
 # Clone WebKit into ./vendor/WebKit
-$ git clone https://github.com/oven-sh/WebKit vendor/WebKit
+git clone https://github.com/oven-sh/WebKit vendor/WebKit
 
 # Check out the commit hash specified in `set(WEBKIT_VERSION <commit_hash>)` in cmake/tools/SetupWebKit.cmake
-$ git -C vendor/WebKit checkout <commit_hash>
+git -C vendor/WebKit checkout <commit_hash>
 
 # Make a debug build of JSC. This will output build artifacts in ./vendor/WebKit/WebKitBuild/Debug
 # Optionally, you can use `bun run jsc:build` for a release build
 bun run jsc:build:debug && rm vendor/WebKit/WebKitBuild/Debug/JavaScriptCore/DerivedSources/inspector/InspectorProtocolObjects.h
 
 # After an initial run of `make jsc-debug`, you can rebuild JSC with:
-$ cmake --build vendor/WebKit/WebKitBuild/Debug --target jsc && rm vendor/WebKit/WebKitBuild/Debug/JavaScriptCore/DerivedSources/inspector/InspectorProtocolObjects.h
+cmake --build vendor/WebKit/WebKitBuild/Debug --target jsc && rm vendor/WebKit/WebKitBuild/Debug/JavaScriptCore/DerivedSources/inspector/InspectorProtocolObjects.h
 
 # Build bun with the local JSC build
 bun run build:local
@@ -322,20 +322,20 @@ is not able to compile a simple test program.
 To fix the error, we need to update the GCC version to 11. To do this, we'll need to check if the latest version is available in the distribution's official repositories or use a third-party repository that provides GCC 11 packages. Here are general steps:
 
 ```bash
-$ sudo apt update
-$ sudo apt install gcc-11 g++-11
+sudo apt update
+sudo apt install gcc-11 g++-11
 # If the above command fails with `Unable to locate package gcc-11` we need
 # to add the APT repository
-$ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 # Now run `apt install` again
-$ sudo apt install gcc-11 g++-11
+sudo apt install gcc-11 g++-11
 ```
 
 Now, we need to set GCC 11 as the default compiler:
 
 ```bash
-$ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
-$ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
 ```
 
 ### libarchive
@@ -343,7 +343,7 @@ $ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
 If you see an error on macOS when compiling `libarchive`, run:
 
 ```bash
-$ brew install pkg-config
+brew install pkg-config
 ```
 
 ### macOS `library not found for -lSystem`
@@ -351,7 +351,7 @@ $ brew install pkg-config
 If you see this error when compiling, run:
 
 ```bash
-$ xcode-select --install
+xcode-select --install
 ```
 
 ### Cannot find `libatomic.a`

--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -19,7 +19,7 @@ If you're looking to create a brand new empty project, use [`bun init`](/runtime
 `bun create ./MyComponent.tsx` turns an existing React component into a complete dev environment with hot reload and production builds in one command.
 
 ```bash
-$ bun create ./MyComponent.jsx # .tsx also supported
+bun create ./MyComponent.jsx # .tsx also supported
 ```
 
 <Frame>

--- a/docs/style.css
+++ b/docs/style.css
@@ -149,25 +149,25 @@ div.callout .code-block {
   margin-bottom: 0px;
 }
 
-.code-block[language="shellscript"] code span.line:not(:empty):has(span)::before {
+[language="shellscript"] code span.line:not(:empty):has(span)::before {
   content: "$ ";
   color: #6272a4;
   user-select: none;
 }
 
-.code-block[language="shellscript"] code span.line:has(> span:first-child[style*="color: rgb(98, 114, 164)"])::before,
-.code-block[language="shellscript"] code span.line:has(> span:first-child[style*="#6272A4"])::before {
+[language="shellscript"] code span.line:has(> span:first-child[style*="color: rgb(98, 114, 164)"])::before,
+[language="shellscript"] code span.line:has(> span:first-child[style*="#6272A4"])::before {
   content: "";
 }
 
-.code-block[language="powershell"] code span.line:not(:empty):has(span)::before {
+[language="powershell"] code span.line:not(:empty):has(span)::before {
   content: "> ";
   color: #6272a4;
   user-select: none;
 }
 
-.code-block[language="powershell"] code span.line:has(> span:first-child[style*="color: rgb(98, 114, 164)"])::before,
-.code-block[language="powershell"] code span.line:has(> span:first-child[style*="#6272A4"])::before {
+[language="powershell"] code span.line:has(> span:first-child[style*="color: rgb(98, 114, 164)"])::before,
+[language="powershell"] code span.line:has(> span:first-child[style*="#6272A4"])::before {
   content: "";
 }
 


### PR DESCRIPTION
Changes:
- Fixes rendering of shell prompt symbols (`$` and `>`)
- Removed hardcoded prompts that annoyingly get copied when clicking the copy button

`.code-block` class prevented rendering of prompts when within the code group. Removing that class does the trick and it's still specific enough to not capture anything it shouldn't. 

| Before | After |
|---|---|
| ![Before 1](https://github.com/user-attachments/assets/6483a6a9-e1a3-40e8-b1b9-ec52db2f7570) | ![After 1](https://github.com/user-attachments/assets/22a6b73d-257e-49ed-8513-7f808d59aecb) |
| ![Before 2](https://github.com/user-attachments/assets/51b97c7e-0085-43b0-a376-8660cfa44765) | ![After 2](https://github.com/user-attachments/assets/d0c861a7-3a37-4e92-bf39-7fa29e94d821) |