### PR TITLE
fix: follow symlinks when scanning workspace packages

### DIFF
--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -3073,6 +3073,8 @@ pub const api = struct {
 
         public_hoist_pattern: ?install.PnpmMatcher = null,
         hoist_pattern: ?install.PnpmMatcher = null,
+
+        follow_workspace_symlinks: ?bool = null,
     };
 
     pub const ClientServerModule = struct {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -728,6 +728,12 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (install_obj.get("followWorkspaceSymlinks")) |follow_symlinks| {
+                        if (follow_symlinks.asBool()) |value| {
+                            install.follow_workspace_symlinks = value;
+                        }
+                    }
+
                     if (install_obj.get("security")) |security_obj| {
                         if (security_obj.data == .e_object) {
                             if (security_obj.get("scanner")) |scanner| {

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -731,6 +731,7 @@ pub fn init(
                             &json_source,
                             prop.loc,
                             null,
+                            if (ctx.install) |install| install.follow_workspace_symlinks orelse true else true,
                         ) catch break;
 
                         for (workspace_names.keys(), workspace_names.values()) |path, entry| {

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -20,6 +20,7 @@ positionals: []const string = &[_]string{},
 update: Update = .{},
 dry_run: bool = false,
 link_workspace_packages: bool = true,
+follow_workspace_symlinks: bool = true,
 remote_package_features: Features = .{
     .optional_dependencies = true,
 },
@@ -255,6 +256,9 @@ pub fn load(
         }
         if (config.link_workspace_packages) |link_workspace_packages| {
             this.link_workspace_packages = link_workspace_packages;
+        }
+        if (config.follow_workspace_symlinks) |follow_workspace_symlinks| {
+            this.follow_workspace_symlinks = follow_workspace_symlinks;
         }
     }
 

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1455,6 +1455,7 @@ pub fn Package(comptime SemverIntType: type) type {
                                 source,
                                 dependencies_q.loc,
                                 &string_builder,
+                                pm.options.follow_workspace_symlinks,
                             );
                         },
                         .e_object => |obj| {
@@ -1489,6 +1490,7 @@ pub fn Package(comptime SemverIntType: type) type {
                                         source,
                                         packages_query.loc,
                                         &string_builder,
+                                        pm.options.follow_workspace_symlinks,
                                     );
                                 }
 

--- a/src/install/lockfile/Package/WorkspaceMap.zig
+++ b/src/install/lockfile/Package/WorkspaceMap.zig
@@ -105,6 +105,7 @@ pub fn processNamesArray(
     source: *const logger.Source,
     loc: logger.Loc,
     string_builder: ?*StringBuilder,
+    follow_symlinks: bool,
 ) !u32 {
     if (arr.items.len == 0) return 0;
 
@@ -226,7 +227,7 @@ pub fn processNamesArray(
             var walker: GlobWalker = .{};
             var cwd = bun.path.dirname(source.path.text, .auto);
             cwd = if (bun.strings.eql(cwd, "")) bun.fs.FileSystem.instance.top_level_dir else cwd;
-            if ((try walker.initWithCwd(&arena, glob_pattern, cwd, false, false, false, false, true)).asErr()) |e| {
+            if ((try walker.initWithCwd(&arena, glob_pattern, cwd, false, false, follow_symlinks, false, true)).asErr()) |e| {
                 log.addErrorFmt(
                     source,
                     loc,

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -245,6 +245,7 @@ pub fn migrateNPMLockfile(
                 &json_src,
                 wksp.loc,
                 null,
+                manager.options.follow_workspace_symlinks,
             );
             debug("found {d} workspace packages", .{workspace_packages_count});
             num_deps += workspace_packages_count;

--- a/test/cli/install/workspace-symlink.test.ts
+++ b/test/cli/install/workspace-symlink.test.ts
@@ -1,0 +1,152 @@
+import { write } from "bun";
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, symlinkSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { tmpdir } from "os";
+import { join } from "path";
+
+describe("workspace symlinks", () => {
+  test("should follow symlinked workspace packages by default", async () => {
+    using rootDir = tempDir("workspace-symlink-test", {});
+    const rootPath = String(rootDir);
+
+    // Create a real workspace package outside the main directory
+    const externalWorkspaceDir = join(tmpdir(), `bun-test-external-workspace-${Date.now()}`);
+    mkdirSync(externalWorkspaceDir, { recursive: true });
+
+    try {
+      // Write the external workspace package.json
+      await write(
+        join(externalWorkspaceDir, "package.json"),
+        JSON.stringify({
+          name: "backend",
+          version: "1.0.0",
+        }),
+      );
+
+      // Create the root package.json with workspace pattern
+      await write(
+        join(rootPath, "package.json"),
+        JSON.stringify({
+          name: "monorepo",
+          version: "1.0.0",
+          workspaces: ["./*"],
+          dependencies: {
+            backend: "workspace:*",
+          },
+        }),
+      );
+
+      // Create a symlink to the external workspace
+      const symlinkPath = join(rootPath, "backend");
+
+      if (isWindows) {
+        // Windows requires different symlink flags
+        symlinkSync(externalWorkspaceDir, symlinkPath, "junction");
+      } else {
+        symlinkSync(externalWorkspaceDir, symlinkPath, "dir");
+      }
+
+      // Verify symlink was created
+      expect(existsSync(symlinkPath)).toBe(true);
+
+      // Run bun install
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: rootPath,
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The installation should succeed
+      expect(stderr).not.toContain('Workspace dependency "backend" not found');
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      // Verify the workspace was linked
+      const nodeModulesBackend = join(rootPath, "node_modules", "backend");
+      expect(existsSync(nodeModulesBackend)).toBe(true);
+    } finally {
+      // Cleanup external workspace directory
+      if (existsSync(externalWorkspaceDir)) {
+        await Bun.$`rm -rf ${externalWorkspaceDir}`.quiet();
+      }
+    }
+  });
+
+  test("should not follow symlinked workspaces when followWorkspaceSymlinks is false", async () => {
+    using rootDir = tempDir("workspace-symlink-disabled-test", {});
+    const rootPath = String(rootDir);
+
+    // Create a real workspace package outside the main directory
+    const externalWorkspaceDir = join(tmpdir(), `bun-test-external-workspace-${Date.now()}`);
+    mkdirSync(externalWorkspaceDir, { recursive: true });
+
+    try {
+      // Write the external workspace package.json
+      await write(
+        join(externalWorkspaceDir, "package.json"),
+        JSON.stringify({
+          name: "backend",
+          version: "1.0.0",
+        }),
+      );
+
+      // Create bunfig.toml to disable symlink following
+      await write(
+        join(rootPath, "bunfig.toml"),
+        `[install]
+followWorkspaceSymlinks = false
+`,
+      );
+
+      // Create the root package.json with workspace pattern
+      await write(
+        join(rootPath, "package.json"),
+        JSON.stringify({
+          name: "monorepo",
+          version: "1.0.0",
+          workspaces: ["./*"],
+          dependencies: {
+            backend: "workspace:*",
+          },
+        }),
+      );
+
+      // Create a symlink to the external workspace
+      const symlinkPath = join(rootPath, "backend");
+
+      if (isWindows) {
+        symlinkSync(externalWorkspaceDir, symlinkPath, "junction");
+      } else {
+        symlinkSync(externalWorkspaceDir, symlinkPath, "dir");
+      }
+
+      // Verify symlink was created
+      expect(existsSync(symlinkPath)).toBe(true);
+
+      // Run bun install - this should fail because we disabled symlink following
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: rootPath,
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The installation should fail with the workspace not found error
+      expect(stderr).toContain('Workspace dependency "backend" not found');
+      expect(exitCode).not.toBe(0);
+    } finally {
+      // Cleanup external workspace directory
+      if (existsSync(externalWorkspaceDir)) {
+        await Bun.$`rm -rf ${externalWorkspaceDir}`.quiet();
+      }
+    }
+  });
+});

--- a/test/cli/install/workspace-symlink.test.ts
+++ b/test/cli/install/workspace-symlink.test.ts
@@ -5,7 +5,7 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 describe("workspace symlinks", () => {
-  test("should follow symlinked workspace packages by default", async () => {
+  test.concurrent("should follow symlinked workspace packages by default", async () => {
     using rootDir = tempDir("workspace-symlink-test", {});
     using externalDir = tempDir("workspace-external", {
       "package.json": JSON.stringify({
@@ -61,16 +61,14 @@ describe("workspace symlinks", () => {
       // Verify the workspace was linked
       const nodeModulesBackend = join(rootPath, "node_modules", "backend");
       expect(existsSync(nodeModulesBackend)).toBe(true);
-    } catch (err) {
-      // Cleanup symlink on error
+    } finally {
       if (existsSync(symlinkPath)) {
         rmSync(symlinkPath, { recursive: true, force: true });
       }
-      throw err;
     }
   });
 
-  test("should not follow symlinked workspaces when followWorkspaceSymlinks is false", async () => {
+  test.concurrent("should not follow symlinked workspaces when followWorkspaceSymlinks is false", async () => {
     using rootDir = tempDir("workspace-symlink-disabled", {});
     using externalDir = tempDir("workspace-external-disabled", {
       "package.json": JSON.stringify({
@@ -129,12 +127,10 @@ followWorkspaceSymlinks = false
       // The installation should fail with the workspace not found error
       expect(stderr).toContain('Workspace dependency "backend" not found');
       expect(exitCode).not.toBe(0);
-    } catch (err) {
-      // Cleanup symlink on error
+    } finally {
       if (existsSync(symlinkPath)) {
         rmSync(symlinkPath, { recursive: true, force: true });
       }
-      throw err;
     }
   });
 });


### PR DESCRIPTION
Adds followWorkspaceSymlinks option (default: true) to allow symlinked workspace packages to be discovered during bun install.

Fixes workspace resolution to follow symlinks by passing follow_symlinks parameter to GlobWalker when scanning workspace patterns.

### What does this PR do?

Fixes symlinked workspace packages not being discovered during `bun install`.

Previously, when a workspace package was a symlink (let it be backage called `backend` which is a symlink), Bun would fail with:
```
error: Workspace dependency "backend" not found
```

**Solution:**
- Added `followWorkspaceSymlinks` option (default: `true`)
- Modified workspace scanning to follow symlinks via `GlobWalker`
- Can be disabled with `[install] followWorkspaceSymlinks = false` in bunfig.toml

### How did you verify your code works?

1. **Tests:** Added `test/cli/install/workspace-symlink.test.ts` - both tests pass
2. **Compilation:** `bun run zig:check-all` - All platforms compile
3. **Verification:** Test fails on system Bun (confirms bug), passes on debug build (confirms fix)

Closes #25801 
