### PR TITLE
docs: reorganize sections in publish.mdx for clarity and consistency

### DIFF
--- a/docs/snippets/cli/publish.mdx
+++ b/docs/snippets/cli/publish.mdx
@@ -1,105 +1,48 @@
 ## CLI Usage
 
 ```bash terminal icon="terminal"
-bun publish dist
+bun publish [directory or tarball]
 ```
 
 ### Access & Tagging
 
 <ParamField path="--access" type="string">
-  The `--access` flag can be used to set the access level of the package being published. The access level can be one of `public` or `restricted`. Unscoped packages are always public, and attempting to publish an unscoped package with `--access restricted` will result in an error.
-
-```sh terminal icon="terminal"
-bun publish --access public
-```
-
-`--access` can also be set in the `publishConfig` field of your `package.json`.
-
-```json package.json icon="file-json"
-{
-  "publishConfig": {
-    "access": "restricted" // [!code ++]
-  }
-}
-```
-
+  Set access level: `public` or `restricted`
 </ParamField>
 
 <ParamField path="--tag" type="string" default="latest">
-Set the tag of the package version being published. By default, the tag is `latest`. The initial version of a package is always given the `latest` tag in addition to the specified tag.
-
-```sh terminal icon="terminal"
-bun publish --tag alpha
-```
-
-`--tag` can also be set in the `publishConfig` field of your `package.json`.
-
-```json package.json icon="file-json"
-{
-  "publishConfig": {
-    "tag": "next" // [!code ++]
-  }
-}
-```
-
+  Set the distribution tag for the published version
 </ParamField>
 
 ### Publish Control
 
-<ParamField path="--dry-run=<val>" type="string">
-The `--dry-run` flag can be used to simulate the publish process without actually publishing the package. This is useful for verifying the contents of the published package without actually publishing the package.
-
-```sh
-bun publish --dry-run
-```
-
+<ParamField path="--dry-run" type="boolean">
+  Simulate publishing without uploading to registry
 </ParamField>
 
-<ParamField path="--gzip-level" type="string" default="9">
-  Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball
-  path argument. Values range from `0` to `9` (default is `9`).
+<ParamField path="--tolerate-republish" type="boolean">
+  Exit with code 0 if version already exists (useful for CI/CD)
+</ParamField>
+
+<ParamField path="--gzip-level" type="number" default="9">
+  Compression level for tarball (0-9)
 </ParamField>
 
 ### Authentication
 
 <ParamField path="--auth-type" type="string" default="web">
-
-If you have 2FA enabled for your npm account, `bun publish` will prompt you for a one-time password. This can be done through a browser or the CLI. The `--auth-type` flag can be used to tell the npm registry which method you prefer. The possible values are `web` and `legacy`, with `web` being the default.
-
-```sh terminal icon="terminal"
-bun publish --auth-type legacy
-...
-This operation requires a one-time password.
-Enter OTP: 123456
-...
-```
-
+  2FA method: `web` or `legacy`
 </ParamField>
 
-<ParamField path="--otp" type="string" default="web">
-
-Provide a one-time password directly to the CLI. If the password is valid, this will skip the extra prompt for a one-time password before publishing. Example usage:
-
-```sh terminal icon="terminal"
-bun publish --otp 123456
-```
-
-<Note>
-  `bun publish` respects the `NPM_CONFIG_TOKEN` environment variable which can be used when publishing in github actions
-  or automated workflows.
-</Note>
-
+<ParamField path="--otp" type="string">
+  Provide one-time password directly
 </ParamField>
 
 ### Registry Configuration
 
 <ParamField path="--registry" type="string">
-  Specify registry URL, overriding .npmrc and bunfig.toml
+  Specify registry URL, overriding `.npmrc` and `bunfig.toml`
 </ParamField>
-
-```bash
-bun publish --registry https://my-private-registry.com
-```
 
 <ParamField path="--ca" type="string">
   Provide Certificate Authority signing certificate
@@ -108,17 +51,6 @@ bun publish --registry https://my-private-registry.com
 <ParamField path="--cafile" type="string">
   Path to Certificate Authority certificate file
 </ParamField>
-
-<CodeGroup>
-```bash Inline Certificate
-bun publish --ca "-----BEGIN CERTIFICATE-----..."
-```
-
-```bash Certificate File
-bun publish --cafile ./ca-cert.pem
-```
-
-</CodeGroup>
 
 ### Dependency Management
 
@@ -143,11 +75,6 @@ bun publish --cafile ./ca-cert.pem
 <ParamField path="--trust" type="boolean">
   Add packages to trustedDependencies and run their scripts
 </ParamField>
-
-<Note>
-  **Lifecycle Scripts** — When providing a pre-built tarball, lifecycle scripts (prepublishOnly, prepack, etc.) are not
-  executed. Scripts only run when Bun packs the package itself.
-</Note>
 
 ### File Management
 

--- a/docs/snippets/cli/publish.mdx
+++ b/docs/snippets/cli/publish.mdx
@@ -4,7 +4,7 @@
 bun publish dist
 ```
 
-### Publishing Options
+### Access & Tagging
 
 <ParamField path="--access" type="string">
   The `--access` flag can be used to set the access level of the package being published. The access level can be one of `public` or `restricted`. Unscoped packages are always public, and attempting to publish an unscoped package with `--access restricted` will result in an error.
@@ -44,6 +44,8 @@ bun publish --tag alpha
 
 </ParamField>
 
+### Publish Control
+
 <ParamField path="--dry-run=<val>" type="string">
 The `--dry-run` flag can be used to simulate the publish process without actually publishing the package. This is useful for verifying the contents of the published package without actually publishing the package.
 
@@ -57,6 +59,8 @@ bun publish --dry-run
   Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball
   path argument. Values range from `0` to `9` (default is `9`).
 </ParamField>
+
+### Authentication
 
 <ParamField path="--auth-type" type="string" default="web">
 
@@ -89,8 +93,6 @@ bun publish --otp 123456
 
 ### Registry Configuration
 
-#### Custom Registry
-
 <ParamField path="--registry" type="string">
   Specify registry URL, overriding .npmrc and bunfig.toml
 </ParamField>
@@ -98,8 +100,6 @@ bun publish --otp 123456
 ```bash
 bun publish --registry https://my-private-registry.com
 ```
-
-#### SSL Certificates
 
 <ParamField path="--ca" type="string">
   Provide Certificate Authority signing certificate
@@ -120,9 +120,7 @@ bun publish --cafile ./ca-cert.pem
 
 </CodeGroup>
 
-### Publishing Options
-
-#### Dependency Management
+### Dependency Management
 
 <ParamField path="-p, --production" type="boolean">
   Don't install devDependencies
@@ -136,7 +134,7 @@ bun publish --cafile ./ca-cert.pem
   Always request the latest versions from the registry & reinstall all dependencies
 </ParamField>
 
-#### Script Control
+### Script Control
 
 <ParamField path="--ignore-scripts" type="boolean">
   Skip lifecycle scripts during packing and publishing
@@ -151,7 +149,7 @@ bun publish --cafile ./ca-cert.pem
   executed. Scripts only run when Bun packs the package itself.
 </Note>
 
-#### File Management
+### File Management
 
 <ParamField path="--no-save" type="boolean">
   Don't update package.json or lockfile
@@ -165,7 +163,7 @@ bun publish --cafile ./ca-cert.pem
   Generate yarn.lock file (yarn v1 compatible)
 </ParamField>
 
-#### Performance
+### Performance
 
 <ParamField path="--backend" type="string">
   Platform optimizations: `clonefile` (default), `hardlink`, `symlink`, or `copyfile`
@@ -179,7 +177,7 @@ bun publish --cafile ./ca-cert.pem
   Maximum concurrent lifecycle scripts
 </ParamField>
 
-#### Output Control
+### Output Control
 
 <ParamField path="--silent" type="boolean">
   Suppress all output


### PR DESCRIPTION
The current structure of [the bun publish doc](https://bun.com/docs/pm/cli/publish) has "Publishing Options" appearing twice with "Registry Configuration" awkwardly placed between them:

<img width="2034" height="1344" alt="2026-01-03 at 15 50 58" src="https://github.com/user-attachments/assets/0a8525c8-ef8f-4aa7-8bb8-1a10c4ab1446" />

This structure is inconsistent with other CLI snippet files (`install.mdx`, `build.mdx`, `run.mdx`, `test.mdx`) which use a flat H3 heading structure.

This PR removes duplicate "Publishing Options" sections and flattens heading structure for clarity and consistency.

EDIT: I noticed that some content in `docs/pm/cli/publish.mdx` was duplicated in `docs/snippets/cli/publish.mdx`, so I simplified the snippet to remove the redundancy. This should matche the style of other CLI docs such as `bun add` and `bun install`.