### PR TITLE
fix(install): bun update --force updates git dependencies

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -433,6 +433,23 @@ pub fn enqueuePatchTaskPre(this: *PackageManager, task: *PatchTask) void {
 
 /// Q: "What do we do with a dependency in a package.json?"
 /// A: "We enqueue it!"
+fn shouldIgnoreExistingResolution(this: *PackageManager, name_hash: PackageNameHash) bool {
+    // If we are forcing an update, the lockfile is cleared at the start.
+    // So any package in the lockfile is one we just resolved in this run.
+    if (this.options.force) return false;
+
+    if (this.subcommand != .update) return false;
+
+    // If we are updating specific packages, we want to ignore the existing resolution for those packages
+    if (this.update_requests.len > 0) {
+        for (this.update_requests) |req| {
+            if (req.name_hash == name_hash) return true;
+        }
+    }
+
+    return false;
+}
+
 pub fn enqueueDependencyWithMainAndSuccessFn(
     this: *PackageManager,
     id: DependencyID,
@@ -811,8 +828,10 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
 
             // First: see if we already loaded the git package in-memory
             if (this.lockfile.getPackageID(name_hash, null, &res)) |pkg_id| {
-                successFn(this, id, pkg_id);
-                return;
+                if (!shouldIgnoreExistingResolution(this, name_hash)) {
+                    successFn(this, id, pkg_id);
+                    return;
+                }
             }
 
             const alias = this.lockfile.str(&dependency.name);
@@ -900,8 +919,10 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
 
             // First: see if we already loaded the github package in-memory
             if (this.lockfile.getPackageID(name_hash, null, &res)) |pkg_id| {
-                successFn(this, id, pkg_id);
-                return;
+                if (!shouldIgnoreExistingResolution(this, name_hash)) {
+                    successFn(this, id, pkg_id);
+                    return;
+                }
             }
 
             const url = this.allocGitHubURL(dep);

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -175,14 +175,14 @@ pub fn callback(task: *ThreadPool.Task) void {
             };
             
             const dir = brk: {
-                if (normalized_url) |https| break :brk Repository.download(
+                if (normalized_url) |effective_url| break :brk Repository.download(
                     manager.allocator,
                     this.request.git_clone.env,
                     &this.log,
                     manager.getCacheDirectory(),
                     this.id,
                     name,
-                    https,
+                    effective_url,
                     attempt,
                 ) catch |err| {
                     // Exit early if git checked and could

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -157,7 +157,7 @@ pub fn callback(task: *ThreadPool.Task) void {
             const url = this.request.git_clone.url.slice();
             var attempt: u8 = 1;
             const dir = brk: {
-                if (Repository.tryHTTPS(url)) |https| break :brk Repository.download(
+                if (Repository.tryHTTPS(url) orelse if (strings.hasPrefix(url, "file:") or strings.hasPrefix(url, "git+file:")) (if (strings.hasPrefix(url, "git+file:")) url["git+".len..] else url) else null) |https| break :brk Repository.download(
                     manager.allocator,
                     this.request.git_clone.env,
                     &this.log,

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -582,8 +582,8 @@ pub const Repository = extern struct {
                         null,
                         logger.Loc.Empty,
                         allocator,
-                        "no commit matching \"{s}\" found for \"{s}\" (but repository exists)",
-                        .{ committish, name },
+                        "no resolvable commit (FETCH_HEAD or HEAD) found for \"{s}\" (but repository exists)",
+                        .{name},
                     ) catch unreachable;
                     return err2;
                 }, " \n\r\t");

--- a/test/cli/install/bun-update-git.test.ts
+++ b/test/cli/install/bun-update-git.test.ts
@@ -15,11 +15,20 @@ it("bun update --force updates git dependencies", async () => {
     "index.js": "console.log('v1');",
   });
 
-  await spawn({ cmd: ["git", "init"], cwd: remoteDir }).exited;
-  await spawn({ cmd: ["git", "config", "user.name", "Bun Test"], cwd: remoteDir }).exited;
-  await spawn({ cmd: ["git", "config", "user.email", "test@bun.sh"], cwd: remoteDir }).exited;
-  await spawn({ cmd: ["git", "add", "."], cwd: remoteDir }).exited;
-  await spawn({ cmd: ["git", "commit", "-m", "v1"], cwd: remoteDir }).exited;
+  let exitCode = await spawn({ cmd: ["git", "init"], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git init failed with exit code ${exitCode}`);
+  
+  exitCode = await spawn({ cmd: ["git", "config", "user.name", "Bun Test"], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git config user.name failed with exit code ${exitCode}`);
+  
+  exitCode = await spawn({ cmd: ["git", "config", "user.email", "test@bun.sh"], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git config user.email failed with exit code ${exitCode}`);
+  
+  exitCode = await spawn({ cmd: ["git", "add", "."], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git add . failed with exit code ${exitCode}`);
+  
+  exitCode = await spawn({ cmd: ["git", "commit", "-m", "v1"], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git commit failed with exit code ${exitCode}`);
 
   // Setup local project
   const localDir = tempDirWithFiles("local-project", {
@@ -34,10 +43,11 @@ it("bun update --force updates git dependencies", async () => {
   // Install v1
   const { exited: installExited, stderr: installStderr } = spawn({ cmd: [bunExe(), "install"], cwd: localDir, env, stderr: "pipe" });
   const installErr = await new Response(installStderr).text();
-  expect(await installExited).toBe(0);
-  if ((await installExited) !== 0) {
+  const installExitCode = await installExited;
+  if (installExitCode !== 0) {
     console.error(installErr);
   }
+  expect(installExitCode).toBe(0);
 
   // Verify v1 installed
   const v1Pkg = await Bun.file(join(localDir, "node_modules", "my-git-dep", "package.json")).json();
@@ -46,8 +56,12 @@ it("bun update --force updates git dependencies", async () => {
   // Update remote to v2
   await writeFile(join(remoteDir, "package.json"), JSON.stringify({ name: "my-git-dep", version: "2.0.0" }));
   await writeFile(join(remoteDir, "index.js"), "console.log('v2');");
-  await spawn({ cmd: ["git", "add", "."], cwd: remoteDir }).exited;
-  await spawn({ cmd: ["git", "commit", "-m", "v2"], cwd: remoteDir }).exited;
+  
+  exitCode = await spawn({ cmd: ["git", "add", "."], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git add . (v2) failed with exit code ${exitCode}`);
+  
+  exitCode = await spawn({ cmd: ["git", "commit", "-m", "v2"], cwd: remoteDir }).exited;
+  if (exitCode !== 0) throw new Error(`git commit (v2) failed with exit code ${exitCode}`);
 
   // Run bun update --force
   const { stderr, exited } = spawn({
@@ -59,7 +73,11 @@ it("bun update --force updates git dependencies", async () => {
   });
 
   const err = await new Response(stderr).text();
-  expect(await exited).toBe(0);
+  const updateExitCode = await exited;
+  if (updateExitCode !== 0) {
+    console.error(err);
+  }
+  expect(updateExitCode).toBe(0);
 
   // Verify v2 installed
   const v2Pkg = await Bun.file(join(localDir, "node_modules", "my-git-dep", "package.json")).json();

--- a/test/cli/install/bun-update-git.test.ts
+++ b/test/cli/install/bun-update-git.test.ts
@@ -1,0 +1,67 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { bunExe, bunEnv as env, tempDirWithFiles } from "harness";
+import { join } from "path";
+import { dummyAfterAll, dummyBeforeAll } from "./dummy.registry.js";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+
+it("bun update --force updates git dependencies", async () => {
+  // Setup remote git repo
+  const remoteDir = tempDirWithFiles("remote-git-repo", {
+    "package.json": JSON.stringify({ name: "my-git-dep", version: "1.0.0" }),
+    "index.js": "console.log('v1');",
+  });
+
+  await spawn({ cmd: ["git", "init"], cwd: remoteDir }).exited;
+  await spawn({ cmd: ["git", "config", "user.name", "Bun Test"], cwd: remoteDir }).exited;
+  await spawn({ cmd: ["git", "config", "user.email", "test@bun.sh"], cwd: remoteDir }).exited;
+  await spawn({ cmd: ["git", "add", "."], cwd: remoteDir }).exited;
+  await spawn({ cmd: ["git", "commit", "-m", "v1"], cwd: remoteDir }).exited;
+
+  // Setup local project
+  const localDir = tempDirWithFiles("local-project", {
+    "package.json": JSON.stringify({
+      name: "my-app",
+      dependencies: {
+        "my-git-dep": `git+file://${remoteDir}`,
+      },
+    }),
+  });
+
+  // Install v1
+  const { exited: installExited, stderr: installStderr } = spawn({ cmd: [bunExe(), "install"], cwd: localDir, env, stderr: "pipe" });
+  const installErr = await new Response(installStderr).text();
+  expect(await installExited).toBe(0);
+  if ((await installExited) !== 0) {
+    console.error(installErr);
+  }
+
+  // Verify v1 installed
+  const v1Pkg = await Bun.file(join(localDir, "node_modules", "my-git-dep", "package.json")).json();
+  expect(v1Pkg.version).toBe("1.0.0");
+
+  // Update remote to v2
+  await writeFile(join(remoteDir, "package.json"), JSON.stringify({ name: "my-git-dep", version: "2.0.0" }));
+  await writeFile(join(remoteDir, "index.js"), "console.log('v2');");
+  await spawn({ cmd: ["git", "add", "."], cwd: remoteDir }).exited;
+  await spawn({ cmd: ["git", "commit", "-m", "v2"], cwd: remoteDir }).exited;
+
+  // Run bun update --force
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--force"],
+    cwd: localDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+
+  const err = await new Response(stderr).text();
+  expect(await exited).toBe(0);
+
+  // Verify v2 installed
+  const v2Pkg = await Bun.file(join(localDir, "node_modules", "my-git-dep", "package.json")).json();
+  expect(v2Pkg.version).toBe("2.0.0");
+});


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where `bun update --force` would not update git dependencies to the latest commit on the tracked branch.

### Changes

- **Re-resolution Logic**: Modified `PackageManagerEnqueue.zig` to ensure git dependencies are re-resolved when running `bun update` or `bun install --force`, bypassing the cached resolution in the lockfile.
- **Git Fetch Strategy**: Updated `repository.zig` to use `git fetch --force` to handle force-pushed remote branches. Added fallback logic to use `rev-parse HEAD` if `FETCH_HEAD` is unavailable.
- **Test Support**: Updated `PackageManagerTask.zig` to support `git+file://` URLs, enabling local git repository tests.

### How did you verify your code works?

- Added `test/cli/install/bun-update-git.test.ts` to reproduce issue #8590 locally to troubleshoot and verify the fix.
- Verified all `bun-update**.test.ts` below are passing.
- [x] `test/cli/install/bun-update-git.test.ts`: **PASS** (New test)
- [x] `test/cli/install/bun-update-security-edge-cases.test.ts`: **PASS**
- [x] `test/cli/install/bun-update-security-provider.test.ts`: **PASS**
- [x] `test/cli/install/bun-update-security-scan-all.test.ts`: **PASS**
- [x] `test/cli/install/bun-update-security-simple.test.ts`: **PASS**
- [x] `test/cli/install/bun-update.test.ts`: **PASS**

Some installation tests (`lifecycle scripts > stress test`) are failing with `ConnectionRefused`.

There's also the two below timing out after 5000ms, which also seems to be happening in the production build.
- `should handle bitbucket git dependencies` 
- `should handle gitlab git dependencies`