### PR TITLE
fix(sql): filter out undefined values in INSERT helper instead of treating as NULL

### DIFF
--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -433,10 +433,25 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
               // insert into users ${sql(users)} or insert into users ${sql(user)}
               //
 
-              query += "(";
+              // Filter out columns with undefined values (use first item to determine columns)
+              const firstItem = $isArray(items) ? items[0] : items;
+              const definedColumns: string[] = [];
               for (let j = 0; j < columnCount; j++) {
-                query += this.escapeIdentifier(columns[j]);
-                if (j < lastColumnIndex) {
+                const column = columns[j];
+                if (typeof firstItem[column] !== "undefined") {
+                  definedColumns.push(column);
+                }
+              }
+              const definedColumnCount = definedColumns.length;
+              if (definedColumnCount === 0) {
+                throw new SyntaxError("Insert needs to have at least one column with a defined value");
+              }
+              const lastDefinedColumnIndex = definedColumnCount - 1;
+
+              query += "(";
+              for (let j = 0; j < definedColumnCount; j++) {
+                query += this.escapeIdentifier(definedColumns[j]);
+                if (j < lastDefinedColumnIndex) {
                   query += ", ";
                 }
               }
@@ -447,16 +462,12 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
                 for (let j = 0; j < itemsCount; j++) {
                   query += "(";
                   const item = items[j];
-                  for (let k = 0; k < columnCount; k++) {
-                    const column = columns[k];
+                  for (let k = 0; k < definedColumnCount; k++) {
+                    const column = definedColumns[k];
                     const columnValue = item[column];
                     // SQLite uses ? for placeholders, not $1, $2, etc.
-                    query += `?${k < lastColumnIndex ? ", " : ""}`;
-                    if (typeof columnValue === "undefined") {
-                      binding_values.push(null);
-                    } else {
-                      binding_values.push(columnValue);
-                    }
+                    query += `?${k < lastDefinedColumnIndex ? ", " : ""}`;
+                    binding_values.push(columnValue);
                   }
                   if (j < lastItemIndex) {
                     query += "),";
@@ -467,16 +478,12 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
               } else {
                 query += "(";
                 const item = items;
-                for (let j = 0; j < columnCount; j++) {
-                  const column = columns[j];
+                for (let j = 0; j < definedColumnCount; j++) {
+                  const column = definedColumns[j];
                   const columnValue = item[column];
                   // SQLite uses ? for placeholders
-                  query += `?${j < lastColumnIndex ? ", " : ""}`;
-                  if (typeof columnValue === "undefined") {
-                    binding_values.push(null);
-                  } else {
-                    binding_values.push(columnValue);
-                  }
+                  query += `?${j < lastDefinedColumnIndex ? ", " : ""}`;
+                  binding_values.push(columnValue);
                 }
                 query += ") "; // the user can add RETURNING * or RETURNING id
               }


### PR DESCRIPTION
## Summary

- Fix `sql()` helper to filter out undefined values in INSERT statements instead of converting them to NULL
- This aligns INSERT behavior with UPDATE, which already skips undefined values
- Add test case for the new behavior

**Before:** `sql({ foo: undefined, id: "123" })` in INSERT would generate `(foo, id) VALUES (NULL, "123")`, causing NOT NULL constraint violations.

**After:** `sql({ foo: undefined, id: "123" })` in INSERT generates `(id) VALUES ("123")`, omitting the undefined column entirely.

## Test plan

- [x] Added test `insert helper filters out undefined values` in `test/js/sql/sqlite-sql.test.ts`
- [x] Verified test fails with system bun (1.3.5) and passes with patched build
- [x] Ran all 24 helper-related tests - all pass

Fixes #22156 (comment https://github.com/oven-sh/bun/issues/22156#issuecomment-3706776687)

🤖 Generated with [Claude Code](https://claude.com/claude-code)