### PR TITLE
docs: BUN_CONFIG_TOKEN is used for registry authentication

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -361,7 +361,7 @@ Environment variables have a higher priority than `bunfig.toml`.
 | Name                               | Description                                                   |
 | ---------------------------------- | ------------------------------------------------------------- |
 | `BUN_CONFIG_REGISTRY`              | Set an npm registry (default: https://registry.npmjs.org)     |
-| `BUN_CONFIG_TOKEN`                 | Set an auth token (currently does nothing)                    |
+| `BUN_CONFIG_TOKEN`                 | Set an auth token for registry authentication                 |
 | `BUN_CONFIG_YARN_LOCKFILE`         | Save a Yarn v1-style yarn.lock                                |
 | `BUN_CONFIG_LINK_NATIVE_BINS`      | Point `bin` in package.json to a platform-specific dependency |
 | `BUN_CONFIG_SKIP_SAVE_LOCKFILE`    | Don’t save a lockfile                                         |


### PR DESCRIPTION
[The npm install doc](https://bun.com/docs/pm/cli/install) stated that `BUN_CONFIG_TOKEN` "currently does nothing", but this is incorrect. The implementation in clearly shows that Bun reads this environment variable (along with `NPM_CONFIG_TOKEN` and `npm_config_token`) and uses it as a Bearer token for registry authentication.

https://github.com/oven-sh/bun/blob/27ff6aaae0e925659c8f82ab6a4be17ec9c35a4a/src/install/PackageManager/PackageManagerOptions.zig#L439-L458