### PR TITLE
fix(scripts): remove `-Wl,--whole-archive` from build-jsc.ts for linux

### DIFF
--- a/scripts/build-jsc.ts
+++ b/scripts/build-jsc.ts
@@ -138,8 +138,7 @@ const getBuildEnv = () => {
   const cxxflags = ["-ffat-lto-objects"];
 
   if (IS_LINUX && buildConfig !== "lto") {
-    cflags.push("-Wl,--whole-archive");
-    cxxflags.push("-Wl,--whole-archive", "-DUSE_BUN_JSC_ADDITIONS=ON", "-DUSE_BUN_EVENT_LOOP=ON");
+    cxxflags.push("-DUSE_BUN_JSC_ADDITIONS=ON", "-DUSE_BUN_EVENT_LOOP=ON");
   }
 
   env.CFLAGS = (env.CFLAGS || "") + " " + cflags.join(" ");


### PR DESCRIPTION
## What does this PR do?

Without this change, the configure phase for jsc fails on Arch Linux.

Namely, the compiler test invocation passes -lgcc twice. With -Wl,--whole-archive enabled globally, duplicate symbol errors break the build.

This is sort of a weird linker flag to enable globally (it's intended to be toggled on before linking a particular archive, then toggled off).

I looked into the original change which introduced this (4f13208547) and couldn't determine the rationale.

<details>

<summary>Compiler test output:</summary>

```
     "/usr/bin/ld" --hash-style=gnu --build-id --eh-frame-hdr -m elf_x
86_64 -pie -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o cmTC_e0eba /
usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib64/Scrt
1.o /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib64
/crti.o /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/crtbeginS.o -
L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1 -L/usr/bin/../lib64/
gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib64 -L/usr/lib64 -L/usr/l
ib --whole-archive -t --verbose --trace-symbol=__multi3 CMakeFiles/cmT
C_e0eba.dir/testCCompiler.c.o -lgcc --as-needed -lgcc_s --no-as-needed
 -lc -lgcc --as-needed -lgcc_s --no-as-needed /usr/bin/../lib64/gcc/x8
6_64-pc-linux-gnu/15.2.1/crtendS.o /usr/bin/../lib64/gcc/x86_64-pc-lin
ux-gnu/15.2.1/../../../../lib64/crtn.o
...
    [2/2] : && /bin/clang -ffat-lto-objects -Wl,--whole-archive  CMakeFiles/cmTC_70ca4.dir/testCCompiler.c.o -o cmTC_70ca4   && :
    FAILED: [code=1] cmTC_70ca4
    : && /bin/clang -ffat-lto-objects -Wl,--whole-archive  CMakeFiles/cmTC_70ca4.dir/testCCompiler.c.o -o cmTC_70ca4   && :
    /usr/bin/ld: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/libgcc.a(_muldi3.o): in function `__multi3':
    (.text+0x0): multiple definition of `__multi3'; /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/libgcc.a(_muldi3.o):(.text+0x0): first defined here
```

</details>

## How did you verify your code works?

After this change, the build succeeds.