### PR TITLE
feat(cmake): simplify bindgenv2 error handling using COMMAND_ERROR_IS_FATAL

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -419,12 +419,9 @@ execute_process(
     --command=list-outputs
     --sources=${BUN_BINDGENV2_SOURCES_COMMA_SEPARATED}
     --codegen-path=${CODEGEN_PATH}
-  RESULT_VARIABLE bindgen_result
   OUTPUT_VARIABLE bindgen_outputs
+  COMMAND_ERROR_IS_FATAL ANY
 )
-if(${bindgen_result})
-  message(FATAL_ERROR "bindgenv2/script.ts exited with non-zero status")
-endif()
 foreach(output IN LISTS bindgen_outputs)
   if(output MATCHES "\.cpp$")
     list(APPEND BUN_BINDGENV2_CPP_OUTPUTS ${output})


### PR DESCRIPTION
### What does this PR do?

In CMake, failure to execute a process will place a message string in the RESULT_VARIABLE. If the message string starts with 'No' such as in 'No such file or directory' then CMake will interpret that as the boolean false and not halt the build. The new code uses a built-in option to halt the build on any failure, so the script will halt correctly if that error occurs. This could also be fixed by quoting, but might as well use the CMake feature.

I encountered this error when I improperly defined BUN_EXECUTABLE.

### How did you verify your code works?

<details>

<summary>Ran the build with invalid executable path:</summary>

```
$ node ./scripts/build.mjs \
                   -GNinja \
                   -DCMAKE_BUILD_TYPE=Debug \
                   -B build/debug \
                   --log-level=NOTICE \
                   -DBUN_EXECUTABLE="foo" \
                   -DNPM_EXECUTABLE="$(which npm)" \
                   -DZIG_EXECUTABLE="$(which zig)" \
                   -DENABLE_ASAN=OFF

Globbed 1971 sources [178.21ms]
CMake Configure
  $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -B /work/bun/build/debug --log-level NOTICE -DBUN_EXECUTABLE=foo -DNPM_EXECUTABLE=/bin/npm -DZIG_EXECUTABLE=/bin/zig -DENABLE_ASAN=OFF -S /work/bun -DCACHE_STRATEGY=auto
sccache: Using local cache strategy.
```

</details>

Result:

```
CMake Error at cmake/targets/BuildBun.cmake:422 (execute_process):
  execute_process failed command indexes:

    1: "Abnormal exit with child return code: no such file or directory"

Call Stack (most recent call first):
  CMakeLists.txt:66 (include)
```