### PR TITLE
fix(cmake): fix include paths for local WebKit

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -28,6 +28,7 @@ if(WEBKIT_LOCAL)
     # make jsc-compile-debug jsc-copy-headers
     include_directories(
       ${WEBKIT_PATH}
+      ${WEBKIT_PATH}/JavaScriptCore/Headers
       ${WEBKIT_PATH}/JavaScriptCore/Headers/JavaScriptCore
       ${WEBKIT_PATH}/JavaScriptCore/PrivateHeaders
       ${WEBKIT_PATH}/bmalloc/Headers


### PR DESCRIPTION
### What does this PR do?

Without this change, building with `-DWEBKIT_LOCAL=ON` fails with:
```
/work/bun/src/bun.js/bindings/BunObject.cpp:12:10: fatal error: 'JavaScriptCore/JSBase.h' file not found
   12 | #include <JavaScriptCore/JSBase.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

The reason for this is because the directory structure differs between downloaded and  local WebKit.

Downloaded WebKit:
```
build/debug/cache/webkit-6d0f3aac0b817cc0/
  └── include/
      └── JavaScriptCore/
          └── JSBase.h          ← Direct path
```

Local WebKit:
```
vendor/WebKit/WebKitBuild/Debug/
  └── JavaScriptCore/Headers/
      └── JavaScriptCore/
          └── JSBase.h          ← Nested path
```

The include paths are thus configured differently for each build type.

For Remote WebKit (when WEBKIT_LOCAL=OFF):
- SetupWebKit.cmake line 22 sets: WEBKIT_INCLUDE_PATH = ${WEBKIT_PATH}/include
- BuildBun.cmake line 1253 adds: include_directories(${WEBKIT_INCLUDE_PATH})
- This resolves to: build/debug/cache/webkit-6d0f3aac0b817cc0/include/
- So #include <JavaScriptCore/JSBase.h> finds the file at include/JavaScriptCore/JSBase.h ✅

For Local WebKit (when WEBKIT_LOCAL=ON):
- The original code only added: ${WEBKIT_PATH}/JavaScriptCore/Headers/JavaScriptCore
- This resolves to: vendor/WebKit/WebKitBuild/Debug/JavaScriptCore/Headers/JavaScriptCore/
- So #include <JavaScriptCore/JSBase.h> fails because there's no JavaScriptCore/ subdirectory at that level ❌
- The fix adds: ${WEBKIT_PATH}/JavaScriptCore/Headers
- Now the include path includes: vendor/WebKit/WebKitBuild/Debug/JavaScriptCore/Headers/
- So #include <JavaScriptCore/JSBase.h> finds the file at Headers/JavaScriptCore/JSBase.h ✅

### How did you verify your code works?

Built locally.