### PR TITLE
fix: use the computed size of the `Offsets` struct instead of hard-co…

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1213,7 +1213,7 @@ pub const StandaloneModuleGraph = struct {
             }
         }
 
-        if (read_amount < trailer.len + @sizeOf(usize) + 32)
+        if (read_amount < trailer.len + @sizeOf(usize) + @sizeOf(Offsets))
             // definitely missing data
             return null;
 


### PR DESCRIPTION
### What does this PR do?

- I was trying to understand how the SEA bundling worked in Bun and noticed the size of the `Offsets` struct is hard-coded here to 32. It should use the computed size to be future proof to changes in the schema.

### How did you verify your code works?

- I didn't. Can add tests if this is not covered by existing tests. ChatGPT agreed with me though. =)