### PR TITLE
[RFC PATCH 00/44] feat(cmake): runtime-agnostic codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<p>This is the bmwalters fork of Bun which enables running codegen scripts and bootstrapping an initial binary using node + npm + esbuild. See [here](https://github.com/bmwalters/bun/commits/codegen-runtime-agnostic) for the list of changes.</p>
+
 <p align="center">
   <a href="https://bun.com"><img src="https://github.com/user-attachments/assets/50282090-adfd-4ddb-9e27-c30753c6b161" alt="Logo" height=170></a>
 </p>


### PR DESCRIPTION
### What does this PR do?

This is an RFC for the Bun team for feedback on some changes I've been working on to enable bootstrapping an initial bun binary from node + npm + esbuild.

The rationale for this is to provide an easier path to onboard to the Bun ecosystem from:

* source-only distros
* potentially new OS / arch combos

Concretely, this should be most of what's needed to remove `sourceProvenance = ...binaryNativeCode` from [Bun's nixpkg](https://github.com/NixOS/nixpkgs/blob/f3007fa61f17107f71630d93397f46c087cbd972/pkgs/by-name/bu/bun/package.nix#L128).

### The changes

Bun's build scripts depend on Bun for 3 key features:

* As a package manager.
* As a bundler.
* As a TypeScript runtime.

#### PM-agnostic codegen

There are 4-5 invocations of `bun install` from CMake. The `package.json` files in the build system are 99% compatible with npm. The patch series updates CMake scripts to enable setting an env var for which package manager to install with.

#### Bundler-agnostic codegen

The patch series replaces Bun.build invocations in codegen with esbuild. This required understanding the bundler output format expected by `bundle-modules.ts` (to create the builtins passed to JSC) and ensuring esbuild can meet that (it can, with a little config).

#### Runtime-agnostic codegen

There are various Bun-isms that the patch series translates to runtime agnostic equivalents. For the most part these were really quick to change (e.g. `Bun.file` --> `fs`, `Bun.spawnSync` --> `child_process`, `import.meta.require` --> `createRequire`). Most of the codegen code is actually already using runtime agnostic patterns.

The only tricky one is `Bun.Transpiler.scan`'s use in `bundle-modules.ts`. I opted to call es-module-lexer but another option would be to package Bun.Transpiler sources for consumption by codegen.

The other patches for runtime support are to improve compatibility with type stripping implementations like Node has. Examples of this are adding file extensions to imports that don't already specify those, and changing declarations that are actually used at runtime (`namespace foo {}; foo.xyz` or `declare unique symbol`) to *be* runtime values (like `const foo = {}` or `Symbol`).

#### Bonus: task runner fixups

These are trivial. A small handful of files are changed from `${BUN_EXECUTABLE} run ...` to `${BUN_EXECUTABLE} ...` when the runnable thing is a script.

#### CI

I haven't drafted any updates to CI scripts or CONTRIBUTING.md

### How did you verify your code works?

I built `bun` and `bun-debug` locally with all these patches stacked. I used `bun-debug` to run the regression suite, and `bun` to run OpenCode.

### Next steps

This is definitely an RFC, I don't want to start sending patches towards this direction unless the Bun team gets a chance to look at this :)

I'm happy to take on the work to redo some of the patches once I send them if there are better appoaches.

Let me know what you think.

Fixes: #22991