### PR TITLE
sql: filter out undefined values in INSERT helper instead of treating as NULL

### DIFF
--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -1,7 +1,7 @@
 import type { MySQLErrorOptions } from "internal/sql/errors";
 import type { Query } from "./query";
 import type { ArrayType, DatabaseAdapter, SQLArrayParameter, SQLHelper, SQLResultArray, SSLMode } from "./shared";
-const { SQLHelper, SSLMode, SQLResultArray, getDefinedColumns } = require("internal/sql/shared");
+const { SQLHelper, SSLMode, SQLResultArray, buildDefinedColumnsAndQuery } = require("internal/sql/shared");
 const {
   Query,
   SQLQueryFlags,
@@ -1019,23 +1019,20 @@ class MySQLAdapter
               // insert into users ${sql(users)} or insert into users ${sql(user)}
               //
 
-              // Filter out columns with undefined values
-              // Check ALL items to build union of defined columns (any item having a value means include the column)
-              const definedColumns = getDefinedColumns(columns, items);
+              // Build column list while determining which columns have at least one defined value
+              const { definedColumns, columnsSql } = buildDefinedColumnsAndQuery(
+                columns,
+                items,
+                this.escapeIdentifier.bind(this),
+              );
+
               const definedColumnCount = definedColumns.length;
               if (definedColumnCount === 0) {
                 throw new SyntaxError("Insert needs to have at least one column with a defined value");
               }
               const lastDefinedColumnIndex = definedColumnCount - 1;
 
-              query += "(";
-              for (let j = 0; j < definedColumnCount; j++) {
-                query += this.escapeIdentifier(definedColumns[j]);
-                if (j < lastDefinedColumnIndex) {
-                  query += ", ";
-                }
-              }
-              query += ") VALUES";
+              query += columnsSql;
               if ($isArray(items)) {
                 const itemsCount = items.length;
                 const lastItemIndex = itemsCount - 1;

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -1,7 +1,7 @@
 import type { MySQLErrorOptions } from "internal/sql/errors";
 import type { Query } from "./query";
 import type { ArrayType, DatabaseAdapter, SQLArrayParameter, SQLHelper, SQLResultArray, SSLMode } from "./shared";
-const { SQLHelper, SSLMode, SQLResultArray } = require("internal/sql/shared");
+const { SQLHelper, SSLMode, SQLResultArray, getDefinedColumns } = require("internal/sql/shared");
 const {
   Query,
   SQLQueryFlags,
@@ -455,11 +455,10 @@ class PooledMySQLConnection {
   }
 }
 
-class MySQLAdapter implements DatabaseAdapter<
-  PooledMySQLConnection,
-  $ZigGeneratedClasses.MySQLConnection,
-  $ZigGeneratedClasses.MySQLQuery
-> {
+class MySQLAdapter
+  implements
+    DatabaseAdapter<PooledMySQLConnection, $ZigGeneratedClasses.MySQLConnection, $ZigGeneratedClasses.MySQLQuery>
+{
   public readonly connectionInfo: Bun.SQL.__internal.DefinedPostgresOrMySQLOptions;
 
   public readonly connections: PooledMySQLConnection[];
@@ -1020,10 +1019,19 @@ class MySQLAdapter implements DatabaseAdapter<
               // insert into users ${sql(users)} or insert into users ${sql(user)}
               //
 
+              // Filter out columns with undefined values
+              // Check ALL items to build union of defined columns (any item having a value means include the column)
+              const definedColumns = getDefinedColumns(columns, items);
+              const definedColumnCount = definedColumns.length;
+              if (definedColumnCount === 0) {
+                throw new SyntaxError("Insert needs to have at least one column with a defined value");
+              }
+              const lastDefinedColumnIndex = definedColumnCount - 1;
+
               query += "(";
-              for (let j = 0; j < columnCount; j++) {
-                query += this.escapeIdentifier(columns[j]);
-                if (j < lastColumnIndex) {
+              for (let j = 0; j < definedColumnCount; j++) {
+                query += this.escapeIdentifier(definedColumns[j]);
+                if (j < lastDefinedColumnIndex) {
                   query += ", ";
                 }
               }
@@ -1034,15 +1042,12 @@ class MySQLAdapter implements DatabaseAdapter<
                 for (let j = 0; j < itemsCount; j++) {
                   query += "(";
                   const item = items[j];
-                  for (let k = 0; k < columnCount; k++) {
-                    const column = columns[k];
+                  for (let k = 0; k < definedColumnCount; k++) {
+                    const column = definedColumns[k];
                     const columnValue = item[column];
-                    query += `?${k < lastColumnIndex ? ", " : ""}`;
-                    if (typeof columnValue === "undefined") {
-                      binding_values.push(null);
-                    } else {
-                      binding_values.push(columnValue);
-                    }
+                    query += `?${k < lastDefinedColumnIndex ? ", " : ""}`;
+                    // If this item has undefined for a column that other items defined, use null
+                    binding_values.push(typeof columnValue === "undefined" ? null : columnValue);
                   }
                   if (j < lastItemIndex) {
                     query += "),";
@@ -1053,15 +1058,11 @@ class MySQLAdapter implements DatabaseAdapter<
               } else {
                 query += "(";
                 const item = items;
-                for (let j = 0; j < columnCount; j++) {
-                  const column = columns[j];
+                for (let j = 0; j < definedColumnCount; j++) {
+                  const column = definedColumns[j];
                   const columnValue = item[column];
-                  query += `?${j < lastColumnIndex ? ", " : ""}`;
-                  if (typeof columnValue === "undefined") {
-                    binding_values.push(null);
-                  } else {
-                    binding_values.push(columnValue);
-                  }
+                  query += `?${j < lastDefinedColumnIndex ? ", " : ""}`;
+                  binding_values.push(columnValue);
                 }
                 query += ") "; // the user can add RETURNING * or RETURNING id
               }

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -1,7 +1,13 @@
 import type { PostgresErrorOptions } from "internal/sql/errors";
 import type { Query } from "./query";
 import type { ArrayType, DatabaseAdapter, SQLArrayParameter, SQLHelper, SQLResultArray, SSLMode } from "./shared";
-const { SQLHelper, SSLMode, SQLResultArray, SQLArrayParameter, getDefinedColumns } = require("internal/sql/shared");
+const {
+  SQLHelper,
+  SSLMode,
+  SQLResultArray,
+  SQLArrayParameter,
+  buildDefinedColumnsAndQuery,
+} = require("internal/sql/shared");
 const {
   Query,
   SQLQueryFlags,
@@ -1252,23 +1258,20 @@ class PostgresAdapter
               // insert into users ${sql(users)} or insert into users ${sql(user)}
               //
 
-              // Filter out columns with undefined values
-              // Check ALL items to build union of defined columns (any item having a value means include the column)
-              const definedColumns = getDefinedColumns(columns, items);
+              // Build column list while determining which columns have at least one defined value
+              const { definedColumns, columnsSql } = buildDefinedColumnsAndQuery(
+                columns,
+                items,
+                this.escapeIdentifier.bind(this),
+              );
+
               const definedColumnCount = definedColumns.length;
               if (definedColumnCount === 0) {
                 throw new SyntaxError("Insert needs to have at least one column with a defined value");
               }
               const lastDefinedColumnIndex = definedColumnCount - 1;
 
-              query += "(";
-              for (let j = 0; j < definedColumnCount; j++) {
-                query += this.escapeIdentifier(definedColumns[j]);
-                if (j < lastDefinedColumnIndex) {
-                  query += ", ";
-                }
-              }
-              query += ") VALUES";
+              query += columnsSql;
               if ($isArray(items)) {
                 const itemsCount = items.length;
                 const lastItemIndex = itemsCount - 1;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -177,6 +177,38 @@ class SQLHelper<T> {
   }
 }
 
+/**
+ * Get columns that have at least one defined value across all items.
+ * Used by INSERT to filter out columns where ALL items have undefined.
+ * If any item has a value for a column, that column is included.
+ */
+function getDefinedColumns<T>(columns: (keyof T)[], items: T | T[]): (keyof T)[] {
+  const definedColumns: (keyof T)[] = [];
+  const columnCount = columns.length;
+
+  for (let j = 0; j < columnCount; j++) {
+    const column = columns[j];
+    let hasDefinedValue = false;
+
+    if ($isArray(items)) {
+      for (let k = 0; k < items.length; k++) {
+        if (typeof items[k][column] !== "undefined") {
+          hasDefinedValue = true;
+          break;
+        }
+      }
+    } else {
+      hasDefinedValue = typeof items[column] !== "undefined";
+    }
+
+    if (hasDefinedValue) {
+      definedColumns.push(column);
+    }
+  }
+
+  return definedColumns;
+}
+
 const SQLITE_MEMORY = ":memory:";
 const SQLITE_MEMORY_VARIANTS: string[] = [":memory:", "sqlite://:memory:", "sqlite:memory"];
 
@@ -911,6 +943,7 @@ export default {
   assertIsOptionsOfAdapter,
   parseOptions,
   SQLHelper,
+  getDefinedColumns,
   normalizeSSLMode,
   SQLResultArray,
   SQLArrayParameter,

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -107,7 +107,7 @@ When callbacks must be used and it's just a single callback, use `Promise.withRe
 
 ```ts
 const ws = new WebSocket("ws://localhost:8080");
-const { promise, resolve, reject } = Promise.withResolvers();
+const { promise, resolve, reject } = Promise.withResolvers<void>(); // Can specify any type here for resolution value
 ws.onopen = resolve;
 ws.onclose = reject;
 await promise;
@@ -152,6 +152,33 @@ To create a repetitive string, use `Buffer.alloc(count, fill).toString()` instea
 - Regression tests for specific issues go in `/test/regression/issue/${issueNumber}.test.ts`. If there's no issue number, do not put them in the regression directory.
 - Unit tests for specific features are organized by module (e.g., `/test/js/bun/`, `/test/js/node/`)
 - Integration tests are in `/test/integration/`
+
+### Nested/complex object equality
+
+Prefer usage of `.toEqual` rather than many `.toBe` assertions for nested or complex objects.
+
+<example>
+
+BAD (try to avoid doing this):
+
+```ts
+expect(result).toHaveLength(3);
+expect(result[0].optional).toBe(null);
+expect(result[1].optional).toBe("middle-value"); // CRITICAL: middle item's value must be preserved
+expect(result[2].optional).toBe(null);
+```
+
+**GOOD (always prefer this):**
+
+```ts
+expect(result).toEqual([
+  { optional: null },
+  { optional: "middle-value" }, // CRITICAL: middle item's value must be preserved
+  { optional: null },
+]);
+```
+
+</example>
 
 ### Common Imports from `harness`
 


### PR DESCRIPTION
### What does this PR do?

the `sql()` helper now filters out `undefined` values in INSERT statements instead of converting them to `NULL`. This allows columns with `DEFAULT` values to use their defaults when `undefined` is passed, rather than being overridden with `NULL`.

  **Before:** `sql({ foo: undefined, id: "123" })` in INSERT would generate `(foo, id) VALUES (NULL, "123")`, causing NOT NULL constraint violations even when the column has a DEFAULT.

  **After:** `sql({ foo: undefined, id: "123" })` in INSERT generates `(id) VALUES ("123")`, omitting the undefined column entirely and letting the database use the DEFAULT value.

  Also fixes a data loss bug in bulk inserts where columns were determined only from the first item - now all items are checked, so values in later items aren't silently dropped.

  Fixes #25829

  ### How did you verify your code works?

  - Added regression test for #25829 (NOT NULL column with DEFAULT)
  - Added tests for bulk insert with mixed undefined patterns which is the data loss scenario