### PR TITLE
fix(terminal): enable SIGINT/SIGTSTP signals for existing Terminal objects

### DIFF
--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1173,8 +1173,8 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
   test("existing terminal sends SIGINT on Ctrl+C", async () => {
     await using terminal = new Bun.Terminal({});
 
-    // Spawn sleep which will run until interrupted
-    await using proc = Bun.spawn(["sleep", "100"], { terminal });
+    // Spawn a process that will run until interrupted (sleepSync uses milliseconds)
+    await using proc = Bun.spawn([bunExe(), "-e", "Bun.sleepSync(100000)"], { terminal, env: bunEnv });
 
     // Wait for process to start - use longer delay for CI reliability
     await Bun.sleep(300);
@@ -1217,8 +1217,8 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
     await proc1.exited;
     expect(proc1.exitCode).toBe(0);
 
-    // Second spawn - interrupt with Ctrl+C
-    await using proc2 = Bun.spawn(["sleep", "100"], { terminal });
+    // Second spawn - interrupt with Ctrl+C (sleepSync uses milliseconds)
+    await using proc2 = Bun.spawn([bunExe(), "-e", "Bun.sleepSync(100000)"], { terminal, env: bunEnv });
     await Bun.sleep(300);
     terminal.write("\x03");
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1176,8 +1176,8 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
     // Spawn sleep which will run until interrupted
     await using proc = Bun.spawn(["sleep", "100"], { terminal, timeout: 2000 });
 
-    // Wait for process to start
-    await Bun.sleep(100);
+    // Wait for process to start - use longer delay for CI reliability
+    await Bun.sleep(300);
 
     // Send Ctrl+C - should send SIGINT and interrupt sleep
     terminal.write("\x03");
@@ -1218,7 +1218,7 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
 
     // Second spawn - interrupt with Ctrl+C
     await using proc2 = Bun.spawn(["sleep", "100"], { terminal, timeout: 2000 });
-    await Bun.sleep(100);
+    await Bun.sleep(300);
     terminal.write("\x03");
 
     await proc2.exited;

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1174,7 +1174,7 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
     await using terminal = new Bun.Terminal({});
 
     // Spawn sleep which will run until interrupted
-    await using proc = Bun.spawn(["sleep", "100"], { terminal, timeout: 2000 });
+    await using proc = Bun.spawn(["sleep", "100"], { terminal });
 
     // Wait for process to start - use longer delay for CI reliability
     await Bun.sleep(300);
@@ -1218,7 +1218,7 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
     expect(proc1.exitCode).toBe(0);
 
     // Second spawn - interrupt with Ctrl+C
-    await using proc2 = Bun.spawn(["sleep", "100"], { terminal, timeout: 2000 });
+    await using proc2 = Bun.spawn(["sleep", "100"], { terminal });
     await Bun.sleep(300);
     terminal.write("\x03");
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1184,6 +1184,7 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
 
     await proc.exited;
     // SIGINT causes null exitCode with signalCode
+    expect(proc.exitCode).toBeNull();
     expect(proc.signalCode).toBe("SIGINT");
   });
 
@@ -1222,6 +1223,7 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
     terminal.write("\x03");
 
     await proc2.exited;
+    expect(proc2.exitCode).toBeNull();
     expect(proc2.signalCode).toBe("SIGINT");
   });
 });


### PR DESCRIPTION
## Summary

- Fixes Ctrl+C (SIGINT), Ctrl+Z (SIGTSTP), and other control character signals not working when using an existing `Bun.Terminal` object with `Bun.spawn()`

## Root Cause

When passing an existing `Bun.Terminal` to `Bun.spawn()`, the `pty_slave_fd` was not being passed to the spawn function. This meant the child process didn't call `setsid()` and `ioctl(TIOCSCTTY)`, so it never acquired the PTY as its controlling terminal.

Without a controlling terminal, control characters like `\x03` (Ctrl+C) are echoed but don't generate signals.

## Test plan

```js
const terminal = new Bun.Terminal({
  cols: 80,
  rows: 24,
  data: (term, data) => process.stdout.write(Buffer.from(data).toString())
});

const proc = Bun.spawn(['/bin/bash', '-i'], {
  terminal,
  env: { TERM: 'xterm-256color', ...Bun.env }
});

await Bun.sleep(500);
terminal.write('sleep 100\n');
await Bun.sleep(500);
terminal.write('\x03');  // Ctrl+C - now correctly interrupts sleep
await proc.exited;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)