### PR TITLE
feat(crypto): add ChaCha20-Poly1305 cipher support

### DIFF
--- a/patches/boringssl/expose_chacha20_poly1305.patch
+++ b/patches/boringssl/expose_chacha20_poly1305.patch
@@ -1,0 +1,358 @@
+--- a/crypto/cipher/get_cipher.cc
++++ b/crypto/cipher/get_cipher.cc
+@@ -56,6 +56,7 @@ static const struct {
+     {NID_rc2_40_cbc, "rc2-40-cbc", EVP_rc2_40_cbc},
+     {NID_rc2_cbc, "rc2-cbc", EVP_rc2_cbc},
+     {NID_rc4, "rc4", EVP_rc4},
++    {NID_chacha20_poly1305, "chacha20-poly1305", EVP_chacha20_poly1305},
+ };
+
+ const EVP_CIPHER *EVP_get_cipherbynid(int nid) {
+--- a/decrepit/evp/evp_do_all.cc
++++ b/decrepit/evp/evp_do_all.cc
+@@ -36,6 +36,7 @@ void EVP_CIPHER_do_all_sorted(void (*callback)(const EVP_CIPHER *cipher,
+   callback(EVP_aes_256_gcm(), "aes-256-gcm", NULL, arg);
+   callback(EVP_bf_cbc(), "bf-cbc", NULL, arg);
+   callback(EVP_bf_cfb(), "bf-cfb", NULL, arg);
++  callback(EVP_chacha20_poly1305(), "chacha20-poly1305", NULL, arg);
+   callback(EVP_bf_ecb(), "bf-ecb", NULL, arg);
+   callback(EVP_des_cbc(), "des-cbc", NULL, arg);
+   callback(EVP_des_ecb(), "des-ecb", NULL, arg);
+--- a/gen/sources.cmake
++++ b/gen/sources.cmake
+@@ -334,6 +334,7 @@ set(CRYPTO_SOURCES
+   crypto/cipher/e_aeseax.cc
+   crypto/cipher/e_aesgcmsiv.cc
+   crypto/cipher/e_chacha20poly1305.cc
++  crypto/cipher/e_chacha20poly1305_cipher.cc
+   crypto/cipher/e_des.cc
+   crypto/cipher/e_null.cc
+   crypto/cipher/e_rc2.cc
+--- a/include/openssl/cipher.h
++++ b/include/openssl/cipher.h
+@@ -33,5 +33,8 @@
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_rc4(void);
+ 
++// EVP_chacha20_poly1305 returns the ChaCha20-Poly1305 AEAD as an EVP_CIPHER.
++OPENSSL_EXPORT const EVP_CIPHER *EVP_chacha20_poly1305(void);
++
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_des_cbc(void);
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_des_ecb(void);
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_des_ede(void);
+--- a/crypto/cipher/e_chacha20poly1305_cipher.cc	2026-01-05 15:16:47
++++ b/crypto/cipher/e_chacha20poly1305_cipher.cc	2026-01-05 14:35:33
+@@ -0,0 +1,314 @@
++// Copyright 2025 Bun
++// Based on OpenSSL's e_chacha20_poly1305.c
++// Licensed under the Apache License, Version 2.0
++
++#include <openssl/chacha.h>
++#include <openssl/cipher.h>
++#include <openssl/err.h>
++#include <openssl/mem.h>
++#include <openssl/nid.h>
++#include <openssl/poly1305.h>
++
++#include <string.h>
++
++#include "../fipsmodule/cipher/internal.h"
++#include "../internal.h"
++
++#define CHACHA20_POLY1305_IVLEN 12
++#define CHACHA20_POLY1305_KEYLEN 32
++#define CHACHA20_POLY1305_TAGLEN 16
++
++typedef struct {
++  uint8_t key[CHACHA20_POLY1305_KEYLEN];
++  uint8_t nonce[CHACHA20_POLY1305_IVLEN];
++  uint8_t tag[CHACHA20_POLY1305_TAGLEN];
++  poly1305_state poly_state;
++  uint8_t poly_key[32];
++  uint8_t keystream[64];  // Buffer for current block's keystream
++  size_t keystream_used;  // Bytes used from current keystream block
++  uint32_t counter;       // Current block counter (starts at 1 for message)
++  size_t aad_len;
++  size_t text_len;
++  int key_set;
++  int iv_set;
++  int tag_set;
++  int tag_len;
++  int poly_initialized;
++  int aad_finished;
++} EVP_CHACHA20_POLY1305_CTX;
++
++static void poly1305_update_length(poly1305_state *poly1305, size_t data_len) {
++  uint8_t length_bytes[8];
++  for (unsigned i = 0; i < sizeof(length_bytes); i++) {
++    length_bytes[i] = data_len;
++    data_len >>= 8;
++  }
++  CRYPTO_poly1305_update(poly1305, length_bytes, sizeof(length_bytes));
++}
++
++static void chacha20_poly1305_init_poly(EVP_CHACHA20_POLY1305_CTX *cctx) {
++  if (cctx->poly_initialized) {
++    return;
++  }
++  OPENSSL_memset(cctx->poly_key, 0, sizeof(cctx->poly_key));
++  CRYPTO_chacha_20(cctx->poly_key, cctx->poly_key, sizeof(cctx->poly_key),
++                   cctx->key, cctx->nonce, 0);
++  CRYPTO_poly1305_init(&cctx->poly_state, cctx->poly_key);
++  cctx->poly_initialized = 1;
++}
++
++static int chacha20_poly1305_init_key(EVP_CIPHER_CTX *ctx, const uint8_t *key,
++                                       const uint8_t *iv, int enc) {
++  EVP_CHACHA20_POLY1305_CTX *cctx =
++      reinterpret_cast<EVP_CHACHA20_POLY1305_CTX *>(ctx->cipher_data);
++
++  if (!iv && !key) {
++    return 1;
++  }
++
++  if (key) {
++    OPENSSL_memcpy(cctx->key, key, CHACHA20_POLY1305_KEYLEN);
++    cctx->key_set = 1;
++  }
++
++  if (iv) {
++    OPENSSL_memcpy(cctx->nonce, iv, CHACHA20_POLY1305_IVLEN);
++    cctx->iv_set = 1;
++  }
++
++  cctx->aad_len = 0;
++  cctx->text_len = 0;
++  cctx->tag_set = 0;
++  cctx->poly_initialized = 0;
++  cctx->aad_finished = 0;
++  cctx->keystream_used = 64;  // Force generation of new keystream on first use
++  cctx->counter = 1;          // Counter 0 is used for poly key
++
++  return 1;
++}
++
++static void chacha20_poly1305_cleanup(EVP_CIPHER_CTX *ctx) {
++  EVP_CHACHA20_POLY1305_CTX *cctx =
++      reinterpret_cast<EVP_CHACHA20_POLY1305_CTX *>(ctx->cipher_data);
++  OPENSSL_cleanse(cctx, sizeof(*cctx));
++}
++
++static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out,
++                                     const uint8_t *in, size_t len) {
++  EVP_CHACHA20_POLY1305_CTX *cctx =
++      reinterpret_cast<EVP_CHACHA20_POLY1305_CTX *>(ctx->cipher_data);
++  static const uint8_t padding[16] = {0};
++
++  if (!cctx->key_set) {
++    return -1;
++  }
++
++  if (out == NULL && in != NULL) {
++    if (!cctx->iv_set) {
++      return -1;
++    }
++    chacha20_poly1305_init_poly(cctx);
++    CRYPTO_poly1305_update(&cctx->poly_state, in, len);
++    cctx->aad_len += len;
++    return (int)len;
++  }
++
++  if (in == NULL && len == 0) {
++    if (!cctx->iv_set) {
++      return -1;
++    }
++    chacha20_poly1305_init_poly(cctx);
++    if (!cctx->aad_finished && cctx->aad_len % 16 != 0) {
++      CRYPTO_poly1305_update(&cctx->poly_state, padding,
++                             16 - (cctx->aad_len % 16));
++    }
++    cctx->aad_finished = 1;
++    if (cctx->text_len % 16 != 0) {
++      CRYPTO_poly1305_update(&cctx->poly_state, padding,
++                             16 - (cctx->text_len % 16));
++    }
++    poly1305_update_length(&cctx->poly_state, cctx->aad_len);
++    poly1305_update_length(&cctx->poly_state, cctx->text_len);
++    CRYPTO_poly1305_finish(&cctx->poly_state, cctx->tag);
++    if (!ctx->encrypt) {
++      if (!cctx->tag_set) {
++        return -1;
++      }
++      if (CRYPTO_memcmp(cctx->tag, ctx->buf, cctx->tag_len) != 0) {
++        return -1;
++      }
++    }
++    return 0;
++  }
++
++  if (!cctx->iv_set) {
++    return -1;
++  }
++  chacha20_poly1305_init_poly(cctx);
++  if (!cctx->aad_finished) {
++    if (cctx->aad_len % 16 != 0) {
++      CRYPTO_poly1305_update(&cctx->poly_state, padding,
++                             16 - (cctx->aad_len % 16));
++    }
++    cctx->aad_finished = 1;
++  }
++
++  // Process data with proper streaming support
++  const uint8_t *inp = in;
++  uint8_t *outp = out;
++  size_t remaining = len;
++
++  // Step 1: Use any remaining keystream from the buffer
++  while (remaining > 0 && cctx->keystream_used < 64) {
++    uint8_t ks_byte = cctx->keystream[cctx->keystream_used];
++    if (ctx->encrypt) {
++      *outp = *inp ^ ks_byte;
++      CRYPTO_poly1305_update(&cctx->poly_state, outp, 1);
++    } else {
++      CRYPTO_poly1305_update(&cctx->poly_state, inp, 1);
++      *outp = *inp ^ ks_byte;
++    }
++    outp++;
++    inp++;
++    cctx->keystream_used++;
++    remaining--;
++  }
++
++  // Step 2: Process full 64-byte blocks directly
++  size_t full_blocks = remaining / 64;
++  if (full_blocks > 0) {
++    size_t full_bytes = full_blocks * 64;
++    if (ctx->encrypt) {
++      CRYPTO_chacha_20(outp, inp, full_bytes, cctx->key, cctx->nonce, cctx->counter);
++      CRYPTO_poly1305_update(&cctx->poly_state, outp, full_bytes);
++    } else {
++      CRYPTO_poly1305_update(&cctx->poly_state, inp, full_bytes);
++      CRYPTO_chacha_20(outp, inp, full_bytes, cctx->key, cctx->nonce, cctx->counter);
++    }
++    cctx->counter += full_blocks;
++    outp += full_bytes;
++    inp += full_bytes;
++    remaining -= full_bytes;
++  }
++
++  // Step 3: Handle final partial block
++  if (remaining > 0) {
++    // Generate new keystream block
++    OPENSSL_memset(cctx->keystream, 0, 64);
++    CRYPTO_chacha_20(cctx->keystream, cctx->keystream, 64, cctx->key,
++                     cctx->nonce, cctx->counter);
++    cctx->counter++;
++    cctx->keystream_used = 0;
++
++    // XOR remaining bytes
++    while (remaining > 0) {
++      uint8_t ks_byte = cctx->keystream[cctx->keystream_used];
++      if (ctx->encrypt) {
++        *outp = *inp ^ ks_byte;
++        CRYPTO_poly1305_update(&cctx->poly_state, outp, 1);
++      } else {
++        CRYPTO_poly1305_update(&cctx->poly_state, inp, 1);
++        *outp = *inp ^ ks_byte;
++      }
++      outp++;
++      inp++;
++      cctx->keystream_used++;
++      remaining--;
++    }
++  }
++
++  cctx->text_len += len;
++  return (int)len;
++}
++
++static int chacha20_poly1305_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
++                                   void *ptr) {
++  EVP_CHACHA20_POLY1305_CTX *cctx =
++      reinterpret_cast<EVP_CHACHA20_POLY1305_CTX *>(ctx->cipher_data);
++
++  switch (type) {
++    case EVP_CTRL_INIT:
++      cctx->key_set = 0;
++      cctx->iv_set = 0;
++      cctx->tag_set = 0;
++      cctx->tag_len = CHACHA20_POLY1305_TAGLEN;
++      cctx->aad_len = 0;
++      cctx->text_len = 0;
++      cctx->poly_initialized = 0;
++      cctx->aad_finished = 0;
++      cctx->keystream_used = 64;  // Force generation of new keystream
++      cctx->counter = 1;          // Counter 0 is for poly key
++      return 1;
++
++    case EVP_CTRL_AEAD_SET_IVLEN:
++      if (arg <= 0 || arg > CHACHA20_POLY1305_IVLEN) {
++        return 0;
++      }
++      return 1;
++
++    case EVP_CTRL_GET_IVLEN:
++      *(int *)ptr = CHACHA20_POLY1305_IVLEN;
++      return 1;
++
++    case EVP_CTRL_AEAD_SET_TAG:
++      if (arg <= 0 || arg > CHACHA20_POLY1305_TAGLEN) {
++        return 0;
++      }
++      if (ptr == nullptr) {
++        // Just setting tag length (used during init)
++        cctx->tag_len = arg;
++        return 1;
++      }
++      // Setting actual tag data (for decryption verification)
++      if (ctx->encrypt) {
++        return 0;
++      }
++      OPENSSL_memcpy(ctx->buf, ptr, arg);
++      cctx->tag_len = arg;
++      cctx->tag_set = 1;
++      return 1;
++
++    case EVP_CTRL_AEAD_GET_TAG:
++      if (arg <= 0 || arg > CHACHA20_POLY1305_TAGLEN) {
++        return 0;
++      }
++      if (!ctx->encrypt) {
++        return 0;
++      }
++      OPENSSL_memcpy(ptr, cctx->tag, arg);
++      return 1;
++
++    case EVP_CTRL_COPY: {
++      EVP_CIPHER_CTX *out_ctx = reinterpret_cast<EVP_CIPHER_CTX *>(ptr);
++      EVP_CHACHA20_POLY1305_CTX *out_cctx =
++          reinterpret_cast<EVP_CHACHA20_POLY1305_CTX *>(out_ctx->cipher_data);
++      if (cctx && out_cctx) {
++        OPENSSL_memcpy(out_cctx, cctx, sizeof(*cctx));
++      }
++      return 1;
++    }
++
++    default:
++      return -1;
++  }
++}
++
++static const EVP_CIPHER chacha20_poly1305_cipher_obj = {
++    /*nid=*/NID_chacha20_poly1305,
++    /*block_size=*/1,
++    /*key_len=*/CHACHA20_POLY1305_KEYLEN,
++    /*iv_len=*/CHACHA20_POLY1305_IVLEN,
++    /*ctx_size=*/sizeof(EVP_CHACHA20_POLY1305_CTX),
++    /*flags=*/EVP_CIPH_STREAM_CIPHER | EVP_CIPH_CUSTOM_IV |
++              EVP_CIPH_FLAG_CUSTOM_CIPHER | EVP_CIPH_ALWAYS_CALL_INIT |
++              EVP_CIPH_CTRL_INIT | EVP_CIPH_FLAG_AEAD_CIPHER |
++              EVP_CIPH_CUSTOM_COPY,
++    /*init=*/chacha20_poly1305_init_key,
++    /*cipher=*/chacha20_poly1305_cipher,
++    /*cleanup=*/chacha20_poly1305_cleanup,
++    /*ctrl=*/chacha20_poly1305_ctrl,
++};
++
++const EVP_CIPHER *EVP_chacha20_poly1305(void) {
++  return &chacha20_poly1305_cipher_obj;
++}

--- a/test/regression/issue/8072.test.ts
+++ b/test/regression/issue/8072.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { createCipheriv, createDecipheriv, getCipherInfo, getCiphers } from "crypto";
+
+describe("ChaCha20-Poly1305 cipher support (issue #8072)", () => {
+  const key = Buffer.alloc(32);
+  const iv = Buffer.alloc(12);
+  const aad = Buffer.from("additional authenticated data");
+  const plaintext = Buffer.from("Hello, ChaCha20-Poly1305!");
+
+  // Initialize test vectors
+  for (let i = 0; i < 32; i++) key[i] = i;
+  for (let i = 0; i < 12; i++) iv[i] = i + 0x10;
+
+  test("chacha20-poly1305 should be listed in getCiphers()", () => {
+    const ciphers = getCiphers();
+    expect(ciphers).toContain("chacha20-poly1305");
+  });
+
+  test("getCipherInfo should return correct info for chacha20-poly1305", () => {
+    const info = getCipherInfo("chacha20-poly1305");
+    expect(info).toBeDefined();
+    expect(info?.name).toBe("chacha20-poly1305");
+    expect(info?.keyLength).toBe(32);
+    expect(info?.ivLength).toBe(12);
+  });
+
+  test("basic encryption and decryption round-trip", () => {
+    const cipher = createCipheriv("chacha20-poly1305", key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    expect(authTag.length).toBe(16);
+
+    const decipher = createDecipheriv("chacha20-poly1305", key, iv);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+    expect(decrypted.toString()).toBe(plaintext.toString());
+  });
+
+  test("encryption with AAD (Additional Authenticated Data)", () => {
+    const cipher = createCipheriv("chacha20-poly1305", key, iv);
+    cipher.setAAD(aad);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const decipher = createDecipheriv("chacha20-poly1305", key, iv);
+    decipher.setAAD(aad);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+    expect(decrypted.toString()).toBe(plaintext.toString());
+  });
+
+  test("decryption fails with wrong auth tag", () => {
+    const cipher = createCipheriv("chacha20-poly1305", key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    // Corrupt the auth tag
+    const wrongTag = Buffer.from(authTag);
+    wrongTag[0] ^= 0xff;
+
+    const decipher = createDecipheriv("chacha20-poly1305", key, iv);
+    decipher.setAuthTag(wrongTag);
+    decipher.update(encrypted);
+
+    expect(() => decipher.final()).toThrow();
+  });
+
+  test("decryption fails with wrong AAD", () => {
+    const cipher = createCipheriv("chacha20-poly1305", key, iv);
+    cipher.setAAD(aad);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const decipher = createDecipheriv("chacha20-poly1305", key, iv);
+    decipher.setAAD(Buffer.from("wrong aad"));
+    decipher.setAuthTag(authTag);
+    decipher.update(encrypted);
+
+    expect(() => decipher.final()).toThrow();
+  });
+
+  test("rejects invalid key length (not 32 bytes)", () => {
+    const shortKey = Buffer.alloc(16, 0x42);
+    expect(() => createCipheriv("chacha20-poly1305", shortKey, iv)).toThrow();
+
+    const longKey = Buffer.alloc(64, 0x42);
+    expect(() => createCipheriv("chacha20-poly1305", longKey, iv)).toThrow();
+  });
+
+  test("supports different IV lengths up to 12 bytes", () => {
+    // 12-byte IV is standard
+    const cipher12 = createCipheriv("chacha20-poly1305", key, Buffer.alloc(12, 0x11));
+    cipher12.update(plaintext);
+    cipher12.final();
+    expect(cipher12.getAuthTag().length).toBe(16);
+  });
+
+  test("RFC 7539 test vector", () => {
+    // Test vector from RFC 7539 Section 2.8.2
+    const rfcKey = Buffer.from("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f", "hex");
+    const rfcNonce = Buffer.from("070000004041424344454647", "hex");
+    const rfcAad = Buffer.from("50515253c0c1c2c3c4c5c6c7", "hex");
+    const rfcPlaintext = Buffer.from(
+      "4c616469657320616e642047656e746c656d656e206f662074686520636c6173" +
+        "73206f66202739393a204966204920636f756c64206f6666657220796f75206f" +
+        "6e6c79206f6e652074697020666f7220746865206675747572652c2073756e73" +
+        "637265656e20776f756c642062652069742e",
+      "hex",
+    );
+    const expectedCiphertext = Buffer.from(
+      "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6" +
+        "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36" +
+        "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc" +
+        "3ff4def08e4b7a9de576d26586cec64b6116",
+      "hex",
+    );
+    const expectedTag = Buffer.from("1ae10b594f09e26a7e902ecbd0600691", "hex");
+
+    const cipher = createCipheriv("chacha20-poly1305", rfcKey, rfcNonce);
+    cipher.setAAD(rfcAad);
+    const ciphertext = Buffer.concat([cipher.update(rfcPlaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+
+    expect(ciphertext.toString("hex")).toBe(expectedCiphertext.toString("hex"));
+    expect(tag.toString("hex")).toBe(expectedTag.toString("hex"));
+
+    // Verify decryption
+    const decipher = createDecipheriv("chacha20-poly1305", rfcKey, rfcNonce);
+    decipher.setAAD(rfcAad);
+    decipher.setAuthTag(expectedTag);
+    const decrypted = Buffer.concat([decipher.update(expectedCiphertext), decipher.final()]);
+
+    expect(decrypted.toString("hex")).toBe(rfcPlaintext.toString("hex"));
+  });
+
+  test("empty plaintext encryption", () => {
+    const cipher = createCipheriv("chacha20-poly1305", key, iv);
+    cipher.setAAD(aad);
+    const encrypted = Buffer.concat([cipher.update(Buffer.alloc(0)), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    expect(encrypted.length).toBe(0);
+    expect(authTag.length).toBe(16);
+
+    const decipher = createDecipheriv("chacha20-poly1305", key, iv);
+    decipher.setAAD(aad);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+    expect(decrypted.length).toBe(0);
+  });
+
+  test("large data encryption", () => {
+    const largeData = Buffer.alloc(1024 * 1024, 0x42); // 1MB of data
+
+    const cipher = createCipheriv("chacha20-poly1305", key, iv);
+    const encrypted = Buffer.concat([cipher.update(largeData), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const decipher = createDecipheriv("chacha20-poly1305", key, iv);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+    expect(decrypted.equals(largeData)).toBe(true);
+  });
+
+  test("incremental encryption matches single-call encryption", () => {
+    const data1 = Buffer.from("first chunk");
+    const data2 = Buffer.from("second chunk");
+    const data3 = Buffer.from("third chunk");
+    const fullData = Buffer.concat([data1, data2, data3]);
+
+    // Single call
+    const cipher1 = createCipheriv("chacha20-poly1305", key, iv);
+    const encrypted1 = Buffer.concat([cipher1.update(fullData), cipher1.final()]);
+    const tag1 = cipher1.getAuthTag();
+
+    // Incremental calls
+    const cipher2 = createCipheriv("chacha20-poly1305", key, iv);
+    const encrypted2 = Buffer.concat([
+      cipher2.update(data1),
+      cipher2.update(data2),
+      cipher2.update(data3),
+      cipher2.final(),
+    ]);
+    const tag2 = cipher2.getAuthTag();
+
+    expect(encrypted2.toString("hex")).toBe(encrypted1.toString("hex"));
+    expect(tag2.toString("hex")).toBe(tag1.toString("hex"));
+  });
+});


### PR DESCRIPTION
## Summary

Add EVP_CIPHER wrapper for ChaCha20-Poly1305 AEAD cipher to enable `createCipheriv('chacha20-poly1305', ...)` in node:crypto module.

- Patch BoringSSL to expose `EVP_chacha20_poly1305()` function
- Add EVP_CIPHER implementation wrapping BoringSSL primitives
- Support streaming encryption with proper keystream buffering
- Handle AEAD operations (AAD, auth tags)

This is needed for HomeKit/hap-nodejs compatibility and other applications that require this cipher.

Fixes #8072

## Test plan

- [x] `bun bd test test/regression/issue/8072.test.ts` - 12 tests pass
- [x] Verified tests fail with system bun (`Unknown cipher: chacha20-poly1305`)
- [x] RFC 7539 test vectors pass
- [x] Streaming encryption matches single-call encryption