### PR TITLE
Add symbols.def to link-metadata.json

### DIFF
--- a/scripts/create-link-metadata.mjs
+++ b/scripts/create-link-metadata.mjs
@@ -28,6 +28,7 @@ console.log("Reading linker files...");
 const linkerLds = await Bun.file(join(repoRoot, "src", "linker.lds")).text();
 const symbolsDyn = await Bun.file(join(repoRoot, "src", "symbols.dyn")).text();
 const symbolsTxt = await Bun.file(join(repoRoot, "src", "symbols.txt")).text();
+const symbolsDef = await Bun.file(join(repoRoot, "src", "symbols.def")).text();
 
 // Create metadata JSON with link command included
 const metadata = {
@@ -41,6 +42,7 @@ const metadata = {
   linker_lds: linkerLds,
   symbols_dyn: symbolsDyn,
   symbols_txt: symbolsTxt,
+  symbols_def: symbolsDef,
 };
 
 const metadataPath = join(buildPath, "link-metadata.json");


### PR DESCRIPTION
Include the Windows module definition file (symbols.def) in link-metadata.json, similar to how
   symbols.txt and symbols.dyn are already included for macOS and Linux.

   🤖 Generated with [Claude Code](https://claude.com/claude-code)