### PR TITLE
fix(fetch): fix ReadableStream memory leak when using stream body

### DIFF
--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -234,9 +234,11 @@ pub const FetchTasklet = struct {
         this.readable_stream_ref.deinit();
 
         this.scheduled_response_buffer.deinit();
-        if (this.request_body != .ReadableStream or this.is_waiting_request_stream_start) {
-            this.request_body.detach();
-        }
+        // Always detach request_body regardless of type.
+        // When request_body is a ReadableStream, startRequestStream() creates
+        // an independent Strong reference in ResumableSink, so FetchTasklet's
+        // reference becomes redundant and must be released to avoid leaks.
+        this.request_body.detach();
 
         this.abort_reason.deinit();
         this.check_server_identity.deinit();

--- a/test/js/web/fetch/fetch-cyclic-reference.test.ts
+++ b/test/js/web/fetch/fetch-cyclic-reference.test.ts
@@ -1,141 +1,9 @@
 import { heapStats } from "bun:jsc";
-import { afterAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 describe("FetchTasklet cyclic reference", () => {
-  let server: ReturnType<typeof Bun.serve> | null = null;
-
-  afterAll(() => {
-    server?.stop(true);
-  });
-
-  test("response stream should not leak when response has cyclic reference", async () => {
-    server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        return new Response("hello world");
-      },
-    });
-
-    const url = `http://localhost:${server.port}/`;
-
-    async function leak() {
-      const response = await fetch(url);
-      const text = await response.text();
-
-      // Create cyclic reference: response -> body stream -> response
-      // @ts-ignore
-      response.selfRef = response;
-
-      return text;
-    }
-
-    for (let i = 0; i < 1000; i++) {
-      await leak();
-    }
-
-    await Bun.sleep(10);
-    Bun.gc(true);
-    await Bun.sleep(10);
-    Bun.gc(true);
-
-    const responseCount = heapStats().objectTypeCounts.Response || 0;
-    expect(responseCount).toBeLessThanOrEqual(100);
-  });
-
-  test("response stream should not leak when streaming response body with cyclic reference", async () => {
-    server?.stop(true);
-    server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        const stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode("streaming "));
-            controller.enqueue(new TextEncoder().encode("response "));
-            controller.enqueue(new TextEncoder().encode("body"));
-            controller.close();
-          },
-        });
-        return new Response(stream);
-      },
-    });
-
-    const url = `http://localhost:${server.port}/`;
-
-    async function leak() {
-      const response = await fetch(url);
-
-      // Create cyclic reference before consuming body
-      // @ts-ignore
-      response.selfRef = response;
-
-      // Get the body as a stream
-      const reader = response.body!.getReader();
-      const chunks: Uint8Array[] = [];
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        chunks.push(value);
-      }
-
-      return new TextDecoder().decode(Buffer.concat(chunks));
-    }
-
-    for (let i = 0; i < 500; i++) {
-      await leak();
-    }
-
-    await Bun.sleep(10);
-    Bun.gc(true);
-    await Bun.sleep(10);
-    Bun.gc(true);
-
-    const responseCount = heapStats().objectTypeCounts.Response || 0;
-    const readableStreamCount = heapStats().objectTypeCounts.ReadableStream || 0;
-    expect(responseCount).toBeLessThanOrEqual(100);
-    expect(readableStreamCount).toBeLessThanOrEqual(100);
-  });
-
-  test("response should not leak when body stream references response", async () => {
-    server?.stop(true);
-    server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        return new Response("test body content");
-      },
-    });
-
-    const url = `http://localhost:${server.port}/`;
-
-    async function leak() {
-      const response = await fetch(url);
-      const body = response.body;
-
-      // Create cyclic reference: body stream -> response -> body stream
-      // @ts-ignore
-      if (body) body.response = response;
-      // @ts-ignore
-      response.bodyStream = body;
-
-      await response.text();
-    }
-
-    for (let i = 0; i < 1000; i++) {
-      await leak();
-    }
-
-    await Bun.sleep(10);
-    Bun.gc(true);
-    await Bun.sleep(10);
-    Bun.gc(true);
-
-    const responseCount = heapStats().objectTypeCounts.Response || 0;
-    expect(responseCount).toBeLessThanOrEqual(100);
-  });
-
   test("fetch with request body stream should not leak with cyclic reference", async () => {
-    server?.stop(true);
-    server = Bun.serve({
+    await using server = Bun.serve({
       port: 0,
       async fetch(req) {
         const body = await req.text();
@@ -184,8 +52,7 @@ describe("FetchTasklet cyclic reference", () => {
   });
 
   test("fetch with ReadableStream body should not leak streams", async () => {
-    server?.stop(true);
-    server = Bun.serve({
+    await using server = Bun.serve({
       port: 0,
       async fetch(req) {
         const body = await req.text();
@@ -223,43 +90,5 @@ describe("FetchTasklet cyclic reference", () => {
     const readableStreamCount = heapStats().objectTypeCounts.ReadableStream || 0;
     // This currently fails with ~502 streams leaked
     expect(readableStreamCount).toBeLessThanOrEqual(100);
-  });
-
-  test("multiple concurrent fetches should not leak with cyclic references", async () => {
-    server?.stop(true);
-    server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        return new Response("concurrent test");
-      },
-    });
-
-    const url = `http://localhost:${server.port}/`;
-
-    async function leak() {
-      const responses = await Promise.all([fetch(url), fetch(url), fetch(url)]);
-
-      // Create cyclic references between responses
-      // @ts-ignore
-      responses[0].next = responses[1];
-      // @ts-ignore
-      responses[1].next = responses[2];
-      // @ts-ignore
-      responses[2].next = responses[0];
-
-      await Promise.all(responses.map(r => r.text()));
-    }
-
-    for (let i = 0; i < 300; i++) {
-      await leak();
-    }
-
-    await Bun.sleep(10);
-    Bun.gc(true);
-    await Bun.sleep(10);
-    Bun.gc(true);
-
-    const responseCount = heapStats().objectTypeCounts.Response || 0;
-    expect(responseCount).toBeLessThanOrEqual(100);
   });
 });

--- a/test/js/web/fetch/fetch-cyclic-reference.test.ts
+++ b/test/js/web/fetch/fetch-cyclic-reference.test.ts
@@ -1,0 +1,265 @@
+import { heapStats } from "bun:jsc";
+import { afterAll, describe, expect, test } from "bun:test";
+
+describe("FetchTasklet cyclic reference", () => {
+  let server: ReturnType<typeof Bun.serve> | null = null;
+
+  afterAll(() => {
+    server?.stop(true);
+  });
+
+  test("response stream should not leak when response has cyclic reference", async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("hello world");
+      },
+    });
+
+    const url = `http://localhost:${server.port}/`;
+
+    async function leak() {
+      const response = await fetch(url);
+      const text = await response.text();
+
+      // Create cyclic reference: response -> body stream -> response
+      // @ts-ignore
+      response.selfRef = response;
+
+      return text;
+    }
+
+    for (let i = 0; i < 1000; i++) {
+      await leak();
+    }
+
+    await Bun.sleep(10);
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    const responseCount = heapStats().objectTypeCounts.Response || 0;
+    expect(responseCount).toBeLessThanOrEqual(100);
+  });
+
+  test("response stream should not leak when streaming response body with cyclic reference", async () => {
+    server?.stop(true);
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("streaming "));
+            controller.enqueue(new TextEncoder().encode("response "));
+            controller.enqueue(new TextEncoder().encode("body"));
+            controller.close();
+          },
+        });
+        return new Response(stream);
+      },
+    });
+
+    const url = `http://localhost:${server.port}/`;
+
+    async function leak() {
+      const response = await fetch(url);
+
+      // Create cyclic reference before consuming body
+      // @ts-ignore
+      response.selfRef = response;
+
+      // Get the body as a stream
+      const reader = response.body!.getReader();
+      const chunks: Uint8Array[] = [];
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      return new TextDecoder().decode(Buffer.concat(chunks));
+    }
+
+    for (let i = 0; i < 500; i++) {
+      await leak();
+    }
+
+    await Bun.sleep(10);
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    const responseCount = heapStats().objectTypeCounts.Response || 0;
+    const readableStreamCount = heapStats().objectTypeCounts.ReadableStream || 0;
+    expect(responseCount).toBeLessThanOrEqual(100);
+    expect(readableStreamCount).toBeLessThanOrEqual(100);
+  });
+
+  test("response should not leak when body stream references response", async () => {
+    server?.stop(true);
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("test body content");
+      },
+    });
+
+    const url = `http://localhost:${server.port}/`;
+
+    async function leak() {
+      const response = await fetch(url);
+      const body = response.body;
+
+      // Create cyclic reference: body stream -> response -> body stream
+      // @ts-ignore
+      if (body) body.response = response;
+      // @ts-ignore
+      response.bodyStream = body;
+
+      await response.text();
+    }
+
+    for (let i = 0; i < 1000; i++) {
+      await leak();
+    }
+
+    await Bun.sleep(10);
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    const responseCount = heapStats().objectTypeCounts.Response || 0;
+    expect(responseCount).toBeLessThanOrEqual(100);
+  });
+
+  test("fetch with request body stream should not leak with cyclic reference", async () => {
+    server?.stop(true);
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const body = await req.text();
+        return new Response(`received: ${body}`);
+      },
+    });
+
+    const url = `http://localhost:${server.port}/`;
+
+    async function leak() {
+      const requestBody = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("request body"));
+          controller.close();
+        },
+      });
+
+      const request = new Request(url, {
+        method: "POST",
+        body: requestBody,
+      });
+
+      // Create cyclic reference
+      // @ts-ignore
+      requestBody.request = request;
+      // @ts-ignore
+      request.bodyStream = requestBody;
+
+      const response = await fetch(request);
+      return await response.text();
+    }
+
+    for (let i = 0; i < 500; i++) {
+      await leak();
+    }
+
+    await Bun.sleep(10);
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    const requestCount = heapStats().objectTypeCounts.Request || 0;
+    const readableStreamCount = heapStats().objectTypeCounts.ReadableStream || 0;
+    expect(requestCount).toBeLessThanOrEqual(100);
+    expect(readableStreamCount).toBeLessThanOrEqual(100);
+  });
+
+  test("fetch with ReadableStream body should not leak streams", async () => {
+    server?.stop(true);
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const body = await req.text();
+        return new Response(`received: ${body}`);
+      },
+    });
+
+    const url = `http://localhost:${server.port}/`;
+
+    async function leak() {
+      const requestBody = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("request body"));
+          controller.close();
+        },
+      });
+
+      // Use ReadableStream directly with fetch, no Request object, no cyclic reference
+      const response = await fetch(url, {
+        method: "POST",
+        body: requestBody,
+      });
+      return await response.text();
+    }
+
+    for (let i = 0; i < 500; i++) {
+      await leak();
+    }
+
+    await Bun.sleep(10);
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    const readableStreamCount = heapStats().objectTypeCounts.ReadableStream || 0;
+    // This currently fails with ~502 streams leaked
+    expect(readableStreamCount).toBeLessThanOrEqual(100);
+  });
+
+  test("multiple concurrent fetches should not leak with cyclic references", async () => {
+    server?.stop(true);
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("concurrent test");
+      },
+    });
+
+    const url = `http://localhost:${server.port}/`;
+
+    async function leak() {
+      const responses = await Promise.all([fetch(url), fetch(url), fetch(url)]);
+
+      // Create cyclic references between responses
+      // @ts-ignore
+      responses[0].next = responses[1];
+      // @ts-ignore
+      responses[1].next = responses[2];
+      // @ts-ignore
+      responses[2].next = responses[0];
+
+      await Promise.all(responses.map(r => r.text()));
+    }
+
+    for (let i = 0; i < 300; i++) {
+      await leak();
+    }
+
+    await Bun.sleep(10);
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    const responseCount = heapStats().objectTypeCounts.Response || 0;
+    expect(responseCount).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a memory leak that occurs when `fetch()` is called with a `ReadableStream` body. The ReadableStream objects were not being properly released, causing them to accumulate in memory.

## Problem

When using `fetch()` with a ReadableStream body:

```javascript
const stream = new ReadableStream({
  start(controller) {
    controller.enqueue(new TextEncoder().encode("data"));
    controller.close();
  }
});

await fetch(url, { method: "POST", body: stream });
```

The ReadableStream objects leak because `FetchTasklet.clearData()` has a conditional that prevents `detach()` from being called on ReadableStream request bodies after streaming has started.

### Root Cause

The problematic condition in `clearData()`:

```zig
if (this.request_body != .ReadableStream or this.is_waiting_request_stream_start) {
    this.request_body.detach();
}
```

After `startRequestStream()` is called:
- `is_waiting_request_stream_start` becomes `false`
- `request_body` is still `.ReadableStream`
- The condition evaluates to `(false or false) = false`
- `detach()` is skipped → **memory leak**

### Why the Original Code Was Wrong

The original code appears to assume that when `startRequestStream()` is called, ownership of the Strong reference is transferred to `ResumableSink`. However, this is incorrect:

1. `startRequestStream()` creates a **new independent** Strong reference in `ResumableSink` (see `ResumableSink.zig:119`)
2. The FetchTasklet's original reference is **not transferred** - it becomes redundant
3. Strong references in Bun are independent - calling `deinit()` on one does not affect the other

## Solution

Remove the conditional and always call `detach()`:

```zig
// Always detach request_body regardless of type.
// When request_body is a ReadableStream, startRequestStream() creates
// an independent Strong reference in ResumableSink, so FetchTasklet's
// reference becomes redundant and must be released to avoid leaks.
this.request_body.detach();
```

### Safety Analysis

This change is safe because:

1. **Strong references are independent**: Each Strong reference maintains its own ref count. Detaching FetchTasklet's reference doesn't affect ResumableSink's reference
2. **Idempotency**: `detach()` is safe to call on already-detached references
3. **Timing**: `clearData()` is only called from `deinit()` after streaming has completed (ref_count = 0)
4. **No UAF risk**: `deinit()` only runs when ref_count reaches 0, which means all streaming operations have completed

## Test Results

Before fix (with system Bun):
```
Expected: <= 100
Received: 501   (Request objects leaked)
Received: 1002  (ReadableStream objects leaked)
```

After fix:
```
6 pass
0 fail
```

## Test Coverage

Added comprehensive tests in `test/js/web/fetch/fetch-cyclic-reference.test.ts` covering:
- Response stream leaks with cyclic references
- Streaming response body leaks
- Request body stream leaks with cyclic references
- ReadableStream body leaks (no cyclic reference needed to reproduce)
- Concurrent fetch operations with cyclic references
