### PR TITLE
test(bundler): add memory option to avoid disk I/O in tests

### DIFF
--- a/test/bundler/css/wpt/background-computed.test.ts
+++ b/test/bundler/css/wpt/background-computed.test.ts
@@ -12,6 +12,7 @@ h1 {
       `,
     },
     outfile: "out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`

--- a/test/bundler/css/wpt/color-computed-rgb.test.ts
+++ b/test/bundler/css/wpt/color-computed-rgb.test.ts
@@ -12,6 +12,7 @@ h1 {
       `,
     },
     outfile: "out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`

--- a/test/bundler/css/wpt/color-computed.test.ts
+++ b/test/bundler/css/wpt/color-computed.test.ts
@@ -11,6 +11,7 @@ h1 {
       `,
     },
     outfile: "out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`

--- a/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
+++ b/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
@@ -13,6 +13,7 @@ h1 {
       `,
     },
     outfile: "out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -33,6 +34,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -53,6 +55,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -73,6 +76,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -93,6 +97,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -113,6 +118,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -133,6 +139,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -153,6 +160,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -173,6 +181,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -193,6 +202,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -213,6 +223,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -233,6 +244,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -253,6 +265,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -273,6 +286,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -293,6 +307,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -313,6 +328,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -333,6 +349,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -353,6 +370,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -373,6 +391,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -393,6 +412,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -413,6 +433,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -433,6 +454,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -453,6 +475,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -473,6 +496,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -493,6 +517,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -513,6 +538,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
@@ -533,6 +559,7 @@ h1 {
         `,
     },
     outfile: "/out.css",
+    memory: true,
 
     onAfterBundle(api) {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`


### PR DESCRIPTION
## Summary

- Add a `memory: true` option to `expectBundled` that keeps build outputs in memory instead of writing to disk
- This reduces I/O overhead for tests that only need to verify bundler output content
- Enable for WPT CSS tests which were timing out on macOS due to slow disk I/O with many small test cases

## Changes

### `test/bundler/expectBundled.ts`
- Added `memory?: boolean` option to `BundlerTestInput` interface (defaults to `false`)
- Force API backend when `memory=true` (CLI doesn't support in-memory outputs)
- Store build artifacts in a `memoryOutputs` Map after successful build
- Updated `readFile`, `writeFile`, and `assertFileExists` to check memory outputs first
- Skip file existence checks when `memory=true`

### WPT CSS test files
- Added `memory: true` to 4 test files:
  - `test/bundler/css/wpt/background-computed.test.ts`
  - `test/bundler/css/wpt/color-computed-rgb.test.ts`
  - `test/bundler/css/wpt/color-computed.test.ts`
  - `test/bundler/css/wpt/relative_color_out_of_gamut.test.ts`

## Test plan

- [x] All 4 WPT CSS test files pass (159 tests total)
- [x] `bundler_edgecase.test.ts` passes (99 tests) - no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)