### PR TITLE
feat(bundler): add `files` option for in-memory bundling

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -220,6 +220,78 @@ An array of paths corresponding to the entrypoints of our application. One bundl
   </Tab>
 </Tabs>
 
+### files
+
+A map of file paths to their contents for in-memory bundling. This allows you to bundle virtual files that don't exist on disk, or override the contents of files that do exist. This option is only available in the JavaScript API.
+
+File contents can be provided as a `string`, `Blob`, `TypedArray`, or `ArrayBuffer`.
+
+#### Bundle entirely from memory
+
+You can bundle code without any files on disk by providing all sources via `files`:
+
+```ts title="build.ts" icon="/icons/typescript.svg"
+const result = await Bun.build({
+  entrypoints: ["/app/index.ts"],
+  files: {
+    "/app/index.ts": `
+      import { greet } from "./greet.ts";
+      console.log(greet("World"));
+    `,
+    "/app/greet.ts": `
+      export function greet(name: string) {
+        return "Hello, " + name + "!";
+      }
+    `,
+  },
+});
+
+const output = await result.outputs[0].text();
+console.log(output);
+```
+
+When all entrypoints are in the `files` map, the current working directory is used as the root.
+
+#### Override files on disk
+
+In-memory files take priority over files on disk. This lets you override specific files while keeping the rest of your codebase unchanged:
+
+```ts title="build.ts" icon="/icons/typescript.svg"
+// Assume ./src/config.ts exists on disk with development settings
+await Bun.build({
+  entrypoints: ["./src/index.ts"],
+  files: {
+    // Override config.ts with production values
+    "./src/config.ts": `
+      export const API_URL = "https://api.production.com";
+      export const DEBUG = false;
+    `,
+  },
+  outdir: "./dist",
+});
+```
+
+#### Mix disk and virtual files
+
+Real files on disk can import virtual files, and virtual files can import real files:
+
+```ts title="build.ts" icon="/icons/typescript.svg"
+// ./src/index.ts exists on disk and imports "./generated.ts"
+await Bun.build({
+  entrypoints: ["./src/index.ts"],
+  files: {
+    // Provide a virtual file that index.ts imports
+    "./src/generated.ts": `
+      export const BUILD_ID = "${crypto.randomUUID()}";
+      export const BUILD_TIME = ${Date.now()};
+    `,
+  },
+  outdir: "./dist",
+});
+```
+
+This is useful for code generation, injecting build-time constants, or testing with mock modules.
+
 ### outdir
 
 The directory where output files will be written.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1962,8 +1962,8 @@ declare module "bun" {
      * File contents can be provided as:
      * - `string` - The source code as a string
      * - `Blob` - A Blob containing the source code
-     * - `TypedArray` - A typed array (e.g., `Uint8Array`) containing the source code
-     * - `ArrayBuffer` - An ArrayBuffer containing the source code
+     * - `NodeJS.TypedArray` - A typed array (e.g., `Uint8Array`) containing the source code
+     * - `ArrayBufferLike` - An ArrayBuffer containing the source code
      *
      * @example
      * ```ts
@@ -2009,7 +2009,7 @@ declare module "bun" {
      * });
      * ```
      */
-    files?: Record<string, string | Blob | TypedArray | ArrayBufferLike>;
+    files?: Record<string, string | Blob | NodeJS.TypedArray | ArrayBufferLike>;
 
     outdir?: string;
   }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1952,6 +1952,65 @@ declare module "bun" {
      */
     reactFastRefresh?: boolean;
 
+    /**
+     * A map of file paths to their contents for in-memory bundling.
+     *
+     * This allows you to bundle virtual files that don't exist on disk, or override
+     * the contents of files that do exist on disk. The keys are file paths (which should
+     * match how they're imported) and the values are the file contents.
+     *
+     * File contents can be provided as:
+     * - `string` - The source code as a string
+     * - `Blob` - A Blob containing the source code
+     * - `TypedArray` - A typed array (e.g., `Uint8Array`) containing the source code
+     * - `ArrayBuffer` - An ArrayBuffer containing the source code
+     *
+     * @example
+     * ```ts
+     * // Bundle entirely from memory (no files on disk needed)
+     * await Bun.build({
+     *   entrypoints: ["/app/index.ts"],
+     *   files: {
+     *     "/app/index.ts": `
+     *       import { helper } from "./helper.ts";
+     *       console.log(helper());
+     *     `,
+     *     "/app/helper.ts": `
+     *       export function helper() {
+     *         return "Hello from memory!";
+     *       }
+     *     `,
+     *   },
+     * });
+     * ```
+     *
+     * @example
+     * ```ts
+     * // Override a file on disk with in-memory contents
+     * await Bun.build({
+     *   entrypoints: ["./src/index.ts"],
+     *   files: {
+     *     // This will be used instead of the actual ./src/config.ts file
+     *     "./src/config.ts": `export const API_URL = "https://production.api.com";`,
+     *   },
+     * });
+     * ```
+     *
+     * @example
+     * ```ts
+     * // Mix disk files with in-memory files
+     * // Entry point is on disk, but imports a virtual file
+     * await Bun.build({
+     *   entrypoints: ["./src/index.ts"], // Real file on disk
+     *   files: {
+     *     // Virtual file that ./src/index.ts can import via "./generated.ts"
+     *     "./src/generated.ts": `export const BUILD_TIME = ${Date.now()};`,
+     *   },
+     * });
+     * ```
+     */
+    files?: Record<string, string | Blob | TypedArray | ArrayBufferLike>;
+
     outdir?: string;
   }
 

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1781,8 +1781,8 @@ const string = []const u8;
 
 const CompileTarget = @import("../../compile_target.zig");
 const Fs = @import("../../fs.zig");
-const resolve_path = @import("../../resolver/resolve_path.zig");
 const _resolver = @import("../../resolver/resolver.zig");
+const resolve_path = @import("../../resolver/resolve_path.zig");
 const std = @import("std");
 
 const options = @import("../../options.zig");

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -58,10 +58,15 @@ pub const JSBundler = struct {
             // Also try with source directory joined for relative specifiers
             // Use .posix to ensure consistent forward slashes across platforms
             if (!bun.path.Platform.posix.isAbsolute(specifier)) {
+                // Normalize source_file to use forward slashes (for Windows compatibility)
+                // On Windows, source_file may have backslashes from the real filesystem
+                var source_file_buf: bun.PathBuffer = undefined;
+                const normalized_source_file = bun.path.platformToPosixBuf(u8, source_file, &source_file_buf);
+
                 // Extract directory from source_file using posix path handling
                 // For "/entry.js", we want "/"; for "/src/index.js", we want "/src/"
                 var buf: bun.PathBuffer = undefined;
-                const source_dir = bun.path.dirname(source_file, .posix);
+                const source_dir = bun.path.dirname(normalized_source_file, .posix);
                 // Empty dirname means we should use root
                 const effective_source_dir = if (source_dir.len == 0) "/" else source_dir;
                 const joined = bun.path.joinAbsStringBuf(effective_source_dir, &buf, &.{specifier}, .posix);

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -47,7 +47,7 @@ pub const JSBundler = struct {
             }
 
             // Normalize backslashes to forward slashes for consistent lookup
-            const buf: bun.PathBuffer = bun.path_buffer_pool.get();
+            const buf = bun.path_buffer_pool.get();
             defer bun.path_buffer_pool.put(buf);
             const normalized = bun.path.pathToPosixBuf(u8, specifier, buf);
             return self.map.contains(normalized);
@@ -74,7 +74,7 @@ pub const JSBundler = struct {
                     };
                 }
             } else {
-                const buf: bun.PathBuffer = bun.path_buffer_pool.get();
+                const buf = bun.path_buffer_pool.get();
                 defer bun.path_buffer_pool.put(buf);
                 const normalized_specifier = bun.path.pathToPosixBuf(u8, specifier, buf);
 

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -117,6 +117,10 @@ pub const JSBundler = struct {
                 // Clone the key since we need to own it
                 const key = try prop.toOwnedSlice(bun.default_allocator);
 
+                // Normalize backslashes to forward slashes for cross-platform consistency
+                // This ensures Windows paths like "C:\foo\bar.js" become "C:/foo/bar.js"
+                bun.path.platformToPosixInPlace(u8, key);
+
                 self.map.putAssumeCapacity(key, blob_or_string);
             }
 

--- a/src/bundler/BundleThread.zig
+++ b/src/bundler/BundleThread.zig
@@ -132,6 +132,11 @@ pub fn BundleThread(CompletionStruct: type) type {
                 BundleV2.JSBundleCompletionTask => completion,
                 else => @compileError("Unknown completion struct: " ++ CompletionStruct),
             };
+            // Set the file_map pointer for in-memory file support
+            this.file_map = if (completion.config.files.map.count() > 0)
+                &completion.config.files
+            else
+                null;
             completion.transpiler = this;
 
             defer {

--- a/src/bundler/ParseTask.zig
+++ b/src/bundler/ParseTask.zig
@@ -636,6 +636,16 @@ fn getCodeForParseTaskWithoutPlugins(
             const trace = bun.perf.trace("Bundler.readFile");
             defer trace.end();
 
+            // Check FileMap for in-memory files first
+            if (task.ctx.file_map) |file_map| {
+                if (file_map.get(file_path.text)) |file_contents| {
+                    break :brk .{
+                        .contents = file_contents,
+                        .fd = bun.invalid_fd,
+                    };
+                }
+            }
+
             if (strings.eqlComptime(file_path.namespace, "node")) lookup_builtin: {
                 if (task.ctx.framework) |f| {
                     if (f.built_in_modules.get(file_path.text)) |file| {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3300,9 +3300,15 @@ pub const BundleV2 = struct {
                     var result_copy = file_map_result;
                     resolve_task.* = ParseTask.init(&result_copy, Index.invalid, this);
                     resolve_task.known_target = target;
+                    // Use transpiler JSX options, applying force_node_env like the disk path does
                     resolve_task.jsx = transpiler.options.jsx;
+                    resolve_task.jsx.development = switch (transpiler.options.force_node_env) {
+                        .development => true,
+                        .production => false,
+                        .unspecified => transpiler.options.jsx.development,
+                    };
                     resolve_task.loader = import_record_loader;
-                    resolve_task.tree_shaking = true;
+                    resolve_task.tree_shaking = transpiler.options.tree_shaking;
                     resolve_task.side_effects = .has_side_effects;
                     resolve_entry.value_ptr.* = resolve_task;
                     continue;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -541,7 +541,7 @@ pub const BundleV2 = struct {
 
         // Check the FileMap first for in-memory files
         if (this.file_map) |file_map| {
-            if (file_map.resolve(source_dir, import_record.specifier)) |file_map_result| {
+            if (file_map.resolve(import_record.source_file, import_record.specifier)) |file_map_result| {
                 const path_text = file_map_result.path_pair.primary.text;
                 const entry = bun.handleOom(this.pathToSourceIndexMap(target).getOrPut(this.allocator(), path_text));
                 if (!entry.found_existing) {
@@ -3277,7 +3277,7 @@ pub const BundleV2 = struct {
 
             // Check the FileMap first for in-memory files
             if (this.file_map) |file_map| {
-                if (file_map.resolve(source_dir, import_record.path.text)) |file_map_result| {
+                if (file_map.resolve(source.path.text, import_record.path.text)) |file_map_result| {
                     const path_text = file_map_result.path_pair.primary.text;
                     const import_record_loader = import_record.loader orelse Fs.Path.init(path_text).loader(&transpiler.options.loaders) orelse .file;
                     import_record.loader = import_record_loader;

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+describe("bundler files option", () => {
+  test("basic in-memory file bundling", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `console.log("hello from memory");`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("hello from memory");
+  });
+
+  test("in-memory file with imports", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `
+          import { foo } from "/lib.js";
+          console.log(foo);
+        `,
+        "/lib.js": `
+          export const foo = 42;
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("42");
+  });
+
+  test("in-memory file with relative imports (same directory)", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `
+          import { bar } from "./utils.js";
+          console.log(bar);
+        `,
+        "/utils.js": `
+          export const bar = "relative import works";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("relative import works");
+  });
+
+  test("in-memory file with relative imports (subdirectory)", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/src/entry.js"],
+      files: {
+        "/src/entry.js": `
+          import { helper } from "./lib/helper.js";
+          console.log(helper);
+        `,
+        "/src/lib/helper.js": `
+          export const helper = "helper from subdirectory";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("helper from subdirectory");
+  });
+
+  test("in-memory file with relative imports (parent directory)", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/src/app/entry.js"],
+      files: {
+        "/src/app/entry.js": `
+          import { shared } from "../shared.js";
+          console.log(shared);
+        `,
+        "/src/shared.js": `
+          export const shared = "shared from parent";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("shared from parent");
+  });
+
+  test("in-memory file with relative imports between multiple files", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/src/index.js"],
+      files: {
+        "/src/index.js": `
+          import { componentA } from "./components/a.js";
+          import { componentB } from "./components/b.js";
+          console.log(componentA, componentB);
+        `,
+        "/src/components/a.js": `
+          import { util } from "../utils/util.js";
+          export const componentA = "A:" + util;
+        `,
+        "/src/components/b.js": `
+          import { util } from "../utils/util.js";
+          export const componentB = "B:" + util;
+        `,
+        "/src/utils/util.js": `
+          export const util = "shared-util";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("shared-util");
+    expect(output).toContain("A:");
+    expect(output).toContain("B:");
+  });
+
+  test("in-memory file with nested imports", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `
+          import { a } from "/a.js";
+          console.log(a);
+        `,
+        "/a.js": `
+          import { b } from "/b.js";
+          export const a = b + 1;
+        `,
+        "/b.js": `
+          export const b = 100;
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    // Without minification, the expression is preserved
+    expect(output).toContain("b + 1");
+    expect(output).toContain("100");
+  });
+
+  test("in-memory file with TypeScript", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.ts"],
+      files: {
+        "/entry.ts": `
+          const x: number = 42;
+          console.log(x);
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("42");
+  });
+
+  test("in-memory file with JSX", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.jsx"],
+      files: {
+        "/entry.jsx": `
+          const element = <div>Hello JSX</div>;
+          console.log(element);
+        `,
+      },
+      // Use classic JSX runtime to avoid needing react
+      jsx: {
+        runtime: "classic",
+        factory: "h",
+        fragment: "Fragment",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("Hello JSX");
+  });
+
+  test("in-memory file with Blob content", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": new Blob([`console.log("hello from blob");`]),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("hello from blob");
+  });
+
+  test("in-memory file with Uint8Array content", async () => {
+    const encoder = new TextEncoder();
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": encoder.encode(`console.log("hello from uint8array");`),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("hello from uint8array");
+  });
+
+  test("in-memory file with ArrayBuffer content", async () => {
+    const encoder = new TextEncoder();
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": encoder.encode(`console.log("hello from arraybuffer");`).buffer,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("hello from arraybuffer");
+  });
+
+  test("in-memory file with re-exports", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `
+          export { foo, bar } from "/lib.js";
+        `,
+        "/lib.js": `
+          export const foo = "foo";
+          export const bar = "bar";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("foo");
+    expect(output).toContain("bar");
+  });
+
+  test("in-memory file with default export", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `
+          import myDefault from "/lib.js";
+          console.log(myDefault);
+        `,
+        "/lib.js": `
+          export default "default export";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("default export");
+  });
+
+  test("in-memory file with chained imports", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      files: {
+        "/entry.js": `
+          import { a } from "/a.js";
+          console.log(a);
+        `,
+        "/a.js": `
+          import { b } from "/b.js";
+          export const a = "a" + b;
+        `,
+        "/b.js": `
+          export const b = "b";
+        `,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    // Without minification, the expression is preserved
+    expect(output).toContain('"a" + b');
+    expect(output).toContain('"b"');
+  });
+
+  test("in-memory file overrides real file on disk", async () => {
+    // Create a temp directory with a real file
+    using dir = tempDir("bundler-files-override", {
+      "entry.js": `
+        import { value } from "./lib.js";
+        console.log(value);
+      `,
+      "lib.js": `
+        export const value = "from disk";
+      `,
+    });
+
+    const entryPath = `${dir}/entry.js`;
+    const libPath = `${dir}/lib.js`;
+
+    // Bundle with in-memory file overriding the real lib.js
+    const result = await Bun.build({
+      entrypoints: [entryPath],
+      files: {
+        [libPath]: `export const value = "from memory";`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    // The in-memory file should override the disk file
+    expect(output).toContain("from memory");
+    expect(output).not.toContain("from disk");
+  });
+
+  test("real file on disk can import in-memory file via relative path", async () => {
+    // Create a temp directory with a real entry file
+    using dir = tempDir("bundler-files-mixed", {
+      "entry.js": `
+        import { helper } from "./helper.js";
+        console.log(helper);
+      `,
+    });
+
+    const entryPath = `${dir}/entry.js`;
+    const helperPath = `${dir}/helper.js`;
+
+    // Bundle with entry from disk, but helper.js only in memory
+    const result = await Bun.build({
+      entrypoints: [entryPath],
+      files: {
+        [helperPath]: `export const helper = "helper from memory";`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("helper from memory");
+  });
+
+  test("real file on disk can import nested in-memory files", async () => {
+    // Create a temp directory with a real entry file
+    using dir = tempDir("bundler-files-nested-mixed", {
+      "entry.js": `
+        import { util } from "./lib/util.js";
+        console.log(util);
+      `,
+    });
+
+    const entryPath = `${dir}/entry.js`;
+    const utilPath = `${dir}/lib/util.js`;
+
+    // Bundle with entry from disk, but lib/util.js only in memory
+    const result = await Bun.build({
+      entrypoints: [entryPath],
+      files: {
+        [utilPath]: `export const util = "nested util from memory";`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    expect(output).toContain("nested util from memory");
+  });
+
+  test("mixed disk and memory files with complex import graph", async () => {
+    // Create a temp directory with some real files
+    using dir = tempDir("bundler-files-complex", {
+      "entry.js": `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        console.log(a, b);
+      `,
+      "a.js": `
+        import { shared } from "./shared.js";
+        export const a = "a:" + shared;
+      `,
+      // b.js will be in memory only
+      // shared.js will be overridden in memory
+      "shared.js": `
+        export const shared = "disk-shared";
+      `,
+    });
+
+    const entryPath = `${dir}/entry.js`;
+    const bPath = `${dir}/b.js`;
+    const sharedPath = `${dir}/shared.js`;
+
+    // Bundle with:
+    // - entry.js from disk
+    // - a.js from disk (imports shared.js)
+    // - b.js from memory (imports shared.js)
+    // - shared.js overridden in memory
+    const result = await Bun.build({
+      entrypoints: [entryPath],
+      files: {
+        [bPath]: `
+          import { shared } from "./shared.js";
+          export const b = "b:" + shared;
+        `,
+        [sharedPath]: `export const shared = "memory-shared";`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    const output = await result.outputs[0].text();
+    // Both a.js and b.js should use the memory version of shared.js
+    expect(output).toContain("memory-shared");
+    expect(output).not.toContain("disk-shared");
+  });
+});


### PR DESCRIPTION
## Summary

Add support for in-memory entrypoints and files in `Bun.build` via the `files` option:

```ts
await Bun.build({
  entrypoints: ["/app/index.ts"],
  files: {
    "/app/index.ts": `
      import { greet } from "./greet.ts";
      console.log(greet("World"));
    `,
    "/app/greet.ts": `
      export function greet(name: string) {
        return "Hello, " + name + "!";
      }
    `,
  },
});
```

### Features

- **Bundle entirely from memory**: No files on disk needed
- **Override files on disk**: In-memory files take priority over disk files
- **Mix disk and virtual files**: Real files can import virtual files and vice versa
- **Multiple content types**: Supports `string`, `Blob`, `TypedArray`, and `ArrayBuffer`

### Use Cases

- Code generation at build time
- Injecting build-time constants
- Testing with mock modules
- Bundling dynamically generated code
- Overriding configuration files for different environments

### Implementation Details

- Added `FileMap` struct in `JSBundler.zig` with `resolve`, `get`, `contains`, `fromJS`, and `deinit` methods
- Uses `"memory"` namespace to avoid `pathWithPrettyInitialized` allocation issues during linking phase
- FileMap checks added in:
  - `runResolver` (entry point resolution)
  - `runResolutionForParseTask` (import resolution)
  - `enqueueEntryPoints` (entry point handling)
  - `getCodeForParseTaskWithoutPlugins` (file content reading)
- Root directory defaults to cwd when all entrypoints are in the FileMap
- Added TypeScript types with JSDoc documentation
- Added bundler documentation with examples

## Test plan

- [x] Basic in-memory file bundling
- [x] In-memory files with absolute imports
- [x] In-memory files with relative imports (same dir, subdirs, parent dirs)
- [x] Nested/chained imports between in-memory files
- [x] TypeScript and JSX support
- [x] Blob, Uint8Array, and ArrayBuffer content types
- [x] Re-exports and default exports
- [x] In-memory file overrides real file on disk
- [x] Real file on disk imports in-memory file via relative path
- [x] Mixed disk and memory files with complex import graphs

Run tests with: `bun bd test test/bundler/bundler_files.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)