### PR TITLE
fix(windows): use INFINITE timeout in _debugProcess WaitForSingleObject

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3899,10 +3899,10 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDebugProcess, (JSC::JSGlobalObject * gl
         return {};
     }
 
-    // Wait briefly for the thread to complete because closing the handles
-    // immediately could terminate the remote thread before it finishes
-    // triggering the inspector in the target process.
-    WaitForSingleObject(hThread, 1000);
+    // Wait for the thread to complete. Closing the handles before the thread
+    // finishes could terminate the remote thread before it triggers the
+    // inspector in the target process. Use INFINITE to match Node.js behavior.
+    WaitForSingleObject(hThread, INFINITE);
     CloseHandle(hThread);
     CloseHandle(hProcess);
 #endif


### PR DESCRIPTION
## Summary
- Fix Windows inspector test timeout by using `INFINITE` instead of 1-second timeout in `WaitForSingleObject`

The 1-second timeout was causing the caller to close the thread handle before the remote thread finished executing, which could terminate the thread prematurely. This caused the Windows inspector tests to timeout waiting for "Debugger listening" because the inspector was never activated.

This matches Node.js behavior: https://github.com/nodejs/node/blob/2030fd345b/src/node_process_methods.cc#L484

## Test plan
- Windows inspector tests in `test/js/bun/runtime-inspector/` should no longer timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)