### PR TITLE
experiment: update c-ares to try fix Windows DNS SRV regression

### DIFF
--- a/cmake/targets/BuildCares.cmake
+++ b/cmake/targets/BuildCares.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     c-ares/c-ares
   COMMIT
-    3ac47ee46edd8ea40370222f91613fc16c434853
+    e29bca8b113d4c5bbf2996f3e94fccbc298a4503
 )
 
 register_cmake_command(


### PR DESCRIPTION
## Summary
- Updates c-ares to include the fix from https://github.com/c-ares/c-ares/pull/1064

## Root Cause
The c-ares v1.34.6 update (commit 81a5c79928) introduced a regression on Windows where DNS SRV queries fail with `ECONNREFUSED`. 

The bug was in c-ares commit [1d1b3d4a](https://github.com/c-ares/c-ares/commit/1d1b3d4a808dff9359cacb4539ac1b775876dcb6) which changed Windows registry reading to use wide strings but left an incorrect check for empty string size (`size == 1` instead of `size == sizeof(WCHAR)`). This caused the DNS server list to be corrupted on Windows.

Tracked upstream: https://github.com/c-ares/c-ares/issues/1056

## Test plan
- Existing `dns.resolveSrv` tests in `test/js/node/dns/node-dns.test.js` should pass on Windows CI
- MongoDB connections using `mongodb+srv://` URLs should work on Windows

Fixes #25718

🤖 Generated with [Claude Code](https://claude.com/claude-code)