### PR TITLE
fix(install): update overrides/resolutions when running bun add

### DIFF
--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -196,6 +196,14 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
                         .before_install = true,
                     },
                 );
+                // Also update any matching overrides/resolutions with the literal version
+                // This ensures the install uses the correct version
+                try PackageJSONEditor.editOverrides(
+                    manager.allocator,
+                    updates.*,
+                    &current_package_json.root,
+                    true, // before_install = use literal version
+                );
             } else if (subcommand == .update) {
                 try PackageJSONEditor.editUpdateNoArgs(
                     manager,
@@ -374,6 +382,13 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
                     .exact_versions = manager.options.enable.exact_versions,
                     .add_trusted_dependencies = manager.options.do.trust_dependencies_from_args,
                 },
+            );
+            // Update any matching overrides/resolutions with the resolved versions
+            try PackageJSONEditor.editOverrides(
+                manager.allocator,
+                updates.*,
+                &new_package_json,
+                false, // before_install = use resolved version from e_string
             );
         }
         var buffer_writer_two = JSPrinter.BufferWriter.init(manager.allocator);


### PR DESCRIPTION
## Summary

- Fixes issue where `bun add pkg@version` would install the old version when the package had an entry in `overrides` (npm) or `resolutions` (yarn)
- Adds `editOverrides` function to update matching overrides/resolutions entries when adding/updating packages

## Test plan

- Added two new tests in `test/cli/install/overrides.test.ts`:
  - `bun add updates overrides when adding new version of overridden package`
  - `bun add updates resolutions when adding new version of package with resolution`
- Tests verify that both the dependency and override/resolution entries are updated
- Tests confirm the new version is installed correctly

Fixes #25843

🤖 Generated with [Claude Code](https://claude.com/claude-code)