### PR TITLE
Fix typo in PM2 configuration example

### DIFF
--- a/docs/guides/ecosystem/pm2.mdx
+++ b/docs/guides/ecosystem/pm2.mdx
@@ -33,7 +33,7 @@ Alternatively, you can create a PM2 configuration file. Create a file named `pm2
 
 ```js pm2.config.js icon="file-code"
 module.exports = {
-  title: "app", // Name of your application
+  name: "app", // Name of your application
   script: "index.ts", // Entry point of your application
   interpreter: "bun", // Bun interpreter
   env: {


### PR DESCRIPTION
According to PM2 documentation, the name of the application is defined by "name" key, not "title"

### What does this PR do?
Fixes a typo in the documentation page https://bun.com/docs/guides/ecosystem/pm2
### How did you verify your code works?
I tested it and checked with `pm2 lsit`