### PR TITLE
fix(shell): remove double-free in createShellInterpreter error path

### DIFF
--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -748,7 +748,6 @@ pub const Interpreter = struct {
             jsobjs.deinit();
             if (export_env) |*ee| ee.deinit();
             if (cwd) |*cc| cc.deref();
-            shargs.deinit();
             interpreter.finalize();
             return error.JSError;
         }


### PR DESCRIPTION
## Summary
- Fixes a double-free bug in `createShellInterpreter` that caused heap corruption and segfaults during GC
- When `globalThis.hasException()` is true after `Interpreter.init` succeeds, both `shargs.deinit()` and `interpreter.finalize()` were called
- Since `interpreter.args == shargs`, and `finalize()` calls `this.args.deinit()`, this caused a double-free

## Test plan
- [ ] Verify CI passes
- [ ] The crash in BUN-ZFQ should no longer occur

Fixes BUN-ZFQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)