### PR TITLE
Align temp directory resolution with os.tmpdir()

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1128,6 +1128,7 @@ async function spawnBun(execPath, { args, cwd, timeout, env, stdout, stderr }) {
     ...process.env,
     PATH: path,
     TMPDIR: tmpdirPath,
+    BUN_TMPDIR: tmpdirPath,
     USER: username,
     HOME: homedir,
     SHELL: shellPath,

--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -74,7 +74,7 @@ pub const FileOperation = struct {
 
     pub fn getPathname(file: *const FileOperation) string {
         if (file.is_tmpdir) {
-            return resolve_path.joinAbs(@TypeOf(Fs.FileSystem.instance.fs).tmpdir_path, .auto, file.pathname);
+            return resolve_path.joinAbs(Fs.FileSystem.RealFS.tmpdirPath(), .auto, file.pathname);
         } else {
             return file.pathname;
         }

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -670,7 +670,7 @@ pub const StandaloneModuleGraph = struct {
                                 if (!tried_changing_abs_dir) {
                                     tried_changing_abs_dir = true;
                                     const zname_z = bun.strings.concat(bun.default_allocator, &.{
-                                        bun.fs.FileSystem.instance.fs.tmpdirPath(),
+                                        bun.fs.FileSystem.RealFS.tmpdirPath(),
                                         std.fs.path.sep_str,
                                         zname,
                                         &.{0},

--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -92,7 +92,7 @@ pub fn resolveEmbeddedFile(vm: *VirtualMachine, path_buf: *bun.PathBuffer, linux
         },
         else => {},
     }
-    return bun.path.joinAbsStringBuf(bun.fs.FileSystem.instance.fs.tmpdirPath(), path_buf, &[_]string{tmpfilename}, .auto);
+    return bun.path.joinAbsStringBuf(bun.fs.FileSystem.RealFS.tmpdirPath(), path_buf, &[_]string{tmpfilename}, .auto);
 }
 
 pub export fn Bun__getDefaultLoader(global: *JSGlobalObject, str: *const bun.String) api.Loader {

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -423,7 +423,7 @@ pub const RuntimeTranspilerCache = struct {
         }
 
         {
-            const parts = &[_][]const u8{ bun.fs.FileSystem.instance.fs.tmpdirPath(), "bun", "@t@" };
+            const parts = &[_][]const u8{ bun.fs.FileSystem.RealFS.tmpdirPath(), "bun", "@t@" };
             return bun.fs.FileSystem.instance.absBufZ(parts, buf);
         }
     }

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -109,11 +109,11 @@ pub const SHELL = PlatformSpecificNew(kind.string, "SHELL", null, .{});
 /// C:\Windows, for example.
 /// Note: Do not use this variable directly -- use os.zig's implementation instead.
 pub const SYSTEMROOT = PlatformSpecificNew(kind.string, null, "SYSTEMROOT", .{});
-pub const TEMP = PlatformSpecificNew(kind.string, null, "TEMP", .{});
+pub const TEMP = PlatformSpecificNew(kind.string, "TEMP", "TEMP", .{});
 pub const TERM = New(kind.string, "TERM", .{});
 pub const TERM_PROGRAM = New(kind.string, "TERM_PROGRAM", .{});
-pub const TMP = PlatformSpecificNew(kind.string, null, "TMP", .{});
-pub const TMPDIR = PlatformSpecificNew(kind.string, "TMPDIR", null, .{});
+pub const TMP = PlatformSpecificNew(kind.string, "TMP", "TMP", .{});
+pub const TMPDIR = PlatformSpecificNew(kind.string, "TMPDIR", "TMPDIR", .{});
 pub const TMUX = New(kind.string, "TMUX", .{});
 pub const TODIUM = New(kind.string, "TODIUM", .{});
 pub const USER = PlatformSpecificNew(kind.string, "USER", "USERNAME", .{});
@@ -598,6 +598,16 @@ fn PlatformSpecificNew(
                 return windows_key;
             }
 
+            return null;
+        }
+
+        pub fn getNotEmpty() ReturnType {
+            if (Self.get()) |v| {
+                if (v.len == 0) {
+                    return null;
+                }
+                return v;
+            }
             return null;
         }
 


### PR DESCRIPTION
## Summary
- Aligns Bun's temp directory resolution with Node.js's `os.tmpdir()` behavior
- Checks `TMPDIR`, `TMP`, and `TEMP` environment variables in order (matching Node.js)
- Uses `bun.once` for lazy initialization instead of mutable static state
- Removes `setTempdir` function and simplifies the API to use `RealFS.tmpdirPath()` directly

## Test plan
- [ ] Verify temp directory resolution matches Node.js behavior
- [ ] Test with various environment variable configurations
- [ ] Ensure existing tests pass with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)