### PR TITLE
fix: use JSONParseWithException for proper error handling

### DIFF
--- a/src/bun.js/bindings/SQLClient.cpp
+++ b/src/bun.js/bindings/SQLClient.cpp
@@ -188,7 +188,7 @@ static JSC::JSValue toJS(JSC::VM& vm, JSC::JSGlobalObject* globalObject, DataCel
     case DataCellTag::Json: {
         if (cell.value.json) {
             auto str = WTF::String(cell.value.json);
-            JSC::JSValue json = JSC::JSONParse(globalObject, str);
+            JSC::JSValue json = JSC::JSONParseWithException(globalObject, str);
             RETURN_IF_EXCEPTION(scope, {});
             return json;
         }


### PR DESCRIPTION
## Summary
- **SQLClient.cpp**: Fix bug where `RETURN_IF_EXCEPTION` after `JSONParse` would never trigger on JSON parse failure since `JSONParse` doesn't throw
- **BunString.cpp**: Simplify by using `JSONParseWithException` instead of manually checking for empty result and throwing

## Details

`JSC::JSONParse` returns an empty `JSValue` on failure **without throwing an exception**. This means that `RETURN_IF_EXCEPTION(scope, {})` will never catch JSON parsing errors when used after `JSONParse`.

Before this fix in `SQLClient.cpp`:
```cpp
JSC::JSValue json = JSC::JSONParse(globalObject, str);
RETURN_IF_EXCEPTION(scope, {});  // This never triggers on parse failure!
return json;  // Returns empty JSValue
```

This could cause issues when parsing invalid JSON data from SQL databases (e.g., PostgreSQL's JSON/JSONB columns).

`JSONParseWithException` properly throws a `SyntaxError` exception that `RETURN_IF_EXCEPTION` can catch.

## Test plan
- [x] Build succeeds with `bun bd`
- The changes follow the same pattern used in `ModuleLoader.cpp` and `BunObject.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)