### PR TITLE
refactor(fs): remove RealFS abstraction and merge into FileSystem

### DIFF
--- a/src/OutputFile.zig
+++ b/src/OutputFile.zig
@@ -74,7 +74,7 @@ pub const FileOperation = struct {
 
     pub fn getPathname(file: *const FileOperation) string {
         if (file.is_tmpdir) {
-            return resolve_path.joinAbs(Fs.FileSystem.RealFS.tmpdirPath(), .auto, file.pathname);
+            return resolve_path.joinAbs(Fs.FileSystem.tmpdirPath(), .auto, file.pathname);
         } else {
             return file.pathname;
         }
@@ -325,7 +325,7 @@ pub fn copyTo(file: *const OutputFile, _: string, rel_path: []const u8, dir: Fil
     const fd_in = bun.FD.fromStdFile(try std.fs.cwd().openFile(file.src_path.text, .{ .mode = .read_only }));
 
     if (Environment.isWindows) {
-        do_close = Fs.FileSystem.instance.fs.needToCloseFiles();
+        do_close = Fs.FileSystem.instance.needToCloseFiles();
 
         // use paths instead of bun.getFdPathW()
         @panic("TODO windows");

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -670,7 +670,7 @@ pub const StandaloneModuleGraph = struct {
                                 if (!tried_changing_abs_dir) {
                                     tried_changing_abs_dir = true;
                                     const zname_z = bun.strings.concat(bun.default_allocator, &.{
-                                        bun.fs.FileSystem.RealFS.tmpdirPath(),
+                                        bun.fs.FileSystem.tmpdirPath(),
                                         std.fs.path.sep_str,
                                         zname,
                                         &.{0},

--- a/src/bake/FrameworkRouter.zig
+++ b/src/bake/FrameworkRouter.zig
@@ -1011,7 +1011,7 @@ fn scanInner(
     ctx: InsertionContext,
 ) bun.OOM!void {
     const fs = r.fs;
-    const fs_impl = &fs.fs;
+    const fs_impl = fs;
 
     if (dir_info.getEntriesConst()) |entries| {
         var it = entries.data.iterator();

--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -92,7 +92,7 @@ pub fn resolveEmbeddedFile(vm: *VirtualMachine, path_buf: *bun.PathBuffer, linux
         },
         else => {},
     }
-    return bun.path.joinAbsStringBuf(bun.fs.FileSystem.RealFS.tmpdirPath(), path_buf, &[_]string{tmpfilename}, .auto);
+    return bun.path.joinAbsStringBuf(bun.fs.FileSystem.tmpdirPath(), path_buf, &[_]string{tmpfilename}, .auto);
 }
 
 pub export fn Bun__getDefaultLoader(global: *JSGlobalObject, str: *const bun.String) api.Loader {

--- a/src/bun.js/RuntimeTranspilerCache.zig
+++ b/src/bun.js/RuntimeTranspilerCache.zig
@@ -423,7 +423,7 @@ pub const RuntimeTranspilerCache = struct {
         }
 
         {
-            const parts = &[_][]const u8{ bun.fs.FileSystem.RealFS.tmpdirPath(), "bun", "@t@" };
+            const parts = &[_][]const u8{ bun.fs.FileSystem.tmpdirPath(), "bun", "@t@" };
             return bun.fs.FileSystem.instance.absBufZ(parts, buf);
         }
     }

--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -28,7 +28,7 @@ pub fn dumpSourceStringFailiable(vm: *VirtualMachine, specifier: string, written
         const base_name = switch (Environment.os) {
             else => "/tmp/bun-debug-src/",
             .windows => brk: {
-                const temp = bun.fs.FileSystem.RealFS.platformTempDir();
+                const temp = bun.fs.FileSystem.platformTempDir();
                 var win_temp_buffer: bun.PathBuffer = undefined;
                 @memcpy(win_temp_buffer[0..temp.len], temp);
                 const suffix = "\\bun-debug-src";

--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -192,7 +192,7 @@ pub const FileSystemRouter = struct {
                     if (entry.base()[0] == '.') {
                         continue :outer;
                     }
-                    if (entry.kind(&vm.transpiler.fs.fs, false) == .dir) {
+                    if (entry.kind(vm.transpiler.fs, false) == .dir) {
                         inline for (Router.banned_dirs) |banned_dir| {
                             if (strings.eqlComptime(entry.base(), comptime banned_dir)) {
                                 continue :outer;

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -76,7 +76,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 
         main: MainFile = .{},
 
-        tombstones: bun.StringHashMapUnmanaged(*bun.fs.FileSystem.RealFS.EntriesOption) = .{},
+        tombstones: bun.StringHashMapUnmanaged(*bun.fs.FileSystem.EntriesOption) = .{},
 
         pub fn init(ctx: *Ctx, fs: *bun.fs.FileSystem, verbose: bool, clear_screen_flag: bool) *Watcher {
             const reloader = bun.handleOom(bun.default_allocator.create(Reloader));
@@ -296,11 +296,11 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             reloader.getContext().start() catch @panic("Failed to start File Watcher");
         }
 
-        fn putTombstone(this: *@This(), key: []const u8, value: *bun.fs.FileSystem.RealFS.EntriesOption) void {
+        fn putTombstone(this: *@This(), key: []const u8, value: *bun.fs.FileSystem.EntriesOption) void {
             this.tombstones.put(bun.default_allocator, key, value) catch unreachable;
         }
 
-        fn getTombstone(this: *@This(), key: []const u8) ?*bun.fs.FileSystem.RealFS.EntriesOption {
+        fn getTombstone(this: *@This(), key: []const u8) ?*bun.fs.FileSystem.EntriesOption {
             return this.tombstones.get(key);
         }
 
@@ -346,7 +346,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             defer Output.flush();
 
             const fs: *Fs.FileSystem = &Fs.FileSystem.instance;
-            const rfs: *Fs.FileSystem.RealFS = &fs.fs;
+            const rfs: *Fs.FileSystem = fs;
             var _on_file_update_path_buf: bun.PathBuffer = undefined;
             var current_task = Task.initEmpty(this);
             defer current_task.enqueue();
@@ -407,7 +407,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                             continue;
                         }
                         var affected_buf: [128][]const u8 = undefined;
-                        var entries_option: ?*Fs.FileSystem.RealFS.EntriesOption = null;
+                        var entries_option: ?*Fs.FileSystem.EntriesOption = null;
 
                         const affected = brk: {
                             if (comptime Environment.isMac) {

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -97,7 +97,7 @@ pub const Fs = struct {
         cached_file_descriptor: ?StoredFileDescriptorType,
         shared: *MutableString,
     ) !Entry {
-        var rfs = _fs.fs;
+        var rfs = _fs;
 
         const file_handle: std.fs.File = if (cached_file_descriptor) |fd| handle: {
             const handle = std.fs.File{ .handle = fd };
@@ -152,7 +152,7 @@ pub const Fs = struct {
         comptime use_shared_buffer: bool,
         _file_handle: ?StoredFileDescriptorType,
     ) !Entry {
-        var rfs = _fs.fs;
+        var rfs = _fs;
 
         var file_handle: std.fs.File = if (_file_handle) |__file| __file.stdFile() else undefined;
 

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -471,7 +471,7 @@ pub const BunxCommand = struct {
         debug("install_param: {s}", .{install_param});
         debug("result_package_name: {s}", .{result_package_name});
 
-        const temp_dir = bun.fs.FileSystem.RealFS.platformTempDir();
+        const temp_dir = bun.fs.FileSystem.platformTempDir();
 
         const PATH_FOR_BIN_DIRS = brk: {
             if (ignore_cwd.len == 0) break :brk PATH;

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -268,7 +268,7 @@ pub const PackageManagerCommand = struct {
                 Output.prettyln("Cleared 'bun install' cache", .{});
 
                 bunx: {
-                    const tmp = bun.fs.FileSystem.RealFS.platformTempDir();
+                    const tmp = bun.fs.FileSystem.platformTempDir();
                     const tmp_dir = std.fs.openDirAbsolute(tmp, .{ .iterate = true }) catch |err| {
                         Output.err(err, "Could not open {s}", .{tmp});
                         had_err = true;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -603,7 +603,7 @@ pub const RunCommand = struct {
         // This path is almost always a path to a user directory. So it cannot be inlined like
         // our uses of /tmp. You can use one of these functions instead:
         // - bun.windows.GetTempPathW (native)
-        // - bun.fs.FileSystem.RealFS.platformTempDir (any platform)
+        // - bun.fs.FileSystem.platformTempDir (any platform)
         .windows => @compileError("Do not use RunCommand.bun_node_dir on Windows"),
 
         .mac => "/private/tmp",
@@ -1041,7 +1041,7 @@ pub const RunCommand = struct {
                         var dir_slice: string = "";
                         while (iter.next()) |entry| {
                             const value = entry.value_ptr.*;
-                            if (value.kind(&this_transpiler.fs.fs, true) == .file) {
+                            if (value.kind(this_transpiler.fs, true) == .file) {
                                 if (!has_copied) {
                                     bun.copy(u8, &path_buf, value.dir);
                                     dir_slice = path_buf[0..value.dir.len];
@@ -1078,7 +1078,7 @@ pub const RunCommand = struct {
                             !strings.contains(name, ".d.ts") and
                             !strings.contains(name, ".d.mts") and
                             !strings.contains(name, ".d.cts") and
-                            value.kind(&this_transpiler.fs.fs, true) == .file)
+                            value.kind(this_transpiler.fs, true) == .file)
                         {
                             _ = try results.getOrPut(this_transpiler.fs.filename_store.append(@TypeOf(name), name) catch continue);
                         }

--- a/src/cli/test/Scanner.zig
+++ b/src/cli/test/Scanner.zig
@@ -78,7 +78,7 @@ pub fn scan(this: *Scanner, path_literal: []const u8) Error!void {
 
     // you typed "." and we already scanned it
     if (!this.has_iterated) {
-        if (@as(FileSystem.RealFS.EntriesOption.Tag, root.*) == .entries) {
+        if (@as(FileSystem.EntriesOption.Tag, root.*) == .entries) {
             var iter = root.entries.data.iterator();
             const fd = root.entries.fd;
             bun.assert(fd != bun.invalid_fd);
@@ -113,8 +113,8 @@ pub fn scan(this: *Scanner, path_literal: []const u8) Error!void {
     }
 }
 
-fn readDirWithName(this: *Scanner, name: []const u8, handle: ?std.fs.Dir) !*FileSystem.RealFS.EntriesOption {
-    return try this.fs.fs.readDirectoryWithIterator(name, handle, 0, true, *Scanner, this);
+fn readDirWithName(this: *Scanner, name: []const u8, handle: ?std.fs.Dir) !*FileSystem.EntriesOption {
+    return try this.fs.readDirectoryWithIterator(name, handle, 0, true, *Scanner, this);
 }
 
 pub const test_name_suffixes = [_][]const u8{
@@ -163,7 +163,7 @@ pub fn isTestFile(this: *Scanner, name: []const u8) bool {
 pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescriptorType) void {
     const name = entry.base_lowercase();
     this.has_iterated = true;
-    switch (entry.kind(&this.fs.fs, true)) {
+    switch (entry.kind(this.fs, true)) {
         .dir => {
             if ((name.len > 0 and name[0] == '.') or strings.eqlComptime(name, "node_modules")) {
                 return;

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -916,7 +916,7 @@ pub const upgrade_js_bindings = struct {
         const w = std.os.windows;
 
         var buf: bun.WPathBuffer = undefined;
-        const tmpdir_path = fs.FileSystem.RealFS.getDefaultTempDir();
+        const tmpdir_path = fs.FileSystem.getDefaultTempDir();
         const path = switch (bun.sys.normalizePathWindows(u8, bun.invalid_fd, tmpdir_path, &buf, .{})) {
             .err => return .js_undefined,
             .result => |norm| norm,

--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -212,7 +212,7 @@ pub const DirEntryAccessor = struct {
             if (self.value) |*value| {
                 const nextval = value.next() orelse return .{ .result = null };
                 const name = nextval.key_ptr.*;
-                const kind = nextval.value_ptr.*.kind(&FS.instance.fs, true);
+                const kind = nextval.value_ptr.*.kind(&FS.instance, true);
                 const fskind = switch (kind) {
                     .file => std.fs.File.Kind.file,
                     .dir => std.fs.File.Kind.directory,
@@ -263,7 +263,7 @@ pub const DirEntryAccessor = struct {
         // TODO do we want to propagate ENOTDIR through the 'Maybe' to match the SyscallAccessor?
         // The glob implementation specifically checks for this error when dealing with symlinks
         // return .{ .err = Syscall.Error.fromCode(bun.sys.E.NOTDIR, Syscall.Tag.open) };
-        const res = try FS.instance.fs.readDirectory(path, null, 0, false);
+        const res = try FS.instance.readDirectory(path, null, 0, false);
         switch (res.*) {
             .entries => |entry| {
                 return .{ .result = .{ .value = entry } };
@@ -281,7 +281,7 @@ pub const DirEntryAccessor = struct {
     }
 
     pub fn getcwd(path_buf: *bun.PathBuffer) Maybe([]const u8) {
-        @memcpy(path_buf, bun.fs.FileSystem.instance.fs.cwd);
+        @memcpy(path_buf, bun.fs.FileSystem.instance.cwd);
     }
 };
 

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -774,7 +774,7 @@ pub fn init(
     fs.top_level_dir = cwd_buf[0..fs.top_level_dir.len :0];
     root_package_json_path = try bun.getFdPathZ(.fromStdFile(root_package_json_file), &root_package_json_path_buf);
 
-    const entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
+    const entries_option = try fs.readDirectory(fs.top_level_dir, null, 0, true);
     if (entries_option.* == .err) {
         return entries_option.err.canonical_error;
     }
@@ -1009,7 +1009,7 @@ pub fn initWithRuntimeOnce(
     const cpu_count = bun.getThreadCount();
     PackageManager.allocatePackageManager();
     const manager = PackageManager.get();
-    var root_dir = Fs.FileSystem.instance.fs.readDirectory(
+    var root_dir = Fs.FileSystem.instance.readDirectory(
         Fs.FileSystem.instance.top_level_dir,
         null,
         0,

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -30,7 +30,7 @@ var getTemporaryDirectoryOnce = bun.once(struct {
         var cache_directory = manager.getCacheDirectory();
         // The chosen tempdir must be on the same filesystem as the cache directory
         // This makes renameat() work
-        const temp_dir_name = Fs.FileSystem.RealFS.getDefaultTempDir();
+        const temp_dir_name = Fs.FileSystem.getDefaultTempDir();
 
         var tried_dot_tmp = false;
         var tempdir: std.fs.Dir = bun.MakePath.makeOpenPath(std.fs.cwd(), temp_dir_name, .{}) catch brk: {
@@ -691,7 +691,7 @@ pub fn writeYarnLock(this: *PackageManager) !void {
 
     var tmpname_buf: [512]u8 = undefined;
     tmpname_buf[0..8].* = "tmplock-".*;
-    var tmpfile = FileSystem.RealFS.Tmpfile{};
+    var tmpfile = FileSystem.Tmpfile{};
     var secret: [32]u8 = undefined;
     std.mem.writeInt(u64, secret[0..8], @as(u64, @intCast(std.time.milliTimestamp())), .little);
     var base64_bytes: [64]u8 = undefined;
@@ -701,7 +701,7 @@ pub fn writeYarnLock(this: *PackageManager) !void {
     tmpname_buf[tmpname__.len + 8] = 0;
     const tmpname = tmpname_buf[0 .. tmpname__.len + 8 :0];
 
-    tmpfile.create(&FileSystem.instance.fs, tmpname) catch |err| {
+    tmpfile.create(&FileSystem.instance, tmpname) catch |err| {
         Output.prettyErrorln("<r><red>error:<r> failed to create tmpfile: {s}", .{@errorName(err)});
         Global.crash();
     };

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1166,7 +1166,7 @@ pub const Printer = struct {
             .max_concurrent_lifecycle_scripts = 1,
         };
 
-        const entries_option = try fs.fs.readDirectory(fs.top_level_dir, null, 0, true);
+        const entries_option = try fs.readDirectory(fs.top_level_dir, null, 0, true);
         if (entries_option.* == .err) {
             return entries_option.err.canonical_error;
         }

--- a/src/linker.zig
+++ b/src/linker.zig
@@ -60,10 +60,10 @@ pub const Linker = struct {
         this: *ThisLinker,
         file_path: Fs.Path,
         fd: ?FileDescriptorType,
-    ) !Fs.FileSystem.RealFS.ModKey {
+    ) !Fs.FileSystem.ModKey {
         var file: std.fs.File = if (fd) |_fd| _fd.stdFile() else try std.fs.cwd().openFile(file_path.text, .{ .mode = .read_only });
         Fs.FileSystem.setMaxFd(file.handle);
-        const modkey = try Fs.FileSystem.RealFS.ModKey.generate(&this.fs.fs, file_path.text, file);
+        const modkey = try Fs.FileSystem.ModKey.generate(this.fs, file_path.text, file);
 
         if (fd == null)
             file.close();

--- a/src/options.zig
+++ b/src/options.zig
@@ -13,7 +13,7 @@ pub const WriteDestination = enum {
 
 pub fn validatePath(
     log: *logger.Log,
-    _: *Fs.FileSystem.Implementation,
+    _: *Fs.FileSystem,
     cwd: string,
     rel_path: string,
     allocator: std.mem.Allocator,
@@ -81,7 +81,7 @@ pub const ExternalModules = struct {
 
     pub fn init(
         allocator: std.mem.Allocator,
-        fs: *Fs.FileSystem.Implementation,
+        fs: *Fs.FileSystem,
         cwd: string,
         externals: []const string,
         log: *logger.Log,
@@ -2084,7 +2084,7 @@ pub const BundleOptions = struct {
             opts.main_fields = transform.main_fields;
         }
 
-        opts.external = ExternalModules.init(allocator, &fs.fs, fs.top_level_dir, transform.external, log, opts.target);
+        opts.external = ExternalModules.init(allocator, fs, fs.top_level_dir, transform.external, log, opts.target);
         opts.out_extensions = opts.target.outExtensions(allocator);
 
         opts.source_map = SourceMapOption.fromApi(transform.source_map orelse .none);

--- a/src/resolver/dir_info.zig
+++ b/src/resolver/dir_info.zig
@@ -66,7 +66,7 @@ pub fn getFileDescriptor(dirinfo: *const DirInfo) StoredFileDescriptorType {
 }
 
 pub fn getEntries(dirinfo: *const DirInfo, generation: bun.Generation) ?*Fs.FileSystem.DirEntry {
-    const entries_ptr = Fs.FileSystem.instance.fs.entriesAt(dirinfo.entries, generation) orelse return null;
+    const entries_ptr = Fs.FileSystem.instance.entriesAt(dirinfo.entries, generation) orelse return null;
     switch (entries_ptr.*) {
         .entries => {
             return entries_ptr.entries;
@@ -78,7 +78,7 @@ pub fn getEntries(dirinfo: *const DirInfo, generation: bun.Generation) ?*Fs.File
 }
 
 pub fn getEntriesConst(dirinfo: *const DirInfo) ?*const Fs.FileSystem.DirEntry {
-    const entries_ptr = Fs.FileSystem.instance.fs.entries.atIndex(dirinfo.entries) orelse return null;
+    const entries_ptr = Fs.FileSystem.instance.entries.atIndex(dirinfo.entries) orelse return null;
     switch (entries_ptr.*) {
         .entries => {
             return entries_ptr.entries;

--- a/src/router.zig
+++ b/src/router.zig
@@ -413,7 +413,7 @@ const RouteLoader = struct {
                     continue :outer;
                 }
 
-                switch (entry.kind(&fs.fs, false)) {
+                switch (entry.kind(fs, false)) {
                     .dir => {
                         inline for (banned_dirs) |banned_dir| {
                             if (strings.eqlComptime(entry.base(), comptime banned_dir)) {
@@ -746,7 +746,7 @@ pub const Route = struct {
                 };
                 FileSystem.setMaxFd(file.handle);
 
-                needs_close = FileSystem.instance.fs.needToCloseFiles();
+                needs_close = FileSystem.instance.needToCloseFiles();
                 if (!needs_close) entry.cache.fd = .fromStdFile(file);
             }
 


### PR DESCRIPTION
## Summary

- Remove the nested `RealFS` struct and merge all its fields and methods directly into `FileSystem`
- Eliminates redundant indirection of `fs.fs.*` calls throughout the codebase
- Simplifies the filesystem abstraction with no behavioral changes

## Test plan

- [x] Build passes with `bun bd`
- [x] Glob tests pass (except for pre-existing timeout issues in leak tests with debug builds)
- [x] Resolve tests pass (except for pre-existing timeout issues in debug builds)
- [x] Verified failing tests also fail on unmodified main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)