### PR TITLE
test(http2): refactor tests to use describe.concurrent and await using

### DIFF
--- a/test/js/node/http2/node-echo-server.fixture.js
+++ b/test/js/node/http2/node-echo-server.fixture.js
@@ -69,12 +69,12 @@ server.on("stream", (stream, headers, flags) => {
     });
   }
 });
-let baseurl = "https://localhost:";
+let baseurl = "https://127.0.0.1:";
 
-server.listen(0, "localhost");
+server.listen(0, "127.0.0.1");
 
 server.on("listening", () => {
   const { port, address, family } = server.address();
-  baseurl = `https://localhost:${port}`;
-  process.stdout.write(JSON.stringify({ port, address: "localhost", family: "IPv4" }));
+  baseurl = `https://127.0.0.1:${port}`;
+  process.stdout.write(JSON.stringify({ port, address: "127.0.0.1", family: "IPv4" }));
 });


### PR DESCRIPTION
## Summary
- Use `describe.concurrent` at module scope for parallel test execution across node/bun executables and padding strategies
- Replace `Bun.spawnSync` with async `Bun.spawn` in memory leak test
- Replace `beforeEach`/`afterEach` server setup with `await using` in each test
- Add `Symbol.asyncDispose` to `nodeEchoServer` helper for proper cleanup
- Fix IPv6/IPv4 binding issue by explicitly binding echo server to 127.0.0.1

## Test plan
- [x] Run `bun test test/js/node/http2/node-http2.test.js` - all 245 tests pass (6 skipped)
- [x] Verify tests run faster due to concurrent execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)