### PR TITLE
fix(console): add 'Assertion failed:' prefix to console.assert output

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -156,12 +156,13 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const is_stderr = level == .Warning or level == .Error or message_type == .Assert;
+    const enable_colors = if (is_stderr)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (is_stderr)
         console.error_writer
     else
         console.writer;
@@ -224,6 +225,15 @@ fn messageWithTypeAndLevel_(
                 if (colors_prop.isBoolean())
                     print_options.enable_colors = colors_prop.toBoolean();
             }
+        }
+    }
+
+    // Print "Assertion failed: " prefix for console.assert with arguments
+    if (message_type == .Assert and print_length > 0) {
+        if (enable_colors) {
+            writer.writeAll(Output.prettyFmt("<r><red>Assertion failed:<r> ", true)) catch {};
+        } else {
+            writer.writeAll("Assertion failed: ") catch {};
         }
     }
 

--- a/test/js/web/console/console-assert.test.ts
+++ b/test/js/web/console/console-assert.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("console.assert", () => {
+  test("with no arguments outputs 'Assertion failed' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.assert(false)"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("Assertion failed\n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with message outputs 'Assertion failed: <message>' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", 'console.assert(false, "test message")'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("Assertion failed: test message\n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with multiple arguments outputs 'Assertion failed: <formatted args>' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", 'console.assert(false, "value is", 42, "and object is", { foo: "bar" })'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe('Assertion failed: value is 42 and object is { foo: "bar" }\n');
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with format string outputs 'Assertion failed: <formatted>' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", 'console.assert(false, "number: %d, string: %s", 123, "hello")'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("Assertion failed: number: 123, string: hello\n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with truthy condition outputs nothing", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", 'console.assert(true, "this should not appear")'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("");
+    expect(proc.exitCode).toBe(0);
+  });
+});

--- a/test/js/web/console/console-assert.test.ts
+++ b/test/js/web/console/console-assert.test.ts
@@ -66,4 +66,57 @@ describe("console.assert", () => {
     expect(proc.stderr.toString()).toBe("");
     expect(proc.exitCode).toBe(0);
   });
+
+  test("with empty string message outputs 'Assertion failed: ' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", 'console.assert(false, "")'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("Assertion failed: \n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with null argument outputs 'Assertion failed: null' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.assert(false, null)"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("Assertion failed: null\n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with undefined argument outputs 'Assertion failed: undefined' to stderr", () => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.assert(false, undefined)"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe("Assertion failed: undefined\n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test("with long message handles output correctly", () => {
+    const longMessage = "a]b]c".repeat(50);
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", `console.assert(false, "${longMessage}")`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.stdout.toString()).toBe("");
+    expect(proc.stderr.toString()).toBe(`Assertion failed: ${longMessage}\n`);
+    expect(proc.exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- `console.assert()` with arguments now correctly prepends "Assertion failed: " to match Node.js and WHATWG Console spec behavior
- Fixes `console.assert` output to go to stderr instead of stdout (was inconsistent with the mutex handling)

## Test plan

- Added `test/js/web/console/console-assert.test.ts` with tests for:
  - `console.assert(false)` → outputs "Assertion failed" to stderr
  - `console.assert(false, "message")` → outputs "Assertion failed: message" to stderr
  - `console.assert(false, ...)` with multiple args → formats correctly with prefix
  - `console.assert(true, ...)` → outputs nothing
  - All output goes to stderr (not stdout)

Closes #19953