### PR TITLE
Fix GitLab registry path matching logic

### DIFF
--- a/src/ini.zig
+++ b/src/ini.zig
@@ -1456,8 +1456,6 @@ fn @"handle _auth"(
     return;
 }
 
-const registry_utils = @import("./install/registry_utils.zig");
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -1472,3 +1470,5 @@ const js_ast = bun.ast;
 const E = bun.ast.E;
 const Expr = bun.ast.Expr;
 const Rope = js_ast.E.Object.Rope;
+
+const registry_utils = @import("./install/registry_utils.zig");

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -1352,7 +1352,7 @@ pub fn loadNpmrc(
 
                     // For GitLab registries, we need exact path matching since each project has its own auth token
                     // The conf_item.registry_url should match the beginning of the scoped registry URL path
-                    const is_gitlab = bun.strings.indexOf(url.host, "gitlab") != null;
+                    const is_gitlab = registry_utils.isGitLabRegistry(url.host);
                     if (is_gitlab) {
                         const scoped_path = bun.strings.withoutTrailingSlash(url.pathname);
                         const conf_path = bun.strings.withoutTrailingSlash(conf_item_url.pathname);
@@ -1455,6 +1455,8 @@ fn @"handle _auth"(
     v.password = password;
     return;
 }
+
+const registry_utils = @import("./install/registry_utils.zig");
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -73,8 +73,6 @@ fn countAuth(header_builder: *HeaderBuilder, scope: *const Npm.Registry.Scope) v
     header_builder.count("npm-auth-type", "legacy");
 }
 
-const registry_utils = @import("./registry_utils.zig");
-
 const ForManifestError = OOM || error{
     InvalidURL,
 };
@@ -352,3 +350,5 @@ const FileSystem = Fs.FileSystem;
 const HTTP = bun.http;
 const AsyncHTTP = HTTP.AsyncHTTP;
 const HeaderBuilder = HTTP.HeaderBuilder;
+
+const registry_utils = @import("./registry_utils.zig");

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -62,11 +62,12 @@ pub fn buildURLWithPrinter(
     // Check if this is a GitLab registry by parsing the URL and checking the hostname
     const is_gitlab_registry = blk: {
         const url = bun.URL.parse(registry);
-        const host = bun.strings.toLowerCaseWithType(u8, url.host, string_buf);
+        const host_buf = bun.default_allocator.alloc(u8, url.host.len) catch break :blk false;
+        defer bun.default_allocator.free(host_buf);
+        const host = bun.strings.toLowerCaseWithType(u8, url.host, host_buf);
         break :blk bun.strings.eqlComptime(host, "gitlab.com") or 
                bun.strings.endsWith(host, ".gitlab.com") or
-               bun.strings.contains(host, ".gitlab.") or
-               bun.strings.startsWith(host, "gitlab.");
+               bun.strings.endsWith(host, ".gitlab.io");
     };
     
     var name = full_name;

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -60,14 +60,7 @@ pub fn buildURLWithPrinter(
     const full_name = full_name_.slice();
 
     // Check if this is a GitLab registry by parsing the URL and checking the hostname
-    const is_gitlab_registry = blk: {
-        const url = bun.URL.parse(registry);
-        if (url.host.len == 0) break :blk false;
-        const host_buf = bun.default_allocator.alloc(u8, url.host.len) catch break :blk false;
-        defer bun.default_allocator.free(host_buf);
-        const host = bun.strings.copyLowercase(url.host, host_buf);
-        break :blk bun.strings.indexOf(host, "gitlab") != null;
-    };
+    const is_gitlab_registry = registry_utils.isGitLabRegistry(registry);
     
     var name = full_name;
     if (name[0] == '@' and !is_gitlab_registry) {
@@ -553,6 +546,8 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
         },
     };
 }
+
+const registry_utils = @import("./registry_utils.zig");
 
 const string = []const u8;
 

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -59,12 +59,16 @@ pub fn buildURLWithPrinter(
     const registry = std.mem.trimRight(u8, registry_, "/");
     const full_name = full_name_.slice();
 
+    // Check if this is a GitLab registry by looking for gitlab in the registry URL
+    const is_gitlab_registry = bun.strings.indexOf(registry, "gitlab") != null;
+    
     var name = full_name;
-    if (name[0] == '@') {
+    if (name[0] == '@' and !is_gitlab_registry) {
         if (strings.indexOfChar(name, '/')) |i| {
             name = name[i + 1 ..];
         }
     }
+    // For GitLab registries, keep the full scoped name
 
     const default_format = "{s}/{s}/-/";
 

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -61,10 +61,11 @@ pub fn buildURLWithPrinter(
 
     // Check if this is a GitLab registry by parsing the URL and checking the hostname
     const is_gitlab_registry = blk: {
-        const url = bun.URL.parse(registry) catch break :blk false;
+        const url = bun.URL.parse(registry);
+        if (url.host.len == 0) break :blk false;
         const host_buf = bun.default_allocator.alloc(u8, url.host.len) catch break :blk false;
         defer bun.default_allocator.free(host_buf);
-        const host = bun.strings.toLowerCaseWithType(u8, url.host, host_buf);
+        const host = bun.strings.copyLowercase(url.host, host_buf);
         break :blk bun.strings.indexOf(host, "gitlab") != null;
     };
     

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -61,7 +61,7 @@ pub fn buildURLWithPrinter(
 
     // Check if this is a GitLab registry by parsing the URL and checking the hostname
     const is_gitlab_registry = blk: {
-        const url = bun.URL.parse(registry);
+        const url = bun.URL.parse(registry) catch break :blk false;
         const host_buf = bun.default_allocator.alloc(u8, url.host.len) catch break :blk false;
         defer bun.default_allocator.free(host_buf);
         const host = bun.strings.toLowerCaseWithType(u8, url.host, host_buf);

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -61,14 +61,14 @@ pub fn buildURLWithPrinter(
 
     // Check if this is a GitLab registry by parsing the URL and checking the hostname
     const is_gitlab_registry = registry_utils.isGitLabRegistry(registry);
-    
+
     var name = full_name;
+    // For GitLab registries, keep the full scoped name
     if (name[0] == '@' and !is_gitlab_registry) {
         if (strings.indexOfChar(name, '/')) |i| {
             name = name[i + 1 ..];
         }
     }
-    // For GitLab registries, keep the full scoped name
 
     const default_format = "{s}/{s}/-/";
 

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -59,8 +59,15 @@ pub fn buildURLWithPrinter(
     const registry = std.mem.trimRight(u8, registry_, "/");
     const full_name = full_name_.slice();
 
-    // Check if this is a GitLab registry by looking for gitlab in the registry URL
-    const is_gitlab_registry = bun.strings.indexOf(registry, "gitlab") != null;
+    // Check if this is a GitLab registry by parsing the URL and checking the hostname
+    const is_gitlab_registry = blk: {
+        const url = bun.URL.parse(registry);
+        const host = bun.strings.toLowerCaseWithType(u8, url.host, string_buf);
+        break :blk bun.strings.eqlComptime(host, "gitlab.com") or 
+               bun.strings.endsWith(host, ".gitlab.com") or
+               bun.strings.contains(host, ".gitlab.") or
+               bun.strings.startsWith(host, "gitlab.");
+    };
     
     var name = full_name;
     if (name[0] == '@' and !is_gitlab_registry) {

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -65,9 +65,7 @@ pub fn buildURLWithPrinter(
         const host_buf = bun.default_allocator.alloc(u8, url.host.len) catch break :blk false;
         defer bun.default_allocator.free(host_buf);
         const host = bun.strings.toLowerCaseWithType(u8, url.host, host_buf);
-        break :blk bun.strings.eqlComptime(host, "gitlab.com") or 
-               bun.strings.endsWith(host, ".gitlab.com") or
-               bun.strings.endsWith(host, ".gitlab.io");
+        break :blk bun.strings.indexOf(host, "gitlab") != null;
     };
     
     var name = full_name;

--- a/src/install/registry_utils.zig
+++ b/src/install/registry_utils.zig
@@ -1,0 +1,14 @@
+/// Registry utilities for package managers
+const std = @import("std");
+const bun = @import("bun");
+const strings = bun.strings;
+
+/// Check if a registry URL is a GitLab registry by examining the hostname
+pub fn isGitLabRegistry(registry_url: []const u8) bool {
+    const url = bun.URL.parse(registry_url);
+    if (url.host.len == 0) return false;
+    const host_buf = bun.default_allocator.alloc(u8, url.host.len) catch return false;
+    defer bun.default_allocator.free(host_buf);
+    const host = strings.copyLowercase(url.host, host_buf);
+    return strings.indexOf(host, "gitlab") != null;
+}

--- a/src/install/registry_utils.zig
+++ b/src/install/registry_utils.zig
@@ -1,8 +1,3 @@
-/// Registry utilities for package managers
-const std = @import("std");
-const bun = @import("bun");
-const strings = bun.strings;
-
 /// Check if a registry URL is a GitLab registry by examining the hostname
 pub fn isGitLabRegistry(registry_url: []const u8) bool {
     const url = bun.URL.parse(registry_url);
@@ -12,3 +7,9 @@ pub fn isGitLabRegistry(registry_url: []const u8) bool {
     const host = strings.copyLowercase(url.host, host_buf);
     return strings.indexOf(host, "gitlab") != null;
 }
+
+/// Registry utilities for package managers
+const strings = bun.strings;
+
+const std = @import("std");
+const bun = @import("bun");


### PR DESCRIPTION
### What does this PR do?

fix(ini.zig): improve GitLab registry path matching logic 

Enhance the matching logic for GitLab registry paths by ensuring exact path matching. This change ensures that the `conf_item` path is a prefix of the scoped registry path, allowing for precise authentication token application. For GitLab registries, the code now breaks upon finding an exact match, rather than continuing.


feat(extract_tarball.zig): handle GitLab registry in URL building

Add logic to identify GitLab registries by checking for "gitlab" in the registry URL. For GitLab registries, retain the full scoped name when building the URL, maintaining integrity in package references.



### How did you verify your code works?
A project with access to multiple gitlab registries from the same instance, with multiple packages using different `_authToken`s.

The `.npmrc` file would have entries like this:
```
@your-scope:registry=https://your-gitlab.com/api/v4/projects/PROJECT_ID1/packages/npm/
//your-gitlab.com/api/v4/projects/PROJECT_ID1/packages/npm/:_authToken=YOUR_TOKEN1

@your-scope:registry=https://your-gitlab.com/api/v4/projects/PROJECT_ID2/packages/npm/
//your-gitlab.com/api/v4/projects/PROJECT_ID2/packages/npm/:_authToken=YOUR_TOKEN2
```


 ### What happens on the current main build?
 Bun will try to access every registry with the last found `_authToken`.
 Bun does the request to the wrong url, since its wrongly formatted.
 
