### PR TITLE
fix(shell): use PATH from .env() for command resolution

### DIFF
--- a/test/regression/issue/25855.test.ts
+++ b/test/regression/issue/25855.test.ts
@@ -1,0 +1,62 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir } from "harness";
+
+describe("issue #25855 - shell .env() PATH should affect command resolution", () => {
+  test("command resolution uses PATH from .env()", async () => {
+    // Create a temp directory with a test executable
+    using dir = tempDir("bun-path-test", {});
+    const binDir = `${dir}/bin`;
+    await $`mkdir -p ${binDir}`.quiet();
+
+    // Create a simple test script
+    const testBinary = `${binDir}/mytest25855`;
+    await Bun.write(testBinary, '#!/bin/bash\necho "hello from mytest25855"');
+    await $`chmod +x ${testBinary}`.quiet();
+
+    // Create enhanced PATH with our bin directory prepended
+    const enhancedPath = `${binDir}:${process.env.PATH}`;
+
+    // Test: Direct command execution should find the binary via enhanced PATH
+    const execResult = await $`mytest25855`.env({ ...bunEnv, PATH: enhancedPath }).quiet();
+    expect(execResult.stdout.toString().trim()).toBe("hello from mytest25855");
+    expect(execResult.exitCode).toBe(0);
+  });
+
+  test("which builtin and command execution use same PATH", async () => {
+    // Create a temp directory with a test executable
+    using dir = tempDir("bun-path-test", {});
+    const binDir = `${dir}/bin`;
+    await $`mkdir -p ${binDir}`.quiet();
+
+    // Create a simple test script
+    const testBinary = `${binDir}/whichtest25855`;
+    await Bun.write(testBinary, '#!/bin/bash\necho "found me"');
+    await $`chmod +x ${testBinary}`.quiet();
+
+    // Create enhanced PATH
+    const enhancedPath = `${binDir}:${process.env.PATH}`;
+    const envWithPath = { ...bunEnv, PATH: enhancedPath };
+
+    // Both which and direct execution should work with the same PATH
+    const whichResult = await $`which whichtest25855`.env(envWithPath).quiet();
+    expect(whichResult.stdout.toString().trim()).toBe(testBinary);
+
+    const execResult = await $`whichtest25855`.env(envWithPath).quiet();
+    expect(execResult.stdout.toString().trim()).toBe("found me");
+  });
+
+  test("command not in custom PATH still fails appropriately", async () => {
+    // Use a PATH that doesn't include standard directories
+    using dir = tempDir("bun-path-test", {});
+    const emptyPath = String(dir);
+
+    // Note: ls, cat, echo, etc. are shell builtins in bun, so they'll work without PATH.
+    // We use 'node' as an example of a real external command that won't be a builtin.
+    const result = await $`node --version`
+      .env({ ...bunEnv, PATH: emptyPath })
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix shell command resolution to use PATH from `.env()` instead of process PATH
- Add regression test for issue #25855

## The Problem

When using the bun shell `$` template literal, setting PATH via `.env()` did not affect command resolution. The `which` builtin correctly saw the new PATH, but actual command execution failed to find binaries:

```ts
const enhancedPath = `${binDir}:${process.env.PATH}`;

// which WORKS - finds the binary
const whichResult = await $`which mytest`.env({ PATH: enhancedPath }).quiet();
// Output: /path/to/bin/mytest ✓

// Direct execution FAILS - "command not found"  
const execResult = await $`mytest`.env({ PATH: enhancedPath }).quiet();
// Output: "mytest: command not found" ✗
```

## Root Cause

In `src/shell/states/Cmd.zig`, command resolution via `which()` happened BEFORE `fillEnv()` was called to update PATH from the shell's environment. The `which` builtin worked because it directly read from `export_env.get("PATH")`.

## The Fix

Check the shell environment (`cmd_local_env` and `export_env`) for PATH before falling back to the process PATH when resolving commands, matching the behavior of the `which` builtin.

## Test plan

- [x] New regression test `test/regression/issue/25855.test.ts`
- [x] Test fails with system bun (USE_SYSTEM_BUN=1), passes with fix
- [x] Existing shell tests pass (`test/js/bun/shell/exec.test.ts`)

Fixes #25855

🤖 Generated with [Claude Code](https://claude.com/claude-code)