### PR TITLE
fix(console): include 'Assertion failed' prefix in console.assert() output

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Assert)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Assert)
         console.error_writer
     else
         console.writer;
@@ -227,7 +227,14 @@ fn messageWithTypeAndLevel_(
         }
     }
 
-    if (print_length > 0)
+    if (print_length > 0) {
+        if (message_type == .Assert) {
+            const prefix = if (print_options.enable_colors)
+                Output.prettyFmt("<r><red>Assertion failed:<r> ", true)
+            else
+                "Assertion failed: ";
+            writer.writeAll(prefix) catch {};
+        }
         try format2(
             level,
             global,
@@ -235,8 +242,8 @@ fn messageWithTypeAndLevel_(
             print_length,
             writer,
             print_options,
-        )
-    else if (message_type == .Log) {
+        );
+    } else if (message_type == .Log) {
         _ = console.writer.write("\n") catch 0;
         console.writer.flush() catch {};
     } else if (message_type != .Trace)

--- a/test/js/web/console/console-assert.fixture.js
+++ b/test/js/web/console/console-assert.fixture.js
@@ -1,0 +1,1 @@
+console.assert(false, "test message");

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -179,3 +179,24 @@ it("console.log with SharedArrayBuffer", () => {
     "
   `);
 });
+
+// https://github.com/oven-sh/bun/issues/19953
+it("console.assert() with message should include 'Assertion failed' prefix", async () => {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), join(import.meta.dir, "console-assert.fixture.js")],
+    stdin: "inherit",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  // Check stdout/stderr before exit code for better error messages on failure
+  const err = await stderr.text();
+  const out = await stdout.text();
+  const exitCode = await exited;
+
+  expect(out).toBe("");
+  expect(err).toContain("Assertion failed:");
+  expect(err).toContain("test message");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

`console.assert()` with a message should output "Assertion failed: <message>" to stderr, matching Node.js behavior. Currently Bun outputs only the message to stdout.

**Before (Bun):**
```bash
$ bun -e 'console.assert(false, "message")'
message
```

**After (matches Node.js):**
```bash
$ bun -e 'console.assert(false, "message")'
Assertion failed: message
```

## Changes

1. Route `console.assert()` output to stderr (like Warning/Error)
2. Prepend "Assertion failed: " prefix to the message  
3. Use red ANSI coloring when colors are enabled

## Test plan

- [x] Added test in `test/js/web/console/console-log.test.ts`
- [x] Added fixture `console-assert.fixture.js`
- [x] Verified Node.js outputs to stderr with prefix
- [x] Verified current Bun outputs to stdout without prefix

Fixes #19953

🤖 Generated with [Claude Code](https://claude.ai/code)