### PR TITLE
fix(bundler): align default chunk naming with documentation

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -2619,23 +2619,15 @@ pub const PathTemplate = struct {
         });
     };
 
-    pub const chunk = PathTemplate{
-        .data = "./chunk-[hash].[ext]",
-        .placeholder = .{
-            .name = "chunk",
-            .ext = "js",
-            .dir = "",
-        },
-    };
-
-    pub const chunkWithTarget = PathTemplate{
-        .data = "[dir]/[target]/chunk-[hash].[ext]",
-        .placeholder = .{
-            .name = "chunk",
-            .ext = "js",
-            .dir = "",
-        },
-    };
+    pub const chunk = PathTemplate{  
+        .data = "./[name]-[hash].[ext]",  
+        .placeholder = .{},  
+    };  
+      
+    pub const chunkWithTarget = PathTemplate{  
+        .data = "[dir]/[target]/[name]-[hash].[ext]",  
+        .placeholder = .{},  
+    };  
 
     pub const file = PathTemplate{
         .data = "[dir]/[name].[ext]",
@@ -2647,15 +2639,9 @@ pub const PathTemplate = struct {
         .placeholder = .{},
     };
 
-    pub const asset = PathTemplate{
-        .data = "./[name]-[hash].[ext]",
-        .placeholder = .{},
-    };
-
-    pub const assetWithTarget = PathTemplate{
-        .data = "[dir]/[target]/[name]-[hash].[ext]",
-        .placeholder = .{},
-    };
+    // Reuse the same default values  
+    pub const asset = chunk;  
+    pub const assetWithTarget = chunkWithTarget;
 };
 
 const string = []const u8;


### PR DESCRIPTION
### What does this PR do?
Fixes inconsistency between the default chunk naming pattern in the source code and the documented behavior in Bun's bundler. The PathTemplate.chunk constant used "./chunk-[hash].[ext]" but should use "./[name]-[hash].[ext]" to match documentation and runtime behavior.

<img width="717" height="405" alt="image" src="https://github.com/user-attachments/assets/679fa6cf-2692-4c8e-8c87-3214326d2f43" />

Also, it's related to #17674

### How did you verify your code works?
Later