### PR TITLE
feat(archive): add TypeScript types, docs, and files() benchmark

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -121,6 +121,7 @@
               "/runtime/file-io",
               "/runtime/streams",
               "/runtime/binary-data",
+              "/runtime/archive",
               "/runtime/sql",
               "/runtime/sqlite",
               "/runtime/s3",

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -148,7 +148,7 @@ const count = await archive.extract("./src", { glob: "**/*.ts" });
 
 // Extract files from multiple directories
 const count = await archive.extract("./output", {
-  glob: ["src/**", "lib/**"]
+  glob: ["src/**", "lib/**"],
 });
 ```
 
@@ -157,13 +157,13 @@ Use ignore patterns to exclude files:
 ```ts
 // Extract everything except test files
 const count = await archive.extract("./dist", {
-  ignore: "**/*.test.*"
+  ignore: "**/*.test.*",
 });
 
 // Combine glob and ignore patterns
 const count = await archive.extract("./output", {
   glob: "src/**",
-  ignore: ["**/*.test.ts", "**/__tests__/**"]
+  ignore: ["**/*.test.ts", "**/__tests__/**"],
 });
 ```
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -160,6 +160,42 @@ Each `File` object includes:
 - `lastModified` - Modification timestamp
 - Standard `Blob` methods: `text()`, `arrayBuffer()`, `stream()`, etc.
 
+### Error Handling
+
+Archive operations can fail due to corrupted data, I/O errors, or invalid paths. Use try/catch to handle these cases:
+
+```ts
+try {
+  const tarball = await Bun.file("package.tar.gz").bytes();
+  const archive = Bun.Archive.from(tarball);
+  const count = await archive.extract("./output");
+  console.log(`Extracted ${count} files`);
+} catch (error) {
+  if (error.code === "EACCES") {
+    console.error("Permission denied");
+  } else if (error.code === "ENOSPC") {
+    console.error("Disk full");
+  } else {
+    console.error("Archive error:", error.message);
+  }
+}
+```
+
+Common error scenarios:
+- **Corrupted/truncated archives** - `Archive.from()` throws when data is invalid
+- **Permission denied** - `extract()` throws if the target directory is not writable
+- **Disk full** - `extract()` throws if there's insufficient space
+- **Invalid paths** - Operations throw for malformed file paths
+
+When using `files()` with a glob pattern, an empty `Map` is returned if no files match:
+
+```ts
+const matches = await archive.files("*.nonexistent");
+if (matches.size === 0) {
+  console.log("No matching files found");
+}
+```
+
 ### Filtering with Glob Patterns
 
 Pass a glob pattern to filter which files are returned:

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -201,7 +201,8 @@ try {
   const archive = Bun.Archive.from(tarball);
   const count = await archive.extract("./output");
   console.log(`Extracted ${count} files`);
-} catch (error) {
+} catch (e: unknown) {
+  const error = e as { code?: string; message?: string };
   if (error.code === "EACCES") {
     console.error("Permission denied");
   } else if (error.code === "ENOSPC") {
@@ -218,6 +219,8 @@ Common error scenarios:
 - **Permission denied** - `extract()` throws if the target directory is not writable
 - **Disk full** - `extract()` throws if there's insufficient space
 - **Invalid paths** - Operations throw for malformed file paths
+
+**Security warning**: When extracting archives from untrusted sources, be aware of potential security risks like path traversal attacks (e.g., `../../../etc/passwd`) or symlink attacks. Consider validating file paths and avoiding extraction of symlinks from untrusted archives.
 
 When using `files()` with a glob pattern, an empty `Map` is returned if no files match:
 
@@ -347,6 +350,8 @@ await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
 ## Reference
 
 ```ts
+type ArrayBufferView = NodeJS.TypedArray | DataView;
+
 type ArchiveCompression = "gzip" | boolean;
 
 type ArchiveInput =
@@ -371,11 +376,14 @@ class Archive {
   /**
    * Write an archive directly to disk
    */
-  static write(path: string, data: ArchiveInput | Archive, compress?: ArchiveCompression): Promise<void>;
+  static write(
+    path: string,
+    data: ArchiveInput | Archive,
+    compress?: ArchiveCompression
+  ): Promise<void>;
 
   /**
    * Extract archive to a directory
-   * @param options - Optional glob/ignore patterns for filtering
    * @returns Number of files extracted
    */
   extract(path: string, options?: ArchiveExtractOptions): Promise<number>;
@@ -392,7 +400,6 @@ class Archive {
 
   /**
    * Get archive contents as File objects
-   * @param glob - Optional glob pattern to filter files
    */
   files(glob?: string): Promise<Map<string, File>>;
 }

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -250,7 +250,7 @@ for (const [path] of files) {
 
 // Extract to a controlled destination after validation
 await archive.extract("./safe-output", {
-  ignore: ["../**", "/**"],  // Extra safety
+  ignore: ["../**", "/**"], // Extra safety
 });
 ```
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -171,6 +171,8 @@ const count = await archive.extract("./output", {
 });
 ```
 
+**Note**: The `glob` and `ignore` options must not be empty arrays. To extract all files, omit the option or pass `undefined`.
+
 ## Reading Archive Contents
 
 ### Get All Files

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -231,6 +231,7 @@ Common error scenarios:
 The count returned by `extract()` includes all successfully written entries (files, directories, and symlinks on POSIX systems).
 
 **Security note**: Bun.Archive automatically validates paths during extraction, rejecting:
+
 - Absolute paths (starting with `/` or `\`)
 - Path traversal attempts (containing `..` components)
 - Unsafe symlink targets

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -376,11 +376,7 @@ class Archive {
   /**
    * Write an archive directly to disk
    */
-  static write(
-    path: string,
-    data: ArchiveInput | Archive,
-    compress?: ArchiveCompression
-  ): Promise<void>;
+  static write(path: string, data: ArchiveInput | Archive, compress?: ArchiveCompression): Promise<void>;
 
   /**
    * Extract archive to a directory

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -171,8 +171,6 @@ const count = await archive.extract("./output", {
 });
 ```
 
-**Note**: The `glob` and `ignore` options must not be empty arrays. To extract all files, omit the option or pass `undefined`.
-
 ## Reading Archive Contents
 
 ### Get All Files

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -136,6 +136,37 @@ console.log(`Extracted ${count} files`);
 
 The target directory is created automatically if it doesn't exist. Existing files are overwritten.
 
+### Filtering Extracted Files
+
+Use glob patterns to extract only specific files:
+
+```ts
+const archive = Bun.Archive.from(tarball);
+
+// Extract only TypeScript files
+const count = await archive.extract("./src", { glob: "**/*.ts" });
+
+// Extract files from multiple directories
+const count = await archive.extract("./output", {
+  glob: ["src/**", "lib/**"]
+});
+```
+
+Use ignore patterns to exclude files:
+
+```ts
+// Extract everything except test files
+const count = await archive.extract("./dist", {
+  ignore: "**/*.test.*"
+});
+
+// Combine glob and ignore patterns
+const count = await archive.extract("./output", {
+  glob: "src/**",
+  ignore: ["**/*.test.ts", "**/__tests__/**"]
+});
+```
+
 ## Reading Archive Contents
 
 ### Get All Files
@@ -324,6 +355,13 @@ type ArchiveInput =
   | ArrayBufferView
   | ArrayBufferLike;
 
+interface ArchiveExtractOptions {
+  /** Glob pattern(s) to include */
+  glob?: string | string[];
+  /** Glob pattern(s) to exclude */
+  ignore?: string | string[];
+}
+
 class Archive {
   /**
    * Create an Archive from input data
@@ -337,9 +375,10 @@ class Archive {
 
   /**
    * Extract archive to a directory
+   * @param options - Optional glob/ignore patterns for filtering
    * @returns Number of files extracted
    */
-  extract(path: string): Promise<number>;
+  extract(path: string, options?: ArchiveExtractOptions): Promise<number>;
 
   /**
    * Get archive as a Blob

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -138,6 +138,8 @@ console.log(`Extracted ${count} files`);
 
 The target directory is created automatically if it doesn't exist. Existing files are overwritten.
 
+**Note**: On Windows, symbolic links in archives are skipped during extraction since they require elevated privileges. On Linux and macOS, symlinks are extracted normally.
+
 ### Filtering Extracted Files
 
 Use glob patterns to extract only specific files:
@@ -204,13 +206,17 @@ try {
   const count = await archive.extract("./output");
   console.log(`Extracted ${count} files`);
 } catch (e: unknown) {
-  const error = e as { code?: string; message?: string };
-  if (error.code === "EACCES") {
-    console.error("Permission denied");
-  } else if (error.code === "ENOSPC") {
-    console.error("Disk full");
+  if (e instanceof Error) {
+    const error = e as Error & { code?: string };
+    if (error.code === "EACCES") {
+      console.error("Permission denied");
+    } else if (error.code === "ENOSPC") {
+      console.error("Disk full");
+    } else {
+      console.error("Archive error:", error.message);
+    }
   } else {
-    console.error("Archive error:", error.message);
+    console.error("Archive error:", String(e));
   }
 }
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -296,11 +296,7 @@ class Archive {
   /**
    * Write an archive directly to disk
    */
-  static write(
-    path: string,
-    data: ArchiveInput | Archive,
-    compress?: ArchiveCompression
-  ): Promise<void>;
+  static write(path: string, data: ArchiveInput | Archive, compress?: ArchiveCompression): Promise<void>;
 
   /**
    * Extract archive to a directory

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -61,6 +61,9 @@ File contents can be:
 - **ArrayBuffers** - Raw binary data
 
 ```ts
+const data = "binary data";
+const arrayBuffer = new ArrayBuffer(8);
+
 const archive = Bun.Archive.from({
   "text.txt": "Plain text",
   "blob.bin": new Blob([data]),
@@ -81,6 +84,7 @@ await Bun.Archive.write("output.tar", {
 });
 
 // Write gzipped tar
+const files = { "src/index.ts": "console.log('Hello');" };
 await Bun.Archive.write("output.tar.gz", files, "gzip");
 ```
 
@@ -89,6 +93,7 @@ await Bun.Archive.write("output.tar.gz", files, "gzip");
 Get the archive data as bytes or a Blob:
 
 ```ts
+const files = { "hello.txt": "Hello, World!" };
 const archive = Bun.Archive.from(files);
 
 // As Uint8Array
@@ -123,7 +128,8 @@ const archive = Bun.Archive.from(await response.blob());
 Use `.extract()` to write all files to a directory:
 
 ```ts
-const archive = Bun.Archive.from(tarballBytes);
+const tarball = await Bun.file("package.tar.gz").bytes();
+const archive = Bun.Archive.from(tarball);
 const count = await archive.extract("./extracted");
 console.log(`Extracted ${count} files`);
 ```
@@ -137,7 +143,8 @@ The target directory is created automatically if it doesn't exist. Existing file
 Use `.files()` to get archive contents as a `Map` of `File` objects without extracting to disk:
 
 ```ts
-const archive = Bun.Archive.from(tarballBytes);
+const tarball = await Bun.file("package.tar.gz").bytes();
+const archive = Bun.Archive.from(tarball);
 const files = await archive.files();
 
 for (const [path, file] of files) {
@@ -182,9 +189,11 @@ Bun.Archive supports gzip compression for both reading and writing:
 
 ```ts
 // Reading: automatically detects gzip
+const gzippedTarball = await Bun.file("archive.tar.gz").bytes();
 const archive = Bun.Archive.from(gzippedTarball);
 
 // Writing: specify compression
+const files = { "hello.txt": "Hello, World!" };
 await Bun.Archive.write("output.tar.gz", files, "gzip");
 
 // Getting bytes: specify compression
@@ -270,6 +279,14 @@ await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
 ## Reference
 
 ```ts
+type ArchiveCompression = "gzip" | boolean;
+
+type ArchiveInput =
+  | Record<string, string | Blob | ArrayBufferView | ArrayBufferLike>
+  | Blob
+  | ArrayBufferView
+  | ArrayBufferLike;
+
 class Archive {
   /**
    * Create an Archive from input data
@@ -279,7 +296,11 @@ class Archive {
   /**
    * Write an archive directly to disk
    */
-  static write(path: string, data: ArchiveInput, compress?: "gzip" | boolean): Promise<void>;
+  static write(
+    path: string,
+    data: ArchiveInput | Archive,
+    compress?: ArchiveCompression
+  ): Promise<void>;
 
   /**
    * Extract archive to a directory
@@ -290,12 +311,12 @@ class Archive {
   /**
    * Get archive as a Blob
    */
-  blob(compress?: "gzip" | boolean): Promise<Blob>;
+  blob(compress?: ArchiveCompression): Promise<Blob>;
 
   /**
    * Get archive as a Uint8Array
    */
-  bytes(compress?: "gzip" | boolean): Promise<Uint8Array>;
+  bytes(compress?: ArchiveCompression): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Get archive contents as File objects
@@ -303,10 +324,4 @@ class Archive {
    */
   files(glob?: string): Promise<Map<string, File>>;
 }
-
-type ArchiveInput =
-  | Record<string, string | Blob | ArrayBufferView | ArrayBuffer>
-  | Blob
-  | ArrayBufferView
-  | ArrayBuffer;
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -1,0 +1,311 @@
+---
+title: Archive
+description: Create and extract tar archives with Bun's fast native implementation
+---
+
+Bun provides a fast, native implementation for working with tar archives through `Bun.Archive`. It supports creating archives from in-memory data, extracting archives to disk, and reading archive contents without extraction.
+
+## Quickstart
+
+**Create an archive from files:**
+
+```ts
+const archive = Bun.Archive.from({
+  "hello.txt": "Hello, World!",
+  "data.json": JSON.stringify({ foo: "bar" }),
+  "nested/file.txt": "Nested content",
+});
+
+// Write to disk
+await Bun.Archive.write("bundle.tar", archive);
+```
+
+**Extract an archive:**
+
+```ts
+const tarball = await Bun.file("package.tar.gz").bytes();
+const archive = Bun.Archive.from(tarball);
+const fileCount = await archive.extract("./output");
+console.log(`Extracted ${fileCount} files`);
+```
+
+**Read archive contents without extracting:**
+
+```ts
+const archive = Bun.Archive.from(tarballBytes);
+const files = await archive.files();
+
+for (const [path, file] of files) {
+  console.log(`${path}: ${await file.text()}`);
+}
+```
+
+## Creating Archives
+
+Use `Bun.Archive.from()` to create an archive from an object where keys are file paths and values are file contents:
+
+```ts
+const archive = Bun.Archive.from({
+  "README.md": "# My Project",
+  "src/index.ts": "console.log('Hello');",
+  "package.json": JSON.stringify({ name: "my-project" }),
+});
+```
+
+File contents can be:
+- **Strings** - Text content
+- **Blobs** - Binary data
+- **TypedArrays** (e.g., `Uint8Array`) - Raw bytes
+- **ArrayBuffers** - Raw binary data
+
+```ts
+const archive = Bun.Archive.from({
+  "text.txt": "Plain text",
+  "blob.bin": new Blob([data]),
+  "bytes.bin": new Uint8Array([1, 2, 3, 4]),
+  "buffer.bin": arrayBuffer,
+});
+```
+
+### Writing Archives to Disk
+
+Use `Bun.Archive.write()` to create and write an archive in one operation:
+
+```ts
+// Write uncompressed tar
+await Bun.Archive.write("output.tar", {
+  "file1.txt": "content1",
+  "file2.txt": "content2",
+});
+
+// Write gzipped tar
+await Bun.Archive.write("output.tar.gz", files, "gzip");
+```
+
+### Getting Archive Bytes
+
+Get the archive data as bytes or a Blob:
+
+```ts
+const archive = Bun.Archive.from(files);
+
+// As Uint8Array
+const bytes = await archive.bytes();
+
+// As Blob
+const blob = await archive.blob();
+
+// With gzip compression
+const gzippedBytes = await archive.bytes("gzip");
+const gzippedBlob = await archive.blob("gzip");
+```
+
+## Extracting Archives
+
+### From Existing Archive Data
+
+Create an archive from existing tar/tar.gz data:
+
+```ts
+// From a file
+const tarball = await Bun.file("package.tar.gz").bytes();
+const archive = Bun.Archive.from(tarball);
+
+// From a fetch response
+const response = await fetch("https://example.com/archive.tar.gz");
+const archive = Bun.Archive.from(await response.blob());
+```
+
+### Extracting to Disk
+
+Use `.extract()` to write all files to a directory:
+
+```ts
+const archive = Bun.Archive.from(tarballBytes);
+const count = await archive.extract("./extracted");
+console.log(`Extracted ${count} files`);
+```
+
+The target directory is created automatically if it doesn't exist. Existing files are overwritten.
+
+## Reading Archive Contents
+
+### Get All Files
+
+Use `.files()` to get archive contents as a `Map` of `File` objects without extracting to disk:
+
+```ts
+const archive = Bun.Archive.from(tarballBytes);
+const files = await archive.files();
+
+for (const [path, file] of files) {
+  console.log(`${path}: ${file.size} bytes`);
+  console.log(await file.text());
+}
+```
+
+Each `File` object includes:
+- `name` - The file path within the archive
+- `size` - File size in bytes
+- `lastModified` - Modification timestamp
+- Standard `Blob` methods: `text()`, `arrayBuffer()`, `stream()`, etc.
+
+### Filtering with Glob Patterns
+
+Pass a glob pattern to filter which files are returned:
+
+```ts
+// Get only TypeScript files
+const tsFiles = await archive.files("**/*.ts");
+
+// Get files in src directory
+const srcFiles = await archive.files("src/*");
+
+// Get all JSON files
+const jsonFiles = await archive.files("*.json");
+```
+
+Supported glob patterns:
+- `*` - Match any characters except `/`
+- `**` - Match any characters including `/`
+- `?` - Match single character
+- `[abc]` - Match character set
+- `{a,b}` - Match alternatives
+
+## Compression
+
+Bun.Archive supports gzip compression for both reading and writing:
+
+```ts
+// Reading: automatically detects gzip
+const archive = Bun.Archive.from(gzippedTarball);
+
+// Writing: specify compression
+await Bun.Archive.write("output.tar.gz", files, "gzip");
+
+// Getting bytes: specify compression
+const gzippedBytes = await archive.bytes("gzip");
+```
+
+The compression argument accepts:
+- `"gzip"` - Enable gzip compression
+- `true` - Same as `"gzip"`
+- `false` or `undefined` - No compression
+
+## Examples
+
+### Bundle Project Files
+
+```ts
+import { Glob } from "bun";
+
+// Collect source files
+const files: Record<string, string> = {};
+const glob = new Glob("src/**/*.ts");
+
+for await (const path of glob.scan(".")) {
+  files[path] = await Bun.file(path).text();
+}
+
+// Add package.json
+files["package.json"] = await Bun.file("package.json").text();
+
+// Create compressed archive
+await Bun.Archive.write("bundle.tar.gz", files, "gzip");
+```
+
+### Extract and Process npm Package
+
+```ts
+const response = await fetch("https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz");
+const archive = Bun.Archive.from(await response.blob());
+
+// Get package.json
+const files = await archive.files("package/package.json");
+const packageJson = files.get("package/package.json");
+
+if (packageJson) {
+  const pkg = JSON.parse(await packageJson.text());
+  console.log(`Package: ${pkg.name}@${pkg.version}`);
+}
+```
+
+### Create Archive from Directory
+
+```ts
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+async function archiveDirectory(dir: string): Promise<Bun.Archive> {
+  const files: Record<string, Blob> = {};
+
+  async function walk(currentDir: string, prefix: string = "") {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry.name);
+      const archivePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+      if (entry.isDirectory()) {
+        await walk(fullPath, archivePath);
+      } else {
+        files[archivePath] = Bun.file(fullPath);
+      }
+    }
+  }
+
+  await walk(dir);
+  return Bun.Archive.from(files);
+}
+
+const archive = await archiveDirectory("./my-project");
+await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
+```
+
+## Reference
+
+```ts
+class Archive {
+  /**
+   * Create an Archive from input data
+   */
+  static from(data: ArchiveInput): Archive;
+
+  /**
+   * Write an archive directly to disk
+   */
+  static write(
+    path: string,
+    data: ArchiveInput,
+    compress?: "gzip" | boolean
+  ): Promise<void>;
+
+  /**
+   * Extract archive to a directory
+   * @returns Number of files extracted
+   */
+  extract(path: string): Promise<number>;
+
+  /**
+   * Get archive as a Blob
+   */
+  blob(compress?: "gzip" | boolean): Promise<Blob>;
+
+  /**
+   * Get archive as a Uint8Array
+   */
+  bytes(compress?: "gzip" | boolean): Promise<Uint8Array>;
+
+  /**
+   * Get archive contents as File objects
+   * @param glob - Optional glob pattern to filter files
+   */
+  files(glob?: string): Promise<Map<string, File>>;
+}
+
+type ArchiveInput =
+  | Record<string, string | Blob | TypedArray | ArrayBuffer>
+  | Blob
+  | TypedArray
+  | ArrayBuffer;
+```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -182,6 +182,7 @@ try {
 ```
 
 Common error scenarios:
+
 - **Corrupted/truncated archives** - `Archive.from()` throws when data is invalid
 - **Permission denied** - `extract()` throws if the target directory is not writable
 - **Disk full** - `extract()` throws if there's insufficient space

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -278,8 +278,11 @@ const tsFiles = await archive.files("**/*.ts");
 // Get files in src directory
 const srcFiles = await archive.files("src/*");
 
-// Get all JSON files
-const jsonFiles = await archive.files("*.json");
+// Get all JSON files (recursive)
+const jsonFiles = await archive.files("**/*.json");
+
+// Get multiple file types with array of patterns
+const codeFiles = await archive.files(["**/*.ts", "**/*.js"]);
 ```
 
 Supported glob patterns:

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -156,18 +156,17 @@ const count = await archive.extract("./output", {
 });
 ```
 
-Use ignore patterns to exclude files:
+Use negative patterns (prefixed with `!`) to exclude files:
 
 ```ts
-// Extract everything except test files
+// Extract everything except node_modules
 const count = await archive.extract("./dist", {
-  ignore: "**/*.test.*",
+  glob: ["**", "!node_modules/**"],
 });
 
-// Combine glob and ignore patterns
+// Extract source files but exclude tests
 const count = await archive.extract("./output", {
-  glob: "src/**",
-  ignore: ["**/*.test.ts", "**/__tests__/**"],
+  glob: ["src/**", "!**/*.test.ts", "!**/__tests__/**"],
 });
 ```
 
@@ -400,10 +399,8 @@ type ArchiveInput =
   | ArrayBufferLike;
 
 interface ArchiveExtractOptions {
-  /** Glob pattern(s) to include */
+  /** Glob pattern(s) to filter extraction. Supports negative patterns with "!" prefix. */
   glob?: string | readonly string[];
-  /** Glob pattern(s) to exclude */
-  ignore?: string | readonly string[];
 }
 
 class Archive {

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -117,7 +117,9 @@ Create an archive from existing tar/tar.gz data:
 // From a file
 const tarball = await Bun.file("package.tar.gz").bytes();
 const archive = Bun.Archive.from(tarball);
+```
 
+```ts
 // From a fetch response
 const response = await fetch("https://example.com/archive.tar.gz");
 const archive = Bun.Archive.from(await response.blob());
@@ -397,6 +399,6 @@ class Archive {
   /**
    * Get archive contents as File objects
    */
-  files(glob?: string): Promise<Map<string, File>>;
+  files(glob?: string | string[]): Promise<Map<string, File>>;
 }
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -32,7 +32,8 @@ console.log(`Extracted ${fileCount} files`);
 **Read archive contents without extracting:**
 
 ```ts
-const archive = Bun.Archive.from(tarballBytes);
+const tarball = await Bun.file("package.tar.gz").bytes();
+const archive = Bun.Archive.from(tarball);
 const files = await archive.files();
 
 for (const [path, file] of files) {
@@ -56,7 +57,7 @@ File contents can be:
 
 - **Strings** - Text content
 - **Blobs** - Binary data
-- **TypedArrays** (e.g., `Uint8Array`) - Raw bytes
+- **ArrayBufferViews** (e.g., `Uint8Array`) - Raw bytes
 - **ArrayBuffers** - Raw binary data
 
 ```ts
@@ -303,5 +304,5 @@ class Archive {
   files(glob?: string): Promise<Map<string, File>>;
 }
 
-type ArchiveInput = Record<string, string | Blob | TypedArray | ArrayBuffer> | Blob | TypedArray | ArrayBuffer;
+type ArchiveInput = Record<string, string | Blob | ArrayBufferView | ArrayBuffer> | Blob | ArrayBufferView | ArrayBuffer;
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -53,6 +53,7 @@ const archive = Bun.Archive.from({
 ```
 
 File contents can be:
+
 - **Strings** - Text content
 - **Blobs** - Binary data
 - **TypedArrays** (e.g., `Uint8Array`) - Raw bytes
@@ -145,6 +146,7 @@ for (const [path, file] of files) {
 ```
 
 Each `File` object includes:
+
 - `name` - The file path within the archive
 - `size` - File size in bytes
 - `lastModified` - Modification timestamp
@@ -166,6 +168,7 @@ const jsonFiles = await archive.files("*.json");
 ```
 
 Supported glob patterns:
+
 - `*` - Match any characters except `/`
 - `**` - Match any characters including `/`
 - `?` - Match single character
@@ -188,6 +191,7 @@ const gzippedBytes = await archive.bytes("gzip");
 ```
 
 The compression argument accepts:
+
 - `"gzip"` - Enable gzip compression
 - `true` - Same as `"gzip"`
 - `false` or `undefined` - No compression
@@ -274,11 +278,7 @@ class Archive {
   /**
    * Write an archive directly to disk
    */
-  static write(
-    path: string,
-    data: ArchiveInput,
-    compress?: "gzip" | boolean
-  ): Promise<void>;
+  static write(path: string, data: ArchiveInput, compress?: "gzip" | boolean): Promise<void>;
 
   /**
    * Extract archive to a directory
@@ -303,9 +303,5 @@ class Archive {
   files(glob?: string): Promise<Map<string, File>>;
 }
 
-type ArchiveInput =
-  | Record<string, string | Blob | TypedArray | ArrayBuffer>
-  | Blob
-  | TypedArray
-  | ArrayBuffer;
+type ArchiveInput = Record<string, string | Blob | TypedArray | ArrayBuffer> | Blob | TypedArray | ArrayBuffer;
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -230,28 +230,31 @@ Common error scenarios:
 
 The count returned by `extract()` includes all successfully written entries (files, directories, and symlinks on POSIX systems).
 
-**Security warning**: When extracting archives from untrusted sources, be aware of potential security risks like path traversal attacks (e.g., `../../../etc/passwd`) or symlink attacks. For untrusted archives, validate paths before extraction:
+**Security note**: Bun.Archive automatically validates paths during extraction, rejecting:
+- Absolute paths (starting with `/` or `\`)
+- Path traversal attempts (containing `..` components)
+- Unsafe symlink targets
+
+For additional security with untrusted archives, you can enumerate and validate paths before extraction:
 
 ```ts
 const archive = Bun.Archive.from(untrustedData);
 const files = await archive.files();
 
-// Validate each path before extraction
+// Optional: Custom validation for additional checks
 for (const [path] of files) {
-  // Reject absolute paths
-  if (path.startsWith("/") || path.startsWith("\\")) {
-    throw new Error(`Unsafe path: ${path}`);
+  // Example: Reject hidden files
+  if (path.startsWith(".") || path.includes("/.")) {
+    throw new Error(`Hidden file rejected: ${path}`);
   }
-  // Reject path traversal
-  if (path.includes("..")) {
-    throw new Error(`Path traversal detected: ${path}`);
+  // Example: Whitelist specific directories
+  if (!path.startsWith("src/") && !path.startsWith("lib/")) {
+    throw new Error(`Unexpected path: ${path}`);
   }
 }
 
-// Extract to a controlled destination after validation
-await archive.extract("./safe-output", {
-  ignore: ["../**", "/**"], // Extra safety
-});
+// Extract to a controlled destination
+await archive.extract("./safe-output");
 ```
 
 When using `files()` with a glob pattern, an empty `Map` is returned if no files match:

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -223,12 +223,36 @@ try {
 
 Common error scenarios:
 
-- **Corrupted/truncated archives** - `Archive.from()` throws when data is invalid
+- **Corrupted/truncated archives** - `Archive.from()` loads the archive data; errors may be deferred until read/extract operations
 - **Permission denied** - `extract()` throws if the target directory is not writable
 - **Disk full** - `extract()` throws if there's insufficient space
 - **Invalid paths** - Operations throw for malformed file paths
 
-**Security warning**: When extracting archives from untrusted sources, be aware of potential security risks like path traversal attacks (e.g., `../../../etc/passwd`) or symlink attacks. Consider validating file paths and avoiding extraction of symlinks from untrusted archives.
+The count returned by `extract()` includes all successfully written entries (files, directories, and symlinks on POSIX systems).
+
+**Security warning**: When extracting archives from untrusted sources, be aware of potential security risks like path traversal attacks (e.g., `../../../etc/passwd`) or symlink attacks. For untrusted archives, validate paths before extraction:
+
+```ts
+const archive = Bun.Archive.from(untrustedData);
+const files = await archive.files();
+
+// Validate each path before extraction
+for (const [path] of files) {
+  // Reject absolute paths
+  if (path.startsWith("/") || path.startsWith("\\")) {
+    throw new Error(`Unsafe path: ${path}`);
+  }
+  // Reject path traversal
+  if (path.includes("..")) {
+    throw new Error(`Path traversal detected: ${path}`);
+  }
+}
+
+// Extract to a controlled destination after validation
+await archive.extract("./safe-output", {
+  ignore: ["../**", "/**"],  // Extra safety
+});
+```
 
 When using `files()` with a glob pattern, an empty `Map` is returned if no files match:
 
@@ -370,9 +394,9 @@ type ArchiveInput =
 
 interface ArchiveExtractOptions {
   /** Glob pattern(s) to include */
-  glob?: string | string[];
+  glob?: string | readonly string[];
   /** Glob pattern(s) to exclude */
-  ignore?: string | string[];
+  ignore?: string | readonly string[];
 }
 
 class Archive {
@@ -388,7 +412,7 @@ class Archive {
 
   /**
    * Extract archive to a directory
-   * @returns Number of files extracted
+   * @returns Number of entries extracted (files, directories, and symlinks)
    */
   extract(path: string, options?: ArchiveExtractOptions): Promise<number>;
 
@@ -405,6 +429,6 @@ class Archive {
   /**
    * Get archive contents as File objects
    */
-  files(glob?: string | string[]): Promise<Map<string, File>>;
+  files(glob?: string | readonly string[]): Promise<Map<string, File>>;
 }
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -304,5 +304,9 @@ class Archive {
   files(glob?: string): Promise<Map<string, File>>;
 }
 
-type ArchiveInput = Record<string, string | Blob | ArrayBufferView | ArrayBuffer> | Blob | ArrayBufferView | ArrayBuffer;
+type ArchiveInput =
+  | Record<string, string | Blob | ArrayBufferView | ArrayBuffer>
+  | Blob
+  | ArrayBufferView
+  | ArrayBuffer;
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -138,13 +138,13 @@ console.log(`Extracted ${count} entries`);
 
 The target directory is created automatically if it doesn't exist. Existing files are overwritten. The returned count includes files, directories, and symlinks (on POSIX systems).
 
-**Note**: On Windows, symbolic links in archives are skipped during extraction since they require elevated privileges. On Linux and macOS, symlinks are extracted normally.
+**Note**: On Windows, symbolic links in archives are always skipped during extraction. Bun does not attempt to create them regardless of privilege level. On Linux and macOS, symlinks are extracted normally.
 
-**Security note**: Bun.Archive validates paths during extraction, rejecting absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, and UNC paths like `\\server\share`) as well as path traversal attempts containing `..` components.
+**Security note**: Bun.Archive validates paths during extraction, rejecting absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, and UNC paths like `\\server\share`). When using glob filters, paths containing `..` components are rejected; without filters, `..` components are normalized away (e.g., `dir/sub/../file` becomes `dir/file`).
 
 ### Filtering Extracted Files
 
-Use glob patterns to extract only specific files:
+Use glob patterns to extract only specific files. Patterns are matched against archive entry paths normalized to use forward slashes (`/`). Positive patterns specify what to include, and negative patterns (prefixed with `!`) specify what to exclude. Negative patterns are applied after positive patterns:
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
@@ -159,7 +159,7 @@ const multiCount = await archive.extract("./extracted", {
 });
 ```
 
-Use negative patterns (prefixed with `!`) to exclude files:
+Use negative patterns (prefixed with `!`) to exclude files. When mixing positive and negative patterns, entries must match at least one positive pattern and not match any negative pattern:
 
 ```ts
 // Extract everything except node_modules

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -289,13 +289,16 @@ const jsonFiles = await archive.files("**/*.json");
 const codeFiles = await archive.files(["**/*.ts", "**/*.js"]);
 ```
 
-Supported glob patterns:
+Supported glob patterns (subset of [Bun.Glob](/docs/api/glob) syntax):
 
 - `*` - Match any characters except `/`
 - `**` - Match any characters including `/`
 - `?` - Match single character
 - `[abc]` - Match character set
 - `{a,b}` - Match alternatives
+- `!pattern` - Exclude files matching pattern (negation)
+
+See [Bun.Glob](/docs/api/glob) for the full glob syntax including escaping and advanced patterns.
 
 ## Compression
 
@@ -332,7 +335,9 @@ const files: Record<string, string> = {};
 const glob = new Glob("src/**/*.ts");
 
 for await (const path of glob.scan(".")) {
-  files[path] = await Bun.file(path).text();
+  // Normalize path separators to forward slashes for cross-platform compatibility
+  const archivePath = path.replaceAll("\\", "/");
+  files[archivePath] = await Bun.file(path).text();
 }
 
 // Add package.json

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -145,13 +145,14 @@ The target directory is created automatically if it doesn't exist. Existing file
 Use glob patterns to extract only specific files:
 
 ```ts
+const tarball = await Bun.file("package.tar.gz").bytes();
 const archive = Bun.Archive.from(tarball);
 
 // Extract only TypeScript files
-const tsCount = await archive.extract("./src", { glob: "**/*.ts" });
+const tsCount = await archive.extract("./extracted", { glob: "**/*.ts" });
 
 // Extract files from multiple directories
-const multiCount = await archive.extract("./output", {
+const multiCount = await archive.extract("./extracted", {
   glob: ["src/**", "lib/**"],
 });
 ```
@@ -160,12 +161,12 @@ Use negative patterns (prefixed with `!`) to exclude files:
 
 ```ts
 // Extract everything except node_modules
-const distCount = await archive.extract("./dist", {
+const distCount = await archive.extract("./extracted", {
   glob: ["**", "!node_modules/**"],
 });
 
 // Extract source files but exclude tests
-const srcCount = await archive.extract("./output", {
+const srcCount = await archive.extract("./extracted", {
   glob: ["src/**", "!**/*.test.ts", "!**/__tests__/**"],
 });
 ```
@@ -189,10 +190,12 @@ for (const [path, file] of files) {
 
 Each `File` object includes:
 
-- `name` - The file path within the archive
+- `name` - The file path within the archive (always uses forward slashes `/` as separators)
 - `size` - File size in bytes
 - `lastModified` - Modification timestamp
 - Standard `Blob` methods: `text()`, `arrayBuffer()`, `stream()`, etc.
+
+**Note**: `files()` loads file contents into memory. For very large archives, consider using `extract()` to write directly to disk instead.
 
 ### Error Handling
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -116,13 +116,13 @@ Create an archive from existing tar/tar.gz data:
 ```ts
 // From a file
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archive = Bun.Archive.from(tarball);
+const archiveFromFile = Bun.Archive.from(tarball);
 ```
 
 ```ts
 // From a fetch response
 const response = await fetch("https://example.com/archive.tar.gz");
-const archive = Bun.Archive.from(await response.blob());
+const archiveFromFetch = Bun.Archive.from(await response.blob());
 ```
 
 ### Extracting to Disk
@@ -148,10 +148,10 @@ Use glob patterns to extract only specific files:
 const archive = Bun.Archive.from(tarball);
 
 // Extract only TypeScript files
-const count = await archive.extract("./src", { glob: "**/*.ts" });
+const tsCount = await archive.extract("./src", { glob: "**/*.ts" });
 
 // Extract files from multiple directories
-const count = await archive.extract("./output", {
+const multiCount = await archive.extract("./output", {
   glob: ["src/**", "lib/**"],
 });
 ```
@@ -160,12 +160,12 @@ Use negative patterns (prefixed with `!`) to exclude files:
 
 ```ts
 // Extract everything except node_modules
-const count = await archive.extract("./dist", {
+const distCount = await archive.extract("./dist", {
   glob: ["**", "!node_modules/**"],
 });
 
 // Extract source files but exclude tests
-const count = await archive.extract("./output", {
+const srcCount = await archive.extract("./output", {
   glob: ["src/**", "!**/*.test.ts", "!**/__tests__/**"],
 });
 ```

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -140,11 +140,11 @@ The target directory is created automatically if it doesn't exist. Existing file
 
 **Note**: On Windows, symbolic links in archives are always skipped during extraction. Bun does not attempt to create them regardless of privilege level. On Linux and macOS, symlinks are extracted normally.
 
-**Security note**: Bun.Archive validates paths during extraction, rejecting absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, and UNC paths like `\\server\share`). When using glob filters, paths containing `..` components are rejected; without filters, `..` components are normalized away (e.g., `dir/sub/../file` becomes `dir/file`).
+**Security note**: Bun.Archive validates paths during extraction, rejecting absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, and UNC paths like `\\server\share`). Path traversal components (`..`) are normalized away (e.g., `dir/sub/../file` becomes `dir/file`) to prevent directory escape attacks.
 
 ### Filtering Extracted Files
 
-Use glob patterns to extract only specific files. Patterns are matched against archive entry paths normalized to use forward slashes (`/`). Positive patterns specify what to include, and negative patterns (prefixed with `!`) specify what to exclude. Negative patterns are applied after positive patterns:
+Use glob patterns to extract only specific files. Patterns are matched against archive entry paths normalized to use forward slashes (`/`). Positive patterns specify what to include, and negative patterns (prefixed with `!`) specify what to exclude. Negative patterns are applied after positive patterns, so **using only negative patterns will match nothing** (you must include a positive pattern like `**` first):
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
@@ -234,11 +234,7 @@ Common error scenarios:
 
 The count returned by `extract()` includes all successfully written entries (files, directories, and symlinks on POSIX systems).
 
-**Security note**: Bun.Archive automatically validates paths during extraction, rejecting:
-
-- Absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, UNC paths like `\\server\share`)
-- Path traversal attempts (containing `..` components)
-- Unsafe symlink targets
+**Security note**: Bun.Archive automatically validates paths during extraction. Absolute paths (POSIX `/`, Windows drive letters, UNC paths) and unsafe symlink targets are rejected. Path traversal components (`..`) are normalized away to prevent directory escape.
 
 For additional security with untrusted archives, you can enumerate and validate paths before extraction:
 
@@ -296,7 +292,7 @@ Supported glob patterns (subset of [Bun.Glob](/docs/api/glob) syntax):
 - `?` - Match single character
 - `[abc]` - Match character set
 - `{a,b}` - Match alternatives
-- `!pattern` - Exclude files matching pattern (negation)
+- `!pattern` - Exclude files matching pattern (negation). Must be combined with positive patterns; using only negative patterns matches nothing.
 
 See [Bun.Glob](/docs/api/glob) for the full glob syntax including escaping and advanced patterns.
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -25,8 +25,8 @@ await Bun.Archive.write("bundle.tar", archive);
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
 const archive = Bun.Archive.from(tarball);
-const fileCount = await archive.extract("./output");
-console.log(`Extracted ${fileCount} files`);
+const entryCount = await archive.extract("./output");
+console.log(`Extracted ${entryCount} entries`);
 ```
 
 **Read archive contents without extracting:**
@@ -133,10 +133,10 @@ Use `.extract()` to write all files to a directory:
 const tarball = await Bun.file("package.tar.gz").bytes();
 const archive = Bun.Archive.from(tarball);
 const count = await archive.extract("./extracted");
-console.log(`Extracted ${count} files`);
+console.log(`Extracted ${count} entries`);
 ```
 
-The target directory is created automatically if it doesn't exist. Existing files are overwritten.
+The target directory is created automatically if it doesn't exist. Existing files are overwritten. The returned count includes files, directories, and symlinks (on POSIX systems).
 
 **Note**: On Windows, symbolic links in archives are skipped during extraction since they require elevated privileges. On Linux and macOS, symlinks are extracted normally.
 
@@ -174,7 +174,7 @@ const srcCount = await archive.extract("./output", {
 
 ### Get All Files
 
-Use `.files()` to get archive contents as a `Map` of `File` objects without extracting to disk:
+Use `.files()` to get archive contents as a `Map` of `File` objects without extracting to disk. Unlike `extract()` which processes all entry types, `files()` returns only regular files (no directories):
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
@@ -203,7 +203,7 @@ try {
   const tarball = await Bun.file("package.tar.gz").bytes();
   const archive = Bun.Archive.from(tarball);
   const count = await archive.extract("./output");
-  console.log(`Extracted ${count} files`);
+  console.log(`Extracted ${count} entries`);
 } catch (e: unknown) {
   if (e instanceof Error) {
     const error = e as Error & { code?: string };
@@ -388,14 +388,12 @@ await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
 ## Reference
 
 ```ts
-type ArrayBufferView = NodeJS.TypedArray | DataView;
-
 type ArchiveCompression = "gzip" | boolean;
 
 type ArchiveInput =
-  | Record<string, string | Blob | ArrayBufferView | ArrayBufferLike>
+  | Record<string, string | Blob | Bun.ArrayBufferView | ArrayBufferLike>
   | Blob
-  | ArrayBufferView
+  | Bun.ArrayBufferView
   | ArrayBufferLike;
 
 interface ArchiveExtractOptions {
@@ -431,7 +429,7 @@ class Archive {
   bytes(compress?: ArchiveCompression): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
-   * Get archive contents as File objects
+   * Get archive contents as File objects (regular files only, no directories)
    */
   files(glob?: string | readonly string[]): Promise<Map<string, File>>;
 }

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -140,6 +140,8 @@ The target directory is created automatically if it doesn't exist. Existing file
 
 **Note**: On Windows, symbolic links in archives are skipped during extraction since they require elevated privileges. On Linux and macOS, symlinks are extracted normally.
 
+**Security note**: Bun.Archive validates paths during extraction, rejecting absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, and UNC paths like `\\server\share`) as well as path traversal attempts containing `..` components.
+
 ### Filtering Extracted Files
 
 Use glob patterns to extract only specific files:
@@ -195,7 +197,7 @@ Each `File` object includes:
 - `lastModified` - Modification timestamp
 - Standard `Blob` methods: `text()`, `arrayBuffer()`, `stream()`, etc.
 
-**Note**: `files()` loads file contents into memory. For very large archives, consider using `extract()` to write directly to disk instead.
+**Note**: `files()` loads file contents into memory. For large archives, consider using `extract()` to write directly to disk instead.
 
 ### Error Handling
 
@@ -234,7 +236,7 @@ The count returned by `extract()` includes all successfully written entries (fil
 
 **Security note**: Bun.Archive automatically validates paths during extraction, rejecting:
 
-- Absolute paths (starting with `/` or `\`)
+- Absolute paths (POSIX `/`, Windows drive letters like `C:\` or `C:/`, UNC paths like `\\server\share`)
 - Path traversal attempts (containing `..` components)
 - Unsafe symlink targets
 
@@ -389,6 +391,8 @@ await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
 ```
 
 ## Reference
+
+> **Note**: The following type signatures are simplified for documentation purposes. See [`packages/bun-types/bun.d.ts`](https://github.com/oven-sh/bun/blob/main/packages/bun-types/bun.d.ts) for the full type definitions.
 
 ```ts
 type ArchiveCompression = "gzip" | boolean;

--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -358,7 +358,7 @@ Bun represents [pointers](<https://en.wikipedia.org/wiki/Pointer_(computer_progr
 
 **Why not `BigInt`?** `BigInt` is slower. JavaScript engines allocate a separate `BigInt` which means they can't fit into a regular JavaScript value. If you pass a `BigInt` to a function, it will be converted to a `number`
 
-**Windows Note**: The Windows API type HANDLE does not represent a virtual address, and using `ptr` for it will *not* work as expected. Use `u64` to safely represent HANDLE values.
+**Windows Note**: The Windows API type HANDLE does not represent a virtual address, and using `ptr` for it will _not_ work as expected. Use `u64` to safely represent HANDLE values.
 
 </Accordion>
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6986,33 +6986,29 @@ declare module "bun" {
    */
   interface ArchiveExtractOptions {
     /**
-     * Glob pattern(s) to include. Only files matching at least one pattern will be extracted.
-     * If not specified, all files are included (unless excluded by `ignore`).
+     * Glob pattern(s) to filter which files are extracted.
+     *
+     * - Positive patterns: Only files matching at least one pattern will be extracted.
+     * - Negative patterns (prefixed with `!`): Files matching these patterns will be excluded.
+     *
+     * If not specified, all files are extracted.
      *
      * @example
      * ```ts
      * // Extract only TypeScript files
-     * await archive.extract("./out", { glob: "src/*.ts" });
+     * await archive.extract("./out", { glob: "**\/*.ts" });
      *
      * // Extract files from multiple directories
      * await archive.extract("./out", { glob: ["src/**", "lib/**"] });
+     *
+     * // Exclude node_modules using negative pattern
+     * await archive.extract("./out", { glob: ["**", "!node_modules/**"] });
+     *
+     * // Extract source files but exclude tests
+     * await archive.extract("./out", { glob: ["src/**", "!**\/*.test.ts"] });
      * ```
      */
     glob?: string | readonly string[];
-
-    /**
-     * Glob pattern(s) to exclude. Files matching any pattern will be skipped.
-     *
-     * @example
-     * ```ts
-     * // Exclude test files
-     * await archive.extract("./out", { ignore: "*.test.*" });
-     *
-     * // Exclude multiple patterns
-     * await archive.extract("./out", { ignore: ["*.test.ts", "__tests__/**"] });
-     * ```
-     */
-    ignore?: string | readonly string[];
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6986,6 +6986,40 @@ declare module "bun" {
   type ArchiveCompression = "gzip" | boolean;
 
   /**
+   * Options for extracting archive contents.
+   */
+  interface ArchiveExtractOptions {
+    /**
+     * Glob pattern(s) to include. Only files matching at least one pattern will be extracted.
+     * If not specified, all files are included (unless excluded by `ignore`).
+     *
+     * @example
+     * ```ts
+     * // Extract only TypeScript files
+     * { glob: "**\/*.ts" }
+     *
+     * // Extract files from multiple directories
+     * { glob: ["src/**", "lib/**"] }
+     * ```
+     */
+    glob?: string | string[];
+
+    /**
+     * Glob pattern(s) to exclude. Files matching any pattern will be skipped.
+     *
+     * @example
+     * ```ts
+     * // Exclude test files
+     * { ignore: "**\/*.test.*" }
+     *
+     * // Exclude multiple patterns
+     * { ignore: ["**\/*.test.ts", "**\/__tests__/**", "node_modules/**"] }
+     * ```
+     */
+    ignore?: string | string[];
+  }
+
+  /**
    * A class for creating and extracting tar archives with optional gzip compression.
    *
    * `Bun.Archive` provides a fast, native implementation for working with tar archives.
@@ -7092,16 +7126,41 @@ declare module "bun" {
      * Existing files will be overwritten.
      *
      * @param path - The directory path to extract files to
+     * @param options - Optional extraction options
+     * @param options.glob - Glob pattern(s) to include (only matching files are extracted)
+     * @param options.ignore - Glob pattern(s) to exclude (matching files are skipped)
      * @returns A promise that resolves with the number of files extracted
      *
      * @example
+     * **Extract all files:**
      * ```ts
      * const archive = Bun.Archive.from(tarballBytes);
      * const count = await archive.extract("./extracted");
      * console.log(`Extracted ${count} files`);
      * ```
+     *
+     * @example
+     * **Extract only TypeScript files:**
+     * ```ts
+     * const count = await archive.extract("./src", { glob: "**\/*.ts" });
+     * ```
+     *
+     * @example
+     * **Extract everything except tests:**
+     * ```ts
+     * const count = await archive.extract("./dist", { ignore: "**\/*.test.*" });
+     * ```
+     *
+     * @example
+     * **Combine glob and ignore patterns:**
+     * ```ts
+     * const count = await archive.extract("./output", {
+     *   glob: ["src/**", "lib/**"],
+     *   ignore: ["**\/*.test.ts", "**\/__tests__/**"]
+     * });
+     * ```
      */
-    extract(path: string): Promise<number>;
+    extract(path: string, options?: ArchiveExtractOptions): Promise<number>;
 
     /**
      * Get the archive contents as a `Blob`.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7083,7 +7083,7 @@ declare module "bun" {
      * await Bun.Archive.write("output.tar.gz", files, "gzip");
      * ```
      */
-    static write(path: string, data: ArchiveInput, compress?: ArchiveCompression): Promise<void>;
+    static write(path: string, data: ArchiveInput | Archive, compress?: ArchiveCompression): Promise<void>;
 
     /**
      * Extract the archive contents to a directory on disk.
@@ -7141,7 +7141,7 @@ declare module "bun" {
      * const gzippedBytes = await archive.bytes("gzip");
      * ```
      */
-    bytes(compress?: ArchiveCompression): Promise<Uint8Array>;
+    bytes(compress?: ArchiveCompression): Promise<Uint8Array<ArrayBuffer>>;
 
     /**
      * Get the archive contents as a `Map` of `File` objects.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6972,9 +6972,9 @@ declare module "bun" {
    * - A TypedArray or ArrayBuffer containing existing archive data
    */
   type ArchiveInput =
-    | Record<string, string | Blob | NodeJS.TypedArray | ArrayBufferLike>
+    | Record<string, string | Blob | ArrayBufferView | ArrayBufferLike>
     | Blob
-    | NodeJS.TypedArray
+    | ArrayBufferView
     | ArrayBufferLike;
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6996,10 +6996,10 @@ declare module "bun" {
      * @example
      * ```ts
      * // Extract only TypeScript files
-     * { glob: "**\/*.ts" }
+     * await archive.extract("./out", { glob: "src/*.ts" });
      *
      * // Extract files from multiple directories
-     * { glob: ["src/**", "lib/**"] }
+     * await archive.extract("./out", { glob: ["src/**", "lib/**"] });
      * ```
      */
     glob?: string | string[];
@@ -7010,10 +7010,10 @@ declare module "bun" {
      * @example
      * ```ts
      * // Exclude test files
-     * { ignore: "**\/*.test.*" }
+     * await archive.extract("./out", { ignore: "*.test.*" });
      *
      * // Exclude multiple patterns
-     * { ignore: ["**\/*.test.ts", "**\/__tests__/**", "node_modules/**"] }
+     * await archive.extract("./out", { ignore: ["*.test.ts", "__tests__/**"] });
      * ```
      */
     ignore?: string | string[];
@@ -7212,7 +7212,7 @@ declare module "bun" {
      *
      * Only regular files are included; directories are not returned.
      *
-     * @param glob - Optional glob pattern to filter files (e.g., `"*.txt"`, `"src/**\/*.js"`)
+     * @param glob - Optional glob pattern(s) to filter files (e.g., `"*.txt"`, `"src/**"`)
      * @returns A promise that resolves with a Map where keys are file paths and values are File objects
      *
      * @example
@@ -7227,8 +7227,8 @@ declare module "bun" {
      * @example
      * **Filter by glob pattern:**
      * ```ts
-     * const tsFiles = await archive.files("**\/*.ts");
-     * const srcFiles = await archive.files("src/*");
+     * const tsFiles = await archive.files("src/*.ts");
+     * const srcFiles = await archive.files(["src/**", "lib/**"]);
      * ```
      *
      * @example
@@ -7241,7 +7241,7 @@ declare module "bun" {
      * }
      * ```
      */
-    files(glob?: string): Promise<Map<string, File>>;
+    files(glob?: string | string[]): Promise<Map<string, File>>;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6998,7 +6998,7 @@ declare module "bun" {
      * await archive.extract("./out", { glob: ["src/**", "lib/**"] });
      * ```
      */
-    glob?: string | string[];
+    glob?: string | readonly string[];
 
     /**
      * Glob pattern(s) to exclude. Files matching any pattern will be skipped.
@@ -7012,7 +7012,7 @@ declare module "bun" {
      * await archive.extract("./out", { ignore: ["*.test.ts", "__tests__/**"] });
      * ```
      */
-    ignore?: string | string[];
+    ignore?: string | readonly string[];
   }
 
   /**
@@ -7237,7 +7237,7 @@ declare module "bun" {
      * }
      * ```
      */
-    files(glob?: string | string[]): Promise<Map<string, File>>;
+    files(glob?: string | readonly string[]): Promise<Map<string, File>>;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6971,11 +6971,7 @@ declare module "bun" {
    * - A Blob containing existing archive data
    * - A TypedArray or ArrayBuffer containing existing archive data
    */
-  type ArchiveInput =
-    | Record<string, string | Blob | ArrayBufferView | ArrayBufferLike>
-    | Blob
-    | ArrayBufferView
-    | ArrayBufferLike;
+  type ArchiveInput = Record<string, BlobPart> | Blob | ArrayBufferView | ArrayBufferLike;
 
   /**
    * Compression format for archive output.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6994,8 +6994,12 @@ declare module "bun" {
      * Uses the same syntax as {@link Bun.Glob}, including support for wildcards (`*`, `**`),
      * character classes (`[abc]`), alternation (`{a,b}`), and negation (`!pattern`).
      *
+     * Patterns are matched against archive entry paths normalized to use forward slashes (`/`),
+     * regardless of the host operating system. Always write patterns using `/` as the separator.
+     *
      * - Positive patterns: Only entries matching at least one pattern will be extracted.
      * - Negative patterns (prefixed with `!`): Entries matching these patterns will be excluded.
+     *   Negative patterns are applied after positive patterns.
      *
      * If not specified, all entries are extracted.
      *
@@ -7210,7 +7214,9 @@ declare module "bun" {
      * Only regular files are included; directories are not returned.
      * File contents are loaded into memory, so for large archives consider using `extract()` instead.
      *
-     * @param glob - Optional glob pattern(s) to filter files (e.g., `"*.txt"`, `"src" + "/**"`)
+     * @param glob - Optional glob pattern(s) to filter files. Supports the same syntax as {@link Bun.Glob},
+     *   including negation patterns (prefixed with `!`). Patterns are matched against paths normalized
+     *   to use forward slashes (`/`).
      * @returns A promise that resolves with a Map where keys are file paths (always using forward slashes `/` as separators) and values are File objects
      *
      * @example
@@ -7227,6 +7233,13 @@ declare module "bun" {
      * ```ts
      * const tsFiles = await archive.files("**" + "/*.ts");
      * const srcFiles = await archive.files(["src/**", "lib/**"]);
+     * ```
+     *
+     * @example
+     * **Exclude files with negative patterns:**
+     * ```ts
+     * // Get all source files except tests
+     * const srcFiles = await archive.files(["src/**", "!**" + "/*.test.ts"]);
      * ```
      *
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7202,9 +7202,9 @@ declare module "bun" {
      * - Standard Blob methods (`text()`, `arrayBuffer()`, `stream()`, etc.)
      *
      * Only regular files are included; directories are not returned.
-     * File contents are loaded into memory, so for very large archives consider using `extract()` instead.
+     * File contents are loaded into memory, so for large archives consider using `extract()` instead.
      *
-     * @param glob - Optional glob pattern(s) to filter files (e.g., `"*.txt"`, `"src/**"`)
+     * @param glob - Optional glob pattern(s) to filter files (e.g., `"*.txt"`, `"src" + "/**"`)
      * @returns A promise that resolves with a Map where keys are file paths (always using forward slashes `/` as separators) and values are File objects
      *
      * @example
@@ -7219,7 +7219,7 @@ declare module "bun" {
      * @example
      * **Filter by glob pattern:**
      * ```ts
-     * const tsFiles = await archive.files("**/*.ts");
+     * const tsFiles = await archive.files("**" + "/*.ts");
      * const srcFiles = await archive.files(["src/**", "lib/**"]);
      * ```
      *

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7119,8 +7119,7 @@ declare module "bun" {
      *
      * @param path - The directory path to extract files to
      * @param options - Optional extraction options
-     * @param options.glob - Glob pattern(s) to include (only matching files are extracted)
-     * @param options.ignore - Glob pattern(s) to exclude (matching files are skipped)
+     * @param options.glob - Glob pattern(s) to filter files (positive patterns include, negative patterns starting with `!` exclude)
      * @returns A promise that resolves with the number of files extracted
      *
      * @example
@@ -7140,15 +7139,14 @@ declare module "bun" {
      * @example
      * **Extract everything except tests:**
      * ```ts
-     * const count = await archive.extract("./dist", { ignore: "**\/*.test.*" });
+     * const count = await archive.extract("./dist", { glob: ["**", "!**\/*.test.*"] });
      * ```
      *
      * @example
-     * **Combine glob and ignore patterns:**
+     * **Extract source files but exclude tests:**
      * ```ts
      * const count = await archive.extract("./output", {
-     *   glob: ["src/**", "lib/**"],
-     *   ignore: ["**\/*.test.ts", "**\/__tests__/**"]
+     *   glob: ["src/**", "lib/**", "!**\/*.test.ts", "!**\/__tests__/**"]
      * });
      * ```
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7032,15 +7032,16 @@ declare module "bun" {
    * **Extract an archive to disk:**
    * ```ts
    * const archive = Bun.Archive.from(tarballBytes);
-   * const fileCount = await archive.extract("./output");
+   * const entryCount = await archive.extract("./output");
+   * console.log(`Extracted ${entryCount} entries`);
    * ```
    *
    * @example
    * **Get archive contents as a Map of File objects:**
    * ```ts
    * const archive = Bun.Archive.from(tarballBytes);
-   * const files = await archive.files();
-   * for (const [path, file] of files) {
+   * const entries = await archive.files();
+   * for (const [path, file] of entries) {
    *   console.log(path, await file.text());
    * }
    * ```
@@ -7201,15 +7202,16 @@ declare module "bun" {
      * - Standard Blob methods (`text()`, `arrayBuffer()`, `stream()`, etc.)
      *
      * Only regular files are included; directories are not returned.
+     * File contents are loaded into memory, so for very large archives consider using `extract()` instead.
      *
      * @param glob - Optional glob pattern(s) to filter files (e.g., `"*.txt"`, `"src/**"`)
-     * @returns A promise that resolves with a Map where keys are file paths and values are File objects
+     * @returns A promise that resolves with a Map where keys are file paths (always using forward slashes `/` as separators) and values are File objects
      *
      * @example
      * **Get all files:**
      * ```ts
-     * const files = await archive.files();
-     * for (const [path, file] of files) {
+     * const entries = await archive.files();
+     * for (const [path, file] of entries) {
      *   console.log(`${path}: ${file.size} bytes`);
      * }
      * ```
@@ -7217,15 +7219,15 @@ declare module "bun" {
      * @example
      * **Filter by glob pattern:**
      * ```ts
-     * const tsFiles = await archive.files("src/*.ts");
+     * const tsFiles = await archive.files("**/*.ts");
      * const srcFiles = await archive.files(["src/**", "lib/**"]);
      * ```
      *
      * @example
      * **Read file contents:**
      * ```ts
-     * const files = await archive.files();
-     * const readme = files.get("README.md");
+     * const entries = await archive.files();
+     * const readme = entries.get("README.md");
      * if (readme) {
      *   console.log(await readme.text());
      * }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6986,17 +6986,17 @@ declare module "bun" {
    */
   interface ArchiveExtractOptions {
     /**
-     * Glob pattern(s) to filter which files are extracted.
+     * Glob pattern(s) to filter which entries are extracted.
      *
-     * - Positive patterns: Only files matching at least one pattern will be extracted.
-     * - Negative patterns (prefixed with `!`): Files matching these patterns will be excluded.
+     * - Positive patterns: Only entries matching at least one pattern will be extracted.
+     * - Negative patterns (prefixed with `!`): Entries matching these patterns will be excluded.
      *
-     * If not specified, all files are extracted.
+     * If not specified, all entries are extracted.
      *
      * @example
      * ```ts
      * // Extract only TypeScript files
-     * await archive.extract("./out", { glob: "**\/*.ts" });
+     * await archive.extract("./out", { glob: "**" + "/*.ts" });
      *
      * // Extract files from multiple directories
      * await archive.extract("./out", { glob: ["src/**", "lib/**"] });
@@ -7005,7 +7005,7 @@ declare module "bun" {
      * await archive.extract("./out", { glob: ["**", "!node_modules/**"] });
      *
      * // Extract source files but exclude tests
-     * await archive.extract("./out", { glob: ["src/**", "!**\/*.test.ts"] });
+     * await archive.extract("./out", { glob: ["src/**", "!**" + "/*.test.ts"] });
      * ```
      */
     glob?: string | readonly string[];
@@ -7117,36 +7117,36 @@ declare module "bun" {
      * Creates the target directory and any necessary parent directories if they don't exist.
      * Existing files will be overwritten.
      *
-     * @param path - The directory path to extract files to
+     * @param path - The directory path to extract to
      * @param options - Optional extraction options
-     * @param options.glob - Glob pattern(s) to filter files (positive patterns include, negative patterns starting with `!` exclude)
-     * @returns A promise that resolves with the number of files extracted
+     * @param options.glob - Glob pattern(s) to filter entries (positive patterns include, negative patterns starting with `!` exclude)
+     * @returns A promise that resolves with the number of entries extracted (files, directories, and symlinks)
      *
      * @example
-     * **Extract all files:**
+     * **Extract all entries:**
      * ```ts
      * const archive = Bun.Archive.from(tarballBytes);
      * const count = await archive.extract("./extracted");
-     * console.log(`Extracted ${count} files`);
+     * console.log(`Extracted ${count} entries`);
      * ```
      *
      * @example
      * **Extract only TypeScript files:**
      * ```ts
-     * const count = await archive.extract("./src", { glob: "**\/*.ts" });
+     * const count = await archive.extract("./src", { glob: "**" + "/*.ts" });
      * ```
      *
      * @example
      * **Extract everything except tests:**
      * ```ts
-     * const count = await archive.extract("./dist", { glob: ["**", "!**\/*.test.*"] });
+     * const count = await archive.extract("./dist", { glob: ["**", "!**" + "/*.test.*"] });
      * ```
      *
      * @example
      * **Extract source files but exclude tests:**
      * ```ts
      * const count = await archive.extract("./output", {
-     *   glob: ["src/**", "lib/**", "!**\/*.test.ts", "!**\/__tests__/**"]
+     *   glob: ["src/**", "lib/**", "!**" + "/*.test.ts", "!**" + "/__tests__/**"]
      * });
      * ```
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6977,7 +6977,11 @@ declare module "bun" {
    * Compression format for archive output.
    * - `"gzip"` - Compress with gzip
    * - `true` - Same as `"gzip"`
-   * - `false` or `undefined` - No compression
+   * - `false` - Explicitly disable compression (no compression)
+   * - `undefined` - No compression (default behavior when omitted)
+   *
+   * Both `false` and `undefined` result in no compression; `false` can be used
+   * to explicitly indicate "no compression" in code where the intent should be clear.
    */
   type ArchiveCompression = "gzip" | boolean;
 
@@ -6987,6 +6991,8 @@ declare module "bun" {
   interface ArchiveExtractOptions {
     /**
      * Glob pattern(s) to filter which entries are extracted.
+     * Uses the same syntax as {@link Bun.Glob}, including support for wildcards (`*`, `**`),
+     * character classes (`[abc]`), alternation (`{a,b}`), and negation (`!pattern`).
      *
      * - Positive patterns: Only entries matching at least one pattern will be extracted.
      * - Negative patterns (prefixed with `!`): Entries matching these patterns will be excluded.

--- a/src/bun.js/api/Archive.classes.ts
+++ b/src/bun.js/api/Archive.classes.ts
@@ -20,7 +20,7 @@ export default [
     proto: {
       extract: {
         fn: "extract",
-        length: 1,
+        length: 2,
       },
       blob: {
         fn: "blob",

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -1005,7 +1005,8 @@ fn extractToDiskFiltered(
         switch (kind) {
             .directory => {
                 dir.makePath(pathname) catch |err| switch (err) {
-                    error.PathAlreadyExists => {},
+                    // Directory already exists - don't count as extracted
+                    error.PathAlreadyExists => continue,
                     else => continue,
                 };
                 count += 1;

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -963,7 +963,7 @@ fn extractToDiskFiltered(
 
         switch (kind) {
             .directory => {
-                dir.makePath(pathname) catch {};
+                dir.makePath(pathname) catch continue;
                 count += 1;
             },
             .file => {
@@ -1012,6 +1012,8 @@ fn extractToDiskFiltered(
             },
             .sym_link => {
                 const link_target = entry.symlink();
+                // Symlinks are only extracted on POSIX systems (Linux/macOS).
+                // On Windows, symlinks are skipped since they require elevated privileges.
                 if (bun.Environment.isPosix) {
                     bun.sys.symlinkat(link_target, .fromNative(dir.fd), pathname).unwrap() catch |err| {
                         switch (err) {

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -859,7 +859,7 @@ pub const FilesTask = AsyncTask(FilesContext);
 fn startFilesTask(globalThis: *jsc.JSGlobalObject, store: *jsc.WebCore.Blob.Store, glob_patterns: ?[]const []const u8) bun.JSError!jsc.JSValue {
     store.ref();
     errdefer store.deref();
-    errdefer if (glob_patterns) |patterns| freePatterns(patterns);
+    // Note: glob_patterns cleanup is handled by the caller's errdefer
 
     const task = try FilesTask.create(globalThis, .{
         .store = store,

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -780,16 +780,9 @@ const FilesContext = struct {
             if (entry.filetype() != @intFromEnum(lib.FileType.regular)) continue;
 
             const pathname = entry.pathnameUtf8();
-            // Apply glob pattern filtering (if patterns specified, at least one must match)
+            // Apply glob pattern filtering (supports both positive and negative patterns)
             if (this.glob_patterns) |patterns| {
-                var matches_any = false;
-                for (patterns) |pattern| {
-                    if (bun.glob.match(pattern, pathname).matches()) {
-                        matches_any = true;
-                        break;
-                    }
-                }
-                if (!matches_any) continue;
+                if (!matchGlobPatterns(patterns, pathname)) continue;
             }
 
             const size: usize = @intCast(@max(entry.size(), 0));

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1158,6 +1158,138 @@ describe("Bun.Archive", () => {
     });
   });
 
+  describe("extract with glob/ignore patterns", () => {
+    test("extracts only files matching glob pattern", async () => {
+      const archive = Bun.Archive.from({
+        "src/index.ts": "export {}",
+        "src/utils.ts": "export {}",
+        "src/types.d.ts": "declare {}",
+        "test/index.test.ts": "test()",
+        "README.md": "# Hello",
+        "package.json": "{}",
+      });
+
+      using dir = tempDir("archive-glob-pattern", {});
+      const count = await archive.extract(String(dir), { glob: "**/*.ts" });
+
+      // Should extract 4 .ts files (including .d.ts and .test.ts)
+      expect(count).toBe(4);
+      expect(await Bun.file(join(String(dir), "src/index.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/utils.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/types.d.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "test/index.test.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "README.md")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "package.json")).exists()).toBe(false);
+    });
+
+    test("extracts files matching any of multiple glob patterns", async () => {
+      const archive = Bun.Archive.from({
+        "src/index.ts": "export {}",
+        "lib/utils.js": "module.exports = {}",
+        "test/test.ts": "test()",
+        "README.md": "# Hello",
+      });
+
+      using dir = tempDir("archive-multi-glob", {});
+      const count = await archive.extract(String(dir), { glob: ["src/**", "lib/**"] });
+
+      expect(count).toBe(2);
+      expect(await Bun.file(join(String(dir), "src/index.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "lib/utils.js")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "test/test.ts")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "README.md")).exists()).toBe(false);
+    });
+
+    test("excludes files matching ignore pattern", async () => {
+      const archive = Bun.Archive.from({
+        "src/index.ts": "export {}",
+        "src/index.test.ts": "test()",
+        "src/utils.ts": "export {}",
+        "src/utils.test.ts": "test()",
+      });
+
+      using dir = tempDir("archive-ignore-pattern", {});
+      const count = await archive.extract(String(dir), { ignore: "**/*.test.ts" });
+
+      expect(count).toBe(2);
+      expect(await Bun.file(join(String(dir), "src/index.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/utils.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/index.test.ts")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "src/utils.test.ts")).exists()).toBe(false);
+    });
+
+    test("excludes files matching any of multiple ignore patterns", async () => {
+      const archive = Bun.Archive.from({
+        "src/index.ts": "export {}",
+        "src/index.test.ts": "test()",
+        "__tests__/helper.ts": "helper",
+        "node_modules/pkg/index.js": "module",
+      });
+
+      using dir = tempDir("archive-multi-ignore", {});
+      const count = await archive.extract(String(dir), {
+        ignore: ["**/*.test.ts", "__tests__/**", "node_modules/**"],
+      });
+
+      expect(count).toBe(1);
+      expect(await Bun.file(join(String(dir), "src/index.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/index.test.ts")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "__tests__/helper.ts")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "node_modules/pkg/index.js")).exists()).toBe(false);
+    });
+
+    test("combines glob and ignore patterns", async () => {
+      const archive = Bun.Archive.from({
+        "src/index.ts": "export {}",
+        "src/index.test.ts": "test()",
+        "src/utils.ts": "export {}",
+        "lib/helper.ts": "helper",
+        "lib/helper.test.ts": "test()",
+        "README.md": "# Hello",
+      });
+
+      using dir = tempDir("archive-glob-and-ignore", {});
+      const count = await archive.extract(String(dir), {
+        glob: ["src/**", "lib/**"],
+        ignore: "**/*.test.ts",
+      });
+
+      expect(count).toBe(3);
+      expect(await Bun.file(join(String(dir), "src/index.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/utils.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "lib/helper.ts")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "src/index.test.ts")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "lib/helper.test.ts")).exists()).toBe(false);
+      expect(await Bun.file(join(String(dir), "README.md")).exists()).toBe(false);
+    });
+
+    test("extracts all files when no patterns are provided", async () => {
+      const archive = Bun.Archive.from({
+        "file1.txt": "content1",
+        "file2.txt": "content2",
+      });
+
+      using dir = tempDir("archive-no-patterns", {});
+      const count = await archive.extract(String(dir), {});
+
+      expect(count).toBe(2);
+      expect(await Bun.file(join(String(dir), "file1.txt")).exists()).toBe(true);
+      expect(await Bun.file(join(String(dir), "file2.txt")).exists()).toBe(true);
+    });
+
+    test("returns 0 when no files match glob pattern", async () => {
+      const archive = Bun.Archive.from({
+        "file.txt": "content",
+        "other.md": "markdown",
+      });
+
+      using dir = tempDir("archive-no-match", {});
+      const count = await archive.extract(String(dir), { glob: "**/*.ts" });
+
+      expect(count).toBe(0);
+    });
+  });
+
   describe("concurrent operations", () => {
     test("multiple extract operations run correctly", async () => {
       const archive = Bun.Archive.from({

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1158,7 +1158,7 @@ describe("Bun.Archive", () => {
     });
   });
 
-  describe("extract with glob/ignore patterns", () => {
+  describe("extract with glob patterns", () => {
     test("extracts only files matching glob pattern", async () => {
       const archive = Bun.Archive.from({
         "src/index.ts": "export {}",
@@ -1200,7 +1200,7 @@ describe("Bun.Archive", () => {
       expect(await Bun.file(join(String(dir), "README.md")).exists()).toBe(false);
     });
 
-    test("excludes files matching ignore pattern", async () => {
+    test("excludes files matching negative pattern", async () => {
       const archive = Bun.Archive.from({
         "src/index.ts": "export {}",
         "src/index.test.ts": "test()",
@@ -1208,8 +1208,9 @@ describe("Bun.Archive", () => {
         "src/utils.test.ts": "test()",
       });
 
-      using dir = tempDir("archive-ignore-pattern", {});
-      const count = await archive.extract(String(dir), { ignore: "**/*.test.ts" });
+      using dir = tempDir("archive-negative-pattern", {});
+      // Use negative pattern to exclude test files
+      const count = await archive.extract(String(dir), { glob: ["**", "!**/*.test.ts"] });
 
       expect(count).toBe(2);
       expect(await Bun.file(join(String(dir), "src/index.ts")).exists()).toBe(true);
@@ -1218,7 +1219,7 @@ describe("Bun.Archive", () => {
       expect(await Bun.file(join(String(dir), "src/utils.test.ts")).exists()).toBe(false);
     });
 
-    test("excludes files matching any of multiple ignore patterns", async () => {
+    test("excludes files matching any of multiple negative patterns", async () => {
       const archive = Bun.Archive.from({
         "src/index.ts": "export {}",
         "src/index.test.ts": "test()",
@@ -1226,9 +1227,9 @@ describe("Bun.Archive", () => {
         "node_modules/pkg/index.js": "module",
       });
 
-      using dir = tempDir("archive-multi-ignore", {});
+      using dir = tempDir("archive-multi-negative", {});
       const count = await archive.extract(String(dir), {
-        ignore: ["**/*.test.ts", "__tests__/**", "node_modules/**"],
+        glob: ["**", "!**/*.test.ts", "!__tests__/**", "!node_modules/**"],
       });
 
       expect(count).toBe(1);
@@ -1238,7 +1239,7 @@ describe("Bun.Archive", () => {
       expect(await Bun.file(join(String(dir), "node_modules/pkg/index.js")).exists()).toBe(false);
     });
 
-    test("combines glob and ignore patterns", async () => {
+    test("combines positive and negative glob patterns", async () => {
       const archive = Bun.Archive.from({
         "src/index.ts": "export {}",
         "src/index.test.ts": "test()",
@@ -1248,10 +1249,9 @@ describe("Bun.Archive", () => {
         "README.md": "# Hello",
       });
 
-      using dir = tempDir("archive-glob-and-ignore", {});
+      using dir = tempDir("archive-glob-and-negative", {});
       const count = await archive.extract(String(dir), {
-        glob: ["src/**", "lib/**"],
-        ignore: "**/*.test.ts",
+        glob: ["src/**", "lib/**", "!**/*.test.ts"],
       });
 
       expect(count).toBe(3);


### PR DESCRIPTION
## Summary

- Add comprehensive TypeScript type definitions for `Bun.Archive` in `bun.d.ts`
  - `ArchiveInput` and `ArchiveCompression` types
  - Full JSDoc documentation with examples for all methods (`from`, `write`, `extract`, `blob`, `bytes`, `files`)
- Add documentation page at `docs/runtime/archive.mdx`
  - Quickstart examples
  - Creating and extracting archives
  - `files()` method with glob filtering
  - Compression support
  - Full API reference section
- Add Archive to docs sidebar under "Data & Storage"
- Add `files()` benchmark comparing `Bun.Archive.files()` vs node-tar
  - Shows ~7x speedup for reading archive contents into memory (59µs vs 434µs)

## Test plan

- [x] TypeScript types compile correctly
- [x] Documentation renders properly in Mintlify format
- [x] Benchmark runs successfully and shows performance comparison
- [x] Verified `files()` method works correctly with both Bun.Archive and node-tar

🤖 Generated with [Claude Code](https://claude.com/claude-code)