### PR TITLE
fix(http): properly handle pipelined data in CONNECT requests

### DIFF
--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -358,7 +358,7 @@ Bun represents [pointers](<https://en.wikipedia.org/wiki/Pointer_(computer_progr
 
 **Why not `BigInt`?** `BigInt` is slower. JavaScript engines allocate a separate `BigInt` which means they can't fit into a regular JavaScript value. If you pass a `BigInt` to a function, it will be converted to a `number`
 
-**Windows Note**: The Windows API type HANDLE does not represent a virtual address, and using `ptr` for it will *not* work as expected. Use `u64` to safely represent HANDLE values.
+**Windows Note**: The Windows API type HANDLE does not represent a virtual address, and using `ptr` for it will _not_ work as expected. Use `u64` to safely represent HANDLE values.
 
 </Accordion>
 

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -160,8 +160,14 @@ namespace uWS
         std::map<std::string, unsigned short, std::less<>> *currentParameterOffsets = nullptr;
 
     public:
-        /* For CONNECT requests, this is any data pipelined after the headers */
-        std::string_view connectHead;
+        /* Any data pipelined after the HTTP headers (before response).
+         * Used for Node.js compatibility: 'connect' and 'upgrade' events
+         * pass this as the 'head' Buffer parameter.
+         * WARNING: This points to stack-allocated data in the receive buffer.
+         * Must be cloned before the request handler returns. */
+        const char* headData = nullptr;
+        unsigned int headLength = 0;
+
         bool isAncient()
         {
             return ancientHttp;
@@ -885,8 +891,14 @@ namespace uWS
             /* If returned socket is not what we put in we need
              * to break here as we either have upgraded to
              * WebSockets or otherwise closed the socket. */
+<<<<<<< HEAD
             /* For CONNECT requests, store the remaining data as the connect head */
             req->connectHead = isConnectRequest ? std::string_view(data, length) : std::string_view();
+=======
+            /* Store any remaining data as head for Node.js compat (connect/upgrade events) */
+            req->headData = data;
+            req->headLength = length;
+>>>>>>> b30dc1e4b4 (fix(http): properly handle pipelined data in CONNECT requests)
             void *returnedUser = requestHandler(user, req);
             if (returnedUser != user) {
                 /* We are upgraded to WebSocket or otherwise broken */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -891,14 +891,9 @@ namespace uWS
             /* If returned socket is not what we put in we need
              * to break here as we either have upgraded to
              * WebSockets or otherwise closed the socket. */
-<<<<<<< HEAD
-            /* For CONNECT requests, store the remaining data as the connect head */
-            req->connectHead = isConnectRequest ? std::string_view(data, length) : std::string_view();
-=======
             /* Store any remaining data as head for Node.js compat (connect/upgrade events) */
             req->headData = data;
             req->headLength = length;
->>>>>>> b30dc1e4b4 (fix(http): properly handle pipelined data in CONNECT requests)
             void *returnedUser = requestHandler(user, req);
             if (returnedUser != user) {
                 /* We are upgraded to WebSocket or otherwise broken */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <climits>
 #include <string_view>
+#include <span>
 #include <map>
 #include "MoveOnlyFunction.h"
 #include "ChunkedEncoding.h"
@@ -165,8 +166,7 @@ namespace uWS
          * pass this as the 'head' Buffer parameter.
          * WARNING: This points to data in the receive buffer and may be stack-allocated.
          * Must be cloned before the request handler returns. */
-        const char* headData = nullptr;
-        unsigned int headLength = 0;
+        std::span<const char> head;
 
         bool isAncient()
         {
@@ -892,8 +892,7 @@ namespace uWS
              * to break here as we either have upgraded to
              * WebSockets or otherwise closed the socket. */
             /* Store any remaining data as head for Node.js compat (connect/upgrade events) */
-            req->headData = data;
-            req->headLength = length;
+            req->head = std::span<const char>(data, length);
             void *returnedUser = requestHandler(user, req);
             if (returnedUser != user) {
                 /* We are upgraded to WebSocket or otherwise broken */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -163,7 +163,7 @@ namespace uWS
         /* Any data pipelined after the HTTP headers (before response).
          * Used for Node.js compatibility: 'connect' and 'upgrade' events
          * pass this as the 'head' Buffer parameter.
-         * WARNING: This points to stack-allocated data in the receive buffer.
+         * WARNING: This points to data in the receive buffer and may be stack-allocated.
          * Must be cloned before the request handler returns. */
         const char* headData = nullptr;
         unsigned int headLength = 0;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -940,7 +940,7 @@ namespace uWS
             } else if(isConnectRequest) {
                 // This only serves to mark that the connect request read all headers
                 // and can start emitting data. Don't try to parse remaining data as HTTP -
-                // it's pipelined data that we've already captured in req->connectHead.
+                // it's pipelined data that we've already captured in req->head.
                 remainingStreamingBytes = STATE_IS_CHUNKED;
                 // Mark remaining data as consumed and break - it's not HTTP
                 consumedTotal += length;

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -476,9 +476,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
 
     // For CONNECT requests, pass the pipelined data (head buffer) from the request
     if (!request->connectHead.empty()) {
-        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(
-            reinterpret_cast<const uint8_t*>(request->connectHead.data()),
-            request->connectHead.length()));
+        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(request->connectHead.data()), request->connectHead.length()));
         args.append(headBuffer);
     } else {
         args.append(jsUndefined());

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -474,6 +474,16 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     }
     args.append(jsBoolean(request->isAncient()));
 
+    // For CONNECT requests, pass the pipelined data (head buffer) from the request
+    if (!request->connectHead.empty()) {
+        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(request->connectHead.data()),
+            request->connectHead.length()));
+        args.append(headBuffer);
+    } else {
+        args.append(jsUndefined());
+    }
+
     JSValue returnValue = AsyncContextFrame::profiledCall(globalObject, callbackObject, jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -475,8 +475,8 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     args.append(jsBoolean(request->isAncient()));
 
     // Pass pipelined data (head buffer) for Node.js compat (connect/upgrade events)
-    if (request->headLength > 0) {
-        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(request->headData), request->headLength));
+    if (!request->head.empty()) {
+        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(request->head.data()), request->head.size()));
         args.append(headBuffer);
     } else {
         args.append(jsUndefined());

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -474,9 +474,9 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     }
     args.append(jsBoolean(request->isAncient()));
 
-    // For CONNECT requests, pass the pipelined data (head buffer) from the request
-    if (!request->connectHead.empty()) {
-        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(request->connectHead.data()), request->connectHead.length()));
+    // Pass pipelined data (head buffer) for Node.js compat (connect/upgrade events)
+    if (request->headLength > 0) {
+        JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(request->headData), request->headLength));
         args.append(headBuffer);
     } else {
         args.append(jsUndefined());

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -477,6 +477,7 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     // Pass pipelined data (head buffer) for Node.js compat (connect/upgrade events)
     if (!request->head.empty()) {
         JSC::JSUint8Array* headBuffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(request->head.data()), request->head.size()));
+        RETURN_IF_EXCEPTION(scope, {});
         args.append(headBuffer);
     } else {
         args.append(jsUndefined());

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -517,6 +517,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         isSocketNew,
         socket,
         isAncientHTTP: boolean,
+        connectHead?: Buffer,
       ) {
         const prevIsNextIncomingMessageHTTPS = getIsNextIncomingMessageHTTPS();
         setIsNextIncomingMessageHTTPS(isHTTPS);
@@ -537,7 +538,9 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             socket[kEnableStreaming](true);
             const { promise, resolve } = $newPromiseCapability(Promise);
             socket.once("close", resolve);
-            server.emit("connect", http_req, socket, kEmptyBuffer);
+            // Pass the pipelined data (head buffer) if any was received with the CONNECT request
+            const head = connectHead ? connectHead : kEmptyBuffer;
+            server.emit("connect", http_req, socket, head);
             return promise;
           } else {
             // Node.js will close the socket and will NOT respond with 400 Bad Request

--- a/test/regression/issue/25862.test.ts
+++ b/test/regression/issue/25862.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+
+// Test for https://github.com/oven-sh/bun/issues/25862
+// Pipelined data sent immediately after CONNECT request headers should be
+// delivered to the `head` parameter of the 'connect' event handler.
+
+test("CONNECT request should receive pipelined data in head parameter", async () => {
+  const PIPELINED_DATA = "PIPELINED_DATA";
+  const { promise: headReceived, resolve: resolveHead } = Promise.withResolvers<Buffer>();
+
+  await using server = http.createServer();
+
+  server.on("connect", (req, socket, head) => {
+    resolveHead(head);
+    socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+    socket.end();
+  });
+
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port, address } = server.address() as AddressInfo;
+
+  const { promise: clientDone, resolve: resolveClient } = Promise.withResolvers<void>();
+
+  const client = net.connect({ port, host: address }, () => {
+    // Send CONNECT request with pipelined data in the same write
+    // This simulates what Cap'n Proto's KJ HTTP library does
+    client.write(`CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n${PIPELINED_DATA}`);
+  });
+
+  client.on("data", () => {
+    // We got the response, we can close
+    client.end();
+  });
+
+  client.on("close", () => {
+    resolveClient();
+  });
+
+  const head = await headReceived;
+  await clientDone;
+
+  expect(head).toBeInstanceOf(Buffer);
+  expect(head.length).toBe(PIPELINED_DATA.length);
+  expect(head.toString()).toBe(PIPELINED_DATA);
+});


### PR DESCRIPTION
Fixes #25862

### What does this PR do?

When a client sends pipelined data immediately after CONNECT request headers in the same TCP segment, Bun now properly delivers this data to the `head` parameter of the 'connect' event handler, matching Node.js behavior.

This enables compatibility with Cap'n Proto's KJ HTTP library used by Cloudflare's workerd runtime, which pipelines RPC data after CONNECT.

### How did you verify your code works?
<img width="694" height="612" alt="CleanShot 2026-01-09 at 15 30 22@2x" src="https://github.com/user-attachments/assets/3ffe840e-1792-429c-8303-d98ac3e6912a" />

Tests