### PR TITLE
feat(archive): change API to constructor-based with S3 support

### DIFF
--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -43,10 +43,10 @@ for (const [path, file] of files) {
 
 ## Creating Archives
 
-Use `new Bun.Archive()` to create an archive from an object where keys are file paths and values are file contents. By default, archives are gzip-compressed at level 6:
+Use `new Bun.Archive()` to create an archive from an object where keys are file paths and values are file contents. By default, archives are uncompressed:
 
 ```ts
-// Creates a gzip-compressed archive (default)
+// Creates an uncompressed tar archive (default)
 const archive = new Bun.Archive({
   "README.md": "# My Project",
   "src/index.ts": "console.log('Hello');",
@@ -78,19 +78,19 @@ const archive = new Bun.Archive({
 Use `Bun.write()` to write an archive to disk:
 
 ```ts
-// Write gzipped tar (default - no options needed)
+// Write uncompressed tar (default)
 const archive = new Bun.Archive({
   "file1.txt": "content1",
   "file2.txt": "content2",
 });
-await Bun.write("output.tar.gz", archive);
+await Bun.write("output.tar", archive);
 
-// Write uncompressed tar (pass empty options)
-const uncompressed = new Bun.Archive(
+// Write gzipped tar
+const compressed = new Bun.Archive(
   { "src/index.ts": "console.log('Hello');" },
-  {}, // Empty options = no compression
+  { compress: "gzip" },
 );
-await Bun.write("output.tar", uncompressed);
+await Bun.write("output.tar.gz", compressed);
 ```
 
 ### Getting Archive Bytes
@@ -303,32 +303,28 @@ See [Bun.Glob](/docs/api/glob) for the full glob syntax including escaping and a
 
 ## Compression
 
-Bun.Archive uses gzip compression by default. When no options are provided, archives are compressed at level 6:
+Bun.Archive creates uncompressed tar archives by default. Use `{ compress: "gzip" }` to enable gzip compression:
 
 ```ts
-// Default: gzip level 6 compression
+// Default: uncompressed tar
 const archive = new Bun.Archive({ "hello.txt": "Hello, World!" });
 
 // Reading: automatically detects gzip
 const gzippedTarball = await Bun.file("archive.tar.gz").bytes();
 const readArchive = new Bun.Archive(gzippedTarball);
 
-// Explicit gzip with custom level (1-12)
-const maxCompression = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress: "gzip", level: 12 });
+// Enable gzip compression
+const compressed = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress: "gzip" });
 
-// No compression (pass empty options)
-const uncompressed = new Bun.Archive(
-  { "hello.txt": "Hello, World!" },
-  {}, // Empty options = uncompressed tar
-);
+// Gzip with custom level (1-12)
+const maxCompression = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress: "gzip", level: 12 });
 ```
 
 The options accept:
 
-- No options - Default gzip compression at level 6
-- `{}` (empty object) - No compression (uncompressed tar)
-- `compress: "gzip"` - Enable gzip compression
-- `level: number` - Compression level 1-12 (1 = fastest, 12 = smallest, default 6)
+- No options or `undefined` - Uncompressed tar (default)
+- `{ compress: "gzip" }` - Enable gzip compression at level 6
+- `{ compress: "gzip", level: number }` - Gzip with custom level 1-12 (1 = fastest, 12 = smallest)
 
 ## Examples
 
@@ -414,18 +410,12 @@ type ArchiveInput =
   | Bun.ArrayBufferView
   | ArrayBufferLike;
 
-type ArchiveOptions =
-  | {
-      /** Compression algorithm. Currently only "gzip" is supported. */
-      compress: "gzip";
-      /** Compression level 1-12 (default 6). */
-      level?: number;
-    }
-  | {
-      /** Pass empty object for no compression (uncompressed tar). */
-      compress?: never;
-      level?: never;
-    };
+type ArchiveOptions = {
+  /** Compression algorithm. Currently only "gzip" is supported. */
+  compress?: "gzip";
+  /** Compression level 1-12 (default 6 when gzip is enabled). */
+  level?: number;
+};
 
 interface ArchiveExtractOptions {
   /** Glob pattern(s) to filter extraction. Supports negative patterns with "!" prefix. */
@@ -436,8 +426,8 @@ class Archive {
   /**
    * Create an Archive from input data
    * @param data - Files to archive (as object) or existing archive data (as bytes/blob)
-   * @param options - Compression options. Defaults to gzip level 6 if omitted.
-   *                  Pass {} for no compression.
+   * @param options - Compression options. Uncompressed by default.
+   *                  Pass { compress: "gzip" } to enable compression.
    */
   constructor(data: ArchiveInput, options?: ArchiveOptions);
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -88,7 +88,7 @@ await Bun.write("output.tar.gz", archive);
 // Write uncompressed tar (pass empty options)
 const uncompressed = new Bun.Archive(
   { "src/index.ts": "console.log('Hello');" },
-  {} // Empty options = no compression
+  {}, // Empty options = no compression
 );
 await Bun.write("output.tar", uncompressed);
 ```
@@ -107,10 +107,7 @@ const bytes = await archive.bytes();
 const blob = await archive.blob();
 
 // With gzip compression (set at construction)
-const gzipped = new Bun.Archive(
-  { "hello.txt": "Hello, World!" },
-  { compress: "gzip" }
-);
+const gzipped = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress: "gzip" });
 const gzippedBytes = await gzipped.bytes();
 const gzippedBlob = await gzipped.blob();
 ```
@@ -317,15 +314,12 @@ const gzippedTarball = await Bun.file("archive.tar.gz").bytes();
 const readArchive = new Bun.Archive(gzippedTarball);
 
 // Explicit gzip with custom level (1-12)
-const maxCompression = new Bun.Archive(
-  { "hello.txt": "Hello, World!" },
-  { compress: "gzip", level: 12 }
-);
+const maxCompression = new Bun.Archive({ "hello.txt": "Hello, World!" }, { compress: "gzip", level: 12 });
 
 // No compression (pass empty options)
 const uncompressed = new Bun.Archive(
   { "hello.txt": "Hello, World!" },
-  {} // Empty options = uncompressed tar
+  {}, // Empty options = uncompressed tar
 );
 ```
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -43,9 +43,10 @@ for (const [path, file] of files) {
 
 ## Creating Archives
 
-Use `new Bun.Archive()` to create an archive from an object where keys are file paths and values are file contents:
+Use `new Bun.Archive()` to create an archive from an object where keys are file paths and values are file contents. By default, archives are gzip-compressed at level 6:
 
 ```ts
+// Creates a gzip-compressed archive (default)
 const archive = new Bun.Archive({
   "README.md": "# My Project",
   "src/index.ts": "console.log('Hello');",
@@ -77,16 +78,19 @@ const archive = new Bun.Archive({
 Use `Bun.write()` to write an archive to disk:
 
 ```ts
-// Write uncompressed tar
+// Write gzipped tar (default - no options needed)
 const archive = new Bun.Archive({
   "file1.txt": "content1",
   "file2.txt": "content2",
 });
-await Bun.write("output.tar", archive);
+await Bun.write("output.tar.gz", archive);
 
-// Write gzipped tar
-const gzipped = new Bun.Archive({ "src/index.ts": "console.log('Hello');" }, { gzip: true });
-await Bun.write("output.tar.gz", gzipped);
+// Write uncompressed tar (pass empty options)
+const uncompressed = new Bun.Archive(
+  { "src/index.ts": "console.log('Hello');" },
+  {} // Empty options = no compression
+);
+await Bun.write("output.tar", uncompressed);
 ```
 
 ### Getting Archive Bytes
@@ -103,7 +107,10 @@ const bytes = await archive.bytes();
 const blob = await archive.blob();
 
 // With gzip compression (set at construction)
-const gzipped = new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: true });
+const gzipped = new Bun.Archive(
+  { "hello.txt": "Hello, World!" },
+  { compress: "gzip" }
+);
 const gzippedBytes = await gzipped.bytes();
 const gzippedBlob = await gzipped.blob();
 ```
@@ -299,27 +306,35 @@ See [Bun.Glob](/docs/api/glob) for the full glob syntax including escaping and a
 
 ## Compression
 
-Bun.Archive supports gzip compression for both reading and writing:
+Bun.Archive uses gzip compression by default. When no options are provided, archives are compressed at level 6:
 
 ```ts
+// Default: gzip level 6 compression
+const archive = new Bun.Archive({ "hello.txt": "Hello, World!" });
+
 // Reading: automatically detects gzip
 const gzippedTarball = await Bun.file("archive.tar.gz").bytes();
-const archive = new Bun.Archive(gzippedTarball);
+const readArchive = new Bun.Archive(gzippedTarball);
 
-// Writing: specify compression at construction time
-const gzipped = new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: true });
-await Bun.write("output.tar.gz", gzipped);
+// Explicit gzip with custom level (1-12)
+const maxCompression = new Bun.Archive(
+  { "hello.txt": "Hello, World!" },
+  { compress: "gzip", level: 12 }
+);
 
-// Or with a specific compression level (1-12)
-const maxCompression = new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: 12 });
+// No compression (pass empty options)
+const uncompressed = new Bun.Archive(
+  { "hello.txt": "Hello, World!" },
+  {} // Empty options = uncompressed tar
+);
 ```
 
-The `gzip` option accepts:
+The options accept:
 
-- `true` - Enable gzip compression with default level (6)
-- A number `1`-`12` - Compression level (1 = fastest, 12 = smallest)
-- `{ level: number }` - Object with explicit level
-- `false` or `undefined` - No compression
+- No options - Default gzip compression at level 6
+- `{}` (empty object) - No compression (uncompressed tar)
+- `compress: "gzip"` - Enable gzip compression
+- `level: number` - Compression level 1-12 (1 = fastest, 12 = smallest, default 6)
 
 ## Examples
 
@@ -342,7 +357,7 @@ for await (const path of glob.scan(".")) {
 files["package.json"] = await Bun.file("package.json").text();
 
 // Create compressed archive and write to disk
-const archive = new Bun.Archive(files, { gzip: true });
+const archive = new Bun.Archive(files, { compress: "gzip" });
 await Bun.write("bundle.tar.gz", archive);
 ```
 
@@ -368,7 +383,7 @@ if (packageJson) {
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-async function archiveDirectory(dir: string, gzip = false): Promise<Bun.Archive> {
+async function archiveDirectory(dir: string, compress = false): Promise<Bun.Archive> {
   const files: Record<string, Blob> = {};
 
   async function walk(currentDir: string, prefix: string = "") {
@@ -387,7 +402,7 @@ async function archiveDirectory(dir: string, gzip = false): Promise<Bun.Archive>
   }
 
   await walk(dir);
-  return new Bun.Archive(files, { gzip });
+  return new Bun.Archive(files, compress ? { compress: "gzip" } : undefined);
 }
 
 const archive = await archiveDirectory("./my-project", true);
@@ -405,10 +420,18 @@ type ArchiveInput =
   | Bun.ArrayBufferView
   | ArrayBufferLike;
 
-interface ArchiveOptions {
-  /** Enable gzip compression. Can be true, a level 1-12, or { level: number } */
-  gzip?: boolean | number | { level?: number };
-}
+type ArchiveOptions =
+  | {
+      /** Compression algorithm. Currently only "gzip" is supported. */
+      compress: "gzip";
+      /** Compression level 1-12 (default 6). */
+      level?: number;
+    }
+  | {
+      /** Pass empty object for no compression (uncompressed tar). */
+      compress?: never;
+      level?: never;
+    };
 
 interface ArchiveExtractOptions {
   /** Glob pattern(s) to filter extraction. Supports negative patterns with "!" prefix. */
@@ -419,7 +442,8 @@ class Archive {
   /**
    * Create an Archive from input data
    * @param data - Files to archive (as object) or existing archive data (as bytes/blob)
-   * @param options - Compression options
+   * @param options - Compression options. Defaults to gzip level 6 if omitted.
+   *                  Pass {} for no compression.
    */
   constructor(data: ArchiveInput, options?: ArchiveOptions);
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -85,10 +85,7 @@ const archive = new Bun.Archive({
 await Bun.write("output.tar", archive);
 
 // Write gzipped tar
-const gzipped = new Bun.Archive(
-  { "src/index.ts": "console.log('Hello');" },
-  { gzip: true }
-);
+const gzipped = new Bun.Archive({ "src/index.ts": "console.log('Hello');" }, { gzip: true });
 await Bun.write("output.tar.gz", gzipped);
 ```
 
@@ -106,10 +103,7 @@ const bytes = await archive.bytes();
 const blob = await archive.blob();
 
 // With gzip compression (set at construction)
-const gzipped = new Bun.Archive(
-  { "hello.txt": "Hello, World!" },
-  { gzip: true }
-);
+const gzipped = new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: true });
 const gzippedBytes = await gzipped.bytes();
 const gzippedBlob = await gzipped.blob();
 ```
@@ -313,17 +307,11 @@ const gzippedTarball = await Bun.file("archive.tar.gz").bytes();
 const archive = new Bun.Archive(gzippedTarball);
 
 // Writing: specify compression at construction time
-const gzipped = new Bun.Archive(
-  { "hello.txt": "Hello, World!" },
-  { gzip: true }
-);
+const gzipped = new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: true });
 await Bun.write("output.tar.gz", gzipped);
 
 // Or with a specific compression level (1-12)
-const maxCompression = new Bun.Archive(
-  { "hello.txt": "Hello, World!" },
-  { gzip: 12 }
-);
+const maxCompression = new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: 12 });
 ```
 
 The `gzip` option accepts:

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -86,10 +86,7 @@ const archive = new Bun.Archive({
 await Bun.write("output.tar", archive);
 
 // Write gzipped tar
-const compressed = new Bun.Archive(
-  { "src/index.ts": "console.log('Hello');" },
-  { compress: "gzip" },
-);
+const compressed = new Bun.Archive({ "src/index.ts": "console.log('Hello');" }, { compress: "gzip" });
 await Bun.write("output.tar.gz", compressed);
 ```
 

--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -10,21 +10,21 @@ Bun provides a fast, native implementation for working with tar archives through
 **Create an archive from files:**
 
 ```ts
-const archive = Bun.Archive.from({
+const archive = new Bun.Archive({
   "hello.txt": "Hello, World!",
   "data.json": JSON.stringify({ foo: "bar" }),
   "nested/file.txt": "Nested content",
 });
 
 // Write to disk
-await Bun.Archive.write("bundle.tar", archive);
+await Bun.write("bundle.tar", archive);
 ```
 
 **Extract an archive:**
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archive = Bun.Archive.from(tarball);
+const archive = new Bun.Archive(tarball);
 const entryCount = await archive.extract("./output");
 console.log(`Extracted ${entryCount} entries`);
 ```
@@ -33,7 +33,7 @@ console.log(`Extracted ${entryCount} entries`);
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archive = Bun.Archive.from(tarball);
+const archive = new Bun.Archive(tarball);
 const files = await archive.files();
 
 for (const [path, file] of files) {
@@ -43,10 +43,10 @@ for (const [path, file] of files) {
 
 ## Creating Archives
 
-Use `Bun.Archive.from()` to create an archive from an object where keys are file paths and values are file contents:
+Use `new Bun.Archive()` to create an archive from an object where keys are file paths and values are file contents:
 
 ```ts
-const archive = Bun.Archive.from({
+const archive = new Bun.Archive({
   "README.md": "# My Project",
   "src/index.ts": "console.log('Hello');",
   "package.json": JSON.stringify({ name: "my-project" }),
@@ -64,7 +64,7 @@ File contents can be:
 const data = "binary data";
 const arrayBuffer = new ArrayBuffer(8);
 
-const archive = Bun.Archive.from({
+const archive = new Bun.Archive({
   "text.txt": "Plain text",
   "blob.bin": new Blob([data]),
   "bytes.bin": new Uint8Array([1, 2, 3, 4]),
@@ -74,18 +74,22 @@ const archive = Bun.Archive.from({
 
 ### Writing Archives to Disk
 
-Use `Bun.Archive.write()` to create and write an archive in one operation:
+Use `Bun.write()` to write an archive to disk:
 
 ```ts
 // Write uncompressed tar
-await Bun.Archive.write("output.tar", {
+const archive = new Bun.Archive({
   "file1.txt": "content1",
   "file2.txt": "content2",
 });
+await Bun.write("output.tar", archive);
 
 // Write gzipped tar
-const files = { "src/index.ts": "console.log('Hello');" };
-await Bun.Archive.write("output.tar.gz", files, "gzip");
+const gzipped = new Bun.Archive(
+  { "src/index.ts": "console.log('Hello');" },
+  { gzip: true }
+);
+await Bun.write("output.tar.gz", gzipped);
 ```
 
 ### Getting Archive Bytes
@@ -93,8 +97,7 @@ await Bun.Archive.write("output.tar.gz", files, "gzip");
 Get the archive data as bytes or a Blob:
 
 ```ts
-const files = { "hello.txt": "Hello, World!" };
-const archive = Bun.Archive.from(files);
+const archive = new Bun.Archive({ "hello.txt": "Hello, World!" });
 
 // As Uint8Array
 const bytes = await archive.bytes();
@@ -102,9 +105,13 @@ const bytes = await archive.bytes();
 // As Blob
 const blob = await archive.blob();
 
-// With gzip compression
-const gzippedBytes = await archive.bytes("gzip");
-const gzippedBlob = await archive.blob("gzip");
+// With gzip compression (set at construction)
+const gzipped = new Bun.Archive(
+  { "hello.txt": "Hello, World!" },
+  { gzip: true }
+);
+const gzippedBytes = await gzipped.bytes();
+const gzippedBlob = await gzipped.blob();
 ```
 
 ## Extracting Archives
@@ -116,13 +123,13 @@ Create an archive from existing tar/tar.gz data:
 ```ts
 // From a file
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archiveFromFile = Bun.Archive.from(tarball);
+const archiveFromFile = new Bun.Archive(tarball);
 ```
 
 ```ts
 // From a fetch response
 const response = await fetch("https://example.com/archive.tar.gz");
-const archiveFromFetch = Bun.Archive.from(await response.blob());
+const archiveFromFetch = new Bun.Archive(await response.blob());
 ```
 
 ### Extracting to Disk
@@ -131,7 +138,7 @@ Use `.extract()` to write all files to a directory:
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archive = Bun.Archive.from(tarball);
+const archive = new Bun.Archive(tarball);
 const count = await archive.extract("./extracted");
 console.log(`Extracted ${count} entries`);
 ```
@@ -148,7 +155,7 @@ Use glob patterns to extract only specific files. Patterns are matched against a
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archive = Bun.Archive.from(tarball);
+const archive = new Bun.Archive(tarball);
 
 // Extract only TypeScript files
 const tsCount = await archive.extract("./extracted", { glob: "**/*.ts" });
@@ -181,7 +188,7 @@ Use `.files()` to get archive contents as a `Map` of `File` objects without extr
 
 ```ts
 const tarball = await Bun.file("package.tar.gz").bytes();
-const archive = Bun.Archive.from(tarball);
+const archive = new Bun.Archive(tarball);
 const files = await archive.files();
 
 for (const [path, file] of files) {
@@ -206,7 +213,7 @@ Archive operations can fail due to corrupted data, I/O errors, or invalid paths.
 ```ts
 try {
   const tarball = await Bun.file("package.tar.gz").bytes();
-  const archive = Bun.Archive.from(tarball);
+  const archive = new Bun.Archive(tarball);
   const count = await archive.extract("./output");
   console.log(`Extracted ${count} entries`);
 } catch (e: unknown) {
@@ -227,7 +234,7 @@ try {
 
 Common error scenarios:
 
-- **Corrupted/truncated archives** - `Archive.from()` loads the archive data; errors may be deferred until read/extract operations
+- **Corrupted/truncated archives** - `new Archive()` loads the archive data; errors may be deferred until read/extract operations
 - **Permission denied** - `extract()` throws if the target directory is not writable
 - **Disk full** - `extract()` throws if there's insufficient space
 - **Invalid paths** - Operations throw for malformed file paths
@@ -239,7 +246,7 @@ The count returned by `extract()` includes all successfully written entries (fil
 For additional security with untrusted archives, you can enumerate and validate paths before extraction:
 
 ```ts
-const archive = Bun.Archive.from(untrustedData);
+const archive = new Bun.Archive(untrustedData);
 const files = await archive.files();
 
 // Optional: Custom validation for additional checks
@@ -303,20 +310,27 @@ Bun.Archive supports gzip compression for both reading and writing:
 ```ts
 // Reading: automatically detects gzip
 const gzippedTarball = await Bun.file("archive.tar.gz").bytes();
-const archive = Bun.Archive.from(gzippedTarball);
+const archive = new Bun.Archive(gzippedTarball);
 
-// Writing: specify compression
-const files = { "hello.txt": "Hello, World!" };
-await Bun.Archive.write("output.tar.gz", files, "gzip");
+// Writing: specify compression at construction time
+const gzipped = new Bun.Archive(
+  { "hello.txt": "Hello, World!" },
+  { gzip: true }
+);
+await Bun.write("output.tar.gz", gzipped);
 
-// Getting bytes: specify compression
-const gzippedBytes = await archive.bytes("gzip");
+// Or with a specific compression level (1-12)
+const maxCompression = new Bun.Archive(
+  { "hello.txt": "Hello, World!" },
+  { gzip: 12 }
+);
 ```
 
-The compression argument accepts:
+The `gzip` option accepts:
 
-- `"gzip"` - Enable gzip compression
-- `true` - Same as `"gzip"`
+- `true` - Enable gzip compression with default level (6)
+- A number `1`-`12` - Compression level (1 = fastest, 12 = smallest)
+- `{ level: number }` - Object with explicit level
 - `false` or `undefined` - No compression
 
 ## Examples
@@ -339,15 +353,16 @@ for await (const path of glob.scan(".")) {
 // Add package.json
 files["package.json"] = await Bun.file("package.json").text();
 
-// Create compressed archive
-await Bun.Archive.write("bundle.tar.gz", files, "gzip");
+// Create compressed archive and write to disk
+const archive = new Bun.Archive(files, { gzip: true });
+await Bun.write("bundle.tar.gz", archive);
 ```
 
 ### Extract and Process npm Package
 
 ```ts
 const response = await fetch("https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz");
-const archive = Bun.Archive.from(await response.blob());
+const archive = new Bun.Archive(await response.blob());
 
 // Get package.json
 const files = await archive.files("package/package.json");
@@ -365,7 +380,7 @@ if (packageJson) {
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-async function archiveDirectory(dir: string): Promise<Bun.Archive> {
+async function archiveDirectory(dir: string, gzip = false): Promise<Bun.Archive> {
   const files: Record<string, Blob> = {};
 
   async function walk(currentDir: string, prefix: string = "") {
@@ -384,11 +399,11 @@ async function archiveDirectory(dir: string): Promise<Bun.Archive> {
   }
 
   await walk(dir);
-  return Bun.Archive.from(files);
+  return new Bun.Archive(files, { gzip });
 }
 
-const archive = await archiveDirectory("./my-project");
-await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
+const archive = await archiveDirectory("./my-project", true);
+await Bun.write("my-project.tar.gz", archive);
 ```
 
 ## Reference
@@ -396,13 +411,16 @@ await Bun.Archive.write("my-project.tar.gz", archive, "gzip");
 > **Note**: The following type signatures are simplified for documentation purposes. See [`packages/bun-types/bun.d.ts`](https://github.com/oven-sh/bun/blob/main/packages/bun-types/bun.d.ts) for the full type definitions.
 
 ```ts
-type ArchiveCompression = "gzip" | boolean;
-
 type ArchiveInput =
   | Record<string, string | Blob | Bun.ArrayBufferView | ArrayBufferLike>
   | Blob
   | Bun.ArrayBufferView
   | ArrayBufferLike;
+
+interface ArchiveOptions {
+  /** Enable gzip compression. Can be true, a level 1-12, or { level: number } */
+  gzip?: boolean | number | { level?: number };
+}
 
 interface ArchiveExtractOptions {
   /** Glob pattern(s) to filter extraction. Supports negative patterns with "!" prefix. */
@@ -412,13 +430,10 @@ interface ArchiveExtractOptions {
 class Archive {
   /**
    * Create an Archive from input data
+   * @param data - Files to archive (as object) or existing archive data (as bytes/blob)
+   * @param options - Compression options
    */
-  static from(data: ArchiveInput): Archive;
-
-  /**
-   * Write an archive directly to disk
-   */
-  static write(path: string, data: ArchiveInput | Archive, compress?: ArchiveCompression): Promise<void>;
+  constructor(data: ArchiveInput, options?: ArchiveOptions);
 
   /**
    * Extract archive to a directory
@@ -427,14 +442,14 @@ class Archive {
   extract(path: string, options?: ArchiveExtractOptions): Promise<number>;
 
   /**
-   * Get archive as a Blob
+   * Get archive as a Blob (uses compression setting from constructor)
    */
-  blob(compress?: ArchiveCompression): Promise<Blob>;
+  blob(): Promise<Blob>;
 
   /**
-   * Get archive as a Uint8Array
+   * Get archive as a Uint8Array (uses compression setting from constructor)
    */
-  bytes(compress?: ArchiveCompression): Promise<Uint8Array<ArrayBuffer>>;
+  bytes(): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Get archive contents as File objects (regular files only, no directories)

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6986,41 +6986,38 @@ declare module "bun" {
   type ArchiveCompression = "gzip" | boolean;
 
   /**
-   * Options for gzip compression level.
-   */
-  interface ArchiveGzipOptions {
-    /**
-     * Compression level (1-12).
-     * - 1: Fastest compression, lowest ratio
-     * - 6: Default balance of speed and ratio
-     * - 12: Best compression ratio, slowest
-     *
-     * @default 6
-     */
-    level?: number;
-  }
-
-  /**
    * Options for creating an Archive instance.
+   *
+   * @example
+   * ```ts
+   * // Enable gzip with default level (6)
+   * new Bun.Archive(data, { compress: "gzip" });
+   *
+   * // Specify compression level
+   * new Bun.Archive(data, { compress: "gzip", level: 9 });
+   * ```
    */
-  interface ArchiveOptions {
-    /**
-     * Enable gzip compression for the archive output.
-     *
-     * @example
-     * ```ts
-     * // Enable with default level (6)
-     * new Bun.Archive(data, { gzip: true });
-     *
-     * // Specify compression level directly
-     * new Bun.Archive(data, { gzip: 9 });
-     *
-     * // Specify compression level with options object
-     * new Bun.Archive(data, { gzip: { level: 12 } });
-     * ```
-     */
-    gzip?: boolean | number | ArchiveGzipOptions;
-  }
+  type ArchiveOptions =
+    | {
+        /**
+         * Compression algorithm to use.
+         * Currently only "gzip" is supported.
+         */
+        compress: "gzip";
+        /**
+         * Compression level (1-12).
+         * - 1: Fastest compression, lowest ratio
+         * - 6: Default balance of speed and ratio
+         * - 12: Best compression ratio, slowest
+         *
+         * @default 6
+         */
+        level?: number;
+      }
+    | {
+        compress?: never;
+        level?: never;
+      };
 
   /**
    * Options for extracting archive contents.
@@ -7117,13 +7114,17 @@ declare module "bun" {
     /**
      * Create an `Archive` instance from input data.
      *
+     * By default, archives are gzip-compressed at level 6 when no options are provided.
+     * Pass `{}` (empty object) for no compression.
+     *
      * @param data - The input data for the archive:
      *   - **Object**: Creates a new tarball with the object's keys as file paths and values as file contents
      *   - **Blob/TypedArray/ArrayBuffer**: Wraps existing archive data (tar or tar.gz)
-     * @param options - Optional archive options including compression settings
+     * @param options - Optional archive options including compression settings.
+     *   Defaults to gzip level 6 if omitted. Pass `{}` for no compression.
      *
      * @example
-     * **From an object (creates new tarball):**
+     * **From an object (creates gzip-compressed tarball by default):**
      * ```ts
      * const archive = new Bun.Archive({
      *   "hello.txt": "Hello, World!",
@@ -7132,11 +7133,15 @@ declare module "bun" {
      * ```
      *
      * @example
-     * **With gzip compression:**
+     * **With explicit gzip compression level:**
      * ```ts
-     * const archive = new Bun.Archive(data, { gzip: true });
-     * const archive = new Bun.Archive(data, { gzip: 9 }); // level 1-12
-     * const archive = new Bun.Archive(data, { gzip: { level: 12 } });
+     * const archive = new Bun.Archive(data, { compress: "gzip", level: 12 });
+     * ```
+     *
+     * @example
+     * **Uncompressed tar (pass empty options):**
+     * ```ts
+     * const archive = new Bun.Archive(data, {});
      * ```
      *
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6975,18 +6975,20 @@ declare module "bun" {
 
   /**
    * Compression format for archive output.
-   * - `"gzip"` - Compress with gzip
-   * - `true` - Same as `"gzip"`
-   * - `false` - Explicitly disable compression (no compression)
-   * - `undefined` - No compression (default behavior when omitted)
+   * Currently only `"gzip"` is supported.
    */
   type ArchiveCompression = "gzip";
 
   /**
    * Options for creating an Archive instance.
    *
+   * By default, archives are not compressed. Use `{ compress: "gzip" }` to enable compression.
+   *
    * @example
    * ```ts
+   * // No compression (default)
+   * new Bun.Archive(data);
+   *
    * // Enable gzip with default level (6)
    * new Bun.Archive(data, { compress: "gzip" });
    *
@@ -6994,27 +6996,23 @@ declare module "bun" {
    * new Bun.Archive(data, { compress: "gzip", level: 9 });
    * ```
    */
-  type ArchiveOptions =
-    | {
-        /**
-         * Compression algorithm to use.
-         * Currently only "gzip" is supported.
-         */
-        compress: "gzip";
-        /**
-         * Compression level (1-12).
-         * - 1: Fastest compression, lowest ratio
-         * - 6: Default balance of speed and ratio
-         * - 12: Best compression ratio, slowest
-         *
-         * @default 6
-         */
-        level?: number;
-      }
-    | {
-        compress?: never;
-        level?: never;
-      };
+  interface ArchiveOptions {
+    /**
+     * Compression algorithm to use.
+     * Currently only "gzip" is supported.
+     * If not specified, no compression is applied.
+     */
+    compress?: ArchiveCompression;
+    /**
+     * Compression level (1-12). Only applies when `compress` is set.
+     * - 1: Fastest compression, lowest ratio
+     * - 6: Default balance of speed and ratio
+     * - 12: Best compression ratio, slowest
+     *
+     * @default 6
+     */
+    level?: number;
+  }
 
   /**
    * Options for extracting archive contents.
@@ -7104,7 +7102,7 @@ declare module "bun" {
    * await Bun.Archive.write("bundle.tar.gz", {
    *   "src/index.ts": sourceCode,
    *   "package.json": packageJson,
-   * }, "gzip");
+   * }, { compress: "gzip" });
    * ```
    */
   export class Archive {
@@ -7192,7 +7190,7 @@ declare module "bun" {
      * @example
      * **Extract all entries:**
      * ```ts
-     * const archive = Bun.Archive.from(tarballBytes);
+     * const archive = new Bun.Archive(tarballBytes);
      * const count = await archive.extract("./extracted");
      * console.log(`Extracted ${count} entries`);
      * ```
@@ -7236,7 +7234,7 @@ declare module "bun" {
      * @example
      * **Get gzipped tarball as Blob:**
      * ```ts
-     * const archive = new Bun.Archive(data, { gzip: true });
+     * const archive = new Bun.Archive(data, { compress: "gzip" });
      * const gzippedBlob = await archive.blob();
      * ```
      */
@@ -7259,7 +7257,7 @@ declare module "bun" {
      * @example
      * **Get gzipped tarball bytes:**
      * ```ts
-     * const archive = new Bun.Archive(data, { gzip: true });
+     * const archive = new Bun.Archive(data, { compress: "gzip" });
      * const gzippedBytes = await archive.bytes();
      * ```
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6979,11 +6979,8 @@ declare module "bun" {
    * - `true` - Same as `"gzip"`
    * - `false` - Explicitly disable compression (no compression)
    * - `undefined` - No compression (default behavior when omitted)
-   *
-   * Both `false` and `undefined` result in no compression; `false` can be used
-   * to explicitly indicate "no compression" in code where the intent should be clear.
    */
-  type ArchiveCompression = "gzip" | boolean;
+  type ArchiveCompression = "gzip";
 
   /**
    * Options for creating an Archive instance.
@@ -7077,10 +7074,10 @@ declare module "bun" {
    * ```ts
    * const archive = new Bun.Archive({
    *   "hello.txt": "Hello, World!",
-   * }, { gzip: true });
+   * }, { compress: "gzip" });
    *
    * // Or with a specific compression level (1-12)
-   * const archive = new Bun.Archive(data, { gzip: 9 });
+   * const archive = new Bun.Archive(data, { compress: "gzip", level: 9 });
    * ```
    *
    * @example
@@ -7114,17 +7111,16 @@ declare module "bun" {
     /**
      * Create an `Archive` instance from input data.
      *
-     * By default, archives are gzip-compressed at level 6 when no options are provided.
-     * Pass `{}` (empty object) for no compression.
+     * By default, archives are not compressed. Use `{ compress: "gzip" }` to enable compression.
      *
      * @param data - The input data for the archive:
      *   - **Object**: Creates a new tarball with the object's keys as file paths and values as file contents
      *   - **Blob/TypedArray/ArrayBuffer**: Wraps existing archive data (tar or tar.gz)
      * @param options - Optional archive options including compression settings.
-     *   Defaults to gzip level 6 if omitted. Pass `{}` for no compression.
+     *   Defaults to no compression if omitted.
      *
      * @example
-     * **From an object (creates gzip-compressed tarball by default):**
+     * **From an object (creates uncompressed tarball):**
      * ```ts
      * const archive = new Bun.Archive({
      *   "hello.txt": "Hello, World!",
@@ -7133,15 +7129,15 @@ declare module "bun" {
      * ```
      *
      * @example
-     * **With explicit gzip compression level:**
+     * **With gzip compression:**
      * ```ts
-     * const archive = new Bun.Archive(data, { compress: "gzip", level: 12 });
+     * const archive = new Bun.Archive(data, { compress: "gzip" });
      * ```
      *
      * @example
-     * **Uncompressed tar (pass empty options):**
+     * **With explicit gzip compression level:**
      * ```ts
-     * const archive = new Bun.Archive(data, {});
+     * const archive = new Bun.Archive(data, { compress: "gzip", level: 12 });
      * ```
      *
      * @example
@@ -7160,8 +7156,8 @@ declare module "bun" {
      * as it streams the data directly to disk.
      *
      * @param path - The file path to write the archive to
-     * @param data - The input data for the archive (same as `Archive.from()`)
-     * @param compress - Optional compression: `"gzip"`, `true` for gzip, or `false`/`undefined` for none
+     * @param data - The input data for the archive (same as `new Archive()`)
+     * @param options - Optional archive options including compression settings
      *
      * @returns A promise that resolves when the write is complete
      *
@@ -7177,10 +7173,10 @@ declare module "bun" {
      * @example
      * **Write gzipped tarball:**
      * ```ts
-     * await Bun.Archive.write("output.tar.gz", files, "gzip");
+     * await Bun.Archive.write("output.tar.gz", files, { compress: "gzip" });
      * ```
      */
-    static write(path: string, data: ArchiveInput | Archive, compress?: ArchiveCompression): Promise<void>;
+    static write(path: string, data: ArchiveInput | Archive, options?: ArchiveOptions): Promise<void>;
 
     /**
      * Extract the archive contents to a directory on disk.

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -609,7 +609,17 @@ declare module "bun" {
      *     });
      */
     write(
-      data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer | Request | Response | BunFile | S3File | Blob,
+      data:
+        | string
+        | ArrayBufferView
+        | ArrayBuffer
+        | SharedArrayBuffer
+        | Request
+        | Response
+        | BunFile
+        | S3File
+        | Blob
+        | Archive,
       options?: S3Options,
     ): Promise<number>;
 
@@ -920,7 +930,8 @@ declare module "bun" {
         | BunFile
         | S3File
         | Blob
-        | File,
+        | File
+        | Archive,
       options?: S3Options,
     ): Promise<number>;
 
@@ -970,7 +981,8 @@ declare module "bun" {
         | BunFile
         | S3File
         | Blob
-        | File,
+        | File
+        | Archive,
       options?: S3Options,
     ): Promise<number>;
 

--- a/src/bun.js/api/Archive.classes.ts
+++ b/src/bun.js/api/Archive.classes.ts
@@ -8,10 +8,6 @@ export default [
     configurable: false,
     JSType: "0b11101110",
     klass: {
-      from: {
-        fn: "from",
-        length: 1,
-      },
       write: {
         fn: "write",
         length: 2,

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -83,19 +83,15 @@ fn countFilesInArchive(data: []const u8) u32 {
 /// Options:
 /// - compress: "gzip" - Enable gzip compression
 /// - level: number (1-12) - Compression level (default 6)
-/// When no options are provided, defaults to gzip level 6 compression
+/// When no options are provided, no compression is applied
 pub fn constructor(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!*Archive {
     const data_arg, const options_arg = callframe.argumentsAsArray(2);
     if (data_arg == .zero) {
         return globalThis.throwInvalidArguments("new Archive() requires an argument", .{});
     }
 
-    // Parse compression options, defaulting to gzip level 6 when no options provided
-    const parsed_compress = try parseCompressionOptions(globalThis, options_arg);
-    const compress: Compression = if (parsed_compress == .none and options_arg.isUndefinedOrNull())
-        .{ .gzip = .{ .level = 6 } }
-    else
-        parsed_compress;
+    // Parse compression options
+    const compress = try parseCompressionOptions(globalThis, options_arg);
 
     // For Blob/Archive, ref the existing store (zero-copy)
     if (data_arg.as(jsc.WebCore.Blob)) |blob_ptr| {

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1484,6 +1484,12 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
             }
         }
 
+        // Check for Archive - allows Bun.write() and S3 writes to accept Archive instances
+        if (data.as(Archive)) |archive| {
+            archive.store.ref();
+            break :brk Blob.initWithStore(archive.store, globalThis);
+        }
+
         break :brk try Blob.get(
             globalThis,
             data,
@@ -4828,6 +4834,7 @@ const NewReadFileHandler = read_file.NewReadFileHandler;
 
 const string = []const u8;
 
+const Archive = @import("../api/Archive.zig");
 const Environment = @import("../../env.zig");
 const S3File = @import("./S3File.zig");
 const std = @import("std");

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -219,30 +219,29 @@ describe("Bun.Archive", () => {
       expect(level12Blob.size).toBeLessThan(level1Blob.size);
     });
 
-    test("defaults to gzip level 6 when no options provided", async () => {
+    test("defaults to no compression when no options provided", async () => {
       const largeContent = Buffer.alloc(13000, "Hello, World!");
 
-      // No options = gzip level 6
+      // No options = no compression
       const defaultArchive = new Bun.Archive({
         "large.txt": largeContent,
       });
 
-      // Explicit gzip level 6
-      const explicitLevel6Archive = new Bun.Archive({ "large.txt": largeContent }, { compress: "gzip", level: 6 });
+      // Explicit empty options = also no compression
+      const emptyOptionsArchive = new Bun.Archive({ "large.txt": largeContent }, {});
 
-      // Uncompressed with empty options
-      const uncompressedArchive = new Bun.Archive({ "large.txt": largeContent }, {});
+      // Explicit gzip compression
+      const compressedArchive = new Bun.Archive({ "large.txt": largeContent }, { compress: "gzip" });
 
       const defaultBlob = await defaultArchive.blob();
-      const explicitLevel6Blob = await explicitLevel6Archive.blob();
-      const uncompressedBlob = await uncompressedArchive.blob();
+      const emptyOptionsBlob = await emptyOptionsArchive.blob();
+      const compressedBlob = await compressedArchive.blob();
 
-      // Default should match explicit level 6
-      expect(defaultBlob.size).toBe(explicitLevel6Blob.size);
+      // Default should match empty options (both uncompressed)
+      expect(defaultBlob.size).toBe(emptyOptionsBlob.size);
 
-      // Both should be smaller than uncompressed
-      expect(defaultBlob.size).toBeLessThan(uncompressedBlob.size);
-      expect(explicitLevel6Blob.size).toBeLessThan(uncompressedBlob.size);
+      // Compressed should be smaller than uncompressed
+      expect(compressedBlob.size).toBeLessThan(defaultBlob.size);
     });
 
     test("throws with invalid gzip level", () => {
@@ -649,7 +648,7 @@ describe("Bun.Archive", () => {
       const file = Bun.file(archivePath);
       expect(await file.exists()).toBe(true);
 
-      // Compare with uncompressed (use empty options to disable default gzip)
+      // Compare with uncompressed (no options = no compression)
       const uncompressedPath = join(String(dir), "test.tar");
       await Bun.Archive.write(
         uncompressedPath,
@@ -1498,10 +1497,10 @@ describe("Bun.Archive", () => {
     test("valid archive options", () => {
       const files = { "hello.txt": "Hello, World!" };
 
-      // Valid: no options (defaults to gzip level 6)
+      // Valid: no options (no compression)
       new Bun.Archive(files);
 
-      // Valid: empty options (no compression)
+      // Valid: empty options (also no compression)
       new Bun.Archive(files, {});
 
       // Valid: explicit gzip compression

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -3,9 +3,9 @@ import { tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Archive", () => {
-  describe("Archive.from", () => {
+  describe("new Archive()", () => {
     test("creates archive from object with string values", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
         "data.json": JSON.stringify({ foo: "bar" }),
       });
@@ -14,7 +14,7 @@ describe("Bun.Archive", () => {
     });
 
     test("creates archive from object with Blob values", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "blob1.txt": new Blob(["Hello from Blob"]),
         "blob2.txt": new Blob(["Another Blob"]),
       });
@@ -24,7 +24,7 @@ describe("Bun.Archive", () => {
 
     test("creates archive from object with Uint8Array values", async () => {
       const encoder = new TextEncoder();
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "bytes1.txt": encoder.encode("Hello from Uint8Array"),
         "bytes2.txt": encoder.encode("Another Uint8Array"),
       });
@@ -34,7 +34,7 @@ describe("Bun.Archive", () => {
 
     test("creates archive from object with ArrayBuffer values", async () => {
       const encoder = new TextEncoder();
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "buffer1.txt": encoder.encode("Hello from ArrayBuffer").buffer,
         "buffer2.txt": encoder.encode("Another ArrayBuffer").buffer,
       });
@@ -44,7 +44,7 @@ describe("Bun.Archive", () => {
 
     test("creates archive from object with mixed value types", async () => {
       const encoder = new TextEncoder();
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "string.txt": "String content",
         "blob.txt": new Blob(["Blob content"]),
         "uint8.txt": encoder.encode("Uint8Array content"),
@@ -56,7 +56,7 @@ describe("Bun.Archive", () => {
 
     test("creates archive from Blob", async () => {
       // First create an archive with some content
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "test.txt": "test content",
       });
 
@@ -64,35 +64,35 @@ describe("Bun.Archive", () => {
       expect(blob).toBeInstanceOf(Blob);
 
       // Create new archive from the blob
-      const archive = Bun.Archive.from(blob);
+      const archive = new Bun.Archive(blob);
       expect(archive).toBeInstanceOf(Bun.Archive);
     });
 
     test("creates archive from ArrayBuffer", async () => {
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "test.txt": "test content",
       });
 
       const bytes = await sourceArchive.bytes();
       const buffer = bytes.buffer;
 
-      const archive = Bun.Archive.from(buffer);
+      const archive = new Bun.Archive(buffer);
       expect(archive).toBeInstanceOf(Bun.Archive);
     });
 
     test("creates archive from Uint8Array", async () => {
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "test.txt": "test content",
       });
 
       const bytes = await sourceArchive.bytes();
 
-      const archive = Bun.Archive.from(bytes);
+      const archive = new Bun.Archive(bytes);
       expect(archive).toBeInstanceOf(Bun.Archive);
     });
 
     test("creates archive with nested directory structure", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "root.txt": "Root file",
         "dir1/file1.txt": "File in dir1",
         "dir1/dir2/file2.txt": "File in dir1/dir2",
@@ -103,7 +103,7 @@ describe("Bun.Archive", () => {
     });
 
     test("creates archive with empty string value", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "empty.txt": "",
       });
 
@@ -113,27 +113,27 @@ describe("Bun.Archive", () => {
     test("throws with no arguments", () => {
       expect(() => {
         // @ts-expect-error - testing runtime behavior
-        Bun.Archive.from();
+        new Bun.Archive();
       }).toThrow();
     });
 
     test("throws with invalid input type (number)", () => {
       expect(() => {
         // @ts-expect-error - testing runtime behavior
-        Bun.Archive.from(123);
+        new Bun.Archive(123);
       }).toThrow();
     });
 
     test("throws with invalid input type (null)", () => {
       expect(() => {
         // @ts-expect-error - testing runtime behavior
-        Bun.Archive.from(null);
+        new Bun.Archive(null);
       }).toThrow();
     });
 
     test("converts non-string/buffer values to strings", async () => {
       // @ts-expect-error - testing runtime behavior
-      const archive = Bun.Archive.from({ "file.txt": 123 });
+      const archive = new Bun.Archive({ "file.txt": 123 });
       // The archive should be created successfully - number is converted to string
       expect(archive).toBeDefined();
       const bytes = await archive.bytes();
@@ -144,7 +144,7 @@ describe("Bun.Archive", () => {
 
   describe("archive.blob()", () => {
     test("returns a Blob", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -154,7 +154,7 @@ describe("Bun.Archive", () => {
     });
 
     test("returns consistent output for same input", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -163,13 +163,19 @@ describe("Bun.Archive", () => {
       expect(blob1.size).toBe(blob2.size);
     });
 
-    test("with gzip returns gzipped blob", async () => {
-      const archive = Bun.Archive.from({
+    test("with gzip option returns gzipped blob", async () => {
+      const regularArchive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
+      const gzipArchive = new Bun.Archive(
+        {
+          "hello.txt": "Hello, World!",
+        },
+        { gzip: {} },
+      );
 
-      const regularBlob = await archive.blob();
-      const gzippedBlob = await archive.blob("gzip");
+      const regularBlob = await regularArchive.blob();
+      const gzippedBlob = await gzipArchive.blob();
 
       expect(gzippedBlob).toBeInstanceOf(Blob);
       // Gzipped should be different size
@@ -178,32 +184,49 @@ describe("Bun.Archive", () => {
 
     test("gzip is smaller for larger repetitive data", async () => {
       const largeContent = Buffer.alloc(13000, "Hello, World!");
-      const archive = Bun.Archive.from({
+      const regularArchive = new Bun.Archive({
         "large.txt": largeContent,
       });
+      const gzipArchive = new Bun.Archive(
+        {
+          "large.txt": largeContent,
+        },
+        { gzip: {} },
+      );
 
-      const regularBlob = await archive.blob();
-      const gzippedBlob = await archive.blob("gzip");
+      const regularBlob = await regularArchive.blob();
+      const gzippedBlob = await gzipArchive.blob();
 
       // For large repetitive data, gzip should be smaller
       expect(gzippedBlob.size).toBeLessThan(regularBlob.size);
     });
 
-    test("throws with invalid compress argument", async () => {
-      const archive = Bun.Archive.from({
-        "hello.txt": "Hello, World!",
-      });
+    test("gzip level affects compression ratio", async () => {
+      const largeContent = Buffer.alloc(50000, "Hello, World!");
+      const level1Archive = new Bun.Archive({ "large.txt": largeContent }, { gzip: { level: 1 } });
+      const level12Archive = new Bun.Archive({ "large.txt": largeContent }, { gzip: { level: 12 } });
 
-      await expect(async () => {
-        // @ts-expect-error - testing runtime behavior
-        await archive.blob("invalid");
+      const level1Blob = await level1Archive.blob();
+      const level12Blob = await level12Archive.blob();
+
+      // Level 12 should produce smaller output than level 1
+      expect(level12Blob.size).toBeLessThan(level1Blob.size);
+    });
+
+    test("throws with invalid gzip level", () => {
+      expect(() => {
+        new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: { level: 0 } });
+      }).toThrow();
+
+      expect(() => {
+        new Bun.Archive({ "hello.txt": "Hello, World!" }, { gzip: { level: 13 } });
       }).toThrow();
     });
   });
 
   describe("archive.bytes()", () => {
     test("returns a Uint8Array", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -213,7 +236,7 @@ describe("Bun.Archive", () => {
     });
 
     test("returns consistent output for same input", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -222,13 +245,19 @@ describe("Bun.Archive", () => {
       expect(bytes1.length).toBe(bytes2.length);
     });
 
-    test("with gzip returns gzipped bytes", async () => {
-      const archive = Bun.Archive.from({
+    test("with gzip option returns gzipped bytes", async () => {
+      const regularArchive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
+      const gzipArchive = new Bun.Archive(
+        {
+          "hello.txt": "Hello, World!",
+        },
+        { gzip: true },
+      );
 
-      const regularBytes = await archive.bytes();
-      const gzippedBytes = await archive.bytes("gzip");
+      const regularBytes = await regularArchive.bytes();
+      const gzippedBytes = await gzipArchive.bytes();
 
       expect(gzippedBytes).toBeInstanceOf(Uint8Array);
       // Gzipped should be different size
@@ -237,19 +266,25 @@ describe("Bun.Archive", () => {
 
     test("gzip is smaller for larger repetitive data", async () => {
       const largeContent = Buffer.alloc(13000, "Hello, World!");
-      const archive = Bun.Archive.from({
+      const regularArchive = new Bun.Archive({
         "large.txt": largeContent,
       });
+      const gzipArchive = new Bun.Archive(
+        {
+          "large.txt": largeContent,
+        },
+        { gzip: true },
+      );
 
-      const regularBytes = await archive.bytes();
-      const gzippedBytes = await archive.bytes("gzip");
+      const regularBytes = await regularArchive.bytes();
+      const gzippedBytes = await gzipArchive.bytes();
 
       // For large repetitive data, gzip should be smaller
       expect(gzippedBytes.length).toBeLessThan(regularBytes.length);
     });
 
     test("bytes match blob content", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -262,24 +297,13 @@ describe("Bun.Archive", () => {
         expect(bytes[i]).toBe(blobBytes[i]);
       }
     });
-
-    test("throws with invalid compress argument", async () => {
-      const archive = Bun.Archive.from({
-        "hello.txt": "Hello, World!",
-      });
-
-      await expect(async () => {
-        // @ts-expect-error - testing runtime behavior
-        await archive.bytes("deflate");
-      }).toThrow();
-    });
   });
 
   describe("archive.extract()", () => {
     test("extracts to directory and returns file count", async () => {
       using dir = tempDir("archive-extract-test", {});
 
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
         "subdir/nested.txt": "Nested content",
       });
@@ -295,7 +319,7 @@ describe("Bun.Archive", () => {
     test("extracts nested directory structure", async () => {
       using dir = tempDir("archive-extract-nested", {});
 
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "root.txt": "Root file",
         "dir1/file1.txt": "File in dir1",
         "dir1/dir2/file2.txt": "File in dir1/dir2",
@@ -316,7 +340,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("archive-extract-binary", {});
 
       const binaryData = new Uint8Array([0, 1, 2, 255, 254, 253, 128, 127]);
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "binary.bin": binaryData,
       });
 
@@ -333,13 +357,13 @@ describe("Bun.Archive", () => {
       using dir = tempDir("archive-extract-from-blob", {});
 
       // Create original archive
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "test.txt": "test content",
       });
 
       // Get as blob and create new archive
       const blob = await sourceArchive.blob();
-      const archive = Bun.Archive.from(blob);
+      const archive = new Bun.Archive(blob);
 
       const count = await archive.extract(String(dir));
       expect(count).toBeGreaterThan(0);
@@ -352,13 +376,13 @@ describe("Bun.Archive", () => {
       using dir = tempDir("archive-extract-from-bytes", {});
 
       // Create original archive
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "test.txt": "test content",
       });
 
       // Get as bytes and create new archive
       const bytes = await sourceArchive.bytes();
-      const archive = Bun.Archive.from(bytes);
+      const archive = new Bun.Archive(bytes);
 
       const count = await archive.extract(String(dir));
       expect(count).toBeGreaterThan(0);
@@ -368,7 +392,7 @@ describe("Bun.Archive", () => {
     });
 
     test("throws with missing path argument", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -379,7 +403,7 @@ describe("Bun.Archive", () => {
     });
 
     test("throws with non-string path argument", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -393,7 +417,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("archive-extract-create-dir", {});
       const newDir = join(String(dir), "new-subdir", "nested");
 
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -410,7 +434,7 @@ describe("Bun.Archive", () => {
         "existing-file.txt": "I am a file",
       });
 
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -425,7 +449,7 @@ describe("Bun.Archive", () => {
     test("throws when extracting corrupted archive data", async () => {
       // Create garbage data that's not a valid archive
       const corruptedData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-      const archive = Bun.Archive.from(corruptedData);
+      const archive = new Bun.Archive(corruptedData);
 
       using dir = tempDir("archive-corrupted", {});
 
@@ -436,14 +460,14 @@ describe("Bun.Archive", () => {
 
     test("throws when extracting truncated archive", async () => {
       // Create a valid archive then truncate it
-      const validArchive = Bun.Archive.from({
+      const validArchive = new Bun.Archive({
         "file.txt": "Hello, World!",
       });
       const bytes = await validArchive.bytes();
 
       // Truncate to only first 10 bytes - definitely incomplete
       const truncated = bytes.slice(0, 10);
-      const archive = Bun.Archive.from(truncated);
+      const archive = new Bun.Archive(truncated);
 
       using dir = tempDir("archive-truncated", {});
 
@@ -459,7 +483,7 @@ describe("Bun.Archive", () => {
         randomBytes[i] = Math.floor(Math.random() * 256);
       }
 
-      const archive = Bun.Archive.from(randomBytes);
+      const archive = new Bun.Archive(randomBytes);
 
       using dir = tempDir("archive-random", {});
 
@@ -471,7 +495,7 @@ describe("Bun.Archive", () => {
     test("handles empty archive gracefully", async () => {
       // Empty data
       const emptyData = new Uint8Array(0);
-      const archive = Bun.Archive.from(emptyData);
+      const archive = new Bun.Archive(emptyData);
 
       using dir = tempDir("archive-empty", {});
 
@@ -487,7 +511,7 @@ describe("Bun.Archive", () => {
 
   describe("path safety", () => {
     test("normalizes paths with redundant separators", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "dir//subdir///file.txt": "content",
       });
 
@@ -500,7 +524,7 @@ describe("Bun.Archive", () => {
     });
 
     test("handles paths with dots correctly", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "dir/./file.txt": "content1",
         "dir/subdir/../file2.txt": "content2",
       });
@@ -516,7 +540,7 @@ describe("Bun.Archive", () => {
     test("handles very long filenames", async () => {
       // Create a filename that's quite long but within reasonable limits
       const longName = "a".repeat(200) + ".txt";
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         [longName]: "content",
       });
 
@@ -535,7 +559,7 @@ describe("Bun.Archive", () => {
     test("handles deeply nested paths", async () => {
       // Create a deeply nested path
       const deepPath = Array(50).fill("dir").join("/") + "/file.txt";
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         [deepPath]: "deep content",
       });
 
@@ -575,10 +599,12 @@ describe("Bun.Archive", () => {
 
       await Bun.Archive.write(
         archivePath,
-        {
-          "hello.txt": largeContent,
-        },
-        "gzip",
+        new Bun.Archive(
+          {
+            "hello.txt": largeContent,
+          },
+          { gzip: true },
+        ),
       );
 
       // Verify file exists and is smaller than uncompressed
@@ -599,7 +625,7 @@ describe("Bun.Archive", () => {
       const archivePath = join(String(dir), "test.tar");
 
       // Create archive and get blob
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "test.txt": "test content",
       });
       const blob = await sourceArchive.blob();
@@ -625,7 +651,7 @@ describe("Bun.Archive", () => {
 
       // Extract it
       const blob = await Bun.file(archivePath).bytes();
-      const archive = Bun.Archive.from(blob);
+      const archive = new Bun.Archive(blob);
       require("fs").mkdirSync(extractDir, { recursive: true });
       const count = await archive.extract(extractDir);
       expect(count).toBeGreaterThan(0);
@@ -649,29 +675,23 @@ describe("Bun.Archive", () => {
       }).toThrow();
     });
 
-    test("throws with invalid compress argument", async () => {
-      using dir = tempDir("archive-write-invalid-compress", {});
+    test("throws with invalid gzip option", async () => {
+      using dir = tempDir("archive-write-invalid-gzip", {});
       const archivePath = join(String(dir), "test.tar");
 
       await expect(async () => {
-        // @ts-expect-error - testing runtime behavior
-        await Bun.Archive.write(archivePath, { "file.txt": "content" }, "invalid");
+        await Bun.Archive.write(archivePath, new Bun.Archive({ "file.txt": "content" }, { gzip: { level: 0 } }));
       }).toThrow();
-    });
-  });
 
-  describe("new Archive()", () => {
-    test("throws when constructed directly", () => {
-      expect(() => {
-        // @ts-expect-error - testing runtime behavior
-        new Bun.Archive();
-      }).toThrow("Archive cannot be constructed directly");
+      await expect(async () => {
+        await Bun.Archive.write(archivePath, new Bun.Archive({ "file.txt": "content" }, { gzip: { level: 13 } }));
+      }).toThrow();
     });
   });
 
   describe("GC safety", () => {
     test("archive remains valid after GC", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
       });
 
@@ -690,7 +710,7 @@ describe("Bun.Archive", () => {
         entries[`file${i}.txt`] = `Content for file ${i}`;
       }
 
-      const archive = Bun.Archive.from(entries);
+      const archive = new Bun.Archive(entries);
 
       // Force GC multiple times
       Bun.gc(true);
@@ -705,7 +725,7 @@ describe("Bun.Archive", () => {
 
     test("original data mutation doesn't affect archive", async () => {
       const data = new Uint8Array([1, 2, 3, 4, 5]);
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "data.bin": data,
       });
 
@@ -728,12 +748,12 @@ describe("Bun.Archive", () => {
     test("blob source mutation doesn't affect archive", async () => {
       const original = new Uint8Array([1, 2, 3, 4, 5]);
       const blob = new Blob([original]);
-      const sourceArchive = Bun.Archive.from({
+      const sourceArchive = new Bun.Archive({
         "data.bin": blob,
       });
 
       const archiveBlob = await sourceArchive.blob();
-      const archive = Bun.Archive.from(archiveBlob);
+      const archive = new Bun.Archive(archiveBlob);
 
       // Force GC
       Bun.gc(true);
@@ -757,7 +777,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("archive-gc-no-ref", {});
 
       // Create promise without keeping archive reference
-      const promise = Bun.Archive.from({
+      const promise = new Bun.Archive({
         "test.txt": "Hello from GC test!",
       }).extract(String(dir));
 
@@ -776,7 +796,7 @@ describe("Bun.Archive", () => {
 
     test("blob() works even if archive is not referenced", async () => {
       // Get blob promise without keeping archive reference
-      const promise = Bun.Archive.from({
+      const promise = new Bun.Archive({
         "file.txt": "Blob GC test content",
       }).blob();
 
@@ -791,7 +811,7 @@ describe("Bun.Archive", () => {
 
     test("bytes() works even if archive is not referenced", async () => {
       // Get bytes promise without keeping archive reference
-      const promise = Bun.Archive.from({
+      const promise = new Bun.Archive({
         "file.txt": "Bytes GC test content",
       }).bytes();
 
@@ -808,7 +828,7 @@ describe("Bun.Archive", () => {
   describe("large archives", () => {
     test("handles large file content", async () => {
       const largeContent = Buffer.alloc(1024 * 1024, "x"); // 1MB
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "large.txt": largeContent,
       });
 
@@ -825,7 +845,7 @@ describe("Bun.Archive", () => {
         entries[`file${i.toString().padStart(4, "0")}.txt`] = `Content ${i}`;
       }
 
-      const archive = Bun.Archive.from(entries);
+      const archive = new Bun.Archive(entries);
 
       using dir = tempDir("archive-many-files", {});
       const count = await archive.extract(String(dir));
@@ -835,7 +855,7 @@ describe("Bun.Archive", () => {
 
   describe("special characters", () => {
     test("handles filenames with spaces", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file with spaces.txt": "content",
       });
 
@@ -849,7 +869,7 @@ describe("Bun.Archive", () => {
     test("handles special characters in filenames", async () => {
       // Note: Some unicode characters may not be supported by all tar formats
       // Using ASCII-only special characters
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file-with-dash.txt": "content1",
         "file_with_underscore.txt": "content2",
         "file.with.dots.txt": "content3",
@@ -864,7 +884,7 @@ describe("Bun.Archive", () => {
     });
 
     test("handles unicode content", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "unicode.txt": "Hello, 世界! Привет! Γειά σου!",
       });
 
@@ -878,7 +898,7 @@ describe("Bun.Archive", () => {
 
   describe("archive.files()", () => {
     test("returns a Map of File objects", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
         "data.json": JSON.stringify({ foo: "bar" }),
       });
@@ -899,14 +919,14 @@ describe("Bun.Archive", () => {
     });
 
     test("returns empty Map for empty archive", async () => {
-      const archive = Bun.Archive.from({});
+      const archive = new Bun.Archive({});
       const files = await archive.files();
       expect(files).toBeInstanceOf(Map);
       expect(files.size).toBe(0);
     });
 
     test("handles nested directory structure", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "root.txt": "Root file",
         "dir1/file1.txt": "File in dir1",
         "dir1/dir2/file2.txt": "File in dir1/dir2",
@@ -921,7 +941,7 @@ describe("Bun.Archive", () => {
     });
 
     test("filters files with glob pattern", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file1.txt": "Text file 1",
         "file2.txt": "Text file 2",
         "file1.json": "JSON file 1",
@@ -937,7 +957,7 @@ describe("Bun.Archive", () => {
     });
 
     test("filters with ** glob pattern", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file1.txt": "Text file 1",
         "subdir/file2.txt": "Text file 2",
         "subdir/deep/file3.txt": "Text file 3",
@@ -953,7 +973,7 @@ describe("Bun.Archive", () => {
     });
 
     test("filters with directory pattern", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "src/index.js": "source 1",
         "src/util.js": "source 2",
         "test/index.test.js": "test 1",
@@ -967,7 +987,7 @@ describe("Bun.Archive", () => {
     });
 
     test("returns empty Map when no files match glob", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file1.txt": "Text file",
         "file2.json": "JSON file",
       });
@@ -979,7 +999,7 @@ describe("Bun.Archive", () => {
 
     test("handles binary data correctly", async () => {
       const binaryData = new Uint8Array([0, 1, 2, 255, 254, 253, 128, 127]);
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "binary.bin": binaryData,
       });
 
@@ -997,7 +1017,7 @@ describe("Bun.Archive", () => {
     test("File objects have lastModified property", async () => {
       // Tar archives store mtime in seconds, so round down to nearest second
       const beforeTime = Math.floor(Date.now() / 1000) * 1000;
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
       });
 
@@ -1010,7 +1030,7 @@ describe("Bun.Archive", () => {
     });
 
     test("throws with non-string glob argument", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
       });
 
@@ -1021,12 +1041,15 @@ describe("Bun.Archive", () => {
     });
 
     test("works with gzipped archive source", async () => {
-      const sourceArchive = Bun.Archive.from({
-        "hello.txt": "Hello from gzip!",
-      });
+      const sourceArchive = new Bun.Archive(
+        {
+          "hello.txt": "Hello from gzip!",
+        },
+        { gzip: true },
+      );
 
-      const gzippedBlob = await sourceArchive.blob("gzip");
-      const archive = Bun.Archive.from(gzippedBlob);
+      const gzippedBlob = await sourceArchive.blob();
+      const archive = new Bun.Archive(gzippedBlob);
 
       const files = await archive.files();
       expect(files.size).toBe(1);
@@ -1034,7 +1057,7 @@ describe("Bun.Archive", () => {
     });
 
     test("concurrent files() operations work correctly", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
       });
 
@@ -1046,7 +1069,7 @@ describe("Bun.Archive", () => {
     });
 
     test("files() works even if archive is not referenced (GC safety)", async () => {
-      const promise = Bun.Archive.from({
+      const promise = new Bun.Archive({
         "test.txt": "GC test content",
       }).files();
 
@@ -1069,7 +1092,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("sparse-small", {});
 
       const tarData = await Bun.file(join(fixturesDir, "small-hole.tar")).bytes();
-      const archive = Bun.Archive.from(tarData);
+      const archive = new Bun.Archive(tarData);
       await archive.extract(String(dir));
 
       const extracted = await Bun.file(join(String(dir), "small-hole.bin")).bytes();
@@ -1085,7 +1108,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("sparse-1block", {});
 
       const tarData = await Bun.file(join(fixturesDir, "one-block-hole.tar")).bytes();
-      const archive = Bun.Archive.from(tarData);
+      const archive = new Bun.Archive(tarData);
       await archive.extract(String(dir));
 
       const extracted = await Bun.file(join(String(dir), "one-block-hole.bin")).bytes();
@@ -1101,7 +1124,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("sparse-multi", {});
 
       const tarData = await Bun.file(join(fixturesDir, "multi-block-hole.tar")).bytes();
-      const archive = Bun.Archive.from(tarData);
+      const archive = new Bun.Archive(tarData);
       await archive.extract(String(dir));
 
       const extracted = await Bun.file(join(String(dir), "multi-block-hole.bin")).bytes();
@@ -1116,7 +1139,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("sparse-leading", {});
 
       const tarData = await Bun.file(join(fixturesDir, "leading-hole.tar")).bytes();
-      const archive = Bun.Archive.from(tarData);
+      const archive = new Bun.Archive(tarData);
       await archive.extract(String(dir));
 
       const extracted = await Bun.file(join(String(dir), "leading-hole.bin")).bytes();
@@ -1131,7 +1154,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("sparse-trailing", {});
 
       const tarData = await Bun.file(join(fixturesDir, "trailing-hole.tar")).bytes();
-      const archive = Bun.Archive.from(tarData);
+      const archive = new Bun.Archive(tarData);
       await archive.extract(String(dir));
 
       const extracted = await Bun.file(join(String(dir), "trailing-hole.bin")).bytes();
@@ -1146,7 +1169,7 @@ describe("Bun.Archive", () => {
       using dir = tempDir("sparse-large", {});
 
       const tarData = await Bun.file(join(fixturesDir, "large-hole.tar")).bytes();
-      const archive = Bun.Archive.from(tarData);
+      const archive = new Bun.Archive(tarData);
       await archive.extract(String(dir));
 
       const extracted = await Bun.file(join(String(dir), "large-hole.bin")).bytes();
@@ -1160,7 +1183,7 @@ describe("Bun.Archive", () => {
 
   describe("extract with glob patterns", () => {
     test("extracts only files matching glob pattern", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "src/index.ts": "export {}",
         "src/utils.ts": "export {}",
         "src/types.d.ts": "declare {}",
@@ -1183,7 +1206,7 @@ describe("Bun.Archive", () => {
     });
 
     test("extracts files matching any of multiple glob patterns", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "src/index.ts": "export {}",
         "lib/utils.js": "module.exports = {}",
         "test/test.ts": "test()",
@@ -1201,7 +1224,7 @@ describe("Bun.Archive", () => {
     });
 
     test("excludes files matching negative pattern", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "src/index.ts": "export {}",
         "src/index.test.ts": "test()",
         "src/utils.ts": "export {}",
@@ -1220,7 +1243,7 @@ describe("Bun.Archive", () => {
     });
 
     test("excludes files matching any of multiple negative patterns", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "src/index.ts": "export {}",
         "src/index.test.ts": "test()",
         "__tests__/helper.ts": "helper",
@@ -1240,7 +1263,7 @@ describe("Bun.Archive", () => {
     });
 
     test("combines positive and negative glob patterns", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "src/index.ts": "export {}",
         "src/index.test.ts": "test()",
         "src/utils.ts": "export {}",
@@ -1264,7 +1287,7 @@ describe("Bun.Archive", () => {
     });
 
     test("extracts all files when no patterns are provided", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file1.txt": "content1",
         "file2.txt": "content2",
       });
@@ -1278,7 +1301,7 @@ describe("Bun.Archive", () => {
     });
 
     test("returns 0 when no files match glob pattern", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
         "other.md": "markdown",
       });
@@ -1292,7 +1315,7 @@ describe("Bun.Archive", () => {
 
   describe("concurrent operations", () => {
     test("multiple extract operations run correctly", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
       });
 
@@ -1316,7 +1339,7 @@ describe("Bun.Archive", () => {
     });
 
     test("multiple blob operations run correctly", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
       });
 
@@ -1327,7 +1350,7 @@ describe("Bun.Archive", () => {
     });
 
     test("mixed operations run correctly", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "file.txt": "content",
       });
 
@@ -1343,7 +1366,7 @@ describe("Bun.Archive", () => {
 
   describe("Bun.write with Archive", () => {
     test("writes archive to local file", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "hello.txt": "Hello, World!",
         "data.json": JSON.stringify({ foo: "bar" }),
       });
@@ -1358,7 +1381,7 @@ describe("Bun.Archive", () => {
       expect(await Bun.file(tarPath).exists()).toBe(true);
 
       // Read it back and verify contents
-      const readArchive = Bun.Archive.from(await Bun.file(tarPath).bytes());
+      const readArchive = new Bun.Archive(await Bun.file(tarPath).bytes());
       const files = await readArchive.files();
       expect(files.size).toBe(2);
       expect(files.get("hello.txt")).toBeDefined();
@@ -1367,7 +1390,7 @@ describe("Bun.Archive", () => {
     });
 
     test("writes archive with nested directories", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "root.txt": "root file",
         "dir1/file1.txt": "file in dir1",
         "dir1/dir2/file2.txt": "file in dir1/dir2",
@@ -1379,7 +1402,7 @@ describe("Bun.Archive", () => {
       await Bun.write(tarPath, archive);
 
       // Read it back
-      const readArchive = Bun.Archive.from(await Bun.file(tarPath).bytes());
+      const readArchive = new Bun.Archive(await Bun.file(tarPath).bytes());
       const files = await readArchive.files();
       expect(files.size).toBe(3);
       expect(await files.get("dir1/dir2/file2.txt")!.text()).toBe("file in dir1/dir2");
@@ -1387,7 +1410,7 @@ describe("Bun.Archive", () => {
 
     test("writes archive with binary content", async () => {
       const binaryData = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "binary.bin": binaryData,
       });
 
@@ -1397,14 +1420,14 @@ describe("Bun.Archive", () => {
       await Bun.write(tarPath, archive);
 
       // Read it back
-      const readArchive = Bun.Archive.from(await Bun.file(tarPath).bytes());
+      const readArchive = new Bun.Archive(await Bun.file(tarPath).bytes());
       const files = await readArchive.files();
       const extractedBinary = await files.get("binary.bin")!.bytes();
       expect(extractedBinary).toEqual(binaryData);
     });
 
     test("writes archive to Bun.file()", async () => {
-      const archive = Bun.Archive.from({
+      const archive = new Bun.Archive({
         "test.txt": "test content",
       });
 
@@ -1415,7 +1438,7 @@ describe("Bun.Archive", () => {
       await Bun.write(bunFile, archive);
 
       expect(await bunFile.exists()).toBe(true);
-      const readArchive = Bun.Archive.from(await bunFile.bytes());
+      const readArchive = new Bun.Archive(await bunFile.bytes());
       const files = await readArchive.files();
       expect(await files.get("test.txt")!.text()).toBe("test content");
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1509,3 +1509,128 @@ describe.concurrent("s3 missing credentials", () => {
     });
   });
 });
+
+// Archive + S3 integration tests
+describe.skipIf(!minioCredentials)("Archive with S3", () => {
+  const credentials = minioCredentials!;
+
+  it("writes archive to S3 via S3Client.write()", async () => {
+    const client = new Bun.S3Client(credentials);
+    const archive = Bun.Archive.from({
+      "hello.txt": "Hello from Archive!",
+      "data.json": JSON.stringify({ test: true }),
+    });
+
+    const key = randomUUIDv7() + ".tar";
+    await client.write(key, archive);
+
+    // Verify by downloading and reading back
+    const downloaded = await client.file(key).bytes();
+    const readArchive = Bun.Archive.from(downloaded);
+    const files = await readArchive.files();
+
+    expect(files.size).toBe(2);
+    expect(await files.get("hello.txt")!.text()).toBe("Hello from Archive!");
+    expect(await files.get("data.json")!.text()).toBe(JSON.stringify({ test: true }));
+
+    // Cleanup
+    await client.unlink(key);
+  });
+
+  it("writes archive to S3 via Bun.write() with s3:// URL", async () => {
+    const archive = Bun.Archive.from({
+      "file1.txt": "content1",
+      "dir/file2.txt": "content2",
+    });
+
+    const key = randomUUIDv7() + ".tar";
+    const s3Url = `s3://${credentials.bucket}/${key}`;
+
+    await Bun.write(s3Url, archive, {
+      ...credentials,
+    });
+
+    // Verify by downloading
+    const s3File = Bun.file(s3Url, credentials);
+    const downloaded = await s3File.bytes();
+    const readArchive = Bun.Archive.from(downloaded);
+    const files = await readArchive.files();
+
+    expect(files.size).toBe(2);
+    expect(await files.get("file1.txt")!.text()).toBe("content1");
+    expect(await files.get("dir/file2.txt")!.text()).toBe("content2");
+
+    // Cleanup
+    await s3File.delete();
+  });
+
+  it("writes archive with binary content to S3", async () => {
+    const client = new Bun.S3Client(credentials);
+    const binaryData = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd, 0x80, 0x7f]);
+    const archive = Bun.Archive.from({
+      "binary.bin": binaryData,
+    });
+
+    const key = randomUUIDv7() + ".tar";
+    await client.write(key, archive);
+
+    // Verify binary data is preserved
+    const downloaded = await client.file(key).bytes();
+    const readArchive = Bun.Archive.from(downloaded);
+    const files = await readArchive.files();
+    const extractedBinary = await files.get("binary.bin")!.bytes();
+
+    expect(extractedBinary).toEqual(binaryData);
+
+    // Cleanup
+    await client.unlink(key);
+  });
+
+  it("writes large archive to S3", async () => {
+    const client = new Bun.S3Client(credentials);
+
+    // Create archive with multiple files
+    const entries: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) {
+      entries[`file${i.toString().padStart(3, "0")}.txt`] = `Content for file ${i}`;
+    }
+    const archive = Bun.Archive.from(entries);
+
+    const key = randomUUIDv7() + ".tar";
+    await client.write(key, archive);
+
+    // Verify
+    const downloaded = await client.file(key).bytes();
+    const readArchive = Bun.Archive.from(downloaded);
+    const files = await readArchive.files();
+
+    expect(files.size).toBe(50);
+    expect(await files.get("file000.txt")!.text()).toBe("Content for file 0");
+    expect(await files.get("file049.txt")!.text()).toBe("Content for file 49");
+
+    // Cleanup
+    await client.unlink(key);
+  });
+
+  it("writes archive via s3File.write()", async () => {
+    const client = new Bun.S3Client(credentials);
+    const archive = Bun.Archive.from({
+      "test.txt": "Hello via s3File.write()!",
+    });
+
+    const key = randomUUIDv7() + ".tar";
+    const s3File = client.file(key);
+    await s3File.write(archive);
+
+    // Verify
+    const downloaded = await s3File.bytes();
+    const readArchive = Bun.Archive.from(downloaded);
+    const files = await readArchive.files();
+
+    expect(files.size).toBe(1);
+    expect(await files.get("test.txt")!.text()).toBe("Hello via s3File.write()!");
+
+    // Cleanup
+    await s3File.delete();
+  });
+});

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1516,7 +1516,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
 
   it("writes archive to S3 via S3Client.write()", async () => {
     const client = new Bun.S3Client(credentials);
-    const archive = Bun.Archive.from({
+    const archive = new Bun.Archive({
       "hello.txt": "Hello from Archive!",
       "data.json": JSON.stringify({ test: true }),
     });
@@ -1526,7 +1526,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
 
     // Verify by downloading and reading back
     const downloaded = await client.file(key).bytes();
-    const readArchive = Bun.Archive.from(downloaded);
+    const readArchive = new Bun.Archive(downloaded);
     const files = await readArchive.files();
 
     expect(files.size).toBe(2);
@@ -1538,7 +1538,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
   });
 
   it("writes archive to S3 via Bun.write() with s3:// URL", async () => {
-    const archive = Bun.Archive.from({
+    const archive = new Bun.Archive({
       "file1.txt": "content1",
       "dir/file2.txt": "content2",
     });
@@ -1553,7 +1553,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
     // Verify by downloading
     const s3File = Bun.file(s3Url, credentials);
     const downloaded = await s3File.bytes();
-    const readArchive = Bun.Archive.from(downloaded);
+    const readArchive = new Bun.Archive(downloaded);
     const files = await readArchive.files();
 
     expect(files.size).toBe(2);
@@ -1567,7 +1567,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
   it("writes archive with binary content to S3", async () => {
     const client = new Bun.S3Client(credentials);
     const binaryData = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd, 0x80, 0x7f]);
-    const archive = Bun.Archive.from({
+    const archive = new Bun.Archive({
       "binary.bin": binaryData,
     });
 
@@ -1576,7 +1576,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
 
     // Verify binary data is preserved
     const downloaded = await client.file(key).bytes();
-    const readArchive = Bun.Archive.from(downloaded);
+    const readArchive = new Bun.Archive(downloaded);
     const files = await readArchive.files();
     const extractedBinary = await files.get("binary.bin")!.bytes();
 
@@ -1594,14 +1594,14 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
     for (let i = 0; i < 50; i++) {
       entries[`file${i.toString().padStart(3, "0")}.txt`] = `Content for file ${i}`;
     }
-    const archive = Bun.Archive.from(entries);
+    const archive = new Bun.Archive(entries);
 
     const key = randomUUIDv7() + ".tar";
     await client.write(key, archive);
 
     // Verify
     const downloaded = await client.file(key).bytes();
-    const readArchive = Bun.Archive.from(downloaded);
+    const readArchive = new Bun.Archive(downloaded);
     const files = await readArchive.files();
 
     expect(files.size).toBe(50);
@@ -1614,7 +1614,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
 
   it("writes archive via s3File.write()", async () => {
     const client = new Bun.S3Client(credentials);
-    const archive = Bun.Archive.from({
+    const archive = new Bun.Archive({
       "test.txt": "Hello via s3File.write()!",
     });
 
@@ -1624,7 +1624,7 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
 
     // Verify
     const downloaded = await s3File.bytes();
-    const readArchive = Bun.Archive.from(downloaded);
+    const readArchive = new Bun.Archive(downloaded);
     const files = await readArchive.files();
 
     expect(files.size).toBe(1);


### PR DESCRIPTION
## Summary
- Change Archive API from `Bun.Archive.from(data)` to `new Bun.Archive(data, options?)`
- Change compression options from `{ gzip: true }` to `{ compress: "gzip", level?: number }`
- Default to no compression when no options provided
- Use `{ compress: "gzip" }` to enable gzip compression (level 6 by default)
- Add Archive support for S3 and local file writes via `Bun.write()`

## New API

```typescript
// Create archive - defaults to uncompressed tar
const archive = new Bun.Archive({
  "hello.txt": "Hello, World!",
  "data.json": JSON.stringify({ foo: "bar" }),
});

// Enable gzip compression
const compressed = new Bun.Archive(files, { compress: "gzip" });

// Gzip with custom level (1-12)
const maxCompression = new Bun.Archive(files, { compress: "gzip", level: 12 });

// Write to local file
await Bun.write("archive.tar", archive);           // uncompressed by default
await Bun.write("archive.tar.gz", compressed);     // gzipped

// Write to S3
await client.write("archive.tar.gz", compressed);          // S3Client.write()
await Bun.write("s3://bucket/archive.tar.gz", compressed); // S3 URL
await s3File.write(compressed);                            // s3File.write()

// Get bytes/blob (uses compression setting from constructor)
const bytes = await archive.bytes();
const blob = await archive.blob();
```

## TypeScript Types

```typescript
type ArchiveCompression = "gzip";

type ArchiveOptions = {
  compress?: "gzip";
  level?: number;  // 1-12, default 6 when gzip enabled
};
```

## Test plan
- [x] 98 archive tests pass
- [x] S3 integration tests updated to new API
- [x] TypeScript types updated
- [x] Documentation updated with new examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)