### PR TITLE
fix(tls): trigger handshake callback when handshake completes during SSL_read

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -569,8 +569,8 @@ restart:
 
         break;
       }
-    } else if (s->handshake_state == HANDSHAKE_RENEGOTIATION_PENDING) {
-      // renegotiation ended successfully call on_handshake
+    } else if (s->handshake_state != HANDSHAKE_COMPLETED && SSL_is_init_finished(s->ssl)) {
+      // handshake just completed during SSL_read, notify the application
       us_internal_trigger_handshake_callback(s, 1);
     }
 


### PR DESCRIPTION
## Summary

- Fixes a race condition where `request.socket._secureEstablished` could be `false` in HTTPS request handlers under load
- The TLS handshake callback was only triggered for renegotiation, not when the initial handshake completes during `SSL_read`

## Root Cause

The server-side TLS flow is:
1. `ssl_on_open` calls `us_internal_update_handshake`, which tries `SSL_do_handshake`
2. `SSL_do_handshake` returns `SSL_ERROR_WANT_READ` (needs client data)
3. Client sends TLS handshake + HTTP request data together
4. `ssl_on_data` is called, `SSL_read` completes the handshake AND returns app data
5. But handshake callback was never triggered because the code only checked for `HANDSHAKE_RENEGOTIATION_PENDING`, not `HANDSHAKE_PENDING`

This caused `isAuthorized` to never be set, making `_secureEstablished` false.

## The Fix

Changed the condition from:
```c
} else if (s->handshake_state == HANDSHAKE_RENEGOTIATION_PENDING) {
```
to:
```c
} else if (s->handshake_state != HANDSHAKE_COMPLETED && SSL_is_init_finished(s->ssl)) {
```

We now ask BoringSSL directly via `SSL_is_init_finished()` whether the handshake has completed, rather than only checking for the renegotiation state. From BoringSSL's `ssl.h`:

> `SSL_is_init_finished` returns one if `ssl` has completed its initial handshake and has no pending handshake. It returns zero otherwise.

## Security Considerations

This is safe because:
- We only trigger the callback when `SSL_is_init_finished()` confirms the handshake is complete
- Certificate verification errors are captured separately via `us_internal_verify_error()` which queries `SSL_get_verify_result()`
- The HTTP callback enforces `rejectUnauthorized` by checking `verify_error.error != 0`

## Test plan

- [x] Reproduced the flaky test with parallel stress testing (failed ~30% before fix)
- [x] Verified fix with 500+ parallel runs - all pass
- [x] Verified no new regressions in TLS connect tests (24 pass)
- [x] Verified `SSL_is_init_finished` behavior in BoringSSL source

🤖 Generated with [Claude Code](https://claude.com/claude-code)