### PR TITLE
docs: Remove DATABASE_URL from datasource configuration

### DIFF
--- a/docs/guides/ecosystem/prisma-postgres.mdx
+++ b/docs/guides/ecosystem/prisma-postgres.mdx
@@ -48,7 +48,6 @@ mode: center
 
     	datasource db {
     		provider = "postgresql"
-    		url      = env("DATABASE_URL")
     	}
 
     	model User { // [!code ++]


### PR DESCRIPTION
### What does this PR do?

Remove DATABASE_URL from datasource configuration

### How did you verify your code works?

Starting with Prisma ORM v7, the database connection URL is now configured in the `prisma.config.ts` file instead of in the `schema.prisma` file.

see: https://www.prisma.io/docs/orm/reference/prisma-config-reference#overview