### PR TITLE
Update Dockerfile from Alpine image 3.22 to 3.23

### DIFF
--- a/dockerhub/alpine/Dockerfile
+++ b/dockerhub/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 AS build
+FROM alpine:3.23 AS build
 
 # https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=latest
@@ -44,7 +44,7 @@ RUN apk --no-cache add ca-certificates curl dirmngr gpg gpg-agent unzip \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun
 
-FROM alpine:3.22
+FROM alpine:3.23
 
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful


### PR DESCRIPTION
### What does this PR do?
Currently used Alpine version 3.22.2 has bug in certificates (https://github.com/alpinelinux/docker-alpine/issues/471). So fetching external API endpoints protected by TLS with Bun or inside Alpine  3.22.2 docker image stopped working today. When I switched docker image from `oven/bun:1-alpine` to `oven/bun:1-debian` external API endpoints with TLS started working again.

`oven/bun:1-alpine`:
<img width="1859" height="1161" alt="image" src="https://github.com/user-attachments/assets/7cf87ff3-7cf1-4d42-b2f7-63f992413cba" />
<img width="1794" height="972" alt="image" src="https://github.com/user-attachments/assets/3d38aa59-0335-4ffd-934f-fb4ff94daf0e" />

everything works fine with `oven/bun:1-debian`
<img width="1161" height="284" alt="image" src="https://github.com/user-attachments/assets/db6df35d-1db2-4784-ad2d-a85012c74b57" />

### How did you verify your code works?
I didn't but I don't see any breaking changes that would impact Bun image when upgrading from Alpine `3.22` to `3.23` (https://www.alpinelinux.org/posts/Alpine-3.23.0-released.html)
