### PR TITLE
fix(FileSink): add `Promise<number>` to `FileSink.write()` return type

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -78,7 +78,7 @@ declare module "bun" {
      * If the network is not writable yet, the data is buffered.
      *
      * @param chunk The data to write
-     * @returns Number of bytes written or a Promise resolving to the number of bytes
+     * @returns Number of bytes written or, if the write is pending, a Promise resolving to the number of bytes
      */
     write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number | Promise<number>;
     /**

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -11,9 +11,9 @@ declare module "bun" {
      * If the file descriptor is not writable yet, the data is buffered.
      *
      * @param chunk The data to write
-     * @returns Number of bytes written
+     * @returns Number of bytes written or a Promise resolving to the number of bytes
      */
-    write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number;
+    write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number | Promise<number>;
     /**
      * Flush the internal buffer, committing the data to disk or the pipe.
      *
@@ -78,9 +78,9 @@ declare module "bun" {
      * If the network is not writable yet, the data is buffered.
      *
      * @param chunk The data to write
-     * @returns Number of bytes written
+     * @returns Number of bytes written or a Promise resolving to the number of bytes
      */
-    write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number;
+    write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number | Promise<number>;
     /**
      * Flush the internal buffer, committing the data to the network.
      *

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -11,7 +11,7 @@ declare module "bun" {
      * If the file descriptor is not writable yet, the data is buffered.
      *
      * @param chunk The data to write
-     * @returns Number of bytes written or a Promise resolving to the number of bytes
+     * @returns Number of bytes written or, if the write is pending, a Promise resolving to the number of bytes
      */
     write(chunk: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer): number | Promise<number>;
     /**


### PR DESCRIPTION
The `FileSink.write()` can also be async if the write is pending so the return type needs to include that.

Partially addresses #12194
