### PR TITLE
fix(s3): include response content params in presign

### DIFF
--- a/test/regression/issue/s3-signature-order.test.ts
+++ b/test/regression/issue/s3-signature-order.test.ts
@@ -13,6 +13,8 @@ test("S3 presigned URL should have correct query parameter order", () => {
     method: "PUT",
     acl: "public-read",
     expiresIn: 300,
+    contentDisposition: 'attachment; filename="test.txt"',
+    type: "text/plain",
   });
 
   // Parse the URL to get query parameters
@@ -20,6 +22,9 @@ test("S3 presigned URL should have correct query parameter order", () => {
   const params = Array.from(urlObj.searchParams.keys());
 
   console.log("Query parameters order:", params);
+
+  expect(urlObj.searchParams.get("response-content-disposition")).toBe('attachment; filename="test.txt"');
+  expect(urlObj.searchParams.get("response-content-type")).toBe("text/plain");
 
   // Verify alphabetical order (after URL decoding)
   const expected = params.slice().sort();


### PR DESCRIPTION
### What does this PR do?
- add presign support for response-content-disposition and response-content-type
- wire S3 presign options to signer (contentDisposition + type)
- add regression test for query param order + presence

### How did you verify your code works?
Wrote a loocal-only script and ran it against a real R2 bucket to confirm download filename honors Content‑Disposition:
```typescript
const accountId = "";
const accessKeyId = "";
const secretAccessKey = "";
const bucket = "bun-test";
const key = "bun-test/video.mp4";
const contentDisposition = "attachment; filename=\"does-patch-work.mp4\"";

const client = new Bun.S3Client({
  accessKeyId,
  secretAccessKey,
  bucket,
  endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
});

const url = client.presign(key, {
  expiresIn: 3600,
  contentDisposition,
  type: "video/mp4",
});

console.log(url);
```

The downloaded file is indeed named, `does-patch-work.mp4`. Ran it using:
```bash
ENABLE_ASAN=OFF NIX_CC=1 CC=/usr/bin/clang CXX=/usr/bin/clang++ bun bd scripts/s3-presign.ts
```
