### PR TITLE
fix(FileSink): truncate existing file using `O_TRUNC` flag

### DIFF
--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -49,14 +49,13 @@ pub const Poll = IOWriter;
 pub const Options = struct {
     chunk_size: Blob.SizeType = 1024,
     input_path: webcore.PathOrFileDescriptor,
-    truncate: bool = true,
     close: bool = false,
     mode: bun.Mode = 0o664,
 
     pub fn flags(this: *const Options) i32 {
         _ = this;
 
-        return bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        return bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY | bun.O.TRUNC;
     }
 };
 

--- a/test/regression/issue/25968.test.ts
+++ b/test/regression/issue/25968.test.ts
@@ -1,3 +1,4 @@
+// https://github.com/oven-sh/bun/issues/25968
 // FileSink should truncate existing files when opening with writer()
 
 import { expect, test } from "bun:test";

--- a/test/regression/issue/filesink-truncate.test.ts
+++ b/test/regression/issue/filesink-truncate.test.ts
@@ -1,0 +1,20 @@
+// FileSink should truncate existing files when opening with writer()
+
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
+test("writer() should truncate existing file when writing shorter content", async () => {
+  using dir = tempDir("filesink-truncate", {});
+  const path = join(dir, "truncate-test.txt");
+
+  await Bun.write(path, "Long content");
+
+  const writer = Bun.file(path).writer();
+  writer.write("Short");
+  await writer.end();
+
+  // should be "Short" not "Shortcontent"
+  const content = await Bun.file(path).text();
+  expect(content).toBe("Short");
+});


### PR DESCRIPTION
Fixes #25968

This PR uses `O_TRUNC` flag. For version using `ftruncate` see #25967

As mentioned in the [append pr](https://github.com/oven-sh/bun/pull/25751), current behavior leads to corrupted output when writing over existing file. E.g writing `Short` over the file with  `Long content` will lead to `Shortcontent`.

This does not feel like an expected behavior. In fact the `Options` even contained the `truncate: bool = true`, but that arguments was never used and no truncation was happening but implies truncation may have been thoughts of.

This implementation uses the `O_TRUNC` flag. I know that in regular `Bun.write` and co it's not used for performance reasons and instead relies on `ftruncate`. I have an alternative PR with that but it feels way more complicated and error prone compared to this.

Added a test to verify correct truncation.