### PR TITLE
fix(FileSink): truncate existing file using `ftruncate`

### DIFF
--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -19,6 +19,7 @@ nonblocking: bool = false,
 force_sync: bool = false,
 
 is_socket: bool = false,
+owns_fd: bool = false,
 fd: bun.FileDescriptor = bun.invalid_fd,
 
 auto_flusher: webcore.AutoFlusher = .{},
@@ -321,6 +322,7 @@ pub fn setup(this: *FileSink, options: *const FileSink.Options) bun.sys.Maybe(vo
         .result => |fd| fd,
     };
     this.fd = fd;
+    this.owns_fd = true;
 
     if (comptime Environment.isWindows) {
         if (this.force_sync) {
@@ -614,7 +616,7 @@ pub fn updateRef(this: *FileSink, value: bool) void {
 }
 
 pub fn truncateFdToWritten(this: *FileSink) void {
-    if (this.fd != bun.invalid_fd and !this.is_socket) {
+    if (this.fd != bun.invalid_fd and !this.is_socket and this.owns_fd) {
         _ = bun.sys.ftruncate(this.fd, @as(isize, @intCast(this.written)));
     }
 }

--- a/test/regression/issue/25968.test.ts
+++ b/test/regression/issue/25968.test.ts
@@ -1,3 +1,4 @@
+// https://github.com/oven-sh/bun/issues/25968
 // FileSink should truncate existing files when opening with writer()
 
 import { expect, test } from "bun:test";

--- a/test/regression/issue/filesink-truncate.test.ts
+++ b/test/regression/issue/filesink-truncate.test.ts
@@ -1,0 +1,20 @@
+// FileSink should truncate existing files when opening with writer()
+
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
+test("writer() should truncate existing file when writing shorter content", async () => {
+  using dir = tempDir("filesink-truncate", {});
+  const path = join(dir, "truncate-test.txt");
+
+  await Bun.write(path, "Long content");
+
+  const writer = Bun.file(path).writer();
+  writer.write("Short");
+  await writer.end();
+
+  // should be "Short" not "Shortcontent"
+  const content = await Bun.file(path).text();
+  expect(content).toBe("Short");
+});


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/25968

This PR uses `ftruncate`. For version using `O_TRUNC` flag see #25966

As mentioned in the [append pr](https://github.com/oven-sh/bun/pull/25751), current behavior leads to corrupted output when writing over existing file. E.g writing `Short` over the file with  `Long content` will lead to `Shortcontent`.

This does not feel like an expected behavior. In fact the `Options` even contained the `truncate: bool = true`, but that arguments was never used and no truncation was happening but implies truncation may have been thoughts of.

This implementation follows the same pattern as regular `Bun.write` etc by using `ftruncate` at the end. Feels way more error prone than just using `O_TRUNC` flag. Also I suppose if the app crashes before the `.end` called it will fail to truncate.

It also uncovered some issues in the existing code:
- `this.written` was incremented twice because it was done both in `onWrite` and after `.flush`. may explain why it was sometimes doubled as reported in https://github.com/oven-sh/bun/issues/12194
- `onAutoFlush` had `const is_registered = !this.writer.hasPendingData();` which was the opposite of what it should be.

Added a test to verify correct truncation.