### PR TITLE
fix(types): remove PromiseConstructor augmentation to respect ES lib settings

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1384,42 +1384,6 @@ interface EventSourceInit {
   withCredentials?: boolean;
 }
 
-interface PromiseConstructor {
-  /**
-   * Create a deferred promise, with exposed `resolve` and `reject` methods which can be called
-   * separately.
-   *
-   * This is useful when you want to return a Promise and have code outside the Promise
-   * resolve or reject it.
-   *
-   * @example
-   * ```ts
-   * const { promise, resolve, reject } = Promise.withResolvers();
-   *
-   * setTimeout(() => {
-   *  resolve("Hello world!");
-   * }, 1000);
-   *
-   * await promise; // "Hello world!"
-   * ```
-   */
-  withResolvers<T>(): {
-    promise: Promise<T>;
-    resolve: (value?: T | PromiseLike<T>) => void;
-    reject: (reason?: any) => void;
-  };
-
-  /**
-   * Try to run a function and return the result.
-   * If the function throws, return the result of the `catch` function.
-   *
-   * @param fn - The function to run
-   * @param args - The arguments to pass to the function. This is similar to `setTimeout` and avoids the extra closure.
-   * @returns The result of the function or the result of the `catch` function
-   */
-  try<T, A extends any[] = []>(fn: (...args: A) => T | PromiseLike<T>, ...args: A): Promise<T>;
-}
-
 interface Navigator {
   readonly userAgent: string;
   readonly platform: "MacIntel" | "Win32" | "Linux x86_64";


### PR DESCRIPTION
## Summary
- Remove `Promise.withResolvers` and `Promise.try` type augmentations from `@types/bun`
- These methods are now part of TypeScript's standard libraries (ES2024 and ESNext respectively)
- Projects can now properly validate ES compatibility by using the appropriate `lib` setting

## Test plan
- [x] Verified that with ES2022 lib, `Promise.withResolvers()` now correctly errors with: `Property 'withResolvers' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2024' or later.`
- [x] Verified that with ES2024 lib, `Promise.withResolvers()` works correctly
- [x] Verified that with ES2022 lib, `Promise.try()` now correctly errors
- [x] Verified that with ESNext lib, `Promise.try()` works correctly
- [x] Verified bun-types still compiles successfully

Fixes #25974

🤖 Generated with [Claude Code](https://claude.com/claude-code)