### PR TITLE
fix(FileSink): truncate existing file when using writer()

### DIFF
--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -54,9 +54,11 @@ pub const Options = struct {
     mode: bun.Mode = 0o664,
 
     pub fn flags(this: *const Options) i32 {
-        _ = this;
-
-        return bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        var f: i32 = bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        if (this.truncate) {
+            f |= bun.O.TRUNC;
+        }
+        return f;
     }
 };
 

--- a/test/regression/issue/25968.test.ts
+++ b/test/regression/issue/25968.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("FileSink truncates existing file", async () => {
+  using dir = tempDir("issue-25968", {});
+  const filePath = `${dir}/file.txt`;
+
+  // Write initial long content
+  const file = Bun.file(filePath);
+  await Bun.write(file, "Long content");
+
+  // Write shorter content using writer
+  const writer = file.writer();
+  writer.write("Short");
+  writer.end();
+
+  // Verify the file is truncated and only contains the new content
+  const result = await file.text();
+  expect(result).toBe("Short");
+});
+
+test("FileSink truncates when writing to existing file via spawn", async () => {
+  using dir = tempDir("issue-25968-spawn", {});
+  const filePath = `${dir}/file.txt`;
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const file = Bun.file("${filePath.replace(/\\/g, "\\\\")}");
+await Bun.write(file, "Long content that is longer");
+const writer = file.writer();
+writer.write("Short");
+writer.end();
+console.log(await file.text());
+`,
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("Short");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes the `FileSink.Options.flags()` method to respect the `truncate` option which defaults to `true`
- When `truncate` is true, the `O_TRUNC` flag is now included when opening the file, ensuring existing content is removed

Closes #25968

## Test plan

- [ ] Added regression test in `test/regression/issue/25968.test.ts`
- [ ] Verified test fails with system Bun (outputs `Shortcontent` instead of `Short`)
- [ ] Verified test passes with debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)