### PR TITLE
fix(cli): support space-separated value for --config flag

### DIFF
--- a/src/deps/zig-clap/clap/args.zig
+++ b/src/deps/zig-clap/clap/args.zig
@@ -28,6 +28,13 @@ pub const SliceIterator = struct {
         }
         return null;
     }
+
+    pub fn peek(iter: *const SliceIterator) ?[]const u8 {
+        if (iter.remain.len > 0) {
+            return iter.remain[0];
+        }
+        return null;
+    }
 };
 
 test "SliceIterator" {
@@ -74,6 +81,13 @@ pub const OsIterator = struct {
             return res;
         }
 
+        return null;
+    }
+
+    pub fn peek(iter: *const OsIterator) ?[:0]const u8 {
+        if (iter.remain.len > 0) {
+            return iter.remain[0];
+        }
         return null;
     }
 };

--- a/test/regression/issue/25930.test.ts
+++ b/test/regression/issue/25930.test.ts
@@ -1,0 +1,149 @@
+// https://github.com/oven-sh/bun/issues/25930
+// bun --config <path> (space-separated) silently does nothing and exits 0
+// only --config=<path> works
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("--config flag should work with space-separated value", () => {
+  test("--config bunfig.toml -e (space-separated)", async () => {
+    using dir = tempDir("config-test", {
+      "bunfig.toml": "[install]\ncache = false",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--config", "bunfig.toml", "-e", "console.log('hello')"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout.trim()).toBe("hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config=bunfig.toml -e (equals form)", async () => {
+    using dir = tempDir("config-test", {
+      "bunfig.toml": "[install]\ncache = false",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--config=bunfig.toml", "-e", "console.log('hello')"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout.trim()).toBe("hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("-c bunfig.toml -e (short form, space-separated)", async () => {
+    using dir = tempDir("config-test", {
+      "bunfig.toml": "[install]\ncache = false",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-c", "bunfig.toml", "-e", "console.log('hello')"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout.trim()).toBe("hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("-c=bunfig.toml -e (short form, equals)", async () => {
+    using dir = tempDir("config-test", {
+      "bunfig.toml": "[install]\ncache = false",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-c=bunfig.toml", "-e", "console.log('hello')"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout.trim()).toBe("hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun run --config bunfig.toml (space-separated)", async () => {
+    using dir = tempDir("config-test", {
+      "bunfig.toml": "[install]\ncache = false",
+      "package.json": JSON.stringify({ scripts: { test: "echo hello" } }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--config", "bunfig.toml", "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config without value should use default bunfig.toml", async () => {
+    using dir = tempDir("config-test", {
+      "bunfig.toml": "[install]\ncache = false",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--config", "-e", "console.log('hello')"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    // When --config is followed by -e (starts with -), it should not consume -e
+    // and should use default bunfig.toml instead
+    expect(stdout.trim()).toBe("hello");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes `--config bunfig.toml` (space-separated) silently doing nothing and exiting with code 0
- The equals form `--config=bunfig.toml` already worked correctly
- Also fixes the short form `-c bunfig.toml`

The issue was in the clap argument parser's handling of `one_optional` parameters. When no `=` was present, it immediately returned null instead of checking if the next argument could be the value.

This fix:
1. Adds a `peek()` method to `SliceIterator` and `OsIterator` in `args.zig`
2. Updates the parser in `streaming.zig` to consume the next argument for `one_optional` parameters if it doesn't start with `-` (i.e., isn't another flag)

## Test plan

- [x] Added regression test in `test/regression/issue/25930.test.ts`
- [x] Tests pass with `bun bd test test/regression/issue/25930.test.ts`
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1`) confirming the bug existed

Fixes #25930

🤖 Generated with [Claude Code](https://claude.com/claude-code)