### PR TITLE
fix(spawn): add memory barrier to fix race condition in exec failure detection

### DIFF
--- a/test/regression/issue/25825.test.ts
+++ b/test/regression/issue/25825.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync } from "fs";
+import { bunEnv, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/25825
+// Bug: When exec fails with EACCES (e.g., noexec mount or no execute permission),
+// the spawn would silently fail with exit code 127 but return success (no error thrown).
+// This was caused by a race condition in the vfork() path on Linux where the
+// child's write to child_errno wasn't visible to the parent due to missing memory barrier.
+
+describe("spawn exec failure should report EACCES error", () => {
+  test.skipIf(isWindows)("spawning a non-executable script should throw EACCES", async () => {
+    using dir = tempDir("issue-25825", {
+      // Create a script file (we'll remove execute permissions)
+      "script.sh": `#!/bin/sh\necho "hello"`,
+    });
+
+    const scriptPath = join(String(dir), "script.sh");
+
+    // Remove execute permissions to simulate EACCES scenario
+    chmodSync(scriptPath, 0o644);
+
+    // This should throw an error, not silently fail
+    let error: Error | undefined;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [scriptPath],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await proc.exited;
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("EACCES");
+  });
+
+  test.skipIf(isWindows)("spawning a non-executable file via Bun.spawnSync should report EACCES", () => {
+    using dir = tempDir("issue-25825-sync", {
+      "script.sh": `#!/bin/sh\necho "hello"`,
+    });
+
+    const scriptPath = join(String(dir), "script.sh");
+    chmodSync(scriptPath, 0o644);
+
+    let error: Error | undefined;
+    try {
+      Bun.spawnSync({
+        cmd: [scriptPath],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("EACCES");
+  });
+
+  test.skipIf(isWindows)("spawning via child_process.spawn should emit error for non-executable", async () => {
+    const { spawn } = await import("child_process");
+
+    using dir = tempDir("issue-25825-child-process", {
+      "script.sh": `#!/bin/sh\necho "hello"`,
+    });
+
+    const scriptPath = join(String(dir), "script.sh");
+    chmodSync(scriptPath, 0o644);
+
+    const { promise, resolve } = Promise.withResolvers<{ error?: Error; code?: number | null }>();
+
+    const child = spawn(scriptPath, [], {
+      env: bunEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let errorEmitted: Error | undefined;
+    child.on("error", err => {
+      errorEmitted = err;
+      resolve({ error: err });
+    });
+    child.on("exit", code => {
+      resolve({ code });
+    });
+
+    const result = await promise;
+
+    // Should emit an error event with EACCES, not silently exit
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain("EACCES");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a race condition in the Linux vfork() path where exec failures (like EACCES from noexec mounts) would be silently ignored
- The issue occurred because the child's write to `child_errno` wasn't guaranteed to be visible to the parent before `rawExit()` was called
- Added `__sync_synchronize()` memory barrier to ensure proper memory visibility

## Root Cause
When using `vfork()` on Linux, the child and parent share the same address space. The code used a `volatile int child_errno` to communicate exec failures:

1. Child sets `child_errno = errno` (e.g., EACCES)
2. Child calls `rawExit(127)`
3. Parent resumes (vfork semantics) and reads `child_errno`

The `volatile` keyword only prevents compiler reordering but does NOT guarantee memory visibility. Without a memory barrier, the CPU store buffer may not be flushed, causing the parent to read 0 (success) instead of the actual error.

## Test plan
- [x] Added regression test in `test/regression/issue/25825.test.ts`
- [x] Test verifies EACCES error is properly reported when spawning non-executable files
- [x] All tests pass with `bun bd test test/regression/issue/25825.test.ts`

Fixes #25825

🤖 Generated with [Claude Code](https://claude.com/claude-code)