### PR TITLE
fix(install): resolve override file: tarball paths relative to workspace root

### DIFF
--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -231,13 +231,31 @@ pub fn callback(task: *ThreadPool.Task) void {
             this.status = Status.success;
         },
         .local_tarball => {
-            const workspace_pkg_id = manager.lockfile.getWorkspacePkgIfWorkspaceDep(this.request.local_tarball.tarball.dependency_id);
+            const dependency_id = this.request.local_tarball.tarball.dependency_id;
+            const workspace_pkg_id = manager.lockfile.getWorkspacePkgIfWorkspaceDep(dependency_id);
 
             var abs_buf: bun.PathBuffer = undefined;
             const tarball_path, const normalize = if (workspace_pkg_id != invalid_package_id) tarball_path: {
                 const workspace_res = manager.lockfile.packages.items(.resolution)[workspace_pkg_id];
 
                 if (workspace_res.tag != .workspace) break :tarball_path .{ this.request.local_tarball.tarball.url.slice(), true };
+
+                // Check if this dependency's tarball path came from an override.
+                // Overrides are defined at the workspace root, so their file: paths should be
+                // resolved relative to the workspace root, not the workspace package.
+                const dep_name_hash = manager.lockfile.buffers.dependencies.items[dependency_id].name_hash;
+                if (manager.lockfile.overrides.get(dep_name_hash)) |override_version| {
+                    if (override_version.tag == .tarball) {
+                        if (override_version.value.tarball.uri == .local) {
+                            const override_path = manager.lockfile.str(&override_version.value.tarball.uri.local);
+                            const tarball_url = this.request.local_tarball.tarball.url.slice();
+                            if (strings.eql(override_path, tarball_url)) {
+                                // This tarball path came from an override, resolve relative to workspace root
+                                break :tarball_path .{ tarball_url, true };
+                            }
+                        }
+                    }
+                }
 
                 // Construct an absolute path to the tarball.
                 // Normally tarball paths are always relative to the root directory, but if a

--- a/test/regression/issue/25835.test.ts
+++ b/test/regression/issue/25835.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+beforeAll(() => {
+  setDefaultTimeout(1000 * 60 * 5);
+});
+
+// https://github.com/oven-sh/bun/issues/25835
+// Bug: When using overrides in a monorepo workspace to redirect dependencies to
+// vendored file: tarballs, Bun resolves the file: path relative to the requesting
+// workspace package rather than the workspace root where the override is defined.
+
+test("override with file: tarball in workspace resolves relative to workspace root", async () => {
+  // Create directory structure with initial files
+  using dir = tempDir("issue-25835", {
+    "package.json": JSON.stringify({
+      name: "monorepo-root",
+      workspaces: ["apps/*"],
+      overrides: {
+        "@pkg/utils": "file:vendored/pkg-utils-1.0.0.tgz",
+      },
+    }),
+    "apps/editor/package.json": JSON.stringify({
+      name: "@app/editor",
+      dependencies: {
+        "@pkg/utils": "1.0.0",
+      },
+    }),
+    // Placeholder for vendored directory
+    "vendored/.gitkeep": "",
+    // Temp package for tarball creation
+    "_tmp_pkg/package/package.json": JSON.stringify({
+      name: "@pkg/utils",
+      version: "1.0.0",
+      main: "index.js",
+    }),
+    "_tmp_pkg/package/index.js": "module.exports = { id: 1 };",
+  });
+
+  const tmpPkgDir = join(String(dir), "_tmp_pkg");
+
+  // Create tarball using tar
+  await using tarProc = Bun.spawn({
+    cmd: ["tar", "-czf", join(String(dir), "vendored", "pkg-utils-1.0.0.tgz"), "-C", tmpPkgDir, "package"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const tarExitCode = await tarProc.exited;
+  expect(tarExitCode).toBe(0);
+
+  // Run bun install
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should not have ENOENT error trying to find tarball in apps/editor/vendored/
+  expect(stderr).not.toContain("ENOENT");
+  expect(stderr).not.toContain("failed to resolve");
+  expect(exitCode).toBe(0);
+
+  // Verify the package was installed (it may be in the workspace's node_modules)
+  const pkgUtilsPath = join(String(dir), "apps", "editor", "node_modules", "@pkg", "utils", "package.json");
+  const pkgUtils = await Bun.file(pkgUtilsPath).json();
+  expect(pkgUtils.name).toBe("@pkg/utils");
+  expect(pkgUtils.version).toBe("1.0.0");
+});

--- a/test/regression/issue/25835.test.ts
+++ b/test/regression/issue/25835.test.ts
@@ -1,10 +1,6 @@
-import { beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
-
-beforeAll(() => {
-  setDefaultTimeout(1000 * 60 * 5);
-});
 
 // https://github.com/oven-sh/bun/issues/25835
 // Bug: When using overrides in a monorepo workspace to redirect dependencies to


### PR DESCRIPTION
## Summary

- Fix override file: tarball paths being resolved relative to the workspace package instead of the workspace root
- Add regression test for #25835

**Root Cause:** When a workspace package (e.g., `apps/editor`) depends on a package that has an override defined in the workspace root, Bun was incorrectly resolving the `file:` path relative to the workspace package's directory instead of the workspace root where the override is defined.

**Fix:** In `PackageManagerTask.zig`, when processing a local tarball, we now check if the dependency's tarball path came from an override. If it matches an override's tarball path, we resolve it relative to the workspace root (using the normalize path) rather than constructing an absolute path from the workspace package's directory.

## Test plan

- [x] New test `test/regression/issue/25835.test.ts` passes with debug build
- [x] Test fails with system bun (reproduces the bug)
- [x] Existing override tests pass (`test/cli/install/overrides.test.ts`)

Fixes #25835

🤖 Generated with [Claude Code](https://claude.com/claude-code)