### PR TITLE
fix(stack): disable TCO for Node.js-compatible stack traces

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -309,6 +309,13 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::heapGrowthMaxIncrease() = 2.0;
             JSC::Options::useAsyncStackTrace() = true;
             JSC::Options::useExplicitResourceManagement() = true;
+            // Disable tail call optimization for Node.js compatibility.
+            // V8/Node.js doesn't implement proper tail calls, so the Node.js ecosystem
+            // expects all intermediate stack frames to be present. Libraries like Nx,
+            // node-depd, and others use Error.prepareStackTrace to analyze call stacks
+            // and break when frames are eliminated by TCO.
+            // See: https://github.com/oven-sh/bun/issues/25738
+            JSC::Options::useTailCalls() = false;
             JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
 #ifdef BUN_DEBUG

--- a/test/regression/issue/25738.test.ts
+++ b/test/regression/issue/25738.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "bun:test";
+
+// Regression test for https://github.com/oven-sh/bun/issues/25738
+// Error.prepareStackTrace should include all intermediate stack frames
+
+test("Error.prepareStackTrace call sites include all intermediate frames", () => {
+  function getCallSites() {
+    const orig = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, stack) => stack;
+    const obj = {};
+    Error.captureStackTrace(obj);
+    const stack = obj.stack;
+    Error.prepareStackTrace = orig;
+    return stack.slice(1); // Skip getCallSites itself
+  }
+
+  function innerFunction() {
+    const sites = getCallSites();
+    return sites.map((s: any) => s.getFunctionName() || "<anonymous>");
+  }
+
+  function middleFunction() {
+    return innerFunction();
+  }
+
+  function outerFunction() {
+    return middleFunction();
+  }
+
+  const result = outerFunction();
+
+  // The first 4 frames should be:
+  // 0: innerFunction (where getCallSites is called)
+  // 1: middleFunction (calls innerFunction)
+  // 2: outerFunction (calls middleFunction)
+  // 3: <anonymous> (test function)
+  expect(result[0]).toBe("innerFunction");
+  expect(result[1]).toBe("middleFunction");
+  expect(result[2]).toBe("outerFunction");
+  // The 4th frame is the anonymous test function - no need to assert its name
+});
+
+test("Error stack trace includes all intermediate frames", () => {
+  let capturedStack: string | undefined;
+
+  function innerFunction() {
+    try {
+      throw new Error("test");
+    } catch (e: any) {
+      capturedStack = e.stack;
+    }
+  }
+
+  function middleFunction() {
+    innerFunction();
+  }
+
+  function outerFunction() {
+    middleFunction();
+  }
+
+  outerFunction();
+
+  expect(capturedStack).toBeDefined();
+  expect(capturedStack).toContain("innerFunction");
+  expect(capturedStack).toContain("middleFunction");
+  expect(capturedStack).toContain("outerFunction");
+});
+
+test("Error.captureStackTrace with caller argument skips frames correctly", () => {
+  function getCallSites(caller?: Function) {
+    const orig = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, stack) => stack;
+    const obj = {};
+    Error.captureStackTrace(obj, caller);
+    const stack = obj.stack;
+    Error.prepareStackTrace = orig;
+    return stack.map((s: any) => s.getFunctionName() || "<anonymous>");
+  }
+
+  function innerFunction() {
+    return getCallSites(innerFunction);
+  }
+
+  function middleFunction() {
+    return innerFunction();
+  }
+
+  function outerFunction() {
+    return middleFunction();
+  }
+
+  const result = outerFunction();
+
+  // When caller is innerFunction, the stack should start from middleFunction
+  expect(result[0]).toBe("middleFunction");
+  expect(result[1]).toBe("outerFunction");
+});
+
+test("deeply nested function calls preserve all frames", () => {
+  function getCallSites() {
+    const orig = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, stack) => stack;
+    const obj = {};
+    Error.captureStackTrace(obj);
+    const stack = obj.stack;
+    Error.prepareStackTrace = orig;
+    return stack.slice(1).map((s: any) => s.getFunctionName() || "<anonymous>");
+  }
+
+  function level1() {
+    return getCallSites();
+  }
+
+  function level2() {
+    return level1();
+  }
+
+  function level3() {
+    return level2();
+  }
+
+  function level4() {
+    return level3();
+  }
+
+  function level5() {
+    return level4();
+  }
+
+  const result = level5();
+
+  expect(result[0]).toBe("level1");
+  expect(result[1]).toBe("level2");
+  expect(result[2]).toBe("level3");
+  expect(result[3]).toBe("level4");
+  expect(result[4]).toBe("level5");
+});


### PR DESCRIPTION
## Summary

- Disable tail call optimization (TCO) by default for Node.js compatibility
- Add regression test for Error.prepareStackTrace stack frame preservation

## Root Cause

JavaScriptCore (JSC) implements proper ES6 tail calls, which eliminates intermediate stack frames when functions return by calling another function directly (tail position). However, V8/Node.js doesn't implement TCO, so the Node.js ecosystem expects all stack frames to always be present.

When `Error.prepareStackTrace` is used to get call site objects, libraries like Nx, node-depd, and others analyze these stack traces to:
- Detect recursion patterns  
- Find the calling module
- Debug and profile applications

With TCO enabled, these intermediate frames were missing, breaking compatibility.

## Test Plan

- [x] New regression test verifies intermediate frames are preserved
- [x] Test fails on system Bun (pre-fix), passes on patched Bun
- [x] Manual verification against Node.js output

Before (broken):
```
#0 innerFunction
#1 <anonymous>          ← middleFunction/outerFunction missing!
#2 moduleEvaluation
```

After (fixed):
```
#0 innerFunction
#1 middleFunction       ← now present
#2 outerFunction        ← now present  
#3 <anonymous>
```

## Note

Users who need tail call optimization for deep recursion can re-enable it with `BUN_JSC_useTailCalls=1`.

Fixes #25738

🤖 Generated with [Claude Code](https://claude.com/claude-code)