### PR TITLE
fix(install): resolve catalog file: paths relative to root, not workspace

### DIFF
--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -231,13 +231,19 @@ pub fn callback(task: *ThreadPool.Task) void {
             this.status = Status.success;
         },
         .local_tarball => {
-            const workspace_pkg_id = manager.lockfile.getWorkspacePkgIfWorkspaceDep(this.request.local_tarball.tarball.dependency_id);
+            const dependency_id = this.request.local_tarball.tarball.dependency_id;
+            const workspace_pkg_id = manager.lockfile.getWorkspacePkgIfWorkspaceDep(dependency_id);
 
             var abs_buf: bun.PathBuffer = undefined;
             const tarball_path, const normalize = if (workspace_pkg_id != invalid_package_id) tarball_path: {
                 const workspace_res = manager.lockfile.packages.items(.resolution)[workspace_pkg_id];
 
                 if (workspace_res.tag != .workspace) break :tarball_path .{ this.request.local_tarball.tarball.url.slice(), true };
+
+                // If the dependency originated from a catalog entry, the tarball path should be
+                // resolved relative to the root (where catalogs are defined), not the workspace.
+                const dependency: Dependency = manager.lockfile.buffers.dependencies.items[dependency_id];
+                if (dependency.version.tag == .catalog) break :tarball_path .{ this.request.local_tarball.tarball.url.slice(), true };
 
                 // Construct an absolute path to the tarball.
                 // Normally tarball paths are always relative to the root directory, but if a
@@ -352,6 +358,7 @@ const string = []const u8;
 const std = @import("std");
 
 const install = @import("./install.zig");
+const Dependency = install.Dependency;
 const DependencyID = install.DependencyID;
 const ExtractData = install.ExtractData;
 const ExtractTarball = install.ExtractTarball;

--- a/test/regression/issue/25752.test.ts
+++ b/test/regression/issue/25752.test.ts
@@ -1,0 +1,72 @@
+// https://github.com/oven-sh/bun/issues/25752
+// Catalog entries with `file:./...` paths should resolve relative to the root
+// package.json (where catalogs are defined), not the workspace that references them.
+
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, pack, tempDir } from "harness";
+import { join } from "path";
+
+test("catalog file: paths resolve relative to root, not workspace", async () => {
+  // First create a simple package and pack it to get a tarball
+  using pkgDir = tempDir("pkg-for-tarball", {
+    "package.json": JSON.stringify({
+      name: "catalog-pkg",
+      version: "1.0.0",
+    }),
+    "index.js": "module.exports = 'catalog-pkg';",
+  });
+
+  await pack(String(pkgDir), bunEnv);
+  const tarballContent = await file(join(String(pkgDir), "catalog-pkg-1.0.0.tgz")).arrayBuffer();
+
+  // Create the monorepo structure
+  using monorepoDir = tempDir("monorepo-25752", {
+    "package.json": JSON.stringify({
+      name: "my-monorepo",
+      workspaces: ["packages/*"],
+      catalogs: {
+        vendored: {
+          "catalog-pkg": "file:./vendored/catalog-pkg-1.0.0.tgz",
+        },
+      },
+    }),
+    vendored: {
+      "catalog-pkg-1.0.0.tgz": new Uint8Array(tarballContent),
+    },
+    packages: {
+      "my-app": {
+        "package.json": JSON.stringify({
+          name: "my-app",
+          dependencies: {
+            "catalog-pkg": "catalog:vendored",
+          },
+        }),
+      },
+    },
+  });
+
+  // Run bun install
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(monorepoDir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The tarball should be resolved relative to the root (where catalogs is defined),
+  // not relative to packages/my-app where the dependency is declared
+  expect(stderr).not.toContain("ENOENT");
+  expect(stderr).not.toContain("failed to resolve");
+  expect(exitCode).toBe(0);
+
+  // Verify the package was installed correctly in the workspace's node_modules
+  const installedPkg = await file(
+    join(String(monorepoDir), "packages", "my-app", "node_modules", "catalog-pkg", "package.json"),
+  ).json();
+  expect(installedPkg.name).toBe("catalog-pkg");
+  expect(installedPkg.version).toBe("1.0.0");
+});


### PR DESCRIPTION
## Summary

- Fixes catalog entries with `file:./...` paths when referenced from workspace packages
- Before: paths were incorrectly resolved relative to the workspace directory
- After: paths are correctly resolved relative to the root package.json (where catalogs are defined)

## Test plan

- Added regression test in `test/regression/issue/25752.test.ts`
- Test creates a monorepo with vendored tarballs and a catalog referencing them
- Verifies that workspace packages can successfully install catalog dependencies with local file: paths

Fixes #25752

🤖 Generated with [Claude Code](https://claude.com/claude-code)