### PR TITLE
fix(bunfig): expand tilde (~) in path settings

### DIFF
--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -670,13 +670,13 @@ pub const Bunfig = struct {
 
                     if (install_obj.get("globalDir")) |dir| {
                         if (dir.asString(allocator)) |value| {
-                            install.global_dir = value;
+                            install.global_dir = bun.path.expandTilde(allocator, value) orelse value;
                         }
                     }
 
                     if (install_obj.get("globalBinDir")) |dir| {
                         if (dir.asString(allocator)) |value| {
-                            install.global_bin_dir = value;
+                            install.global_bin_dir = bun.path.expandTilde(allocator, value) orelse value;
                         }
                     }
 
@@ -696,7 +696,7 @@ pub const Bunfig = struct {
                             }
 
                             if (cache.asString(allocator)) |value| {
-                                install.cache_directory = value;
+                                install.cache_directory = bun.path.expandTilde(allocator, value) orelse value;
                                 break :load;
                             }
 
@@ -715,7 +715,7 @@ pub const Bunfig = struct {
 
                                 if (cache.get("dir")) |directory| {
                                     if (directory.asString(allocator)) |value| {
-                                        install.cache_directory = value;
+                                        install.cache_directory = bun.path.expandTilde(allocator, value) orelse value;
                                     }
                                 }
                             }

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2095,7 +2095,7 @@ pub fn expandTilde(allocator: std.mem.Allocator, path: []const u8) ?[]const u8 {
         const rest = path[2..]; // Skip ~/
         const result = allocator.alloc(u8, home_dir.len + 1 + rest.len) catch return null;
         @memcpy(result[0..home_dir.len], home_dir);
-        result[home_dir.len] = '/';
+        result[home_dir.len] = std.fs.path.sep;
         @memcpy(result[home_dir.len + 1 ..], rest);
         return result;
     }

--- a/test/regression/issue/25766.test.ts
+++ b/test/regression/issue/25766.test.ts
@@ -38,7 +38,7 @@ globalBinDir = "~/.bun/bin"
     });
 
     // Read output before awaiting exited for better error messages
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [_stdout, _stderr, _exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -81,7 +81,7 @@ globalDir = "~/.bun/install/global"
     });
 
     // Read output before awaiting exited for better error messages
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [_stdout, _stderr, _exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -123,7 +123,7 @@ dir = "~/.bun/install/cache"
     });
 
     // Read output before awaiting exited for better error messages
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [_stdout, _stderr, _exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -164,7 +164,7 @@ cache = "~/.bun/install/cache"
     });
 
     // Read output before awaiting exited for better error messages
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [_stdout, _stderr, _exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,

--- a/test/regression/issue/25766.test.ts
+++ b/test/regression/issue/25766.test.ts
@@ -37,12 +37,21 @@ globalBinDir = "~/.bun/bin"
       stderr: "pipe",
     });
 
-    await proc.exited;
+    // Read output before awaiting exited for better error messages
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
 
     // The key assertion: a literal "~" directory should NOT be created in cwd
     // If the bug exists, it would create a directory literally named "~"
     const literalTildeDir = join(String(dir), "~");
     expect(existsSync(literalTildeDir)).toBe(false);
+
+    // Positive assertion: the expanded path under fake home should be used
+    const expandedBinDir = join(fakeHome, ".bun", "bin");
+    expect(existsSync(expandedBinDir)).toBe(true);
   });
 
   test("globalDir with tilde expands to home directory", async () => {
@@ -71,11 +80,20 @@ globalDir = "~/.bun/install/global"
       stderr: "pipe",
     });
 
-    await proc.exited;
+    // Read output before awaiting exited for better error messages
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
 
     // No literal "~" directory should be created
     const literalTildeDir = join(String(dir), "~");
     expect(existsSync(literalTildeDir)).toBe(false);
+
+    // Positive assertion: the expanded path under fake home should be used
+    const expandedGlobalDir = join(fakeHome, ".bun", "install", "global");
+    expect(existsSync(expandedGlobalDir)).toBe(true);
   });
 
   test("cache.dir with tilde expands to home directory", async () => {
@@ -104,11 +122,20 @@ dir = "~/.bun/install/cache"
       stderr: "pipe",
     });
 
-    await proc.exited;
+    // Read output before awaiting exited for better error messages
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
 
     // No literal "~" directory should be created
     const literalTildeDir = join(String(dir), "~");
     expect(existsSync(literalTildeDir)).toBe(false);
+
+    // Positive assertion: the expanded path under fake home should be used
+    const expandedCacheDir = join(fakeHome, ".bun", "install", "cache");
+    expect(existsSync(expandedCacheDir)).toBe(true);
   });
 
   test("cache shorthand with tilde expands to home directory", async () => {
@@ -136,10 +163,19 @@ cache = "~/.bun/install/cache"
       stderr: "pipe",
     });
 
-    await proc.exited;
+    // Read output before awaiting exited for better error messages
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
 
     // No literal "~" directory should be created
     const literalTildeDir = join(String(dir), "~");
     expect(existsSync(literalTildeDir)).toBe(false);
+
+    // Positive assertion: the expanded path under fake home should be used
+    const expandedCacheDir = join(fakeHome, ".bun", "install", "cache");
+    expect(existsSync(expandedCacheDir)).toBe(true);
   });
 });

--- a/test/regression/issue/25766.test.ts
+++ b/test/regression/issue/25766.test.ts
@@ -1,0 +1,145 @@
+// https://github.com/oven-sh/bun/issues/25766
+// Tilde expansion (~) should work in bunfig.toml path settings
+//
+// When users specify paths like `globalBinDir = "~/.bun/bin"` in their bunfig.toml,
+// Bun should expand the `~` to $HOME. Without the fix, it creates a literal folder named `~`.
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+describe("bunfig.toml tilde expansion", () => {
+  test("globalBinDir with tilde expands to home directory", async () => {
+    // Create a fake home directory and a bunfig that uses tilde for globalBinDir
+    using dir = tempDir("issue-25766-bin", {
+      "fake-home/.bun/bin/.gitkeep": "",
+      "package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]
+globalBinDir = "~/.bun/bin"
+`,
+    });
+
+    const fakeHome = join(String(dir), "fake-home");
+
+    // Use `bun link` which triggers the openGlobalBinDir and openGlobalDir code paths
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "link"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        HOME: fakeHome,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await proc.exited;
+
+    // The key assertion: a literal "~" directory should NOT be created in cwd
+    // If the bug exists, it would create a directory literally named "~"
+    const literalTildeDir = join(String(dir), "~");
+    expect(existsSync(literalTildeDir)).toBe(false);
+  });
+
+  test("globalDir with tilde expands to home directory", async () => {
+    using dir = tempDir("issue-25766-global", {
+      "fake-home/.bun/install/global/.gitkeep": "",
+      "package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]
+globalDir = "~/.bun/install/global"
+`,
+    });
+
+    const fakeHome = join(String(dir), "fake-home");
+
+    // Use `bun link` which triggers the openGlobalDir code path
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "link"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        HOME: fakeHome,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await proc.exited;
+
+    // No literal "~" directory should be created
+    const literalTildeDir = join(String(dir), "~");
+    expect(existsSync(literalTildeDir)).toBe(false);
+  });
+
+  test("cache.dir with tilde expands to home directory", async () => {
+    using dir = tempDir("issue-25766-cache", {
+      "fake-home/.bun/install/cache/.gitkeep": "",
+      "package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install.cache]
+dir = "~/.bun/install/cache"
+`,
+    });
+
+    const fakeHome = join(String(dir), "fake-home");
+
+    // Regular install should trigger cache directory access
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        HOME: fakeHome,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await proc.exited;
+
+    // No literal "~" directory should be created
+    const literalTildeDir = join(String(dir), "~");
+    expect(existsSync(literalTildeDir)).toBe(false);
+  });
+
+  test("cache shorthand with tilde expands to home directory", async () => {
+    using dir = tempDir("issue-25766-cache-short", {
+      "fake-home/.bun/install/cache/.gitkeep": "",
+      "package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]
+cache = "~/.bun/install/cache"
+`,
+    });
+
+    const fakeHome = join(String(dir), "fake-home");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        HOME: fakeHome,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await proc.exited;
+
+    // No literal "~" directory should be created
+    const literalTildeDir = join(String(dir), "~");
+    expect(existsSync(literalTildeDir)).toBe(false);
+  });
+});

--- a/test/regression/issue/25766.test.ts
+++ b/test/regression/issue/25766.test.ts
@@ -38,7 +38,7 @@ globalBinDir = "~/.bun/bin"
     });
 
     // Read output before awaiting exited for better error messages
-    const [_stdout, _stderr, _exitCode] = await Promise.all([
+    const [_stdout, _stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -52,6 +52,9 @@ globalBinDir = "~/.bun/bin"
     // Positive assertion: the expanded path under fake home should be used
     const expandedBinDir = join(fakeHome, ".bun", "bin");
     expect(existsSync(expandedBinDir)).toBe(true);
+
+    // Assert command succeeded
+    expect(exitCode).toBe(0);
   });
 
   test("globalDir with tilde expands to home directory", async () => {
@@ -81,7 +84,7 @@ globalDir = "~/.bun/install/global"
     });
 
     // Read output before awaiting exited for better error messages
-    const [_stdout, _stderr, _exitCode] = await Promise.all([
+    const [_stdout, _stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -94,6 +97,9 @@ globalDir = "~/.bun/install/global"
     // Positive assertion: the expanded path under fake home should be used
     const expandedGlobalDir = join(fakeHome, ".bun", "install", "global");
     expect(existsSync(expandedGlobalDir)).toBe(true);
+
+    // Assert command succeeded
+    expect(exitCode).toBe(0);
   });
 
   test("cache.dir with tilde expands to home directory", async () => {
@@ -123,7 +129,7 @@ dir = "~/.bun/install/cache"
     });
 
     // Read output before awaiting exited for better error messages
-    const [_stdout, _stderr, _exitCode] = await Promise.all([
+    const [_stdout, _stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -136,6 +142,9 @@ dir = "~/.bun/install/cache"
     // Positive assertion: the expanded path under fake home should be used
     const expandedCacheDir = join(fakeHome, ".bun", "install", "cache");
     expect(existsSync(expandedCacheDir)).toBe(true);
+
+    // Assert command succeeded
+    expect(exitCode).toBe(0);
   });
 
   test("cache shorthand with tilde expands to home directory", async () => {
@@ -164,7 +173,7 @@ cache = "~/.bun/install/cache"
     });
 
     // Read output before awaiting exited for better error messages
-    const [_stdout, _stderr, _exitCode] = await Promise.all([
+    const [_stdout, _stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -177,5 +186,8 @@ cache = "~/.bun/install/cache"
     // Positive assertion: the expanded path under fake home should be used
     const expandedCacheDir = join(fakeHome, ".bun", "install", "cache");
     expect(existsSync(expandedCacheDir)).toBe(true);
+
+    // Assert command succeeded
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds tilde (`~`) expansion for path settings in bunfig.toml
- When users specify paths like `globalBinDir = "~/.bun/bin"`, the `~` is now properly expanded to `$HOME`
- Previously, Bun would create a literal directory named `~` relative to the current working directory

## Affected Settings

- `install.globalDir`
- `install.globalBinDir`
- `install.cache.dir`
- `install.cache` (shorthand)

## Changes

1. Added `expandTilde()` function to `src/resolver/resolve_path.zig` that expands leading `~` to `$HOME`
2. Applied tilde expansion when parsing the affected path settings in `src/bunfig.zig`
3. Added regression tests in `test/regression/issue/25766.test.ts`

## Test plan

- [x] Added regression tests that verify no literal `~` directory is created
- [x] Tests fail with system bun (v1.3.5) demonstrating the bug
- [x] Tests pass with the fix applied

Fixes #25766

🤖 Generated with [Claude Code](https://claude.com/claude-code)