### PR TITLE
fix(server): show proper DNS error instead of EADDRINUSE for unresolvable hostnames

### DIFF
--- a/test/regression/issue/25765.test.ts
+++ b/test/regression/issue/25765.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/25765
+// Bun.serve() with unresolvable hostname should show proper DNS error, not EADDRINUSE
+
+test("Bun.serve() with unresolvable hostname shows DNS error", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `Bun.serve({ hostname: "something.localhost", fetch: () => new Response("Hello") });`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should not claim the port is in use (EADDRINUSE)
+  expect(stderr).not.toContain("EADDRINUSE");
+  expect(stderr).not.toContain("Is port");
+
+  // Should show a DNS resolution error
+  expect(stderr).toContain("ENOTFOUND");
+  expect(stderr).toContain("getaddrinfo");
+
+  // Should fail
+  expect(exitCode).not.toBe(0);
+});
+
+test("Bun.serve() with valid hostname still works", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const server = Bun.serve({
+        hostname: "localhost",
+        port: 0,
+        fetch: () => new Response("Hello")
+      });
+      console.log("listening on port", server.port);
+      server.stop();
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("listening on port");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- When `Bun.serve()` is called with a hostname that cannot be resolved via DNS (e.g., `something.localhost`), the error message now correctly shows `getaddrinfo EAI_NONAME` with code `ENOTFOUND` instead of the misleading `EADDRINUSE` error suggesting the port is in use.

## Changes

- Capture `getaddrinfo()` return code in `bsd.c` and map it to libuv-style error codes (UV__EAI_*)
- Detect DNS resolution errors in `server.zig` and display the proper error message with hostname

### Before
```
error: Failed to start server. Is port 3000 in use?
 syscall: "listen",
   errno: 0,
    code: "EADDRINUSE"
```

### After
```
error: getaddrinfo EAI_NONAME
  syscall: "getaddrinfo",
 hostname: "something.localhost",
    errno: 0,
     code: "ENOTFOUND"
```

## Test plan

- [x] New test added in `test/regression/issue/25765.test.ts`
- [x] Test verifies DNS error is shown (not EADDRINUSE)
- [x] Test verifies valid hostnames still work


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #25765