### PR TITLE
fix(fs.watch): emit 'change' events for files in watched directories on Linux

### DIFF
--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -166,12 +166,7 @@ pub const WatchEvent = struct {
 
     pub fn merge(this: *WatchEvent, other: WatchEvent) void {
         this.name_len += other.name_len;
-        this.op = Op{
-            .delete = this.op.delete or other.op.delete,
-            .metadata = this.op.metadata or other.op.metadata,
-            .rename = this.op.rename or other.op.rename,
-            .write = this.op.write or other.op.write,
-        };
+        this.op = Op.merge(this.op, other.op);
     }
 
     pub const Op = packed struct(u8) {
@@ -180,7 +175,8 @@ pub const WatchEvent = struct {
         rename: bool = false,
         write: bool = false,
         move_to: bool = false,
-        _padding: u3 = 0,
+        create: bool = false,
+        _padding: u2 = 0,
 
         pub fn merge(before: Op, after: Op) Op {
             return .{
@@ -189,6 +185,7 @@ pub const WatchEvent = struct {
                 .metadata = before.metadata or after.metadata,
                 .rename = before.rename or after.rename,
                 .move_to = before.move_to or after.move_to,
+                .create = before.create or after.create,
             };
         }
 

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -248,7 +248,9 @@ pub const PathWatcherManager = struct {
                         const hash = Watcher.getHash(path_slice);
 
                         // skip consecutive duplicates
-                        const event_type: PathWatcher.EventType = .rename; // renaming folders, creating folder or files will be always be rename
+                        // If it's a create, delete, rename, or move event, emit "rename"
+                        // If it's a pure write (modify) event, emit "change"
+                        const event_type: PathWatcher.EventType = if (event.op.create or event.op.delete or event.op.rename or event.op.move_to) .rename else .change;
                         for (watchers) |w| {
                             if (w) |watcher| {
                                 if (comptime Environment.isMac) {

--- a/src/watcher/INotifyWatcher.zig
+++ b/src/watcher/INotifyWatcher.zig
@@ -77,7 +77,7 @@ pub fn watchDir(this: *INotifyWatcher, pathname: [:0]const u8) bun.sys.Maybe(Eve
     bun.assert(this.loaded);
     const old_count = this.watch_count.fetchAdd(1, .release);
     defer if (old_count == 0) Futex.wake(&this.watch_count, 10);
-    const watch_dir_mask = IN.EXCL_UNLINK | IN.DELETE | IN.DELETE_SELF | IN.CREATE | IN.MOVE_SELF | IN.ONLYDIR | IN.MOVED_TO;
+    const watch_dir_mask = IN.EXCL_UNLINK | IN.DELETE | IN.DELETE_SELF | IN.CREATE | IN.MOVE_SELF | IN.ONLYDIR | IN.MOVED_TO | IN.MODIFY;
     const rc = system.inotify_add_watch(this.fd.cast(), pathname, watch_dir_mask);
     log("inotify_add_watch({f}) = {}", .{ this.fd, rc });
     return bun.sys.Maybe(EventListIndex).errnoSysP(rc, .watch, pathname) orelse
@@ -364,6 +364,7 @@ pub fn watchEventFromInotifyEvent(event: *align(1) const INotifyWatcher.Event, i
             .rename = (event.mask & IN.MOVE_SELF) > 0,
             .move_to = (event.mask & IN.MOVED_TO) > 0,
             .write = (event.mask & IN.MODIFY) > 0,
+            .create = (event.mask & IN.CREATE) > 0,
         },
         .index = index,
     };

--- a/test/regression/issue/3657.test.ts
+++ b/test/regression/issue/3657.test.ts
@@ -1,0 +1,111 @@
+// https://github.com/oven-sh/bun/issues/3657
+// fs.watch on a directory should emit 'change' events for files created after the watch is established
+
+import { describe, expect, test } from "bun:test";
+import { isLinux, tempDirWithFiles } from "harness";
+import fs from "node:fs";
+import path from "node:path";
+
+describe.skipIf(!isLinux)("GitHub Issue #3657", () => {
+  test("fs.watch on directory emits 'change' events for files created after watch starts", async () => {
+    const testDir = tempDirWithFiles("issue-3657", {});
+    const testFile = path.join(testDir, "test.txt");
+
+    const events: Array<{ eventType: string; filename: string | null }> = [];
+    let resolver: () => void;
+    const promise = new Promise<void>(resolve => {
+      resolver = resolve;
+    });
+
+    const watcher = fs.watch(testDir, { signal: AbortSignal.timeout(5000) }, (eventType, filename) => {
+      events.push({ eventType, filename: filename as string | null });
+      // We expect at least 2 events: one rename (create) and one change (modify)
+      if (events.length >= 2) {
+        resolver();
+      }
+    });
+
+    // Give the watcher time to initialize
+    await Bun.sleep(100);
+
+    // Create the file - should emit 'rename' event
+    fs.writeFileSync(testFile, "hello");
+
+    // Wait a bit for the event to be processed
+    await Bun.sleep(100);
+
+    // Modify the file - should emit 'change' event
+    fs.appendFileSync(testFile, " world");
+
+    try {
+      await promise;
+    } finally {
+      watcher.close();
+    }
+
+    // Verify we got at least one event for "test.txt"
+    const testFileEvents = events.filter(e => e.filename === "test.txt");
+    expect(testFileEvents.length).toBeGreaterThanOrEqual(2);
+
+    // Verify we got a 'rename' event (file creation)
+    const renameEvents = testFileEvents.filter(e => e.eventType === "rename");
+    expect(renameEvents.length).toBeGreaterThanOrEqual(1);
+
+    // Verify we got a 'change' event (file modification)
+    const changeEvents = testFileEvents.filter(e => e.eventType === "change");
+    expect(changeEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("fs.watch emits multiple 'change' events for repeated modifications", async () => {
+    const testDir = tempDirWithFiles("issue-3657-multi", {});
+    const testFile = path.join(testDir, "multi.txt");
+
+    const events: Array<{ eventType: string; filename: string | null }> = [];
+    let resolver: () => void;
+    const promise = new Promise<void>(resolve => {
+      resolver = resolve;
+    });
+
+    const watcher = fs.watch(testDir, { signal: AbortSignal.timeout(5000) }, (eventType, filename) => {
+      events.push({ eventType, filename: filename as string | null });
+      // We expect 1 rename (create) + 3 change events = 4 total
+      if (events.length >= 4) {
+        resolver();
+      }
+    });
+
+    // Give the watcher time to initialize
+    await Bun.sleep(100);
+
+    // Create the file - should emit 'rename' event
+    fs.writeFileSync(testFile, "line1\n");
+    await Bun.sleep(100);
+
+    // Multiple modifications - should emit 'change' events
+    fs.appendFileSync(testFile, "line2\n");
+    await Bun.sleep(100);
+
+    fs.appendFileSync(testFile, "line3\n");
+    await Bun.sleep(100);
+
+    fs.appendFileSync(testFile, "line4\n");
+
+    try {
+      await promise;
+    } finally {
+      watcher.close();
+    }
+
+    // Verify we got events for "multi.txt"
+    const testFileEvents = events.filter(e => e.filename === "multi.txt");
+    expect(testFileEvents.length).toBeGreaterThanOrEqual(4);
+
+    // Verify we got a 'rename' event (file creation)
+    const renameEvents = testFileEvents.filter(e => e.eventType === "rename");
+    expect(renameEvents.length).toBeGreaterThanOrEqual(1);
+
+    // Verify we got multiple 'change' events (file modifications)
+    const changeEvents = testFileEvents.filter(e => e.eventType === "change");
+    expect(changeEvents.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #3657 - `fs.watch` on directory doesn't emit `change` events for files created after watch starts

When watching a directory with `fs.watch`, files created after the watch was established would only emit a 'rename' event on creation, but subsequent modifications would not emit 'change' events.

## Root Cause

The issue was twofold:
1. `watch_dir_mask` in INotifyWatcher.zig was missing `IN.MODIFY`, so the inotify system call was not subscribed to file modification events for watched directories.
2. When directory events were processed in path_watcher.zig, all events were hardcoded to emit 'rename' instead of properly distinguishing between file creation/deletion ('rename') and file modification ('change').

## Changes

- Adds `IN.MODIFY` to `watch_dir_mask` to receive modification events
- Adds a `create` flag to `WatchEvent.Op` to track `IN.CREATE` events
- Updates directory event processing to emit 'change' for pure write events and 'rename' for create/delete/move events

## Test plan
- [x] Added regression test `test/regression/issue/3657.test.ts`
- [x] Verified test fails with system Bun (before fix)
- [x] Verified test passes with debug build (after fix)
- [x] Verified manual reproduction from issue now works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)