### PR TITLE
fix(net): guard against null context/handle in internalConnectMultipleTimeout

### DIFF
--- a/test/regression/issue/25633.test.ts
+++ b/test/regression/issue/25633.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/25633
+// TypeError: null is not an object (evaluating 'context') in internalConnectMultipleTimeout
+// when using node:tls connect with timeout and autoSelectFamily under high concurrent load
+
+describe("issue #25633", () => {
+  test("TLS connect with timeout and autoSelectFamily should not crash when destroyed early", async () => {
+    using dir = tempDir("issue-25633", {
+      "test.js": `
+        const net = require("node:net");
+
+        // Use localhost addresses that will likely fail/timeout to trigger the race condition
+        // The key is that we destroy the socket while the timeout is still pending
+        const connCount = 10;
+        let completed = 0;
+        let crashErrors = [];
+
+        process.on("uncaughtException", (err) => {
+          crashErrors.push(err);
+        });
+
+        for (let i = 0; i < connCount; i++) {
+          const socket = net.connect({
+            // Use localhost with a port that's unlikely to be open
+            host: "localhost",
+            port: 65432,
+            timeout: 200,
+            autoSelectFamily: true,
+            autoSelectFamilyAttemptTimeout: 50,
+          });
+
+          socket.on('error', () => {
+            completed++;
+            checkDone();
+          });
+
+          socket.on('connect', () => {
+            completed++;
+            socket.destroy();
+            checkDone();
+          });
+
+          socket.on('timeout', () => {
+            socket.destroy();
+          });
+
+          // Immediately destroy some sockets to trigger race condition
+          if (i % 2 === 0) {
+            setTimeout(() => socket.destroy(), 5);
+          }
+        }
+
+        function checkDone() {
+          if (completed >= connCount) {
+            finish();
+          }
+        }
+
+        function finish() {
+          if (crashErrors.length > 0) {
+            console.error("CRASH_ERRORS:", crashErrors.map(e => e.message).join(", "));
+            process.exit(1);
+          } else {
+            console.log("SUCCESS");
+            process.exit(0);
+          }
+        }
+
+        // Safety timeout
+        setTimeout(finish, 1500);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The test passes if it doesn't crash with "null is not an object"
+    expect(stderr).not.toContain("null is not an object");
+    expect(stdout).toContain("SUCCESS");
+    expect(exitCode).toBe(0);
+  }, 10000);
+});


### PR DESCRIPTION
## Summary
- Add null checks in `internalConnectMultipleTimeout` to prevent TypeError when context or handle are null/invalid
- This fixes a race condition that could occur under high concurrent load when using TLS connect with `autoSelectFamily` and `timeout` options

The issue was that the timeout callback scheduled at line 1913 could fire after the socket was destroyed or the handle was replaced, resulting in "null is not an object (evaluating 'context')" errors.

Fixes #25633

## Test plan
- [x] Added regression test at `test/regression/issue/25633.test.ts`
- [x] Verified `test/js/node/test/parallel/test-net-autoselectfamily-default.js` passes
- [x] Verified `test/js/node/test/parallel/test-net-autoselectfamily-ipv4first.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)