### PR TITLE
fix(compile): respect autoloadBunfig: false when execArgv is present

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1159,7 +1159,9 @@ pub const StandaloneModuleGraph = struct {
         return .success;
     }
 
-    pub fn fromExecutable(allocator: std.mem.Allocator) !?StandaloneModuleGraph {
+    /// Loads the standalone module graph from the executable, allocates it on the heap,
+    /// sets it globally, and returns the pointer.
+    pub fn fromExecutable(allocator: std.mem.Allocator) !?*StandaloneModuleGraph {
         if (comptime Environment.isMac) {
             const macho_bytes = Macho.getData() orelse return null;
             if (macho_bytes.len < @sizeOf(Offsets) + trailer.len) {
@@ -1173,7 +1175,7 @@ pub const StandaloneModuleGraph = struct {
                 return null;
             }
             const offsets = std.mem.bytesAsValue(Offsets, macho_bytes_slice).*;
-            return try StandaloneModuleGraph.fromBytes(allocator, @constCast(macho_bytes), offsets);
+            return try fromBytesAlloc(allocator, @constCast(macho_bytes), offsets);
         }
 
         if (comptime Environment.isWindows) {
@@ -1189,7 +1191,7 @@ pub const StandaloneModuleGraph = struct {
                 return null;
             }
             const offsets = std.mem.bytesAsValue(Offsets, pe_bytes_slice).*;
-            return try StandaloneModuleGraph.fromBytes(allocator, @constCast(pe_bytes), offsets);
+            return try fromBytesAlloc(allocator, @constCast(pe_bytes), offsets);
         }
 
         // Do not invoke libuv here.
@@ -1284,7 +1286,15 @@ pub const StandaloneModuleGraph = struct {
             }
         }
 
-        return try StandaloneModuleGraph.fromBytes(allocator, to_read, offsets);
+        return try fromBytesAlloc(allocator, to_read, offsets);
+    }
+
+    /// Allocates a StandaloneModuleGraph on the heap, populates it from bytes, sets it globally, and returns the pointer.
+    fn fromBytesAlloc(allocator: std.mem.Allocator, raw_bytes: []u8, offsets: Offsets) !*StandaloneModuleGraph {
+        const graph_ptr = try allocator.create(StandaloneModuleGraph);
+        graph_ptr.* = try StandaloneModuleGraph.fromBytes(allocator, raw_bytes, offsets);
+        graph_ptr.set();
+        return graph_ptr;
     }
 
     /// heuristic: `bun build --compile` won't be supported if the name is "bun", "bunx", or "node".

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -13,18 +13,10 @@ pub const Run = struct {
 
     var run: Run = undefined;
 
-    pub fn bootStandalone(ctx: Command.Context, entry_path: string, graph: bun.StandaloneModuleGraph) !void {
+    pub fn bootStandalone(ctx: Command.Context, entry_path: string, graph_ptr: *bun.StandaloneModuleGraph) !void {
         jsc.markBinding(@src());
         bun.jsc.initialize(false);
         bun.analytics.Features.standalone_executable += 1;
-
-        // Use the already-set graph from cli.zig, or create one if not set
-        const graph_ptr = bun.StandaloneModuleGraph.get() orelse brk: {
-            const ptr = try bun.default_allocator.create(bun.StandaloneModuleGraph);
-            ptr.* = graph;
-            ptr.set();
-            break :brk ptr;
-        };
 
         js_ast.Expr.Data.Store.create();
         js_ast.Stmt.Data.Store.create();
@@ -92,7 +84,7 @@ pub const Run = struct {
 
         // If .env loading is disabled, only load process env vars
         // Otherwise, load all .env files
-        if (graph.flags.disable_default_env_files) {
+        if (graph_ptr.flags.disable_default_env_files) {
             b.options.env.behavior = .disable;
         } else {
             b.options.env.behavior = .load_all_without_inlining;
@@ -100,8 +92,8 @@ pub const Run = struct {
 
         // Control loading of tsconfig.json and package.json at runtime
         // By default, these are disabled for standalone executables
-        b.resolver.opts.load_tsconfig_json = !graph.flags.disable_autoload_tsconfig;
-        b.resolver.opts.load_package_json = !graph.flags.disable_autoload_package_json;
+        b.resolver.opts.load_tsconfig_json = !graph_ptr.flags.disable_autoload_tsconfig;
+        b.resolver.opts.load_package_json = !graph_ptr.flags.disable_autoload_package_json;
 
         b.configureDefines() catch {
             failWithBuildError(vm);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -685,6 +685,11 @@ pub const Command = struct {
             if (try bun.StandaloneModuleGraph.fromExecutable(bun.default_allocator)) |graph| {
                 var offset_for_passthrough: usize = 0;
 
+                // Store graph globally so Arguments.loadConfig can check disable_autoload_bunfig
+                const graph_ptr = try bun.default_allocator.create(bun.StandaloneModuleGraph);
+                graph_ptr.* = graph;
+                graph_ptr.set();
+
                 const ctx: *ContextData = brk: {
                     if (graph.compile_exec_argv.len > 0) {
                         const original_argv_len = bun.argv.len;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -685,11 +685,6 @@ pub const Command = struct {
             if (try bun.StandaloneModuleGraph.fromExecutable(bun.default_allocator)) |graph| {
                 var offset_for_passthrough: usize = 0;
 
-                // Store graph globally so Arguments.loadConfig can check disable_autoload_bunfig
-                const graph_ptr = try bun.default_allocator.create(bun.StandaloneModuleGraph);
-                graph_ptr.* = graph;
-                graph_ptr.set();
-
                 const ctx: *ContextData = brk: {
                     if (graph.compile_exec_argv.len > 0) {
                         const original_argv_len = bun.argv.len;

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -297,6 +297,16 @@ fn getHomeConfigPath(buf: *bun.PathBuffer) ?[:0]const u8 {
     return null;
 }
 pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx: Command.Context, comptime cmd: Command.Tag) OOM!void {
+    // If running as a standalone executable with autoloadBunfig disabled, skip config loading
+    // unless an explicit config path was provided via --config
+    if (user_config_path_ == null) {
+        if (bun.StandaloneModuleGraph.get()) |graph| {
+            if (graph.flags.disable_autoload_bunfig) {
+                return;
+            }
+        }
+    }
+
     var config_buf: bun.PathBuffer = undefined;
     if (comptime cmd.readGlobalConfig()) {
         if (!ctx.has_loaded_global_config) {

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -453,6 +453,84 @@ console.log("PRELOAD");
     },
   });
 
+  // Test that autoloadBunfig: false works with execArgv (regression test for #25640)
+  // When execArgv is present, bunfig should still be disabled if autoloadBunfig: false
+  itBundled("compile/AutoloadBunfigDisabledWithExecArgv", {
+    compile: {
+      autoloadBunfig: false,
+      execArgv: ["--smol"],
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      // When bunfig is disabled, preload should NOT execute even with execArgv
+      stdout: "ENTRY",
+      setCwd: true,
+    },
+  });
+
+  // Test CLI backend for autoloadBunfig: false with execArgv (regression test for #25640)
+  itBundled("compile/AutoloadBunfigDisabledWithExecArgvCLI", {
+    compile: {
+      autoloadBunfig: false,
+      execArgv: ["--smol"],
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      stdout: "ENTRY",
+      setCwd: true,
+    },
+  });
+
+  // Test that autoloadBunfig: true with execArgv still loads bunfig
+  itBundled("compile/AutoloadBunfigEnabledWithExecArgv", {
+    compile: {
+      autoloadBunfig: true,
+      execArgv: ["--smol"],
+    },
+    files: {
+      "/entry.ts": /* js */ `
+        console.log("ENTRY");
+      `,
+    },
+    runtimeFiles: {
+      "/bunfig.toml": `
+preload = ["./preload.ts"]
+      `,
+      "/preload.ts": `
+console.log("PRELOAD");
+      `,
+    },
+    run: {
+      stdout: "PRELOAD\nENTRY",
+      setCwd: true,
+    },
+  });
+
   // Test that both tsconfig and package.json can be enabled together
   itBundled("compile/AutoloadBothTsconfigAndPackageJson", {
     compile: {


### PR DESCRIPTION
## Summary

Fixes #25640

- Fixed bug where compiled binaries with `autoloadBunfig: false` would still load `bunfig.toml` when `execArgv` was also provided
- The issue was that `Command.init(.AutoCommand)` was called to parse execArgv, which loaded bunfig before checking the disable flag

## Test plan

- [x] Added tests for `autoloadBunfig: false` with `execArgv` in `test/bundler/bundler_compile_autoload.test.ts`
- [x] Verified tests pass with debug build: `bun bd test test/bundler/bundler_compile_autoload.test.ts`
- [x] Verified tests fail with system bun (demonstrates fix works): `USE_SYSTEM_BUN=1 bun test test/bundler/bundler_compile_autoload.test.ts -t "AutoloadBunfigDisabledWithExecArgv"`
- [x] All existing autoload tests still pass (22 tests total)

🤖 Generated with [Claude Code](https://claude.ai/code)