### PR TITLE
fix(test): support section names in --config flag

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -360,6 +360,9 @@ pub const Command = struct {
             junit: bool = false,
         } = .{},
         reporter_outfile: ?[]const u8 = null,
+
+        /// The name of a conditional config section from bunfig.toml (e.g., "ci" for [test.ci])
+        config_section_name: ?[]const u8 = null,
     };
 
     pub const Debugger = union(enum) {

--- a/test/regression/issue/25647.test.ts
+++ b/test/regression/issue/25647.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/25647
+describe("issue #25647: bun test --config= should support section names", () => {
+  test("--config=ci should load [test.ci] section from bunfig.toml", async () => {
+    using dir = tempDir("test-25647", {
+      "bunfig.toml": `
+[test]
+timeout = 5000
+
+[test.ci]
+timeout = 30000
+`,
+      "example.test.ts": `
+import { test, expect } from "bun:test";
+
+test("check timeout from conditional config", () => {
+  // The test runner reads the timeout from config
+  // We can't directly check the timeout value, but we can verify
+  // the config was loaded successfully by running the test
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    // Run with --config=ci (section name, not file path)
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--config=ci", "example.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should NOT get ENOENT error trying to open "ci" as a file
+    expect(stderr).not.toContain("ENOENT");
+    expect(stderr).not.toContain("No such file or directory");
+
+    // Test should pass (1 pass, 0 fail). Results are printed to stderr.
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config=staging should load [test.staging] section", async () => {
+    using dir = tempDir("test-25647-staging", {
+      "bunfig.toml": `
+[test]
+timeout = 1000
+
+[test.staging]
+timeout = 60000
+`,
+      "example.test.ts": `
+import { test, expect } from "bun:test";
+
+test("staging config test", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--config=staging", "example.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("ENOENT");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config=./bunfig.toml should still work as a file path", async () => {
+    using dir = tempDir("test-25647-filepath", {
+      "bunfig.toml": `
+[test]
+timeout = 5000
+`,
+      "example.test.ts": `
+import { test, expect } from "bun:test";
+
+test("file path config test", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    // Pass an explicit file path (with ./)
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--config=./bunfig.toml", "example.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config=custom.toml should work as a file path", async () => {
+    using dir = tempDir("test-25647-custom", {
+      "custom.toml": `
+[test]
+timeout = 5000
+`,
+      "example.test.ts": `
+import { test, expect } from "bun:test";
+
+test("custom file config test", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    // Pass a .toml file (should be treated as file path)
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--config=custom.toml", "example.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config=nonexistent (section that doesn't exist) should still work", async () => {
+    using dir = tempDir("test-25647-nonexistent", {
+      "bunfig.toml": `
+[test]
+timeout = 5000
+`,
+      "example.test.ts": `
+import { test, expect } from "bun:test";
+
+test("test with missing conditional section", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    // Pass a section name that doesn't exist - should still load base [test] and not error
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--config=nonexistent", "example.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should NOT get ENOENT error
+    expect(stderr).not.toContain("ENOENT");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/25647.test.ts
+++ b/test/regression/issue/25647.test.ts
@@ -33,7 +33,7 @@ test("check timeout from conditional config", () => {
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Should NOT get ENOENT error trying to open "ci" as a file
     expect(stderr).not.toContain("ENOENT");
@@ -70,7 +70,7 @@ test("staging config test", () => {
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("ENOENT");
     expect(exitCode).toBe(0);
@@ -100,7 +100,7 @@ test("file path config test", () => {
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(exitCode).toBe(0);
   });
@@ -129,7 +129,7 @@ test("custom file config test", () => {
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(exitCode).toBe(0);
   });
@@ -158,7 +158,7 @@ test("test with missing conditional section", () => {
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Should NOT get ENOENT error
     expect(stderr).not.toContain("ENOENT");


### PR DESCRIPTION
## Summary
- Fixes #25647 - `bun test --config=ci` now correctly loads conditional configuration sections from bunfig.toml
- When using `--config=ci`, the test runner now looks for `[test.ci]` section instead of treating "ci" as a file path
- File paths are still supported with explicit paths like `--config=./bunfig.toml` or `--config=custom.toml`

## Test plan
- [x] `bun bd test test/regression/issue/25647.test.ts` - All 5 tests pass
- [x] Test fails with `USE_SYSTEM_BUN=1` (confirms bug exists in current release)
- [x] Test passes with debug build (confirms fix works)
- [x] Manual verification: `bun test --config=ci` loads `[test.ci]` section correctly

## Changes
1. **src/cli/Arguments.zig**: Added `isConfigSectionName()` to detect section names vs file paths, and modified `loadConfig()` to store section names for the bunfig parser
2. **src/cli.zig**: Added `config_section_name` field to `TestOptions` struct
3. **src/bunfig.zig**: Refactored test config parsing into `parseTestOptions()` helper and added conditional section support
4. **test/regression/issue/25647.test.ts**: Added regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)