### PR TITLE
fix(server): memory leak in streaming response proxy

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1896,6 +1896,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                                 }
                                 this.ref();
                                 byte_stream.pipe = jsc.WebCore.Pipe.Wrap(@This(), onPipe).init(this);
+                                // Deinit the old reference before creating a new one to avoid leaking the Strong.Impl
+                                this.response_body_readable_stream_ref.deinit();
                                 this.response_body_readable_stream_ref = jsc.WebCore.ReadableStream.Strong.init(stream, globalThis);
 
                                 this.byte_stream = byte_stream;

--- a/test/regression/issue/25630.test.ts
+++ b/test/regression/issue/25630.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+describe("issue 25630 - streaming response proxy memory leak", () => {
+  test("should not leak ReadableStream Strong references when proxying streaming responses", async () => {
+    // Backend server producing streaming data
+    const backendServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const stream = new ReadableStream({
+          async start(controller) {
+            for (let i = 0; i < 3; i++) {
+              await Bun.sleep(5);
+              controller.enqueue(new TextEncoder().encode(`data: chunk ${i}\n\n`));
+            }
+            controller.close();
+          },
+        });
+        return new Response(stream, {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      },
+    });
+
+    // Proxy server that forwards streaming responses (simulates SvelteKit with AI SDK)
+    const proxyServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const response = await fetch(backendServer.url);
+        // This is the pattern that leaks: passing response.body to a new Response
+        return new Response(response.body, {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Transfer-Encoding": "chunked",
+          },
+        });
+      },
+    });
+
+    try {
+      // Force GC and get initial ReadableStream count
+      Bun.gc(true);
+      const jsc = require("bun:jsc");
+      const initialCount = jsc.heapStats().objectTypeCounts.ReadableStream ?? 0;
+
+      // Make many requests through the proxy
+      const numRequests = 20;
+      for (let i = 0; i < numRequests; i++) {
+        const resp = await fetch(proxyServer.url);
+        // Consume the entire response to ensure stream completes
+        await resp.text();
+      }
+
+      // Force GC multiple times to ensure cleanup
+      for (let i = 0; i < 5; i++) {
+        Bun.gc(true);
+        await Bun.sleep(5);
+      }
+
+      const finalCount = jsc.heapStats().objectTypeCounts.ReadableStream ?? 0;
+      const leakedStreams = finalCount - initialCount;
+
+      // With the bug, we'd see ~numRequests leaked streams
+      // With the fix, we should see very few (ideally 0, but allow some slack for timing)
+      // The threshold of 10 is generous - without the fix, we'd see 20+ leaked streams
+      expect(leakedStreams).toBeLessThan(10);
+    } finally {
+      backendServer.stop(true);
+      proxyServer.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `Strong` reference leak in `RequestContext.doRenderWithBody()` when proxying streaming responses
- Add `deinit()` call before reassigning `response_body_readable_stream_ref` in the `.Bytes` stream path
- Add regression test that verifies ReadableStream objects are properly garbage collected

Fixes #25630

## Root Cause

In the `.Bytes` stream path when `has_received_last_chunk=false`, a new Strong reference was created without first deinit'ing the existing reference. This caused `Strong.Impl` memory to leak on every streaming response.

Before fix (20 requests through proxy):
```
Final ReadableStream count: 22
Leaked: 22
```

After fix (20 requests through proxy):
```
Final ReadableStream count: 2
Leaked: 2
```

## Test plan

- [x] New regression test `test/regression/issue/25630.test.ts` verifies the fix
- [x] Test fails with `USE_SYSTEM_BUN=1` (showing 22 leaked streams)
- [x] Test passes with `bun bd test` (showing only 2 remaining streams)
- [x] All existing streaming tests pass (`bun bd test test/js/bun/http/serve.test.ts -t "streaming"`)
- [x] All ReadableStream tests pass (`bun bd test test/js/bun/http/serve.test.ts -t "ReadableStream"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)