### PR TITLE
fix(bundler): process resources inside `<noscript>` tags in HTML bundler

### DIFF
--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -66,6 +66,11 @@ pub fn onTag(this: *HTMLScanner, _: *lol.Element, path: []const u8, url_attribut
     this.createImportRecord(path, kind) catch {};
 }
 
+/// Handle URLs found inside noscript elements (parsed from raw text content)
+pub fn onNoscriptUrl(this: *HTMLScanner, path: []const u8, kind: ImportKind) void {
+    this.createImportRecord(path, kind) catch {};
+}
+
 const processor = HTMLProcessor(HTMLScanner, false);
 
 pub fn scan(this: *HTMLScanner, input: []const u8) !void {
@@ -198,6 +203,181 @@ pub fn HTMLProcessor(
             //     },
         };
 
+        /// URL location within noscript content for replacement
+        pub const NoscriptUrlLocation = struct {
+            start: usize,
+            end: usize,
+            kind: ImportKind,
+        };
+
+        /// Maximum number of URLs we expect to find in a single noscript element
+        const max_noscript_urls = 32;
+
+        /// Parse noscript raw text content to find URL locations.
+        /// Returns a list of (start, end, kind) tuples for each URL found.
+        /// Since lol-html treats noscript content as raw text (scripting flag is enabled),
+        /// we manually parse the content to find resource references.
+        fn findNoscriptUrls(content: []const u8) bun.BoundedArray(NoscriptUrlLocation, max_noscript_urls) {
+            var urls: bun.BoundedArray(NoscriptUrlLocation, max_noscript_urls) = .{};
+
+            // Parse href attributes (for <link> stylesheets)
+            var offset: usize = 0;
+            while (offset < content.len) {
+                // Look for href=" or href='
+                if (std.mem.indexOfPos(u8, content, offset, "href=")) |href_pos| {
+                    const quote_pos = href_pos + 5;
+                    if (quote_pos < content.len) {
+                        const quote_char = content[quote_pos];
+                        if (quote_char == '"' or quote_char == '\'') {
+                            const value_start = quote_pos + 1;
+                            if (std.mem.indexOfScalarPos(u8, content, value_start, quote_char)) |value_end| {
+                                // Check if this is a stylesheet link by looking for rel="stylesheet" nearby
+                                // Note: In streaming mode, the '<' might be in a previous chunk, so we check
+                                // for "link" without requiring the '<' prefix
+                                const tag_start = std.mem.lastIndexOfScalar(u8, content[0..href_pos], '<') orelse 0;
+                                const tag_end = std.mem.indexOfScalarPos(u8, content, href_pos, '>') orelse content.len;
+                                const tag_content = content[tag_start..tag_end];
+                                // Check for <link or just "link" at start (streaming might split the '<')
+                                const is_link = std.mem.indexOf(u8, tag_content, "<link") != null or
+                                    (tag_start == 0 and tag_content.len >= 4 and std.mem.startsWith(u8, tag_content, "link"));
+                                if (is_link) {
+                                    const kind: ImportKind = if (std.mem.indexOf(u8, tag_content, "rel=\"stylesheet\"") != null or
+                                        std.mem.indexOf(u8, tag_content, "rel='stylesheet'") != null)
+                                        .at
+                                    else
+                                        .url;
+                                    urls.append(.{ .start = value_start, .end = value_end, .kind = kind }) catch break;
+                                }
+                                offset = value_end + 1;
+                                continue;
+                            }
+                        }
+                    }
+                    offset = href_pos + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Parse src attributes (for <script>, <img>, <video>, <audio>, <source>)
+            offset = 0;
+            while (offset < content.len) {
+                if (std.mem.indexOfPos(u8, content, offset, "src=")) |src_pos| {
+                    // Make sure this is not "srcset="
+                    if (src_pos > 0 and content[src_pos - 1] == 'c') {
+                        offset = src_pos + 1;
+                        continue;
+                    }
+                    const quote_pos = src_pos + 4;
+                    if (quote_pos < content.len) {
+                        const quote_char = content[quote_pos];
+                        if (quote_char == '"' or quote_char == '\'') {
+                            const value_start = quote_pos + 1;
+                            if (std.mem.indexOfScalarPos(u8, content, value_start, quote_char)) |value_end| {
+                                // Determine the kind based on the tag
+                                // Note: In streaming mode, the '<' might be in a previous chunk
+                                const tag_start = std.mem.lastIndexOfScalar(u8, content[0..src_pos], '<') orelse 0;
+                                const tag_content = content[tag_start..src_pos];
+                                const is_script = std.mem.indexOf(u8, tag_content, "<script") != null or
+                                    (tag_start == 0 and std.mem.startsWith(u8, tag_content, "script"));
+                                const kind: ImportKind = if (is_script)
+                                    .stmt
+                                else
+                                    .url; // img, video, audio, source, etc.
+                                urls.append(.{ .start = value_start, .end = value_end, .kind = kind }) catch break;
+                                offset = value_end + 1;
+                                continue;
+                            }
+                        }
+                    }
+                    offset = src_pos + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Parse srcset attributes (for <img>, <source>)
+            offset = 0;
+            while (offset < content.len) {
+                if (std.mem.indexOfPos(u8, content, offset, "srcset=")) |srcset_pos| {
+                    const quote_pos = srcset_pos + 7;
+                    if (quote_pos < content.len) {
+                        const quote_char = content[quote_pos];
+                        if (quote_char == '"' or quote_char == '\'') {
+                            const value_start = quote_pos + 1;
+                            if (std.mem.indexOfScalarPos(u8, content, value_start, quote_char)) |value_end| {
+                                urls.append(.{ .start = value_start, .end = value_end, .kind = .url }) catch break;
+                                offset = value_end + 1;
+                                continue;
+                            }
+                        }
+                    }
+                    offset = srcset_pos + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Parse poster attributes (for <video>)
+            offset = 0;
+            while (offset < content.len) {
+                if (std.mem.indexOfPos(u8, content, offset, "poster=")) |poster_pos| {
+                    const quote_pos = poster_pos + 7;
+                    if (quote_pos < content.len) {
+                        const quote_char = content[quote_pos];
+                        if (quote_char == '"' or quote_char == '\'') {
+                            const value_start = quote_pos + 1;
+                            if (std.mem.indexOfScalarPos(u8, content, value_start, quote_char)) |value_end| {
+                                urls.append(.{ .start = value_start, .end = value_end, .kind = .url }) catch break;
+                                offset = value_end + 1;
+                                continue;
+                            }
+                        }
+                    }
+                    offset = poster_pos + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Sort by start position to process in order
+            std.mem.sort(NoscriptUrlLocation, urls.slice(), {}, struct {
+                pub fn lessThan(_: void, a: NoscriptUrlLocation, b: NoscriptUrlLocation) bool {
+                    return a.start < b.start;
+                }
+            }.lessThan);
+
+            return urls;
+        }
+
+        fn handleNoscriptText(this: *T, text_chunk: *lol.TextChunk) bool {
+            const chunk_content = text_chunk.getContent();
+            if (chunk_content.len == 0) return false;
+
+            const content = chunk_content.slice();
+
+            // Find all URLs in the content
+            var urls = findNoscriptUrls(content);
+
+            if (urls.len == 0) return false;
+
+            // Call onNoscriptUrl for each URL found
+            for (urls.slice()) |url_loc| {
+                const url_value = content[url_loc.start..url_loc.end];
+                debug("noscript url: {s} kind={}", .{ url_value, url_loc.kind });
+                T.onNoscriptUrl(this, url_value, url_loc.kind);
+            }
+
+            // If the type has a rewriteNoscriptContent method, use it to replace the content
+            if (@hasDecl(T, "rewriteNoscriptContent")) {
+                if (T.rewriteNoscriptContent(this, content, urls.slice(), text_chunk)) {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
         fn generateHandlerForTag(comptime tag_info: TagHandler) fn (*T, *lol.Element) bool {
             const Handler = struct {
                 pub fn handle(this: *T, element: *lol.Element) bool {
@@ -222,7 +402,8 @@ pub fn HTMLProcessor(
             var builder = lol.HTMLRewriter.Builder.init();
             defer builder.deinit();
 
-            var selectors: bun.BoundedArray(*lol.HTMLSelector, tag_handlers.len + if (visit_document_tags) 3 else 0) = .{};
+            // +1 for noscript handler
+            var selectors: bun.BoundedArray(*lol.HTMLSelector, tag_handlers.len + 1 + if (visit_document_tags) 3 else 0) = .{};
             defer for (selectors.slice()) |selector| {
                 selector.deinit();
             };
@@ -242,6 +423,26 @@ pub fn HTMLProcessor(
                     void,
                     null,
                     null,
+                );
+            }
+
+            // Add noscript handler with text content handler to parse raw content
+            // The HTML parser treats noscript content as raw text (scripting flag enabled),
+            // so we use a text handler to capture and parse the content manually.
+            if (@hasDecl(T, "onNoscriptUrl")) {
+                const noscript_selector = try lol.HTMLSelector.parse("noscript");
+                selectors.appendAssumeCapacity(noscript_selector);
+                try builder.addElementContentHandlers(
+                    noscript_selector,
+                    void, // No element handler needed
+                    null,
+                    null,
+                    void,
+                    null,
+                    null,
+                    T,
+                    handleNoscriptText,
+                    this,
                 );
             }
 

--- a/test/regression/issue/25618.test.ts
+++ b/test/regression/issue/25618.test.ts
@@ -1,0 +1,135 @@
+// https://github.com/oven-sh/bun/issues/25618
+// HTML bundler ignores resources inside <noscript> tags
+
+import { expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("bun build bundles CSS inside noscript tags - issue #25618", async () => {
+  using dir = tempDir("25618-noscript-css", {
+    "index.html": `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <noscript><link rel="stylesheet" href="noscript.css"></noscript>
+  </head>
+  <body>
+    <p>Hello, World!</p>
+  </body>
+</html>`,
+    "noscript.css": `p {
+  color: red;
+}`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir", "./output"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  // Check that output directory exists
+  const outputDir = join(String(dir), "output");
+  expect(existsSync(outputDir)).toBe(true);
+
+  // Check that CSS file was created (with hash)
+  const files = readdirSync(outputDir);
+  const cssFiles = files.filter((f: string) => f.endsWith(".css"));
+  expect(cssFiles.length).toBeGreaterThan(0);
+
+  // Check that HTML references the hashed CSS, not the original
+  const htmlContent = readFileSync(join(outputDir, "index.html"), "utf-8");
+  expect(htmlContent).not.toContain('href="noscript.css"');
+  expect(htmlContent).toMatch(/href="[^"]*\.css"/);
+
+  // Check that the CSS file contains the expected content
+  const cssContent = readFileSync(join(outputDir, cssFiles[0]), "utf-8");
+  expect(cssContent).toContain("color:");
+});
+
+test("bun build bundles images inside noscript tags - issue #25618", async () => {
+  using dir = tempDir("25618-noscript-img", {
+    "index.html": `<!DOCTYPE html>
+<html>
+  <body>
+    <noscript>
+      <img src="fallback.png" alt="Fallback">
+    </noscript>
+  </body>
+</html>`,
+    "fallback.png": "fake png content",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir", "./output"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  // Check that output directory exists
+  const outputDir = join(String(dir), "output");
+  expect(existsSync(outputDir)).toBe(true);
+
+  // Check that image file was created (with hash)
+  const files = readdirSync(outputDir);
+  const imgFiles = files.filter((f: string) => f.endsWith(".png"));
+  expect(imgFiles.length).toBeGreaterThan(0);
+
+  // Check that HTML references the hashed image, not the original
+  const htmlContent = readFileSync(join(outputDir, "index.html"), "utf-8");
+  expect(htmlContent).not.toContain('src="fallback.png"');
+  expect(htmlContent).toMatch(/src="[^"]*\.png"/);
+});
+
+test("bun build bundles scripts inside noscript tags - issue #25618", async () => {
+  using dir = tempDir("25618-noscript-script", {
+    "index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=nojs.html">
+    </noscript>
+  </head>
+  <body>
+    <noscript>
+      <link rel="stylesheet" href="nojs.css">
+    </noscript>
+  </body>
+</html>`,
+    "nojs.css": `body { background: yellow; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir", "./output"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  const outputDir = join(String(dir), "output");
+  const files = readdirSync(outputDir);
+  const cssFiles = files.filter((f: string) => f.endsWith(".css"));
+  expect(cssFiles.length).toBeGreaterThan(0);
+
+  const htmlContent = readFileSync(join(outputDir, "index.html"), "utf-8");
+  expect(htmlContent).not.toContain('href="nojs.css"');
+});


### PR DESCRIPTION
## Summary
- Fix HTML bundler ignoring resources inside `<noscript>` tags
- Add manual parsing of noscript raw text content to extract resource URLs
- Properly update URLs in noscript content to point to bundled files

## Technical Details
The HTML bundler uses lol-html for parsing, which treats `<noscript>` content as raw text when the scripting flag is enabled (the default behavior per HTML spec). This means CSS selectors like `noscript link[href]` don't work.

This fix adds:
1. A text content handler for `<noscript>` elements that captures the raw text
2. Manual parsing of the raw text to find `href`, `src`, `srcset`, and `poster` attributes
3. URL rewriting during the linking phase that properly updates noscript content

For CSS files inside noscript, the URL is pointed to the bundled CSS chunk. For other assets (images, etc.), the unique key is used.

## Test plan
- [x] Added regression test for CSS inside noscript (`test/regression/issue/25618.test.ts`)
- [x] Added regression test for images inside noscript
- [x] Added bundler tests (`test/bundler/bundler_html.test.ts`)
- [x] Verified tests fail with system bun (v1.3.5) and pass with fix
- [x] Verified existing HTML bundler tests still pass

Fixes #25618

🤖 Generated with [Claude Code](https://claude.com/claude-code)