### PR TITLE
fix(hot): close Bun.listen() sockets on hot reload to prevent EADDRINUSE

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -733,6 +733,11 @@ pub fn reload(this: *VirtualMachine, _: *HotReloader.Task) void {
         );
     }
 
+    // Close all listening sockets to avoid EADDRINUSE on hot reload
+    if (this.rare_data) |rare| {
+        rare.closeAllListenSocketsForWatchMode();
+    }
+
     if (should_clear_terminal) {
         Output.flush();
         Output.disableBuffering();
@@ -2302,14 +2307,14 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
 }
 
 pub fn addListeningSocketForWatchMode(this: *VirtualMachine, socket: bun.FileDescriptor) void {
-    if (this.hot_reload != .watch) {
+    if (this.hot_reload == .none) {
         return;
     }
 
     this.rareData().addListeningSocketForWatchMode(socket);
 }
 pub fn removeListeningSocketForWatchMode(this: *VirtualMachine, socket: bun.FileDescriptor) void {
-    if (this.hot_reload != .watch) {
+    if (this.hot_reload == .none) {
         return;
     }
 

--- a/test/regression/issue/26036.test.ts
+++ b/test/regression/issue/26036.test.ts
@@ -1,0 +1,110 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("Bun.listen() should not fail with EADDRINUSE on hot reload", async () => {
+  // Find an available port
+  const portFinder = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open() {},
+      data() {},
+      close() {},
+      error() {},
+    },
+  });
+  const port = portFinder.port;
+  portFinder.stop();
+
+  using dir = tempDir("issue-26036", {
+    "server.ts": `
+const server = Bun.listen({
+  hostname: "127.0.0.1",
+  port: ${port},
+  socket: {
+    open(socket) {},
+    data(socket, data) {},
+    close(socket) {},
+    error(socket, err) {},
+  },
+});
+console.log("[LISTENING] port=" + server.port);
+`,
+  });
+
+  const serverPath = join(String(dir), "server.ts");
+
+  await using runner = spawn({
+    cmd: [bunExe(), "--hot", serverPath],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  let reloadCount = 0;
+  let stdout = "";
+  let stderr = "";
+  const targetReloads = 3;
+
+  // Read stderr in parallel
+  const stderrPromise = (async () => {
+    for await (const chunk of runner.stderr) {
+      stderr += new TextDecoder().decode(chunk);
+      // If we see EADDRINUSE, the test has already failed
+      if (stderr.includes("EADDRINUSE")) {
+        runner.kill();
+      }
+    }
+  })();
+
+  // Wait for the server to start listening
+  outer: for await (const chunk of runner.stdout) {
+    stdout += new TextDecoder().decode(chunk);
+
+    // Count successful reloads by counting [LISTENING] messages
+    const matches = stdout.match(/\[LISTENING\]/g);
+    if (matches) {
+      const newCount = matches.length;
+      if (newCount > reloadCount) {
+        reloadCount = newCount;
+
+        if (reloadCount >= targetReloads) {
+          runner.kill();
+          break;
+        }
+
+        // Trigger a hot reload by modifying the file
+        writeFileSync(
+          serverPath,
+          `
+const server = Bun.listen({
+  hostname: "127.0.0.1",
+  port: ${port},
+  socket: {
+    open(socket) {},
+    data(socket, data) {},
+    close(socket) {},
+    error(socket, err) {},
+  },
+});
+console.log("[LISTENING] port=" + server.port + " reload=${reloadCount}");
+`,
+        );
+      }
+    }
+  }
+
+  await stderrPromise;
+
+  // Verify no EADDRINUSE error occurred
+  expect(stderr).not.toContain("EADDRINUSE");
+  expect(stderr).not.toContain("Failed to listen");
+
+  // Verify we successfully reloaded multiple times
+  expect(reloadCount).toBeGreaterThanOrEqual(targetReloads);
+});


### PR DESCRIPTION
## Summary
- Fixes `Bun.listen()` TCP servers failing with EADDRINUSE when using `bun --hot`
- The hot reload mechanism wasn't closing listening sockets before reloading, causing port conflicts

## Changes
- Register `Bun.listen()` sockets for watch mode cleanup (previously only done for `--watch`, not `--hot`)
- Call `closeAllListenSocketsForWatchMode()` in `VirtualMachine.reload()` to close sockets before hot reload

## Test plan
- Added regression test `test/regression/issue/26036.test.ts`
- Test verifies multiple hot reloads succeed without EADDRINUSE
- Test fails with system Bun and passes with the fix

Fixes #26036

🤖 Generated with [Claude Code](https://claude.com/claude-code)