### PR TITLE
fix(init): respect --minimal flag for agent rule files

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -791,7 +791,9 @@ pub const InitCommand = struct {
 
         switch (template) {
             .blank, .typescript_library => {
-                Template.createAgentRule();
+                if (!minimal) {
+                    Template.createAgentRule();
+                }
 
                 if (package_json_file != null and !did_load_package_json) {
                     Output.prettyln(" + <r><d>package.json<r>", .{});


### PR DESCRIPTION
## Summary
- Fixes `bun init --minimal` creating Cursor rules files and CLAUDE.md when it shouldn't
- Adds regression test to verify `--minimal` only creates package.json and tsconfig.json

## Test plan
- [x] Verify test fails with system bun (unfixed): `USE_SYSTEM_BUN=1 bun test test/cli/init/init.test.ts -t "bun init --minimal"`
- [x] Verify test passes with debug build: `bun bd test test/cli/init/init.test.ts -t "bun init --minimal"`
- [x] All existing init tests pass: `bun bd test test/cli/init/init.test.ts`

Fixes #26050

🤖 Generated with [Claude Code](https://claude.ai/code)