### PR TITLE
fix(install): skip lifecycle script comparison for workspace packages

### DIFF
--- a/test/regression/issue/26070.test.ts
+++ b/test/regression/issue/26070.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("workspace packages with lifecycle scripts should not trigger unnecessary HTTP requests", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-26070", {
+    "package.json": JSON.stringify({
+      name: "test-workspace",
+      workspaces: ["packages/*"],
+    }),
+    "packages/app/package.json": JSON.stringify({
+      name: "@workspace/app",
+      version: "1.0.0",
+      scripts: {
+        prepare: "echo 'Do some preparations...'",
+      },
+      dependencies: {
+        "@workspace/lib": "workspace:*",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "@workspace/lib",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "^3.0.1",
+      },
+    }),
+  });
+
+  // First install creates the lockfile
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  }
+
+  // Second install with --force should detect no real changes in workspace packages
+  // and should NOT report "updated 1 dependencies" for lifecycle script false positives
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--force", "--verbose"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The verbose output should not show "updated 1 dependencies" for workspace packages
+    // when no actual dependencies have changed. This was the bug - lifecycle scripts
+    // were incorrectly triggering this count.
+    const output = stdout + stderr;
+
+    // Check that we're not seeing false positive updates for workspace packages
+    if (
+      output.includes(
+        'Workspace package "packages/app" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies',
+      )
+    ) {
+      throw new Error(
+        "Bug #26070: Workspace package lifecycle scripts are incorrectly triggering 'updated 1 dependencies' message",
+      );
+    }
+
+    expect(exitCode).toBe(0);
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #26070

Workspace packages with lifecycle scripts (e.g., `prepare`, `postinstall`) were incorrectly triggering dependency re-resolution and unnecessary HTTP requests to the npm registry when running `bun install` after the lockfile cache expired.

## Root Cause
The `Diff.generate()` function in `src/install/lockfile/Package.zig` compared lifecycle scripts for all non-root packages, including workspace packages. Since workspace packages are freshly parsed from their package.json files during diff generation, this could produce false positives even when scripts hadn't changed.

## Solution
Skip lifecycle script comparison for workspace packages since:
- Workspace packages are resolved locally from their package.json files
- Script changes don't affect dependency resolution
- Any actual script changes are still detected and run during script execution

## Test plan
- [x] Added regression test `test/regression/issue/26070.test.ts` that verifies:
  - Test fails with system bun (reproduces bug)
  - Test passes with the fix
- [x] Verified existing workspace tests pass (12 pre-existing failures due to network issues, no new failures)


🤖 Generated with [Claude Code](https://claude.ai/code)