### PR TITLE
fix(build): request baseline WebKit for x64 baseline builds

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -64,6 +64,11 @@ if(LINUX AND ABI STREQUAL "musl")
   set(WEBKIT_SUFFIX "-musl")
 endif()
 
+# Baseline builds require a WebKit compiled without AVX instructions
+if(ENABLE_BASELINE AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|x64|AMD64")
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
+endif()
+
 if(DEBUG)
   set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-debug")
 elseif(ENABLE_LTO)


### PR DESCRIPTION
## Summary
- Adds `-baseline` suffix to WebKit download URL for x64 baseline builds
- Prevents shipping binaries that crash on CPUs without AVX support
- Fixes #26071
- Fixes #26136

## Problem
The baseline build of Bun (v1.3.6 and earlier) crashes with `Illegal instruction` on CPUs without AVX support because the prebuilt WebKit library contains AVX instructions:
- WebKit is compiled with `-march=haswell` (includes AVX2)
- Baseline Bun is compiled with `-march=nehalem` (no AVX)
- When baseline Bun runs on a CPU with SSE4.2 but no AVX, it crashes

## Solution
This PR modifies `SetupWebKit.cmake` to append `-baseline` to the WebKit download URL when `ENABLE_BASELINE` is set on x86_64. This will make the build request WebKit libraries compiled for baseline CPUs (nehalem/SSE4.2).

## Dependencies
This fix requires corresponding changes to the WebKit CI at [oven-sh/WebKit](https://github.com/oven-sh/WebKit) to produce baseline variants:
- Add matrix entries for `linux-amd64-baseline`, `linux-amd64-musl-baseline`, `linux-amd64-lto-baseline`
- Pass `CPU="nehalem"` and `MARCH_FLAG="-march=nehalem"` to docker builds

Until the WebKit CI changes are merged, baseline builds will fail to download the WebKit library (404 error). This is intentional - it's better to fail the build than to silently ship binaries that crash on older CPUs.

## Test plan
- [ ] Verify baseline build fails to download WebKit (expected until WebKit CI is updated)
- [ ] After WebKit CI update: verify baseline build succeeds
- [ ] After WebKit CI update: verify baseline binary runs on CPU with only SSE4.2 (no AVX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)