### PR TITLE
fix(runner): filter out non-JS files from node tests

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1585,6 +1585,9 @@ function isNodeTest(path) {
   if (isCI && isMacOS && isX64) {
     return false;
   }
+  if (!isJavaScript(path)) {
+    return false;
+  }
   const unixPath = path.replaceAll(sep, "/");
   return (
     unixPath.includes("js/node/test/parallel/") ||


### PR DESCRIPTION
## Summary
- `isNodeTest()` was only checking if the path included the node test directories but not verifying the file was actually a JavaScript file
- This caused `test/js/node/test/parallel/CLAUDE.md` to be incorrectly treated as a test file
- Added `isJavaScript(path)` check to filter out non-JS files

## Test plan
- [x] Verify CLAUDE.md is no longer picked up as a test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)