### PR TITLE
fix(node): emit warning for unimplemented module.register()

### DIFF
--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "headers-handwritten.h"
 #include "NodeModuleModule.h"
+#include "BunProcess.h"
 
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/VM.h>
@@ -870,6 +871,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSyncBuiltinESMExports,
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionRegister, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
+    auto& vm = globalObject->vm();
+    Bun::Process::emitWarning(
+        globalObject,
+        jsString(vm, String("module.register() is not implemented in Bun. Loaders registered with module.register() will not be invoked. To intercept and transform modules, consider using Bun's plugin API: https://bun.sh/docs/bundler/plugins"_s)),
+        jsString(vm, String("Warning"_s)),
+        jsString(vm, String("BUN_UNSUPPORTED_REGISTER"_s)),
+        jsUndefined());
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/test/regression/issue/3775.test.ts
+++ b/test/regression/issue/3775.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/3775
+// module.register() should emit a warning since it's not implemented
+test("module.register() emits a warning", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `import { register } from 'node:module'; register('./test.mjs', import.meta.url);`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Check that the warning is emitted
+  expect(stderr).toContain("module.register() is not implemented in Bun");
+  expect(stderr).toContain("BUN_UNSUPPORTED_REGISTER");
+  expect(stderr).toContain("https://bun.sh/docs/bundler/plugins");
+
+  // Exit code should be 0 (warning, not error)
+  expect(exitCode).toBe(0);
+});
+
+test("module.register() with require syntax emits a warning", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const { register } = require('node:module'); register('./test.mjs');`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Check that the warning is emitted
+  expect(stderr).toContain("module.register() is not implemented in Bun");
+  expect(stderr).toContain("BUN_UNSUPPORTED_REGISTER");
+
+  // Exit code should be 0 (warning, not error)
+  expect(exitCode).toBe(0);
+});
+
+test("module.register() emits warning only once per call", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import { register } from 'node:module';
+      register('./test1.mjs', import.meta.url);
+      register('./test2.mjs', import.meta.url);
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The warning should be emitted twice (once per call)
+  const warningMatches = stderr.match(/module\.register\(\) is not implemented in Bun/g);
+  expect(warningMatches?.length).toBe(2);
+
+  // Exit code should be 0
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/3775.test.ts
+++ b/test/regression/issue/3775.test.ts
@@ -35,6 +35,7 @@ test("module.register() with require syntax emits a warning", async () => {
   // Check that the warning is emitted
   expect(stderr).toContain("module.register() is not implemented in Bun");
   expect(stderr).toContain("BUN_UNSUPPORTED_REGISTER");
+  expect(stderr).toContain("https://bun.sh/docs/bundler/plugins");
 
   // Exit code should be 0 (warning, not error)
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- Emit a process warning when `module.register()` is called, informing users that ESM loader hooks are not yet implemented in Bun
- The warning includes a link to Bun's plugin API as an alternative solution

## Motivation
`module.register()` is used by OpenTelemetry and other tooling to register ESM loader hooks that intercept module resolution and loading. Previously, this function was a silent no-op stub, which caused confusion as tools appeared to fail silently without any indication of why they weren't working.

This change provides clear feedback to users by emitting a warning with:
- A message explaining that the feature is not implemented
- A code (`BUN_UNSUPPORTED_REGISTER`) for easy identification
- A link to Bun's plugin API documentation as an alternative

## Test plan
- [x] New test file `test/regression/issue/3775.test.ts` verifies warning is emitted
- [x] Tests pass with `bun bd test test/regression/issue/3775.test.ts`
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirming the fix is necessary)

Fixes #3775

🤖 Generated with [Claude Code](https://claude.ai/code)