### PR TITLE
fix: handle SIGILL during CPU feature detection in sandboxed environments

### DIFF
--- a/test/regression/issue/03536.test.ts
+++ b/test/regression/issue/03536.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Issue #3536: Bun crashes with SIGILL when run in nsjail or sandboxed environments
+// that block CPUID instructions. This test verifies that Bun starts correctly under
+// normal conditions. The fix adds SIGILL signal handlers to catch blocked CPU
+// feature detection calls and fall back gracefully.
+test("3536 - CPU feature detection does not crash on startup", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "console.log('ok')"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Verify no crash warnings related to CPU features
+  expect(stderr).not.toContain("illegal instruction");
+  expect(stderr).not.toContain("SIGILL");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix crash when running Bun inside nsjail or similar sandboxed environments
- CPUID instruction used for CPU feature detection can be blocked by seccomp filters, causing SIGILL
- Added SIGILL signal handlers using sigsetjmp/siglongjmp to catch blocked instructions and fall back gracefully

## Changes
- **CPUFeatures.cpp**: Wrap CPU feature detection with SIGILL handler, return 0 features if blocked (conservative fallback)
- **c-bindings.cpp**: Wrap AVX check with SIGILL handler, skip warning if in sandboxed environment since baseline build doesn't help

## Test plan
- [x] Added regression test `test/regression/issue/03536.test.ts`
- [x] Test passes with `bun bd test test/regression/issue/03536.test.ts`
- [x] Build compiles successfully with `bun bd`

Fixes #3536

🤖 Generated with [Claude Code](https://claude.com/claude-code)