### PR TITLE
fix(install): treat `bun link .` the same as `bun link`

### DIFF
--- a/src/cli/link_command.zig
+++ b/src/cli/link_command.zig
@@ -21,7 +21,11 @@ fn link(ctx: Command.Context) !void {
         Output.flush();
     }
 
-    if (manager.options.positionals.len == 1) {
+    // Treat `bun link .` the same as `bun link` (register current package)
+    const is_register = manager.options.positionals.len == 1 or
+        (manager.options.positionals.len == 2 and std.mem.eql(u8, manager.options.positionals[1], "."));
+
+    if (is_register) {
         // bun link
 
         var lockfile: Lockfile = undefined;

--- a/test/regression/issue/2686.test.ts
+++ b/test/regression/issue/2686.test.ts
@@ -1,0 +1,28 @@
+import { spawn } from "bun";
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/2686
+// `bun link .` should work the same as `bun link` (register the current package globally)
+it("bun link . should register the current package", async () => {
+  using dir = tempDir("bun-link-dot", {
+    "package.json": JSON.stringify({
+      name: "test-link-dot-pkg",
+      version: "1.0.0",
+    }),
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "link", "."],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain('Success! Registered "test-link-dot-pkg"');
+  expect(stderr).not.toContain("unrecognised dependency format");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix `bun link .` to register the current package globally instead of failing with "unrecognised dependency format: ."
- Added regression test for the fix

Fixes #2686

## Test plan
- [x] Run `bun link .` in a directory with package.json - should succeed with "Success! Registered..."
- [x] Run `bun link` - should still work as before
- [x] Run `bun link <package-name>` - should still work as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)