### PR TITLE
fix(cli): handle BrokenPipe gracefully in `bun completions`

### DIFF
--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -138,7 +138,10 @@ pub const InstallCompletionsCommand = struct {
             // don't fail on this if we don't actually need to
             if (fail_exit_code == 1) {
                 if (!stdout.isTty()) {
-                    try stdout.writeAll(shell.completions());
+                    stdout.writeAll(shell.completions()) catch |err| switch (err) {
+                        error.BrokenPipe => Global.exit(0),
+                        else => return err,
+                    };
                     Global.exit(0);
                 }
             }
@@ -171,7 +174,10 @@ pub const InstallCompletionsCommand = struct {
 
         if (!bun.env_var.IS_BUN_AUTO_UPDATE.get()) {
             if (!stdout.isTty()) {
-                try stdout.writeAll(shell.completions());
+                stdout.writeAll(shell.completions()) catch |err| switch (err) {
+                    error.BrokenPipe => Global.exit(0),
+                    else => return err,
+                };
                 Global.exit(0);
             }
         }

--- a/test/regression/issue/02977.test.ts
+++ b/test/regression/issue/02977.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isPosix } from "harness";
 
 // https://github.com/oven-sh/bun/issues/2977
-test("bun completions handles BrokenPipe gracefully", async () => {
+test.if(isPosix)("bun completions handles BrokenPipe gracefully", async () => {
   // Simulate piping to a command that closes stdin immediately (like `true`)
   // This tests that bun completions doesn't crash with BrokenPipe error
   await using proc = Bun.spawn({

--- a/test/regression/issue/02977.test.ts
+++ b/test/regression/issue/02977.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/2977
+test("bun completions handles BrokenPipe gracefully", async () => {
+  // Simulate piping to a command that closes stdin immediately (like `true`)
+  // This tests that bun completions doesn't crash with BrokenPipe error
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `SHELL=/bin/bash ${bunExe()} completions | true`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should exit cleanly (0) instead of crashing with BrokenPipe error
+  // The stderr should NOT contain "BrokenPipe" error
+  expect(stderr).not.toContain("BrokenPipe");
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes `bun completions` crashing with `BrokenPipe` error when piped to commands that close stdout early (e.g., `bun completions | true`)
- The fix catches `error.BrokenPipe` and exits cleanly with status 0 instead of propagating the error

## Test plan
- [x] Added regression test that pipes `bun completions` to `true` and verifies no BrokenPipe error occurs
- [x] Verified test fails with system Bun and passes with fixed build

Fixes #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)