### PR TITLE
fix(completions): install zsh completions to subdirectory to avoid insecure directory error

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -143,6 +143,12 @@ if [[ ! -d $bin_dir ]]; then
         error "Failed to create install directory \"$bin_dir\""
 fi
 
+completions_dir=$install_dir/completions
+if [[ ! -d $completions_dir ]]; then
+    mkdir -p "$completions_dir" ||
+        error "Failed to create completions directory \"$completions_dir\""
+fi
+
 curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri" ||
     error "Failed to download bun from \"$bun_uri\""
 

--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -279,10 +279,11 @@ pub const InstallCompletionsCommand = struct {
                         }
                     }
 
-                    if (bun.env_var.BUN_INSTALL.get()) |home_dir| {
+                    if (bun.env_var.BUN_INSTALL.get()) |install_dir| {
                         outer: {
-                            completions_dir = home_dir;
-                            break :found std.fs.openDirAbsolute(home_dir, .{}) catch
+                            var paths = [_]string{ install_dir, "./completions" };
+                            completions_dir = resolve_path.joinAbsString(cwd, &paths, .auto);
+                            break :found std.fs.openDirAbsolute(completions_dir, .{}) catch
                                 break :outer;
                         }
                     }
@@ -299,7 +300,7 @@ pub const InstallCompletionsCommand = struct {
 
                         {
                             outer: {
-                                var paths = [_]string{ home_dir, "./.bun" };
+                                var paths = [_]string{ home_dir, "./.bun/completions" };
                                 completions_dir = resolve_path.joinAbsString(cwd, &paths, .auto);
                                 break :found std.fs.openDirAbsolute(completions_dir, .{}) catch
                                     break :outer;

--- a/test/regression/issue/00222.test.ts
+++ b/test/regression/issue/00222.test.ts
@@ -1,0 +1,89 @@
+// https://github.com/oven-sh/bun/issues/222
+// ZSH "Insecure Directories" error when zsh completions are installed directly
+// to ~/.bun instead of ~/.bun/completions subdirectory
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { join } from "path";
+
+describe("zsh completions", () => {
+  test.skipIf(!isPosix)("completions are installed to $BUN_INSTALL/completions subdirectory", async () => {
+    using dir = tempDir("issue-222", {
+      "completions/.gitkeep": "",
+    });
+
+    const bunInstallDir = String(dir);
+    const completionsDir = join(bunInstallDir, "completions");
+
+    // Run bun completions with BUN_INSTALL set
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "completions"],
+      env: {
+        ...bunEnv,
+        BUN_INSTALL: bunInstallDir,
+        SHELL: "/bin/zsh",
+        HOME: "/nonexistent", // Ensure we don't fall back to HOME-based paths
+        ZDOTDIR: "/nonexistent",
+        FPATH: "",
+        XDG_DATA_HOME: "",
+        IS_BUN_AUTO_UPDATE: "true", // Skip tty check and write to file
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The completion file should be at $BUN_INSTALL/completions/_bun
+    const completionFile = Bun.file(join(completionsDir, "_bun"));
+    expect(await completionFile.exists()).toBe(true);
+
+    // Verify the completion file has content
+    const content = await completionFile.text();
+    expect(content).toContain("compdef _bun bun");
+
+    // Verify the file was NOT created directly in $BUN_INSTALL
+    const directFile = Bun.file(join(bunInstallDir, "_bun"));
+    expect(await directFile.exists()).toBe(false);
+
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isPosix)("completions fall back to $HOME/.bun/completions", async () => {
+    using dir = tempDir("issue-222-home", {
+      ".bun/completions/.gitkeep": "",
+    });
+
+    const homeDir = String(dir);
+    const completionsDir = join(homeDir, ".bun", "completions");
+
+    // Run bun completions with HOME set but no BUN_INSTALL
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "completions"],
+      env: {
+        ...bunEnv,
+        HOME: homeDir,
+        SHELL: "/bin/zsh",
+        // BUN_INSTALL is not set (undefined) - let it fall back to HOME
+        ZDOTDIR: "/nonexistent",
+        FPATH: "",
+        XDG_DATA_HOME: "",
+        IS_BUN_AUTO_UPDATE: "true", // Skip tty check and write to file
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The completion file should be at $HOME/.bun/completions/_bun
+    const completionFile = Bun.file(join(completionsDir, "_bun"));
+    expect(await completionFile.exists()).toBe(true);
+
+    // Verify the file was NOT created directly in $HOME/.bun
+    const directFile = Bun.file(join(homeDir, ".bun", "_bun"));
+    expect(await directFile.exists()).toBe(false);
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix ZSH "compinit: insecure directories" error that occurs after running Bun's install script on macOS
- Install zsh completions to `~/.bun/completions/_bun` instead of directly to `~/.bun/_bun`
- Update `install.sh` to create the completions directory

## Root Cause

When zsh completions were installed directly to `~/.bun`, users would see "compinit: insecure directories" errors because `compaudit` (called by `compinit` in the completion file) checks that directories containing completion files have secure permissions (not group-writable or world-writable).

Using a dedicated `completions` subdirectory follows the same pattern as `~/.oh-my-zsh/completions` (which is already in the fallback list) and keeps the completion files organized separately from the rest of `~/.bun`.

## Test plan

- [x] New regression test verifies completions go to `$BUN_INSTALL/completions/_bun` instead of `$BUN_INSTALL/_bun`
- [x] Test verifies fallback to `$HOME/.bun/completions/_bun` instead of `$HOME/.bun/_bun`
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with debug build

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)