### PR TITLE
fix(install): quote workspace: versions in yarn lockfile

### DIFF
--- a/src/install/lockfile/printer/Yarn.zig
+++ b/src/install/lockfile/printer/Yarn.zig
@@ -129,7 +129,7 @@ fn packages(
                     needs_comma = false;
                 }
                 const version_name = dependency_version.literal.slice(string_buf);
-                const needs_quote = always_needs_quote or bun.strings.indexAnyComptime(version_name, " |\t-/!") != null or strings.hasPrefixComptime(version_name, "npm:");
+                const needs_quote = always_needs_quote or bun.strings.indexAnyComptime(version_name, " |\t-/!:") != null or strings.hasPrefixComptime(version_name, "npm:");
 
                 if (needs_quote) {
                     try writer.writeByte('"');

--- a/test/regression/issue/3192.test.ts
+++ b/test/regression/issue/3192.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("issue #3192", () => {
+  test("yarn lockfile quotes workspace:* versions correctly", async () => {
+    using dir = tempDir("issue-3192", {
+      "package.json": JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/package-a/package.json": JSON.stringify({
+        name: "package-a",
+        version: "1.0.0",
+        dependencies: {
+          "package-b": "workspace:*",
+        },
+      }),
+      "packages/package-b/package.json": JSON.stringify({
+        name: "package-b",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--yarn"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(exitCode).toBe(0);
+
+    // Read the generated yarn.lock
+    const yarnLock = await Bun.file(`${dir}/yarn.lock`).text();
+
+    // The workspace:* version should be quoted
+    // Bad output: "package-b@packages/package-b", package-b@workspace:*:
+    // Good output: "package-b@packages/package-b", "package-b@workspace:*":
+    expect(yarnLock).toContain('"package-b@workspace:*"');
+    expect(yarnLock).not.toMatch(/package-b@workspace:\*[^"]/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add colon (`:`) to the list of characters that require quoting in yarn lockfile version strings
- This fixes yarn parse errors when using `workspace:*` dependencies in monorepo setups

Fixes #3192

## Test plan
- [x] Added regression test that verifies `workspace:*` versions are properly quoted
- [x] Test fails with system bun (before fix)
- [x] Test passes with debug build (after fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)