### PR TITLE
fix(resolver): show warning when tsconfig extends non-existent file

### DIFF
--- a/test/regression/issue/02804.test.ts
+++ b/test/regression/issue/02804.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("tsconfig extends non-existent file shows warning", () => {
+  const dir = tempDirWithFiles("02804", {
+    "tsconfig.json": JSON.stringify({
+      extends: "./nonexistent-config.json",
+      compilerOptions: {
+        strict: true,
+      },
+    }),
+    "index.ts": `const x: string = "hello"; console.log(x);`,
+  });
+
+  const proc = Bun.spawnSync([bunExe(), "index.ts"], {
+    env: bunEnv,
+    cwd: dir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const stderr = proc.stderr.toString("utf-8");
+  expect(stderr).toContain('Cannot find base config file "./nonexistent-config.json"');
+  expect(stderr).toContain("warn:");
+});
+
+test("tsconfig extends inside node_modules does not warn", () => {
+  const dir = tempDirWithFiles("02804-node-modules", {
+    "index.ts": `import "./node_modules/foo/index.js"; console.log("done");`,
+    "node_modules/foo/tsconfig.json": JSON.stringify({
+      extends: "./nonexistent-config.json",
+    }),
+    "node_modules/foo/index.js": `console.log("foo");`,
+  });
+
+  const proc = Bun.spawnSync([bunExe(), "index.ts"], {
+    env: bunEnv,
+    cwd: dir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const stderr = proc.stderr.toString("utf-8");
+  // Should NOT show warning for files inside node_modules
+  expect(stderr).not.toContain("Cannot find base config file");
+});


### PR DESCRIPTION
## Summary

- Show a warning when `tsconfig.json` has an `extends` field that references a non-existent file
- Suppress warnings for tsconfig files inside `node_modules` to avoid noise from third-party packages

Previously, Bun silently ignored missing extended config files (only logging at debug level). This made it difficult for users to diagnose configuration issues.

**Before:**
```bash
$ bun run test.ts
# (no warning about missing extended config)
```

**After:**
```bash
$ bun run test.ts
warn: Cannot find base config file "./nonexistent-config.json"
   at /path/to/tsconfig.json:0
```

## Test plan

- [x] Verify warning is shown for missing extended config outside node_modules
- [x] Verify warning is NOT shown for missing extended config inside node_modules
- [x] Verify existing tests pass: `bun bd test test/regression/issue/02804.test.ts`
- [x] Verify test fails with system bun (without fix): `USE_SYSTEM_BUN=1 bun test test/regression/issue/02804.test.ts`

Fixes #2804

🤖 Generated with [Claude Code](https://claude.com/claude-code)