### PR TITLE
fix(create): respect custom registry configuration

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1409,6 +1409,7 @@ pub const Command = struct {
         pub fn readGlobalConfig(this: Tag) bool {
             return switch (this) {
                 .BunxCommand,
+                .CreateCommand,
                 .PackageManagerCommand,
                 .InstallCommand,
                 .AddCommand,
@@ -1427,6 +1428,7 @@ pub const Command = struct {
         pub fn isNPMRelated(this: Tag) bool {
             return switch (this) {
                 .BunxCommand,
+                .CreateCommand,
                 .LinkCommand,
                 .UnlinkCommand,
                 .PackageManagerCommand,
@@ -1479,6 +1481,7 @@ pub const Command = struct {
             .UpdateInteractiveCommand = true,
             .PublishCommand = true,
             .AuditCommand = true,
+            .CreateCommand = true,
         });
 
         pub const uses_global_options: std.EnumArray(Tag, bool) = std.EnumArray(Tag, bool).initDefault(true, .{
@@ -1630,6 +1633,9 @@ pub const Command = struct {
 
         // Create command wraps bunx
         const ctx = try Command.init(allocator, log, .CreateCommand);
+
+        // Load bunfig configuration to respect custom registry settings
+        try Arguments.loadConfig(allocator, null, ctx, .CreateCommand);
 
         var args = try std.process.argsAlloc(allocator);
 

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1839,8 +1839,46 @@ pub const Example = struct {
         }
     };
 
-    const examples_url: string = "https://registry.npmjs.org/bun-examples-all/latest";
     var url: URL = undefined;
+
+    /// Resolves the registry URL using Npm.Registry.Scope.fromAPI for
+    /// $ENV_VAR expansion, matching `bun install` (PackageManagerOptions.zig).
+    /// Priority: env vars > bunfig.toml > default.
+    fn getRegistryUrl(ctx: Command.Context, env_loader: *DotEnv.Loader) string {
+        // Check env vars first (highest priority).
+        const registry_keys = [_]string{
+            "BUN_CONFIG_REGISTRY",
+            "NPM_CONFIG_REGISTRY",
+            "npm_config_registry",
+        };
+        inline for (registry_keys) |key| {
+            if (env_loader.get(key)) |registry_url| {
+                if (registry_url.len > 0 and
+                    (strings.startsWith(registry_url, "https://") or
+                        strings.startsWith(registry_url, "http://")))
+                {
+                    return registry_url;
+                }
+            }
+        }
+
+        // Fall back to bunfig, using Scope.fromAPI for $ENV_VAR expansion.
+        var base = std.mem.zeroes(Api.NpmRegistry);
+        if (ctx.install) |install| {
+            if (install.default_registry) |registry| {
+                base = registry;
+            }
+        }
+        if (base.url.len == 0) return Npm.Registry.default_url;
+        const scope = bun.handleOom(Npm.Registry.Scope.fromAPI("", base, ctx.allocator, env_loader));
+        // Validate scheme — fromAPI may leave unresolved $ENV_VAR placeholders.
+        if (strings.startsWith(scope.url.href, "https://") or
+            strings.startsWith(scope.url.href, "http://"))
+        {
+            return scope.url.href;
+        }
+        return Npm.Registry.default_url;
+    }
 
     var app_name_buf: [512]u8 = undefined;
     pub fn print(examples: []const Example, default_app_name: ?string) void {
@@ -2069,7 +2107,9 @@ pub const Example = struct {
         var mutable = try ctx.allocator.create(MutableString);
         mutable.* = try MutableString.init(ctx.allocator, 2048);
 
-        url = URL.parse(try std.fmt.bufPrint(&url_buf, "https://registry.npmjs.org/@bun-examples/{s}/latest", .{name}));
+        const registry_url = getRegistryUrl(ctx, env_loader);
+        const registry_without_trailing_slash = strings.withoutTrailingSlash(registry_url);
+        url = URL.parse(try std.fmt.bufPrint(&url_buf, "{s}/@bun-examples/{s}/latest", .{ registry_without_trailing_slash, name }));
 
         var http_proxy: ?URL = env_loader.getHttpProxyFor(url);
 
@@ -2190,7 +2230,10 @@ pub const Example = struct {
     }
 
     pub fn fetchAll(ctx: Command.Context, env_loader: *DotEnv.Loader, progress_node: ?*Progress.Node) ![]Example {
-        url = URL.parse(examples_url);
+        var url_buf: [1024]u8 = undefined;
+        const registry_url = getRegistryUrl(ctx, env_loader);
+        const registry_without_trailing_slash = strings.withoutTrailingSlash(registry_url);
+        url = URL.parse(try std.fmt.bufPrint(&url_buf, "{s}/bun-examples-all/latest", .{registry_without_trailing_slash}));
 
         const http_proxy: ?URL = env_loader.getHttpProxyFor(url);
 
@@ -2454,7 +2497,9 @@ const default_allocator = bun.default_allocator;
 const js_ast = bun.ast;
 const logger = bun.logger;
 const strings = bun.strings;
+const Api = bun.schema.api;
 const Archiver = bun.libarchive.Archiver;
+const Npm = bun.install.Npm;
 
 const HTTP = bun.http;
 const Headers = bun.http.Headers;

--- a/test/regression/issue/617.test.ts
+++ b/test/regression/issue/617.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Test that `bun create` respects custom registry configuration
+// Issue: https://github.com/oven-sh/bun/issues/617
+
+// Base env with all registry env vars cleared to prevent CI env interference.
+const cleanEnv: NodeJS.Dict<string> = {
+  ...bunEnv,
+  BUN_CONFIG_REGISTRY: undefined,
+  NPM_CONFIG_REGISTRY: undefined,
+  npm_config_registry: undefined,
+};
+
+// Stub server that returns 500 for all requests, tracking hits to prove
+// bun create actually contacted it.
+function stubRegistry() {
+  const hits = { count: 0 };
+  const server = Bun.serve({
+    port: 0,
+    fetch: () => {
+      hits.count++;
+      return new Response("stub registry", { status: 500 });
+    },
+  });
+  return { server, url: `http://127.0.0.1:${server.port}`, hits };
+}
+
+describe("bun create respects custom registry", () => {
+  test(
+    "BUN_CONFIG_REGISTRY environment variable",
+    async () => {
+      const stub = stubRegistry();
+      await using server = stub.server;
+
+      using dir = tempDir("bun-create-registry-env", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "create", "elysia", "my-app", "--no-install", "--no-git"],
+        cwd: String(dir),
+        env: {
+          ...cleanEnv,
+          BUN_CONFIG_REGISTRY: stub.url,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stub.hits.count).toBeGreaterThan(0);
+      expect(await proc.exited).not.toBe(0);
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "NPM_CONFIG_REGISTRY environment variable",
+    async () => {
+      const stub = stubRegistry();
+      await using server = stub.server;
+
+      using dir = tempDir("bun-create-npm-registry-env", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "create", "elysia", "my-app", "--no-install", "--no-git"],
+        cwd: String(dir),
+        env: {
+          ...cleanEnv,
+          NPM_CONFIG_REGISTRY: stub.url,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stub.hits.count).toBeGreaterThan(0);
+      expect(await proc.exited).not.toBe(0);
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "npm_config_registry environment variable (lowercase)",
+    async () => {
+      const stub = stubRegistry();
+      await using server = stub.server;
+
+      using dir = tempDir("bun-create-npm-config-registry-lc", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "create", "elysia", "my-app", "--no-install", "--no-git"],
+        cwd: String(dir),
+        env: {
+          ...cleanEnv,
+          npm_config_registry: stub.url,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stub.hits.count).toBeGreaterThan(0);
+      expect(await proc.exited).not.toBe(0);
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "bunfig.toml registry configuration",
+    async () => {
+      const stub = stubRegistry();
+      await using server = stub.server;
+
+      using dir = tempDir("bun-create-bunfig-registry", {
+        "bunfig.toml": ["[install]", `registry = "${stub.url}/"`, ""].join("\n"),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "create", "elysia", "my-app", "--no-install", "--no-git"],
+        cwd: String(dir),
+        env: cleanEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stub.hits.count).toBeGreaterThan(0);
+      expect(await proc.exited).not.toBe(0);
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "bunfig.toml $ENV_VAR registry expansion",
+    async () => {
+      const stub = stubRegistry();
+      await using server = stub.server;
+
+      using dir = tempDir("bun-create-bunfig-env-expansion", {
+        "bunfig.toml": ["[install]", `registry = "$TEST_CUSTOM_REGISTRY"`, ""].join("\n"),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "create", "elysia", "my-app", "--no-install", "--no-git"],
+        cwd: String(dir),
+        env: {
+          ...cleanEnv,
+          TEST_CUSTOM_REGISTRY: stub.url,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stub.hits.count).toBeGreaterThan(0);
+      expect(await proc.exited).not.toBe(0);
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    "BUN_CONFIG_REGISTRY overrides bunfig.toml registry",
+    async () => {
+      const stub = stubRegistry();
+      await using server = stub.server;
+
+      using dir = tempDir("bun-create-env-overrides-bunfig", {
+        "bunfig.toml": ["[install]", `registry = "https://registry.npmjs.org/"`, ""].join("\n"),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "create", "elysia", "my-app", "--no-install", "--no-git"],
+        cwd: String(dir),
+        env: {
+          ...cleanEnv,
+          BUN_CONFIG_REGISTRY: stub.url,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stub.hits.count).toBeGreaterThan(0);
+      expect(await proc.exited).not.toBe(0);
+    },
+    { timeout: 30_000 },
+  );
+});


### PR DESCRIPTION
## Summary
`bun create` now respects custom registry configuration from bunfig.toml, `BUN_CONFIG_REGISTRY`, `NPM_CONFIG_REGISTRY`, and `npm_config_registry` environment variables.

Previously, `bun create` hardcoded `https://registry.npmjs.org` and ignored all registry configuration for the legacy template path (elysia, elysia-buchta, stric).

## Changes
- Added `CreateCommand` to `readGlobalConfig`, `isNPMRelated`, `loads_config`, and `always_loads_config` in cli.zig so bunfig.toml is loaded before create runs
- Added `getRegistryUrl()` helper in `create_command.zig` that checks env vars first (BUN_CONFIG_REGISTRY > NPM_CONFIG_REGISTRY > npm_config_registry), then bunfig.toml via `Scope.fromAPI` for $ENV_VAR expansion, then falls back to default
- Replaced hardcoded `registry.npmjs.org` URLs in `create_command.zig`

## Test plan
6 regression tests in `test/regression/issue/617.test.ts` covering all env var variants, bunfig.toml, `$ENV_VAR` expansion, and env-overrides-bunfig priority.

Fixes #617

---
Verification (robobun, iteration 38): CI Build #40714 running on commit ea3252b (rebased single commit); prior Build #40452 passed 49/49 (only ASAN infra kill, unrelated). JS lint passed. Diff touches exactly 3 files (cli.zig, create_command.zig, 617.test.ts), no TODO/FIXME/HACK. getRegistryUrl() correctly implements env > bunfig > default priority with http/https scheme validation and $ENV_VAR expansion via Scope.fromAPI; bufPrint uses `try`. 6 hermetic tests use port:0 stub servers returning 500, assert hits.count > 0 — would fail on main where registry.npmjs.org is hardcoded. alii rebase request resolved; all CodeRabbit threads addressed.