### PR TITLE
fix: wrap dynamic import of CJS chunks with __toESM when splitting

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.zig
+++ b/src/bundler/linker_context/scanImportsAndExports.zig
@@ -698,8 +698,11 @@ pub fn scanImportsAndExports(this: *LinkerContext) ScanImportsAndExportsError!vo
                                         record.flags.contains_default_alias or
                                         record.flags.contains_es_module_alias))
                                 {
-                                    record.flags.wrap_with_to_esm = true;
-                                    to_esm_uses += 1;
+                                    // Only wrap with __toESM if target is CJS (or truly external with unknown kind)
+                                    if (!record.source_index.isValid() or exports_kind[record.source_index.get()] == .cjs) {
+                                        record.flags.wrap_with_to_esm = true;
+                                        to_esm_uses += 1;
+                                    }
                                 }
                             }
                         }

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1789,6 +1789,9 @@ fn NewPrinter(
 
             p.printSpaceBeforeIdentifier();
 
+            // Wrap with __toESM if importing a CommonJS module
+            const wrap_with_to_esm = record.flags.wrap_with_to_esm;
+
             // Allow it to fail at runtime, if it should
             if (module_type != .internal_bake_dev) {
                 p.print("import(");
@@ -1806,6 +1809,17 @@ fn NewPrinter(
             }
 
             p.print(")");
+
+            // For CJS modules, unwrap the default export and convert to ESM
+            if (wrap_with_to_esm) {
+                p.print(".then((m)=>");
+                p.printSymbol(p.options.to_esm_ref);
+                p.print("(m.default");
+                if (p.options.input_module_type == .esm) {
+                    p.print(",1");
+                }
+                p.print("))");
+            }
 
             // if (leading_interior_comments.len > 0) {
             //     p.printNewline();

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -608,4 +608,52 @@ describe("bundler", () => {
       stdout: "42 true 42",
     },
   });
+  // Test that CJS modules with dynamic imports to other CJS entry points work correctly
+  // when code splitting causes the dynamically imported module to be in a separate chunk.
+  // The dynamic import should properly unwrap the default export using __toESM.
+  // Regression test for: dynamic import of CJS chunk returns { default: { __esModule, ... } }
+  // and needs .then((m)=>__toESM(m.default)) to unwrap correctly.
+  itBundled("splitting/CJSDynamicImportOfCJSChunk", {
+    files: {
+      "/main.ts": /* js */ `
+        import { getValue } from "./loader.js";
+        async function run() {
+          const v = await getValue();
+          console.log(v);
+        }
+        run();
+      `,
+      "/loader.js": /* js */ `
+        "use strict";
+        Object.defineProperty(exports, "__esModule", { value: true });
+        exports.getValue = void 0;
+        let impl;
+        async function getValue() {
+          if (!impl) {
+            const mod = await import("./impl.js");
+            impl = mod.getValue;
+          }
+          return impl();
+        }
+        exports.getValue = getValue;
+      `,
+      "/impl.js": /* js */ `
+        "use strict";
+        Object.defineProperty(exports, "__esModule", { value: true });
+        exports.getValue = void 0;
+        function getValue() {
+          return "success";
+        }
+        exports.getValue = getValue;
+      `,
+    },
+    entryPoints: ["/main.ts", "/impl.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "bun",
+    run: {
+      file: "/out/main.js",
+      stdout: "success",
+    },
+  });
 });


### PR DESCRIPTION
### What does this PR do?

### How did you verify your code works?
