### PR TITLE
fix(runtime): preserve symlink path in process.argv[1]

### DIFF
--- a/test/regression/issue/02900.test.ts
+++ b/test/regression/issue/02900.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+import { symlinkSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/2900
+// process.argv[1] should preserve the symlink path, not resolve to the real path
+test("process.argv[1] preserves symlink path", async () => {
+  using dir = tempDir("issue-2900", {
+    "foo.mjs": "console.log(process.argv[1]);",
+  });
+
+  // Create symlink bar.mjs -> foo.mjs
+  const fooPath = join(String(dir), "foo.mjs");
+  const barPath = join(String(dir), "bar.mjs");
+  try {
+    symlinkSync(fooPath, barPath);
+  } catch (e: any) {
+    if (process.platform === "win32") {
+      console.log("symlinkSync failed on Windows, skipping test:", e.message);
+      return;
+    }
+    throw e;
+  }
+
+  // Run through symlink
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), barPath],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // process.argv[1] should be the symlink path, not the resolved path
+  expect(stdout.trim()).toBe(barPath);
+  expect(exitCode).toBe(0);
+});
+
+test("process.argv[1] preserves relative symlink path (resolved to absolute)", async () => {
+  using dir = tempDir("issue-2900-rel", {
+    "foo.mjs": "console.log(process.argv[1]);",
+  });
+
+  // Create relative symlink bar.mjs -> foo.mjs
+  const barPath = join(String(dir), "bar.mjs");
+  try {
+    symlinkSync("foo.mjs", barPath);
+  } catch (e: any) {
+    if (process.platform === "win32") {
+      console.log("symlinkSync failed on Windows, skipping test:", e.message);
+      return;
+    }
+    throw e;
+  }
+
+  // Run through symlink
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "bar.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // process.argv[1] should be the absolute symlink path
+  expect(stdout.trim()).toBe(barPath);
+  expect(exitCode).toBe(0);
+});
+
+test("process.argv[1] works correctly for non-symlink files", async () => {
+  using dir = tempDir("issue-2900-nosym", {
+    "foo.mjs": "console.log(process.argv[1]);",
+  });
+
+  const fooPath = join(String(dir), "foo.mjs");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fooPath],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(fooPath);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/08757.test.ts
+++ b/test/regression/issue/08757.test.ts
@@ -29,8 +29,9 @@ test("absolute path to a file that is symlinked has import.meta.main", () => {
   });
   expect(result.stdout.trim()).toBe(
     [
-      //
-      import.meta.path,
+      // process.argv[1] should be the symlink path (issue #2900)
+      root + "/main.js",
+      // Bun.main should be the resolved path
       import.meta.path,
       "true",
       import.meta.dir,


### PR DESCRIPTION
## Summary
- When running a script through a symlink, `process.argv[1]` now contains the symlink path instead of the resolved real path, matching Node.js behavior
- Previously, `bun bar.mjs` (where bar.mjs -> foo.mjs) would set `process.argv[1]` to `/path/to/foo.mjs`. Now it correctly sets it to `/path/to/bar.mjs`

## Changes
The fix handles two code paths in `run_command.zig`:
1. `maybeOpenWithBunJS`: Use the original `file_path` instead of calling `getFdPath()` which resolves symlinks
2. `exec` via resolver: Use `path.pretty` (original symlink path) when `path.is_symlink` is true

## Test plan
- Added regression test `test/regression/issue/02900.test.ts` that verifies:
  - Symlink path is preserved for absolute symlinks
  - Symlink path is preserved for relative symlinks (resolved to absolute)
  - Non-symlink files continue to work correctly

Fixes #2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)