### PR TITLE
feat(http): add --max-http-header-count CLI flag

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -666,6 +666,11 @@ public:
         return std::move(*this);
     }
 
+    TemplatedApp &&setMaxHTTPHeadersCount(uint32_t maxHeadersCount) {
+        httpContext->getSocketContextData()->maxHeadersCount = maxHeadersCount;
+        return std::move(*this);
+    }
+
 };
 
 typedef TemplatedApp<false> App;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -243,7 +243,7 @@ private:
 
             /* The return value is entirely up to us to interpret. The HttpParser cares only for whether the returned value is DIFFERENT from passed user */
 
-            auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
+            auto result = httpResponseData->consumePostPadded(httpContextData->maxHeaderSize, httpContextData->maxHeadersCount, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
                 /* For every request we reset the timeout and hang until user makes action */

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -70,6 +70,7 @@ private:
     OnClientErrorCallback onClientError = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
+    uint32_t maxHeadersCount = 0; // 0 means use default (UWS_HTTP_MAX_HEADERS_COUNT)
 
     // TODO: SNI
     void clearRoutes() {

--- a/src/bun.js/node/node_http_binding.zig
+++ b/src/bun.js/node/node_http_binding.zig
@@ -65,5 +65,6 @@ pub fn setMaxHTTPHeadersCount(globalThis: *jsc.JSGlobalObject, callframe: *jsc.C
 }
 
 const std = @import("std");
+
 const bun = @import("bun");
 const jsc = bun.jsc;

--- a/src/bun.js/node/node_http_binding.zig
+++ b/src/bun.js/node/node_http_binding.zig
@@ -40,5 +40,30 @@ pub fn setMaxHTTPHeaderSize(globalThis: *jsc.JSGlobalObject, callframe: *jsc.Cal
     return jsc.JSValue.jsNumber(bun.http.max_http_header_size);
 }
 
+pub fn getMaxHTTPHeadersCount(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    _ = globalThis;
+    _ = callframe;
+    return jsc.JSValue.jsNumber(bun.http.max_http_headers_count);
+}
+
+pub fn setMaxHTTPHeadersCount(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const arguments = callframe.arguments_old(1).slice();
+    if (arguments.len < 1) {
+        return globalThis.throwNotEnoughArguments("setMaxHTTPHeadersCount", 1, arguments.len);
+    }
+    const value = arguments[0];
+    const num = try value.coerceToInt64(globalThis);
+    if (num < 0) {
+        return globalThis.throwInvalidArgumentTypeValue("maxHeadersCount", "non-negative integer", value);
+    }
+    if (num == 0) {
+        bun.http.max_http_headers_count = std.math.maxInt(u32);
+    } else {
+        bun.http.max_http_headers_count = @intCast(num);
+    }
+    return jsc.JSValue.jsNumber(bun.http.max_http_headers_count);
+}
+
+const std = @import("std");
 const bun = @import("bun");
 const jsc = bun.jsc;

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -103,6 +103,7 @@ pub const runtime_params_ = [_]ParamType{
     clap.parseParam("--conditions <STR>...             Pass custom conditions to resolve") catch unreachable,
     clap.parseParam("--fetch-preconnect <STR>...       Preconnect to a URL while code is loading") catch unreachable,
     clap.parseParam("--max-http-header-size <INT>      Set the maximum size of HTTP headers in bytes. Default is 16KiB") catch unreachable,
+    clap.parseParam("--max-http-header-count <INT>     Set the maximum number of HTTP headers. Default is 100") catch unreachable,
     clap.parseParam("--dns-result-order <STR>          Set the default order of DNS lookup results. Valid orders: verbatim (default), ipv4first, ipv6first") catch unreachable,
     clap.parseParam("--expose-gc                       Expose gc() on the global object. Has no effect on Bun.gc().") catch unreachable,
     clap.parseParam("--no-deprecation                  Suppress all reporting of the custom deprecation.") catch unreachable,
@@ -732,6 +733,18 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 bun.http.max_http_header_size = 1024 * 1024 * 1024;
             } else {
                 bun.http.max_http_header_size = size;
+            }
+        }
+
+        if (args.option("--max-http-header-count")) |count_str| {
+            const count = std.fmt.parseInt(u32, count_str, 10) catch {
+                Output.errGeneric("Invalid value for --max-http-header-count: \"{s}\". Must be a positive integer\n", .{count_str});
+                Global.exit(1);
+            };
+            if (count == 0) {
+                bun.http.max_http_headers_count = std.math.maxInt(u32);
+            } else {
+                bun.http.max_http_headers_count = count;
             }
         }
 

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -531,6 +531,15 @@ extern "C"
       uwsApp->setMaxHTTPHeaderSize(max_header_size);
     }
   }
+  void uws_app_set_max_http_headers_count(int ssl, uws_app_t *app, uint32_t max_headers_count) {
+    if (ssl) {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->setMaxHTTPHeadersCount(max_headers_count);
+    } else {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->setMaxHTTPHeadersCount(max_headers_count);
+    }
+  }
   void uws_app_set_flags(int ssl, uws_app_t *app, bool require_host_header, bool use_strict_method_validation) {
     if (ssl) {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;

--- a/src/deps/uws/App.zig
+++ b/src/deps/uws/App.zig
@@ -63,6 +63,10 @@ pub fn NewApp(comptime ssl: bool) type {
             return c.uws_app_set_max_http_header_size(ssl_flag, @as(*uws_app_t, @ptrCast(this)), max_header_size);
         }
 
+        pub fn setMaxHTTPHeadersCount(this: *ThisApp, max_headers_count: u32) void {
+            return c.uws_app_set_max_http_headers_count(ssl_flag, @as(*uws_app_t, @ptrCast(this)), max_headers_count);
+        }
+
         pub fn clearRoutes(app: *ThisApp) void {
             return c.uws_app_clear_routes(ssl_flag, @as(*uws_app_t, @ptrCast(app)));
         }
@@ -404,6 +408,7 @@ pub const c = struct {
     pub extern fn uws_app_destroy(ssl: i32, app: *uws_app_t) void;
     pub extern fn uws_app_set_flags(ssl: i32, app: *uws_app_t, require_host_header: bool, use_strict_method_validation: bool) void;
     pub extern fn uws_app_set_max_http_header_size(ssl: i32, app: *uws_app_t, max_header_size: u64) void;
+    pub extern fn uws_app_set_max_http_headers_count(ssl: i32, app: *uws_app_t, max_headers_count: u32) void;
     pub extern fn uws_app_get(ssl: i32, app: *uws_app_t, pattern: [*]const u8, pattern_len: usize, handler: uws_method_handler, user_data: ?*anyopaque) void;
     pub extern fn uws_app_post(ssl: i32, app: *uws_app_t, pattern: [*]const u8, pattern_len: usize, handler: uws_method_handler, user_data: ?*anyopaque) void;
     pub extern fn uws_app_options(ssl: i32, app: *uws_app_t, pattern: [*]const u8, pattern_len: usize, handler: uws_method_handler, user_data: ?*anyopaque) void;

--- a/src/http.zig
+++ b/src/http.zig
@@ -15,6 +15,11 @@ comptime {
     @export(&max_http_header_size, .{ .name = "BUN_DEFAULT_MAX_HTTP_HEADER_SIZE" });
 }
 
+pub var max_http_headers_count: u32 = 100;
+comptime {
+    @export(&max_http_headers_count, .{ .name = "BUN_DEFAULT_MAX_HTTP_HEADERS_COUNT" });
+}
+
 pub var overridden_default_user_agent: []const u8 = "";
 
 const print_every = 0;

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -352,6 +352,8 @@ function emitErrorNt(msg, err, callback) {
 }
 const setMaxHTTPHeaderSize = $newZigFunction("node_http_binding.zig", "setMaxHTTPHeaderSize", 1);
 const getMaxHTTPHeaderSize = $newZigFunction("node_http_binding.zig", "getMaxHTTPHeaderSize", 0);
+const setMaxHTTPHeadersCount = $newZigFunction("node_http_binding.zig", "setMaxHTTPHeadersCount", 1);
+const getMaxHTTPHeadersCount = $newZigFunction("node_http_binding.zig", "getMaxHTTPHeadersCount", 0);
 const kOutHeaders = Symbol("kOutHeaders");
 
 function ipToInt(ip) {
@@ -502,6 +504,7 @@ export {
   getHeader,
   getIsNextIncomingMessageHTTPS,
   getMaxHTTPHeaderSize,
+  getMaxHTTPHeadersCount,
   getRawKeys,
   hasServerResponseFinished,
   headerStateSymbol,
@@ -551,6 +554,7 @@ export {
   setHeader,
   setIsNextIncomingMessageHTTPS,
   setMaxHTTPHeaderSize,
+  setMaxHTTPHeadersCount,
   setRequestTimeout,
   setServerCustomOptions,
   setServerIdleTimeout,

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -6,7 +6,14 @@ const { IncomingMessage } = require("node:_http_incoming");
 const { OutgoingMessage } = require("node:_http_outgoing");
 const { Server, ServerResponse } = require("node:_http_server");
 
-const { METHODS, STATUS_CODES, setMaxHTTPHeaderSize, getMaxHTTPHeaderSize } = require("internal/http");
+const {
+  METHODS,
+  STATUS_CODES,
+  setMaxHTTPHeaderSize,
+  getMaxHTTPHeaderSize,
+  setMaxHTTPHeadersCount,
+  getMaxHTTPHeadersCount,
+} = require("internal/http");
 
 const { WebSocket, CloseEvent, MessageEvent } = globalThis;
 
@@ -53,6 +60,12 @@ const http_exports = {
   },
   set maxHeaderSize(value) {
     setMaxHTTPHeaderSize(value);
+  },
+  get maxHeadersCount() {
+    return getMaxHTTPHeadersCount();
+  },
+  set maxHeadersCount(value) {
+    setMaxHTTPHeadersCount(value);
   },
   validateHeaderName,
   validateHeaderValue,

--- a/test/regression/issue/6982.test.ts
+++ b/test/regression/issue/6982.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("--max-http-header-count", () => {
+  test("http.maxHeadersCount getter returns default value", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log(require('http').maxHeadersCount)"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("100");
+    expect(exitCode).toBe(0);
+  });
+
+  test("http.maxHeadersCount setter works", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http = require('http');
+        console.log(http.maxHeadersCount);
+        http.maxHeadersCount = 500;
+        console.log(http.maxHeadersCount);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const lines = stdout.trim().split("\n");
+    expect(lines[0]).toBe("100");
+    expect(lines[1]).toBe("500");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--max-http-header-count CLI flag sets the value", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--max-http-header-count=200", "-e", "console.log(require('http').maxHeadersCount)"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("200");
+    expect(exitCode).toBe(0);
+  });
+
+  test("server accepts requests with many headers when limit is increased", async () => {
+    using dir = tempDir("header-count-test", {
+      "server.ts": `
+        const server = Bun.serve({
+          port: 0,
+          fetch(req) {
+            const count = [...req.headers].length;
+            return new Response(String(count));
+          },
+        });
+        console.log(server.url.href);
+      `,
+    });
+
+    // Start server with higher header limit
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--max-http-header-count=200", "server.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Read server URL from stdout
+    const reader = proc.stdout.getReader();
+    const { value } = await reader.read();
+    reader.releaseLock();
+    const url = new TextDecoder().decode(value).trim();
+
+    // Build request with 150 headers
+    const headers = new Headers();
+    for (let i = 0; i < 150; i++) {
+      headers.set(`X-Custom-Header-${i}`, `value-${i}`);
+    }
+
+    const res = await fetch(url, { headers });
+    expect(res.status).toBe(200);
+    const count = parseInt(await res.text());
+    // Account for default headers that fetch adds (Host, Accept, etc.)
+    expect(count).toBeGreaterThanOrEqual(150);
+
+    proc.kill();
+  });
+
+  test("server rejects requests with too many headers", async () => {
+    using dir = tempDir("header-count-reject-test", {
+      "server.ts": `
+        const server = Bun.serve({
+          port: 0,
+          fetch(req) {
+            const count = [...req.headers].length;
+            return new Response(String(count));
+          },
+        });
+        console.log(server.url.href);
+      `,
+    });
+
+    // Start server with low header limit (50)
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--max-http-header-count=50", "server.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Read server URL from stdout
+    const reader = proc.stdout.getReader();
+    const { value } = await reader.read();
+    reader.releaseLock();
+    const url = new TextDecoder().decode(value).trim();
+
+    // Build request with 60 headers (exceeds limit)
+    const headers = new Headers();
+    for (let i = 0; i < 60; i++) {
+      headers.set(`X-Custom-Header-${i}`, `value-${i}`);
+    }
+
+    const res = await fetch(url, { headers });
+    // Should get 431 Request Header Fields Too Large
+    expect(res.status).toBe(431);
+
+    proc.kill();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--max-http-header-count` CLI flag to configure the maximum number of HTTP headers allowed per request (default: 100)
- Adds `http.maxHeadersCount` getter/setter for Node.js compatibility
- Uses dynamic allocation when limit > 100, with stack allocation fast path for default case

## Test plan

- [x] `bun bd test test/regression/issue/6982.test.ts` passes
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` (feature doesn't exist in current release)
- [x] Tested CLI flag: `bun --max-http-header-count=200 -e "console.log(require('http').maxHeadersCount)"` outputs `200`
- [x] Tested server accepts 150 headers with `--max-http-header-count=200`
- [x] Tested server rejects 60 headers with `--max-http-header-count=50` (returns 431)

Fixes #6982

🤖 Generated with [Claude Code](https://claude.com/claude-code)